### PR TITLE
Use merging of event properties in async target wrapper to fix empty collection issue

### DIFF
--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -476,7 +476,12 @@ namespace NLog.Targets
             InternalLogger.Trace("{0} has {1} layouts", this, this.allLayouts.Count);
         }
 
-        private void MergeEventProperties(LogEventInfo logEvent)
+        /// <summary>
+        /// Merges (copies) the event context properties from any event info object stored in
+        /// parameters of the given event info object.
+        /// </summary>
+        /// <param name="logEvent">The event info object to perform the merge to.</param>
+        protected void MergeEventProperties(LogEventInfo logEvent)
         {
 			if (logEvent.Parameters == null)
 			{

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -237,6 +237,7 @@ namespace NLog.Targets.Wrappers
         /// </remarks>
         protected override void Write(AsyncLogEventInfo logEvent)
         {
+            this.MergeEventProperties(logEvent.LogEvent);
             this.PrecalculateVolatileLayouts(logEvent.LogEvent);
             this.RequestQueue.Enqueue(logEvent);
         }


### PR DESCRIPTION
The empty 'properties' collection (issue #331) was fixed by copying the properties from the original object stored in the parameters. However, the async target wrapper 'Write' is overwritten such that the merge method is never called, causing the same issue when using <targets async="true"> configuration. The solution is to call the merge operation in the overridden 'Write' method.

I ran into this issue and was able to produce a solution that seems to work for us, but we have not used NLog extensively yet, so please take a look if this fix is any good.

Thanks!
