### PR TITLE
#110 Exceptions swallowed in custom target

### DIFF
--- a/src/NLog.netfx40.vsmdi
+++ b/src/NLog.netfx40.vsmdi
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <TestLists xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
   <TestList name="Lists of Tests" id="8c43106b-9dc1-4907-a29f-aa66a61bf5b6">
-    <RunConfiguration id="d5ad33a1-e178-4da8-880b-e73a8eedbdbe" name="Local Test Run" storage="localtestrun.vs2010.testrunconfig" type="Microsoft.VisualStudio.TestTools.Common.TestRunConfiguration, Microsoft.VisualStudio.QualityTools.Common,   PublicKeyToken=b03f5f7f11d50a3a" />
+    <RunConfiguration id="d5ad33a1-e178-4da8-880b-e73a8eedbdbe" name="Local Test Run" storage="localtestrun.vs2010.testrunconfig" type="Microsoft.VisualStudio.TestTools.Common.TestRunConfiguration, Microsoft.VisualStudio.QualityTools.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   </TestList>
 </TestLists>

--- a/src/NLog/Internal/ExceptionHelper.cs
+++ b/src/NLog/Internal/ExceptionHelper.cs
@@ -63,6 +63,11 @@ namespace NLog.Internal
                 return true;
             }
 
+            if (exception is NLogConfigurationException)
+            {
+                return true;
+            }
+
             return false;
         }
     }

--- a/src/NLog/Internal/SingleCallContinuation.cs
+++ b/src/NLog/Internal/SingleCallContinuation.cs
@@ -74,6 +74,11 @@ namespace NLog.Internal
                     throw;
                 }
 
+                if (LogManager.ThrowExceptions)
+                {
+                    throw;
+                }
+
                 ReportExceptionInHandler(ex);
             }
         }

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -210,6 +210,11 @@ namespace NLog.Targets
                         throw;
                     }
 
+                    if (LogManager.ThrowExceptions)
+                    {
+                        throw;
+                    }
+
                     wrappedContinuation(exception);
                 }
             }

--- a/tests/NLog.UnitTests/AsyncHelperTests.cs
+++ b/tests/NLog.UnitTests/AsyncHelperTests.cs
@@ -97,6 +97,8 @@ namespace NLog.UnitTests
         [Test]
         public void OneTimeOnlyExceptionInHandlerTest()
         {
+            LogManager.ThrowExceptions = false;
+
             var exceptions = new List<Exception>();
             var sampleException = new InvalidOperationException("some message");
             AsyncContinuation cont = ex => { exceptions.Add(ex); throw sampleException; };
@@ -105,6 +107,40 @@ namespace NLog.UnitTests
             cont(null);
             cont(null);
             cont(null);
+
+            Assert.AreEqual(1, exceptions.Count);
+            Assert.IsNull(exceptions[0]);
+        }
+
+        [Test]
+        public void OneTimeOnlyExceptionInHandlerTest_RethrowExceptionEnabled()
+        {
+            LogManager.ThrowExceptions = true;
+
+            var exceptions = new List<Exception>();
+            var sampleException = new InvalidOperationException("some message");
+            AsyncContinuation cont = ex => { exceptions.Add(ex); throw sampleException; };
+            cont = AsyncHelpers.PreventMultipleCalls(cont);
+
+            try
+            {
+                cont(null);
+            }
+            catch{}
+
+            try
+            {
+                cont(null);
+            }
+            catch { }
+            try
+            {
+                cont(null);
+            }
+            catch { }
+
+            // cleanup
+            LogManager.ThrowExceptions = false;
 
             Assert.AreEqual(1, exceptions.Count);
             Assert.IsNull(exceptions[0]);

--- a/tests/NLog.UnitTests/Conditions/ConditionParserTests.cs
+++ b/tests/NLog.UnitTests/Conditions/ConditionParserTests.cs
@@ -308,7 +308,7 @@ namespace NLog.UnitTests.Conditions
         }
 
         [Test]
-        [ExpectedException(typeof(ConditionParseException))]
+        [ExpectedException(typeof(NLogConfigurationException))]
         public void UnrecognizedMethod()
         {
             ConditionParser.ParseExpression("unrecognized-method()");

--- a/tests/NLog.UnitTests/GetLoggerTests.cs
+++ b/tests/NLog.UnitTests/GetLoggerTests.cs
@@ -142,7 +142,7 @@ namespace NLog.UnitTests
         }
         
         [Test]
-        public void InvalidLoggerConfiguration_DoesNotThrowConfigurationException_IfThrowExceptionsFlagIsSet()
+        public void InvalidLoggerConfiguration_ThrowsConfigurationException_IfThrowExceptionsFlagIsSet()
         {
             bool ExceptionThrown = false;
             try 
@@ -154,7 +154,7 @@ namespace NLog.UnitTests
             {
                 ExceptionThrown = true;
             }
-            Assert.IsFalse(ExceptionThrown);
+            Assert.IsTrue(ExceptionThrown);
         }
         
         [Test]

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -570,6 +570,9 @@ namespace NLog.UnitTests.Targets
                 LogManager.Configuration = null;
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
+
+                // Clean up configuration change, breaks onetimeonlyexceptioninhandlertest
+                LogManager.ThrowExceptions = true;
             }
         }
 


### PR DESCRIPTION
Most closely relates to #110, although havent tested with WCF. (My scenario is MVC4 web api)
### My understanding of NLog Exception handling
- All NLogConfiguration Exceptions should be rethrown
- NLogRuntime exceptions should be thrown only if throwExceptions is set 'true' in the nlog config (or in code)
### Changes
- Modified singlecallcontinuation class to rethrow if throwExceptions is true
- Modified base Target.cs to rethrow if throwExceptions is true
- Updated associated unit tests
### Caveat

If throwExceptions is true, relogging an exception would presumably throw another exception. Temporarily disabling throwExceptions in your handler may prevent this.

Good

```
try
{
    logger.Info(msg);
    ...   
}
catch (NLogRuntimeException rtException)
{
    LogManager.ThrowExceptions = false;
    logger.Error(rtException.Message);
}
```

Bad

```
try
{
    logger.Info(msg);
    ...   
}
catch (NLogRuntimeException rtException)
{
    logger.Error(rtException.Message);
}
```
