### PR TITLE
Archive file zip compression

### DIFF
--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -57,7 +57,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Messaging" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -55,6 +56,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Messaging" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -878,10 +878,15 @@ namespace NLog.Targets
 #if NET4_5
             if (enableCompression)
             {
-                using (var stream = new FileStream(archiveFileName, FileMode.Create))
-                using (var archive = new ZipArchive(stream, ZipArchiveMode.Create))
+                using (var archiveStream = new FileStream(archiveFileName, FileMode.Create))
+                using (var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create))
+                using (var originalFileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
                 {
-                    archive.CreateEntryFromFile(fileName, Path.GetFileName(fileName));
+                    var zipArchiveEntry = archive.CreateEntry(Path.GetFileName(fileName));
+                    using (var destination = zipArchiveEntry.Open())
+                    {
+                        originalFileStream.CopyTo(destination);
+                    }
                 }
 
                 File.Delete(fileName);

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -38,7 +38,8 @@ namespace NLog.Targets
     using System.ComponentModel;
     using System.Globalization;
     using System.IO;
-using System.Linq;
+    using System.IO.Compression;
+    using System.Linq;
     using System.Text;
     using System.Threading;
     using Common;
@@ -215,8 +216,8 @@ using System.Linq;
             set
             {
                 this.lineEndingMode = value;
-                }
             }
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether to automatically flush the file buffers after each log message.
@@ -387,14 +388,26 @@ using System.Linq;
         /// <docgen category='Archival Options' order='10' />
         public ArchiveNumberingMode ArchiveNumbering { get; set; }
 
+#if NET4_5
+        /// <summary>
+        /// Gets or sets a value indicating whether to compress archive files into the zip archive format.
+        /// </summary>
+        /// <docgen category='Archival Options' order='10' />
+        [DefaultValue(false)]
+        public bool EnableArchiveFileCompression { get; set; }
+#else
+        private const bool EnableArchiveFileCompression = false;
+#endif
+
         /// <summary>
         /// Gets the characters that are appended after each line.
         /// </summary>
-        protected internal string NewLineChars { 
-            get 
-            { 
-                return lineEndingMode.NewLineCharacters; 
-            } 
+        protected internal string NewLineChars
+        {
+            get
+            {
+                return lineEndingMode.NewLineCharacters;
+            }
         }
 
         /// <summary>
@@ -777,9 +790,10 @@ using System.Linq;
 
             InternalLogger.Trace("Renaming {0} to {1}", fileName, newFileName);
 
+            var shouldCompress = archiveNumber == 0;
             try
             {
-                RollArchiveForward(fileName, newFileName);
+                RollArchiveForward(fileName, newFileName, shouldCompress);
             }
             catch (IOException)
             {
@@ -790,16 +804,16 @@ using System.Linq;
                     Directory.CreateDirectory(dir);
                 }
 
-                RollArchiveForward(fileName, newFileName);
+                RollArchiveForward(fileName, newFileName, shouldCompress);
             }
         }
 
         private void SequentialArchive(string fileName, string pattern)
         {
             FileNameTemplate fileTemplate = new FileNameTemplate(Path.GetFileName(pattern));
-            int trailerLength = fileTemplate.Template.Length - fileTemplate.EndAt; 
+            int trailerLength = fileTemplate.Template.Length - fileTemplate.EndAt;
             string fileNameMask = fileTemplate.ReplacePattern("*");
-            
+
             string dirName = Path.GetDirectoryName(Path.GetFullPath(pattern));
             int nextNumber = -1;
             int minNumber = -1;
@@ -856,12 +870,32 @@ using System.Linq;
             }
 
             string newFileName = ReplaceNumberPattern(pattern, nextNumber);
-            RollArchiveForward(fileName, newFileName);
+            RollArchiveForward(fileName, newFileName, shouldCompress: true);
         }
 
-        private void RollArchiveForward(string existingFileName, string archiveFileName)
+        private static void ArchiveFile(string fileName, string archiveFileName, bool enableCompression)
         {
-            File.Move(existingFileName, archiveFileName);
+#if NET4_5
+            if (enableCompression)
+            {
+                using (var stream = new FileStream(archiveFileName, FileMode.Create))
+                using (var archive = new ZipArchive(stream, ZipArchiveMode.Create))
+                {
+                    archive.CreateEntryFromFile(fileName, Path.GetFileName(fileName));
+                }
+
+                File.Delete(fileName);
+            }
+            else
+#endif
+            {
+                File.Move(fileName, archiveFileName);
+            }
+        }
+
+        private void RollArchiveForward(string existingFileName, string archiveFileName, bool shouldCompress)
+        {
+            ArchiveFile(existingFileName, archiveFileName, shouldCompress && EnableArchiveFileCompression);
 
             string fileName = Path.GetFileName(existingFileName);
             if (fileName == null) { return; }
@@ -987,7 +1021,7 @@ using System.Linq;
             string newFileName = Path.Combine(dirName,
                 fileNameMask.Replace("*", string.Format("{0}.{1}", newFileDate.ToString(dateFormat), nextSequenceNumber)));
 
-            RollArchiveForward(fileName, newFileName);
+            RollArchiveForward(fileName, newFileName, shouldCompress: true);
         }
 
         private string ReplaceReplaceFileNamePattern(string pattern, string replacementValue)
@@ -1024,14 +1058,14 @@ using System.Linq;
 
                 if (this.MaxArchiveFiles != 0)
                 {
-                for (int fileIndex = 0; fileIndex < filesByDate.Count; fileIndex++)
-                {
-                    if (fileIndex > files.Count - this.MaxArchiveFiles)
-                        break;
+                    for (int fileIndex = 0; fileIndex < filesByDate.Count; fileIndex++)
+                    {
+                        if (fileIndex > files.Count - this.MaxArchiveFiles)
+                            break;
 
-                    File.Delete(filesByDate[fileIndex]);
+                        File.Delete(filesByDate[fileIndex]);
+                    }
                 }
-            }
             }
             catch (DirectoryNotFoundException)
             {
@@ -1040,7 +1074,7 @@ using System.Linq;
 
             DateTime newFileDate = GetArchiveDate(true);
             string newFileName = Path.Combine(dirName, fileNameMask.Replace("*", newFileDate.ToString(dateFormat)));
-            RollArchiveForward(fileName, newFileName);
+            RollArchiveForward(fileName, newFileName, shouldCompress: true);
         }
 #endif
 
@@ -1137,12 +1171,12 @@ using System.Linq;
 
             if (!ContainFileNamePattern(fileNamePattern))
             {
-                if (fileArchive.Archive(fileNamePattern, fi.FullName, CreateDirs))
+                if (fileArchive.Archive(fileNamePattern, fi.FullName, CreateDirs, EnableArchiveFileCompression))
                 {
                     if (this.initializedFiles.ContainsKey(fi.FullName))
                     {
                         this.initializedFiles.Remove(fi.FullName);
-            }
+                    }
                 }
             }
             else
@@ -1379,7 +1413,7 @@ using System.Linq;
             }
 
             return appenderToWrite;
-                    }
+        }
 
         private byte[] GetHeaderBytes()
         {
@@ -1393,7 +1427,7 @@ using System.Linq;
 
             string renderedText = this.Header.Render(LogEventInfo.CreateNullEvent()) + this.NewLineChars;
             return this.TransformBytes(this.Encoding.GetBytes(renderedText));
-            */ 
+            */
         }
 
         private byte[] GetFooterBytes()
@@ -1407,7 +1441,7 @@ using System.Linq;
 
             string renderedText = this.Footer.Render(LogEventInfo.CreateNullEvent()) + this.NewLineChars;
             return this.TransformBytes(this.Encoding.GetBytes(renderedText));
-            */ 
+            */
         }
 
         private void WriteToFile(string fileName, byte[] bytes, bool justData)
@@ -1617,28 +1651,30 @@ using System.Linq;
             fileName1 = Path.GetInvalidFileNameChars().Aggregate(fileName1, (current, c) => current.Replace(c, '_'));
             return Path.Combine(dirName, fileName1);
         }
-        #endif
+#endif
 
-                private class DynamicFileArchive
-                {
+        private class DynamicFileArchive
+        {
             public bool CreateDirectory { get; set; }
 
             public int MaxArchiveFileToKeep { get; set; }
 
-            public DynamicFileArchive(int maxArchivedFiles) : this()
+            public DynamicFileArchive(int maxArchivedFiles)
+                : this()
             {
                 this.MaxArchiveFileToKeep = maxArchivedFiles;
             }
- 
+
             /// <summary>
             /// Adds a file into archive.
             /// </summary>
             /// <param name="archiveFileName">File name of the archive</param>
             /// <param name="fileName">Original file name</param>
             /// <param name="createDirectory">Create a directory, if it does not exist</param>
+            /// <param name="enableCompression">Enables file compression</param>
             /// <returns><c>true</c> if the file has been moved successfully; <c>false</c> otherwise</returns>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-            public bool Archive(string archiveFileName, string fileName, bool createDirectory)
+            public bool Archive(string archiveFileName, string fileName, bool createDirectory, bool enableCompression)
             {
                 if (MaxArchiveFileToKeep < 1)
                 {
@@ -1653,11 +1689,11 @@ using System.Linq;
                 }
 
                 DeleteOldArchiveFiles();
-                AddToArchive(archiveFileName, fileName, createDirectory);
+                AddToArchive(archiveFileName, fileName, createDirectory, enableCompression);
                 archiveFileQueue.Enqueue(archiveFileName);
                 return true;
             }
-            
+
             public DynamicFileArchive()
             {
                 this.MaxArchiveFileToKeep = -1;
@@ -1672,7 +1708,8 @@ using System.Linq;
             /// <param name="archiveFileName"></param>
             /// <param name="fileName"></param>
             /// <param name="createDirectory"></param>
-            private void AddToArchive(string archiveFileName, string fileName, bool createDirectory)
+            /// <param name="enableCompression"></param>
+            private void AddToArchive(string archiveFileName, string fileName, bool createDirectory, bool enableCompression)
             {
                 String alternativeFileName = archiveFileName;
 
@@ -1684,7 +1721,7 @@ using System.Linq;
 
                 try
                 {
-                    File.Move(fileName, alternativeFileName);
+                    ArchiveFile(fileName, alternativeFileName, enableCompression);
                 }
                 catch (DirectoryNotFoundException)
                 {
@@ -1695,7 +1732,7 @@ using System.Linq;
                         try
                         {
                             Directory.CreateDirectory(Path.GetDirectoryName(archiveFileName));
-                            File.Move(fileName, alternativeFileName);
+                            ArchiveFile(fileName, alternativeFileName, enableCompression);
                         }
                         catch (Exception ex)
                         {
@@ -1761,8 +1798,8 @@ using System.Linq;
                     numberToStartWith++;
                 }
                 return targetFileName;
-            }            
-                }
+            }
+        }
 
 
         private sealed class FileNameTemplate
@@ -1771,7 +1808,7 @@ using System.Linq;
             /// Characters determining the start of the <see cref="P:FileNameTemplate.Pattern"/>.
             /// </summary>
             public const string PatternStartCharacters = "{#";
-            
+
             /// <summary>
             /// Characters determining the end of the <see cref="P:FileNameTemplate.Pattern"/>.
             /// </summary>
@@ -1833,13 +1870,13 @@ using System.Linq;
 
             public FileNameTemplate(string template)
             {
-                this.template = template;                
+                this.template = template;
                 this.startIndex = template.IndexOf(PatternStartCharacters, StringComparison.Ordinal);
                 this.endIndex = template.IndexOf(PatternEndCharacters, StringComparison.Ordinal) + PatternEndCharacters.Length;
 
                 this.pattern = this.HasPattern() ? template.Substring(this.startIndex, this.endIndex - this.startIndex) : String.Empty;
 
-            }            
+            }
 
             /// <summary>
             /// Checks if there the <see cref="P:FileNameTemplate.Template"/> 

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -65,6 +65,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Messaging" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows.Forms" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -66,7 +66,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Messaging" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows.Forms" />

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -134,7 +134,8 @@ using System.Xml.Linq;
                 Assert.True(true, "File '" + fileName + "' doesn't exist.");
 
             byte[] encodedBuf = encoding.GetBytes(contents);
-            using (var zip = ZipFile.OpenRead(fileName))
+            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Read))
             {
                 Assert.Equal(1, zip.Entries.Count);
                 Assert.Equal(encodedBuf.Length, zip.Entries[0].Length);

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -31,6 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.IO.Compression;
 using System.Security.Permissions;
 
 namespace NLog.UnitTests
@@ -124,6 +125,33 @@ using System.Xml.Linq;
                 Assert.True(true, string.Format("Filesize of \"{0}\" unequals {1}.", filename, expectedSize));
             }
         }
+
+#if NET4_5
+        public void AssertZipFileContents(string fileName, string contents, Encoding encoding)
+        {
+            FileInfo fi = new FileInfo(fileName);
+            if (!fi.Exists)
+                Assert.True(true, "File '" + fileName + "' doesn't exist.");
+
+            byte[] encodedBuf = encoding.GetBytes(contents);
+            using (var zip = ZipFile.OpenRead(fileName))
+            {
+                Assert.Equal(1, zip.Entries.Count);
+                Assert.Equal(encodedBuf.Length, zip.Entries[0].Length);
+
+                byte[] buf = new byte[(int)zip.Entries[0].Length];
+                using (var fs = zip.Entries[0].Open())
+                {
+                    fs.Read(buf, 0, buf.Length);
+                }
+
+                for (int i = 0; i < buf.Length; ++i)
+                {
+                    Assert.Equal(encodedBuf[i], buf[i]);
+                }
+            }
+        }
+#endif
 
         public void AssertFileContents(string fileName, string contents, Encoding encoding)
         {


### PR DESCRIPTION
Adds the `EnableArchiveFileCompression` property to `FileTarget`, which zips the archive files to save space. Supported only in .NET 4.5 (using System.IO.Compression).
Includes unit tests.