### PR TITLE
Fix #367: Use current date/time when date archiving a file

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1036,7 +1036,7 @@ namespace NLog.Targets
                 Directory.CreateDirectory(dirName);
             }
 
-            DateTime newFileDate = GetArchiveDate();
+            DateTime newFileDate = DateTime.Now;
             string newFileName = Path.Combine(dirName, fileNameMask.Replace("*", newFileDate.ToString(dateFormat)));
             MoveFileToArchive(fileName, newFileName);
         }
@@ -1072,38 +1072,6 @@ namespace NLog.Targets
                 }
             }
             return formatString;
-        }
-
-        private DateTime GetArchiveDate()
-        {
-            DateTime archiveDate = DateTime.Now;
-
-            // Because AutoArchive/DateArchive gets called after the FileArchivePeriod condition matches, decrement the archive period by 1
-            // (i.e. If ArchiveEvery = Day, the file will be archived with yesterdays date)
-            switch (this.ArchiveEvery)
-            {
-                case FileArchivePeriod.Day:
-                    archiveDate = archiveDate.AddDays(-1);
-                    break;
-
-                case FileArchivePeriod.Hour:
-                    archiveDate = archiveDate.AddHours(-1);
-                    break;
-
-                case FileArchivePeriod.Minute:
-                    archiveDate = archiveDate.AddMinutes(-1);
-                    break;
-
-                case FileArchivePeriod.Month:
-                    archiveDate = archiveDate.AddMonths(-1);
-                    break;
-
-                case FileArchivePeriod.Year:
-                    archiveDate = archiveDate.AddYears(-1);
-                    break;
-            }
-
-            return archiveDate;
         }
 
         private void DoAutoArchive(string fileName, LogEventInfo ev)


### PR DESCRIPTION
As described in #367, whenever a log file will be date archived the DateTime.Now will be used instead of DateTime.Now minus one FileArchivePeriod.