### PR TITLE
LogLevel Implements IEquatable<LogLevel>

### DIFF
--- a/src/NLog/LogLevel.cs
+++ b/src/NLog/LogLevel.cs
@@ -39,7 +39,7 @@ namespace NLog
     /// <summary>
     /// Defines available log levels.
     /// </summary>
-    public sealed class LogLevel : IComparable
+    public sealed class LogLevel : IComparable, IEquatable<LogLevel>
     {
         /// <summary>
         /// Trace log level.
@@ -85,10 +85,6 @@ namespace NLog
 
         private readonly int ordinal;
         private readonly string name;
-
-        private LogLevel()
-        {
-        }
 
         /// <summary>
         /// Initializes a new instance of <see cref="LogLevel"/>.
@@ -340,12 +336,8 @@ namespace NLog
         /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
         /// </summary>
         /// <param name="obj">The <see cref="System.Object"/> to compare with this instance.</param>
-        /// <returns>
-        /// Value of <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
-        /// </returns>
-        /// <exception cref="T:System.NullReferenceException">
-        /// The <paramref name="obj"/> parameter is null.
-        /// </exception>
+        /// <returns>Value of <c>true</c> if the specified <see cref="System.Object"/> is equal to 
+        /// this instance; otherwise, <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
             LogLevel other = obj as LogLevel;
@@ -355,6 +347,17 @@ namespace NLog
             }
 
             return this.Ordinal == other.Ordinal;
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="NLog.LogLevel"/> instance is equal to this instance.
+        /// </summary>
+        /// <param name="other">The <see cref="NLog.LogLevel"/> to compare with this instance.</param>
+        /// <returns>Value of <c>true</c> if the specified <see cref="NLog.LogLevel"/> is equal to 
+        /// this instance; otherwise, <c>false</c>.</returns>
+        public bool Equals(LogLevel other)
+        {
+            return other == null ? false : this.Ordinal == other.Ordinal;
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/LogLevelTests.cs
+++ b/tests/NLog.UnitTests/LogLevelTests.cs
@@ -270,8 +270,51 @@ namespace NLog.UnitTests
         [Fact]
         [Trait("Component", "Core")]
         public void LogLevelEquals_Null_ExpectFalse()
-        { 
+        {
             Assert.False(LogLevel.Debug.Equals(null));
+
+            LogLevel logLevel = null;
+            Assert.False(LogLevel.Debug.Equals(logLevel));
+
+            Object obj = logLevel;
+            Assert.False(LogLevel.Debug.Equals(obj));
+        }
+
+        [Fact]
+        public void LogLevelEqual_TypeOfObject()
+        {
+            // Objects of any other type should always return false.
+            Assert.False(LogLevel.Debug.Equals((int) 1));
+            Assert.False(LogLevel.Debug.Equals((string)"Debug"));
+
+            // Valid LogLevel objects boxed as Object type.
+            Object levelTrace = LogLevel.Trace;
+            Object levelDebug = LogLevel.Debug;
+            Object levelInfo = LogLevel.Info;
+            Object levelWarn = LogLevel.Warn;
+            Object levelError = LogLevel.Error;
+            Object levelFatal = LogLevel.Fatal;
+            Object levelOff = LogLevel.Off;
+
+            Assert.False(LogLevel.Warn.Equals(levelTrace));
+            Assert.False(LogLevel.Warn.Equals(levelDebug));
+            Assert.False(LogLevel.Warn.Equals(levelInfo));
+            Assert.True(LogLevel.Warn.Equals(levelWarn));
+            Assert.False(LogLevel.Warn.Equals(levelError));
+            Assert.False(LogLevel.Warn.Equals(levelFatal));
+            Assert.False(LogLevel.Warn.Equals(levelOff));
+        }
+
+        [Fact]
+        public void LogLevelEqual_TypeOfLogLevel()
+        {
+            Assert.False(LogLevel.Warn.Equals(LogLevel.Trace));
+            Assert.False(LogLevel.Warn.Equals(LogLevel.Debug));
+            Assert.False(LogLevel.Warn.Equals(LogLevel.Info));
+            Assert.True(LogLevel.Warn.Equals(LogLevel.Warn));
+            Assert.False(LogLevel.Warn.Equals(LogLevel.Error));
+            Assert.False(LogLevel.Warn.Equals(LogLevel.Fatal));
+            Assert.False(LogLevel.Warn.Equals(LogLevel.Off));
         }
     }
 }


### PR DESCRIPTION
* LogLevel class now implements IEquatable<LogLevel>. This can
potentially help slightly the performance is certain cases as no object
boxing is required.
* Private default constructor was removed as it was obsolete.
* Unit tests added to cover Equals(Object) and Equals(LogLevel) methods.