### PR TITLE
Fluent API uses the same time source for timestamping as the Logger.

### DIFF
--- a/src/NLog/Fluent/LogBuilder.cs
+++ b/src/NLog/Fluent/LogBuilder.cs
@@ -33,6 +33,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using NLog.Time;
 
 namespace NLog.Fluent
 {
@@ -70,7 +71,7 @@ namespace NLog.Fluent
             {
                 Level = logLevel,
                 LoggerName = logger.Name,
-                TimeStamp = DateTime.Now
+                TimeStamp = TimeSource.Current.Time
             };
         }
 


### PR DESCRIPTION
When new `LogEventInfo` is created by the `Logger` it uses `TimeSource.Current.Time` value as it's timestamp.
The `LogBuilder` does the same now.