### PR TITLE
Add of archiveOldFileOnStartup parameter in FileTarget

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -253,6 +253,17 @@ namespace NLog.Targets
         public bool DeleteOldFileOnStartup { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to archive old log file on startup.
+        /// </summary>
+        /// <remarks>
+        /// This option works only when the "FileName" parameter denotes a single file.
+        /// After archiving the old file, the current log file will be empty.
+        /// </remarks>
+        /// <docgen category='Output Options' order='10' />
+        [DefaultValue(false)]
+        public bool ArchiveOldFileOnStartup { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to replace file contents on each write instead of appending log message at the end.
         /// </summary>
         /// <docgen category='Output Options' order='10' />
@@ -1266,6 +1277,19 @@ namespace NLog.Targets
             {
                 if (!this.initializedFiles.ContainsKey(fileName))
                 {
+                    if (this.ArchiveOldFileOnStartup)
+                    {
+                        try
+                        {
+                            this.DoAutoArchive(fileName, null);
+                        }
+                        catch (Exception exception)
+                        {
+                            if (exception.MustBeRethrown())
+                                throw;
+                            InternalLogger.Warn("Unable to archive old log file '{0}': {1}", fileName, exception);
+                        }
+                    }
                     if (this.DeleteOldFileOnStartup)
                     {
                         try


### PR DESCRIPTION
This adds the possibility of archiving an existing log file every time an application starts. As described/proposed in #213.
The added parameter for the File target is <code>archiveOldFileOnStartup</code>.

The following config will archive the current log file each time the application is started.

``` xml
<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <targets>
    <target name="filelog"
            xsi:type="File"
            FileName="${basedir}/log.txt"
            layout="${longdate} ${message}"
            archiveFileName="${basedir}/Archives/log.{#}.txt"
            archiveNumbering="Rolling"
            archiveOldFileOnStartup="true"/>
  </targets>
  <rules>
    <logger name="Logger1" writeTo="filelog"></logger>
  </rules>
</nlog>
```

(The xsd and wiki needs to be updated if this PR is accepted)
