### PR TITLE
Dispose of dequeued SocketAsyncEventArgs

### DIFF
--- a/src/NLog/Internal/NetworkSenders/TcpNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/TcpNetworkSender.cs
@@ -158,7 +158,12 @@ namespace NLog.Internal.NetworkSenders
             {
                 if (this.MaxQueueSize != 0 && this.pendingRequests.Count >= this.MaxQueueSize)
                 {
-                    this.pendingRequests.Dequeue();
+                    var dequeued = this.pendingRequests.Dequeue();
+
+                    if (dequeued != null)
+                    {
+                        dequeued.Dispose();
+                    }
                 }
 
                 this.pendingRequests.Enqueue(args);


### PR DESCRIPTION
Repro case: https://gist.github.com/gcschorer/9054202

fixes #314
