### PR TITLE
Run logging code outside of transaction

### DIFF
--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Messaging" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />

--- a/src/NLog/NLog.mono2.csproj
+++ b/src/NLog/NLog.mono2.csproj
@@ -56,6 +56,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Services" />
+    <Reference Include="System.Transactions" />
     <Reference Include="Mono.Posix" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NLog/NLog.monodevelop.csproj
+++ b/src/NLog/NLog.monodevelop.csproj
@@ -58,6 +58,7 @@
     <Reference Include="Mono.Posix" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -27,7 +27,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>bin\Debug</OutputPath>
-    <CodeAnalysisRules></CodeAnalysisRules>
+    <CodeAnalysisRules>
+    </CodeAnalysisRules>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -52,6 +53,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.Messaging" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -58,6 +58,7 @@
     <Reference Include="System.Messaging" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Transactions;
+
 #if !SILVERLIGHT
 
 namespace NLog.Targets
@@ -438,48 +440,55 @@ namespace NLog.Targets
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "It's up to the user to ensure proper quoting.")]
         private void WriteEventToDatabase(LogEventInfo logEvent)
         {
-            this.EnsureConnectionOpen(this.BuildConnectionString(logEvent));
-
-            IDbCommand command = this.activeConnection.CreateCommand();
-            command.CommandText = this.CommandText.Render(logEvent);
-	    command.CommandType = this.CommandType;
-	    
-            InternalLogger.Trace("Executing {0}: {1}", command.CommandType, command.CommandText);
-
-            foreach (DatabaseParameterInfo par in this.Parameters)
+            //Always suppress transaction so that the caller does not rollback loggin if they are rolling back their transaction.
+            using (TransactionScope transactionScope = new TransactionScope(TransactionScopeOption.Suppress))
             {
-                IDbDataParameter p = command.CreateParameter();
-                p.Direction = ParameterDirection.Input;
-                if (par.Name != null)
+                this.EnsureConnectionOpen(this.BuildConnectionString(logEvent));
+
+                IDbCommand command = this.activeConnection.CreateCommand();
+                command.CommandText = this.CommandText.Render(logEvent);
+                command.CommandType = this.CommandType;
+
+                InternalLogger.Trace("Executing {0}: {1}", command.CommandType, command.CommandText);
+
+                foreach (DatabaseParameterInfo par in this.Parameters)
                 {
-                    p.ParameterName = par.Name;
+                    IDbDataParameter p = command.CreateParameter();
+                    p.Direction = ParameterDirection.Input;
+                    if (par.Name != null)
+                    {
+                        p.ParameterName = par.Name;
+                    }
+
+                    if (par.Size != 0)
+                    {
+                        p.Size = par.Size;
+                    }
+
+                    if (par.Precision != 0)
+                    {
+                        p.Precision = par.Precision;
+                    }
+
+                    if (par.Scale != 0)
+                    {
+                        p.Scale = par.Scale;
+                    }
+
+                    string stringValue = par.Layout.Render(logEvent);
+
+                    p.Value = stringValue;
+                    command.Parameters.Add(p);
+
+                    InternalLogger.Trace("  Parameter: '{0}' = '{1}' ({2})", p.ParameterName, p.Value, p.DbType);
                 }
 
-                if (par.Size != 0)
-                {
-                    p.Size = par.Size;
-                }
+                int result = command.ExecuteNonQuery();
+                InternalLogger.Trace("Finished execution, result = {0}", result);
 
-                if (par.Precision != 0)
-                {
-                    p.Precision = par.Precision;
-                }
-
-                if (par.Scale != 0)
-                {
-                    p.Scale = par.Scale;
-                }
-
-                string stringValue = par.Layout.Render(logEvent);
-
-                p.Value = stringValue;
-                command.Parameters.Add(p);
-
-                InternalLogger.Trace("  Parameter: '{0}' = '{1}' ({2})", p.ParameterName, p.Value, p.DbType);
+                //not really needed as there is no transaction at all.
+                transactionScope.Complete();
             }
-
-            int result = command.ExecuteNonQuery();
-            InternalLogger.Trace("Finished execution, result = {0}", result);
         }
 
         private string BuildConnectionString(LogEventInfo logEvent)

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -31,7 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.Transactions;
 
 #if !SILVERLIGHT
 
@@ -46,6 +45,7 @@ namespace NLog.Targets
     using System.Globalization;
     using System.Reflection;
     using System.Text;
+    using System.Transactions;
     using NLog.Common;
     using NLog.Config;
     using NLog.Internal;

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -164,14 +164,6 @@ namespace NLog.Targets
         public bool KeepConnection { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to use database transactions. 
-        /// Some data providers require this.
-        /// </summary>
-        /// <docgen category='Connection Options' order='10' />
-        [DefaultValue(false)]
-        public bool UseTransactions { get; set; }
-
-        /// <summary>
         /// Gets or sets the database host name. If the ConnectionString is not provided
         /// this value will be used to construct the "Server=" part of the
         /// connection string.


### PR DESCRIPTION
If the user tries to log to database inside transaction scope and rollbacks that transaction the logging will be rolled back to0. With this change we never create a transaction when writing to database.