### PR TITLE
Fixes empty "properties" collection.

### DIFF
--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -435,6 +435,8 @@ namespace NLog.Targets
         {
             try
             {
+                this.MergeEventProperties(logEvent.LogEvent);
+
                 this.Write(logEvent.LogEvent);
                 logEvent.Continuation(null);
             }
@@ -472,6 +474,22 @@ namespace NLog.Targets
         {
             this.allLayouts = new List<Layout>(ObjectGraphScanner.FindReachableObjects<Layout>(this));
             InternalLogger.Trace("{0} has {1} layouts", this, this.allLayouts.Count);
+        }
+
+        private void MergeEventProperties(LogEventInfo logEvent)
+        {
+            foreach (var item in logEvent.Parameters)
+            {
+                if (item.GetType() == typeof(LogEventInfo))
+                {
+
+                    foreach (var propertyItem in ((LogEventInfo)item).Properties)
+                    {
+                        logEvent.Properties.Remove(propertyItem.Key);
+                        logEvent.Properties.Add(propertyItem);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
When using an event-context variable, the properties collection was
empty, even when property items where explicitly given. This function
fixes this.

For more information, see this stackoverflow question (and answer!) on how and why this small patch was created: 

http://stackoverflow.com/questions/23272439/nlog-event-contextitem-xxxx-not-writing-in-logging-database
