### PR TITLE
LogFactory Class Refactored

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -273,6 +273,11 @@ namespace NLog.Config
 
         internal void Dump()
         {
+            if (!InternalLogger.IsDebugEnabled)
+            {
+                return;
+            }
+
             InternalLogger.Debug("--- NLog configuration dump. ---");
             InternalLogger.Debug("Targets:");
             foreach (Target target in this.targets.Values)

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -31,8 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.Linq;
-
 namespace NLog
 {
     using System;
@@ -40,14 +38,16 @@ namespace NLog
     using System.Diagnostics;
     using System.Globalization;
     using System.IO;
+    using System.Linq;
     using System.Runtime.CompilerServices;
     using System.Text;
     using System.Threading;
-    using Internal.Fakeables;
+
     using NLog.Common;
     using NLog.Config;
     using NLog.Internal;
     using NLog.Targets;
+    using NLog.Internal.Fakeables;
 
 #if SILVERLIGHT
     using System.Windows;
@@ -59,56 +59,22 @@ namespace NLog
     public class LogFactory : IDisposable
     {
 #if !SILVERLIGHT
-        private readonly MultiFileWatcher watcher;
         private const int ReconfigAfterFileChangedTimeout = 1000;
-#endif
-
-        private static IAppDomain currentAppDomain;
-        private readonly Dictionary<LoggerCacheKey, WeakReference> loggerCache = new Dictionary<LoggerCacheKey, WeakReference>();
 
         private static TimeSpan defaultFlushTimeout = TimeSpan.FromSeconds(15);
-
-#if !SILVERLIGHT
         private Timer reloadTimer;
-#endif
-
-        private LoggingConfiguration config;
-        private LogLevel globalThreshold = LogLevel.MinLevel;
+        private readonly MultiFileWatcher watcher;                
+#endif        
+        private static IAppDomain currentAppDomain;
+        private LogLevel globalThreshold = LogLevel.MinLevel;        
+        
         private bool configLoaded;
+        private LoggingConfiguration config;
+
+        private readonly LoggerCache loggerCache = new LoggerCache();
+
+		// TODO: logsEnabled property can be encaspulated into LogFactory.LogsEnabler class. 
         private int logsEnabled;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LogFactory" /> class.
-        /// </summary>
-        public LogFactory()
-        {
-#if !SILVERLIGHT
-            this.watcher = new MultiFileWatcher();
-            this.watcher.OnChange += this.ConfigFileChanged;
-#endif
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LogFactory" /> class.
-        /// </summary>
-        /// <param name="config">The config.</param>
-        public LogFactory(LoggingConfiguration config)
-            : this()
-        {
-            this.Configuration = config;
-        }
-
-        /// <summary>
-        /// Occurs when logging <see cref="Configuration" /> changes.
-        /// </summary>
-        public event EventHandler<LoggingConfigurationChangedEventArgs> ConfigurationChanged;
-
-#if !SILVERLIGHT
-        /// <summary>
-        /// Occurs when logging <see cref="Configuration" /> gets reloaded.
-        /// </summary>
-        public event EventHandler<LoggingConfigurationReloadedEventArgs> ConfigurationReloaded;
-#endif
 
         /// <summary>
         /// Gets the current <see cref="IAppDomain"/>.
@@ -122,10 +88,8 @@ namespace NLog
         /// <summary>
         /// Gets or sets a value indicating whether exceptions should be thrown.
         /// </summary>
-        /// <value>A value of <c>true</c> if exceptiosn should be thrown; otherwise, <c>false</c>.</value>
-        /// <remarks>By default exceptions
-        /// are not thrown under any circumstances.
-        /// </remarks>
+        /// <value><c>True</c> if an exception should be thrown; <c>false</c> otherwise.</value>
+        /// <remarks>By default exceptions are not thrown under any circumstances.</remarks>
         public bool ThrowExceptions { get; set; }
 
         /// <summary>
@@ -147,45 +111,36 @@ namespace NLog
 #if !SILVERLIGHT
                     if (this.config == null)
                     {
-                        // try to load default configuration
+                        // Try to load default configuration.
                         this.config = XmlLoggingConfiguration.AppConfig;
                     }
 #endif
-
+                    // Retest the condition as we might have loaded a config.
                     if (this.config == null)
                     {
-                        foreach (string configFile in GetCandidateFileNames())
+                        foreach (string configFile in GetCandidateConfigFileNames())
                         {
-#if !SILVERLIGHT && !MONO
-                            if (File.Exists(configFile))
-                            {
-                                InternalLogger.Debug("Attempting to load config from {0}", configFile);
-                                this.config = new XmlLoggingConfiguration(configFile);
-                                break;
-                            }
-#elif SILVERLIGHT
+#if SILVERLIGHT
                             Uri configFileUri = new Uri(configFile, UriKind.Relative);
                             if (Application.GetResourceStream(configFileUri) != null)
                             {
-                                InternalLogger.Debug("Attempting to load config from {0}", configFile);
-                                this.config = new XmlLoggingConfiguration(configFile);
+                                LoadLoggingConfiguration(configFile);
                                 break;
                             }
 #else
                             if (File.Exists(configFile))
                             {
-                                InternalLogger.Debug("Attempting to load config from {0}", configFile);
-                                this.config = new XmlLoggingConfiguration(configFile);
+                                LoadLoggingConfiguration(configFile);                                
                                 break;
                             }
 #endif
                         }
                     }
 
-#if !SILVERLIGHT
                     if (this.config != null)
                     {
-                        Dump(this.config);
+#if !SILVERLIGHT
+                        config.Dump();
                         try
                         {
                             this.watcher.Watch(this.config.FileNamesToWatch);
@@ -194,10 +149,7 @@ namespace NLog
                         {
                             InternalLogger.Warn("Cannot start file watching: {0}. File watching is disabled", exception);
                         }
-                    }
 #endif
-                    if (this.config != null)
-                    {
                         this.config.InitializeAll();
                     }
 
@@ -240,10 +192,10 @@ namespace NLog
 
                     if (this.config != null)
                     {
-                        Dump(this.config);
-
+                        config.Dump();
+                        
                         this.config.InitializeAll();
-                        this.ReconfigExistingLoggers(this.config);
+                        this.ReconfigExistingLoggers();
 #if !SILVERLIGHT
                         try
                         {
@@ -261,12 +213,7 @@ namespace NLog
 #endif
                     }
 
-                    var configurationChangedDelegate = this.ConfigurationChanged;
-
-                    if (configurationChangedDelegate != null)
-                    {
-                        configurationChangedDelegate(this, new LoggingConfigurationChangedEventArgs(oldConfig, value));
-                    }
+                    this.OnConfigurationChanged(new LoggingConfigurationChangedEventArgs(value, oldConfig));
                 }
             }
         }
@@ -292,7 +239,41 @@ namespace NLog
         }
 
         /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// Occurs when logging <see cref="Configuration" /> changes.
+        /// </summary>
+        public event EventHandler<LoggingConfigurationChangedEventArgs> ConfigurationChanged;
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// Occurs when logging <see cref="Configuration" /> gets reloaded.
+        /// </summary>
+        public event EventHandler<LoggingConfigurationReloadedEventArgs> ConfigurationReloaded;
+#endif
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogFactory" /> class.
+        /// </summary>
+        public LogFactory()
+        {
+#if !SILVERLIGHT
+            this.watcher = new MultiFileWatcher();
+            this.watcher.OnChange += this.ConfigFileChanged;
+#endif
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogFactory" /> class.
+        /// </summary>
+        /// <param name="config">The config.</param>
+        public LogFactory(LoggingConfiguration config)
+            : this()
+        {
+            this.Configuration = config;
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting 
+        /// unmanaged resources.
         /// </summary>
         public void Dispose()
         {
@@ -304,7 +285,6 @@ namespace NLog
         /// Creates a logger that discards all log messages.
         /// </summary>
         /// <returns>Null logger instance.</returns>
-        [CLSCompliant(false)]
         public Logger CreateNullLogger()
         {
             TargetWithFilterChain[] targetsByLevel = new TargetWithFilterChain[LogLevel.MaxLevel.Ordinal + 1];
@@ -319,7 +299,6 @@ namespace NLog
         /// <returns>The logger.</returns>
         /// <remarks>This is a slow-running method. 
         /// Make sure you're not doing this in a loop.</remarks>
-        [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public Logger GetCurrentClassLogger()
         {
@@ -335,11 +314,11 @@ namespace NLog
         /// <summary>
         /// Gets the logger named after the currently-being-initialized class.
         /// </summary>
-        /// <param name="loggerType">The type of the logger to create. The type must inherit from NLog.Logger.</param>
+        /// <param name="loggerType">The type of the logger to create. The type must inherit from 
+        /// NLog.Logger.</param>
         /// <returns>The logger.</returns>
-        /// <remarks>This is a slow-running method. 
-        /// Make sure you're not doing this in a loop.</remarks>
-        [CLSCompliant(false)]
+        /// <remarks>This is a slow-running method. Make sure you are not calling this method in a 
+        /// loop.</remarks>
         [MethodImpl(MethodImplOptions.NoInlining)]
         public Logger GetCurrentClassLogger(Type loggerType)
         {
@@ -356,11 +335,11 @@ namespace NLog
         /// Gets the specified named logger.
         /// </summary>
         /// <param name="name">Name of the logger.</param>
-        /// <returns>The logger reference. Multiple calls to <c>GetLogger</c> with the same argument aren't guaranteed to return the same logger reference.</returns>
-        [CLSCompliant(false)]
+        /// <returns>The logger reference. Multiple calls to <c>GetLogger</c> with the same argument 
+        /// are not guaranteed to return the same logger reference.</returns>
         public Logger GetLogger(string name)
         {
-            return this.GetLogger(new LoggerCacheKey(typeof(ILogger), name));
+            return this.GetLogger(new LoggerCacheKey(name, typeof(Logger)));
         }
 
         /// <summary>
@@ -370,20 +349,27 @@ namespace NLog
         /// <param name="loggerType">The type of the logger to create. The type must inherit from NLog.Logger.</param>
         /// <returns>The logger reference. Multiple calls to <c>GetLogger</c> with the 
         /// same argument aren't guaranteed to return the same logger reference.</returns>
-        [CLSCompliant(false)]
         public Logger GetLogger(string name, Type loggerType)
         {
-            return this.GetLogger(new LoggerCacheKey(loggerType, name));
+            return this.GetLogger(new LoggerCacheKey(name, loggerType));
         }
 
         /// <summary>
-        /// Loops through all loggers previously returned by GetLogger
-        /// and recalculates their target and filter list. Useful after modifying the configuration programmatically
+        /// Loops through all loggers previously returned by GetLogger and recalculates their 
+        /// target and filter list. Useful after modifying the configuration programmatically
         /// to ensure that all loggers have been properly configured.
         /// </summary>
         public void ReconfigExistingLoggers()
         {
-            this.ReconfigExistingLoggers(this.config);
+            if (this.config != null)
+            {
+                this.config.InitializeAll();
+            }
+
+            foreach (var logger in loggerCache.Loggers)
+            {
+                logger.SetConfiguration(this.GetConfigurationForLogger(logger.Name, this.config));
+            }            
         }
 
 #if !SILVERLIGHT
@@ -398,7 +384,8 @@ namespace NLog
         /// <summary>
         /// Flush any pending log messages (in case of asynchronous targets).
         /// </summary>
-        /// <param name="timeout">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
+        /// <param name="timeout">Maximum time to allow for the flush. Any messages after that time 
+        /// will be discarded.</param>
         public void Flush(TimeSpan timeout)
         {
             try
@@ -419,7 +406,8 @@ namespace NLog
         /// <summary>
         /// Flush any pending log messages (in case of asynchronous targets).
         /// </summary>
-        /// <param name="timeoutMilliseconds">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
+        /// <param name="timeoutMilliseconds">Maximum time to allow for the flush. Any messages 
+        /// after that time will be discarded.</param>
         public void Flush(int timeoutMilliseconds)
         {
             this.Flush(TimeSpan.FromMilliseconds(timeoutMilliseconds));
@@ -439,7 +427,8 @@ namespace NLog
         /// Flush any pending log messages (in case of asynchronous targets).
         /// </summary>
         /// <param name="asyncContinuation">The asynchronous continuation.</param>
-        /// <param name="timeoutMilliseconds">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
+        /// <param name="timeoutMilliseconds">Maximum time to allow for the flush. Any messages 
+        /// after that time will be discarded.</param>
         public void Flush(AsyncContinuation asyncContinuation, int timeoutMilliseconds)
         {
             this.Flush(asyncContinuation, TimeSpan.FromMilliseconds(timeoutMilliseconds));
@@ -478,13 +467,43 @@ namespace NLog
             }
         }
 
-        /// <summary>Decreases the log enable counter and if it reaches -1 
-        /// the logs are disabled.</summary>
-        /// <remarks>Logging is enabled if the number of <see cref="EnableLogging"/> calls is greater 
-        /// than or equal to <see cref="DisableLogging"/> calls.</remarks>
-        /// <returns>An object that iplements IDisposable whose Dispose() method
-        /// reenables logging. To be used with C# <c>using ()</c> statement.</returns>
+        /// <summary>
+        /// Decreases the log enable counter and if it reaches -1 the logs are disabled.
+        /// </summary>
+        /// <remarks>
+        /// Logging is enabled if the number of <see cref="ResumeLogging"/> calls is greater than 
+        /// or equal to <see cref="SuspendLogging"/> calls.
+        /// </remarks>
+        /// <returns>An object that iplements IDisposable whose Dispose() method re-enables logging. 
+        /// To be used with C# <c>using ()</c> statement.</returns>
+        [Obsolete("Use SuspendLogging() instead.")]
         public IDisposable DisableLogging()
+        {
+            return SuspendLogging();
+        }
+
+        /// <summary>
+        /// Increases the log enable counter and if it reaches 0 the logs are disabled.
+        /// </summary>
+        /// <remarks>
+        /// Logging is enabled if the number of <see cref="ResumeLogging"/> calls is greater than 
+        /// or equal to <see cref="SuspendLogging"/> calls.</remarks>
+        [Obsolete("Use ResumeLogging() instead.")]
+        public void EnableLogging()
+        {
+            ResumeLogging();
+        }
+
+        /// <summary>
+        /// Decreases the log enable counter and if it reaches -1 the logs are disabled.
+        /// </summary>
+        /// <remarks>
+        /// Logging is enabled if the number of <see cref="ResumeLogging"/> calls is greater than 
+        /// or equal to <see cref="SuspendLogging"/> calls.
+        /// </remarks>
+        /// <returns>An object that iplements IDisposable whose Dispose() method re-enables logging. 
+        /// To be used with C# <c>using ()</c> statement.</returns>
+        public IDisposable SuspendLogging()
         {
             lock (this)
             {
@@ -498,10 +517,12 @@ namespace NLog
             return new LogEnabler(this);
         }
 
-        /// <summary>Increases the log enable counter and if it reaches 0 the logs are disabled.</summary>
-        /// <remarks>Logging is enabled if the number of <see cref="EnableLogging"/> calls is greater 
-        /// than or equal to <see cref="DisableLogging"/> calls.</remarks>
-        public void EnableLogging()
+        /// <summary>
+        /// Increases the log enable counter and if it reaches 0 the logs are disabled.
+        /// </summary>
+        /// <remarks>Logging is enabled if the number of <see cref="ResumeLogging"/> calls is greater 
+        /// than or equal to <see cref="SuspendLogging"/> calls.</remarks>
+        public void ResumeLogging()
         {
             lock (this)
             {
@@ -518,11 +539,24 @@ namespace NLog
         /// </summary>
         /// <returns>A value of <see langword="true" /> if logging is currently enabled, 
         /// <see langword="false"/> otherwise.</returns>
-        /// <remarks>Logging is enabled if the number of <see cref="EnableLogging"/> calls is greater 
-        /// than or equal to <see cref="DisableLogging"/> calls.</remarks>
+        /// <remarks>Logging is enabled if the number of <see cref="ResumeLogging"/> calls is greater 
+        /// than or equal to <see cref="SuspendLogging"/> calls.</remarks>
         public bool IsLoggingEnabled()
         {
             return this.logsEnabled >= 0;
+        }
+
+        /// <summary>
+        /// Invoke the Changed event; called whenever list changes
+        /// </summary>
+        /// <param name="e">Event arguements.</param>
+        protected virtual void OnConfigurationChanged(LoggingConfigurationChangedEventArgs e)
+        {
+            var changed = this.ConfigurationChanged;
+            if (changed != null)
+            {
+                changed(this, e);
+            }
         }
 
 #if !SILVERLIGHT
@@ -578,26 +612,8 @@ namespace NLog
                 }
             }
         }
-#endif
-
-        internal void ReconfigExistingLoggers(LoggingConfiguration configuration)
-        {
-            if (configuration != null)
-            {
-                configuration.EnsureInitialized();
-            }
-
-            foreach (var loggerWrapper in this.loggerCache.Values.ToList())
-            {
-                Logger logger = loggerWrapper.Target as Logger;
-                if (logger != null)
-                {
-                    logger.SetConfiguration(this.GetConfigurationForLogger(logger.Name, configuration));
-                }
-            }
-        }
-
-        internal void GetTargetsByLevelForLogger(string name, IList<LoggingRule> rules, TargetWithFilterChain[] targetsByLevel, TargetWithFilterChain[] lastTargetsByLevel)
+#endif        
+        private void GetTargetsByLevelForLogger(string name, IEnumerable<LoggingRule> rules, TargetWithFilterChain[] targetsByLevel, TargetWithFilterChain[] lastTargetsByLevel)
         {
             foreach (LoggingRule rule in rules)
             {
@@ -629,6 +645,7 @@ namespace NLog
                     }
                 }
 
+                // Recursively analyse the child rules.
                 this.GetTargetsByLevelForLogger(name, rule.ChildRules, targetsByLevel, lastTargetsByLevel);
 
                 if (rule.Final)
@@ -680,12 +697,13 @@ namespace NLog
         /// <summary>
         /// Releases unmanaged and - optionally - managed resources.
         /// </summary>
-        /// <param name="disposing">True to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        /// <param name="disposing"><c>True</c> to release both managed and unmanaged resources;
+        /// <c>false</c> to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
+#if !SILVERLIGHT
             if (disposing)
             {
-#if !SILVERLIGHT
                 this.watcher.Dispose();
 
                 if (this.reloadTimer != null)
@@ -693,11 +711,11 @@ namespace NLog
                     this.reloadTimer.Dispose();
                     this.reloadTimer = null;
                 }
-#endif
             }
+#endif
         }
 
-        private static IEnumerable<string> GetCandidateFileNames()
+        private static IEnumerable<string> GetCandidateConfigFileNames()
         {
 #if SILVERLIGHT
             yield return "NLog.config";
@@ -708,7 +726,7 @@ namespace NLog
                 yield return Path.Combine(CurrentAppDomain.BaseDirectory, "NLog.config");
             }
  
-            // current config file with .config renamed to .nlog
+            // Current config file with .config renamed to .nlog
             string cf = CurrentAppDomain.ConfigurationFile;
             if (cf != null)
             {
@@ -726,7 +744,7 @@ namespace NLog
                 }
             }
 
-            // get path to NLog.dll.nlog only if the assembly is not in the GAC
+            // Get path to NLog.dll.nlog only if the assembly is not in the GAC
             var nlogAssembly = typeof(LogFactory).Assembly;
             if (!nlogAssembly.GlobalAssemblyCache)
             {
@@ -738,61 +756,39 @@ namespace NLog
 #endif
         }
 
-        private static void Dump(LoggingConfiguration config)
-        {
-            if (!InternalLogger.IsDebugEnabled)
-            {
-                return;
-            }
-
-            config.Dump();
-        }
-
         private Logger GetLogger(LoggerCacheKey cacheKey)
         {
             lock (this)
             {
-                WeakReference l;
-
-                if (this.loggerCache.TryGetValue(cacheKey, out l))
+                Logger existngLogger = loggerCache.Retrieve(cacheKey);
+                if (existngLogger != null) 
                 {
-                    Logger existingLogger = l.Target as Logger;
-                    if (existingLogger != null)
-                    {
-                        // logger in the cache and still referenced
-                        return existingLogger;
-                    }
+                    // Logger is still in cache and referenced.
+                    return existngLogger;
                 }
 
                 Logger newLogger;
 
-                if (cacheKey.ConcreteType != null && cacheKey.ConcreteType != typeof(ILogger))
-                {
-                    
+                if (cacheKey.ConcreteType != null && cacheKey.ConcreteType != typeof(Logger))
+                {                    
                     try
                     {
-                        newLogger = (Logger)FactoryHelper.CreateInstance(cacheKey.ConcreteType);
+                        newLogger = (Logger) FactoryHelper.CreateInstance(cacheKey.ConcreteType);
                     }
                     catch(Exception exception)
                     {
-                        if(exception.MustBeRethrown())
+                        if(exception.MustBeRethrown() || ThrowExceptions)
                         {
                             throw;
                         }
                         
-                        if(ThrowExceptions)
-                        {
-                            throw;
-                        }
+                        InternalLogger.Error("Cannot create instance of specified type. Proceeding with default type instance. Exception : {0}", exception);
                         
-                        InternalLogger.Error("Cannot create instance of specified type. Proceeding with default type instance. Exception : {0}",exception);
-                        
-                        //Creating default instance of logger if instance of specified type cannot be created.
-                        cacheKey = new LoggerCacheKey(typeof(Logger),cacheKey.Name);
+                        // Creating default instance of logger if instance of specified type cannot be created.
+                        cacheKey = new LoggerCacheKey(cacheKey.Name, typeof(Logger));
                         
                         newLogger = new Logger();
-                    }
-                    
+                    }                    
                 }
                 else
                 {
@@ -804,7 +800,12 @@ namespace NLog
                     newLogger.Initialize(cacheKey.Name, this.GetConfigurationForLogger(cacheKey.Name, this.Configuration), this);
                 }
 
-                this.loggerCache[cacheKey] = new WeakReference(newLogger);
+                // TODO: Clarify what is the intention when cacheKey.ConcreteType = null.
+                //      At the moment, a logger typeof(Logger) will be created but the ConcreteType 
+                //      will remain null and inserted into the cache. 
+                //      Should we set cacheKey.ConcreteType = typeof(Logger) for default loggers?
+
+                loggerCache.InsertOrUpdate(cacheKey, newLogger);
                 return newLogger;
             }
         }
@@ -812,7 +813,7 @@ namespace NLog
 #if !SILVERLIGHT
         private void ConfigFileChanged(object sender, EventArgs args)
         {
-            InternalLogger.Info("Configuration file change detected! Reloading in {0}ms...", ReconfigAfterFileChangedTimeout);
+            InternalLogger.Info("Configuration file change detected! Reloading in {0}ms...", LogFactory.ReconfigAfterFileChangedTimeout);
 
             // In the rare cases we may get multiple notifications here, 
             // but we need to reload config only once.
@@ -824,33 +825,41 @@ namespace NLog
                 if (this.reloadTimer == null)
                 {
                     this.reloadTimer = new Timer(
-                        this.ReloadConfigOnTimer,
-                        this.Configuration,
-                        ReconfigAfterFileChangedTimeout,
-                        Timeout.Infinite);
+                            this.ReloadConfigOnTimer,
+                            this.Configuration,
+                            LogFactory.ReconfigAfterFileChangedTimeout,
+                            Timeout.Infinite);
                 }
                 else
                 {
-                    this.reloadTimer.Change(ReconfigAfterFileChangedTimeout, Timeout.Infinite);
+                    this.reloadTimer.Change(
+                            LogFactory.ReconfigAfterFileChangedTimeout, 
+                            Timeout.Infinite);
                 }
             }
         }
 #endif
 
+        private void LoadLoggingConfiguration(string configFile)
+        {
+            InternalLogger.Debug("Loading config from {0}", configFile);
+            this.config = new XmlLoggingConfiguration(configFile);
+        }
+
         /// <summary>
         /// Logger cache key.
         /// </summary>
-        internal class LoggerCacheKey
+        private class LoggerCacheKey : IEquatable<LoggerCacheKey>
         {
-            internal LoggerCacheKey(Type loggerConcreteType, string name)
+            public string Name { get; private set; }
+
+            public Type ConcreteType { get; private set; }
+
+            public LoggerCacheKey(string name, Type concreteType)
             {
-                this.ConcreteType = loggerConcreteType;
                 this.Name = name;
+                this.ConcreteType = concreteType;
             }
-
-            internal Type ConcreteType { get; private set; }
-
-            internal string Name { get; private set; }
 
             /// <summary>
             /// Serves as a hash function for a particular type.
@@ -866,17 +875,86 @@ namespace NLog
             /// <summary>
             /// Determines if two objects are equal in value.
             /// </summary>
-            /// <param name="o">Other object to compare to.</param>
+            /// <param name="obj">Other object to compare to.</param>
             /// <returns>True if objects are equal, false otherwise.</returns>
-            public override bool Equals(object o)
+            public override bool Equals(object obj)
             {
-                var key = o as LoggerCacheKey;
+                LoggerCacheKey key = obj as LoggerCacheKey;
                 if (ReferenceEquals(key, null))
                 {
                     return false;
                 }
 
                 return (this.ConcreteType == key.ConcreteType) && (key.Name == this.Name);
+            }
+
+            /// <summary>
+            /// Determines if two objects of the same type are equal in value.
+            /// </summary>
+            /// <param name="key">Other object to compare to.</param>
+            /// <returns>True if objects are equal, false otherwise.</returns>
+            public bool Equals(LoggerCacheKey key)
+            {
+                if (ReferenceEquals(key, null))
+                {
+                    return false;
+                }
+
+                return (this.ConcreteType == key.ConcreteType) && (key.Name == this.Name);
+            }
+        }
+        
+        /// <summary>
+        /// Logger cache.
+        /// </summary>
+        private class LoggerCache
+        {
+            // The values of WeakReferences are of type Logger i.e. Directory<LoggerCacheKey, Logger>.
+            private readonly Dictionary<LoggerCacheKey, WeakReference> loggerCache =
+                    new Dictionary<LoggerCacheKey, WeakReference>();
+
+            /// <summary>
+            /// Inserts or updates. 
+            /// </summary>
+            /// <param name="cacheKey"></param>
+            /// <param name="logger"></param>
+            public void InsertOrUpdate(LoggerCacheKey cacheKey, Logger logger)
+            {
+                loggerCache[cacheKey] = new WeakReference(logger);
+            }
+
+            public Logger Retrieve(LoggerCacheKey cacheKey)
+            {
+                WeakReference loggerReference;
+                if (loggerCache.TryGetValue(cacheKey, out loggerReference))
+                {
+                    // logger in the cache and still referenced
+                    return loggerReference.Target as Logger;
+                }
+
+                return null;
+            }
+
+            public IEnumerable<Logger> Loggers
+            {
+                get { return GetLoggers(); }
+            }
+
+            private IEnumerable<Logger> GetLoggers()
+            {
+                // TODO: Test if loggerCache.Values.ToList<Logger>() can be used for the conversion instead.
+                List<Logger> values = new List<Logger>(loggerCache.Count);
+
+                foreach (WeakReference loggerReference in loggerCache.Values)
+                {
+                    Logger logger = loggerReference.Target as Logger;
+                    if (logger != null)
+                    {
+                        values.Add(logger);
+                    }
+                }
+
+                return values;
             }
         }
 
@@ -901,7 +979,7 @@ namespace NLog
             /// </summary>
             void IDisposable.Dispose()
             {
-                this.factory.EnableLogging();
+                this.factory.ResumeLogging();
             }
         }
     }

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -274,7 +274,7 @@ namespace NLog
         ///     To be used with C# <c>using ()</c> statement.</returns>
         public static IDisposable DisableLogging()
         {
-            return factory.DisableLogging();
+            return factory.SuspendLogging();
         }
 
         /// <summary>
@@ -284,7 +284,7 @@ namespace NLog
         ///     than or equal to <see cref="DisableLogging"/> calls.</remarks>
         public static void EnableLogging()
         {
-            factory.EnableLogging();
+            factory.ResumeLogging();
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/GetLoggerTests.cs
+++ b/tests/NLog.UnitTests/GetLoggerTests.cs
@@ -52,8 +52,8 @@ namespace NLog.UnitTests
 
             MyLogger l1 = (MyLogger)lf.GetLogger("AAA", typeof(MyLogger));
             MyLogger l2 = (MyLogger)lf.GetLogger("AAA", typeof(MyLogger));
-            ILogger l3 = lf.GetLogger("AAA", typeof(ILogger));
-            ILogger l4 = lf.GetLogger("AAA", typeof(ILogger));
+            ILogger l3 = lf.GetLogger("AAA", typeof(Logger));
+            ILogger l4 = lf.GetLogger("AAA", typeof(Logger));
             ILogger l5 = lf.GetLogger("AAA");
             ILogger l6 = lf.GetLogger("AAA");
 
@@ -75,8 +75,8 @@ namespace NLog.UnitTests
 
             MyLogger l1 = (MyLogger)lf.GetCurrentClassLogger(typeof(MyLogger));
             MyLogger l2 = (MyLogger)lf.GetCurrentClassLogger(typeof(MyLogger));
-            ILogger l3 = lf.GetCurrentClassLogger(typeof(ILogger));
-            ILogger l4 = lf.GetCurrentClassLogger(typeof(ILogger));
+            ILogger l3 = lf.GetCurrentClassLogger(typeof(Logger));
+            ILogger l4 = lf.GetCurrentClassLogger(typeof(Logger));
             ILogger l5 = lf.GetCurrentClassLogger();
             ILogger l6 = lf.GetCurrentClassLogger();
 
@@ -135,7 +135,7 @@ namespace NLog.UnitTests
                 LogManager.ThrowExceptions = false;
                 LogManager.GetCurrentClassLogger(typeof(InvalidLogger));
             }
-            catch(Exception )
+            catch (NLogConfigurationException)
             {
                 ExceptionThrown = true;
             }
@@ -151,7 +151,7 @@ namespace NLog.UnitTests
                 LogManager.ThrowExceptions = true;
                 LogManager.GetCurrentClassLogger(typeof(InvalidLogger));
             }
-            catch(Exception)
+            catch (NLogConfigurationException)
             {
                 ExceptionThrown = true;
             }


### PR DESCRIPTION
* New inner class LoggerCache added. It encapsulates the operations
around Dictionary loggerCache
* The LoggerCacheKey class now implements the IEquatable. This can
potentially help performance in cases it is invoked
* Removed ReconfigExistingLoggers(LoggingConfiguration) internal method.
ReconfigExistingLoggers(LoggingConfiguration) was merged into
ReconfigExistingLoggers() public method. This is because the internal
one was always invoked with parameter value of this.config
* Renamed DisableLogging() and EnableLogging() methods in LogManager
class to SuspendLogging() and ResumeLogging() respectively. This will
align the naming with Microsoft conventions (see Control.ResumeLayout
method). The DisableLogging() and EnableLogging() were marked as
obsolete.
* Remove CLSCompliant(false) attribute from various methods as it is not
required.
* Comments and code reformatted.
* [Fix] Narrowed the captured exceptions within
InvalidLoggerConfiguration tests in UnitTests\GetLoggerTests class.

[**Note**] The name changes on DisableLogging() and EnableLogging()
methods affect the public interface.