### PR TITLE
add context properties to Nlog data section of Log4JXmlEventLayoutRenderer

### DIFF
--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -238,6 +238,16 @@ namespace NLog.LayoutRenderers
                         }
 
                         xtw.WriteEndElement();
+
+                        xtw.WriteStartElement("nlog", "properties", dummyNLogNamespace);
+                        foreach (var contextProperty in logEvent.Properties)
+                        {
+                            xtw.WriteStartElement("nlog", "data", dummyNLogNamespace);
+                            xtw.WriteAttributeString("name", Convert.ToString(contextProperty.Key, CultureInfo.InvariantCulture));
+                            xtw.WriteAttributeString("value", Convert.ToString(contextProperty.Value, CultureInfo.InvariantCulture));
+                            xtw.WriteEndElement();
+                        }
+                        xtw.WriteEndElement();
                     }
                 }
 #endif


### PR DESCRIPTION
I had a need to add my custom properties to the Log4JXmlEventLayoutRenderer so I could get them over to a network listener expecting a Log4JXmlEvent.
