### PR TITLE
Fix #283: throwExceptions ="false" but Is still an error

### DIFF
--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -107,6 +107,35 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        public void ReloadConfigOnTimer_DoesNotThrowConfigException_IfConfigChangedInBetween()
+        {
+            var loggingConfiguration = new LoggingConfiguration();
+            LogManager.Configuration = loggingConfiguration;
+            var logFactory = new LogFactory(loggingConfiguration);
+            var differentConfiguration = new LoggingConfiguration();
+
+            Assert.DoesNotThrow(() => logFactory.ReloadConfigOnTimer(differentConfiguration));
+        }
+
+        private class ReloadNullConfiguration : LoggingConfiguration
+        {
+            public override LoggingConfiguration Reload()
+            {
+                return null;
+            }
+        }
+
+        [Fact]
+        public void ReloadConfigOnTimer_DoesNotThrowConfigException_IfConfigReloadReturnsNull()
+        {
+            var loggingConfiguration = new ReloadNullConfiguration();
+            LogManager.Configuration = loggingConfiguration;
+            var logFactory = new LogFactory(loggingConfiguration);
+
+            Assert.DoesNotThrow(() => logFactory.ReloadConfigOnTimer(loggingConfiguration));
+        }
+
+        [Fact]
         public void ReloadConfigOnTimer_Raises_ConfigurationReloadedEvent()
         {
             var called = false;


### PR DESCRIPTION
Altered conditions in the MustBeRethrown extension method.
Fixed relevant tests and added a new one.

---

I'm unsure of what to do with the `ConditionParseException`:
- should it be thrown even if `throwException="false"`?
- should it be sub-classed from `NLogConfigurationException` and swallowed as well?
