### PR TITLE
Get[*]Logger() return Logger instead of ILogger

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -305,7 +305,7 @@ namespace NLog
         /// </summary>
         /// <returns>Null logger instance.</returns>
         [CLSCompliant(false)]
-        public ILogger CreateNullLogger()
+        public Logger CreateNullLogger()
         {
             TargetWithFilterChain[] targetsByLevel = new TargetWithFilterChain[LogLevel.MaxLevel.Ordinal + 1];
             Logger newLogger = new Logger();
@@ -321,7 +321,7 @@ namespace NLog
         /// Make sure you're not doing this in a loop.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public ILogger GetCurrentClassLogger()
+        public Logger GetCurrentClassLogger()
         {
 #if SILVERLIGHT
             var frame = new StackFrame(1);
@@ -341,7 +341,7 @@ namespace NLog
         /// Make sure you're not doing this in a loop.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public ILogger GetCurrentClassLogger(Type loggerType)
+        public Logger GetCurrentClassLogger(Type loggerType)
         {
 #if !SILVERLIGHT
             var frame = new StackFrame(1, false);
@@ -358,7 +358,7 @@ namespace NLog
         /// <param name="name">Name of the logger.</param>
         /// <returns>The logger reference. Multiple calls to <c>GetLogger</c> with the same argument aren't guaranteed to return the same logger reference.</returns>
         [CLSCompliant(false)]
-        public ILogger GetLogger(string name)
+        public Logger GetLogger(string name)
         {
             return this.GetLogger(new LoggerCacheKey(typeof(ILogger), name));
         }
@@ -371,7 +371,7 @@ namespace NLog
         /// <returns>The logger reference. Multiple calls to <c>GetLogger</c> with the 
         /// same argument aren't guaranteed to return the same logger reference.</returns>
         [CLSCompliant(false)]
-        public ILogger GetLogger(string name, Type loggerType)
+        public Logger GetLogger(string name, Type loggerType)
         {
             return this.GetLogger(new LoggerCacheKey(loggerType, name));
         }

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -159,7 +159,7 @@ namespace NLog
         /// Make sure you're not doing this in a loop.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static ILogger GetCurrentClassLogger()
+        public static Logger GetCurrentClassLogger()
         {
             string loggerName;
             Type declaringType;
@@ -195,7 +195,7 @@ namespace NLog
         /// Make sure you're not doing this in a loop.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static ILogger GetCurrentClassLogger(Type loggerType)
+        public static Logger GetCurrentClassLogger(Type loggerType)
         {
             Type declaringType;
             int framesToSkip = 1;
@@ -218,7 +218,7 @@ namespace NLog
         /// </summary>
         /// <returns>Null logger which discards all log messages.</returns>
         [CLSCompliant(false)]
-        public static ILogger CreateNullLogger()
+        public static Logger CreateNullLogger()
         {
             return globalFactory.CreateNullLogger();
         }
@@ -229,7 +229,7 @@ namespace NLog
         /// <param name="name">Name of the logger.</param>
         /// <returns>The logger reference. Multiple calls to <c>GetLogger</c> with the same argument aren't guaranteed to return the same logger reference.</returns>
         [CLSCompliant(false)]
-        public static ILogger GetLogger(string name)
+        public static Logger GetLogger(string name)
         {
             return globalFactory.GetLogger(name);
         }
@@ -241,7 +241,7 @@ namespace NLog
         /// <param name="loggerType">The logger class. The class must inherit from <see cref="Logger" />.</param>
         /// <returns>The logger reference. Multiple calls to <c>GetLogger</c> with the same argument aren't guaranteed to return the same logger reference.</returns>
         [CLSCompliant(false)]
-        public static ILogger GetLogger(string name, Type loggerType)
+        public static Logger GetLogger(string name, Type loggerType)
         {
             return globalFactory.GetLogger(name, loggerType);
         }

--- a/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
+++ b/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
@@ -30,16 +30,17 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
-using System;
-using System.IO;
-using NLog.Fluent;
-using Xunit;
 
 namespace NLog.UnitTests.Fluent
 {
+    using System;
+    using System.IO;
+    using Xunit;
+    using NLog.Fluent;
+
     public class LogBuilderTests
     {
-        private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
         [Fact]
         public void TraceWrite()


### PR DESCRIPTION
Revert the various method overloads of GetCurrentClassLogger() and
GetLogger in LogFactory class. Now they return a Logger class instance
instead of the ILogger interface. (Reference: Issue "ILogger interface
added" #375)
