### PR TITLE
Fluent API available for ILogger interface

### DIFF
--- a/src/NLog/Fluent/Log.cs
+++ b/src/NLog/Fluent/Log.cs
@@ -42,7 +42,7 @@ namespace NLog.Fluent
     /// </summary>
     public static class Log
     {
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+        private static readonly ILogger _logger = LogManager.GetCurrentClassLogger();
 
         /// <summary>
         /// Starts building a log event with the specified <see cref="LogLevel" />.

--- a/src/NLog/Fluent/LogBuilder.cs
+++ b/src/NLog/Fluent/LogBuilder.cs
@@ -43,13 +43,14 @@ namespace NLog.Fluent
     public class LogBuilder
     {
         private readonly LogEventInfo _logEvent;
-        private readonly Logger _logger;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LogBuilder"/> class.
         /// </summary>
         /// <param name="logger">The <see cref="Logger"/> to send the log event.</param>
-        public LogBuilder(Logger logger)
+        [CLSCompliant(false)]
+        public LogBuilder(ILogger logger)
             : this(logger, LogLevel.Debug)
         {
         }
@@ -59,7 +60,8 @@ namespace NLog.Fluent
         /// </summary>
         /// <param name="logger">The <see cref="Logger"/> to send the log event.</param>
         /// <param name="logLevel">The <see cref="LogLevel"/> for the log event.</param>
-        public LogBuilder(Logger logger, LogLevel logLevel)
+        [CLSCompliant(false)]
+        public LogBuilder(ILogger logger, LogLevel logLevel)
         {
             if (logger == null)
                 throw new ArgumentNullException("logger");

--- a/src/NLog/Fluent/LoggerExtensions.cs
+++ b/src/NLog/Fluent/LoggerExtensions.cs
@@ -45,7 +45,8 @@ namespace NLog.Fluent
         /// <param name="logger">The logger to write the log event to.</param>
         /// <param name="logLevel">The log level.</param>
         /// <returns></returns>
-        public static LogBuilder Log(this Logger logger, LogLevel logLevel)
+        [CLSCompliant(false)]
+        public static LogBuilder Log(this ILogger logger, LogLevel logLevel)
         {
             var builder = new LogBuilder(logger, logLevel);
             return builder;
@@ -56,7 +57,8 @@ namespace NLog.Fluent
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
         /// <returns></returns>
-        public static LogBuilder Trace(this Logger logger)
+        [CLSCompliant(false)]
+        public static LogBuilder Trace(this ILogger logger)
         {
             var builder = new LogBuilder(logger, LogLevel.Trace);
             return builder;
@@ -67,7 +69,8 @@ namespace NLog.Fluent
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
         /// <returns></returns>
-        public static LogBuilder Debug(this Logger logger)
+        [CLSCompliant(false)]
+        public static LogBuilder Debug(this ILogger logger)
         {
             var builder = new LogBuilder(logger, LogLevel.Debug);
             return builder;
@@ -78,7 +81,8 @@ namespace NLog.Fluent
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
         /// <returns></returns>
-        public static LogBuilder Info(this Logger logger)
+        [CLSCompliant(false)]
+        public static LogBuilder Info(this ILogger logger)
         {
             var builder = new LogBuilder(logger, LogLevel.Info);
             return builder;
@@ -89,7 +93,8 @@ namespace NLog.Fluent
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
         /// <returns></returns>
-        public static LogBuilder Warn(this Logger logger)
+        [CLSCompliant(false)]
+        public static LogBuilder Warn(this ILogger logger)
         {
             var builder = new LogBuilder(logger, LogLevel.Warn);
             return builder;
@@ -100,7 +105,8 @@ namespace NLog.Fluent
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
         /// <returns></returns>
-        public static LogBuilder Error(this Logger logger)
+        [CLSCompliant(false)]
+        public static LogBuilder Error(this ILogger logger)
         {
             var builder = new LogBuilder(logger, LogLevel.Error);
             return builder;
@@ -111,7 +117,8 @@ namespace NLog.Fluent
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
         /// <returns></returns>
-        public static LogBuilder Fatal(this Logger logger)
+        [CLSCompliant(false)]
+        public static LogBuilder Fatal(this ILogger logger)
         {
             var builder = new LogBuilder(logger, LogLevel.Fatal);
             return builder;

--- a/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
+++ b/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
@@ -40,7 +40,7 @@ namespace NLog.UnitTests.Fluent
 
     public class LogBuilderTests
     {
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+        private static readonly ILogger _logger = LogManager.GetCurrentClassLogger();
 
         [Fact]
         public void TraceWrite()


### PR DESCRIPTION
Now fluent API extension methods can be applied to the `ILogger` interface.

I have to attribute every method receiving `ILogger` paramater with CLSCompliant(false), because the `ILogger` itself is marked as non-CLSCompliant.