### PR TITLE
Integrate JetBrains Annotations

### DIFF
--- a/src/NLog/Annotations.cs
+++ b/src/NLog/Annotations.cs
@@ -1,0 +1,587 @@
+﻿using System;
+
+#pragma warning disable 1591
+// ReSharper disable UnusedMember.Global
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable IntroduceOptionalParameters.Global
+// ReSharper disable MemberCanBeProtected.Global
+// ReSharper disable InconsistentNaming
+
+namespace JetBrains.Annotations
+{
+  /// <summary>
+  /// Indicates that the value of the marked element could be <c>null</c> sometimes,
+  /// so the check for <c>null</c> is necessary before its usage
+  /// </summary>
+  /// <example><code>
+  /// [CanBeNull] public object Test() { return null; }
+  /// public void UseTest() {
+  ///   var p = Test();
+  ///   var s = p.ToString(); // Warning: Possible 'System.NullReferenceException'
+  /// }
+  /// </code></example>
+  [AttributeUsage(
+    AttributeTargets.Method | AttributeTargets.Parameter |
+    AttributeTargets.Property | AttributeTargets.Delegate |
+    AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+  public sealed class CanBeNullAttribute : Attribute { }
+
+  /// <summary>
+  /// Indicates that the value of the marked element could never be <c>null</c>
+  /// </summary>
+  /// <example><code>
+  /// [NotNull] public object Foo() {
+  ///   return null; // Warning: Possible 'null' assignment
+  /// }
+  /// </code></example>
+  [AttributeUsage(
+    AttributeTargets.Method | AttributeTargets.Parameter |
+    AttributeTargets.Property | AttributeTargets.Delegate |
+    AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+  public sealed class NotNullAttribute : Attribute { }
+
+  /// <summary>
+  /// Indicates that the marked method builds string by format pattern and (optional) arguments.
+  /// Parameter, which contains format string, should be given in constructor. The format string
+  /// should be in <see cref="string.Format(IFormatProvider,string,object[])"/>-like form
+  /// </summary>
+  /// <example><code>
+  /// [StringFormatMethod("message")]
+  /// public void ShowError(string message, params object[] args) { /* do something */ }
+  /// public void Foo() {
+  ///   ShowError("Failed: {0}"); // Warning: Non-existing argument in format string
+  /// }
+  /// </code></example>
+  [AttributeUsage(
+    AttributeTargets.Constructor | AttributeTargets.Method,
+    AllowMultiple = false, Inherited = true)]
+  public sealed class StringFormatMethodAttribute : Attribute
+  {
+    /// <param name="formatParameterName">
+    /// Specifies which parameter of an annotated method should be treated as format-string
+    /// </param>
+    public StringFormatMethodAttribute(string formatParameterName)
+    {
+      FormatParameterName = formatParameterName;
+    }
+
+    public string FormatParameterName { get; private set; }
+  }
+
+  /// <summary>
+  /// Indicates that the function argument should be string literal and match one
+  /// of the parameters of the caller function. For example, ReSharper annotates
+  /// the parameter of <see cref="System.ArgumentNullException"/>
+  /// </summary>
+  /// <example><code>
+  /// public void Foo(string param) {
+  ///   if (param == null)
+  ///     throw new ArgumentNullException("par"); // Warning: Cannot resolve symbol
+  /// }
+  /// </code></example>
+  [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+  public sealed class InvokerParameterNameAttribute : Attribute { }
+
+  /// <summary>
+  /// Indicates that the method is contained in a type that implements
+  /// <see cref="System.ComponentModel.INotifyPropertyChanged"/> interface
+  /// and this method is used to notify that some property value changed
+  /// </summary>
+  /// <remarks>
+  /// The method should be non-static and conform to one of the supported signatures:
+  /// <list>
+  /// <item><c>NotifyChanged(string)</c></item>
+  /// <item><c>NotifyChanged(params string[])</c></item>
+  /// <item><c>NotifyChanged{T}(Expression{Func{T}})</c></item>
+  /// <item><c>NotifyChanged{T,U}(Expression{Func{T,U}})</c></item>
+  /// <item><c>SetProperty{T}(ref T, T, string)</c></item>
+  /// </list>
+  /// </remarks>
+  /// <example><code>
+  /// public class Foo : INotifyPropertyChanged {
+  ///   public event PropertyChangedEventHandler PropertyChanged;
+  ///   [NotifyPropertyChangedInvocator]
+  ///   protected virtual void NotifyChanged(string propertyName) { ... }
+  ///
+  ///   private string _name;
+  ///   public string Name {
+  ///     get { return _name; }
+  ///     set { _name = value; NotifyChanged("LastName"); /* Warning */ }
+  ///   }
+  /// }
+  /// </code>
+  /// Examples of generated notifications:
+  /// <list>
+  /// <item><c>NotifyChanged("Property")</c></item>
+  /// <item><c>NotifyChanged(() =&gt; Property)</c></item>
+  /// <item><c>NotifyChanged((VM x) =&gt; x.Property)</c></item>
+  /// <item><c>SetProperty(ref myField, value, "Property")</c></item>
+  /// </list>
+  /// </example>
+  [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+  public sealed class NotifyPropertyChangedInvocatorAttribute : Attribute
+  {
+    public NotifyPropertyChangedInvocatorAttribute() { }
+    public NotifyPropertyChangedInvocatorAttribute(string parameterName)
+    {
+      ParameterName = parameterName;
+    }
+
+    public string ParameterName { get; private set; }
+  }
+
+  /// <summary>
+  /// Describes dependency between method input and output
+  /// </summary>
+  /// <syntax>
+  /// <p>Function Definition Table syntax:</p>
+  /// <list>
+  /// <item>FDT      ::= FDTRow [;FDTRow]*</item>
+  /// <item>FDTRow   ::= Input =&gt; Output | Output &lt;= Input</item>
+  /// <item>Input    ::= ParameterName: Value [, Input]*</item>
+  /// <item>Output   ::= [ParameterName: Value]* {halt|stop|void|nothing|Value}</item>
+  /// <item>Value    ::= true | false | null | notnull | canbenull</item>
+  /// </list>
+  /// If method has single input parameter, it's name could be omitted.<br/>
+  /// Using <c>halt</c> (or <c>void</c>/<c>nothing</c>, which is the same)
+  /// for method output means that the methos doesn't return normally.<br/>
+  /// <c>canbenull</c> annotation is only applicable for output parameters.<br/>
+  /// You can use multiple <c>[ContractAnnotation]</c> for each FDT row,
+  /// or use single attribute with rows separated by semicolon.<br/>
+  /// </syntax>
+  /// <examples><list>
+  /// <item><code>
+  /// [ContractAnnotation("=> halt")]
+  /// public void TerminationMethod()
+  /// </code></item>
+  /// <item><code>
+  /// [ContractAnnotation("halt &lt;= condition: false")]
+  /// public void Assert(bool condition, string text) // regular assertion method
+  /// </code></item>
+  /// <item><code>
+  /// [ContractAnnotation("s:null => true")]
+  /// public bool IsNullOrEmpty(string s) // string.IsNullOrEmpty()
+  /// </code></item>
+  /// <item><code>
+  /// // A method that returns null if the parameter is null, and not null if the parameter is not null
+  /// [ContractAnnotation("null => null; notnull => notnull")]
+  /// public object Transform(object data) 
+  /// </code></item>
+  /// <item><code>
+  /// [ContractAnnotation("s:null=>false; =>true,result:notnull; =>false, result:null")]
+  /// public bool TryParse(string s, out Person result)
+  /// </code></item>
+  /// </list></examples>
+  [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+  public sealed class ContractAnnotationAttribute : Attribute
+  {
+    public ContractAnnotationAttribute([NotNull] string contract)
+      : this(contract, false) { }
+
+    public ContractAnnotationAttribute([NotNull] string contract, bool forceFullStates)
+    {
+      Contract = contract;
+      ForceFullStates = forceFullStates;
+    }
+
+    public string Contract { get; private set; }
+    public bool ForceFullStates { get; private set; }
+  }
+
+  /// <summary>
+  /// Indicates that marked element should be localized or not
+  /// </summary>
+  /// <example><code>
+  /// [LocalizationRequiredAttribute(true)]
+  /// public class Foo {
+  ///   private string str = "my string"; // Warning: Localizable string
+  /// }
+  /// </code></example>
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = true)]
+  public sealed class LocalizationRequiredAttribute : Attribute
+  {
+    public LocalizationRequiredAttribute() : this(true) { }
+    public LocalizationRequiredAttribute(bool required)
+    {
+      Required = required;
+    }
+
+    public bool Required { get; private set; }
+  }
+
+  /// <summary>
+  /// Indicates that the value of the marked type (or its derivatives)
+  /// cannot be compared using '==' or '!=' operators and <c>Equals()</c>
+  /// should be used instead. However, using '==' or '!=' for comparison
+  /// with <c>null</c> is always permitted.
+  /// </summary>
+  /// <example><code>
+  /// [CannotApplyEqualityOperator]
+  /// class NoEquality { }
+  /// class UsesNoEquality {
+  ///   public void Test() {
+  ///     var ca1 = new NoEquality();
+  ///     var ca2 = new NoEquality();
+  ///     if (ca1 != null) { // OK
+  ///       bool condition = ca1 == ca2; // Warning
+  ///     }
+  ///   }
+  /// }
+  /// </code></example>
+  [AttributeUsage(
+    AttributeTargets.Interface | AttributeTargets.Class |
+    AttributeTargets.Struct, AllowMultiple = false, Inherited = true)]
+  public sealed class CannotApplyEqualityOperatorAttribute : Attribute { }
+
+  /// <summary>
+  /// When applied to a target attribute, specifies a requirement for any type marked
+  /// with the target attribute to implement or inherit specific type or types.
+  /// </summary>
+  /// <example><code>
+  /// [BaseTypeRequired(typeof(IComponent)] // Specify requirement
+  /// public class ComponentAttribute : Attribute { }
+  /// [Component] // ComponentAttribute requires implementing IComponent interface
+  /// public class MyComponent : IComponent { }
+  /// </code></example>
+  [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+  [BaseTypeRequired(typeof(Attribute))]
+  public sealed class BaseTypeRequiredAttribute : Attribute
+  {
+    public BaseTypeRequiredAttribute([NotNull] Type baseType)
+    {
+      BaseType = baseType;
+    }
+
+    [NotNull]
+    public Type BaseType { get; private set; }
+  }
+
+  /// <summary>
+  /// Indicates that the marked symbol is used implicitly
+  /// (e.g. via reflection, in external library), so this symbol
+  /// will not be marked as unused (as well as by other usage inspections)
+  /// </summary>
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = true)]
+  public sealed class UsedImplicitlyAttribute : Attribute
+  {
+    public UsedImplicitlyAttribute()
+      : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default) { }
+
+    public UsedImplicitlyAttribute(ImplicitUseKindFlags useKindFlags)
+      : this(useKindFlags, ImplicitUseTargetFlags.Default) { }
+
+    public UsedImplicitlyAttribute(ImplicitUseTargetFlags targetFlags)
+      : this(ImplicitUseKindFlags.Default, targetFlags) { }
+
+    public UsedImplicitlyAttribute(
+      ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+    {
+      UseKindFlags = useKindFlags;
+      TargetFlags = targetFlags;
+    }
+
+    public ImplicitUseKindFlags UseKindFlags { get; private set; }
+    public ImplicitUseTargetFlags TargetFlags { get; private set; }
+  }
+
+  /// <summary>
+  /// Should be used on attributes and causes ReSharper
+  /// to not mark symbols marked with such attributes as unused
+  /// (as well as by other usage inspections)
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+  public sealed class MeansImplicitUseAttribute : Attribute
+  {
+    public MeansImplicitUseAttribute()
+      : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default) { }
+
+    public MeansImplicitUseAttribute(ImplicitUseKindFlags useKindFlags)
+      : this(useKindFlags, ImplicitUseTargetFlags.Default) { }
+
+    public MeansImplicitUseAttribute(ImplicitUseTargetFlags targetFlags)
+      : this(ImplicitUseKindFlags.Default, targetFlags) { }
+
+    public MeansImplicitUseAttribute(
+      ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+    {
+      UseKindFlags = useKindFlags;
+      TargetFlags = targetFlags;
+    }
+
+    [UsedImplicitly]
+    public ImplicitUseKindFlags UseKindFlags { get; private set; }
+    [UsedImplicitly]
+    public ImplicitUseTargetFlags TargetFlags { get; private set; }
+  }
+
+  [Flags]
+  public enum ImplicitUseKindFlags
+  {
+    Default = Access | Assign | InstantiatedWithFixedConstructorSignature,
+    /// <summary>Only entity marked with attribute considered used</summary>
+    Access = 1,
+    /// <summary>Indicates implicit assignment to a member</summary>
+    Assign = 2,
+    /// <summary>
+    /// Indicates implicit instantiation of a type with fixed constructor signature.
+    /// That means any unused constructor parameters won't be reported as such.
+    /// </summary>
+    InstantiatedWithFixedConstructorSignature = 4,
+    /// <summary>Indicates implicit instantiation of a type</summary>
+    InstantiatedNoFixedConstructorSignature = 8,
+  }
+
+  /// <summary>
+  /// Specify what is considered used implicitly
+  /// when marked with <see cref="MeansImplicitUseAttribute"/>
+  /// or <see cref="UsedImplicitlyAttribute"/>
+  /// </summary>
+  [Flags]
+  public enum ImplicitUseTargetFlags
+  {
+    Default = Itself,
+    Itself = 1,
+    /// <summary>Members of entity marked with attribute are considered used</summary>
+    Members = 2,
+    /// <summary>Entity marked with attribute and all its members considered used</summary>
+    WithMembers = Itself | Members
+  }
+
+  /// <summary>
+  /// This attribute is intended to mark publicly available API
+  /// which should not be removed and so is treated as used
+  /// </summary>
+  [MeansImplicitUse]
+  public sealed class PublicAPIAttribute : Attribute
+  {
+    public PublicAPIAttribute() { }
+    public PublicAPIAttribute([NotNull] string comment)
+    {
+      Comment = comment;
+    }
+
+    [NotNull]
+    public string Comment { get; private set; }
+  }
+
+  /// <summary>
+  /// Tells code analysis engine if the parameter is completely handled
+  /// when the invoked method is on stack. If the parameter is a delegate,
+  /// indicates that delegate is executed while the method is executed.
+  /// If the parameter is an enumerable, indicates that it is enumerated
+  /// while the method is executed
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter, Inherited = true)]
+  public sealed class InstantHandleAttribute : Attribute { }
+
+  /// <summary>
+  /// Indicates that a method does not make any observable state changes.
+  /// The same as <c>System.Diagnostics.Contracts.PureAttribute</c>
+  /// </summary>
+  /// <example><code>
+  /// [Pure] private int Multiply(int x, int y) { return x * y; }
+  /// public void Foo() {
+  ///   const int a = 2, b = 2;
+  ///   Multiply(a, b); // Waring: Return value of pure method is not used
+  /// }
+  /// </code></example>
+  [AttributeUsage(AttributeTargets.Method, Inherited = true)]
+  public sealed class PureAttribute : Attribute { }
+
+  /// <summary>
+  /// Indicates that a parameter is a path to a file or a folder
+  /// within a web project. Path can be relative or absolute,
+  /// starting from web root (~)
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public class PathReferenceAttribute : Attribute
+  {
+    public PathReferenceAttribute() { }
+    public PathReferenceAttribute([PathReference] string basePath)
+    {
+      BasePath = basePath;
+    }
+
+    [NotNull]
+    public string BasePath { get; private set; }
+  }
+
+  // ASP.NET MVC attributes
+
+  /// <summary>
+  /// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter
+  /// is an MVC action. If applied to a method, the MVC action name is calculated
+  /// implicitly from the context. Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Html.ChildActionExtensions.RenderAction(HtmlHelper, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+  public sealed class AspMvcActionAttribute : Attribute
+  {
+    public AspMvcActionAttribute() { }
+    public AspMvcActionAttribute([NotNull] string anonymousProperty)
+    {
+      AnonymousProperty = anonymousProperty;
+    }
+
+    [NotNull]
+    public string AnonymousProperty { get; private set; }
+  }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Indicates that a parameter is an MVC area.
+  /// Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Html.ChildActionExtensions.RenderAction(HtmlHelper, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public sealed class AspMvcAreaAttribute : PathReferenceAttribute
+  {
+    public AspMvcAreaAttribute() { }
+    public AspMvcAreaAttribute([NotNull] string anonymousProperty)
+    {
+      AnonymousProperty = anonymousProperty;
+    }
+
+    [NotNull]
+    public string AnonymousProperty { get; private set; }
+  }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. If applied to a parameter, indicates that
+  /// the parameter is an MVC controller. If applied to a method,
+  /// the MVC controller name is calculated implicitly from the context.
+  /// Use this attribute for custom wrappers similar to 
+  /// <c>System.Web.Mvc.Html.ChildActionExtensions.RenderAction(HtmlHelper, String, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+  public sealed class AspMvcControllerAttribute : Attribute
+  {
+    public AspMvcControllerAttribute() { }
+    public AspMvcControllerAttribute([NotNull] string anonymousProperty)
+    {
+      AnonymousProperty = anonymousProperty;
+    }
+
+    [NotNull]
+    public string AnonymousProperty { get; private set; }
+  }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Indicates that a parameter is an MVC Master.
+  /// Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Controller.View(String, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public sealed class AspMvcMasterAttribute : Attribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Indicates that a parameter is an MVC model type.
+  /// Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Controller.View(String, Object)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public sealed class AspMvcModelTypeAttribute : Attribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. If applied to a parameter, indicates that
+  /// the parameter is an MVC partial view. If applied to a method,
+  /// the MVC partial view name is calculated implicitly from the context.
+  /// Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Html.RenderPartialExtensions.RenderPartial(HtmlHelper, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+  public sealed class AspMvcPartialViewAttribute : PathReferenceAttribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Allows disabling all inspections
+  /// for MVC views within a class or a method.
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+  public sealed class AspMvcSupressViewErrorAttribute : Attribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Indicates that a parameter is an MVC display template.
+  /// Use this attribute for custom wrappers similar to 
+  /// <c>System.Web.Mvc.Html.DisplayExtensions.DisplayForModel(HtmlHelper, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public sealed class AspMvcDisplayTemplateAttribute : Attribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Indicates that a parameter is an MVC editor template.
+  /// Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Html.EditorExtensions.EditorForModel(HtmlHelper, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public sealed class AspMvcEditorTemplateAttribute : Attribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Indicates that a parameter is an MVC template.
+  /// Use this attribute for custom wrappers similar to
+  /// <c>System.ComponentModel.DataAnnotations.UIHintAttribute(System.String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public sealed class AspMvcTemplateAttribute : Attribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter
+  /// is an MVC view. If applied to a method, the MVC view name is calculated implicitly
+  /// from the context. Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Controller.View(Object)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+  public sealed class AspMvcViewAttribute : PathReferenceAttribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. When applied to a parameter of an attribute,
+  /// indicates that this parameter is an MVC action name
+  /// </summary>
+  /// <example><code>
+  /// [ActionName("Foo")]
+  /// public ActionResult Login(string returnUrl) {
+  ///   ViewBag.ReturnUrl = Url.Action("Foo"); // OK
+  ///   return RedirectToAction("Bar"); // Error: Cannot resolve action
+  /// }
+  /// </code></example>
+  [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
+  public sealed class AspMvcActionSelectorAttribute : Attribute { }
+
+  [AttributeUsage(
+    AttributeTargets.Parameter | AttributeTargets.Property |
+    AttributeTargets.Field, Inherited = true)]
+  public sealed class HtmlElementAttributesAttribute : Attribute
+  {
+    public HtmlElementAttributesAttribute() { }
+    public HtmlElementAttributesAttribute([NotNull] string name)
+    {
+      Name = name;
+    }
+
+    [NotNull]
+    public string Name { get; private set; }
+  }
+
+  [AttributeUsage(
+    AttributeTargets.Parameter | AttributeTargets.Field |
+    AttributeTargets.Property, Inherited = true)]
+  public sealed class HtmlAttributeValueAttribute : Attribute
+  {
+    public HtmlAttributeValueAttribute([NotNull] string name)
+    {
+      Name = name;
+    }
+
+    [NotNull]
+    public string Name { get; private set; }
+  }
+
+  // Razor attributes
+
+  /// <summary>
+  /// Razor attribute. Indicates that a parameter or a method is a Razor section.
+  /// Use this attribute for custom wrappers similar to 
+  /// <c>System.Web.WebPages.WebPageBase.RenderSection(String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method, Inherited = true)]
+  public sealed class RazorSectionAttribute : Attribute { }
+}

--- a/src/NLog/Logger-V1Compat.cs
+++ b/src/NLog/Logger-V1Compat.cs
@@ -37,6 +37,7 @@ namespace NLog
 {
     using System;
     using System.ComponentModel;
+    using JetBrains.Annotations;
 
     /// <content>
     /// Auto-generated Logger members for binary compatibility with NLog 1.0.
@@ -83,6 +84,7 @@ namespace NLog
         /// <param name="arg1">First argument to format.</param>
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, string message, object arg1, object arg2)
         {
             if (this.IsEnabled(level))
@@ -100,6 +102,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, string message, object arg1, object arg2, object arg3)
         {
             if (this.IsEnabled(level))
@@ -116,6 +119,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, bool argument)
         {
             if (this.IsEnabled(level))
@@ -147,6 +151,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, char argument)
         {
             if (this.IsEnabled(level))
@@ -178,6 +183,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, byte argument)
         {
             if (this.IsEnabled(level))
@@ -209,6 +215,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, string argument)
         {
             if (this.IsEnabled(level))
@@ -240,6 +247,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, int argument)
         {
             if (this.IsEnabled(level))
@@ -271,6 +279,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, long argument)
         {
             if (this.IsEnabled(level))
@@ -302,6 +311,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, float argument)
         {
             if (this.IsEnabled(level))
@@ -333,6 +343,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, double argument)
         {
             if (this.IsEnabled(level))
@@ -364,6 +375,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, decimal argument)
         {
             if (this.IsEnabled(level))
@@ -395,6 +407,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, object argument)
         {
             if (this.IsEnabled(level))
@@ -427,6 +440,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, sbyte argument)
         { 
             if (this.IsEnabled(level))
@@ -443,6 +457,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, string message, sbyte argument)
         { 
             if (this.IsEnabled(level))
@@ -460,6 +475,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, uint argument)
         { 
             if (this.IsEnabled(level))
@@ -476,6 +492,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, string message, uint argument)
         { 
             if (this.IsEnabled(level))
@@ -493,6 +510,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, ulong argument)
         { 
             if (this.IsEnabled(level))
@@ -509,6 +527,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, string message, ulong argument)
         { 
             if (this.IsEnabled(level))
@@ -555,6 +574,7 @@ namespace NLog
         /// <param name="arg1">First argument to format.</param>
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(string message, object arg1, object arg2)
         {
             if (this.IsTraceEnabled)
@@ -571,6 +591,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(string message, object arg1, object arg2, object arg3)
         {
             if (this.IsTraceEnabled)
@@ -586,6 +607,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, bool argument)
         {
             if (this.IsTraceEnabled)
@@ -615,6 +637,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, char argument)
         {
             if (this.IsTraceEnabled)
@@ -644,6 +667,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, byte argument)
         {
             if (this.IsTraceEnabled)
@@ -673,6 +697,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, string argument)
         {
             if (this.IsTraceEnabled)
@@ -702,6 +727,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, int argument)
         {
             if (this.IsTraceEnabled)
@@ -731,6 +757,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, long argument)
         {
             if (this.IsTraceEnabled)
@@ -760,6 +787,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, float argument)
         {
             if (this.IsTraceEnabled)
@@ -789,6 +817,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, double argument)
         {
             if (this.IsTraceEnabled)
@@ -818,6 +847,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, decimal argument)
         {
             if (this.IsTraceEnabled)
@@ -847,6 +877,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, object argument)
         {
             if (this.IsTraceEnabled)
@@ -877,6 +908,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, sbyte argument)
         { 
             if (this.IsTraceEnabled)
@@ -892,6 +924,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(string message, sbyte argument)
         { 
             if (this.IsTraceEnabled)
@@ -908,6 +941,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, uint argument)
         { 
             if (this.IsTraceEnabled)
@@ -923,6 +957,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(string message, uint argument)
         { 
             if (this.IsTraceEnabled)
@@ -939,6 +974,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, string message, ulong argument)
         { 
             if (this.IsTraceEnabled)
@@ -954,6 +990,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Trace(string message, ulong argument)
         { 
             if (this.IsTraceEnabled)
@@ -1000,6 +1037,7 @@ namespace NLog
         /// <param name="arg1">First argument to format.</param>
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(string message, object arg1, object arg2)
         {
             if (this.IsDebugEnabled)
@@ -1016,6 +1054,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(string message, object arg1, object arg2, object arg3)
         {
             if (this.IsDebugEnabled)
@@ -1031,6 +1070,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, bool argument)
         {
             if (this.IsDebugEnabled)
@@ -1060,6 +1100,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, char argument)
         {
             if (this.IsDebugEnabled)
@@ -1089,6 +1130,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, byte argument)
         {
             if (this.IsDebugEnabled)
@@ -1118,6 +1160,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, string argument)
         {
             if (this.IsDebugEnabled)
@@ -1147,6 +1190,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, int argument)
         {
             if (this.IsDebugEnabled)
@@ -1176,6 +1220,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, long argument)
         {
             if (this.IsDebugEnabled)
@@ -1205,6 +1250,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, float argument)
         {
             if (this.IsDebugEnabled)
@@ -1234,6 +1280,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, double argument)
         {
             if (this.IsDebugEnabled)
@@ -1263,6 +1310,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, decimal argument)
         {
             if (this.IsDebugEnabled)
@@ -1292,6 +1340,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, object argument)
         {
             if (this.IsDebugEnabled)
@@ -1322,6 +1371,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, sbyte argument)
         { 
             if (this.IsDebugEnabled)
@@ -1337,6 +1387,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(string message, sbyte argument)
         { 
             if (this.IsDebugEnabled)
@@ -1353,6 +1404,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, uint argument)
         { 
             if (this.IsDebugEnabled)
@@ -1368,6 +1420,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(string message, uint argument)
         { 
             if (this.IsDebugEnabled)
@@ -1384,6 +1437,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, string message, ulong argument)
         { 
             if (this.IsDebugEnabled)
@@ -1399,6 +1453,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Debug(string message, ulong argument)
         { 
             if (this.IsDebugEnabled)
@@ -1445,6 +1500,7 @@ namespace NLog
         /// <param name="arg1">First argument to format.</param>
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(string message, object arg1, object arg2)
         {
             if (this.IsInfoEnabled)
@@ -1461,6 +1517,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(string message, object arg1, object arg2, object arg3)
         {
             if (this.IsInfoEnabled)
@@ -1476,6 +1533,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, bool argument)
         {
             if (this.IsInfoEnabled)
@@ -1505,6 +1563,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, char argument)
         {
             if (this.IsInfoEnabled)
@@ -1534,6 +1593,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, byte argument)
         {
             if (this.IsInfoEnabled)
@@ -1563,6 +1623,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, string argument)
         {
             if (this.IsInfoEnabled)
@@ -1592,6 +1653,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, int argument)
         {
             if (this.IsInfoEnabled)
@@ -1621,6 +1683,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, long argument)
         {
             if (this.IsInfoEnabled)
@@ -1650,6 +1713,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, float argument)
         {
             if (this.IsInfoEnabled)
@@ -1679,6 +1743,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, double argument)
         {
             if (this.IsInfoEnabled)
@@ -1708,6 +1773,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, decimal argument)
         {
             if (this.IsInfoEnabled)
@@ -1737,6 +1803,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, object argument)
         {
             if (this.IsInfoEnabled)
@@ -1767,6 +1834,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, sbyte argument)
         { 
             if (this.IsInfoEnabled)
@@ -1782,6 +1850,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(string message, sbyte argument)
         { 
             if (this.IsInfoEnabled)
@@ -1798,6 +1867,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, uint argument)
         { 
             if (this.IsInfoEnabled)
@@ -1813,6 +1883,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(string message, uint argument)
         { 
             if (this.IsInfoEnabled)
@@ -1829,6 +1900,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, string message, ulong argument)
         { 
             if (this.IsInfoEnabled)
@@ -1844,6 +1916,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Info(string message, ulong argument)
         { 
             if (this.IsInfoEnabled)
@@ -1890,6 +1963,7 @@ namespace NLog
         /// <param name="arg1">First argument to format.</param>
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(string message, object arg1, object arg2)
         {
             if (this.IsWarnEnabled)
@@ -1906,6 +1980,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(string message, object arg1, object arg2, object arg3)
         {
             if (this.IsWarnEnabled)
@@ -1921,6 +1996,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, bool argument)
         {
             if (this.IsWarnEnabled)
@@ -1950,6 +2026,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, char argument)
         {
             if (this.IsWarnEnabled)
@@ -1979,6 +2056,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, byte argument)
         {
             if (this.IsWarnEnabled)
@@ -2008,6 +2086,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, string argument)
         {
             if (this.IsWarnEnabled)
@@ -2037,6 +2116,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, int argument)
         {
             if (this.IsWarnEnabled)
@@ -2066,6 +2146,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, long argument)
         {
             if (this.IsWarnEnabled)
@@ -2095,6 +2176,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, float argument)
         {
             if (this.IsWarnEnabled)
@@ -2124,6 +2206,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, double argument)
         {
             if (this.IsWarnEnabled)
@@ -2153,6 +2236,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, decimal argument)
         {
             if (this.IsWarnEnabled)
@@ -2182,6 +2266,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, object argument)
         {
             if (this.IsWarnEnabled)
@@ -2212,6 +2297,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, sbyte argument)
         { 
             if (this.IsWarnEnabled)
@@ -2227,6 +2313,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(string message, sbyte argument)
         { 
             if (this.IsWarnEnabled)
@@ -2243,6 +2330,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, uint argument)
         { 
             if (this.IsWarnEnabled)
@@ -2258,6 +2346,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(string message, uint argument)
         { 
             if (this.IsWarnEnabled)
@@ -2274,6 +2363,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, string message, ulong argument)
         { 
             if (this.IsWarnEnabled)
@@ -2289,6 +2379,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Warn(string message, ulong argument)
         { 
             if (this.IsWarnEnabled)
@@ -2335,6 +2426,7 @@ namespace NLog
         /// <param name="arg1">First argument to format.</param>
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(string message, object arg1, object arg2)
         {
             if (this.IsErrorEnabled)
@@ -2351,6 +2443,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(string message, object arg1, object arg2, object arg3)
         {
             if (this.IsErrorEnabled)
@@ -2366,6 +2459,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, bool argument)
         {
             if (this.IsErrorEnabled)
@@ -2395,6 +2489,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, char argument)
         {
             if (this.IsErrorEnabled)
@@ -2424,6 +2519,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, byte argument)
         {
             if (this.IsErrorEnabled)
@@ -2453,6 +2549,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, string argument)
         {
             if (this.IsErrorEnabled)
@@ -2482,6 +2579,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, int argument)
         {
             if (this.IsErrorEnabled)
@@ -2511,6 +2609,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, long argument)
         {
             if (this.IsErrorEnabled)
@@ -2540,6 +2639,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, float argument)
         {
             if (this.IsErrorEnabled)
@@ -2569,6 +2669,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, double argument)
         {
             if (this.IsErrorEnabled)
@@ -2598,6 +2699,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, decimal argument)
         {
             if (this.IsErrorEnabled)
@@ -2627,6 +2729,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, object argument)
         {
             if (this.IsErrorEnabled)
@@ -2657,6 +2760,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, sbyte argument)
         { 
             if (this.IsErrorEnabled)
@@ -2672,6 +2776,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(string message, sbyte argument)
         { 
             if (this.IsErrorEnabled)
@@ -2688,6 +2793,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, uint argument)
         { 
             if (this.IsErrorEnabled)
@@ -2703,6 +2809,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(string message, uint argument)
         { 
             if (this.IsErrorEnabled)
@@ -2719,6 +2826,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, string message, ulong argument)
         { 
             if (this.IsErrorEnabled)
@@ -2734,6 +2842,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Error(string message, ulong argument)
         { 
             if (this.IsErrorEnabled)
@@ -2780,6 +2889,7 @@ namespace NLog
         /// <param name="arg1">First argument to format.</param>
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(string message, object arg1, object arg2)
         {
             if (this.IsFatalEnabled)
@@ -2796,6 +2906,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(string message, object arg1, object arg2, object arg3)
         {
             if (this.IsFatalEnabled)
@@ -2811,6 +2922,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, bool argument)
         {
             if (this.IsFatalEnabled)
@@ -2840,6 +2952,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, char argument)
         {
             if (this.IsFatalEnabled)
@@ -2869,6 +2982,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, byte argument)
         {
             if (this.IsFatalEnabled)
@@ -2898,6 +3012,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, string argument)
         {
             if (this.IsFatalEnabled)
@@ -2927,6 +3042,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, int argument)
         {
             if (this.IsFatalEnabled)
@@ -2956,6 +3072,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, long argument)
         {
             if (this.IsFatalEnabled)
@@ -2985,6 +3102,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, float argument)
         {
             if (this.IsFatalEnabled)
@@ -3014,6 +3132,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, double argument)
         {
             if (this.IsFatalEnabled)
@@ -3043,6 +3162,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, decimal argument)
         {
             if (this.IsFatalEnabled)
@@ -3072,6 +3192,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, object argument)
         {
             if (this.IsFatalEnabled)
@@ -3102,6 +3223,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, sbyte argument)
         { 
             if (this.IsFatalEnabled)
@@ -3117,6 +3239,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(string message, sbyte argument)
         { 
             if (this.IsFatalEnabled)
@@ -3133,6 +3256,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, uint argument)
         { 
             if (this.IsFatalEnabled)
@@ -3148,6 +3272,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(string message, uint argument)
         { 
             if (this.IsFatalEnabled)
@@ -3164,6 +3289,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, string message, ulong argument)
         { 
             if (this.IsFatalEnabled)
@@ -3179,6 +3305,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [StringFormatMethod("message")]
         public void Fatal(string message, ulong argument)
         { 
             if (this.IsFatalEnabled)

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -36,6 +36,7 @@ namespace NLog
     using System;
     using System.ComponentModel;
     using NLog.Internal;
+    using JetBrains.Annotations;
 
     /// <summary>
     /// Provides logging interface and utility functions.
@@ -238,6 +239,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing format items.</param>
         /// <param name="args">Arguments to format.</param>
+        [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
         { 
             if (this.IsEnabled(level))
@@ -281,6 +283,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Log<TArgument>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsEnabled(level))
@@ -296,6 +299,7 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Log<TArgument>(LogLevel level, [Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsEnabled(level))
@@ -331,6 +335,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
+        [StringFormatMethod("message")]
         public void Log<TArgument1, TArgument2>(LogLevel level, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
         { 
             if (this.IsEnabled(level))
@@ -370,6 +375,7 @@ namespace NLog
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
+        [StringFormatMethod("message")]
         public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         { 
             if (this.IsEnabled(level))
@@ -448,6 +454,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing format items.</param>
         /// <param name="args">Arguments to format.</param>
+        [StringFormatMethod("message")]
         public void Trace(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
         { 
             if (this.IsTraceEnabled)
@@ -488,6 +495,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Trace<TArgument>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsTraceEnabled)
@@ -502,6 +510,7 @@ namespace NLog
         /// <typeparam name="TArgument">The type of the argument.</typeparam>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Trace<TArgument>([Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsTraceEnabled)
@@ -535,6 +544,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
+        [StringFormatMethod("message")]
         public void Trace<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
         { 
             if (this.IsTraceEnabled)
@@ -572,6 +582,7 @@ namespace NLog
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
+        [StringFormatMethod("message")]
         public void Trace<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         { 
             if (this.IsTraceEnabled)
@@ -650,6 +661,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing format items.</param>
         /// <param name="args">Arguments to format.</param>
+        [StringFormatMethod("message")]
         public void Debug(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
         { 
             if (this.IsDebugEnabled)
@@ -690,6 +702,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Debug<TArgument>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsDebugEnabled)
@@ -704,6 +717,7 @@ namespace NLog
         /// <typeparam name="TArgument">The type of the argument.</typeparam>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Debug<TArgument>([Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsDebugEnabled)
@@ -737,6 +751,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
+        [StringFormatMethod("message")]
         public void Debug<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
         { 
             if (this.IsDebugEnabled)
@@ -774,6 +789,7 @@ namespace NLog
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
+        [StringFormatMethod("message")]
         public void Debug<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         { 
             if (this.IsDebugEnabled)
@@ -852,6 +868,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing format items.</param>
         /// <param name="args">Arguments to format.</param>
+        [StringFormatMethod("message")]
         public void Info(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
         { 
             if (this.IsInfoEnabled)
@@ -892,6 +909,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Info<TArgument>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsInfoEnabled)
@@ -906,6 +924,7 @@ namespace NLog
         /// <typeparam name="TArgument">The type of the argument.</typeparam>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Info<TArgument>([Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsInfoEnabled)
@@ -939,6 +958,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
+        [StringFormatMethod("message")]
         public void Info<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
         { 
             if (this.IsInfoEnabled)
@@ -976,6 +996,7 @@ namespace NLog
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
+        [StringFormatMethod("message")]
         public void Info<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         { 
             if (this.IsInfoEnabled)
@@ -1054,6 +1075,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing format items.</param>
         /// <param name="args">Arguments to format.</param>
+        [StringFormatMethod("message")]
         public void Warn(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
         { 
             if (this.IsWarnEnabled)
@@ -1094,6 +1116,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Warn<TArgument>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsWarnEnabled)
@@ -1108,6 +1131,7 @@ namespace NLog
         /// <typeparam name="TArgument">The type of the argument.</typeparam>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Warn<TArgument>([Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsWarnEnabled)
@@ -1141,6 +1165,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
+        [StringFormatMethod("message")]
         public void Warn<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
         { 
             if (this.IsWarnEnabled)
@@ -1178,6 +1203,7 @@ namespace NLog
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
+        [StringFormatMethod("message")]
         public void Warn<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         { 
             if (this.IsWarnEnabled)
@@ -1256,6 +1282,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing format items.</param>
         /// <param name="args">Arguments to format.</param>
+        [StringFormatMethod("message")]
         public void Error(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
         { 
             if (this.IsErrorEnabled)
@@ -1296,6 +1323,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Error<TArgument>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsErrorEnabled)
@@ -1310,6 +1338,7 @@ namespace NLog
         /// <typeparam name="TArgument">The type of the argument.</typeparam>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Error<TArgument>([Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsErrorEnabled)
@@ -1343,6 +1372,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
+        [StringFormatMethod("message")]
         public void Error<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
         { 
             if (this.IsErrorEnabled)
@@ -1380,6 +1410,7 @@ namespace NLog
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
+        [StringFormatMethod("message")]
         public void Error<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         { 
             if (this.IsErrorEnabled)
@@ -1458,6 +1489,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing format items.</param>
         /// <param name="args">Arguments to format.</param>
+        [StringFormatMethod("message")]
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
         { 
             if (this.IsFatalEnabled)
@@ -1498,6 +1530,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Fatal<TArgument>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsFatalEnabled)
@@ -1512,6 +1545,7 @@ namespace NLog
         /// <typeparam name="TArgument">The type of the argument.</typeparam>
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
+        [StringFormatMethod("message")]
         public void Fatal<TArgument>([Localizable(false)] string message, TArgument argument)
         { 
             if (this.IsFatalEnabled)
@@ -1545,6 +1579,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
+        [StringFormatMethod("message")]
         public void Fatal<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
         { 
             if (this.IsFatalEnabled)
@@ -1582,6 +1617,7 @@ namespace NLog
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
+        [StringFormatMethod("message")]
         public void Fatal<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         { 
             if (this.IsFatalEnabled)

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -132,6 +132,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.mono2.csproj
+++ b/src/NLog/NLog.mono2.csproj
@@ -131,6 +131,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.monodevelop.csproj
+++ b/src/NLog/NLog.monodevelop.csproj
@@ -133,6 +133,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.netcf20.csproj
+++ b/src/NLog/NLog.netcf20.csproj
@@ -135,6 +135,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.netcf35.csproj
+++ b/src/NLog/NLog.netcf35.csproj
@@ -136,6 +136,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.netfx20.csproj
+++ b/src/NLog/NLog.netfx20.csproj
@@ -127,6 +127,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -127,6 +127,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -135,6 +135,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -138,6 +138,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.sl2.csproj
+++ b/src/NLog/NLog.sl2.csproj
@@ -129,6 +129,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.sl3.csproj
+++ b/src/NLog/NLog.sl3.csproj
@@ -129,6 +129,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -130,6 +130,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -131,6 +131,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -132,6 +132,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -132,6 +132,7 @@
     <Compile Include="GDC.cs" />
     <Compile Include="GlobalDiagnosticsContext.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Annotations.cs" />
     <Compile Include="Internal\AspHelper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>


### PR DESCRIPTION
- Intergrate JetBrains code-annotations to help ReSharper users
  enjoy better development experience:
- Add [StringFormatMethod()] attribute for all public facing
  (Log|Trace|Debug|Warn|Error|Fatal) methods that use a format string
