### PR TITLE
fix default value of Commandtype

### DIFF
--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -90,6 +90,7 @@ namespace NLog.Targets
             this.DBProvider = "sqlserver";
             this.DBHost = ".";
             this.ConnectionStringsSettings = ConfigurationManager.ConnectionStrings;
+            this.CommandType = CommandType.Text;
         }
 
         /// <summary>


### PR DESCRIPTION
fixes #571 

The default value was not set. The default of enums are always 0. (http://stackoverflow.com/questions/4967656/what-is-the-default-value-for-enum-variable)

This seems the same bug as #555 ! The `[DefaultValue]` attribute was set, but it wasn't set from the ctor. 