### PR TITLE
Changed Wiki URLs to point at GitHub 

### DIFF
--- a/src/NLog.Extended/Targets/AspNetTraceTarget.cs
+++ b/src/NLog.Extended/Targets/AspNetTraceTarget.cs
@@ -40,7 +40,7 @@ namespace NLog.Targets
     /// <summary>
     /// Writes log messages to the ASP.NET trace.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/AspNetTrace_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/AspNetTrace-target">Documentation on NLog Wiki</seealso>
     /// <remarks>
     /// Log entries can then be viewed by navigating to http://server/path/Trace.axd.
     /// </remarks>

--- a/src/NLog.Extended/Targets/MessageQueueTarget.cs
+++ b/src/NLog.Extended/Targets/MessageQueueTarget.cs
@@ -44,7 +44,7 @@ namespace NLog.Targets
     /// <summary>
     /// Writes log message to the specified message queue handled by MSMQ.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/MessageQueue_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/MessageQueue-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog.Extended/Targets/Wrappers/AspNetBufferingTargetWrapper.cs
+++ b/src/NLog.Extended/Targets/Wrappers/AspNetBufferingTargetWrapper.cs
@@ -46,7 +46,7 @@ namespace NLog.Targets.Wrappers
     /// Buffers log events for the duration of ASP.NET request and sends them down 
     /// to the wrapped target at the end of a request.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/AspNetBufferingWrapper_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/AspNetBufferingWrapper-target">Documentation on NLog Wiki</seealso>
     /// <remarks>
     /// <p>
     /// Typically this target is used in cooperation with PostFilteringTargetWrapper

--- a/src/NLog/Targets/AspResponseTarget.cs
+++ b/src/NLog/Targets/AspResponseTarget.cs
@@ -41,7 +41,7 @@ namespace NLog.Targets
     /// <summary>
     /// Outputs log messages through the ASP Response object.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/AspResponse_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/AspResponse-target">Documentation on NLog Wiki</seealso>
     [Target("AspResponse")]
     public sealed class AspResponseTarget : TargetWithLayout
     {

--- a/src/NLog/Targets/ChainsawTarget.cs
+++ b/src/NLog/Targets/ChainsawTarget.cs
@@ -36,7 +36,7 @@ namespace NLog.Targets
     /// <summary>
     /// Sends log messages to the remote instance of Chainsaw application from log4j. 
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/Chainsaw_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/Chainsaw-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -44,7 +44,7 @@ namespace NLog.Targets
     /// <summary>
     /// Writes log messages to the console with customizable coloring.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/ColoredConsole_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/ColoredConsole-target">Documentation on NLog Wiki</seealso>
     [Target("ColoredConsole")]
     public sealed class ColoredConsoleTarget : TargetWithLayoutHeaderAndFooter
     {

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -39,7 +39,7 @@ namespace NLog.Targets
     /// <summary>
     /// Writes log messages to the console.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/Console_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/Console-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -53,7 +53,7 @@ namespace NLog.Targets
 	/// <summary>
     /// Writes log messages to the database using an ADO.NET provider.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/Database_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/Database-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <para>
     /// The configuration is dependent on the database type, because

--- a/src/NLog/Targets/DebugTarget.cs
+++ b/src/NLog/Targets/DebugTarget.cs
@@ -38,7 +38,7 @@ namespace NLog.Targets
     /// <summary>
     /// Mock target - useful for testing.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/Debug_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/Debug-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -49,7 +49,7 @@ namespace NLog.Targets
     /// <summary>
     /// Writes log message to the Event Log.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/EventLog_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/EventLog-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -51,7 +51,7 @@ namespace NLog.Targets
     /// <summary>
     /// Writes log messages to one or more files.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/File_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/File-target">Documentation on NLog Wiki</seealso>
     [Target("File")]
     public class FileTarget : TargetWithLayoutHeaderAndFooter, ICreateFileParameters
     {

--- a/src/NLog/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog/Targets/LogReceiverWebServiceTarget.cs
@@ -54,7 +54,7 @@ namespace NLog.Targets
     /// <summary>
     /// Sends log messages to a NLog Receiver Service (using WCF or Web Services).
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/LogReceiverService_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/LogReceiverService-target">Documentation on NLog Wiki</seealso>
     [Target("LogReceiverService")]
     public class LogReceiverWebServiceTarget : Target
     {

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -49,7 +49,7 @@ namespace NLog.Targets
     /// <summary>
     /// Sends log messages by email using SMTP protocol.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/Mail_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/Mail-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/MemoryTarget.cs
+++ b/src/NLog/Targets/MemoryTarget.cs
@@ -38,7 +38,7 @@ namespace NLog.Targets
     /// <summary>
     /// Writes log messages to an ArrayList in memory for programmatic retrieval.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/Memory_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/Memory-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/MessageBoxTarget.cs
+++ b/src/NLog/Targets/MessageBoxTarget.cs
@@ -43,7 +43,7 @@ namespace NLog.Targets
     /// <summary>
     /// Pops up log messages as message boxes.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/MessageBox_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/MessageBox-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/MethodCallTarget.cs
+++ b/src/NLog/Targets/MethodCallTarget.cs
@@ -39,7 +39,7 @@ namespace NLog.Targets
     /// <summary>
     /// Calls the specified static method on each log message and passes contextual parameters to it.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/MethodCall_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/MethodCall-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -42,7 +42,7 @@ namespace NLog.Targets
     /// <summary>
     /// Sends log messages to the remote instance of NLog Viewer. 
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/NLogViewer_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/NLogViewer-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -45,7 +45,7 @@ namespace NLog.Targets
     /// <summary>
     /// Sends log messages over the network.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/Network_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/Network-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/NullTarget.cs
+++ b/src/NLog/Targets/NullTarget.cs
@@ -38,7 +38,7 @@ namespace NLog.Targets
     /// <summary>
     /// Discards log messages. Used mainly for debugging and benchmarking.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/Null_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/Null-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/OutputDebugStringTarget.cs
+++ b/src/NLog/Targets/OutputDebugStringTarget.cs
@@ -40,7 +40,7 @@ namespace NLog.Targets
     /// <summary>
     /// Outputs log messages through the <c>OutputDebugString()</c> Win32 API.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/OutputDebugString_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/OutputDebugString-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/PerformanceCounterTarget.cs
+++ b/src/NLog/Targets/PerformanceCounterTarget.cs
@@ -50,7 +50,7 @@ namespace NLog.Targets
     /// <summary>
     /// Increments specified performance counter on each write.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/PerformanceCounter_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/PerformanceCounter-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/RichTextBoxTarget.cs
+++ b/src/NLog/Targets/RichTextBoxTarget.cs
@@ -48,7 +48,7 @@ namespace NLog.Targets
     /// <summary>
     /// Log text a Rich Text Box control in an existing or new form.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/RichTextBox_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/RichTextBox-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/TraceTarget.cs
+++ b/src/NLog/Targets/TraceTarget.cs
@@ -42,7 +42,7 @@ namespace NLog.Targets
     /// <summary>
     /// Sends log messages through System.Diagnostics.Trace.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/Trace_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/Trace-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -47,7 +47,7 @@ namespace NLog.Targets
     /// <summary>
     /// Calls the specified web service on each log message.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/WebService_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/WebService-target">Documentation on NLog Wiki</seealso>
     /// <remarks>
     /// The web service must implement a method that accepts a number of string parameters.
     /// </remarks>

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -43,7 +43,7 @@ namespace NLog.Targets.Wrappers
     /// <summary>
     /// Provides asynchronous, buffered execution of target writes.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/AsyncWrapper_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/AsyncWrapper-target">Documentation on NLog Wiki</seealso>
     /// <remarks>
     /// <p>
     /// Asynchronous target wrapper allows the logger code to execute more quickly, by queueing

--- a/src/NLog/Targets/Wrappers/AutoFlushTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AutoFlushTargetWrapper.cs
@@ -40,7 +40,7 @@ namespace NLog.Targets.Wrappers
     /// <summary>
     /// Causes a flush after each write on a wrapped target.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/AutoFlushWrapper_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/AutoFlushWrapper-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>
     /// To set up the target in the <a href="config.html">configuration file</a>, 

--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -41,7 +41,7 @@ namespace NLog.Targets.Wrappers
     /// <summary>
     /// A target that buffers log events and sends them in batches to the wrapped target.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/BufferingWrapper_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/BufferingWrapper-target">Documentation on NLog Wiki</seealso>
     [Target("BufferingWrapper", IsWrapper = true)]
     public class BufferingTargetWrapper : WrapperTargetBase
     {

--- a/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
@@ -40,7 +40,7 @@ namespace NLog.Targets.Wrappers
     /// <summary>
     /// Provides fallback-on-error.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/FallbackGroup_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/FallbackGroup-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>This example causes the messages to be written to server1, 
     /// and if it fails, messages go to server2.</p>

--- a/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
@@ -42,7 +42,7 @@ namespace NLog.Targets.Wrappers
     /// <summary>
     /// Filters log entries based on a condition.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/FilteringWrapper_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/FilteringWrapper-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>This example causes the messages not contains the string '1' to be ignored.</p>
     /// <p>

--- a/src/NLog/Targets/Wrappers/ImpersonatingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/ImpersonatingTargetWrapper.cs
@@ -46,7 +46,7 @@ namespace NLog.Targets.Wrappers
     /// <summary>
     /// Impersonates another user for the duration of the write.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/ImpersonatingWrapper_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/ImpersonatingWrapper-target">Documentation on NLog Wiki</seealso>
     [SecuritySafeCritical]
     [Target("ImpersonatingWrapper", IsWrapper = true)]
     public class ImpersonatingTargetWrapper : WrapperTargetBase

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -43,7 +43,7 @@ namespace NLog.Targets.Wrappers
     /// <summary>
     /// Filters buffered log entries based on a set of conditions that are evaluated on a group of events.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/PostFilteringWrapper_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/PostFilteringWrapper-target">Documentation on NLog Wiki</seealso>
     /// <remarks>
     /// PostFilteringWrapper must be used with some type of buffering target or wrapper, such as
     /// AsyncTargetWrapper, BufferingWrapper or ASPNetBufferingWrapper.

--- a/src/NLog/Targets/Wrappers/RandomizeGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/RandomizeGroupTarget.cs
@@ -40,7 +40,7 @@ namespace NLog.Targets.Wrappers
     /// <summary>
     /// Sends log messages to a randomly selected target.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/RandomizeGroup_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/RandomizeGroup-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>This example causes the messages to be written to either file1.txt or file2.txt 
     /// chosen randomly on a per-message basis.

--- a/src/NLog/Targets/Wrappers/RepeatingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/RepeatingTargetWrapper.cs
@@ -42,7 +42,7 @@ namespace NLog.Targets.Wrappers
     /// <summary>
     /// Repeats each log event the specified number of times.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/RepeatingWrapper_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/RepeatingWrapper-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>This example causes each log message to be repeated 3 times.</p>
     /// <p>

--- a/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
@@ -42,7 +42,7 @@ namespace NLog.Targets.Wrappers
     /// <summary>
     /// Retries in case of write error.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/RetryingWrapper_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/RetryingWrapper-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>This example causes each write attempt to be repeated 3 times, 
     /// sleeping 1 second between attempts if first one fails.</p>

--- a/src/NLog/Targets/Wrappers/RoundRobinGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/RoundRobinGroupTarget.cs
@@ -41,7 +41,7 @@ namespace NLog.Targets.Wrappers
     /// <summary>
     /// Distributes log events to targets in a round-robin fashion.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/RoundRobinGroup_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/RoundRobinGroup-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>This example causes the messages to be written to either file1.txt or file2.txt.
     /// Each odd message is written to file2.txt, each even message goes to file1.txt.

--- a/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
@@ -42,7 +42,7 @@ namespace NLog.Targets.Wrappers
     /// <summary>
     /// Writes log events to all targets.
     /// </summary>
-    /// <seealso href="http://nlog-project.org/wiki/SplitGroup_target">Documentation on NLog Wiki</seealso>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/SplitGroup-target">Documentation on NLog Wiki</seealso>
     /// <example>
     /// <p>This example causes the messages to be written to both file1.txt or file2.txt 
     /// </p>

--- a/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
+++ b/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
@@ -39,7 +39,7 @@ namespace NLog.UnitTests.Fluent
 {
     public class LogBuilderTests
     {
-        private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+        private static readonly NLog.Logger _logger = (Logger) NLog.LogManager.GetCurrentClassLogger();
 
         [Fact]
         public void TraceWrite()


### PR DESCRIPTION
The URLs on the XML comments were pointing to old non-existing pages at http://nlog-project.org/wiki/. Replaced the links and now correctly point at https://github.com/nlog/nlog/wiki/.
