### PR TITLE
Fix #370:  EventLogTarget source and log name case insensitive comparison

### DIFF
--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -132,7 +132,7 @@ namespace NLog.Targets
             if (EventLog.SourceExists(this.Source, this.MachineName))
             {
                 string currentLogName = EventLog.LogNameFromSourceName(this.Source, this.MachineName);
-                if (currentLogName != this.Log)
+                if (!currentLogName.Equals(this.Log, StringComparison.CurrentCultureIgnoreCase))            
                 {
                     // re-create the association between Log and Source
                     EventLog.DeleteEventSource(this.Source, this.MachineName);
@@ -185,7 +185,7 @@ namespace NLog.Targets
             base.InitializeTarget();
 
             var s = EventLog.LogNameFromSourceName(this.Source, this.MachineName);
-            if (s != this.Log)
+            if (!s.Equals(this.Log, StringComparison.CurrentCultureIgnoreCase))            
             {
                 this.CreateEventSourceIfNeeded();
             }
@@ -250,7 +250,7 @@ namespace NLog.Targets
                 if (EventLog.SourceExists(this.Source, this.MachineName))
                 {
                     string currentLogName = EventLog.LogNameFromSourceName(this.Source, this.MachineName);
-                    if (currentLogName != this.Log)
+                    if (!currentLogName.Equals(this.Log, StringComparison.CurrentCultureIgnoreCase))            
                     {
                         // re-create the association between Log and Source
                         EventLog.DeleteEventSource(this.Source, this.MachineName);

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)'==''">v4.0</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -19,8 +21,10 @@
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <SignAssembly>true</SignAssembly>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <FileUpgradeFlags></FileUpgradeFlags>
-    <UpgradeBackupLocation></UpgradeBackupLocation>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -174,6 +178,7 @@
     <Compile Include="Targets\ConcurrentFileTargetTests.cs" />
     <Compile Include="Targets\ConsoleTargetTests.cs" />
     <Compile Include="Targets\DatabaseTargetTests.cs" />
+    <Compile Include="Targets\EventLogTargetTests.cs" />
     <Compile Include="Targets\FileTargetTests.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTargetTests.cs" />
     <Compile Include="Targets\MailTargetTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -153,6 +155,7 @@
     <Compile Include="Targets\ConcurrentFileTargetTests.cs" />
     <Compile Include="Targets\ConsoleTargetTests.cs" />
     <Compile Include="Targets\DatabaseTargetTests.cs" />
+    <Compile Include="Targets\EventLogTargetTests.cs" />
     <Compile Include="Targets\FileTargetTests.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTargetTests.cs" />
     <Compile Include="Targets\MailTargetTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -157,6 +159,7 @@
     <Compile Include="Targets\ConcurrentFileTargetTests.cs" />
     <Compile Include="Targets\ConsoleTargetTests.cs" />
     <Compile Include="Targets\DatabaseTargetTests.cs" />
+    <Compile Include="Targets\EventLogTargetTests.cs" />
     <Compile Include="Targets\FileTargetTests.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTargetTests.cs" />
     <Compile Include="Targets\MailTargetTests.cs" />

--- a/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
@@ -1,0 +1,41 @@
+﻿#if !SILVERLIGHT && !MONO
+
+namespace NLog.UnitTests.Targets
+{
+    using System.Diagnostics;
+    using NLog.Config;
+    using NLog.Targets;
+    using System;
+    using System.Linq;
+    using Xunit;
+
+    public class EventLogTargetTests : NLogTestBase
+    {
+        [Fact]
+        public void WriteEventLogEntry()
+        {
+            var target = new EventLogTarget();
+            //The Log to write to is intentionally lower case!!
+            target.Log = "application";  
+
+            SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Debug);
+            var logger = LogManager.GetLogger("WriteEventLogEntry");
+            var el = new EventLog(target.Log);
+
+            var latestEntryTime  = el.Entries.Cast<EventLogEntry>().Max(n => n.TimeWritten);
+
+
+            var testValue = Guid.NewGuid();
+            logger.Debug(testValue.ToString());
+            
+            var entryExists = (from entry in el.Entries.Cast<EventLogEntry>()
+                                where entry.TimeWritten >= latestEntryTime
+                                && entry.Message.Contains(testValue.ToString())
+                                select entry).Any();
+
+            Assert.True(entryExists);
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Added fix for #370: EventLogTarget source and log name should be treated as case insensitive.
Added test for writing to event log.
