### PR TITLE
Right way to log exceptions

### DIFF
--- a/src/NLog/ILogger.cs
+++ b/src/NLog/ILogger.cs
@@ -135,6 +135,23 @@ namespace NLog
         void TraceException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        void Trace(Exception exception, [Localizable(false)] string message, params object[] args);
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        void Trace(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
+
+        /// <summary>
         /// Writes the diagnostic message at the <c>Trace</c> level using the specified parameters and formatting them with the supplied format provider.
         /// </summary>
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
@@ -265,6 +282,23 @@ namespace NLog
         /// <param name="exception">An exception to be logged.</param>
         [Obsolete("Use Debug(String, Exception) method instead.")]
         void DebugException([Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        void Debug(Exception exception, [Localizable(false)] string message, params object[] args);
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        void Debug(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
 
         /// <summary>
         /// Writes the diagnostic message at the <c>Debug</c> level using the specified parameters and formatting them with the supplied format provider.
@@ -399,6 +433,23 @@ namespace NLog
         void InfoException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        void Info(Exception exception, [Localizable(false)] string message, params object[] args);
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        void Info(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
+
+        /// <summary>
         /// Writes the diagnostic message at the <c>Info</c> level using the specified parameters and formatting them with the supplied format provider.
         /// </summary>
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
@@ -529,6 +580,23 @@ namespace NLog
         /// <param name="exception">An exception to be logged.</param>
         [Obsolete("Use Warn(String, Exception) method instead.")]
         void WarnException([Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        void Warn(Exception exception, [Localizable(false)] string message, params object[] args);
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        void Warn(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
 
         /// <summary>
         /// Writes the diagnostic message at the <c>Warn</c> level using the specified parameters and formatting them with the supplied format provider.
@@ -663,6 +731,24 @@ namespace NLog
         void ErrorException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        void Error(Exception exception, [Localizable(false)] string message, params object[] args);
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        void Error(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
+
+
+        /// <summary>
         /// Writes the diagnostic message at the <c>Error</c> level using the specified parameters and formatting them with the supplied format provider.
         /// </summary>
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
@@ -795,6 +881,23 @@ namespace NLog
         void FatalException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        void Fatal(Exception exception, [Localizable(false)] string message, params object[] args);
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        void Fatal(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
+
+        /// <summary>
         /// Writes the diagnostic message at the <c>Fatal</c> level using the specified parameters and formatting them with the supplied format provider.
         /// </summary>
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
@@ -891,5 +994,6 @@ namespace NLog
         void Fatal<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
         #endregion
+
     }
 }

--- a/src/NLog/ILogger.cs
+++ b/src/NLog/ILogger.cs
@@ -131,7 +131,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Trace(String, Exception) method instead.")]
+        [Obsolete("Use Trace(Exception exception, string message, params object[] args) method instead.")]
         void TraceException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -178,6 +178,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+        [Obsolete("Use Trace(Exception exception, string message, params object[] args) method instead.")]
         void Trace([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -280,7 +281,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Debug(String, Exception) method instead.")]
+        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead.")]
         void DebugException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -327,6 +328,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead.")]
         void Debug([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -429,7 +431,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Info(String, Exception) method instead.")]
+        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead.")]
         void InfoException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -476,6 +478,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead.")]
         void Info([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -578,7 +581,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Warn(String, Exception) method instead.")]
+        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead.")]
         void WarnException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -625,6 +628,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead.")]
         void Warn([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -727,7 +731,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Error(String, Exception) method instead.")]
+        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead.")]
         void ErrorException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -775,6 +779,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead.")]
         void Error([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -877,7 +882,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Fatal(String, Exception) method instead.")]
+        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead.")]
         void FatalException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -924,6 +929,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead.")]
         void Fatal([Localizable(false)] string message, Exception exception);
 
         /// <summary>

--- a/src/NLog/ILoggerBase.cs
+++ b/src/NLog/ILoggerBase.cs
@@ -115,8 +115,27 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Log(LogLevel, String, Exception) method instead.")]
+        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args)")]
         void LogException(LogLevel level, [Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the specified level.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="args">Arguments to format.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        void Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args);
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the specified level.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="args">Arguments to format.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        void Log(LogLevel level, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
 
         /// <summary>
         /// Writes the diagnostic message at the specified level using the specified parameters and formatting them with the supplied format provider.
@@ -149,6 +168,7 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args)")]
         void Log(LogLevel level, [Localizable(false)] string message, Exception exception);
 
         /// <summary>

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -347,7 +347,7 @@ namespace NLog
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
         /// <returns>Instance of <see cref="LogEventInfo"/>.</returns>
-        [Obsolete("use Create(LogLevel logLevel, string loggerName, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message)")]
+        [Obsolete("use Create(LogLevel logLevel, string loggerName, Exception exception, IFormatProvider formatProvider, string message)")]
         public static LogEventInfo Create(LogLevel logLevel, string loggerName, [Localizable(false)] string message, Exception exception)
         {
             return new LogEventInfo(logLevel, loggerName, null, message, null, exception);

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -347,9 +347,39 @@ namespace NLog
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
         /// <returns>Instance of <see cref="LogEventInfo"/>.</returns>
+        [Obsolete("use Create(LogLevel logLevel, string loggerName, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message)")]
         public static LogEventInfo Create(LogLevel logLevel, string loggerName, [Localizable(false)] string message, Exception exception)
         {
             return new LogEventInfo(logLevel, loggerName, null, message, null, exception);
+        }
+
+        /// <summary>
+        /// Creates the log event.
+        /// </summary>
+        /// <param name="logLevel">The log level.</param>
+        /// <param name="loggerName">Name of the logger.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <param name="message">The message.</param>
+        /// <returns>Instance of <see cref="LogEventInfo"/>.</returns>
+        public static LogEventInfo Create(LogLevel logLevel, string loggerName, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message)
+        {
+            return Create(logLevel, loggerName, exception, formatProvider, message, null);
+        }
+
+        /// <summary>
+        /// Creates the log event.
+        /// </summary>
+        /// <param name="logLevel">The log level.</param>
+        /// <param name="loggerName">Name of the logger.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="parameters">The parameters.</param>
+        /// <returns>Instance of <see cref="LogEventInfo"/>.</returns>
+        public static LogEventInfo Create(LogLevel logLevel, string loggerName, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, object[] parameters)
+        {
+            return new LogEventInfo(logLevel, loggerName,formatProvider, message, parameters, exception);
         }
 
         /// <summary>

--- a/src/NLog/Logger-Conditional.cs
+++ b/src/NLog/Logger-Conditional.cs
@@ -91,10 +91,24 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
         [Conditional("DEBUG")]
-        public void ConditionalDebugException(string message, Exception exception)
+        public void ConditionalDebug(Exception exception, string message, params object[] args)
         {
-            DebugException(message, exception);
+            Debug(exception, message, args);
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        [Conditional("DEBUG")]
+        public void ConditionalDebug(Exception exception, IFormatProvider formatProvider, string message, params object[] args)
+        {
+            Debug(exception, formatProvider, message, args);
         }
 
         /// <summary>
@@ -130,17 +144,7 @@ namespace NLog
             Debug(message, args);
         }
 
-        /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        [Conditional("DEBUG")]
-        public void ConditionalDebug(string message, Exception exception)
-        {
-            Debug(message, exception);
-        }
-
+   
         /// <summary>
         /// Writes the diagnostic message at the <c>Debug</c> level using the specified parameter and formatting it with the supplied format provider.
         /// </summary>
@@ -549,11 +553,26 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
         [Conditional("DEBUG")]
-        public void ConditionalTraceException(string message, Exception exception)
+        public void ConditionalTrace(Exception exception, string message, params object[] args)
         {
-            TraceException(message, exception);
+            Trace(exception, message, args);
         }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        [Conditional("DEBUG")]
+        public void ConditionalTrace(Exception exception, IFormatProvider formatProvider, string message, params object[] args)
+        {
+            Trace(exception, formatProvider, message, args);
+        }
+
 
         /// <summary>
         /// Writes the diagnostic message at the <c>Trace</c> level using the specified parameters and formatting them with the supplied format provider.
@@ -586,17 +605,6 @@ namespace NLog
         public void ConditionalTrace(string message, params object[] args)
         {
             Trace(message, args);
-        }
-
-        /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        [Conditional("DEBUG")]
-        public void ConditionalTrace(string message, Exception exception)
-        {
-            Trace(message, exception);
         }
 
         /// <summary>

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -253,7 +253,7 @@ namespace NLog
         {
             if (this.IsEnabled(level))
             {
-                this.WriteToTargetsWithException(level, exception, message, args);
+                this.WriteToTargets(level, exception, message, args);
             }
         }
 
@@ -269,7 +269,7 @@ namespace NLog
         {
             if (this.IsEnabled(level))
             {
-                this.WriteToTargetsWithException(level, exception, formatProvider, message, args);
+                this.WriteToTargets(level, exception, formatProvider, message, args);
             }
         }
 
@@ -516,12 +516,12 @@ namespace NLog
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, message, ex)), this.Factory);
         }
 
-        internal void WriteToTargetsWithException(LogLevel level, Exception ex, [Localizable(false)] string message, object[] args)
+        internal void WriteToTargets(LogLevel level, Exception ex, [Localizable(false)] string message, object[] args)
         {
-            WriteToTargetsWithException(level, ex, this.Factory.DefaultCultureInfo, message, args);
+            WriteToTargets(level, ex, this.Factory.DefaultCultureInfo, message, args);
         }
 
-        internal void WriteToTargetsWithException(LogLevel level, Exception ex, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)
+        internal void WriteToTargets(LogLevel level, Exception ex, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)
         {
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, ex, formatProvider, message, args)), this.Factory);
         }

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -510,7 +510,7 @@ namespace NLog
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, formatProvider, value)), this.Factory);
         }
 
-        [Obsolete("use WriteToTargetsWithException(Exception ex, LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)")]
+        [Obsolete("Use WriteToTargetsWithException(Exception ex, LogLevel level, IFormatProvider formatProvider, string message, object[] args) method instead.")]
         internal void WriteToTargetsWithException(LogLevel level, [Localizable(false)] string message, Exception ex)
         {
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, message, ex)), this.Factory);

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -518,7 +518,7 @@ namespace NLog
 
         internal void WriteToTargets(LogLevel level, Exception ex, [Localizable(false)] string message, object[] args)
         {
-            WriteToTargets(level, ex, this.Factory.DefaultCultureInfo, message, args);
+            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, ex, this.Factory.DefaultCultureInfo, message, args)), this.Factory);
         }
 
         internal void WriteToTargets(LogLevel level, Exception ex, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -79,7 +79,7 @@ namespace NLog
         /// </summary>
         public LogFactory Factory { get; private set; }
 
-        
+
         /// <summary>
         /// Gets a value indicating whether logging is enabled for the specified level.
         /// </summary>
@@ -119,8 +119,8 @@ namespace NLog
                 this.WriteToTargets(wrapperType, logEvent);
             }
         }
-    
-        #region Log() overloads 
+
+        #region Log() overloads
 
         /// <overloads>
         /// Writes the diagnostic message at the specified level using the specified format provider and format parameters.
@@ -193,10 +193,10 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [StringFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
-        { 
+        {
             if (this.IsEnabled(level))
             {
-                this.WriteToTargets(level, formatProvider, message, args); 
+                this.WriteToTargets(level, formatProvider, message, args);
             }
         }
 
@@ -205,8 +205,8 @@ namespace NLog
         /// </summary>
         /// <param name="level">The log level.</param>
         /// <param name="message">Log message.</param>
-        public void Log(LogLevel level, [Localizable(false)] string message) 
-        { 
+        public void Log(LogLevel level, [Localizable(false)] string message)
+        {
             if (this.IsEnabled(level))
             {
                 this.WriteToTargets(level, null, message);
@@ -219,8 +219,8 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="message">A <see langword="string" /> containing format items.</param>
         /// <param name="args">Arguments to format.</param>
-        public void Log(LogLevel level, [Localizable(false)] string message, params object[] args) 
-        { 
+        public void Log(LogLevel level, [Localizable(false)] string message, params object[] args)
+        {
             if (this.IsEnabled(level))
             {
                 this.WriteToTargets(level, message, args);
@@ -233,11 +233,43 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args)")]
         public void Log(LogLevel level, [Localizable(false)] string message, Exception exception)
         {
             if (this.IsEnabled(level))
             {
-                this.WriteToTargets(level, message, exception);
+                this.WriteToTargetsWithException(level, message, exception);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the specified level.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="args">Arguments to format.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        public void Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsEnabled(level))
+            {
+                this.WriteToTargetsWithException2(exception, level, message, args);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the specified level.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="args">Arguments to format.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        public void Log(LogLevel level, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsEnabled(level))
+            {
+                this.WriteToTargetsWithException2(exception, level, formatProvider, message, args);
             }
         }
 
@@ -251,10 +283,10 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [StringFormatMethod("message")]
         public void Log<TArgument>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument)
-        { 
+        {
             if (this.IsEnabled(level))
             {
-                this.WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                this.WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -267,7 +299,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [StringFormatMethod("message")]
         public void Log<TArgument>(LogLevel level, [Localizable(false)] string message, TArgument argument)
-        { 
+        {
             if (this.IsEnabled(level))
             {
                 var exceptionCandidate = argument as Exception;
@@ -291,11 +323,11 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
-        public void Log<TArgument1, TArgument2>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2) 
-        { 
+        public void Log<TArgument1, TArgument2>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
+        {
             if (this.IsEnabled(level))
             {
-                this.WriteToTargets(level, formatProvider, message, new object[] { argument1, argument2 }); 
+                this.WriteToTargets(level, formatProvider, message, new object[] { argument1, argument2 });
             }
         }
 
@@ -310,7 +342,7 @@ namespace NLog
         /// <param name="argument2">The second argument to format.</param>
         [StringFormatMethod("message")]
         public void Log<TArgument1, TArgument2>(LogLevel level, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
-        { 
+        {
             if (this.IsEnabled(level))
             {
                 this.WriteToTargets(level, message, new object[] { argument1, argument2 });
@@ -329,11 +361,11 @@ namespace NLog
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
-        public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) 
-        { 
+        public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
             if (this.IsEnabled(level))
             {
-                this.WriteToTargets(level, formatProvider, message, new object[] { argument1, argument2, argument3 }); 
+                this.WriteToTargets(level, formatProvider, message, new object[] { argument1, argument2, argument3 });
             }
         }
 
@@ -350,7 +382,7 @@ namespace NLog
         /// <param name="argument3">The third argument to format.</param>
         [StringFormatMethod("message")]
         public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
-        { 
+        {
             if (this.IsEnabled(level))
             {
                 this.WriteToTargets(level, message, new object[] { argument1, argument2, argument3 });
@@ -359,7 +391,7 @@ namespace NLog
 
         #endregion
 
- 
+
         /// <summary>
         /// Runs action. If the action throws, the exception is logged at <c>Error</c> level. Exception is not propagated outside of this method.
         /// </summary>
@@ -485,10 +517,22 @@ namespace NLog
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, formatProvider, value)), this.Factory);
         }
 
-        internal void WriteToTargets(LogLevel level, [Localizable(false)] string message, Exception ex)
+        [Obsolete("use WriteToTargetsWithException(Exception ex, LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)")]
+        internal void WriteToTargetsWithException(LogLevel level, [Localizable(false)] string message, Exception ex)
         {
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, message, ex)), this.Factory);
         }
+
+        internal void WriteToTargetsWithException2(Exception ex, LogLevel level, [Localizable(false)] string message, object[] args)
+        {
+            WriteToTargetsWithException2(ex, level, this.Factory.DefaultCultureInfo, message, args);
+        }
+
+        internal void WriteToTargetsWithException2(Exception ex, LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)
+        {
+            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, ex, formatProvider, message, args)), this.Factory);
+        }
+
 
         internal void WriteToTargets(LogLevel level, [Localizable(false)] string message, object[] args)
         {

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -253,7 +253,7 @@ namespace NLog
         {
             if (this.IsEnabled(level))
             {
-                this.WriteToTargetsWithException2(exception, level, message, args);
+                this.WriteToTargetsWithException(exception, level, message, args);
             }
         }
 
@@ -269,7 +269,7 @@ namespace NLog
         {
             if (this.IsEnabled(level))
             {
-                this.WriteToTargetsWithException2(exception, level, formatProvider, message, args);
+                this.WriteToTargetsWithException(exception, level, formatProvider, message, args);
             }
         }
 
@@ -516,12 +516,12 @@ namespace NLog
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, message, ex)), this.Factory);
         }
 
-        internal void WriteToTargetsWithException2(Exception ex, LogLevel level, [Localizable(false)] string message, object[] args)
+        internal void WriteToTargetsWithException(Exception ex, LogLevel level, [Localizable(false)] string message, object[] args)
         {
-            WriteToTargetsWithException2(ex, level, this.Factory.DefaultCultureInfo, message, args);
+            WriteToTargetsWithException(ex, level, this.Factory.DefaultCultureInfo, message, args);
         }
 
-        internal void WriteToTargetsWithException2(Exception ex, LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)
+        internal void WriteToTargetsWithException(Exception ex, LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)
         {
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, ex, formatProvider, message, args)), this.Factory);
         }

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -238,7 +238,7 @@ namespace NLog
         {
             if (this.IsEnabled(level))
             {
-                this.WriteToTargetsWithException(level, message, exception);
+                this.WriteToTargets(level, message, exception);
             }
         }
 
@@ -511,7 +511,7 @@ namespace NLog
         }
 
         [Obsolete("Use WriteToTargetsWithException(Exception ex, LogLevel level, IFormatProvider formatProvider, string message, object[] args) method instead.")]
-        internal void WriteToTargetsWithException(LogLevel level, [Localizable(false)] string message, Exception ex)
+        internal void WriteToTargets(LogLevel level, [Localizable(false)] string message, Exception ex)
         {
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, message, ex)), this.Factory);
         }

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -510,7 +510,7 @@ namespace NLog
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, formatProvider, value)), this.Factory);
         }
 
-        [Obsolete("Use WriteToTargetsWithException(Exception ex, LogLevel level, IFormatProvider formatProvider, string message, object[] args) method instead.")]
+        [Obsolete("Use WriteToTargets(Exception ex, LogLevel level, IFormatProvider formatProvider, string message, object[] args) method instead.")]
         internal void WriteToTargets(LogLevel level, [Localizable(false)] string message, Exception ex)
         {
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, message, ex)), this.Factory);

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -253,7 +253,7 @@ namespace NLog
         {
             if (this.IsEnabled(level))
             {
-                this.WriteToTargetsWithException(exception, level, message, args);
+                this.WriteToTargetsWithException(level, exception, message, args);
             }
         }
 
@@ -269,7 +269,7 @@ namespace NLog
         {
             if (this.IsEnabled(level))
             {
-                this.WriteToTargetsWithException(exception, level, formatProvider, message, args);
+                this.WriteToTargetsWithException(level, exception, formatProvider, message, args);
             }
         }
 
@@ -516,12 +516,12 @@ namespace NLog
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, message, ex)), this.Factory);
         }
 
-        internal void WriteToTargetsWithException(Exception ex, LogLevel level, [Localizable(false)] string message, object[] args)
+        internal void WriteToTargetsWithException(LogLevel level, Exception ex, [Localizable(false)] string message, object[] args)
         {
-            WriteToTargetsWithException(ex, level, this.Factory.DefaultCultureInfo, message, args);
+            WriteToTargetsWithException(level, ex, this.Factory.DefaultCultureInfo, message, args);
         }
 
-        internal void WriteToTargetsWithException(Exception ex, LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)
+        internal void WriteToTargetsWithException(LogLevel level, Exception ex, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)
         {
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, ex, formatProvider, message, args)), this.Factory);
         }

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -302,13 +302,6 @@ namespace NLog
         {
             if (this.IsEnabled(level))
             {
-                var exceptionCandidate = argument as Exception;
-                if (exceptionCandidate != null)
-                {
-                    this.Log(level, message, exceptionCandidate);
-                    return;
-                }
-
                 this.WriteToTargets(level, message, new object[] { argument });
             }
         }

--- a/src/NLog/Logger.tt
+++ b/src/NLog/Logger.tt
@@ -216,13 +216,6 @@ namespace NLog
         { 
             if (this.Is<#=level#>Enabled)
             {
-                var exceptionCandidate = argument as Exception;
-                if (exceptionCandidate != null)
-                {
-                    this.<#=level#>(message, exceptionCandidate);
-                    return;
-                }
-
                 this.WriteToTargets(LogLevel.<#=level#>, message, new object[] { argument });
             }
         }

--- a/src/NLog/Logger.tt
+++ b/src/NLog/Logger.tt
@@ -185,7 +185,7 @@ namespace NLog
         {
             if (this.Is<#=level#>Enabled)
             {
-                this.WriteToTargets(LogLevel.<#=level#>, message, exception);
+                this.WriteToTargetsWithException(LogLevel.<#=level#>, message, exception);
             }
         }
 

--- a/src/NLog/Logger.tt
+++ b/src/NLog/Logger.tt
@@ -187,7 +187,7 @@ namespace NLog
         {
             if (this.Is<#=level#>Enabled)
             {
-                this.WriteToTargetsWithException(LogLevel.<#=level#>, message, exception);
+                this.WriteToTargets(LogLevel.<#=level#>, message, exception);
             }
         }
 
@@ -201,7 +201,7 @@ namespace NLog
         {
             if (this.Is<#=level#>Enabled)
             {
-                this.WriteToTargetsWithException(LogLevel.<#=level#>, exception, message, args);
+                this.WriteToTargets(LogLevel.<#=level#>, exception, message, args);
             }
         }
 
@@ -216,7 +216,7 @@ namespace NLog
         {
             if (this.Is<#=level#>Enabled)
             {
-                this.WriteToTargetsWithException(LogLevel.<#=level#>, exception, formatProvider, message, args);
+                this.WriteToTargets(LogLevel.<#=level#>, exception, formatProvider, message, args);
             }
         }
 

--- a/src/NLog/Logger.tt
+++ b/src/NLog/Logger.tt
@@ -130,6 +130,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+	    [Obsolete("Use <#=level#>(LogLevel level, Exception exception, string message, params object[] args)")]
         public void <#=level#>Exception([Localizable(false)] string message, Exception exception)
         {
             this.<#=level#>(message, exception); 
@@ -181,11 +182,41 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+		[Obsolete("Use <#=level#>(LogLevel level, Exception exception, string message, params object[] args)")]
         public void <#=level#>([Localizable(false)] string message, Exception exception)
         {
             if (this.Is<#=level#>Enabled)
             {
                 this.WriteToTargetsWithException(LogLevel.<#=level#>, message, exception);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c><#=level#></c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void <#=level#>(Exception exception, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.Is<#=level#>Enabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.<#=level#>, exception, message, args);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c><#=level#></c> level.
+        /// </summary>
+		/// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void <#=level#>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.Is<#=level#>Enabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.<#=level#>, exception, formatProvider, message, args);
             }
         }
 

--- a/src/NLog/Logger.tt
+++ b/src/NLog/Logger.tt
@@ -130,7 +130,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-	    [Obsolete("Use <#=level#>(LogLevel level, Exception exception, string message, params object[] args)")]
+	    [Obsolete("Use <#=level#>(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void <#=level#>Exception([Localizable(false)] string message, Exception exception)
         {
             this.<#=level#>(message, exception); 
@@ -182,7 +182,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-		[Obsolete("Use <#=level#>(LogLevel level, Exception exception, string message, params object[] args)")]
+		[Obsolete("Use <#=level#>(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void <#=level#>([Localizable(false)] string message, Exception exception)
         {
             if (this.Is<#=level#>Enabled)

--- a/src/NLog/Logger1.cs
+++ b/src/NLog/Logger1.cs
@@ -151,6 +151,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+	    [Obsolete("Use Trace(LogLevel level, Exception exception, string message, params object[] args)")]
         public void TraceException([Localizable(false)] string message, Exception exception)
         {
             this.Trace(message, exception); 
@@ -202,11 +203,41 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+		[Obsolete("Use Trace(LogLevel level, Exception exception, string message, params object[] args)")]
         public void Trace([Localizable(false)] string message, Exception exception)
         {
             if (this.IsTraceEnabled)
             {
-                this.WriteToTargets(LogLevel.Trace, message, exception);
+                this.WriteToTargetsWithException(LogLevel.Trace, message, exception);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void Trace(Exception exception, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsTraceEnabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.Trace, exception, message, args);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// </summary>
+		/// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void Trace(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsTraceEnabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.Trace, exception, formatProvider, message, args);
             }
         }
 
@@ -237,13 +268,6 @@ namespace NLog
         { 
             if (this.IsTraceEnabled)
             {
-                var exceptionCandidate = argument as Exception;
-                if (exceptionCandidate != null)
-                {
-                    this.Trace(message, exceptionCandidate);
-                    return;
-                }
-
                 this.WriteToTargets(LogLevel.Trace, message, new object[] { argument });
             }
         }
@@ -378,6 +402,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+	    [Obsolete("Use Debug(LogLevel level, Exception exception, string message, params object[] args)")]
         public void DebugException([Localizable(false)] string message, Exception exception)
         {
             this.Debug(message, exception); 
@@ -429,11 +454,41 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+		[Obsolete("Use Debug(LogLevel level, Exception exception, string message, params object[] args)")]
         public void Debug([Localizable(false)] string message, Exception exception)
         {
             if (this.IsDebugEnabled)
             {
-                this.WriteToTargets(LogLevel.Debug, message, exception);
+                this.WriteToTargetsWithException(LogLevel.Debug, message, exception);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void Debug(Exception exception, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsDebugEnabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.Debug, exception, message, args);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+		/// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void Debug(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsDebugEnabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.Debug, exception, formatProvider, message, args);
             }
         }
 
@@ -464,13 +519,6 @@ namespace NLog
         { 
             if (this.IsDebugEnabled)
             {
-                var exceptionCandidate = argument as Exception;
-                if (exceptionCandidate != null)
-                {
-                    this.Debug(message, exceptionCandidate);
-                    return;
-                }
-
                 this.WriteToTargets(LogLevel.Debug, message, new object[] { argument });
             }
         }
@@ -605,6 +653,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+	    [Obsolete("Use Info(LogLevel level, Exception exception, string message, params object[] args)")]
         public void InfoException([Localizable(false)] string message, Exception exception)
         {
             this.Info(message, exception); 
@@ -656,11 +705,41 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+		[Obsolete("Use Info(LogLevel level, Exception exception, string message, params object[] args)")]
         public void Info([Localizable(false)] string message, Exception exception)
         {
             if (this.IsInfoEnabled)
             {
-                this.WriteToTargets(LogLevel.Info, message, exception);
+                this.WriteToTargetsWithException(LogLevel.Info, message, exception);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void Info(Exception exception, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsInfoEnabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.Info, exception, message, args);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// </summary>
+		/// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void Info(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsInfoEnabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.Info, exception, formatProvider, message, args);
             }
         }
 
@@ -691,13 +770,6 @@ namespace NLog
         { 
             if (this.IsInfoEnabled)
             {
-                var exceptionCandidate = argument as Exception;
-                if (exceptionCandidate != null)
-                {
-                    this.Info(message, exceptionCandidate);
-                    return;
-                }
-
                 this.WriteToTargets(LogLevel.Info, message, new object[] { argument });
             }
         }
@@ -832,6 +904,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+	    [Obsolete("Use Warn(LogLevel level, Exception exception, string message, params object[] args)")]
         public void WarnException([Localizable(false)] string message, Exception exception)
         {
             this.Warn(message, exception); 
@@ -883,11 +956,41 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+		[Obsolete("Use Warn(LogLevel level, Exception exception, string message, params object[] args)")]
         public void Warn([Localizable(false)] string message, Exception exception)
         {
             if (this.IsWarnEnabled)
             {
-                this.WriteToTargets(LogLevel.Warn, message, exception);
+                this.WriteToTargetsWithException(LogLevel.Warn, message, exception);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void Warn(Exception exception, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsWarnEnabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.Warn, exception, message, args);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// </summary>
+		/// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void Warn(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsWarnEnabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.Warn, exception, formatProvider, message, args);
             }
         }
 
@@ -918,13 +1021,6 @@ namespace NLog
         { 
             if (this.IsWarnEnabled)
             {
-                var exceptionCandidate = argument as Exception;
-                if (exceptionCandidate != null)
-                {
-                    this.Warn(message, exceptionCandidate);
-                    return;
-                }
-
                 this.WriteToTargets(LogLevel.Warn, message, new object[] { argument });
             }
         }
@@ -1059,6 +1155,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+	    [Obsolete("Use Error(LogLevel level, Exception exception, string message, params object[] args)")]
         public void ErrorException([Localizable(false)] string message, Exception exception)
         {
             this.Error(message, exception); 
@@ -1110,11 +1207,41 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+		[Obsolete("Use Error(LogLevel level, Exception exception, string message, params object[] args)")]
         public void Error([Localizable(false)] string message, Exception exception)
         {
             if (this.IsErrorEnabled)
             {
-                this.WriteToTargets(LogLevel.Error, message, exception);
+                this.WriteToTargetsWithException(LogLevel.Error, message, exception);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void Error(Exception exception, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsErrorEnabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.Error, exception, message, args);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// </summary>
+		/// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void Error(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsErrorEnabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.Error, exception, formatProvider, message, args);
             }
         }
 
@@ -1145,13 +1272,6 @@ namespace NLog
         { 
             if (this.IsErrorEnabled)
             {
-                var exceptionCandidate = argument as Exception;
-                if (exceptionCandidate != null)
-                {
-                    this.Error(message, exceptionCandidate);
-                    return;
-                }
-
                 this.WriteToTargets(LogLevel.Error, message, new object[] { argument });
             }
         }
@@ -1286,6 +1406,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+	    [Obsolete("Use Fatal(LogLevel level, Exception exception, string message, params object[] args)")]
         public void FatalException([Localizable(false)] string message, Exception exception)
         {
             this.Fatal(message, exception); 
@@ -1337,11 +1458,41 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+		[Obsolete("Use Fatal(LogLevel level, Exception exception, string message, params object[] args)")]
         public void Fatal([Localizable(false)] string message, Exception exception)
         {
             if (this.IsFatalEnabled)
             {
-                this.WriteToTargets(LogLevel.Fatal, message, exception);
+                this.WriteToTargetsWithException(LogLevel.Fatal, message, exception);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void Fatal(Exception exception, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsFatalEnabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.Fatal, exception, message, args);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// </summary>
+		/// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+		/// <param name="args">Arguments to format.</param>
+        public void Fatal(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        {
+            if (this.IsFatalEnabled)
+            {
+                this.WriteToTargetsWithException(LogLevel.Fatal, exception, formatProvider, message, args);
             }
         }
 
@@ -1372,13 +1523,6 @@ namespace NLog
         { 
             if (this.IsFatalEnabled)
             {
-                var exceptionCandidate = argument as Exception;
-                if (exceptionCandidate != null)
-                {
-                    this.Fatal(message, exceptionCandidate);
-                    return;
-                }
-
                 this.WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
             }
         }

--- a/src/NLog/Logger1.cs
+++ b/src/NLog/Logger1.cs
@@ -208,7 +208,7 @@ namespace NLog
         {
             if (this.IsTraceEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Trace, message, exception);
+                this.WriteToTargets(LogLevel.Trace, message, exception);
             }
         }
 
@@ -222,7 +222,7 @@ namespace NLog
         {
             if (this.IsTraceEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Trace, exception, message, args);
+                this.WriteToTargets(LogLevel.Trace, exception, message, args);
             }
         }
 
@@ -237,7 +237,7 @@ namespace NLog
         {
             if (this.IsTraceEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Trace, exception, formatProvider, message, args);
+                this.WriteToTargets(LogLevel.Trace, exception, formatProvider, message, args);
             }
         }
 
@@ -459,7 +459,7 @@ namespace NLog
         {
             if (this.IsDebugEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Debug, message, exception);
+                this.WriteToTargets(LogLevel.Debug, message, exception);
             }
         }
 
@@ -473,7 +473,7 @@ namespace NLog
         {
             if (this.IsDebugEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Debug, exception, message, args);
+                this.WriteToTargets(LogLevel.Debug, exception, message, args);
             }
         }
 
@@ -488,7 +488,7 @@ namespace NLog
         {
             if (this.IsDebugEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Debug, exception, formatProvider, message, args);
+                this.WriteToTargets(LogLevel.Debug, exception, formatProvider, message, args);
             }
         }
 
@@ -710,7 +710,7 @@ namespace NLog
         {
             if (this.IsInfoEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Info, message, exception);
+                this.WriteToTargets(LogLevel.Info, message, exception);
             }
         }
 
@@ -724,7 +724,7 @@ namespace NLog
         {
             if (this.IsInfoEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Info, exception, message, args);
+                this.WriteToTargets(LogLevel.Info, exception, message, args);
             }
         }
 
@@ -739,7 +739,7 @@ namespace NLog
         {
             if (this.IsInfoEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Info, exception, formatProvider, message, args);
+                this.WriteToTargets(LogLevel.Info, exception, formatProvider, message, args);
             }
         }
 
@@ -961,7 +961,7 @@ namespace NLog
         {
             if (this.IsWarnEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Warn, message, exception);
+                this.WriteToTargets(LogLevel.Warn, message, exception);
             }
         }
 
@@ -975,7 +975,7 @@ namespace NLog
         {
             if (this.IsWarnEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Warn, exception, message, args);
+                this.WriteToTargets(LogLevel.Warn, exception, message, args);
             }
         }
 
@@ -990,7 +990,7 @@ namespace NLog
         {
             if (this.IsWarnEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Warn, exception, formatProvider, message, args);
+                this.WriteToTargets(LogLevel.Warn, exception, formatProvider, message, args);
             }
         }
 
@@ -1212,7 +1212,7 @@ namespace NLog
         {
             if (this.IsErrorEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Error, message, exception);
+                this.WriteToTargets(LogLevel.Error, message, exception);
             }
         }
 
@@ -1226,7 +1226,7 @@ namespace NLog
         {
             if (this.IsErrorEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Error, exception, message, args);
+                this.WriteToTargets(LogLevel.Error, exception, message, args);
             }
         }
 
@@ -1241,7 +1241,7 @@ namespace NLog
         {
             if (this.IsErrorEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Error, exception, formatProvider, message, args);
+                this.WriteToTargets(LogLevel.Error, exception, formatProvider, message, args);
             }
         }
 
@@ -1463,7 +1463,7 @@ namespace NLog
         {
             if (this.IsFatalEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Fatal, message, exception);
+                this.WriteToTargets(LogLevel.Fatal, message, exception);
             }
         }
 
@@ -1477,7 +1477,7 @@ namespace NLog
         {
             if (this.IsFatalEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Fatal, exception, message, args);
+                this.WriteToTargets(LogLevel.Fatal, exception, message, args);
             }
         }
 
@@ -1492,7 +1492,7 @@ namespace NLog
         {
             if (this.IsFatalEnabled)
             {
-                this.WriteToTargetsWithException(LogLevel.Fatal, exception, formatProvider, message, args);
+                this.WriteToTargets(LogLevel.Fatal, exception, formatProvider, message, args);
             }
         }
 

--- a/src/NLog/Logger1.cs
+++ b/src/NLog/Logger1.cs
@@ -151,7 +151,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-	    [Obsolete("Use Trace(LogLevel level, Exception exception, string message, params object[] args)")]
+	    [Obsolete("Use Trace(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void TraceException([Localizable(false)] string message, Exception exception)
         {
             this.Trace(message, exception); 
@@ -203,7 +203,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-		[Obsolete("Use Trace(LogLevel level, Exception exception, string message, params object[] args)")]
+		[Obsolete("Use Trace(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void Trace([Localizable(false)] string message, Exception exception)
         {
             if (this.IsTraceEnabled)
@@ -402,7 +402,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-	    [Obsolete("Use Debug(LogLevel level, Exception exception, string message, params object[] args)")]
+	    [Obsolete("Use Debug(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void DebugException([Localizable(false)] string message, Exception exception)
         {
             this.Debug(message, exception); 
@@ -454,7 +454,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-		[Obsolete("Use Debug(LogLevel level, Exception exception, string message, params object[] args)")]
+		[Obsolete("Use Debug(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void Debug([Localizable(false)] string message, Exception exception)
         {
             if (this.IsDebugEnabled)
@@ -653,7 +653,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-	    [Obsolete("Use Info(LogLevel level, Exception exception, string message, params object[] args)")]
+	    [Obsolete("Use Info(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void InfoException([Localizable(false)] string message, Exception exception)
         {
             this.Info(message, exception); 
@@ -705,7 +705,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-		[Obsolete("Use Info(LogLevel level, Exception exception, string message, params object[] args)")]
+		[Obsolete("Use Info(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void Info([Localizable(false)] string message, Exception exception)
         {
             if (this.IsInfoEnabled)
@@ -904,7 +904,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-	    [Obsolete("Use Warn(LogLevel level, Exception exception, string message, params object[] args)")]
+	    [Obsolete("Use Warn(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void WarnException([Localizable(false)] string message, Exception exception)
         {
             this.Warn(message, exception); 
@@ -956,7 +956,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-		[Obsolete("Use Warn(LogLevel level, Exception exception, string message, params object[] args)")]
+		[Obsolete("Use Warn(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void Warn([Localizable(false)] string message, Exception exception)
         {
             if (this.IsWarnEnabled)
@@ -1155,7 +1155,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-	    [Obsolete("Use Error(LogLevel level, Exception exception, string message, params object[] args)")]
+	    [Obsolete("Use Error(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void ErrorException([Localizable(false)] string message, Exception exception)
         {
             this.Error(message, exception); 
@@ -1207,7 +1207,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-		[Obsolete("Use Error(LogLevel level, Exception exception, string message, params object[] args)")]
+		[Obsolete("Use Error(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void Error([Localizable(false)] string message, Exception exception)
         {
             if (this.IsErrorEnabled)
@@ -1406,7 +1406,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-	    [Obsolete("Use Fatal(LogLevel level, Exception exception, string message, params object[] args)")]
+	    [Obsolete("Use Fatal(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void FatalException([Localizable(false)] string message, Exception exception)
         {
             this.Fatal(message, exception); 
@@ -1458,7 +1458,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-		[Obsolete("Use Fatal(LogLevel level, Exception exception, string message, params object[] args)")]
+		[Obsolete("Use Fatal(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void Fatal([Localizable(false)] string message, Exception exception)
         {
             if (this.IsFatalEnabled)

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -118,7 +118,7 @@ namespace NLog.UnitTests.LayoutRenderers
             const string exceptionDataValue = "testvalue";
             Exception ex = GetExceptionWithStackTrace(exceptionMessage);
             ex.Data.Add(exceptionDataKey, exceptionDataValue);
-            logger.Error("msg", ex);
+            logger.Error(ex, "msg");
             AssertDebugLastMessage("debug1", exceptionMessage);
             AssertDebugLastMessage("debug2", ex.StackTrace);
             AssertDebugLastMessage("debug3", typeof(InvalidOperationException).FullName);
@@ -202,7 +202,7 @@ namespace NLog.UnitTests.LayoutRenderers
             const string exceptionDataValue = "testvalue";
             Exception ex = GetExceptionWithoutStackTrace(exceptionMessage);
             ex.Data.Add(exceptionDataKey, exceptionDataValue);
-            logger.Error("msg", ex);
+            logger.Error(ex, "msg");
             AssertDebugLastMessage("debug1", exceptionMessage);
             AssertDebugLastMessage("debug2", "");
             AssertDebugLastMessage("debug3", typeof(InvalidOperationException).FullName);
@@ -236,7 +236,7 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug1", "Test exception\r\n" + typeof(InvalidOperationException).Name);
 #pragma warning restore 0618
 
-            logger.Error("msg", ex);
+            logger.Error(ex, "msg");
             AssertDebugLastMessage("debug1", "Test exception\r\n" + typeof(InvalidOperationException).Name);
         }
 
@@ -246,7 +246,7 @@ namespace NLog.UnitTests.LayoutRenderers
             SetConfigurationForExceptionUsingRootMethodTests();
             string exceptionMessage = "Test exception";
             Exception ex = GetExceptionWithStackTrace(exceptionMessage);
-            logger.Log(LogLevel.Error, "msg", ex);
+            logger.Log(LogLevel.Error, ex, "msg");
             AssertDebugLastMessage("debug1", "ERROR*Test exception*" + typeof(InvalidOperationException).Name);
         }
 
@@ -256,7 +256,7 @@ namespace NLog.UnitTests.LayoutRenderers
             SetConfigurationForExceptionUsingRootMethodTests();
             string exceptionMessage = "Test exception";
             Exception ex = GetExceptionWithStackTrace(exceptionMessage);
-            logger.Trace("msg", ex);
+            logger.Trace(ex, "msg");
             AssertDebugLastMessage("debug1", "TRACE*Test exception*" + typeof(InvalidOperationException).Name);
         }
 
@@ -266,7 +266,7 @@ namespace NLog.UnitTests.LayoutRenderers
             SetConfigurationForExceptionUsingRootMethodTests();
             string exceptionMessage = "Test exception";
             Exception ex = GetExceptionWithStackTrace(exceptionMessage);
-            logger.Debug("msg", ex);
+            logger.Debug(ex, "msg");
             AssertDebugLastMessage("debug1", "DEBUG*Test exception*" + typeof(InvalidOperationException).Name);
         }
 
@@ -276,7 +276,7 @@ namespace NLog.UnitTests.LayoutRenderers
             SetConfigurationForExceptionUsingRootMethodTests();
             string exceptionMessage = "Test exception";
             Exception ex = GetExceptionWithStackTrace(exceptionMessage);
-            logger.Info("msg", ex);
+            logger.Info(ex, "msg");
             AssertDebugLastMessage("debug1", "INFO*Test exception*" + typeof(InvalidOperationException).Name);
         }
 
@@ -286,7 +286,7 @@ namespace NLog.UnitTests.LayoutRenderers
             SetConfigurationForExceptionUsingRootMethodTests();
             string exceptionMessage = "Test exception";
             Exception ex = GetExceptionWithStackTrace(exceptionMessage);
-            logger.Warn("msg", ex);
+            logger.Warn(ex, "msg");
             AssertDebugLastMessage("debug1", "WARN*Test exception*" + typeof(InvalidOperationException).Name);
         }
 
@@ -296,7 +296,7 @@ namespace NLog.UnitTests.LayoutRenderers
             SetConfigurationForExceptionUsingRootMethodTests();
             string exceptionMessage = "Test exception";
             Exception ex = GetExceptionWithStackTrace(exceptionMessage);
-            logger.Error("msg", ex);
+            logger.Error(ex, "msg");
             AssertDebugLastMessage("debug1", "ERROR*Test exception*" + typeof(InvalidOperationException).Name);
         }
 
@@ -306,7 +306,7 @@ namespace NLog.UnitTests.LayoutRenderers
             SetConfigurationForExceptionUsingRootMethodTests();
             string exceptionMessage = "Test exception";
             Exception ex = GetExceptionWithStackTrace(exceptionMessage);
-            logger.Fatal("msg", ex);
+            logger.Fatal(ex, "msg");
             AssertDebugLastMessage("debug1", "FATAL*Test exception*" + typeof(InvalidOperationException).Name);
         }
 
@@ -334,7 +334,7 @@ namespace NLog.UnitTests.LayoutRenderers
                 "InvalidOperationException Test exception");
 #pragma warning restore 0618
 
-            logger.Error("msg", ex);
+            logger.Error(ex, "msg");
             AssertDebugLastMessage("debug1", "InvalidOperationException Wrapper2" + EnvironmentHelper.NewLine +
                 "InvalidOperationException Wrapper1" + EnvironmentHelper.NewLine +
                 "InvalidOperationException Test exception");
@@ -400,7 +400,7 @@ namespace NLog.UnitTests.LayoutRenderers
             const string exceptionDataValue = "testvalue";
             Exception ex = GetNestedExceptionWithStackTrace(exceptionMessage);
             ex.InnerException.Data.Add(exceptionDataKey, exceptionDataValue);
-            logger.Error("msg", ex);
+            logger.Error(ex, "msg");
             AssertDebugLastMessage("debug1", "InvalidOperationException Wrapper2" + 
                 "\r\n----INNER----\r\n" +
                 "System.InvalidOperationException Wrapper1");
@@ -423,9 +423,10 @@ namespace NLog.UnitTests.LayoutRenderers
             </nlog>");
 
             var ex = new ExceptionWithBrokenMessagePropertyException();
-
+#pragma warning disable 0618
+            // Obsolete method requires testing until completely removed.
             Assert.ThrowsDelegate action = () => logger.ErrorException("msg", ex);
-
+#pragma warning restore 0618
             Assert.DoesNotThrow(action);
         }
 

--- a/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
@@ -205,7 +205,7 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug", "Foo," + ex.ToString());
 #pragma warning restore 0618
 
-            logger.Debug("Foo", ex);
+            logger.Debug(ex, "Foo");
             AssertDebugLastMessage("debug", "Foo," + ex.ToString());
         }
     }

--- a/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
@@ -179,7 +179,7 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug", "Foo" + newline + ex.ToString());
 #pragma warning restore 0618
 
-            logger.Debug("Foo", ex);
+            logger.Debug(ex, "Foo");
             AssertDebugLastMessage("debug", "Foo" + newline + ex.ToString());
         }
 

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -180,7 +180,7 @@ namespace NLog.UnitTests
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
 #pragma warning restore 0618
 
-                logger.Trace("message", new Exception("test"));
+                logger.Trace(new Exception("test"), "message");
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
 
                 logger.Trace(delegate { return "message from lambda"; });
@@ -469,7 +469,7 @@ namespace NLog.UnitTests
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
 #pragma warning restore 0618
 
-                logger.Info("message", new Exception("test"));
+                logger.Info(new Exception("test"), "message");
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
 
                 logger.Info(delegate { return "message from lambda"; });
@@ -615,7 +615,7 @@ namespace NLog.UnitTests
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
 #pragma warning restore 0618
 
-                logger.Warn("message", new Exception("test"));
+                logger.Warn(new Exception("test"), "message");
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
 
                 logger.Warn(delegate { return "message from lambda"; });
@@ -761,7 +761,7 @@ namespace NLog.UnitTests
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
 #pragma warning restore 0618
 
-                logger.Error("message", new Exception("test"));
+                logger.Error(new Exception("test"), "message");
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
 
                 logger.Error(delegate { return "message from lambda"; });
@@ -907,7 +907,7 @@ namespace NLog.UnitTests
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
 #pragma warning restore 0618
 
-                logger.Fatal("message", new Exception("test"));
+                logger.Fatal(new Exception("test"), "message");
                 if (enabled == 1) AssertDebugLastMessage("debug", "message");
 
                 logger.Fatal(delegate { return "message from lambda"; });
@@ -1051,7 +1051,7 @@ namespace NLog.UnitTests
                     logger.Log(level, CultureInfo.InvariantCulture, "message{0}", (decimal)2.5);
                     if (enabled == 1) AssertDebugLastMessage("debug", "message2.5");
 
-                    logger.Log(level, "message", new Exception("test"));
+                    logger.Log(level, new Exception("test"), "message");
                     if (enabled == 1) AssertDebugLastMessage("debug", "message");
 
 #pragma warning disable 0618


### PR DESCRIPTION
Closes #431

Changes:

- All "exception" methods are starting with exception. E.g `Error(Exception exception, [Localizable(false)] string message, params object[] args);`
- All "exception" methods has 'args' as parameters
- All "exception" methods has an overload with an `IFormatProvider` as parameter.
- Also changed the "conditional" methods from #616 . This wasn't released yet, so no need for Obsoletes. 

Backwardscomp changes:
- removed "exceptionCandidate" hack: Log<Exception>(string message, Exception ex) would write to exception property instead of message. This is non-backwards compatible in behaviour! 
- all other "exception methods": Eg. `ErrorException` and 'Error(string message, Exception exception)` marked as Obsolete, also in the interfaces (`ILogger, ILoggerBase). No removals, only additions or adding Obsolete attributes. 

Note: You can ignore changes in logger1.cs, this file is generated with logger.tt