### PR TITLE
Default value added in EnviromentLayoutRender

### DIFF
--- a/src/NLog/LayoutRenderers/EnvironmentLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EnvironmentLayoutRenderer.cs
@@ -55,20 +55,34 @@ namespace NLog.LayoutRenderers
         public string Variable { get; set; }
 
         /// <summary>
+        /// Gets or sets the default value to be used when the environment variable is not set.
+        /// </summary>
+        /// <docgen category='Rendering Options' order='10' />
+        public string Default { get; set; }
+	
+ 
+        /// <summary>
         /// Renders the specified environment variable and appends it to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            if (this.Variable != null)
-            {
-                var environmentVariable = EnvironmentHelper.GetSafeEnvironmentVariable(this.Variable);
-                if (!string.IsNullOrEmpty(environmentVariable))
-                {
-                    var layout = new SimpleLayout(environmentVariable);
-                    builder.Append(layout.Render(logEvent));
-                }
+	        if (this.Variable != null)
+	        {
+	            var environmentVariable = EnvironmentHelper.GetSafeEnvironmentVariable(this.Variable);
+	            if (!string.IsNullOrEmpty(environmentVariable))
+	            {
+	                var layout = new SimpleLayout(environmentVariable);
+	                builder.Append(layout.Render(logEvent));
+	            }
+	            else {
+	                if (this.Default != null) 
+	                {
+	                    var layout = new SimpleLayout(this.Default);
+	                    builder.Append(layout.Render(logEvent));
+	                }
+	            }
             }
         }
     }

--- a/tests/NLog.UnitTests/LayoutRenderers/EnvironmentTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/EnvironmentTests.cs
@@ -55,8 +55,51 @@ namespace NLog.UnitTests.LayoutRenderers
         [Fact]
         public void Environment_WhenVariableIsLayout_ShouldBeWrittenAsLayout()
         {
-            Environment.SetEnvironmentVariable("NLOGTEST", "${level}");
-            AssertLayoutRendererOutput("${environment:NLOGTEST}", "Info");
+ 	        Environment.SetEnvironmentVariable("NLOGTEST", "${level}");
+	        AssertLayoutRendererOutput("${environment:variable=NLOGTEST}", "Info");
+ 	        AssertLayoutRendererOutput("${environment:NLOGTEST}", "Info");
+        }
+	
+        [Fact]
+        public void Environment_WhenVariableExists_DoNothing()
+        {
+	        Environment.SetEnvironmentVariable("NLOGTEST", "ABC1234");           
+	        // Test default value with different variations on variable parameter syntax. 
+	        AssertLayoutRendererOutput("${environment:variable=NLOGTEST:default=5678}", "ABC1234");
+	        AssertLayoutRendererOutput("${environment:NLOGTEST:default=5678}", "ABC1234");
+        }
+	
+        [Fact]
+        public void Environment_WhenVariableIsLayoutAndExists_DoNothing()
+        {
+	        Environment.SetEnvironmentVariable("NLOGTEST", "${level}");
+	        AssertLayoutRendererOutput("${environment:NLOGTEST:default=5678}", "Info");
+        }
+	
+        [Fact]
+        public void Environment_WhenVariableDoesNotExists_UseDefault()
+        {
+	        if (Environment.GetEnvironmentVariable("NLOGTEST") != null)
+	        {
+	            Environment.SetEnvironmentVariable("NLOGTEST", null);
+	        }
+	
+	        // Test default value with different variations on variable parameter syntax. 
+	        AssertLayoutRendererOutput("${environment:variable=NLOGTEST:default=1234}", "1234");
+	        AssertLayoutRendererOutput("${environment:NLOGTEST:default=5678}", "5678");
+        }
+	
+        [Fact]
+        public void Environment_WhenDefaultEmpty_EmptyString()
+        {
+	        if (Environment.GetEnvironmentVariable("NLOGTEST") != null)
+	        {
+	            Environment.SetEnvironmentVariable("NLOGTEST", null);
+	        }
+	
+	        // Test default value with different variations on variable parameter syntax. 
+	        AssertLayoutRendererOutput("${environment:variable=NLOGTEST:default=}", "");
+	        AssertLayoutRendererOutput("${environment:NLOGTEST:default=}", "");
         }
     }
 }


### PR DESCRIPTION
The code below implements request  #317 "Environment layout renderer feature request: Default value"

Default value can now specified on EnviromentLayoutRenderer along variable name. When the variable has not defined the layout will return the default value instead.

Apologies for the commit under 4a583e937174329c6f7cc091234c05c33b574353
