### PR TITLE
Avoid Win32-specific file functions in Mono where parts not implemented.

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -197,7 +197,7 @@ namespace NLog.Internal.FileAppenders
             throw new InvalidOperationException("Should not be reached.");
         }
 
-#if !NET_CF && !SILVERLIGHT
+#if !NET_CF && !SILVERLIGHT && !MONO
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Objects are disposed elsewhere")]
         private FileStream WindowsCreateFile(string fileName, bool allowConcurrentWrite)
         {
@@ -250,7 +250,7 @@ namespace NLog.Internal.FileAppenders
             }
 #endif
 
-#if !NET_CF && !SILVERLIGHT
+#if !NET_CF && !SILVERLIGHT && !MONO
             try
             {
                 if (PlatformDetector.IsDesktopWin32)


### PR DESCRIPTION
Add && !MONO compiler switch around Win32-specific file functions in BaseFileAppender.cs. Specifically, WindowsCreateFile() calls Marshal.GetHRForLastWin32Error() which is unimplemented (in Mono 3). Without this fix, many log messages are not emitted. The try/catch block added to TryCreateFileStream() does NOT fix this.
