### PR TITLE
LogManager class refactored

### DIFF
--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -31,14 +31,14 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.Globalization;
-using System.Threading;
-
 namespace NLog
 {
     using System;
     using System.Diagnostics;
+    using System.Globalization;
+    using System.Reflection;
     using System.Runtime.CompilerServices;
+    using System.Threading;
     using Internal.Fakeables;
     using NLog.Common;
     using NLog.Config;
@@ -49,14 +49,13 @@ namespace NLog
     /// </summary>
     public sealed class LogManager
     {
-        private static readonly LogFactory globalFactory = new LogFactory();
-        private static IAppDomain _currentAppDomain;
-        private static GetCultureInfo _defaultCultureInfo = () => CultureInfo.CurrentCulture;
+        private static readonly LogFactory factory = new LogFactory();
+        private static IAppDomain currentAppDomain;
+        private static GetCultureInfo defaultCultureInfo = () => CultureInfo.CurrentCulture;
 
         /// <summary>
-        /// Delegate used to the the culture to use.
+        /// Delegate used to set/get the culture in use.
         /// </summary>
-        /// <returns></returns>
         public delegate CultureInfo GetCultureInfo();
 
 #if !SILVERLIGHT && !MONO
@@ -66,19 +65,7 @@ namespace NLog
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline", Justification = "Significant logic in .cctor()")]
         static LogManager()
         {
-            try
-            {
-                SetupTerminationEvents();
-            }
-            catch (Exception exception)
-            {
-                if (exception.MustBeRethrown())
-                {
-                    throw;
-                }
-
-                InternalLogger.Warn("Error setting up termiation events: {0}", exception);
-            }
+            SetupTerminationEvents();            
         }
 #endif
 
@@ -94,8 +81,8 @@ namespace NLog
         /// </summary>
         public static event EventHandler<LoggingConfigurationChangedEventArgs> ConfigurationChanged
         {
-            add { globalFactory.ConfigurationChanged += value; }
-            remove { globalFactory.ConfigurationChanged -= value; }
+            add { factory.ConfigurationChanged += value; }
+            remove { factory.ConfigurationChanged -= value; }
         }
 
 #if !SILVERLIGHT
@@ -104,8 +91,8 @@ namespace NLog
         /// </summary>
         public static event EventHandler<LoggingConfigurationReloadedEventArgs> ConfigurationReloaded
         {
-            add { globalFactory.ConfigurationReloaded += value; }
-            remove { globalFactory.ConfigurationReloaded -= value; }
+            add { factory.ConfigurationReloaded += value; }
+            remove { factory.ConfigurationReloaded -= value; }
         }
 #endif
         /// <summary>
@@ -114,14 +101,14 @@ namespace NLog
         /// </summary>
         public static bool ThrowExceptions
         {
-            get { return globalFactory.ThrowExceptions; }
-            set { globalFactory.ThrowExceptions = value; }
+            get { return factory.ThrowExceptions; }
+            set { factory.ThrowExceptions = value; }
         }
 
         internal static IAppDomain CurrentAppDomain
         {
-            get { return _currentAppDomain ?? (_currentAppDomain = AppDomainWrapper.CurrentDomain); }
-            set { _currentAppDomain = value; }
+            get { return currentAppDomain ?? (currentAppDomain = AppDomainWrapper.CurrentDomain); }
+            set { currentAppDomain = value; }
         }
 
         /// <summary>
@@ -129,8 +116,8 @@ namespace NLog
         /// </summary>
         public static LoggingConfiguration Configuration
         {
-            get { return globalFactory.Configuration; }
-            set { globalFactory.Configuration = value; }
+            get { return factory.Configuration; }
+            set { factory.Configuration = value; }
         }
 
         /// <summary>
@@ -138,8 +125,8 @@ namespace NLog
         /// </summary>
         public static LogLevel GlobalThreshold
         {
-            get { return globalFactory.GlobalThreshold; }
-            set { globalFactory.GlobalThreshold = value; }
+            get { return factory.GlobalThreshold; }
+            set { factory.GlobalThreshold = value; }
         }
 
         /// <summary>
@@ -147,8 +134,8 @@ namespace NLog
         /// </summary>
         public static GetCultureInfo DefaultCultureInfo
         {
-            get { return _defaultCultureInfo; }
-            set { _defaultCultureInfo = value; }
+            get { return defaultCultureInfo; }
+            set { defaultCultureInfo = value; }
         }
 
         /// <summary>
@@ -161,29 +148,7 @@ namespace NLog
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static ILogger GetCurrentClassLogger()
         {
-            string loggerName;
-            Type declaringType;
-            int framesToSkip = 1;
-            do
-            {
-#if SILVERLIGHT
-                StackFrame frame = new StackTrace().GetFrame(framesToSkip);
-#else
-                StackFrame frame = new StackFrame(framesToSkip, false);
-#endif
-                var method = frame.GetMethod();
-                declaringType = method.DeclaringType;
-                if (declaringType == null)
-                {
-                    loggerName = method.Name;
-                    break;
-                }
-
-                framesToSkip++;
-                loggerName = declaringType.FullName;
-            } while (declaringType.Module.Name.Equals("mscorlib.dll", StringComparison.OrdinalIgnoreCase));
-
-            return globalFactory.GetLogger(loggerName);
+            return factory.GetLogger(GetClassFullName());
         }
 
         /// <summary>
@@ -197,20 +162,7 @@ namespace NLog
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static ILogger GetCurrentClassLogger(Type loggerType)
         {
-            Type declaringType;
-            int framesToSkip = 1;
-            do
-            {
-#if SILVERLIGHT
-                StackFrame frame = new StackTrace().GetFrame(framesToSkip);
-#else
-                StackFrame frame = new StackFrame(framesToSkip, false);
-#endif
-                declaringType = frame.GetMethod().DeclaringType;
-                framesToSkip++;
-            } while (declaringType.Module.Name.Equals("mscorlib.dll", StringComparison.OrdinalIgnoreCase));
-            
-            return globalFactory.GetLogger(declaringType.FullName, loggerType);
+            return factory.GetLogger(GetClassFullName(), loggerType);            
         }
 
         /// <summary>
@@ -220,7 +172,7 @@ namespace NLog
         [CLSCompliant(false)]
         public static ILogger CreateNullLogger()
         {
-            return globalFactory.CreateNullLogger();
+            return factory.CreateNullLogger();
         }
 
         /// <summary>
@@ -231,7 +183,7 @@ namespace NLog
         [CLSCompliant(false)]
         public static ILogger GetLogger(string name)
         {
-            return globalFactory.GetLogger(name);
+            return factory.GetLogger(name);
         }
 
         /// <summary>
@@ -243,7 +195,7 @@ namespace NLog
         [CLSCompliant(false)]
         public static ILogger GetLogger(string name, Type loggerType)
         {
-            return globalFactory.GetLogger(name, loggerType);
+            return factory.GetLogger(name, loggerType);
         }
 
         /// <summary>
@@ -253,95 +205,98 @@ namespace NLog
         /// </summary>
         public static void ReconfigExistingLoggers()
         {
-            globalFactory.ReconfigExistingLoggers();
+            factory.ReconfigExistingLoggers();
         }
 
 #if !SILVERLIGHT
-/// <summary>
-/// Flush any pending log messages (in case of asynchronous targets).
-/// </summary>
-public static void Flush()
-{
-    globalFactory.Flush();
-}
-
-/// <summary>
-/// Flush any pending log messages (in case of asynchronous targets).
-/// </summary>
-/// <param name="timeout">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
-public static void Flush(TimeSpan timeout)
-{
-    globalFactory.Flush(timeout);
-}
-
-/// <summary>
-/// Flush any pending log messages (in case of asynchronous targets).
-/// </summary>
-/// <param name="timeoutMilliseconds">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
-public static void Flush(int timeoutMilliseconds)
-{
-    globalFactory.Flush(timeoutMilliseconds);
-}
-#endif
-
-/// <summary>
-/// Flush any pending log messages (in case of asynchronous targets).
-/// </summary>
-/// <param name="asyncContinuation">The asynchronous continuation.</param>
-public static void Flush(AsyncContinuation asyncContinuation)
-{
-    globalFactory.Flush(asyncContinuation);
-}
-
-/// <summary>
-/// Flush any pending log messages (in case of asynchronous targets).
-/// </summary>
-/// <param name="asyncContinuation">The asynchronous continuation.</param>
-/// <param name="timeout">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
-public static void Flush(AsyncContinuation asyncContinuation, TimeSpan timeout)
-{
-    globalFactory.Flush(asyncContinuation, timeout);
-}
-
-/// <summary>
-/// Flush any pending log messages (in case of asynchronous targets).
-/// </summary>
-/// <param name="asyncContinuation">The asynchronous continuation.</param>
-/// <param name="timeoutMilliseconds">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
-public static void Flush(AsyncContinuation asyncContinuation, int timeoutMilliseconds)
-{
-    globalFactory.Flush(asyncContinuation, timeoutMilliseconds);
-}
-
-        /// <summary>Decreases the log enable counter and if it reaches -1 
-        /// the logs are disabled.</summary>
-        /// <remarks>Logging is enabled if the number of <see cref="EnableLogging"/> calls is greater 
-        /// than or equal to <see cref="DisableLogging"/> calls.</remarks>
-        /// <returns>An object that iplements IDisposable whose Dispose() method
-        /// reenables logging. To be used with C# <c>using ()</c> statement.</returns>
-        public static IDisposable DisableLogging()
+        /// <summary>
+        /// Flush any pending log messages (in case of asynchronous targets).
+        /// </summary>
+        public static void Flush()
         {
-            return globalFactory.DisableLogging();
-        }
-
-        /// <summary>Increases the log enable counter and if it reaches 0 the logs are disabled.</summary>
-        /// <remarks>Logging is enabled if the number of <see cref="EnableLogging"/> calls is greater 
-        /// than or equal to <see cref="DisableLogging"/> calls.</remarks>
-        public static void EnableLogging()
-        {
-            globalFactory.EnableLogging();
+            factory.Flush();
         }
 
         /// <summary>
-        /// Returns <see langword="true" /> if logging is currently enabled.
+        /// Flush any pending log messages (in case of asynchronous targets).
         /// </summary>
-        /// <returns>A value of <see langword="true" /> if logging is currently enabled, 
-        /// <see langword="false"/> otherwise.</returns>
+        /// <param name="timeout">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
+        public static void Flush(TimeSpan timeout)
+        {
+            factory.Flush(timeout);
+        }
+
+        /// <summary>
+        /// Flush any pending log messages (in case of asynchronous targets).
+        /// </summary>
+        /// <param name="timeoutMilliseconds">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
+        public static void Flush(int timeoutMilliseconds)
+        {
+            factory.Flush(timeoutMilliseconds);
+        }
+#endif
+
+        /// <summary>
+        /// Flush any pending log messages (in case of asynchronous targets).
+        /// </summary>
+        /// <param name="asyncContinuation">The asynchronous continuation.</param>
+        public static void Flush(AsyncContinuation asyncContinuation)
+        {
+            factory.Flush(asyncContinuation);
+        }
+
+        /// <summary>
+        /// Flush any pending log messages (in case of asynchronous targets).
+        /// </summary>
+        /// <param name="asyncContinuation">The asynchronous continuation.</param>
+        /// <param name="timeout">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
+        public static void Flush(AsyncContinuation asyncContinuation, TimeSpan timeout)
+        {
+            factory.Flush(asyncContinuation, timeout);
+        }
+
+        /// <summary>
+        /// Flush any pending log messages (in case of asynchronous targets).
+        /// </summary>
+        /// <param name="asyncContinuation">The asynchronous continuation.</param>
+        /// <param name="timeoutMilliseconds">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
+        public static void Flush(AsyncContinuation asyncContinuation, int timeoutMilliseconds)
+        {
+            factory.Flush(asyncContinuation, timeoutMilliseconds);
+        }
+
+        /// <summary>
+        /// Decreases the log enable counter and if it reaches -1 the logs are disabled.
+        /// </summary>
         /// <remarks>Logging is enabled if the number of <see cref="EnableLogging"/> calls is greater 
-        /// than or equal to <see cref="DisableLogging"/> calls.</remarks>
+        ///     than or equal to <see cref="DisableLogging"/> calls.</remarks>
+        /// <returns>An object that iplements IDisposable whose Dispose() method reenables logging. 
+        ///     To be used with C# <c>using ()</c> statement.</returns>
+        public static IDisposable DisableLogging()
+        {
+            return factory.DisableLogging();
+        }
+
+        /// <summary>
+        /// Increases the log enable counter and if it reaches 0 the logs are disabled.
+        /// </summary>
+        /// <remarks>Logging is enabled if the number of <see cref="EnableLogging"/> calls is greater 
+        ///     than or equal to <see cref="DisableLogging"/> calls.</remarks>
+        public static void EnableLogging()
+        {
+            factory.EnableLogging();
+        }
+
+        /// <summary>
+        /// Checks if logging is currently enabled.
+        /// </summary>
+        /// <returns><see langword="true" /> if logging is currently enabled, <see langword="false"/> 
+        ///     otherwise.</returns>
+        /// <remarks>Logging is enabled if the number of <see cref="EnableLogging"/> calls is greater 
+        ///     than or equal to <see cref="DisableLogging"/> calls.</remarks>
         public static bool IsLoggingEnabled()
         {
-            return globalFactory.IsLoggingEnabled();
+            return factory.IsLoggingEnabled();
         }
 
         /// <summary>
@@ -355,17 +310,61 @@ public static void Flush(AsyncContinuation asyncContinuation, int timeoutMillise
             }
         }
 
+        /// <summary>
+        /// Gets the fully qualified name of the class invoking the LogManager, including the 
+        /// namespace but not the assembly.    
+        /// </summary>
+        private static string GetClassFullName()
+        {
+            string className;
+            Type declaringType;
+            int framesToSkip = 2;
+
+            do
+            {
+#if SILVERLIGHT
+                StackFrame frame = new StackTrace().GetFrame(framesToSkip);
+#else
+                StackFrame frame = new StackFrame(framesToSkip, false);
+#endif
+                MethodBase method = frame.GetMethod();
+                declaringType = method.DeclaringType;
+                if (declaringType == null)
+                {
+                    className = method.Name;
+                    break;
+                }
+
+                framesToSkip++;
+                className = declaringType.FullName;
+            } while (declaringType.Module.Name.Equals("mscorlib.dll", StringComparison.OrdinalIgnoreCase));
+
+            return className;
+        }
+
 #if !SILVERLIGHT && !MONO
         private static void SetupTerminationEvents()
         {
-            CurrentAppDomain.ProcessExit += TurnOffLogging;
-            CurrentAppDomain.DomainUnload += TurnOffLogging;
+            try
+            {
+                CurrentAppDomain.ProcessExit += TurnOffLogging;
+                CurrentAppDomain.DomainUnload += TurnOffLogging;
+            }
+            catch (Exception exception)
+            {
+                if (exception.MustBeRethrown())
+                {
+                    throw;
+                }
+
+                InternalLogger.Warn("Error setting up termination events: {0}", exception);
+            }            
         }
 
         private static void TurnOffLogging(object sender, EventArgs args)
         {
-            // reset logging configuration to null
-            // this causes old configuration (if any) to be closed.
+            // Reset logging configuration to null; this causes old configuration (if any) to be 
+            // closed.
             InternalLogger.Info("Shutting down logging...");
             Configuration = null;
             InternalLogger.Info("Logger has been shut down.");


### PR DESCRIPTION
In LogManager class
- New method GetClassFullName() created from the common code extracted from GetCurrentClassLogger() and GetCurrentClassLogger(Type) methods. 
- Try Catch block moved from LogManager static constructor into SetupTerminationEvents() method. 
- Comments and code reformatted.

**Note:** The string GetClassFullName() method in LogManager class should be tested in SilverLight.
