### PR TITLE
DateRenderer now includes milliseconds

### DIFF
--- a/src/NLog/LayoutRenderers/DateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/DateLayoutRenderer.cs
@@ -50,7 +50,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         public DateLayoutRenderer()
         {
-            this.Format = "G";
+            this.Format = "yyyy/MM/dd HH:mm:ss.fff";
             this.Culture = CultureInfo.InvariantCulture;
         }
 

--- a/tests/NLog.UnitTests/LayoutRenderers/DateTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/DateTests.cs
@@ -52,7 +52,7 @@ namespace NLog.UnitTests.LayoutRenderers
             </nlog>");
 
             LogManager.GetLogger("d").Debug("zzz");
-            DateTime dt = DateTime.ParseExact(GetDebugLastMessage("debug"), "MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture);
+            DateTime dt = DateTime.ParseExact(GetDebugLastMessage("debug"), "yyyy/MM/dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
             DateTime now = DateTime.Now;
 
             Assert.True(Math.Abs((dt - now).TotalSeconds) < 5);


### PR DESCRIPTION
Fixes issue #278
