### PR TITLE
Make ExceptionLayoutRenderer more extensible

### DIFF
--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -172,6 +172,11 @@ namespace NLog.LayoutRenderers
             }
         }
 
+        /// <summary>
+        /// Appends the Message of an Exception to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="ex">The exception containing the Message to append.</param>
         protected virtual void AppendMessage(StringBuilder sb, Exception ex)
         {
             try
@@ -190,6 +195,11 @@ namespace NLog.LayoutRenderers
             }
         }
 
+        /// <summary>
+        /// Appends the method name from Exception's stack trace to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="ex">The Exception whose method name should be appended.</param>
         protected virtual void AppendMethod(StringBuilder sb, Exception ex)
         {
 #if SILVERLIGHT
@@ -202,26 +212,51 @@ namespace NLog.LayoutRenderers
 #endif
         }
 
+        /// <summary>
+        /// Appends the stack trace from an Exception to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="ex">The Exception whose stack trace should be appended.</param>
         protected virtual void AppendStackTrace(StringBuilder sb, Exception ex)
         {
             sb.Append(ex.StackTrace);
         }
 
+        /// <summary>
+        /// Appends the result of calling ToString() on an Exception to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="ex">The Exception whose call to ToString() should be appended.</param>
         protected virtual void AppendToString(StringBuilder sb, Exception ex)
         {
             sb.Append(ex.ToString());
         }
 
+        /// <summary>
+        /// Appends the type of an Exception to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="ex">The Exception whose type should be appended.</param>
         protected virtual void AppendType(StringBuilder sb, Exception ex)
         {
             sb.Append(ex.GetType().FullName);
         }
 
+        /// <summary>
+        /// Appends the short type of an Exception to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="ex">The Exception whose short type should be appended.</param>
         protected virtual void AppendShortType(StringBuilder sb, Exception ex)
         {
             sb.Append(ex.GetType().Name);
         }
 
+        /// <summary>
+        /// Appends the contents of an Exception's Data property to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="ex">The Exception whose Data property elements should be appended.</param>
         protected virtual void AppendData(StringBuilder sb, Exception ex)
         {
             string separator = string.Empty;
@@ -233,7 +268,7 @@ namespace NLog.LayoutRenderers
             }
         }
 
-        private static ExceptionDataTarget[] CompileFormat(string formatSpecifier)
+        private ExceptionDataTarget[] CompileFormat(string formatSpecifier)
         {
             string[] parts = formatSpecifier.Replace(" ", string.Empty).Split(',');
             var dataTargets = new List<ExceptionDataTarget>();


### PR DESCRIPTION
Right now there's no easy way to tweak how a particular layout token (i.e. Message or Data) is rendered by extending ExceptionLayoutRenderer, because the Append... methods are private static
