### PR TITLE
Fix #492: RichTextBox target breaks row coloring

### DIFF
--- a/src/NLog/Targets/RichTextBoxTarget.cs
+++ b/src/NLog/Targets/RichTextBoxTarget.cs
@@ -355,7 +355,7 @@ namespace NLog.Targets
                 {
                     rtbx.SelectionStart = 0;
                     rtbx.SelectionLength = rtbx.GetFirstCharIndexFromLine(1);
-                    rtbx.Text = rtbx.Text.Remove(rtbx.SelectionStart, rtbx.SelectionLength);
+                    rtbx.SelectedRtf = "{\\rtf1\\ansi}";
                     this.lineCount--;
                 }
             }


### PR DESCRIPTION
Fix #492: RichTextBox target breaks row coloring when using MaxLines.
Using method decribed in "How can I programmatically remove text from a
ReadOnly RichTextBox?"
http://stackoverflow.com/questions/13318238/