### PR TITLE
Deadlock in NLog library using Control-Target (WinForms)

### DIFF
--- a/src/NLog/Targets/FormControlTarget.cs
+++ b/src/NLog/Targets/FormControlTarget.cs
@@ -132,7 +132,7 @@ namespace NLog.Targets
                 return;
             }
 
-            ctrl.Invoke(new DelSendTheMessageToFormControl(this.SendTheMessageToFormControl), new object[] { ctrl, logMessage });
+            ctrl.BeginInvoke(new DelSendTheMessageToFormControl(this.SendTheMessageToFormControl), new object[] { ctrl, logMessage });
         }
 
         private void SendTheMessageToFormControl(Control ctrl, string logMessage)


### PR DESCRIPTION
My commit fixes a deadlock in the NLog library by using BeginInvoke. There was a similar issue with RichTextBox-Target with the same solution.
