### PR TITLE
Added UTC options to ArchiveEvery.

### DIFF
--- a/src/NLog/Targets/FileArchivePeriod.cs
+++ b/src/NLog/Targets/FileArchivePeriod.cs
@@ -66,6 +66,31 @@ namespace NLog.Targets
         /// <summary>
         /// Archive every minute.
         /// </summary>
-        Minute
+        Minute,
+
+        /// <summary>
+        /// Archive every UTC year.
+        /// </summary>
+        UTCYear,
+
+        /// <summary>
+        /// Archive every UTC month.
+        /// </summary>
+        UTCMonth,
+
+        /// <summary>
+        /// Archive UTC daily.
+        /// </summary>
+        UTCDay,
+
+        /// <summary>
+        /// Archive every UTC hour.
+        /// </summary>
+        UTCHour,
+
+        /// <summary>
+        /// Archive every UTC minute.
+        /// </summary>
+        UTCMinute
     }
 }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1024,10 +1024,12 @@ namespace NLog.Targets
                 switch (this.ArchiveEvery)
                 {
                     case FileArchivePeriod.Year:
+                    case FileArchivePeriod.UTCYear:
                         formatString = "yyyy";
                         break;
 
                     case FileArchivePeriod.Month:
+                    case FileArchivePeriod.UTCMonth:
                         formatString = "yyyyMM";
                         break;
 
@@ -1036,10 +1038,12 @@ namespace NLog.Targets
                         break;
 
                     case FileArchivePeriod.Hour:
+                    case FileArchivePeriod.UTCHour:
                         formatString = "yyyyMMddHH";
                         break;
 
                     case FileArchivePeriod.Minute:
+                    case FileArchivePeriod.UTCMinute:
                         formatString = "yyyyMMddHHmm";
                         break;
                 }
@@ -1050,28 +1054,37 @@ namespace NLog.Targets
         private DateTime GetArchiveDate()
         {
             DateTime archiveDate = DateTime.Now;
+            if (this.ArchiveEvery >= FileArchivePeriod.UTCYear)
+            {
+                archiveDate = DateTime.UtcNow;
+            }
 
             // Because AutoArchive/DateArchive gets called after the FileArchivePeriod condition matches, decrement the archive period by 1
             // (i.e. If ArchiveEvery = Day, the file will be archived with yesterdays date)
             switch (this.ArchiveEvery)
             {
                 case FileArchivePeriod.Day:
+                case FileArchivePeriod.UTCDay:
                     archiveDate = archiveDate.AddDays(-1);
                     break;
 
                 case FileArchivePeriod.Hour:
+                case FileArchivePeriod.UTCHour:
                     archiveDate = archiveDate.AddHours(-1);
                     break;
 
                 case FileArchivePeriod.Minute:
+                case FileArchivePeriod.UTCMinute:
                     archiveDate = archiveDate.AddMinutes(-1);
                     break;
 
                 case FileArchivePeriod.Month:
+                case FileArchivePeriod.UTCMonth:
                     archiveDate = archiveDate.AddMonths(-1);
                     break;
 
                 case FileArchivePeriod.Year:
+                case FileArchivePeriod.UTCYear:
                     archiveDate = archiveDate.AddYears(-1);
                     break;
             }


### PR DESCRIPTION
Added support for archiving on UTC time, currently NLog lets you use UTC date and times in log entries but archiving files operates in whatever time zone the system is set to. By amending additional UTC versions to the end of the archive periods this should be a backwards compatible fix for adding UTC support to creating archives.   

Added UTCYear, UTCMonth, UTCDay, UTCHour, UTCMinute to the FileArchivePeriod enum.
In  FileTargetcs added check for UTC version of the enums and if so DateTime.UTCNow is used. Added UTC versions of the enum to the switch statements that get the date and formatted date string.