### PR TITLE
Added unit test to validate the [DefaultValue] attribute values + update DefaultAttributes

### DIFF
--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -162,7 +162,7 @@ namespace NLog.Targets
         /// database connection open between the log events.
         /// </summary>
         /// <docgen category='Connection Options' order='10' />
-        [DefaultValue(true)]
+        [DefaultValue(false)]
         public bool KeepConnection { get; set; }
 
         /// <summary>

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -148,7 +148,7 @@ namespace NLog.Targets
         /// </summary>
         /// <remarks>Alias for the <c>Layout</c> property.</remarks>
         /// <docgen category='Message Options' order='6' />
-        [DefaultValue("${message}")]
+        [DefaultValue("${message}${newline}")]
         public Layout Body
         {
             get { return this.Layout; }


### PR DESCRIPTION
Added unit test to validate the `[DefaultValue]` attribute values because of the recurring bugs.

Closes #652

Note: the unit tests are failing for 3 properties. We have to fix those 3. (also I would like to see the error message in AppVeyor.

message:
----

Additional information: 3 errors: 

 -------- 

- NLog.Targets.DatabaseTarget.KeepConnection has a wrong value for [DefaultValueAttribute] compared to the default ctor. DefaultValueAttribute says = 'True' and ctor tells = 'False'

- NLog.Targets.DatabaseTarget.CommandType has a wrong value for [DefaultValueAttribute] compared to the default ctor. DefaultValueAttribute says = 'Text' and ctor tells = '0'

- NLog.Targets.MailTarget.Body has a wrong value for [DefaultValueAttribute] compared to the default ctor. DefaultValueAttribute says = '${message}' and ctor tells = ''${message}${newline}''

