### PR TITLE
Event Log Target unit tests improvement

### DIFF
--- a/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
@@ -132,7 +132,7 @@ namespace NLog.UnitTests.Targets
             {
                 logger.Log(logLevel, testValue);
                 // introduce small delay to catch the event on another worker thread
-                Thread.Sleep(50);
+                Thread.Sleep(200);
             }
             finally
             {

--- a/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
@@ -32,7 +32,7 @@
 // 
 
 using System.Collections.Generic;
-using System.Threading;
+using System.Diagnostics.Eventing.Reader;
 using NLog.Layouts;
 
 #if !SILVERLIGHT && !MONO
@@ -122,39 +122,58 @@ namespace NLog.UnitTests.Targets
             var logger = LogManager.GetLogger("WriteEventLogEntry");
             var el = new EventLog(target.Log);
 
-            var entriesWritten = new List<EventLogEntry>();
-            EntryWrittenEventHandler onEntryWritten = (s, e) => entriesWritten.Add(e.Entry);
-            el.EnableRaisingEvents = true;
-            el.EntryWritten += onEntryWritten;
+            var loggedNotBefore = DateTime.Now.AddMinutes(-1);
 
             var testValue = Guid.NewGuid().ToString();
-            try
-            {
-                logger.Log(logLevel, testValue);
-                // introduce small delay to catch the event on another worker thread
-                Thread.Sleep(200);
-            }
-            finally
-            {
-                el.EnableRaisingEvents = false;
-                el.EntryWritten -= onEntryWritten;
-            }
+            logger.Log(logLevel, testValue);
 
+            var entries = GetEventRecords(el.Log).TakeWhile(e => e.TimeCreated > loggedNotBefore).ToList();
             //debug-> error
-            EntryExists(entriesWritten, testValue, target.Source, eventLogEntryType);
+            EntryExists(entries, testValue, target.Source, eventLogEntryType);
         }
 
-        private static void EntryExists(IEnumerable<EventLogEntry> entries, string expectedValue, string expectedSource, EventLogEntryType expectedEntryType)
+        private static void EntryExists(IEnumerable<EventRecord> entries, string expectedValue, string expectedSource, EventLogEntryType expectedEntryType)
         {
             var entryExists = entries
-                .Any(entry => 
-                    entry.Source == expectedSource && 
-                    entry.EntryType == expectedEntryType && 
-                    entry.Message.Contains(expectedValue));
+                .Any(entry =>
+                    entry.ProviderName == expectedSource &&
+                    HasEntryType(entry, expectedEntryType) &&
+                    entry.Properties.Any(prop => Convert.ToString(prop.Value).Contains(expectedValue))
+                    );
 
             Assert.True(entryExists, string.Format(
                 "Failed to find entry of type '{1}' from source '{0}' containing text '{2}' in the message", 
                 expectedSource, expectedEntryType, expectedValue));
+        }
+
+
+        private static IEnumerable<EventRecord> GetEventRecords(string logName)
+        {
+            var query = new EventLogQuery(logName, PathType.LogName) { ReverseDirection = true };
+            using (var reader = new EventLogReader(query))
+                for (var eventInstance = reader.ReadEvent(); eventInstance != null; eventInstance = reader.ReadEvent())
+                    yield return eventInstance;
+        }
+
+        private static bool HasEntryType(EventRecord eventRecord, EventLogEntryType entryType)
+        {
+            var keywords = (StandardEventKeywords) (eventRecord.Keywords ?? 0);
+            var level = (StandardEventLevel) (eventRecord.Level ?? 0);
+            bool isClassicEvent = keywords.HasFlag(StandardEventKeywords.EventLogClassic);
+            switch (entryType)
+            {
+                case EventLogEntryType.Error:
+                    return isClassicEvent && level == StandardEventLevel.Error;
+                case EventLogEntryType.Warning:
+                    return isClassicEvent && level == StandardEventLevel.Warning;
+                case EventLogEntryType.Information:
+                    return isClassicEvent && level == StandardEventLevel.Informational;
+                case EventLogEntryType.SuccessAudit:
+                    return keywords.HasFlag(StandardEventKeywords.AuditSuccess);
+                case EventLogEntryType.FailureAudit:
+                    return keywords.HasFlag(StandardEventKeywords.AuditFailure);
+            }
+            return false;
         }
 
     }


### PR DESCRIPTION
I've noticed that EventLogTarget tests run relatively slow on my machine: approximately 5 sec per every test in the `EventLogTargetTests` fixture.

When I digged into the tests, I've found 2 issues:

1. The `EventLogTarget.Source` property is not specified explicitly, and that results in AppDomain name being used as the source name. When the unit test runner executes tests, it creates an app domain with a random name (namely, random Guid). So on every test run a new source is  created, thus polluting system registry with source names, that will never be used again.
To prevent this I've set fixed source name `NLog.UnitTests`.

2. Every test in this fixture required to scan the entire Application log to find events it had written before. I've found a different approach to verify that an event is created. The `EventLog.EntryWritten` event have a handler attached, which collects all events written to this log. Then these collected entries are used to find the event entry being tested.

