### PR TITLE
Add variables property

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -65,6 +65,20 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Gets the variables defined in the configuration.
+        /// </summary>
+        /// <remarks>
+        /// Returns null if not configured using XML configuration.
+        /// </remarks>
+        public virtual Dictionary<string, string> Variables
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Gets a collection of named targets specified in the configuration.
         /// </summary>
         /// <returns>

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -74,7 +74,7 @@ namespace NLog.Config
         {
             get
             {
-                return null;
+                throw new NotSupportedException("Variables is only supported in XmlConfiguration");
             }
         }
 

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -159,7 +159,7 @@ namespace NLog.Config
         /// <summary>
         /// Gets the variables defined in the configuration.
         /// </summary>
-        public Dictionary<string, string> Variables
+        public override Dictionary<string, string> Variables
         {
             get
             {

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.UnitTests.Config
 {
+    using NLog.Config;
     using NLog.LayoutRenderers;
     using NLog.Layouts;
     using NLog.Targets;
@@ -66,6 +67,34 @@ namespace NLog.UnitTests.Config
             Assert.NotNull(lr3);
             Assert.Equal("[[", lr1.Text);
             Assert.Equal("]]", lr3.Text);
+        }
+
+        [Fact]
+        public void None_xml_configuration_returns_null_when_accessing_variables()
+        {
+            var configuration = new LoggingConfiguration();
+            LogManager.Configuration = configuration;
+            
+            Assert.Null(LogManager.Configuration.Variables);
+        }
+
+        [Fact]
+        public void Xml_configuration_returns_defined_variables()
+        {
+            var configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+    <variable name='prefix' value='[[' />
+    <variable name='suffix' value=']]' />
+
+    <targets>
+        <target name='d1' type='Debug' layout='${prefix}${message}${suffix}' />
+    </targets>
+</nlog>");
+
+            LogManager.Configuration = configuration;
+
+            Assert.Equal("[[", LogManager.Configuration.Variables["prefix"]);
+            Assert.Equal("]]", LogManager.Configuration.Variables["suffix"]);
         }
     }
 }

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.UnitTests.Config
 {
+    using System;
     using NLog.Config;
     using NLog.LayoutRenderers;
     using NLog.Layouts;
@@ -70,12 +71,12 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
-        public void None_xml_configuration_returns_null_when_accessing_variables()
+        public void None_xml_configuration_throws_not_supported_exception_when_accessing_variables()
         {
             var configuration = new LoggingConfiguration();
             LogManager.Configuration = configuration;
             
-            Assert.Null(LogManager.Configuration.Variables);
+            Assert.Throws<NotSupportedException>(() =>LogManager.Configuration.Variables);
         }
 
         [Fact]


### PR DESCRIPTION
Otherwise LogManager.Configuration cannot be used to read variables
defined in XML

closes #518 