### PR TITLE
Logger.Swallow and Logger.SwallowAsync methods

### DIFF
--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -36,6 +36,9 @@ namespace NLog
     using System;
     using System.ComponentModel;
     using NLog.Internal;
+#if ASYNC_SUPPORTED
+    using System.Threading.Tasks;
+#endif
 
     /// <summary>
     /// Provides logging interface and utility functions.
@@ -1593,6 +1596,83 @@ namespace NLog
         #endregion
 
         // end of generated code
+
+        /// <summary>
+        /// Runs action. If the action throws, the exception is logged at <c>Error</c> level. Exception is not propagated outside of this method.
+        /// </summary>
+        /// <param name="action">Action to execute.</param>
+        public void Swallow(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception e)
+            {
+                Error(e);
+            }
+        }
+
+        /// <summary>
+        /// Runs the provided function and returns its result. If exception is thrown, it is logged at <c>Error</c> level.
+        /// Exception is not propagated outside of this method. Fallback value is returned instead.
+        /// </summary>
+        /// <typeparam name="T">Return type of the provided function.</typeparam>
+        /// <param name="func">Function to run.</param>
+        /// <param name="fallback">Fallback value to return in case of exception. Defaults to default value of type T.</param>
+        /// <returns>Result returned by the provided function or fallback value in case of exception.</returns>
+        public T Swallow<T>(Func<T> func, T fallback = default(T))
+        {
+            try
+            {
+                return func();
+            }
+            catch (Exception e)
+            {
+                Error(e);
+                return fallback;
+            }
+        }
+
+#if ASYNC_SUPPORTED
+        /// <summary>
+        /// Runs async action. If the action throws, the exception is logged at <c>Error</c> level. Exception is not propagated outside of this method.
+        /// </summary>
+        /// <param name="asyncAction">Async action to execute.</param>
+        public async Task SwallowAsync(Func<Task> asyncAction)
+        {
+            try
+            {
+                await asyncAction();
+            }
+            catch (Exception e)
+            {
+                Error(e);
+            }
+        }
+
+        /// <summary>
+        /// Runs the provided async function and returns its result. If exception is thrown, it is logged at <c>Error</c> level.
+        /// Exception is not propagated outside of this method. Fallback value is returned instead.
+        /// </summary>
+        /// <typeparam name="T">Return type of the provided function.</typeparam>
+        /// <param name="asyncFunc">Async function to run.</param>
+        /// <param name="fallback">Fallback value to return in case of exception. Defaults to default value of type T.</param>
+        /// <returns>Result returned by the provided function or fallback value in case of exception.</returns>
+        public async Task<T> SwallowAsync<T>(Func<Task<T>> asyncFunc, T fallback = default(T))
+        {
+            try
+            {
+                return await asyncFunc();
+            }
+            catch (Exception e)
+            {
+                Error(e);
+                return fallback;
+            }
+        }
+#endif
+
         internal void Initialize(string name, LoggerConfiguration loggerConfiguration, LogFactory factory)
         {
             this.Name = name;

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -28,7 +28,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;NET4_5;CLIENT_SKU;WCF_SUPPORTED</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>..\..\build\bin\Debug\.NET Framework 4.5\</OutputPath>
@@ -48,7 +48,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworkName>.NET Framework 4.5</TargetFrameworkName>
-    <DefineConstants>NET4_5;CLIENT_SKU;WCF_SUPPORTED;$(DefineConstants)</DefineConstants>
+    <DefineConstants>NET4_5;CLIENT_SKU;WCF_SUPPORTED;ASYNC_SUPPORTED;$(DefineConstants)</DefineConstants>
     <OutputPath>$(BaseOutputDirectory)bin\$(Configuration)\$(TargetFrameworkName)</OutputPath>
     <IntermediateOutputPath>$(BaseOutputDirectory)obj\$(Configuration)\$(TargetFrameworkName)</IntermediateOutputPath>
     <DocumentationFile>$(OutputPath)\NLog.xml</DocumentationFile>

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -45,6 +45,9 @@ namespace NLog.UnitTests
 {
     using System.Reflection;
     using NLog.Targets;
+#if ASYNC_SUPPORTED
+    using System.Threading.Tasks;
+#endif
 
     [TestFixture]
     public class LoggerTests : NLogTestBase
@@ -1032,6 +1035,58 @@ namespace NLog.UnitTests
                         AssertDebugCounter("debug", 0);
                 }
             }
+        }
+
+        [Test]
+        public void SwallowTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog>
+                    <targets><target name='debug' type='Debug' layout='${message}' /></targets>
+                    <rules>
+                        <logger name='*' levels='Error' writeTo='debug' />
+                    </rules>
+                </nlog>");
+            Logger logger = LogManager.GetLogger("A");
+            bool warningFix = true;
+            
+            bool executed = false;
+            logger.Swallow(() => executed = true);
+            Assert.IsTrue(executed);
+
+            Assert.AreEqual(1, logger.Swallow(() => 1));
+            Assert.AreEqual(1, logger.Swallow(() => 1, 2));
+
+#if ASYNC_SUPPORTED
+            executed = false;
+            logger.SwallowAsync(async () => { await Task.Delay(20); executed = true; }).Wait();
+            Assert.IsTrue(executed);
+
+            Assert.AreEqual(1, logger.SwallowAsync(async () => { await Task.Delay(20); return 1; }).Result);
+            Assert.AreEqual(1, logger.SwallowAsync(async () => { await Task.Delay(20); return 1; }, 2).Result);
+#endif
+
+            AssertDebugCounter("debug", 0);
+
+            logger.Swallow(() => { throw new ApplicationException("Test message 1"); });
+            AssertDebugLastMessageContains("debug", "Test message 1");
+
+            Assert.AreEqual(0, logger.Swallow(() => { if (warningFix) throw new ApplicationException("Test message 2"); return 1; }));
+            AssertDebugLastMessageContains("debug", "Test message 2");
+            
+            Assert.AreEqual(2, logger.Swallow(() => { if (warningFix) throw new ApplicationException("Test message 3"); return 1; }, 2));
+            AssertDebugLastMessageContains("debug", "Test message 3");
+
+#if ASYNC_SUPPORTED
+            logger.SwallowAsync(async () => { await Task.Delay(20); throw new ApplicationException("Test message 4"); }).Wait();
+            AssertDebugLastMessageContains("debug", "Test message 4");
+
+            Assert.AreEqual(0, logger.SwallowAsync(async () => { await Task.Delay(20); if (warningFix) throw new ApplicationException("Test message 5"); return 1; }).Result);
+            AssertDebugLastMessageContains("debug", "Test message 5");
+
+            Assert.AreEqual(2, logger.SwallowAsync(async () => { await Task.Delay(20); if (warningFix) throw new ApplicationException("Test message 6"); return 1; }, 2).Result);
+            AssertDebugLastMessageContains("debug", "Test message 6");
+#endif
         }
 
         [Test]

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <BaseAddress>285212672</BaseAddress>
-    <DefineConstants>TRACE;DEBUG;NET4_5;WCF_SUPPORTED</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugSymbols>true</DebugSymbols>
     <FileAlignment>4096</FileAlignment>
     <Optimize>false</Optimize>
@@ -55,7 +55,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworkName>.NET Framework 4.5</TargetFrameworkName>
-    <DefineConstants>NET4_5;WCF_SUPPORTED;$(DefineConstants)</DefineConstants>
+    <DefineConstants>NET4_5;WCF_SUPPORTED;ASYNC_SUPPORTED;$(DefineConstants)</DefineConstants>
     <OutputPath>$(BaseOutputDirectory)bin\$(Configuration)\$(TargetFrameworkName)</OutputPath>
     <IntermediateOutputPath>$(BaseOutputDirectory)obj\$(Configuration)\$(TargetFrameworkName)</IntermediateOutputPath>
   </PropertyGroup>

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -75,6 +75,16 @@ namespace NLog.UnitTests
             Assert.AreEqual(msg, debugTarget.LastMessage, "Unexpected last message value on '" + targetName + "'");
         }
 
+        public void AssertDebugLastMessageContains(string targetName, string msg)
+        {
+            NLog.Targets.DebugTarget debugTarget = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName(targetName);
+
+            // Console.WriteLine("lastmsg: {0}", debugTarget.LastMessage);
+
+            Assert.IsNotNull(debugTarget, "Debug target '" + targetName + "' not found");
+            Assert.IsTrue(debugTarget.LastMessage.Contains(msg), "Unexpected last message value on '" + targetName + "'");
+        }
+
         public string GetDebugLastMessage(string targetName)
         {
             var debugTarget = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName(targetName);


### PR DESCRIPTION
Instead of repeatedly typing try/catch handlers like this:

``` C#
try
{
    MightFail();
}
catch (Exception e)
{
    Logger.Error(e);
}
```

You can now write a single line:

``` C#
Logger.Swallow(() => MightFail());
```

Several variants are provided:

``` C#
Logger.Swallow(() => MightFail());
result = Logger.Swallow(() => UnreliableFunc(), fallbackResult);
result = Logger.Swallow(() => UnreliableFunc()); // returns default(T) in case of exception
await Logger.SwallowAsync(async () => await MightFailAsync());
result = await Logger.SwallowAsync(async () => await UnreliableFuncAsync(), fallback);
result = await Logger.SwallowAsync(async () => await UnreliableFuncAsync());
```
