### PR TITLE
Make alignment stay consistent when fixed-length truncation occurs.

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/PaddingHorizontalAlignment.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/PaddingHorizontalAlignment.cs
@@ -1,0 +1,52 @@
+﻿// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.LayoutRenderers.Wrappers
+{
+    /// <summary>
+    /// Horizontal alignment for padding layout renderers.
+    /// </summary>
+    public enum PaddingHorizontalAlignment
+    {
+        /// <summary>
+        /// When layout text is too long, align it to the left
+        /// (remove characters from the right).
+        /// </summary>
+        Left,
+        /// <summary>
+        /// When layout text is too long, align it to the right
+        /// (remove characters from the left).
+        /// </summary>
+        Right,
+    }
+}

--- a/src/NLog/LayoutRenderers/Wrappers/PaddingLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/PaddingLayoutRendererWrapper.cs
@@ -44,6 +44,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AmbientProperty("Padding")]
     [AmbientProperty("PadCharacter")]
     [AmbientProperty("FixedLength")]
+    [AmbientProperty("AlignmentOnTruncation")]
     [ThreadAgnostic]
     public sealed class PaddingLayoutRendererWrapper : WrapperLayoutRendererBase
     {
@@ -81,6 +82,16 @@ namespace NLog.LayoutRenderers.Wrappers
         public bool FixedLength { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether a value that has
+        /// been truncated (when <see cref="FixedLength" /> is true)
+        /// will be left-aligned (characters removed from the right)
+        /// or right-aligned (characters removed from the left). The
+        /// default is left alignment.
+        /// </summary>
+        [DefaultValue(PaddingHorizontalAlignment.Left)]
+        public PaddingHorizontalAlignment AlignmentOnTruncation { get; set; }
+
+        /// <summary>
         /// Transforms the output of another layout.
         /// </summary>
         /// <param name="text">Output to be transform.</param>
@@ -108,13 +119,17 @@ namespace NLog.LayoutRenderers.Wrappers
 
                 if (this.FixedLength && s.Length > absolutePadding)
                 {
-                    if (this.Padding > 0)
+                    switch (this.AlignmentOnTruncation)
                     {
-                        s = s.Substring(s.Length - absolutePadding);
-                    }
-                    else
-                    {
-                        s = s.Substring(0, absolutePadding);
+                        case PaddingHorizontalAlignment.Left:
+                            s = s.Substring(0, absolutePadding);
+                            break;
+                        case PaddingHorizontalAlignment.Right:
+                            s = s.Substring(s.Length - absolutePadding);
+                            break;
+
+                        default:
+                            goto case PaddingHorizontalAlignment.Left;
                     }
                 }
             }

--- a/src/NLog/LayoutRenderers/Wrappers/PaddingLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/PaddingLayoutRendererWrapper.cs
@@ -108,7 +108,14 @@ namespace NLog.LayoutRenderers.Wrappers
 
                 if (this.FixedLength && s.Length > absolutePadding)
                 {
-                    s = s.Substring(0, absolutePadding);
+                    if (this.Padding > 0)
+                    {
+                        s = s.Substring(s.Length - absolutePadding);
+                    }
+                    else
+                    {
+                        s = s.Substring(0, absolutePadding);
+                    }
                 }
             }
 

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -259,6 +259,7 @@
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\LowercaseLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionLayoutRendererWrapper.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingHorizontalAlignment.cs" />
     <Compile Include="LayoutRenderers\Wrappers\PaddingLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\Rot13LayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.mono2.csproj
+++ b/src/NLog/NLog.mono2.csproj
@@ -261,6 +261,7 @@
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\LowercaseLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionLayoutRendererWrapper.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingHorizontalAlignment.cs" />
     <Compile Include="LayoutRenderers\Wrappers\PaddingLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\Rot13LayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.monodevelop.csproj
+++ b/src/NLog/NLog.monodevelop.csproj
@@ -263,6 +263,7 @@
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\LowercaseLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionLayoutRendererWrapper.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingHorizontalAlignment.cs" />
     <Compile Include="LayoutRenderers\Wrappers\PaddingLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\Rot13LayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BaseOutputDirectory Condition=" '$(BaseOutputDirectory)' == '' ">$(MSBuildProjectDirectory)\..\..\build\</BaseOutputDirectory>
@@ -27,8 +27,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>bin\Debug</OutputPath>
-    <CodeAnalysisRules>
-    </CodeAnalysisRules>
+    <CodeAnalysisRules></CodeAnalysisRules>
     <CodeAnalysisRules></CodeAnalysisRules>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -262,6 +261,7 @@
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\LowercaseLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionLayoutRendererWrapper.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingHorizontalAlignment.cs" />
     <Compile Include="LayoutRenderers\Wrappers\PaddingLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\Rot13LayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -262,6 +262,7 @@
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\LowercaseLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionLayoutRendererWrapper.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingHorizontalAlignment.cs" />
     <Compile Include="LayoutRenderers\Wrappers\PaddingLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\Rot13LayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -266,6 +267,7 @@
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\LowercaseLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionLayoutRendererWrapper.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingHorizontalAlignment.cs" />
     <Compile Include="LayoutRenderers\Wrappers\PaddingLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\Rot13LayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -265,6 +265,7 @@
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\LowercaseLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionLayoutRendererWrapper.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingHorizontalAlignment.cs" />
     <Compile Include="LayoutRenderers\Wrappers\PaddingLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\Rot13LayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -262,6 +262,7 @@
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\LowercaseLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionLayoutRendererWrapper.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingHorizontalAlignment.cs" />
     <Compile Include="LayoutRenderers\Wrappers\PaddingLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\Rot13LayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -261,6 +261,7 @@
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\LowercaseLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionLayoutRendererWrapper.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingHorizontalAlignment.cs" />
     <Compile Include="LayoutRenderers\Wrappers\PaddingLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\Rot13LayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -261,6 +261,7 @@
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\LowercaseLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionLayoutRendererWrapper.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingHorizontalAlignment.cs" />
     <Compile Include="LayoutRenderers\Wrappers\PaddingLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\Rot13LayoutRendererWrapper.cs" />

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -171,7 +171,7 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${callsite:classname=true:methodname=false:padding=3:fixedlength=true} ${message}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${callsite:classname=true:methodname=false:padding=-3:fixedlength=true} ${message}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>
@@ -188,7 +188,7 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${callsite:classname=false:methodname=true:padding=16:fixedlength=true} ${message}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${callsite:classname=false:methodname=true:padding=-16:fixedlength=true} ${message}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -167,11 +167,11 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
-        public void ClassNameWithPaddingTestTest()
+        public void ClassNameWithPaddingTestPadLeftAlignLeftTest()
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${callsite:classname=true:methodname=false:padding=-3:fixedlength=true} ${message}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${callsite:classname=true:methodname=false:padding=3:fixedlength=true} ${message}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>
@@ -184,11 +184,64 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
-        public void MethodNameWithPaddingTestTest()
+        public void ClassNameWithPaddingTestPadLeftAlignRightTest()
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${callsite:classname=false:methodname=true:padding=-16:fixedlength=true} ${message}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${callsite:classname=true:methodname=false:padding=3:fixedlength=true:alignmentOnTruncation=right} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("msg");
+            MethodBase currentMethod = MethodBase.GetCurrentMethod();
+            var typeName = currentMethod.DeclaringType.FullName;
+            AssertDebugLastMessage("debug", typeName.Substring(typeName.Length - 3) + " msg");
+        }
+
+        [Fact]
+        public void ClassNameWithPaddingTestPadRightAlignLeftTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${callsite:classname=true:methodname=false:padding=-3:fixedlength=true:alignmentOnTruncation=left} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("msg");
+            MethodBase currentMethod = MethodBase.GetCurrentMethod();
+            AssertDebugLastMessage("debug", currentMethod.DeclaringType.FullName.Substring(0, 3) + " msg");
+        }
+
+        [Fact]
+        public void ClassNameWithPaddingTestPadRightAlignRightTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${callsite:classname=true:methodname=false:padding=-3:fixedlength=true:alignmentOnTruncation=right} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("msg");
+            MethodBase currentMethod = MethodBase.GetCurrentMethod();
+            var typeName = currentMethod.DeclaringType.FullName;
+            AssertDebugLastMessage("debug", typeName.Substring(typeName.Length - 3) + " msg");
+        }
+
+        [Fact]
+        public void MethodNameWithPaddingTestPadLeftAlignLeftTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${callsite:classname=false:methodname=true:padding=16:fixedlength=true} ${message}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>
@@ -197,6 +250,54 @@ namespace NLog.UnitTests.LayoutRenderers
             ILogger logger = LogManager.GetLogger("A");
             logger.Debug("msg");
             AssertDebugLastMessage("debug", "MethodNameWithPa msg");
+        }
+
+        [Fact]
+        public void MethodNameWithPaddingTestPadLeftAlignRightTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${callsite:classname=false:methodname=true:padding=16:fixedlength=true:alignmentOnTruncation=right} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("msg");
+            AssertDebugLastMessage("debug", "ftAlignRightTest msg");
+        }
+
+        [Fact]
+        public void MethodNameWithPaddingTestPadRightAlignLeftTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${callsite:classname=false:methodname=true:padding=-16:fixedlength=true:alignmentOnTruncation=left} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("msg");
+            AssertDebugLastMessage("debug", "MethodNameWithPa msg");
+        }
+
+        [Fact]
+        public void MethodNameWithPaddingTestPadRightAlignRightTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${callsite:classname=false:methodname=true:padding=-16:fixedlength=true:alignmentOnTruncation=right} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("msg");
+            AssertDebugLastMessage("debug", "htAlignRightTest msg");
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/LayoutRenderers/LongDateTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/LongDateTests.cs
@@ -85,7 +85,7 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${longdate:padding=5:fixedlength=true}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${longdate:padding=-5:fixedlength=true}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>

--- a/tests/NLog.UnitTests/LayoutRenderers/LongDateTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/LongDateTests.cs
@@ -81,11 +81,11 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
-        public void LongDateWithPadding()
+        public void LongDateWithPaddingPadLeftAlignLeft()
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${longdate:padding=-5:fixedlength=true}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${longdate:padding=5:fixedlength=true}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>
@@ -95,6 +95,57 @@ namespace NLog.UnitTests.LayoutRenderers
             string date = GetDebugLastMessage("debug");
             Assert.Equal(5, date.Length);
             Assert.Equal(date[4], '-');
+        }
+
+        [Fact]
+        public void LongDateWithPaddingPadLeftAlignRight()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${longdate:padding=5:fixedlength=true:alignmentOnTruncation=right}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            LogManager.GetLogger("d").Debug("zzz");
+            string date = GetDebugLastMessage("debug");
+            Assert.Equal(5, date.Length);
+            Assert.Equal(date[0], '.');
+        }
+
+        [Fact]
+        public void LongDateWithPaddingPadRightAlignLeft()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${longdate:padding=-5:fixedlength=true:alignmentOnTruncation=left}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            LogManager.GetLogger("d").Debug("zzz");
+            string date = GetDebugLastMessage("debug");
+            Assert.Equal(5, date.Length);
+            Assert.Equal(date[4], '-');
+        }
+
+        [Fact]
+        public void LongDateWithPaddingPadRightAlignRight()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${longdate:padding=-5:fixedlength=true:alignmentOnTruncation=right}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            LogManager.GetLogger("d").Debug("zzz");
+            string date = GetDebugLastMessage("debug");
+            Assert.Equal(5, date.Length);
+            Assert.Equal(date[0], '.');
         }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
@@ -155,7 +155,7 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${message:padding=-3:padcharacter=x:fixedlength=true:alignmentOnTruncation=left}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${message:padding=-3:padcharacter=x:fixedlength=true}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>

--- a/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
@@ -85,11 +85,11 @@ namespace NLog.UnitTests.LayoutRenderers
 
 
         [Fact]
-        public void MessageFixedLengthRightPaddingTest()
+        public void MessageFixedLengthRightPaddingLeftAlignmentTest()
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${message:padding=-3:fixedlength=true}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${message:padding=3:fixedlength=true}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>
@@ -97,13 +97,35 @@ namespace NLog.UnitTests.LayoutRenderers
 
             ILogger logger = LogManager.GetLogger("A");
             logger.Debug("a");
-            AssertDebugLastMessage("debug", "a  ");
+            AssertDebugLastMessage("debug", "  a");
             logger.Debug("a{0}", 1);
-            AssertDebugLastMessage("debug", "a1 ");
+            AssertDebugLastMessage("debug", " a1");
             logger.Debug("a{0}{1}", 1, "2");
             AssertDebugLastMessage("debug", "a12");
             logger.Debug(CultureInfo.InvariantCulture, "a{0}", new DateTime(2005, 1, 1));
             AssertDebugLastMessage("debug", "a01");
+        }
+
+        [Fact]
+        public void MessageFixedLengthRightPaddingRightAlignmentTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${message:padding=3:fixedlength=true:alignmentOnTruncation=right}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("a");
+            AssertDebugLastMessage("debug", "  a");
+            logger.Debug("a{0}", 1);
+            AssertDebugLastMessage("debug", " a1");
+            logger.Debug("a{0}{1}", 1, "2");
+            AssertDebugLastMessage("debug", "a12");
+            logger.Debug(CultureInfo.InvariantCulture, "a{0}", new DateTime(2005, 1, 1));
+            AssertDebugLastMessage("debug", ":00");
         }
 
         [Fact]
@@ -129,11 +151,11 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
-        public void MessageFixedLengthLeftPaddingTest()
+        public void MessageFixedLengthLeftPaddingLeftAlignmentTest()
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${message:padding=-3:padcharacter=x:fixedlength=true}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${message:padding=-3:padcharacter=x:fixedlength=true:alignmentOnTruncation=left}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>
@@ -148,6 +170,28 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug", "a12");
             logger.Debug(CultureInfo.InvariantCulture, "a{0}", new DateTime(2005, 1, 1));
             AssertDebugLastMessage("debug", "a01");
+        }
+
+        [Fact]
+        public void MessageFixedLengthLeftPaddingRightAlignmentTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${message:padding=-3:padcharacter=x:fixedlength=true:alignmentOnTruncation=right}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("a");
+            AssertDebugLastMessage("debug", "axx");
+            logger.Debug("a{0}", 1);
+            AssertDebugLastMessage("debug", "a1x");
+            logger.Debug("a{0}{1}", 1, "2");
+            AssertDebugLastMessage("debug", "a12");
+            logger.Debug(CultureInfo.InvariantCulture, "a{0}", new DateTime(2005, 1, 1));
+            AssertDebugLastMessage("debug", ":00");
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
@@ -89,7 +89,7 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${message:padding=3:fixedlength=true}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${message:padding=-3:fixedlength=true}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>
@@ -97,9 +97,9 @@ namespace NLog.UnitTests.LayoutRenderers
 
             ILogger logger = LogManager.GetLogger("A");
             logger.Debug("a");
-            AssertDebugLastMessage("debug", "  a");
+            AssertDebugLastMessage("debug", "a  ");
             logger.Debug("a{0}", 1);
-            AssertDebugLastMessage("debug", " a1");
+            AssertDebugLastMessage("debug", "a1 ");
             logger.Debug("a{0}{1}", 1, "2");
             AssertDebugLastMessage("debug", "a12");
             logger.Debug(CultureInfo.InvariantCulture, "a{0}", new DateTime(2005, 1, 1));

--- a/tests/NLog.UnitTests/LayoutRenderers/TimeTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/TimeTests.cs
@@ -82,7 +82,7 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${longdate:padding=5:fixedlength=true}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${longdate:padding=-5:fixedlength=true}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>

--- a/tests/NLog.UnitTests/LayoutRenderers/TimeTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/TimeTests.cs
@@ -78,11 +78,11 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
-        public void LongDateWithPadding()
+        public void LongDateWithPaddingPadLeftAlignLeft()
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${longdate:padding=-5:fixedlength=true}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${longdate:padding=5:fixedlength=true}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>
@@ -92,6 +92,57 @@ namespace NLog.UnitTests.LayoutRenderers
             string date = GetDebugLastMessage("debug");
             Assert.Equal(5, date.Length);
             Assert.Equal(date[4], '-');
+        }
+
+        [Fact]
+        public void LongDateWithPaddingPadLeftAlignRight()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${longdate:padding=5:fixedlength=true:alignmentOnTruncation=right}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            LogManager.GetLogger("d").Debug("zzz");
+            string date = GetDebugLastMessage("debug");
+            Assert.Equal(5, date.Length);
+            Assert.Equal(date[0], '.');
+        }
+
+        [Fact]
+        public void LongDateWithPaddingPadRightAlignLeft()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${longdate:padding=-5:fixedlength=true:alignmentOnTruncation=left}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            LogManager.GetLogger("d").Debug("zzz");
+            string date = GetDebugLastMessage("debug");
+            Assert.Equal(5, date.Length);
+            Assert.Equal(date[4], '-');
+        }
+
+        [Fact]
+        public void LongDateWithPaddingPadRightAlignRight()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${longdate:padding=-5:fixedlength=true:alignmentOnTruncation=right}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            LogManager.GetLogger("d").Debug("zzz");
+            string date = GetDebugLastMessage("debug");
+            Assert.Equal(5, date.Length);
+            Assert.Equal(date[0], '.');
         }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/PaddingTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/PaddingTests.cs
@@ -40,61 +40,134 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
     public class PaddingTests : NLogTestBase
     {
         [Fact]
-        public void PositivePaddingIsRightAlign()
+        public void PositivePaddingWithLeftAlign()
         {
             SimpleLayout l;
 
             var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
 
-            l = @"${message:padding=10}";
+            l = @"${message:padding=10:alignmentOnTruncation=left}";
             Assert.Equal("   message", l.Render(le));
 
-            l = @"${message:padding=9}";
+            l = @"${message:padding=9:alignmentOnTruncation=left}";
             Assert.Equal("  message", l.Render(le));
 
-            l = @"${message:padding=8}";
+            l = @"${message:padding=8:alignmentOnTruncation=left}";
             Assert.Equal(" message", l.Render(le));
 
-            l = @"${message:padding=7}";
+            l = @"${message:padding=7:alignmentOnTruncation=left}";
             Assert.Equal("message", l.Render(le));
 
-            l = @"${message:padding=6}";
+            l = @"${message:padding=6:alignmentOnTruncation=left}";
             Assert.Equal("message", l.Render(le));
 
-            l = @"${message:padding=6:fixedLength=true}";
+            l = @"${message:padding=6:fixedLength=true:alignmentOnTruncation=left}";
+            Assert.Equal("messag", l.Render(le));
+
+            l = @"${message:padding=5:fixedLength=true:alignmentOnTruncation=left}";
+            Assert.Equal("messa", l.Render(le));
+        }
+
+        [Fact]
+        public void PositivePaddingWithRightAlign()
+        {
+            SimpleLayout l;
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+
+            l = @"${message:padding=10:alignmentOnTruncation=right}";
+            Assert.Equal("   message", l.Render(le));
+
+            l = @"${message:padding=9:alignmentOnTruncation=right}";
+            Assert.Equal("  message", l.Render(le));
+
+            l = @"${message:padding=8:alignmentOnTruncation=right}";
+            Assert.Equal(" message", l.Render(le));
+
+            l = @"${message:padding=7:alignmentOnTruncation=right}";
+            Assert.Equal("message", l.Render(le));
+
+            l = @"${message:padding=6:alignmentOnTruncation=right}";
+            Assert.Equal("message", l.Render(le));
+
+            l = @"${message:padding=6:fixedLength=true:alignmentOnTruncation=right}";
             Assert.Equal("essage", l.Render(le));
 
-            l = @"${message:padding=5:fixedLength=true}";
+            l = @"${message:padding=5:fixedLength=true:alignmentOnTruncation=right}";
             Assert.Equal("ssage", l.Render(le));
         }
 
         [Fact]
-        public void NegativePaddingIsLeftAlign()
+        public void NegativePaddingWithLeftAlign()
         {
             SimpleLayout l;
 
             var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
 
-            l = @"${message:padding=-10}";
+            l = @"${message:padding=-10:alignmentOnTruncation=left}";
             Assert.Equal("message   ", l.Render(le));
 
-            l = @"${message:padding=-9}";
+            l = @"${message:padding=-9:alignmentOnTruncation=left}";
             Assert.Equal("message  ", l.Render(le));
 
-            l = @"${message:padding=-8}";
+            l = @"${message:padding=-8:alignmentOnTruncation=left}";
             Assert.Equal("message ", l.Render(le));
 
-            l = @"${message:padding=-7}";
+            l = @"${message:padding=-7:alignmentOnTruncation=left}";
             Assert.Equal("message", l.Render(le));
 
-            l = @"${message:padding=-6}";
+            l = @"${message:padding=-6:alignmentOnTruncation=left}";
             Assert.Equal("message", l.Render(le));
 
-            l = @"${message:padding=-6:fixedLength=true}";
+            l = @"${message:padding=-6:fixedLength=true:alignmentOnTruncation=left}";
             Assert.Equal("messag", l.Render(le));
 
-            l = @"${message:padding=-5:fixedLength=true}";
+            l = @"${message:padding=-5:fixedLength=true:alignmentOnTruncation=left}";
             Assert.Equal("messa", l.Render(le));
+        }
+
+        [Fact]
+        public void NegativePaddingWithRightAlign()
+        {
+            SimpleLayout l;
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+
+            l = @"${message:padding=-10:alignmentOnTruncation=right}";
+            Assert.Equal("message   ", l.Render(le));
+
+            l = @"${message:padding=-9:alignmentOnTruncation=right}";
+            Assert.Equal("message  ", l.Render(le));
+
+            l = @"${message:padding=-8:alignmentOnTruncation=right}";
+            Assert.Equal("message ", l.Render(le));
+
+            l = @"${message:padding=-7:alignmentOnTruncation=right}";
+            Assert.Equal("message", l.Render(le));
+
+            l = @"${message:padding=-6:alignmentOnTruncation=right}";
+            Assert.Equal("message", l.Render(le));
+
+            l = @"${message:padding=-6:fixedLength=true:alignmentOnTruncation=right}";
+            Assert.Equal("essage", l.Render(le));
+
+            l = @"${message:padding=-5:fixedLength=true:alignmentOnTruncation=right}";
+            Assert.Equal("ssage", l.Render(le));
+        }
+
+        [Fact]
+        public void DefaultAlignmentIsLeft()
+        {
+            SimpleLayout defaultLayout, leftLayout, rightLayout;
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+
+            defaultLayout = @"${message:padding=5:fixedLength=true}";
+            leftLayout = @"${message:padding=5:fixedLength=true:alignmentOnTruncation=left}";
+            rightLayout = @"${message:padding=5:fixedLength=true:alignmentOnTruncation=right}";
+
+            Assert.Equal(leftLayout.Render(le), defaultLayout.Render(le));
+            Assert.NotEqual(rightLayout.Render(le), defaultLayout.Render(le));
         }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/PaddingTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/PaddingTests.cs
@@ -1,0 +1,100 @@
+﻿// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.LayoutRenderers.Wrappers
+{
+    using NLog;
+    using NLog.Layouts;
+    using Xunit;
+
+    public class PaddingTests : NLogTestBase
+    {
+        [Fact]
+        public void PositivePaddingIsRightAlign()
+        {
+            SimpleLayout l;
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+
+            l = @"${message:padding=10}";
+            Assert.Equal("   message", l.Render(le));
+
+            l = @"${message:padding=9}";
+            Assert.Equal("  message", l.Render(le));
+
+            l = @"${message:padding=8}";
+            Assert.Equal(" message", l.Render(le));
+
+            l = @"${message:padding=7}";
+            Assert.Equal("message", l.Render(le));
+
+            l = @"${message:padding=6}";
+            Assert.Equal("message", l.Render(le));
+
+            l = @"${message:padding=6:fixedLength=true}";
+            Assert.Equal("essage", l.Render(le));
+
+            l = @"${message:padding=5:fixedLength=true}";
+            Assert.Equal("ssage", l.Render(le));
+        }
+
+        [Fact]
+        public void NegativePaddingIsLeftAlign()
+        {
+            SimpleLayout l;
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+
+            l = @"${message:padding=-10}";
+            Assert.Equal("message   ", l.Render(le));
+
+            l = @"${message:padding=-9}";
+            Assert.Equal("message  ", l.Render(le));
+
+            l = @"${message:padding=-8}";
+            Assert.Equal("message ", l.Render(le));
+
+            l = @"${message:padding=-7}";
+            Assert.Equal("message", l.Render(le));
+
+            l = @"${message:padding=-6}";
+            Assert.Equal("message", l.Render(le));
+
+            l = @"${message:padding=-6:fixedLength=true}";
+            Assert.Equal("messag", l.Render(le));
+
+            l = @"${message:padding=-5:fixedLength=true}";
+            Assert.Equal("messa", l.Render(le));
+        }
+    }
+}

--- a/tests/NLog.UnitTests/Layouts/ThreadAgnosticTests.cs
+++ b/tests/NLog.UnitTests/Layouts/ThreadAgnosticTests.cs
@@ -49,9 +49,9 @@ namespace NLog.UnitTests.Layouts
             {
                 if (t.Namespace == typeof(WrapperLayoutRendererBase).Namespace)
                 {
-                    if (t.IsAbstract)
+                    if (t.IsAbstract || t.IsEnum)
                     {
-                        // skip non-concrete types
+                        // skip non-concrete types and enumerations
                         continue;
                     }
 

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono2.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono2.csproj
@@ -109,6 +109,7 @@
     <Compile Include="LayoutRenderers\ShortDateTests.cs" />
     <Compile Include="LayoutRenderers\ThreadNameTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedTests.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingTests.cs" />
     <Compile Include="Layouts\AllEventPropertiesLayoutRendererTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.monodevelop.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.monodevelop.csproj
@@ -127,6 +127,7 @@
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionTests.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\TrimWhiteSpaceTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WhenEmptyTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -156,6 +156,7 @@
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionTests.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\TrimWhiteSpaceTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WhenEmptyTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -136,6 +136,7 @@
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionTests.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\TrimWhiteSpaceTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WhenEmptyTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -140,6 +140,7 @@
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionTests.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\TrimWhiteSpaceTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WhenEmptyTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -155,6 +155,7 @@
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionTests.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\TrimWhiteSpaceTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WhenEmptyTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -156,6 +156,7 @@
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\OnExceptionTests.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\PaddingTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\ReplaceTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\TrimWhiteSpaceTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WhenEmptyTests.cs" />


### PR DESCRIPTION
The `PaddingLayoutRenderWrapper` class implements left and right padding, based on the sign of the `Padding` parameter. However, something unexpected happens when `FixedLength` is turned on, if the string is too long to fit:
```
"        T" <= "T"
"       Th" <= "Th"
"      Thi" <= "Thi"
"     This" <= "This"
"    This " <= "This "
"   This m" <= "This m"
"  This me" <= "This me"
" This mes" <= "This mes"
"This mess" <= "This mess"
"This mess" <= "This messa"
"This mess" <= "This messag"
"This mess" <= "This message"
"This mess" <= "This message is"
"This mess" <= "This message is too"
"This mess" <= "This message is too long"
```
What's happening, in effect, is that we're getting right-alignment of text shorter than the pad length, but then left-alignment of text that is too long. Intuitively, this sequence should end like this:
```
" This mes" <= "This mes"
"This mess" <= "This mess"
"his messa" <= "This messa"
"is messag" <= "This messag"
"s message" <= "This message"
"essage is" <= "This message is"
"ge is too" <= "This message is too"
" too long" <= "This message is too long"
```
When `Padding` is negative, the current behaviour is what you'd expect:
```
"T        " <= "T"
"Th       " <= "Th"
"Thi      " <= "Thi"
"This     " <= "This"
"This     " <= "This "
"This m   " <= "This m"
"This me  " <= "This me"
"This mes " <= "This mes"
"This mess" <= "This mess"
"This mess" <= "This messa"
"This mess" <= "This messag"
"This mess" <= "This message"
"This mess" <= "This message is"
"This mess" <= "This message is too"
"This mess" <= "This message is too long"
```
This pull request updates `PaddingLayoutRendererWrapper.cs` to remove characters from the start of the string instead of the end when `Padding` is positive. Negative values continue to remove characters from the end of the string. In effect, this means that the padding action, whether it is to add or remove characters, always modifies the same end of the string.

The pull request also adds unit tests that verify this behaviour.