### PR TITLE
ExceptionLayoutRenderer extension

### DIFF
--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -211,9 +211,12 @@ namespace NLog.LayoutRenderers
 
         private static void AppendData(StringBuilder sb, Exception ex)
         {
+            string separator = string.Empty;
             foreach (var key in ex.Data.Keys)
             {
-                sb.AppendFormat("{0}: {1};", key, ex.Data[key]);
+                sb.Append(separator);
+                sb.AppendFormat("{0}: {1}", key, ex.Data[key]);
+                separator = ";";
             }
         }
 


### PR DESCRIPTION
Extended the Exception layout renderer, so the exception data can also be rendered for the log entries.

The _data_ property can be added to the exception format setting (can be used for inner exception as well):

```
${exception:format=type,message,data}
```

And the output will be similar to this:

```
System.Exception Some exception message  testkey: testvalue;testkey2: moredata
```
