### PR TITLE
Fix/callsite incorrect

### DIFF
--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -113,7 +113,6 @@ namespace NLog
                     methodAssembly = mb.DeclaringType.Assembly;
                 }
 
-                //if ((loggerType == null && SkipAssembly(methodAssembly)) || mb.DeclaringType == loggerType)
 				if (SkipAssembly(methodAssembly) || (loggerType != null && mb.DeclaringType == loggerType))
                 {
                     firstUserFrame = i + 1;


### PR DESCRIPTION
I had the problem with callsite on certain x64 systems.. It reported NLog.LoggerImpl.Write instead of the actual callsite.. This fixes the problem for me:

_Before:_
2014-05-01 15:01:39.5402|33|Info|NLog.LoggerImpl.Write|User '' () logged in from xxx.xxx.xxx.xxx

_After:_
2014-05-01 15:03:02.7554|28|Info|Login.LoginUser|User '' () logged in from xxx.xxx.xxx.xxx 
