### PR TITLE
Date Based File Archiving

### DIFF
--- a/src/NLog/Targets/ArchiveNumberingMode.cs
+++ b/src/NLog/Targets/ArchiveNumberingMode.cs
@@ -48,7 +48,12 @@ namespace NLog.Targets
         /// <summary>
         /// Rolling style numbering (the most recent is always #0 then #1, ..., #N.
         /// </summary>
-        Rolling, 
+        Rolling,
+
+        /// <summary>
+        /// Date style numbering.  Archives will be stamped with the prior period (Year, Month, Day, Hour, Minute) datetime.
+        /// </summary>
+        Date, 
     }
 }
 


### PR DESCRIPTION
I made a few minor changes that allows archiving based on dates instead of rolling/sequential numbering.
The changes have minimal impact and work with the existing code/parameters as much as possible.
I found many posts/bug reports about deleting archive files with dates in the file name as I was having the same issue.
I've been testing this for a couple days and is working as expected.

Sample output showing archive files with datetime and maxArchiveFiles of 2 (The log file for 4:29 has been deleted):
![image](https://f.cloud.github.com/assets/4999672/791657/53af56e0-eb4b-11e2-94d1-8df8d2546580.png)

Config used to achieve the results in the previous screenshot (archiveDateFormat is optional and will be generated based on archiveEvery setting if not specified):
![image](https://f.cloud.github.com/assets/4999672/791667/876dd5ba-eb4b-11e2-82f2-ef8bebd6555e.png)
