### PR TITLE
Optional ConditionMethod arguments, ignoreCase argument for standard condition methods, EventLogTarget enhancements

### DIFF
--- a/src/NLog/Conditions/ConditionMethodExpression.cs
+++ b/src/NLog/Conditions/ConditionMethodExpression.cs
@@ -1,6 +1,5 @@
 // 
 // Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
-// Copyright (c) 2011 Zany Ants Limited <opensource@zanyants.com>
 // 
 // All rights reserved.
 // 

--- a/src/NLog/Conditions/ConditionMethods.cs
+++ b/src/NLog/Conditions/ConditionMethods.cs
@@ -1,6 +1,5 @@
 // 
 // Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
-// Copyright (c) 2011 Zany Ants Limited <opensource@zanyants.com>
 // 
 // All rights reserved.
 // 


### PR DESCRIPTION
/\* These changes were posted as part of a pull request against jkowalski/NLog a _long_ time ago (Oct 2011) , but there seems to be a graveyard of pull requests there and NLog/NLog is active. There have been no subsequent changes to the files I touched back then. Below is part of my original pull request message (there were some EventLogTarget changes too, which I've left out as we now put them in our own custom extension assembly). */

Hi,

I noted that the ability to specify case sensitivity was present in the deprecated "whenEquals" (etc) conditions, but not in the newer "when" condition. So I've added support for optional (defaulted) arguments for ConditionMethod methods, and given the standard string-related ones an optional ignoreCase argument.

As a general note, I couldn't find any "how to contribute" documentation, so I'm not sure how you handle contributions, notably regarding copyright. For now, I've added copyright entries in the files I've touched/created with my employer's details, but I'm open to discussion on this.

I've built the code via build.cmd for netfx40, netfx35, netfx20 and sl3 (that's all the SDKs I've got installed) and addressed any code analysis issues. I've tested under netfx40 (including my silverlight-only code).

Regards,

Tom
