### PR TITLE
Allow configuring LogReceiverWebServiceTarget's Wcf client from code

### DIFF
--- a/src/NLog/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog/Targets/LogReceiverWebServiceTarget.cs
@@ -306,6 +306,13 @@ namespace NLog.Targets
         }
 
 #if WCF_SUPPORTED
+		/// <summary>
+		/// Creating a new instance of WcfLogReceiverClient
+		/// 
+		/// Inheritors can override this method and provide their own 
+		/// service configuration - binding and endpoint address
+		/// </summary>
+		/// <returns></returns>
         protected virtual WcfLogReceiverClient CreateWcfLogReceiverClient()
         {
             WcfLogReceiverClient client;


### PR DESCRIPTION
Extracted WcfLogReceiverClient creation to a protected virtual method to allow overriding and providing parameters (binding and endpoint address) from code.

Or may be there is a better way to achieve it?
