### PR TITLE
Fix for invalid XML characters in Log4JXmlEventLayoutRenderer

### DIFF
--- a/src/NLog/Internal/XmlHelper.cs
+++ b/src/NLog/Internal/XmlHelper.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using System.Xml;
+
+namespace NLog.Internal
+{
+	/// <summary>
+	///  Helper class for XML
+	/// </summary>
+	public static class XmlHelper
+	{
+		// found on http://stackoverflow.com/questions/397250/unicode-regex-invalid-xml-characters/961504#961504
+		// filters control characters but allows only properly-formed surrogate sequences
+		private static readonly Regex InvalidXmlChars = new Regex(
+			@"(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\uFEFF\uFFFE\uFFFF]",
+			RegexOptions.Compiled);
+
+		/// <summary>
+		/// removes any unusual unicode characters that can't be encoded into XML
+		/// </summary>
+		private static string RemoveInvalidXmlChars(string text)
+		{
+			return String.IsNullOrEmpty(text) ? "" : InvalidXmlChars.Replace(text, "");
+		}
+
+
+		/// <summary>
+		/// Safe version of WriteAttributeString
+		/// </summary>
+		/// <param name="writer"></param>
+		/// <param name="prefix"></param>
+		/// <param name="localName"></param>
+		/// <param name="ns"></param>
+		/// <param name="value"></param>
+		public static void WriteAttributeSafeString(this XmlWriter writer, string prefix, string localName, string ns, string value)
+		{
+			writer.WriteAttributeString(RemoveInvalidXmlChars(prefix), RemoveInvalidXmlChars(localName), RemoveInvalidXmlChars(ns), RemoveInvalidXmlChars(value));
+		}
+
+		/// <summary>
+		/// Safe version of WriteAttributeString
+		/// </summary>
+		/// <param name="writer"></param>
+		/// <param name="thread"></param>
+		/// <param name="localName"></param>
+		public static void WriteAttributeSafeString(this XmlWriter writer, string thread, string localName)
+		{
+			writer.WriteAttributeString(RemoveInvalidXmlChars(thread), RemoveInvalidXmlChars(localName));
+		}
+
+
+
+		/// <summary>
+		/// Safe version of WriteElementSafeString
+		/// </summary>
+		/// <param name="writer"></param>
+		/// <param name="prefix"></param>
+		/// <param name="localName"></param>
+		/// <param name="ns"></param>
+		/// <param name="value"></param>
+		public static void WriteElementSafeString(this XmlWriter writer, string prefix, string localName, string ns, string value)
+		{
+			writer.WriteElementString(RemoveInvalidXmlChars(prefix), RemoveInvalidXmlChars(localName), RemoveInvalidXmlChars(ns),
+			                          RemoveInvalidXmlChars(value));
+		}
+
+		/// <summary>
+		/// Safe version of WriteCData
+		/// </summary>
+		/// <param name="writer"></param>
+		/// <param name="text"></param>
+		public static void WriteSafeCData(this XmlWriter writer, string text)
+		{
+			writer.WriteCData(RemoveInvalidXmlChars(text));
+		}
+	}
+}

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -182,27 +182,27 @@ namespace NLog.LayoutRenderers
             using (XmlWriter xtw = XmlWriter.Create(sb, settings))
             {
                 xtw.WriteStartElement("log4j", "event", dummyNamespace);
-                xtw.WriteAttributeString("xmlns", "nlog", null, dummyNLogNamespace);
-                xtw.WriteAttributeString("logger", logEvent.LoggerName);
-                xtw.WriteAttributeString("level", logEvent.Level.Name.ToUpper(CultureInfo.InvariantCulture));
-                xtw.WriteAttributeString("timestamp", Convert.ToString((long)(logEvent.TimeStamp.ToUniversalTime() - log4jDateBase).TotalMilliseconds, CultureInfo.InvariantCulture));
-                xtw.WriteAttributeString("thread", System.Threading.Thread.CurrentThread.ManagedThreadId.ToString(CultureInfo.InvariantCulture));
+                xtw.WriteAttributeSafeString("xmlns", "nlog", null, dummyNLogNamespace);
+                xtw.WriteAttributeSafeString("logger", logEvent.LoggerName);
+                xtw.WriteAttributeSafeString("level", logEvent.Level.Name.ToUpper(CultureInfo.InvariantCulture));
+                xtw.WriteAttributeSafeString("timestamp", Convert.ToString((long)(logEvent.TimeStamp.ToUniversalTime() - log4jDateBase).TotalMilliseconds, CultureInfo.InvariantCulture));
+                xtw.WriteAttributeSafeString("thread", System.Threading.Thread.CurrentThread.ManagedThreadId.ToString(CultureInfo.InvariantCulture));
 
-                xtw.WriteElementString("log4j", "message", dummyNamespace, logEvent.FormattedMessage);
+                xtw.WriteElementSafeString("log4j", "message", dummyNamespace, logEvent.FormattedMessage);
                 if (logEvent.Exception != null)
                 {
-                    xtw.WriteElementString("log4j", "throwable", dummyNamespace, logEvent.Exception.ToString());
+                    xtw.WriteElementSafeString("log4j", "throwable", dummyNamespace, logEvent.Exception.ToString());
                 }
 
                 if (this.IncludeNdc)
                 {
-                    xtw.WriteElementString("log4j", "NDC", dummyNamespace, string.Join(this.NdcItemSeparator, NestedDiagnosticsContext.GetAllMessages()));
+                    xtw.WriteElementSafeString("log4j", "NDC", dummyNamespace, string.Join(this.NdcItemSeparator, NestedDiagnosticsContext.GetAllMessages()));
                 }
 
                 if (logEvent.Exception != null)
                 {
                     xtw.WriteStartElement("log4j", "throwable", dummyNamespace);
-                    xtw.WriteCData(logEvent.Exception.ToString());
+                    xtw.WriteSafeCData(logEvent.Exception.ToString());
                     xtw.WriteEndElement();
                 }
 
@@ -217,26 +217,26 @@ namespace NLog.LayoutRenderers
                         xtw.WriteStartElement("log4j", "locationInfo", dummyNamespace);
                         if (type != null)
                         {
-                            xtw.WriteAttributeString("class", type.FullName);
+                            xtw.WriteAttributeSafeString("class", type.FullName);
                         }
 
-                        xtw.WriteAttributeString("method", methodBase.ToString());
+                        xtw.WriteAttributeSafeString("method", methodBase.ToString());
 #if !SILVERLIGHT
                         if (this.IncludeSourceInfo)
                         {
-                            xtw.WriteAttributeString("file", frame.GetFileName());
-                            xtw.WriteAttributeString("line", frame.GetFileLineNumber().ToString(CultureInfo.InvariantCulture));
+                            xtw.WriteAttributeSafeString("file", frame.GetFileName());
+                            xtw.WriteAttributeSafeString("line", frame.GetFileLineNumber().ToString(CultureInfo.InvariantCulture));
                         }
 #endif
                         xtw.WriteEndElement();
 
                         if (this.IncludeNLogData)
                         {
-                            xtw.WriteElementString("nlog", "eventSequenceNumber", dummyNLogNamespace, logEvent.SequenceID.ToString(CultureInfo.InvariantCulture));
+                            xtw.WriteElementSafeString("nlog", "eventSequenceNumber", dummyNLogNamespace, logEvent.SequenceID.ToString(CultureInfo.InvariantCulture));
                             xtw.WriteStartElement("nlog", "locationInfo", dummyNLogNamespace);
                             if (type != null)
                             {
-                                xtw.WriteAttributeString("assembly", type.Assembly.FullName);
+                                xtw.WriteAttributeSafeString("assembly", type.Assembly.FullName);
                             }
 
                             xtw.WriteEndElement();
@@ -245,8 +245,8 @@ namespace NLog.LayoutRenderers
                             foreach (var contextProperty in logEvent.Properties)
                             {
                                 xtw.WriteStartElement("nlog", "data", dummyNLogNamespace);
-                                xtw.WriteAttributeString("name", Convert.ToString(contextProperty.Key, CultureInfo.InvariantCulture));
-                                xtw.WriteAttributeString("value", Convert.ToString(contextProperty.Value, CultureInfo.InvariantCulture));
+                                xtw.WriteAttributeSafeString("name", Convert.ToString(contextProperty.Key, CultureInfo.InvariantCulture));
+                                xtw.WriteAttributeSafeString("value", Convert.ToString(contextProperty.Value, CultureInfo.InvariantCulture));
                                 xtw.WriteEndElement();
                             }
                             xtw.WriteEndElement();
@@ -261,8 +261,8 @@ namespace NLog.LayoutRenderers
                     foreach (KeyValuePair<string, string> entry in MappedDiagnosticsContext.ThreadDictionary)
                     {
                         xtw.WriteStartElement("log4j", "data", dummyNamespace);
-                        xtw.WriteAttributeString("name", entry.Key);
-                        xtw.WriteAttributeString("value", entry.Value);
+                        xtw.WriteAttributeSafeString("name", entry.Key);
+                        xtw.WriteAttributeSafeString("value", entry.Value);
                         xtw.WriteEndElement();
                     }
                 }
@@ -270,23 +270,23 @@ namespace NLog.LayoutRenderers
                 foreach (NLogViewerParameterInfo parameter in this.Parameters)
                 {
                     xtw.WriteStartElement("log4j", "data", dummyNamespace);
-                    xtw.WriteAttributeString("name", parameter.Name);
-                    xtw.WriteAttributeString("value", parameter.Layout.Render(logEvent));
+                    xtw.WriteAttributeSafeString("name", parameter.Name);
+                    xtw.WriteAttributeSafeString("value", parameter.Layout.Render(logEvent));
                     xtw.WriteEndElement();
                 }
 
                 xtw.WriteStartElement("log4j", "data", dummyNamespace);
-                xtw.WriteAttributeString("name", "log4japp");
-                xtw.WriteAttributeString("value", this.AppInfo);
+                xtw.WriteAttributeSafeString("name", "log4japp");
+                xtw.WriteAttributeSafeString("value", this.AppInfo);
                 xtw.WriteEndElement();
 
                 xtw.WriteStartElement("log4j", "data", dummyNamespace);
-                xtw.WriteAttributeString("name", "log4jmachinename");
+                xtw.WriteAttributeSafeString("name", "log4jmachinename");
 
 #if SILVERLIGHT
-            xtw.WriteAttributeString("value", "silverlight");
+            xtw.WriteAttributeSafeString("value", "silverlight");
 #else
-                xtw.WriteAttributeString("value", Environment.MachineName);
+                xtw.WriteAttributeSafeString("value", Environment.MachineName);
 #endif
                 xtw.WriteEndElement();
                 xtw.WriteEndElement();

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -193,6 +194,7 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Internal\Win32ThreadIDHelper.cs" />
+    <Compile Include="Internal\XmlHelper.cs" />
     <Compile Include="LayoutRenderers\AmbientPropertyAttribute.cs" />
     <Compile Include="LayoutRenderers\AspApplicationValueLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\AspRequestValueLayoutRenderer.cs" />


### PR DESCRIPTION
Added a helper class for handling invalid XML characters (Use in Log4JXmlEventLayoutRenderer)

I'm using a external obfuscated dll.. They used obfuscated method names which contain invalid XML characters. The XmlWriter methods in Log4JXmlEventLayoutRenderer could not handle them.

![image](https://cloud.githubusercontent.com/assets/5426370/2852781/27ccdd64-d13b-11e3-8ac8-72640b39d02a.png)

I created extension methods which filters the invalid XML-characters..
