### PR TITLE
Bugfix: Broken xml stops logging

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -62,6 +62,8 @@ namespace NLog.Config
 
         private string originalFileName;
 
+
+
         /// <summary>
         /// Initializes a new instance of the <see cref="XmlLoggingConfiguration" /> class.
         /// </summary>
@@ -155,6 +157,11 @@ namespace NLog.Config
             }
         }
 #endif
+
+        /// <summary>
+        /// Did the <see cref="Initialize"/> Succeeded? <c>true</c>= success, <c>false</c>= error, <c>null</c> = initialize not started yet.
+        /// </summary>
+        public bool? InitializeSucceeded { get; private set; }
 
         /// <summary>
         /// Gets the variables defined in the configuration.
@@ -259,6 +266,7 @@ namespace NLog.Config
         {
             try
             {
+                InitializeSucceeded = null;
                 reader.MoveToContent();
                 var content = new NLogXmlElement(reader);
                 if (fileName != null)
@@ -279,9 +287,11 @@ namespace NLog.Config
                 {
                     this.ParseTopLevel(content, null);
                 }
+                InitializeSucceeded = true;
             }
             catch (Exception exception)
             {
+                InitializeSucceeded = false;
                 if (exception.MustBeRethrown())
                 {
                     throw;

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -61,9 +61,7 @@ namespace NLog.Config
         private readonly Dictionary<string, string> variables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase); 
 
         private string originalFileName;
-
-
-
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="XmlLoggingConfiguration" /> class.
         /// </summary>

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -597,9 +597,22 @@ namespace NLog
                     {
                         throw new NLogConfigurationException("Config changed in between. Not reloading.");
                     }
-                    //problem: XmlLoggingConfiguration.Initialize eats exception. ALso XmlLoggingConfiguration.Reload never returns null.
-                    //therefor reload is always turned of
+                
                     LoggingConfiguration newConfig = configurationToReload.Reload();
+
+                    //problem: XmlLoggingConfiguration.Initialize eats exception with invalid XML. ALso XmlLoggingConfiguration.Reload never returns null.
+                    //therefor we check the InitializeSucceeded property.
+                    
+                    var xmlConfig = newConfig as XmlLoggingConfiguration;
+                    if (xmlConfig != null)
+                    {
+                        
+                        if (!xmlConfig.InitializeSucceeded.HasValue || !xmlConfig.InitializeSucceeded.Value)
+                        {
+                            throw new NLogConfigurationException("Configuration.Reload() failed. Invalid XML?");
+                        }
+                    }
+
                     if (newConfig != null)
                     {
                         this.Configuration = newConfig;

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -597,7 +597,8 @@ namespace NLog
                     {
                         throw new NLogConfigurationException("Config changed in between. Not reloading.");
                     }
-
+                    //problem: XmlLoggingConfiguration.Initialize eats exception. ALso XmlLoggingConfiguration.Reload never returns null.
+                    //therefor reload is always turned of
                     LoggingConfiguration newConfig = configurationToReload.Reload();
                     if (newConfig != null)
                     {

--- a/tests/NLog.UnitTests/Config/IncludeTests.cs
+++ b/tests/NLog.UnitTests/Config/IncludeTests.cs
@@ -45,12 +45,6 @@ namespace NLog.UnitTests.Config
 
     public class IncludeTests : NLogTestBase
     {
-
-       
-
-
-    
-
         [Fact]
         public void IncludeTest()
         {

--- a/tests/NLog.UnitTests/Config/IncludeTests.cs
+++ b/tests/NLog.UnitTests/Config/IncludeTests.cs
@@ -33,6 +33,7 @@
 
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using NLog.Targets;
 
 namespace NLog.UnitTests.Config
@@ -45,112 +46,10 @@ namespace NLog.UnitTests.Config
     public class IncludeTests : NLogTestBase
     {
 
-
-        [Fact]
-        public void ReloadInvalidXMlTest()
-        {
-            var validXML = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
-<nlog xmlns=""http://www.nlog-project.org/schemas/NLog.xsd""
-      xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" 
-      autoReload=""true"" 
-      internalLogLevel=""Info"" 
-      throwExceptions=""false"">
-  <targets>
-    <target name=""file"" xsi:type=""File""   fileName=""c:\temp\log.txt"" layout=""${level} "" />
-  </targets>
-  <rules>
-    <logger name=""*"" minlevel=""Error"" writeTo=""file"" />
-  </rules>
-</nlog>
-";
-
-            var validXML2 = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
-<nlog xmlns=""http://www.nlog-project.org/schemas/NLog.xsd""
-      xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" 
-      autoReload=""true"" 
-      internalLogLevel=""Info"" 
-      throwExceptions=""false"">
-  <targets>
-    <target name=""file"" xsi:type=""File""   fileName=""c:\temp\log2.txt"" layout=""${level} "" />
-  </targets>
-  <rules>
-    <logger name=""*"" minlevel=""Error"" writeTo=""file"" />
-  </rules>
-</nlog>
-";
-
-            var invalidXML = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
-<nlog xmlns=""http://www.nlog-project.org/schemas/NLog.xsd""
-      xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" 
-      autoReload=""true"" 
-      internalLogLevel=""Info"" 
-      throwExceptions=""false"">
-  <targets>
-    <target name=""file"" xsi:type=""File""   fileName=""c:\temp\log.txt"" layout=""${level} "" />
-  </targets>
-  <rules>
-    <logger name=""*"" minlevel=""Error"" writeTo=""file"" />
-
-";
-
-            
-          
-
-            try
-            {
-
-                string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-                Directory.CreateDirectory(tempPath);
-
-                var tempPathFile = Path.Combine(tempPath, "main.nlog");
-
-                var path = WriteToFile(validXML, tempPathFile);
-
-                var xmlLoggingConfiguration = new XmlLoggingConfiguration(path);
-                LogManager.Configuration = xmlLoggingConfiguration;
-
-                Test(@"c:\temp\log.txt");
-
-                WriteToFile(validXML2, tempPathFile);
+       
 
 
-
-                Test(@"c:\temp\log2.txt");
-
-            }
-            finally
-            {
-                LogManager.Configuration = null;
-
-            }
-        }
-
-        private static void Test(string test)
-        {
-
-          
-            var loggingConfiguration = LogManager.Configuration;
-            LogManager.Configuration = loggingConfiguration;
-           // xmlLoggingConfiguration.Reload();
-            Assert.True(((XmlLoggingConfiguration)loggingConfiguration).AutoReload);
-            Assert.Equal(1, loggingConfiguration.FileNamesToWatch.Count());
-            //   Assert.Equal(1, xmlLoggingConfiguration.AllTargets.Count);
-
-            var target = LogManager.Configuration.FindTargetByName("file") as FileTarget;
-            Assert.NotNull(target);
-            Assert.Equal(string.Format(@"'{0}'", test), target.FileName.ToString());
-        }
-
-        private static string WriteToFile(string configXML, string path)
-        {
-          
-
-            using (StreamWriter fs = File.CreateText(path))
-                fs.Write(configXML);
-
-            string fileToLoad = path;
-            return fileToLoad;
-        }
+    
 
         [Fact]
         public void IncludeTest()

--- a/tests/NLog.UnitTests/Config/IncludeTests.cs
+++ b/tests/NLog.UnitTests/Config/IncludeTests.cs
@@ -92,8 +92,6 @@ namespace NLog.UnitTests.Config
             }
         }
 
-
-
         [Fact]
         public void IncludeNotExistingTest()
         {

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -211,7 +211,12 @@ namespace NLog.UnitTests
                 LogManager.Configuration = xmlLoggingConfiguration;
 
 
-                LogManager.ConfigurationReloaded += (sender, e) => counterEvent.Signal();
+                LogManager.ConfigurationReloaded += (sender, e) =>
+                {
+                    
+                    if(counterEvent.CurrentCount < 1)
+                        counterEvent.Signal();
+                };
 
                 Test_if_reload_success(@"c:\temp\log.txt");
 
@@ -259,7 +264,11 @@ namespace NLog.UnitTests
                 var xmlLoggingConfiguration = new XmlLoggingConfiguration(tempPathFile);
                 LogManager.Configuration = xmlLoggingConfiguration;
 
-                LogManager.ConfigurationReloaded += (sender, e) => counterEvent.Signal();
+                LogManager.ConfigurationReloaded += (sender, e) =>
+                {
+                    if(counterEvent.CurrentCount <3 )
+                        counterEvent.Signal();
+                };
 
                 Test_if_reload_success(@"c:\temp\log.txt");
 

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -192,10 +192,8 @@ namespace NLog.UnitTests
         [Fact]
         public void Auto_reload_validxml_test()
         {
-
             try
             {
-
                 string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
                 Directory.CreateDirectory(tempPath);
 
@@ -208,8 +206,7 @@ namespace NLog.UnitTests
 
                 var xmlLoggingConfiguration = new XmlLoggingConfiguration(tempPathFile);
                 LogManager.Configuration = xmlLoggingConfiguration;
-
-
+                
                 LogManager.ConfigurationReloaded += (sender, e) =>
                 {
                     
@@ -226,8 +223,6 @@ namespace NLog.UnitTests
 
                 Test_if_reload_success(@"c:\temp\log2.txt");
 
-
-
             }
             finally
             {
@@ -239,12 +234,8 @@ namespace NLog.UnitTests
         [Fact]
         public void Auto_Reload_invalidxml_test()
         {
-
-
-
             try
             {
-
                 string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
                 Directory.CreateDirectory(tempPath);
 
@@ -284,7 +275,6 @@ namespace NLog.UnitTests
             finally
             {
                 LogManager.Configuration = null;
-
             }
         }
 
@@ -352,8 +342,6 @@ namespace NLog.UnitTests
         /// <param name="filenameTest"></param>
         private static void Test_if_reload_success(string filenameTest)
         {
-
-
             var loggingConfiguration = LogManager.Configuration;
             LogManager.Configuration = loggingConfiguration;
             // xmlLoggingConfiguration.Reload();
@@ -373,12 +361,8 @@ namespace NLog.UnitTests
         /// <param name="path">path to file</param>
         private static void WriteToFile(string configXML, string path)
         {
-
-
             using (StreamWriter fs = File.CreateText(path))
                 fs.Write(configXML);
-
-
         }
     }
 }

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -186,7 +186,6 @@ namespace NLog.UnitTests
             throw new Exception();
         }
 
-
         /// <summary>
         /// Reload by writing file test
         /// </summary>
@@ -236,11 +235,6 @@ namespace NLog.UnitTests
 
             }
         }
-
-
-
-
-
 
         [Fact]
         public void Auto_Reload_invalidxml_test()

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -255,19 +255,30 @@ namespace NLog.UnitTests
 
 
                 //set invalid, set valid
-
                 WriteToFile(invalidXML, tempPathFile);
 
-                counterEvent.Wait(2000);
+                counterEvent.Wait(5000);
+
+                if (counterEvent.CurrentCount != 0)
+                {
+                    throw new Exception("failed to reload");
+                }
                
-                WriteToFile(validXML2, tempPathFile);
+               
 
                 LogManager.ConfigurationReloaded -= SignalCounterEvent1(counterEvent);
 
                 var counterEvent2 = new CountdownEvent(1);
                 LogManager.ConfigurationReloaded += (sender, e) => SignalCounterEvent(counterEvent2);
 
-                counterEvent2.Wait(2000);
+                WriteToFile(validXML2, tempPathFile);
+
+                counterEvent2.Wait(5000);
+
+                if (counterEvent2.CurrentCount != 0)
+                {
+                    throw new Exception("failed to reload - 2");
+                }
 
                 Test_if_reload_success(@"c:\temp\log2.txt");
 
@@ -285,8 +296,8 @@ namespace NLog.UnitTests
 
         private static void SignalCounterEvent(CountdownEvent counterEvent)
         {
-            //we get this event sometimes mulitple times for 1 change
-            if (counterEvent.CurrentCount < 1)
+            //we get this event sometimes mulitple times for 1 change. So no signal if not needed.
+            if (counterEvent.CurrentCount > 0)
             {
                 counterEvent.Signal();
             }


### PR DESCRIPTION
fixes #273 

problem: `XmlLoggingConfiguration.Initialize` eats exception with invalid
XML. ALso `XmlLoggingConfiguration.Reload` never returns `null`.
So the `null` check is not enough

- added `InitializeSucceeded` (nullable `bool`) in `XmlLoggingConfiguration`
- checks also `InitializeSucceeded`. If` false`, DON't apply the config.

Result: invalidating the XML won't stop logging, the old config will be used.
Also, the auto reload won't turned to `false` (the default)

The unit tests proves the solution and also the previous problem. 