### PR TITLE
LogFactory Class Refactored

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -273,6 +273,11 @@ namespace NLog.Config
 
         internal void Dump()
         {
+            if (!InternalLogger.IsDebugEnabled)
+            {
+                return;
+            }
+
             InternalLogger.Debug("--- NLog configuration dump. ---");
             InternalLogger.Debug("Targets:");
             foreach (Target target in this.targets.Values)

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -35,10 +35,10 @@ namespace NLog
 {
     using System;
     using System.Diagnostics;
-using System.Globalization;
+    using System.Globalization;
     using System.Reflection;
-using System.Threading;
     using System.Runtime.CompilerServices;
+    using System.Threading;
     using Internal.Fakeables;
     using NLog.Common;
     using NLog.Config;
@@ -246,23 +246,23 @@ using System.Threading;
             factory.Flush();
         }
 
-/// <summary>
-/// Flush any pending log messages (in case of asynchronous targets).
-/// </summary>
-/// <param name="timeout">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
-public static void Flush(TimeSpan timeout)
-{
-    factory.Flush(timeout);
-}
+        /// <summary>
+        /// Flush any pending log messages (in case of asynchronous targets).
+        /// </summary>
+        /// <param name="timeout">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
+        public static void Flush(TimeSpan timeout)
+        {
+            factory.Flush(timeout);
+        }
 
-/// <summary>
-/// Flush any pending log messages (in case of asynchronous targets).
-/// </summary>
-/// <param name="timeoutMilliseconds">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
-public static void Flush(int timeoutMilliseconds)
-{
-    factory.Flush(timeoutMilliseconds);
-}
+        /// <summary>
+        /// Flush any pending log messages (in case of asynchronous targets).
+        /// </summary>
+        /// <param name="timeoutMilliseconds">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
+        public static void Flush(int timeoutMilliseconds)
+        {
+            factory.Flush(timeoutMilliseconds);
+        }
 #endif
 
         /// <summary>
@@ -274,25 +274,25 @@ public static void Flush(int timeoutMilliseconds)
             factory.Flush(asyncContinuation);
         }
 
-/// <summary>
-/// Flush any pending log messages (in case of asynchronous targets).
-/// </summary>
-/// <param name="asyncContinuation">The asynchronous continuation.</param>
-/// <param name="timeout">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
-public static void Flush(AsyncContinuation asyncContinuation, TimeSpan timeout)
-{
-    factory.Flush(asyncContinuation, timeout);
-}
+        /// <summary>
+        /// Flush any pending log messages (in case of asynchronous targets).
+        /// </summary>
+        /// <param name="asyncContinuation">The asynchronous continuation.</param>
+        /// <param name="timeout">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
+        public static void Flush(AsyncContinuation asyncContinuation, TimeSpan timeout)
+        {
+            factory.Flush(asyncContinuation, timeout);
+        }
 
-/// <summary>
-/// Flush any pending log messages (in case of asynchronous targets).
-/// </summary>
-/// <param name="asyncContinuation">The asynchronous continuation.</param>
-/// <param name="timeoutMilliseconds">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
-public static void Flush(AsyncContinuation asyncContinuation, int timeoutMilliseconds)
-{
-    factory.Flush(asyncContinuation, timeoutMilliseconds);
-}
+        /// <summary>
+        /// Flush any pending log messages (in case of asynchronous targets).
+        /// </summary>
+        /// <param name="asyncContinuation">The asynchronous continuation.</param>
+        /// <param name="timeoutMilliseconds">Maximum time to allow for the flush. Any messages after that time will be discarded.</param>
+        public static void Flush(AsyncContinuation asyncContinuation, int timeoutMilliseconds)
+        {
+            factory.Flush(asyncContinuation, timeoutMilliseconds);
+        }
 
         /// <summary>
         /// Decreases the log enable counter and if it reaches -1 the logs are disabled.
@@ -303,7 +303,7 @@ public static void Flush(AsyncContinuation asyncContinuation, int timeoutMillise
         ///     To be used with C# <c>using ()</c> statement.</returns>
         public static IDisposable DisableLogging()
         {
-            return factory.DisableLogging();
+            return factory.SuspendLogging();
         }
 
         /// <summary>
@@ -313,7 +313,7 @@ public static void Flush(AsyncContinuation asyncContinuation, int timeoutMillise
         ///     than or equal to <see cref="DisableLogging"/> calls.</remarks>
         public static void EnableLogging()
         {
-            factory.EnableLogging();
+            factory.ResumeLogging();
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/GetLoggerTests.cs
+++ b/tests/NLog.UnitTests/GetLoggerTests.cs
@@ -52,8 +52,8 @@ namespace NLog.UnitTests
 
             MyLogger l1 = (MyLogger)lf.GetLogger("AAA", typeof(MyLogger));
             MyLogger l2 = (MyLogger)lf.GetLogger("AAA", typeof(MyLogger));
-            ILogger l3 = lf.GetLogger("AAA", typeof(ILogger));
-            ILogger l4 = lf.GetLogger("AAA", typeof(ILogger));
+            ILogger l3 = lf.GetLogger("AAA", typeof(Logger));
+            ILogger l4 = lf.GetLogger("AAA", typeof(Logger));
             ILogger l5 = lf.GetLogger("AAA");
             ILogger l6 = lf.GetLogger("AAA");
 
@@ -75,8 +75,8 @@ namespace NLog.UnitTests
 
             MyLogger l1 = (MyLogger)lf.GetCurrentClassLogger(typeof(MyLogger));
             MyLogger l2 = (MyLogger)lf.GetCurrentClassLogger(typeof(MyLogger));
-            ILogger l3 = lf.GetCurrentClassLogger(typeof(ILogger));
-            ILogger l4 = lf.GetCurrentClassLogger(typeof(ILogger));
+            ILogger l3 = lf.GetCurrentClassLogger(typeof(Logger));
+            ILogger l4 = lf.GetCurrentClassLogger(typeof(Logger));
             ILogger l5 = lf.GetCurrentClassLogger();
             ILogger l6 = lf.GetCurrentClassLogger();
 
@@ -135,7 +135,7 @@ namespace NLog.UnitTests
                 LogManager.ThrowExceptions = false;
                 LogManager.GetCurrentClassLogger(typeof(InvalidLogger));
             }
-            catch(Exception )
+            catch (NLogConfigurationException)
             {
                 ExceptionThrown = true;
             }
@@ -151,7 +151,7 @@ namespace NLog.UnitTests
                 LogManager.ThrowExceptions = true;
                 LogManager.GetCurrentClassLogger(typeof(InvalidLogger));
             }
-            catch(Exception)
+            catch (NLogConfigurationException)
             {
                 ExceptionThrown = true;
             }


### PR DESCRIPTION
* New inner class LoggerCache added which encapsulates the operations
related to Dictionary loggerCache.
* The LoggerCacheKey class now implements the IEquatable. This can
potentially improve performance in certain cases.
* ReconfigExistingLoggers(LoggingConfiguration) internal method was
merged into ReconfigExistingLoggers() public method as it was always
invoked with the same parameter value of this.config
* Renamed DisableLogging() and EnableLogging() methods in LogManager
class to SuspendLogging() and ResumeLogging() respectively. This will
align the naming with Microsoft conventions (see Control.ResumeLayout
method). The DisableLogging() and EnableLogging() were marked as
obsolete.
* Remove CLSCompliant(false) attribute from various methods as it is not
required.
* Comments and code reformatted.
* [Fix] Narrowed the captured exceptions within
InvalidLoggerConfiguration tests in UnitTests\GetLoggerTests class.

[**Note**] The name changes on DisableLogging() and EnableLogging() methods
affect the public interface.