### PR TITLE
Handle .tt in .csproj better 

### DIFF
--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -396,4 +396,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(StyleCopTargetsFile)" Condition="Exists('$(StyleCopTargetsFile)')" />
+  <ItemGroup>
+    <None Include="Logger.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Logger1.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/NLog/NLog.mono2.csproj
+++ b/src/NLog/NLog.mono2.csproj
@@ -403,4 +403,10 @@
     </ItemGroup>
   </Target>
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <ItemGroup>
+    <None Include="Logger.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Logger1.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/NLog/NLog.monodevelop.csproj
+++ b/src/NLog/NLog.monodevelop.csproj
@@ -399,4 +399,10 @@
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <None Include="Logger.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Logger1.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -403,4 +403,10 @@
     </ItemGroup>
   </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <ItemGroup>
+    <None Include="Logger.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Logger1.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -396,6 +396,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Logger.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Logger1.cs</LastGenOutput>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(StyleCopTargetsFile)" Condition="Exists('$(StyleCopTargetsFile)')" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -400,6 +400,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Logger.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Logger1.cs</LastGenOutput>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(StyleCopTargetsFile)" Condition="Exists('$(StyleCopTargetsFile)')" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -399,6 +399,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Migrated rules for NLog.sl4.ruleset" />
+    <None Include="Logger.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Logger1.cs</LastGenOutput>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Silverlight\$(SilverlightVersion)\Microsoft.Silverlight.CSharp.targets" />
   <ProjectExtensions>

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -409,4 +409,10 @@
     </ItemGroup>
   </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <ItemGroup>
+    <None Include="Logger.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Logger1.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -406,4 +406,10 @@
       <Compile Include="$(BuildInfoFile)" />
     </ItemGroup>
   </Target>
+  <ItemGroup>
+    <None Include="Logger.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Logger1.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -401,4 +401,10 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <None Include="Logger.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Logger1.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/NLog/ProjectFileInfo.xml
+++ b/src/NLog/ProjectFileInfo.xml
@@ -1,124 +1,165 @@
 <ProjectFiles>
-   <!--
+  <!--
      this file contains information necessary to regenerate Compile items in all NLog project files 
      based on contents of this directory
 
      The file is processed by SyncProjectItems.exe in tools directory.
    -->
 
-   <FileSet Name="AllFilesToCompile">
-     <Include File="*.cs" />
-   </FileSet>
+  <FileSet Name="AllFilesToCompile">
+    <Include File="*.cs" />
+  </FileSet>
 
-   <FileSet Name="AllResources">
-     <Include File="*.ico" />
-   </FileSet>
 
-   <FileSet Name="CommonFiles">
+  <FileSet Name="AllResources">
+    <Include File="*.ico" />
+  </FileSet>
+
+  <FileSet Name="CommonFiles">
     <Include File="AssemblyBuildInfo.cs" />
     <Include File="GlobalSuppressions.cs" />
     <Include File="Properties\AssemblyInfo.cs" />
     <Include File="Internal\LogEventInfoBuffer.cs" />
-   </FileSet>
+  </FileSet>
 
-   <FileSet Name="ExcludedFromStyleCop">
+  <FileSet Name="ExcludedFromStyleCop">
     <Include File="ComInterop\IComLogManager.cs" />
     <Include File="ComInterop\IComLogger.cs" />
     <Include File="Internal\AspHelper.cs" />
     <Include File="Internal\NativeMethods.cs" />
     <Include File="Internal\Win32FileNativeMethods.cs" />
     <Include File="Logger-V1Compat.cs" />
-   </FileSet>
+  </FileSet>
 
-   <Customize FileSet="ExcludedFromStyleCop" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-   </Customize>
-   
-  <FileSet Name="logger.tt">
+  <Customize FileSet="ExcludedFromStyleCop" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+  </Customize>
+
+  <FileSet Name="Logger.tt-result">
     <Include File="Logger1.cs" />
   </FileSet>
-  <Customize FileSet="logger.tt" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Customize FileSet="Logger.tt-result" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <AutoGen>True</AutoGen>
     <DesignTime>True</DesignTime>
     <DependentUpon>Logger.tt</DependentUpon>
   </Customize>
 
-   <Project File="NLog.sl4.csproj">
-     <ItemGroup Name="Compile">
-        <FileSet Include="AllFilesToCompile" />
-     </ItemGroup>
-   </Project>
+  <FileSet Name="Logger.tt">
+    <Include File="Logger.tt" />
+  </FileSet>
+  <Customize FileSet="Logger.tt" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Generator>TextTemplatingFileGenerator</Generator>
+    <LastGenOutput>Logger1.cs</LastGenOutput>
+  </Customize>
 
-   <Project File="NLog.sl5.csproj">
-     <ItemGroup Name="Compile">
-        <FileSet Include="AllFilesToCompile" />
-     </ItemGroup>
-   </Project>
+  <Project File="NLog.sl4.csproj">
+    <ItemGroup Name="Compile">
+      <FileSet Include="AllFilesToCompile" />
+    </ItemGroup>
+    <ItemGroup Name="None" KeepOldFiles="true">
+      <FileSet Include="Logger.tt" />
+    </ItemGroup>
+  </Project>
 
-   <Project File="NLog.mono2.csproj">
-     <ItemGroup Name="Compile">
-        <FileSet Include="AllFilesToCompile" />
-     </ItemGroup>
-     <ItemGroup Name="EmbeddedResource">
-        <FileSet Include="AllResources" />
-     </ItemGroup>
-   </Project>
+  <Project File="NLog.sl5.csproj">
+    <ItemGroup Name="Compile">
+      <FileSet Include="AllFilesToCompile" />
+    </ItemGroup>
+    <ItemGroup Name="None" KeepOldFiles="true">
+      <FileSet Include="Logger.tt" />
+    </ItemGroup>
+  </Project>
 
-   <Project File="NLog.monodevelop.csproj">
-     <ItemGroup Name="Compile">
-        <FileSet Include="AllFilesToCompile" />
-     </ItemGroup>
-     <ItemGroup Name="EmbeddedResource">
-        <FileSet Include="AllResources" />
-     </ItemGroup>
-   </Project>
+  <Project File="NLog.mono2.csproj">
+    <ItemGroup Name="Compile">
+      <FileSet Include="AllFilesToCompile" />
+    </ItemGroup>
+    <ItemGroup Name="None" KeepOldFiles="true">
+      <FileSet Include="Logger.tt" />
+    </ItemGroup>
+    <ItemGroup Name="EmbeddedResource">
+      <FileSet Include="AllResources" />
+    </ItemGroup>
+  </Project>
 
-   <Project File="NLog.netfx35.csproj">
-     <ItemGroup Name="Compile">
-        <FileSet Include="AllFilesToCompile" />
-     </ItemGroup>
-     <ItemGroup Name="EmbeddedResource">
-        <FileSet Include="AllResources" />
-     </ItemGroup>
-   </Project>
+  <Project File="NLog.monodevelop.csproj">
+    <ItemGroup Name="Compile">
+      <FileSet Include="AllFilesToCompile" />
+    </ItemGroup>
+    <ItemGroup Name="None" KeepOldFiles="true">
+      <FileSet Include="Logger.tt" />
+    </ItemGroup>
+    <ItemGroup Name="EmbeddedResource">
+      <FileSet Include="AllResources" />
+    </ItemGroup>
+  </Project>
 
-   <Project File="NLog.netfx40.csproj">
-     <ItemGroup Name="Compile">
-        <FileSet Include="AllFilesToCompile" />
-     </ItemGroup>
-     <ItemGroup Name="EmbeddedResource">
-        <FileSet Include="AllResources" />
-     </ItemGroup>
-   </Project>
+  <Project File="NLog.netfx35.csproj">
+    <ItemGroup Name="Compile">
+      <FileSet Include="AllFilesToCompile" />
+    </ItemGroup>
+    <ItemGroup Name="None" KeepOldFiles="true">
+      <FileSet Include="Logger.tt" />
+    </ItemGroup>
+    <ItemGroup Name="EmbeddedResource">
+      <FileSet Include="AllResources" />
+    </ItemGroup>
+  </Project>
 
-   <Project File="NLog.netfx45.csproj">
-     <ItemGroup Name="Compile">
-        <FileSet Include="AllFilesToCompile" />
-     </ItemGroup>
-     <ItemGroup Name="EmbeddedResource">
-        <FileSet Include="AllResources" />
-     </ItemGroup>
-   </Project>
+  <Project File="NLog.netfx40.csproj">
+    <ItemGroup Name="Compile">
+      <FileSet Include="AllFilesToCompile" />
+    </ItemGroup>
+    <ItemGroup Name="None" KeepOldFiles="true">
+      <FileSet Include="Logger.tt" />
+    </ItemGroup>
+    <ItemGroup Name="EmbeddedResource">
+      <FileSet Include="AllResources" />
+    </ItemGroup>
+  </Project>
 
-   <Project File="NLog.wp7.csproj">
-     <ItemGroup Name="Compile">
-        <FileSet Include="AllFilesToCompile" />
-     </ItemGroup>
-   </Project>
-                          
-   <Project File="NLog.wp71.csproj">
-     <ItemGroup Name="Compile">
-        <FileSet Include="AllFilesToCompile" />
-     </ItemGroup>
-   </Project>
+  <Project File="NLog.netfx45.csproj">
+    <ItemGroup Name="Compile">
+      <FileSet Include="AllFilesToCompile" />
+    </ItemGroup>
+    <ItemGroup Name="None" KeepOldFiles="true">
+      <FileSet Include="Logger.tt" />
+    </ItemGroup>
+    <ItemGroup Name="EmbeddedResource">
+      <FileSet Include="AllResources" />
+    </ItemGroup>
+  </Project>
 
-   <Project File="NLog.doc.csproj">
-     <ItemGroup Name="Compile">
-        <FileSet Include="AllFilesToCompile" />
-     </ItemGroup>
-     <ItemGroup Name="EmbeddedResource">
-        <FileSet Include="AllResources" />
-     </ItemGroup>
-   </Project>
+  <Project File="NLog.wp7.csproj">
+    <ItemGroup Name="Compile">
+      <FileSet Include="AllFilesToCompile" />
+    </ItemGroup>
+    <ItemGroup Name="None" KeepOldFiles="true">
+      <FileSet Include="Logger.tt" />
+    </ItemGroup>
+
+  </Project>
+
+  <Project File="NLog.wp71.csproj">
+    <ItemGroup Name="Compile">
+      <FileSet Include="AllFilesToCompile" />
+    </ItemGroup>
+    <ItemGroup Name="None" KeepOldFiles="true">
+      <FileSet Include="Logger.tt" />
+    </ItemGroup>
+
+  </Project>
+
+  <Project File="NLog.doc.csproj">
+    <ItemGroup Name="Compile">
+      <FileSet Include="AllFilesToCompile" />
+    </ItemGroup>
+    <ItemGroup Name="None" KeepOldFiles="true">
+      <FileSet Include="Logger.tt" />
+    </ItemGroup>
+    <ItemGroup Name="EmbeddedResource">
+      <FileSet Include="AllResources" />
+    </ItemGroup>
+  </Project>
 
 </ProjectFiles>


### PR DESCRIPTION
The SyncProjectItems tool had some problems with the .tt files.

This is now resolved with configuration + new features in SyncProjectItems.


- SyncProjectItems config now handles 'None' itemgroup
- SyncProjectItems can now keep current files in an itemgroup. (`KeepOldFiles` attribute in .xml)
- SyncProjectItems  handles some errors better (no nullref)