### PR TITLE
Auto load extensions to allow easier integration with extensions

### DIFF
--- a/src/InstallNLogConfig/InstallNLogConfig.netfx35.csproj
+++ b/src/InstallNLogConfig/InstallNLogConfig.netfx35.csproj
@@ -71,9 +71,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\NLog\NLog.netfx35.csproj">
-      <Project>{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}</Project>
-      <Name>NLog.netfx40</Name>
+    <ProjectReference Include="..\NLog\NLog.netfx35.csproj">
+      <Project>{C124B63D-1658-4311-9BA8-9C3CFAF9B32E}</Project>
+      <Name>NLog.netfx35</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NLog.netfx35.sln
+++ b/src/NLog.netfx35.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7638C35C-A8AC-437C-94FD-9DABD9D5839C}"
 	ProjectSection(SolutionItems) = preProject
@@ -19,6 +19,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InstallNLogConfig.netfx35", "InstallNLogConfig\InstallNLogConfig.netfx35.csproj", "{0CF95BE4-0546-4CE9-AB49-B9E4DA59AEAA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.Extended.netfx35", "NLog.Extended\NLog.Extended.netfx35.csproj", "{F801A1F9-1024-4446-BF9E-A923137340B8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLogAutoLoadExtension.netfx35", "NLogAutoLoadExtension\NLogAutoLoadExtension.netfx35.csproj", "{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -90,6 +92,16 @@ Global
 		{F801A1F9-1024-4446-BF9E-A923137340B8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{F801A1F9-1024-4446-BF9E-A923137340B8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{F801A1F9-1024-4446-BF9E-A923137340B8}.Release|x86.ActiveCfg = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NLog.netfx40.sln
+++ b/src/NLog.netfx40.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7638C35C-A8AC-437C-94FD-9DABD9D5839C}"
 	ProjectSection(SolutionItems) = preProject
@@ -25,10 +25,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{A2DA21
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLogAutoLoadExtension.netfx40", "NLogAutoLoadExtension\NLogAutoLoadExtension.netfx40.csproj", "{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}"
+EndProject
 Global
-	GlobalSection(CodealikeProperties) = postSolution
-		SolutionGuid = 93c37543-86b0-4a4b-a98f-94ed9590add7
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms
@@ -88,9 +87,22 @@ Global
 		{A961A1F9-1024-4446-BF9E-A923137340B8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{A961A1F9-1024-4446-BF9E-A923137340B8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{A961A1F9-1024-4446-BF9E-A923137340B8}.Release|x86.ActiveCfg = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(CodealikeProperties) = postSolution
+		SolutionGuid = 93c37543-86b0-4a4b-a98f-94ed9590add7
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = NLog.netfx40.vsmdi

--- a/src/NLog.netfx45.sln
+++ b/src/NLog.netfx45.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7638C35C-A8AC-437C-94FD-9DABD9D5839C}"
 	ProjectSection(SolutionItems) = preProject
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{A2DA21
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLogAutoLoadExtension.netfx45", "NLogAutoLoadExtension\NLogAutoLoadExtension.netfx45.csproj", "{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -85,6 +87,16 @@ Global
 		{A961A1F9-1024-4446-BF9E-A923137340B8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{A961A1F9-1024-4446-BF9E-A923137340B8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{A961A1F9-1024-4446-BF9E-A923137340B8}.Release|x86.ActiveCfg = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.IO;
+using System.Linq;
 using NLog.Common;
 
 namespace NLog.Config
@@ -229,8 +231,29 @@ namespace NLog.Config
         /// <returns>Default factory.</returns>
         private static ConfigurationItemFactory BuildDefaultFactory()
         {
-            var factory = new ConfigurationItemFactory(typeof(ILogger).Assembly);
+            var nlogAssembly = typeof(ILogger).Assembly;
+            var factory = new ConfigurationItemFactory(nlogAssembly);
             factory.RegisterExtendedItems();
+#if !SILVERLIGHT
+            var assemblyLocation = Path.GetDirectoryName(nlogAssembly.Location);
+            if (assemblyLocation == null)
+            {
+                return factory;
+            }
+
+            var extensionDlls = Directory.GetFiles(assemblyLocation, "NLog*.dll")
+                .Select(Path.GetFileName)
+                .Where(x => !x.Equals("NLog.dll", StringComparison.OrdinalIgnoreCase))
+                .Where(x => !x.Equals("NLog.UnitTests.dll", StringComparison.OrdinalIgnoreCase))
+                .Where(x => !x.Equals("NLog.Extended.dll", StringComparison.OrdinalIgnoreCase))
+                .Select(x => Path.Combine(assemblyLocation, x));
+            foreach (var extensionDll in extensionDlls)
+            {
+                InternalLogger.Info("Auto loading assembly file: {0}", extensionDll);
+                var extensionAssembly = Assembly.LoadFrom(extensionDll);
+                factory.RegisterItemsFromAssembly(extensionAssembly);
+            }
+#endif
 
             return factory;
         }

--- a/src/NLogAutoLoadExtension/AutoLoadTarget.cs
+++ b/src/NLogAutoLoadExtension/AutoLoadTarget.cs
@@ -1,0 +1,47 @@
+﻿// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using NLog;
+using NLog.Targets;
+
+namespace NLogAutloadExtension
+{
+    [Target("AutoLoadTarget")]
+    public class AutoLoadTarget : Target
+    {
+        protected override void Write(LogEventInfo logEvent)
+        {
+            // do nothing
+        }
+    }
+}

--- a/src/NLogAutoLoadExtension/NLogAutoLoadExtension.netfx35.csproj
+++ b/src/NLogAutoLoadExtension/NLogAutoLoadExtension.netfx35.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NLogAutloadExtension</RootNamespace>
+    <AssemblyName>NLogAutloadExtension</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AutoLoadTarget.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NLog\NLog.netfx35.csproj">
+      <Project>{c124b63d-1658-4311-9ba8-9c3cfaf9b32e}</Project>
+      <Name>NLog.netfx35</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NLogAutoLoadExtension/NLogAutoLoadExtension.netfx40.csproj
+++ b/src/NLogAutoLoadExtension/NLogAutoLoadExtension.netfx40.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NLogAutloadExtension</RootNamespace>
+    <AssemblyName>NLogAutloadExtension</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AutoLoadTarget.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NLog\NLog.netfx40.csproj">
+      <Project>{a0bff0db-ed9a-4639-ae86-8e709a1efc66}</Project>
+      <Name>NLog.netfx40</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NLogAutoLoadExtension/NLogAutoLoadExtension.netfx45.csproj
+++ b/src/NLogAutoLoadExtension/NLogAutoLoadExtension.netfx45.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0AA8FB16-A377-4541-BEF6-81D437D7B5E9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NLogAutloadExtension</RootNamespace>
+    <AssemblyName>NLogAutloadExtension</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AutoLoadTarget.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NLog\NLog.netfx45.csproj">
+      <Project>{a0bff0db-ed9a-4639-ae86-8e709a1efc66}</Project>
+      <Name>NLog.netfx45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NLogAutoLoadExtension/Properties/AssemblyInfo.cs
+++ b/src/NLogAutoLoadExtension/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NLogAutloadExtension")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("NLogAutloadExtension")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("919e2993-46d1-41d2-9acf-60a151ea2719")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -245,5 +245,24 @@ namespace NLog.UnitTests.Config
             var d1Target = (DebugTarget)configuration.FindTargetByName("d");
             Assert.NotNull(d1Target);
         }
+
+        [Fact]
+        public void Extension_should_be_auto_loaded_when_following_NLog_dll_format()
+        {
+            var configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+    <targets>
+        <target name='t' type='AutoLoadTarget' />
+    </targets>
+
+    <rules>
+      <logger name='*' writeTo='t'>
+      </logger>
+    </rules>
+</nlog>");
+
+            var autoLoadedTarget = configuration.FindTargetByName("t");
+            Assert.Equal("NLogAutloadExtension.AutoLoadTarget", autoLoadedTarget.GetType().FullName);
+        }
     }
 }

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)'==''">v4.0</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -19,8 +21,10 @@
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <SignAssembly>true</SignAssembly>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <FileUpgradeFlags></FileUpgradeFlags>
-    <UpgradeBackupLocation></UpgradeBackupLocation>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -224,6 +228,10 @@
     <ProjectReference Include="..\..\src\NLog.Extended\NLog.Extended.netfx35.csproj">
       <Project>{F801A1F9-1024-4446-BF9E-A923137340B8}</Project>
       <Name>NLog.Extended.netfx35</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\NLogAutoLoadExtension\NLogAutoLoadExtension.netfx35.csproj">
+      <Project>{0aa8fb16-a377-4541-bef6-81d437d7b5e9}</Project>
+      <Name>NLogAutloadExtension.netfx35</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\NLog\NLog.netfx35.csproj">
       <Project>{C124B63D-1658-4311-9BA8-9C3CFAF9B32E}</Project>

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -10,8 +10,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -205,6 +207,10 @@
     <ProjectReference Include="..\..\src\NLog.Extended\NLog.Extended.netfx40.csproj">
       <Project>{A961A1F9-1024-4446-BF9E-A923137340B8}</Project>
       <Name>NLog.Extended.netfx40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\NLogAutoLoadExtension\NLogAutoLoadExtension.netfx40.csproj">
+      <Project>{0aa8fb16-a377-4541-bef6-81d437d7b5e9}</Project>
+      <Name>NLogAutoLoadExtension.netfx40</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\NLog\NLog.netfx40.csproj">
       <Project>{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}</Project>

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -209,6 +211,10 @@
     <ProjectReference Include="..\..\src\NLog.Extended\NLog.Extended.netfx45.csproj">
       <Project>{A961A1F9-1024-4446-BF9E-A923137340B8}</Project>
       <Name>NLog.Extended.netfx45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\NLogAutoLoadExtension\NLogAutoLoadExtension.netfx45.csproj">
+      <Project>{0aa8fb16-a377-4541-bef6-81d437d7b5e9}</Project>
+      <Name>NLogAutoLoadExtension.netfx45</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\NLog\NLog.netfx45.csproj">
       <Project>{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}</Project>


### PR DESCRIPTION
Because we have started moving a lot of targets into separate repositories and assemblies, I think it would be nice to allow using extensions more easily.
Auto loading assemblies following the naming format, NLog*.dll, could be a way. This is almost the same solution, used to load NLog.Extended automatically.
Please comment on this solution, this is not necessarily the final solution, or the solution at all.