### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+; Top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+
+; 4-column space indentation
+[*.cs]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This allows developers who install the editor config vs extension:
https://visualstudiogallery.msdn.microsoft.com/c8bccfe2-650c-4b42-bc5c-845e21f96328

To automagically switch their tab/newline settings to match NLog's when opening the NLog project/solution