### PR TITLE
.gitattributes specifies which files should be considered as text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,43 @@
+# All files: detect if file is text automatically
+
+* text=auto
+
+# Text files that should be normalized to LF
+
+*.cs text diff=csharp
+*.config text
+*.sln text
+*.csproj text
+*.md text
+*.sh text
+*.ps1 text
+*.cmd text
+*.bat text
+*.markdown text
+*.msbuild text
+
+# Binary files that should not be normalized or diffed
+
+*.exe binary
+*.dll binary
+*.pdb binary
+*.pfx binary
+*.snk binary
+
+*.png binary
+*.gif binary
+*.jpg binary
+*.bmp binary
+*.ico binary
+
+*.chm binary
+*.7z  binary
+*.zip binary
+
+tools/SHFB/**/* binary
+tools/Wix/**/* binary
+
+
 tools/SHFB export-ignore
 tools/Sandcastle export-ignore
 tools/Wix export-ignore
-
-
-


### PR DESCRIPTION
Specified in .gitattributes which files should be considered as text and have their line endings normalized.
closes #572 