### PR TITLE
Fixed issue (#414) with AutoFlush on FileTarget.

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1403,6 +1403,11 @@ namespace NLog.Targets
             }
 
             appenderToWrite.Write(bytes);
+
+            if (this.AutoFlush)
+            {
+                appenderToWrite.Flush();
+            }
         }
 
         private byte[] GetHeaderBytes()


### PR DESCRIPTION
FileTarget will now call Flush on the BasicFileAppender if AutoFlush is set.
closes #414 
