### PR TITLE
Archiving system runs when new log file is created #390

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -630,15 +630,9 @@ namespace NLog.Targets
 #endif
             byte[] bytes = this.GetBytesToWrite(logEvent);
 
-            if (this.ShouldAutoArchive(fileName, logEvent, bytes.Length))
-            {
-                this.InvalidateCacheItem(fileName);
-                this.DoAutoArchive(fileName, logEvent);
-            }
-
             // Clean up old archives if this is the first time a log record has been written to
             // this log file and the archiving system is date/time based.
-            if (this.ArchiveNumbering == ArchiveNumberingMode.Date  && this.ArchiveEvery != FileArchivePeriod.None)
+            if (this.ArchiveNumbering == ArchiveNumberingMode.Date && this.ArchiveEvery != FileArchivePeriod.None)
             {
                 FileInfo fileInfo = new FileInfo(fileName);
                 if (!fileInfo.Exists)
@@ -647,7 +641,12 @@ namespace NLog.Targets
                     this.DeleteOldDateArchive(fileNamePattern);
                 }
             }
-            
+
+            if (this.ShouldAutoArchive(fileName, logEvent, bytes.Length))
+            {
+                this.InvalidateCacheItem(fileName);
+                this.DoAutoArchive(fileName, logEvent);
+            }
 
             this.WriteToFile(fileName, bytes, false);
         }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -72,6 +72,8 @@ namespace NLog.Targets
 
         private readonly DynamicFileArchive fileArchive;
 
+        private string previousFileName;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FileTarget" /> class.
         /// </summary>
@@ -105,6 +107,8 @@ namespace NLog.Targets
             this.fileArchive = new DynamicFileArchive(MaxArchiveFiles);
             this.ForceManaged = false;
             this.ArchiveDateFormat = string.Empty;
+
+            this.previousFileName = "";
         }
 
         /// <summary>
@@ -616,6 +620,7 @@ namespace NLog.Targets
             }
         }
 
+
         /// <summary>
         /// Writes the specified logging event to a file specified in the FileName 
         /// parameter.
@@ -634,11 +639,12 @@ namespace NLog.Targets
             // this log file and the archiving system is date/time based.
             if (this.ArchiveNumbering == ArchiveNumberingMode.Date && this.ArchiveEvery != FileArchivePeriod.None)
             {
-                FileInfo fileInfo = new FileInfo(fileName);
-                if (!fileInfo.Exists)
+                if (this.previousFileName != fileName)
                 {
+                    FileInfo fileInfo = new FileInfo(fileName);
                     string fileNamePattern = this.GetFileNamePattern(fileName, logEvent, fileInfo);
                     this.DeleteOldDateArchive(fileNamePattern);
+                    this.previousFileName = fileName;
                 }
             }
 

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -562,6 +562,71 @@ namespace NLog.UnitTests.Targets
             }
         }
 
+        // Test commented out as it takes 5 minutes to run
+        /*
+        [Fact]
+        public void DeleteArchiveFilesByDateWithDateName()
+        {
+            var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var tempFile = Path.Combine(tempPath, "${date:format=yyyyMMddHHmm}.txt");
+            try
+            {
+                var ft = new FileTarget
+                {
+                    FileName = tempFile,
+                    ArchiveFileName = Path.Combine(tempPath, "{#}.txt"),
+                    ArchiveEvery = FileArchivePeriod.Minute,
+                    LineEnding = LineEndingMode.LF,
+                    ArchiveNumbering = ArchiveNumberingMode.Date,
+                    ArchiveDateFormat = "yyyyMMddHHmm", //make sure the minutes are set in the filename
+                    Layout = "${message}",
+                    MaxArchiveFiles = 3
+                };
+
+                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                //writing 4 times 10 bytes (9 char + linefeed) will result in 2 archive files and 1 current file
+                for (var i = 0; i < 4; ++i)
+                {
+                    logger.Debug("123456789");
+                    //build in a  sleep to make sure the current time is reflected in the filename
+                    Thread.Sleep(60000);
+                }
+                //Setting the Configuration to [null] will result in a 'Dump' of the current log entries
+                LogManager.Configuration = null;
+
+                var files = Directory.GetFiles(tempPath).OrderBy(s => s);
+                //the amount of archived files may not exceed the set 'MaxArchiveFiles'
+                Assert.Equal(ft.MaxArchiveFiles, files.Count());
+
+
+                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                //writing one minute later will trigger the cleanup of old archived files
+                //as stated by the MaxArchiveFiles property, but will only delete the oldest file
+                Thread.Sleep(60000);
+                logger.Debug("123456789");
+                LogManager.Configuration = null;
+
+                var files2 = Directory.GetFiles(tempPath).OrderBy(s => s);
+                Assert.Equal(ft.MaxArchiveFiles, files2.Count());
+
+                //the oldest file should be deleted
+                Assert.DoesNotContain(files.ElementAt(0), files2);
+                //two files should still be there
+                Assert.Equal(files.ElementAt(1), files2.ElementAt(0));
+                Assert.Equal(files.ElementAt(2), files2.ElementAt(1));
+                //one new archive file shoud be created
+                Assert.DoesNotContain(files2.ElementAt(2), files);
+            }
+            finally
+            {
+                LogManager.Configuration = null;
+                if (File.Exists(tempFile))
+                    File.Delete(tempFile);
+                if (Directory.Exists(tempPath))
+                    Directory.Delete(tempPath, true);
+            }
+        }*/
+
         public static IEnumerable<object[]> DateArchive_UsesDateFromCurrentTimeSource_TestParameters
         {
             get

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -562,13 +562,11 @@ namespace NLog.UnitTests.Targets
             }
         }
 
-        // Test commented out as it takes 5 minutes to run
-        /*
         [Fact]
         public void DeleteArchiveFilesByDateWithDateName()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "${date:format=yyyyMMddHHmm}.txt");
+            var tempFile = Path.Combine(tempPath, "${date:format=yyyyMMddHHmmssfff}.txt");
             try
             {
                 var ft = new FileTarget
@@ -578,7 +576,7 @@ namespace NLog.UnitTests.Targets
                     ArchiveEvery = FileArchivePeriod.Minute,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = ArchiveNumberingMode.Date,
-                    ArchiveDateFormat = "yyyyMMddHHmm", //make sure the minutes are set in the filename
+                    ArchiveDateFormat = "yyyyMMddHHmmssfff", //make sure the milliseconds are set in the filename
                     Layout = "${message}",
                     MaxArchiveFiles = 3
                 };
@@ -589,7 +587,7 @@ namespace NLog.UnitTests.Targets
                 {
                     logger.Debug("123456789");
                     //build in a  sleep to make sure the current time is reflected in the filename
-                    Thread.Sleep(60000);
+                    Thread.Sleep(50);
                 }
                 //Setting the Configuration to [null] will result in a 'Dump' of the current log entries
                 LogManager.Configuration = null;
@@ -600,9 +598,9 @@ namespace NLog.UnitTests.Targets
 
 
                 SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
-                //writing one minute later will trigger the cleanup of old archived files
+                //writing 50ms later will trigger the cleanup of old archived files
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest file
-                Thread.Sleep(60000);
+                Thread.Sleep(50);
                 logger.Debug("123456789");
                 LogManager.Configuration = null;
 
@@ -625,7 +623,7 @@ namespace NLog.UnitTests.Targets
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
-        }*/
+        }
 
         public static IEnumerable<object[]> DateArchive_UsesDateFromCurrentTimeSource_TestParameters
         {


### PR DESCRIPTION
If archiving mode is set to date when a new log file is created, due to naming rules, the program will delete any
out of date archives.

Summary of changes
--------------------------
* Moved code to delete old archives in date mode to separate function 
* Moved code to get file name pattern into a separate function
* Added code to write function that runs the delete archive function when a new log file is started
* Added unit test for bug 390

Unit test for bug 390 is commented out as it takes 5 minutes to run it. This is due to the fact the minimum time period for archiving is a minute.

Fixes bug 390