### PR TITLE
Issue #260 resolution

### DIFF
--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -56,6 +56,15 @@ namespace NLog.Internal.FileAppenders
         /// <param name="parameters">The parameters.</param>
         public SingleProcessFileAppender(string fileName, ICreateFileParameters parameters) : base(fileName, parameters)
         {
+        	var fi = new FileInfo(fileName);
+        	if (fi.Exists)
+			{
+				this.FileTouched(fi.LastWriteTime);
+			}
+			else
+			{
+				this.FileTouched();
+			}
             this.file = CreateFileStream(false);
         }
 
@@ -113,10 +122,18 @@ namespace NLog.Internal.FileAppenders
         /// </returns>
         public override bool GetFileInfo(out DateTime lastWriteTime, out long fileLength)
         {
-	        var fi = new FileInfo(base.FileName);
-	        lastWriteTime = fi.LastWriteTime;
-	        fileLength = fi.Length;
-	        return true;
+            if (file != null)
+			{
+				lastWriteTime = LastWriteTime;
+				fileLength = file.Length;
+				return true;
+			}
+			else
+			{
+				lastWriteTime = new DateTime();
+				fileLength = 0;
+				return false;
+			}
         }
 
         /// <summary>


### PR DESCRIPTION
Solves in a better way the bug "SingleProcessFileAppender crashes on startup".
I didn't have the tools and I'm a newby in GitHub therefore I think the online editor has made some more changes in the tabs (or spaces) before the code. 

Basically, it has been changed the constructor and the GetFileInfo method following the same pattern like in the CountingSingleProcessFileAppender 
