### PR TITLE
Ensure exception as last formatting parameter is picked up as exception

### DIFF
--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -91,7 +91,9 @@ namespace NLog
         /// <param name="message">Log message including parameter placeholders.</param>
         /// <param name="parameters">Parameter array.</param>
         public LogEventInfo(LogLevel level, string loggerName, IFormatProvider formatProvider, [Localizable(false)] string message, object[] parameters) 
-            : this(level, loggerName, formatProvider, message, parameters, null)
+            : this(level, loggerName, formatProvider, message, parameters, parameters == null 
+                                                                            ? null
+                                                                            : parameters[parameters.Length - 1] as Exception)
         {
         }
 

--- a/src/NLog/Targets/DebugTarget.cs
+++ b/src/NLog/Targets/DebugTarget.cs
@@ -82,12 +82,19 @@ namespace NLog.Targets
         public string LastMessage { get; private set; }
 
         /// <summary>
+        /// Gets the last event rendered by this target.
+        /// </summary>
+        /// <docgen category='Debugging Options' order='10' />
+        public LogEventInfo LastEvent { get; private set; }
+
+        /// <summary>
         /// Increases the number of messages.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>
         protected override void Write(LogEventInfo logEvent)
         {
             this.Counter++;
+            this.LastEvent = logEvent;
             this.LastMessage = this.Layout.Render(logEvent);
         }
     }

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -176,12 +176,26 @@ namespace NLog.UnitTests
 
 #pragma warning disable 0618
                 // Obsolete method requires testing until removed.
-                logger.TraceException("message", new Exception("test"));
+                var testEx1 = new Exception("test1");
+                logger.TraceException("message", testEx1);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx1);
 #pragma warning restore 0618
 
-                logger.Trace("message", new Exception("test"));
+                var testEx2 = new Exception("test2");
+                logger.Trace("message", testEx2);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx2);
+
+                var testEx3 = new Exception("test3");
+                logger.Trace("message {0}", 1, testEx3);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message 1");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx3);
+
+                var testEx4 = new Exception("test4");
+                logger.Trace("message {0} {1}", 2, testEx4);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message 1 System.Exception: test4");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx4);
 
                 logger.Trace(delegate { return "message from lambda"; });
                 if (enabled == 1) AssertDebugLastMessage("debug", "message from lambda");
@@ -321,10 +335,27 @@ namespace NLog.UnitTests
                 if (enabled == 1) AssertDebugLastMessage("debug", "message2.5");
 
 #pragma warning disable 0618
-                // Obsolete method requires testing until completely removed.
-                logger.DebugException("message", new Exception("test"));
+                // Obsolete method requires testing until removed.
+                var testEx1 = new Exception("test1");
+                logger.DebugException("message", testEx1);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx1);
 #pragma warning restore 0618
+
+                var testEx2 = new Exception("test2");
+                logger.Debug("message", testEx2);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx2);
+
+                var testEx3 = new Exception("test3");
+                logger.Debug("message {0}", 1, testEx3);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message 1");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx3);
+
+                var testEx4 = new Exception("test4");
+                logger.Debug("message {0} {1}", 2, testEx4);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message 1 System.Exception: test4");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx4);
 
                 logger.Debug(delegate { return "message from lambda"; });
                 if (enabled == 1) AssertDebugLastMessage("debug", "message from lambda");
@@ -465,12 +496,26 @@ namespace NLog.UnitTests
 
 #pragma warning disable 0618
                 // Obsolete method requires testing until removed.
-                logger.InfoException("message", new Exception("test"));
+                var testEx1 = new Exception("test1");
+                logger.InfoException("message", testEx1);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx1);
 #pragma warning restore 0618
 
-                logger.Info("message", new Exception("test"));
+                var testEx2 = new Exception("test2");
+                logger.Info("message", testEx2);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx2);
+
+                var testEx3 = new Exception("test3");
+                logger.Info("message {0}", 1, testEx3);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message 1");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx3);
+
+                var testEx4 = new Exception("test4");
+                logger.Info("message {0} {1}", 2, testEx4);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message 1 System.Exception: test4");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx4);
 
                 logger.Info(delegate { return "message from lambda"; });
                 if (enabled == 1) AssertDebugLastMessage("debug", "message from lambda");
@@ -611,12 +656,26 @@ namespace NLog.UnitTests
 
 #pragma warning disable 0618
                 // Obsolete method requires testing until removed.
-                logger.WarnException("message", new Exception("test"));
+                var testEx1 = new Exception("test1");
+                logger.WarnException("message", testEx1);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx1);
 #pragma warning restore 0618
 
-                logger.Warn("message", new Exception("test"));
+                var testEx2 = new Exception("test2");
+                logger.Warn("message", testEx2);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx2);
+
+                var testEx3 = new Exception("test3");
+                logger.Warn("message {0}", 1, testEx3);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message 1");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx3);
+
+                var testEx4 = new Exception("test4");
+                logger.Warn("message {0} {1}", 2, testEx4);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message 1 System.Exception: test4");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx4);
 
                 logger.Warn(delegate { return "message from lambda"; });
                 if (enabled == 1) AssertDebugLastMessage("debug", "message from lambda");
@@ -756,13 +815,27 @@ namespace NLog.UnitTests
                 if (enabled == 1) AssertDebugLastMessage("debug", "message2.5");
 
 #pragma warning disable 0618
-                // Obsolete method requires testing until completely removed.
-                logger.ErrorException("message", new Exception("test"));
+                // Obsolete method requires testing until removed.
+                var testEx1 = new Exception("test1");
+                logger.ErrorException("message", testEx1);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx1);
 #pragma warning restore 0618
 
-                logger.Error("message", new Exception("test"));
+                var testEx2 = new Exception("test2");
+                logger.Error("message", testEx2);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx2);
+
+                var testEx3 = new Exception("test3");
+                logger.Error("message {0}", 1, testEx3);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message 1");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx3);
+
+                var testEx4 = new Exception("test4");
+                logger.Error("message {0} {1}", 2, testEx4);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message 1 System.Exception: test4");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx4);
 
                 logger.Error(delegate { return "message from lambda"; });
                 if (enabled == 1) AssertDebugLastMessage("debug", "message from lambda");
@@ -903,12 +976,26 @@ namespace NLog.UnitTests
 
 #pragma warning disable 0618
                 // Obsolete method requires testing until removed.
-                logger.FatalException("message", new Exception("test"));
+                var testEx1 = new Exception("test1");
+                logger.FatalException("message", testEx1);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx1);
 #pragma warning restore 0618
 
-                logger.Fatal("message", new Exception("test"));
+                var testEx2 = new Exception("test2");
+                logger.Fatal("message", testEx2);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx2);
+
+                var testEx3 = new Exception("test3");
+                logger.Fatal("message {0}", 1, testEx3);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message 1");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx3);
+
+                var testEx4 = new Exception("test4");
+                logger.Fatal("message {0} {1}", 2, testEx4);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message 1 System.Exception: test4");
+                if (enabled == 1) AssertDebugLastEventsException("debug", testEx4);
 
                 logger.Fatal(delegate { return "message from lambda"; });
                 if (enabled == 1) AssertDebugLastMessage("debug", "message from lambda");
@@ -1056,9 +1143,26 @@ namespace NLog.UnitTests
 
 #pragma warning disable 0618
                     // Obsolete method requires testing until removed.
-                    logger.LogException(level, "message", new Exception("test"));
+                    var testEx1 = new Exception("test1");
+                    logger.LogException(level, "message", testEx1);
                     if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                    if (enabled == 1) AssertDebugLastEventsException("debug", testEx1);
 #pragma warning restore 0618
+
+                    var testEx2 = new Exception("test2");
+                    logger.Log(level, "message", testEx2);
+                    if (enabled == 1) AssertDebugLastMessage("debug", "message");
+                    if (enabled == 1) AssertDebugLastEventsException("debug", testEx2);
+
+                    var testEx3 = new Exception("test3");
+                    logger.Log(level, "message {0}", 1, testEx3);
+                    if (enabled == 1) AssertDebugLastMessage("debug", "message 1");
+                    if (enabled == 1) AssertDebugLastEventsException("debug", testEx3);
+
+                    var testEx4 = new Exception("test4");
+                    logger.Log(level, "message {0} {1}", 2, testEx4);
+                    if (enabled == 1) AssertDebugLastMessage("debug", "message 1 System.Exception: test4");
+                    if (enabled == 1) AssertDebugLastEventsException("debug", testEx4);
 
                     logger.Log(level, delegate { return "message from lambda"; });
                     if (enabled == 1) AssertDebugLastMessage("debug", "message from lambda");

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -84,10 +84,24 @@ using System.Xml.Linq;
             Assert.True(debugTarget.LastMessage.Contains(msg), "Unexpected last message value on '" + targetName + "'");
         }
 
+        public void AssertDebugLastEventsException(string targetName, Exception e)
+        {
+            NLog.Targets.DebugTarget debugTarget = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName(targetName);
+
+            Assert.NotNull(debugTarget);
+            Assert.Same(e, debugTarget.LastEvent.Exception);
+        }
+
         public string GetDebugLastMessage(string targetName)
         {
             var debugTarget = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName(targetName);
             return debugTarget.LastMessage;
+        }
+
+        public LogEventInfo GetDebugLastEvent(string targetName)
+        {
+            var debugTarget = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName(targetName);
+            return debugTarget.LastEvent;
         }
 
         public void AssertFileContentsStartsWith(string fileName, string contents, Encoding encoding)


### PR DESCRIPTION
It would be really nice if the string-formatting overload of Logger's methods pick up an exception as last parameter and allow it to be used as a 'real exception' that will be logged according the the formatting for an exception.

This will allow a usage such as:

        public void TestExceptionLog()
        {
            string name = "my name";
            try
            {

                throw new Exception("Broken");
            }
            catch (Exception e)
            {
                Logger.Error("Unable to work for {0}", name, e);
            }
        }

Where e will be picked up as an actual exception and not ignored. The only way to do this currently is as below, but I would prefer to use a formatting overload:

        Logger.Error("Unable to work for " + name, e);


I added unit test statements to validate which exception was captured (I did not see such test statements in the tests so far, but maybe I overlooked them). Furthermore I was unfortunately not able to build the solution directly in visual studio (and did not spend enough time figuring out how to do a correct build and full unit test run) so my changes might not be completely correct, but I believe the basic working should be ok.