### PR TITLE
BUG FIX: Modification to LogEventInfo.Properties While Iterating

### DIFF
--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -493,11 +493,11 @@ namespace NLog.Targets
                 var logEventParameter = item as LogEventInfo;
                 if (logEventParameter != null)
                 {
-                    foreach (var propertyItem in logEventParameter.Properties)
+                    foreach (var key in logEventParameter.Properties.Keys)
                     {
-                        logEventParameter.Properties.Remove(propertyItem.Key);
-                        logEventParameter.Properties.Add(propertyItem);
+                        logEvent.Properties.Add(key, logEventParameter.Properties[key]);
                     }
+                    logEventParameter.Properties.Clear();
                 }
             }
         }


### PR DESCRIPTION
I modified the loop here to use the keys of the logEventParameter.Properties collection instead of the collection itself. Modifying a collection while iterating over it causes an error. In addition, as you can see, the previous version removed the item according to its key and then tried to add it back. This was obviously not the intent.

Using LogEventInfo.Properties["myKey"] = "myValue" when logging a message is broken in all use cases right now until this change is applied. That's how I found this.
