### PR TITLE
Added 'enabled' attribute to the logging rule element.

### DIFF
--- a/tools/MakeNLogXSD/TemplateXSD.xml
+++ b/tools/MakeNLogXSD/TemplateXSD.xml
@@ -143,6 +143,12 @@
         <xs:documentation>Ignore further rules if this one matches.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+
+    <xs:attribute name="enabled" type="xs:boolean" default="true">
+      <xs:annotation>
+        <xs:documentation>Enable or disable logging rule. Disabled rules are ignored.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="NLogFilters">


### PR DESCRIPTION
Enabled attribute was added in revision 9a069ef3121b7d87edaaf1c40a7b5f6bc57886e2. Now it's supported in NLog.xsd schema too.
closes #13
