### PR TITLE
Obsolete added to LogException() method in Logger class.

### DIFF
--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -232,6 +232,7 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+        [Obsolete("Use Log(LogLevel, String, Exception) method instead.")]
         public void LogException(LogLevel level, [Localizable(false)] string message, Exception exception)
         {
             this.Log(level, message, exception);
@@ -326,7 +327,7 @@ namespace NLog
                 var exceptionCandidate = argument as Exception;
                 if (exceptionCandidate != null)
                 {
-                    this.LogException(level, message, exceptionCandidate);
+                    this.Log(level, message, exceptionCandidate);
                     return;
                 }
 

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -1051,8 +1051,14 @@ namespace NLog.UnitTests
                     logger.Log(level, CultureInfo.InvariantCulture, "message{0}", (decimal)2.5);
                     if (enabled == 1) AssertDebugLastMessage("debug", "message2.5");
 
+                    logger.Log(level, "message", new Exception("test"));
+                    if (enabled == 1) AssertDebugLastMessage("debug", "message");
+
+#pragma warning disable 0618
+                    // Obsolete method requires testing until removed.
                     logger.LogException(level, "message", new Exception("test"));
                     if (enabled == 1) AssertDebugLastMessage("debug", "message");
+#pragma warning restore 0618
 
                     logger.Log(level, delegate { return "message from lambda"; });
                     if (enabled == 1) AssertDebugLastMessage("debug", "message from lambda");


### PR DESCRIPTION
In pull request #344 "Replacement for [LogLevel]Exception methods" the Obsolete attribute was missed for the LogException(LogLevel, String, Exception) method in Logger class.
