### PR TITLE
Pluggable time sources support in NLog.xsd generator utility

### DIFF
--- a/tools/DumpApiXml/DocFileBuilder.cs
+++ b/tools/DumpApiXml/DocFileBuilder.cs
@@ -69,6 +69,8 @@
             this.DumpApiDocs(writer, "layout", "NLog.LayoutAttribute", "", "");
             this.DumpApiDocs(writer, "layout-renderer", "NLog.LayoutRendererAttribute", "${", "}");
             this.DumpApiDocs(writer, "filter", "NLog.FilterAttribute", "", " filter");
+
+            this.DumpApiDocs(writer, "time-source", "NLog.Time.TimeSourceAttribute", "", " time source");
             writer.WriteEndElement();
         }
 
@@ -557,6 +559,9 @@
 
                 case "filter":
                     return name + "_filter";
+
+                case "time-source":
+                    return name + "_time_source";
             }
 
             string slugBase;

--- a/tools/MakeNLogXSD/TemplateXSD.xml
+++ b/tools/MakeNLogXSD/TemplateXSD.xml
@@ -14,6 +14,7 @@
       <xs:element name="variable" type="NLogVariable" />
       <xs:element name="targets" type="NLogTargets" />
       <xs:element name="rules" type="NLogRules" />
+      <xs:element name="time" type="TimeSource" />
     </xs:choice>
     <xs:attribute name="autoReload" type="xs:boolean">
       <xs:annotation>
@@ -241,6 +242,9 @@
   </xs:complexType>
 
   <xs:complexType name="Filter" abstract="true">
+  </xs:complexType>
+
+  <xs:complexType name="TimeSource" abstract="true">
   </xs:complexType>
 
   <xs:simpleType name="SimpleLayoutAttribute">

--- a/tools/MakeNLogXSD/XsdFileGenerator.cs
+++ b/tools/MakeNLogXSD/XsdFileGenerator.cs
@@ -92,6 +92,10 @@ namespace MakeNLogXSD
                     case "layout":
                         baseType = "Layout";
                         break;
+
+                    case "time-source":
+                        baseType = "TimeSource";
+                        break;
                 }
 
                 if (baseType == null)


### PR DESCRIPTION
Addresses issue #308.
Added time source types support to configuration file schema generator utility (MakeNLogXSD).
Now schema allows specifying time source type with `xsi:type` attribute, same way as with targets:

``` xml
<time xsi:type="AccurateLocal" />
```
