### PR TITLE
Fix for codeplex issue 6575

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -659,6 +659,14 @@ namespace NLog.Targets
             return value;
         }
 
+        private static Boolean IsContainValidNumberPatternForReplacement(string pattern)
+        {
+            int StartingIndex = pattern.IndexOf("{#", StringComparison.Ordinal);
+            int EndingIndex = pattern.IndexOf("#}", StringComparison.Ordinal);
+
+            return (StartingIndex != -1 && EndingIndex != -1 && StartingIndex < EndingIndex);
+        }
+        
         private static string ReplaceNumber(string pattern, int value)
         {
             int firstPart = pattern.IndexOf("{#", StringComparison.Ordinal);
@@ -835,7 +843,18 @@ namespace NLog.Targets
             }
             else
             {
+                //The archive file name is given. There are two possibiliy 
+                //(1) User supplied the Filename with pattern
+                //(2) User supplied the normal filename
                 fileNamePattern = this.ArchiveFileName.Render(ev);
+
+                if (!IsContainValidNumberPatternForReplacement(fileNamePattern))
+                {
+                    //ArchiveFileName doesn't contain valid File Name Pattern For Archiving.
+                    //Note that In both cases either the archiving done at certain time or it is done because of size of file , it is necessary to number the files.
+                    //So , We have to Put pattern in default place. Otherwise archiving will not be done.
+                    fileNamePattern = Path.ChangeExtension(fileNamePattern, ".{#}" + Path.GetExtension(fileNamePattern));
+                }
             }
 
             switch (this.ArchiveNumbering)


### PR DESCRIPTION
This fix inject the pattern in the archive file name pattern so that even if user do not provide pattern in file name , code will inject it.

How the archiving is done is depend on three variables :
ArchiveEvery : Specifies Time period
ArchiveAboveSize : Specifies size
MaxArchiveFiles : Specifies maximum archived files to keep.

There are three cases mainly :

(1) Lets say developer has set ArchiveEvery to hour and ArchiveAboveSize to 10 MB 
So , Whatever condition occurs first , then NLog will start archiving the current log file , in this case numbering is required otherwise NLog will overwrite the previous archive file.

(2) Lets say developer has set ArchiveEvery to none (default) and ArchiveAboveSize to 10 MB
So , in this case if the current log file's size is going to increase above 10 MB , then it will move this file to archive and create a new log file , in this case also we require numbering. Otherwise NLog will overwrite the previous file that was created when the size first increased.

(3) Lets say developer has set ArchiveEvery to hour and ArchiveAboveSize to -1(default)
So , in this case if the hour passed then regardless of the size of the log file , it will be moved to the archive . So , numbering is required. So After second hour if NLog archive the file then it should not overwrite the file that was created after completion of first hour.So , Numbering is required.

In all cases Numbering is required , because NLog will archive file upto MaxArchiveFiles specified.and We don't want to overwrite them.
