### PR TITLE
Instance property XmlLoggingConfiguration.DefaultCultureInfo should not change global state

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -41,6 +41,8 @@ namespace NLog.Config
     using System.Collections.ObjectModel;
     using System.Reflection;
 
+    using JetBrains.Annotations;
+
     using NLog.Common;
     using NLog.Internal;
     using NLog.Targets;
@@ -92,13 +94,13 @@ namespace NLog.Config
         public IList<LoggingRule> LoggingRules { get; private set; }
 
         /// <summary>
-        /// Gets or sets the default culture info use.
+        /// Gets or sets the default culture info to use as <see cref="LogEventInfo.FormatProvider"/>.
         /// </summary>
-        public CultureInfo DefaultCultureInfo
-        {
-            get { return LogManager.DefaultCultureInfo(); }
-            set { LogManager.DefaultCultureInfo = () => value; }
-        }
+        /// <value>
+        /// Specific culture info or null to use <see cref="CultureInfo.CurrentCulture"/>
+        /// </value>
+        [CanBeNull]
+        public CultureInfo DefaultCultureInfo { get; set; }
 
         /// <summary>
         /// Gets all targets.

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -439,7 +439,7 @@ namespace NLog
             {
                 try
                 {
-                    this.formattedMessage = string.Format(this.FormatProvider ?? LogManager.DefaultCultureInfo(), this.Message, this.Parameters);
+                    this.formattedMessage = string.Format(this.FormatProvider ?? CultureInfo.CurrentCulture, this.Message, this.Parameters);
                 }
                 catch (Exception exception)
                 {

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -60,6 +60,9 @@ namespace NLog
         private readonly object layoutCacheLock = new object();
 
         private string formattedMessage;
+        private string message;
+        private object[] parameters;
+        private IFormatProvider formatProvider;
         private IDictionary<Layout, string> layoutCache;
         private IDictionary<object, object> properties;
         private IDictionary eventContextAdapter;
@@ -197,19 +200,46 @@ namespace NLog
         /// <summary>
         /// Gets or sets the log message including any parameter placeholders.
         /// </summary>
-        public string Message { get; set; }
+        public string Message
+        {
+            get { return message; }
+            set
+            {
+                message = value; 
+                ResetFormattedMessage();
+            }
+        }
 
         /// <summary>
         /// Gets or sets the parameter values or null if no parameters have been specified.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "For backwards compatibility.")]
-        public object[] Parameters { get; set; }
+        public object[] Parameters
+        {
+            get { return parameters; }
+            set
+            {
+                parameters = value;
+                ResetFormattedMessage();
+            }
+        }
 
         /// <summary>
         /// Gets or sets the format provider that was provided while logging or <see langword="null" />
         /// when no formatProvider was specified.
         /// </summary>
-        public IFormatProvider FormatProvider { get; set; }
+        public IFormatProvider FormatProvider
+        {
+            get { return formatProvider; }
+            set
+            {
+                if (formatProvider != value)
+                {
+                    formatProvider = value;
+                    ResetFormattedMessage();
+                }
+            }
+        }
 
         /// <summary>
         /// Gets the formatted message.
@@ -452,6 +482,11 @@ namespace NLog
                     InternalLogger.Warn("Error when formatting a message: {0}", exception);
                 }
             }
+        }
+
+        private void ResetFormattedMessage()
+        {
+            this.formattedMessage = null;
         }
 
         private void InitEventContext()

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -43,6 +43,8 @@ namespace NLog
     using System.Text;
     using System.Threading;
 
+    using JetBrains.Annotations;
+
     using NLog.Common;
     using NLog.Config;
     using NLog.Internal;
@@ -267,6 +269,22 @@ namespace NLog
                     this.globalThreshold = value;
                     this.ReconfigExistingLoggers();
                 }
+            }
+        }
+
+        /// <summary>
+        /// Gets the default culture info to use as <see cref="LogEventInfo.FormatProvider"/>.
+        /// </summary>
+        /// <value>
+        /// Specific culture info or null to use <see cref="CultureInfo.CurrentCulture"/>
+        /// </value>
+        [CanBeNull]
+        public CultureInfo DefaultCultureInfo
+        {
+            get
+            {
+                var configuration = this.Configuration;
+                return configuration != null ? configuration.DefaultCultureInfo : null;
             }
         }
 

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -51,12 +51,12 @@ namespace NLog
     {
         private static readonly LogFactory factory = new LogFactory();
         private static IAppDomain currentAppDomain;
-        private static GetCultureInfo defaultCultureInfo = () => CultureInfo.CurrentCulture;
         private static readonly System.Collections.Generic.List<System.Reflection.Assembly> _hiddenAssemblies = new System.Collections.Generic.List<System.Reflection.Assembly>();
 
         /// <summary>
         /// Delegate used to set/get the culture in use.
         /// </summary>
+        [Obsolete]
         public delegate CultureInfo GetCultureInfo();
 
 #if !SILVERLIGHT && !MONO
@@ -140,10 +140,11 @@ namespace NLog
         /// <summary>
         /// Gets or sets the default culture to use.
         /// </summary>
+        [Obsolete("Use Configuration.DefaultCultureInfo property instead")]
         public static GetCultureInfo DefaultCultureInfo
         {
-            get { return defaultCultureInfo; }
-            set { defaultCultureInfo = value; }
+            get { return () => factory.DefaultCultureInfo ?? CultureInfo.CurrentCulture; }
+            set { throw new NotSupportedException("Setting the DefaultCultureInfo delegate is no longer supported. Use the Configuration.DefaultCultureInfo property to change the default CultureInfo."); }
         }
 
         /// <summary>

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -1909,7 +1909,7 @@ namespace NLog
 
         internal void WriteToTargets(LogLevel level, [Localizable(false)] string message, object[] args)
         {
-            this.WriteToTargets(level, null, message, args);
+            this.WriteToTargets(level, this.Factory.DefaultCultureInfo, message, args);
         }
 
         internal void WriteToTargets(LogEventInfo logEvent)

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -1886,7 +1886,7 @@ namespace NLog
 
         internal void WriteToTargets(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)
         {
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), LogEventInfo.Create(level, this.Name, formatProvider, message, args), this.Factory);
+            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, formatProvider, message, args)), this.Factory);
         }
 
         internal void WriteToTargets(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message)
@@ -1894,17 +1894,17 @@ namespace NLog
             // please note that this overload calls the overload of LogEventInfo.Create with object[] parameter on purpose -
             // to avoid unnecessary string.Format (in case of calling Create(LogLevel, string, IFormatProvider, object))
             var logEvent = LogEventInfo.Create(level, this.Name, formatProvider, message, (object[])null);
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), logEvent, this.Factory);
+            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(logEvent), this.Factory);
         }
 
         internal void WriteToTargets<T>(LogLevel level, IFormatProvider formatProvider, T value)
         {
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), LogEventInfo.Create(level, this.Name, formatProvider, value), this.Factory);
+            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, formatProvider, value)), this.Factory);
         }
 
         internal void WriteToTargets(LogLevel level, [Localizable(false)] string message, Exception ex)
         {
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), LogEventInfo.Create(level, this.Name, message, ex), this.Factory);
+            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, message, ex)), this.Factory);
         }
 
         internal void WriteToTargets(LogLevel level, [Localizable(false)] string message, object[] args)
@@ -1914,12 +1914,22 @@ namespace NLog
 
         internal void WriteToTargets(LogEventInfo logEvent)
         {
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(logEvent.Level), logEvent, this.Factory);
+            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(logEvent.Level), PrepareLogEventInfo(logEvent), this.Factory);
         }
 
         internal void WriteToTargets(Type wrapperType, LogEventInfo logEvent)
         {
-            LoggerImpl.Write(wrapperType, this.GetTargetsForLevel(logEvent.Level), logEvent, this.Factory);
+            LoggerImpl.Write(wrapperType, this.GetTargetsForLevel(logEvent.Level), PrepareLogEventInfo(logEvent), this.Factory);
+        }
+
+
+        private LogEventInfo PrepareLogEventInfo(LogEventInfo logEvent)
+        {
+            if (logEvent.FormatProvider == null)
+            {
+                logEvent.FormatProvider = this.Factory.DefaultCultureInfo;
+            }
+            return logEvent;
         }
 
         internal void SetConfiguration(LoggerConfiguration newConfiguration)

--- a/tests/NLog.UnitTests/Config/CultureInfoTests.cs
+++ b/tests/NLog.UnitTests/Config/CultureInfoTests.cs
@@ -68,7 +68,7 @@ namespace NLog.UnitTests.Config
 
                 // configuration with current culture
                 var configuration1 = CreateConfigurationFromString(string.Format(configurationTemplate, false));
-                Assert.Equal(CultureInfo.CurrentCulture, configuration1.DefaultCultureInfo);
+                Assert.Equal(null, configuration1.DefaultCultureInfo);
 
                 // configuration with invariant culture
                 var configuration2 = CreateConfigurationFromString(string.Format(configurationTemplate, true));

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -60,34 +60,42 @@ using System.Xml.Linq;
 
         public void AssertDebugCounter(string targetName, int val)
         {
-            var debugTarget = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName(targetName);
-
-            Assert.NotNull(debugTarget);
-            Assert.Equal(val, debugTarget.Counter);
+            Assert.Equal(val, GetDebugTarget(targetName).Counter);
         }
 
         public void AssertDebugLastMessage(string targetName, string msg)
         {
-            NLog.Targets.DebugTarget debugTarget = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName(targetName);
-
-            Assert.NotNull(debugTarget);
-            Assert.Equal(msg, debugTarget.LastMessage);
+            Assert.Equal(msg, GetDebugLastMessage(targetName));
         }
+
 
         public void AssertDebugLastMessageContains(string targetName, string msg)
         {
-            NLog.Targets.DebugTarget debugTarget = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName(targetName);
-
-            // Console.WriteLine("lastmsg: {0}", debugTarget.LastMessage);
-
-            Assert.NotNull(debugTarget);
-            Assert.True(debugTarget.LastMessage.Contains(msg), "Unexpected last message value on '" + targetName + "'");
+            string debugLastMessage = GetDebugLastMessage(targetName);
+            Assert.True(debugLastMessage.Contains(msg),
+                string.Format("Expected to find '{0}' in last message value on '{1}', but found '{2}'", msg, targetName, debugLastMessage));
         }
 
         public string GetDebugLastMessage(string targetName)
         {
-            var debugTarget = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName(targetName);
-            return debugTarget.LastMessage;
+            return GetDebugLastMessage(targetName, LogManager.Configuration);
+        }
+
+        public string GetDebugLastMessage(string targetName, LoggingConfiguration configuration)
+        {
+            return GetDebugTarget(targetName, configuration).LastMessage;
+        }
+
+        public NLog.Targets.DebugTarget GetDebugTarget(string targetName)
+        {
+            return GetDebugTarget(targetName, LogManager.Configuration);
+        }
+
+        public NLog.Targets.DebugTarget GetDebugTarget(string targetName, LoggingConfiguration configuration)
+        {
+            var debugTarget = (NLog.Targets.DebugTarget)configuration.FindTargetByName(targetName);
+            Assert.NotNull(debugTarget);
+            return debugTarget;
         }
 
         public void AssertFileContentsStartsWith(string fileName, string contents, Encoding encoding)

--- a/tests/NLog.UnitTests/NLogTraceListenerTests.cs
+++ b/tests/NLog.UnitTests/NLogTraceListenerTests.cs
@@ -37,11 +37,29 @@
 
 namespace NLog.UnitTests
 {
+    using System;
+    using System.Globalization;
+    using System.Threading;
     using System.Diagnostics;
     using Xunit;
 
-    public class NLogTraceListenerTests : NLogTestBase
+    public class NLogTraceListenerTests : NLogTestBase, IDisposable
     {
+        private readonly CultureInfo previousCultureInfo;
+
+        public NLogTraceListenerTests()
+        {
+            this.previousCultureInfo = Thread.CurrentThread.CurrentCulture;
+            // set the culture info with the decimal separator (comma) different from InvariantCulture separator (point)
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+        }
+        
+        public void Dispose()
+        {
+            // restore previous culture info
+            Thread.CurrentThread.CurrentCulture = this.previousCultureInfo;
+        }
+
         [Fact]
         public void TraceWriteTest()
         {


### PR DESCRIPTION
When running all tests at once I have `NLogTraceListenerTests` constantly failing with the following output:

````
NLog.UnitTests.NLogTraceListenerTests.TraceDataTests: Assert.Equal() Failure [d:\NLog\src\NLog.proj]                                                                   
Position: First difference is at position 21 [d:\NLog\src\NLog.proj]                                                                                                   
Expected: MySource1 Fatal 42, 3,14, foo 145 [d:\NLog\src\NLog.proj]                                                                                                    
Actual:   MySource1 Fatal 42, 3.14, foo 145 [d:\NLog\src\NLog.proj]                                                                                                    
   at NLog.UnitTests.NLogTestBase.AssertDebugLastMessage(String targetName, String msg) in d:\NLog\tests\NLog.UnitTests\NLogTestBase.cs:line 74 [d:\NLog\src\NLog.proj]
   at NLog.UnitTests.NLogTraceListenerTests.TraceDataTests() in d:\NLog\tests\NLog.UnitTests\NLogTraceListenerTests.cs:line 187 [d:\NLog\src\NLog.proj]                
````

The reason why it passes in AppVeyor is because the CurrentCulture has the same decimal separator as the InvariantCulture there and this difference is not seen.

I have examined this test thoroughly, but lauched alone it passes! So the reason why it fails may be in some interference with other tests run before it. That interfering test appeared to be the `CultureInfoTests`.

This seems strange: at first sight `CultureInfoTests.WhenInvariantCultureDefinedThenDefaultCultureIsInvariantCulture` test doesn't change any global state in the LogManager, but in reality it is so, because the `XmlLoggingConfiguration.DefaultCultureInfo` actually changes `LogManager.DefaultCultureInfo` delegate.

