### PR TITLE
Fixed an issue where log files couldn't use the same name as archive file...

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1006,9 +1006,12 @@ namespace NLog.Targets
                 var filesByDate = new List<string>();
                 for (int index = 0; index < files.Count; index++)
                 {
-                    string archiveFileName = Path.GetFileName(files[index]);
+                    //Get the archive file name or empty string if it's null
+                    string archiveFileName = Path.GetFileName(files[index]) ?? "";
 
-                    if (string.IsNullOrEmpty(archiveFileName))
+                    //If our archive name is empty or it's the same as our intended log file, just continue checking.
+                    if (string.IsNullOrEmpty(archiveFileName) || 
+                        archiveFileName.Equals(Path.GetFileName(fileName)))
                     {
                         continue;
                     }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1004,15 +1004,20 @@ namespace NLog.Targets
 #endif
 
                 var filesByDate = new List<string>();
+
+                //It's possible that the log file itself has a name that will match the archive file mask.
+                var archiveFileCount = files.Count; 
+
                 for (int index = 0; index < files.Count; index++)
                 {
                     //Get the archive file name or empty string if it's null
                     string archiveFileName = Path.GetFileName(files[index]) ?? "";
 
-                    //If our archive name is empty or it's the same as our intended log file, just continue checking.
+
                     if (string.IsNullOrEmpty(archiveFileName) || 
                         archiveFileName.Equals(Path.GetFileName(fileName)))
                     {
+                        archiveFileCount--;
                         continue;
                     }
 
@@ -1050,7 +1055,7 @@ namespace NLog.Targets
                 // Cleanup archive files
                 for (int fileIndex = 0; fileIndex < filesByDate.Count; fileIndex++)
                 {
-                    if (fileIndex > files.Count - this.MaxArchiveFiles)
+                    if (fileIndex > archiveFileCount - this.MaxArchiveFiles)
                         break;
 
                     File.Delete(filesByDate[fileIndex]);

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -31,7 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.Runtime.InteropServices;
 using NLog.Internal;
 using NLog.LayoutRenderers;
 using Xunit.Extensions;

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -31,6 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Runtime.InteropServices;
 using NLog.Internal;
 using NLog.LayoutRenderers;
 using Xunit.Extensions;
@@ -1393,7 +1394,7 @@ namespace NLog.UnitTests.Targets
 #if NET4_5
                     enableCompression ? new Action<string, string, Encoding>(AssertZipFileContents) : AssertFileContents;
 #else
- new Action<string, string, Encoding>(AssertFileContents);
+                new Action<string, string, Encoding>(AssertFileContents);
 #endif
                 AssertFileContents(tempFile,
                     StringRepeat(250, "eee\n"),
@@ -1500,6 +1501,51 @@ namespace NLog.UnitTests.Targets
             }
         }
 
+        [Fact]
+        public void FileTarget_LogAndArchiveFilesWithSameName_ShouldArchive()
+        {
+            var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var logFile = Path.Combine(tempPath, "Application.log");
+            var tempDirectory = new DirectoryInfo(tempPath);
+            try
+            {
+
+                var archiveFile = Path.Combine(tempPath, "Application{#}.log");
+                var archiveFileMask = "Application*.log";
+
+                var ft = new FileTarget
+                {
+                    FileName = logFile,
+                    ArchiveFileName = archiveFile,
+                    ArchiveAboveSize = 1, //Force immediate archival
+                    ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
+                    MaxArchiveFiles = 5
+                };
+
+                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+
+                //Creates 5 archive files.
+                for (int i = 0; i <= 5; i++)
+                {
+                    logger.Debug("a");
+                }
+
+                Assert.True(File.Exists(logFile));
+
+                //Five archive files, plus the log file itself.
+                Assert.True(tempDirectory.GetFiles(archiveFileMask).Count() == 5 + 1);
+            }
+            finally
+            {
+                LogManager.Configuration = null;
+
+                if (tempDirectory.Exists)
+                {
+                    tempDirectory.Delete(true);
+                }
+            }
+            
+        }
 
     
     }


### PR DESCRIPTION
Fixed an issue where log files couldn't use the same name as archive files when archiving with DateSequence when the files were in the same directory. Didn't affect other archive types.