### PR TITLE
Added caller attributes for a single log method (WIP)

### DIFF
--- a/src/NLog/ILoggerBase.cs
+++ b/src/NLog/ILoggerBase.cs
@@ -36,6 +36,9 @@ namespace NLog
     using System;
     using System.ComponentModel;
     using JetBrains.Annotations;
+#if NET4_5
+    using System.Runtime.CompilerServices;
+#endif
 
     public partial interface ILoggerBase
     {
@@ -69,11 +72,27 @@ namespace NLog
 
         #region Log() overloads
 
+#if NET4_5
         /// <summary>
         /// Writes the specified diagnostic message.
         /// </summary>
         /// <param name="logEvent">Log event.</param>
-        void Log(LogEventInfo logEvent);
+        /// <param name="memberName">Method or property name of the caller.</param>
+        /// <param name="sourceFilePath">Full path of the source file that contains the caller.</param>
+        /// <param name="sourceLineNumber">Line number in the source file at which the method is called.</param>
+#else
+        /// <summary>
+        /// Writes the specified diagnostic message.
+        /// </summary>
+        /// <param name="logEvent">Log event.</param>
+#endif
+        void Log(LogEventInfo logEvent
+#if NET4_5
+           , [CallerMemberName] string memberName = ""
+           , [CallerFilePath] string sourceFilePath = ""
+           , [CallerLineNumber] int sourceLineNumber = 0
+#endif
+            );
 
         /// <summary>
         /// Writes the specified diagnostic message.

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -39,6 +39,7 @@ namespace NLog
     using JetBrains.Annotations;
 #if ASYNC_SUPPORTED
     using System.Threading.Tasks;
+    using System.Runtime.CompilerServices;
 #endif
 
     /// <summary>
@@ -95,14 +96,35 @@ namespace NLog
             return this.GetTargetsForLevel(level) != null;
         }
 
+#if NET4_5 
         /// <summary>
         /// Writes the specified diagnostic message.
         /// </summary>
         /// <param name="logEvent">Log event.</param>
-        public void Log(LogEventInfo logEvent)
+        /// <param name="memberName">Method or property name of the caller.</param>
+        /// <param name="sourceFilePath">Full path of the source file that contains the caller.</param>
+        /// <param name="sourceLineNumber">Line number in the source file at which the method is called.</param>
+#else   
+        /// <summary>
+        /// Writes the specified diagnostic message.
+        /// </summary>
+        /// <param name="logEvent">Log event.</param>
+#endif
+        public void Log(LogEventInfo logEvent
+#if NET4_5
+           , [CallerMemberName] string memberName = ""
+           , [CallerFilePath] string sourceFilePath = ""
+           , [CallerLineNumber] int sourceLineNumber = 0
+#endif
+            )
         {
             if (this.IsEnabled(logEvent.Level))
             {
+#if NET4_5
+                logEvent.CallerMethodName = memberName;
+                logEvent.CallerSourceFilePath = sourceFilePath;
+                logEvent.CallerLineNumber = sourceLineNumber;
+#endif
                 this.WriteToTargets(logEvent);
             }
         }


### PR DESCRIPTION
Applies to #532.

I added Caller attributes to a single method from the Llogger class:
 `public void Log(LogEventInfo logEvent, [CallerMemberName] string memberName = "", [CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)`

I also made the necessary changes to `LogEventInfo` and `CallSiteLayoutRenderer`.

I can extend the changes to all Logger public methods but I wanted to try with a single method firs.

I think the existing unit tests cover the functionality well enough, but I can add tests if needed.