### PR TITLE
Added Webservice tests with REST api.

### DIFF
--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -98,13 +98,13 @@ namespace NLog.Targets
         public Uri Url { get; set; }
 
         /// <summary>
-        /// Gets or sets the Web service method name.
+        /// Gets or sets the Web service method name. Only used with Soap.
         /// </summary>
         /// <docgen category='Web Service Options' order='10' />
         public string MethodName { get; set; }
 
         /// <summary>
-        /// Gets or sets the Web service namespace.
+        /// Gets or sets the Web service namespace. Only used with Soap.
         /// </summary>
         /// <docgen category='Web Service Options' order='10' />
         public string Namespace { get; set; }

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -58,6 +60,21 @@
     <IntermediateOutputPath>$(BaseOutputDirectory)obj\$(Configuration)\$(TargetFrameworkName)</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Owin">
+      <HintPath>..\..\src\packages\Microsoft.Owin.2.0.2\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener">
+      <HintPath>..\..\src\packages\Microsoft.Owin.Host.HttpListener.2.0.2\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting">
+      <HintPath>..\..\src\packages\Microsoft.Owin.Hosting.2.0.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\src\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin">
+      <HintPath>..\..\src\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -65,7 +82,19 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Messaging" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\src\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\src\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Owin">
+      <HintPath>..\..\src\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -276,6 +276,29 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             LogManager.Configuration = configuration;
             var logger = LogManager.GetCurrentClassLogger();
 
+            //            Test Name:	TestWebserviceCall_get
+            //Test FullName:	NLog.UnitTests.Targets.WebServiceTargetTests.TestWebserviceCall_get
+            //Test Source:	x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs : line 293
+            //Test Outcome:	Failed
+            //Test Duration:	0:00:00,463
+
+            //Result Message:	System.Net.ProtocolViolationException : Cannot send a content-body with this verb-type.
+            //Result StackTrace:	
+            //at System.Net.HttpWebRequest.CheckProtocol(Boolean onRequestStream)
+            //   at System.Net.HttpWebRequest.BeginGetRequestStream(AsyncCallback callback, Object state)
+            //   at NLog.Targets.WebServiceTarget.<>c__DisplayClass1.<DoInvoke>b__0(AsyncCallback r) in x:\_GitHub\NLog\src\NLog\Targets\WebServiceTarget.cs:line 151
+            //   at NLog.Targets.WebServiceTarget.DoInvoke(Object[] parameters, AsyncContinuation continuation, HttpWebRequest request, Func`2 beginFunc, Func`2 getStreamFunc) in x:\_GitHub\NLog\src\NLog\Targets\WebServiceTarget.cs:line 218
+            //   at NLog.Targets.WebServiceTarget.DoInvoke(Object[] parameters, AsyncContinuation continuation) in x:\_GitHub\NLog\src\NLog\Targets\WebServiceTarget.cs:line 154
+            //   at NLog.Targets.MethodCallTargetBase.Write(AsyncLogEventInfo logEvent) in x:\_GitHub\NLog\src\NLog\Targets\MethodCallTargetBase.cs:line 79
+            //   at NLog.Targets.Target.WriteAsyncLogEvent(AsyncLogEventInfo logEvent) in x:\_GitHub\NLog\src\NLog\Targets\Target.cs:line 215
+            //   at NLog.LoggerImpl.WriteToTargetWithFilterChain(TargetWithFilterChain targetListHead, LogEventInfo logEvent, AsyncContinuation onException) in x:\_GitHub\NLog\src\NLog\LoggerImpl.cs:line 194
+            //   at NLog.LoggerImpl.Write(Type loggerType, TargetWithFilterChain targets, LogEventInfo logEvent, LogFactory factory) in x:\_GitHub\NLog\src\NLog\LoggerImpl.cs:line 97
+            //   at NLog.Logger.WriteToTargets(LogLevel level, IFormatProvider formatProvider, String message) in x:\_GitHub\NLog\src\NLog\Logger.cs:line 480
+            //   at NLog.Logger.Info(String message) in x:\_GitHub\NLog\src\NLog\Logger1.cs:line 636
+            //   at NLog.UnitTests.Targets.WebServiceTargetTests.<>c__DisplayClassc.<TestWebserviceCall_get>b__b() in x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 326
+            //   at NLog.UnitTests.Targets.WebServiceTargetTests.StartOwinTest(Action tests) in x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 422
+            //   at NLog.UnitTests.Targets.WebServiceTargetTests.TestWebserviceCall_get() in x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 323
+
 
 
             StartOwinTest(() =>
@@ -405,7 +428,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             // Start OWIN host 
             using (WebApp.Start<Startup>(url: ws_address))
             {
-              
+
 
                 //plain tests for testing call with httpclient
                 //HttpClient client = new HttpClient();

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -276,7 +276,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             LogManager.Configuration = configuration;
             var logger = LogManager.GetCurrentClassLogger();
 
-          
+
 
 
 
@@ -395,9 +395,31 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             }
 
             // POST api/values 
-            public void Post(string param1 = "", string param2 = "")
+            //public void Post(string param1 = "", string param2 = "", [FromBody] object body = null)
+            //{
+            //    logger.Info(LogTemplate, "POST", param1, param2, body);
+            //} 
+            // POST api/values 
+            //public void Post(string param1 = "", string param2 = "")
+            //{
+
+
+            //    logger.Info(LogTemplate, "POST", param1, param2, null);
+
+            //    //var res = Request.Content.ReadAsStringAsync().Result;
+            //}
+
+
+            public void Post([FromBody] ComplexType complexType)
             {
-                logger.Info(LogTemplate, "POST", param1, param2, null);
+                //this is working. 
+                logger.Info(LogTemplate, "POST", null, null, complexType);
+            }
+
+            public class ComplexType
+            {
+                public object Param1 { get; set; }
+                public object Param2 { get; set; }
             }
 
             //// POST api/values 

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -36,19 +36,16 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Cache;
-using System.Net.Http;
-using System.Runtime.Serialization;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web.Http;
-using Microsoft.Owin.Hosting;
-using NLog.Fluent;
 using NLog.Internal;
-using NLog.Layouts;
 using NLog.Targets;
+
+#if NET4_5
+using System.Web.Http;
 using Owin;
+using Microsoft.Owin.Hosting;
+#endif
 using Xunit;
 
 namespace NLog.UnitTests.Targets
@@ -244,10 +241,16 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
 
         #endregion
 
+#if NET4_5
 
-        const string ws_address = "http://localhost:9000/";
+
+        const string WsAddress = "http://localhost:9000/";
+
+        /// <summary>
+        /// Test the Webservice with REST api - <see cref="WebServiceProtocol.HttpPost"/> (only checking for no exception)
+        /// </summary>
         [Fact]
-        public void TestWebserviceCall_post()
+        public void WebserviceTest_restapi_httppost()
         {
 
 
@@ -270,7 +273,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                        
                       </logger>
                     </rules>
-                </nlog>", ws_address, "api/values"));
+                </nlog>", WsAddress, "api/values"));
 
 
             LogManager.Configuration = configuration;
@@ -289,9 +292,11 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
 
         }
 
-
-        [Fact]
-        public void TestWebserviceCall_get()
+        /// <summary>
+        /// Test the Webservice with REST api -  <see cref="WebServiceProtocol.HttpGet"/>  (only checking for no exception)
+        /// </summary>
+        [Fact(Skip = "Not working - ProtocolViolationException - skip for fix later")]
+        public void WebserviceTest_restapi_httpget()
         {
 
 
@@ -314,36 +319,13 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                        
                       </logger>
                     </rules>
-                </nlog>", ws_address, "api/values"));
+                </nlog>", WsAddress, "api/values"));
 
 
             LogManager.Configuration = configuration;
             var logger = LogManager.GetCurrentClassLogger();
 
-            //            Test Name:	TestWebserviceCall_get
-            //Test FullName:	NLog.UnitTests.Targets.WebServiceTargetTests.TestWebserviceCall_get
-            //Test Source:	x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs : line 293
-            //Test Outcome:	Failed
-            //Test Duration:	0:00:00,463
-
-            //Result Message:	System.Net.ProtocolViolationException : Cannot send a content-body with this verb-type.
-            //Result StackTrace:	
-            //at System.Net.HttpWebRequest.CheckProtocol(Boolean onRequestStream)
-            //   at System.Net.HttpWebRequest.BeginGetRequestStream(AsyncCallback callback, Object state)
-            //   at NLog.Targets.WebServiceTarget.<>c__DisplayClass1.<DoInvoke>b__0(AsyncCallback r) in x:\_GitHub\NLog\src\NLog\Targets\WebServiceTarget.cs:line 151
-            //   at NLog.Targets.WebServiceTarget.DoInvoke(Object[] parameters, AsyncContinuation continuation, HttpWebRequest request, Func`2 beginFunc, Func`2 getStreamFunc) in x:\_GitHub\NLog\src\NLog\Targets\WebServiceTarget.cs:line 218
-            //   at NLog.Targets.WebServiceTarget.DoInvoke(Object[] parameters, AsyncContinuation continuation) in x:\_GitHub\NLog\src\NLog\Targets\WebServiceTarget.cs:line 154
-            //   at NLog.Targets.MethodCallTargetBase.Write(AsyncLogEventInfo logEvent) in x:\_GitHub\NLog\src\NLog\Targets\MethodCallTargetBase.cs:line 79
-            //   at NLog.Targets.Target.WriteAsyncLogEvent(AsyncLogEventInfo logEvent) in x:\_GitHub\NLog\src\NLog\Targets\Target.cs:line 215
-            //   at NLog.LoggerImpl.WriteToTargetWithFilterChain(TargetWithFilterChain targetListHead, LogEventInfo logEvent, AsyncContinuation onException) in x:\_GitHub\NLog\src\NLog\LoggerImpl.cs:line 194
-            //   at NLog.LoggerImpl.Write(Type loggerType, TargetWithFilterChain targets, LogEventInfo logEvent, LogFactory factory) in x:\_GitHub\NLog\src\NLog\LoggerImpl.cs:line 97
-            //   at NLog.Logger.WriteToTargets(LogLevel level, IFormatProvider formatProvider, String message) in x:\_GitHub\NLog\src\NLog\Logger.cs:line 480
-            //   at NLog.Logger.Info(String message) in x:\_GitHub\NLog\src\NLog\Logger1.cs:line 636
-            //   at NLog.UnitTests.Targets.WebServiceTargetTests.<>c__DisplayClassc.<TestWebserviceCall_get>b__b() in x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 326
-            //   at NLog.UnitTests.Targets.WebServiceTargetTests.StartOwinTest(Action tests) in x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 422
-            //   at NLog.UnitTests.Targets.WebServiceTargetTests.TestWebserviceCall_get() in x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 323
-
-            StartOwinTest(() =>
+               StartOwinTest(() =>
             {
 
                 logger.Info("message 1 with a post");
@@ -394,21 +376,6 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                 return "value";
             }
 
-            // POST api/values 
-            //public void Post(string param1 = "", string param2 = "", [FromBody] object body = null)
-            //{
-            //    logger.Info(LogTemplate, "POST", param1, param2, body);
-            //} 
-            // POST api/values 
-            //public void Post(string param1 = "", string param2 = "")
-            //{
-
-
-            //    logger.Info(LogTemplate, "POST", param1, param2, null);
-
-            //    //var res = Request.Content.ReadAsStringAsync().Result;
-            //}
-
 
             public void Post([FromBody] ComplexType complexType)
             {
@@ -416,19 +383,16 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                 logger.Info(LogTemplate, "POST", null, null, complexType);
             }
 
+            /// <summary>
+            /// We need complext type because of content-type: "application/x-www-form-urlencoded"
+            /// </summary>
             public class ComplexType
             {
                 public object Param1 { get; set; }
                 public object Param2 { get; set; }
             }
 
-            //// POST api/values 
-            //public void Post(string param1, [FromBody]string value, string param2 = "")
-            //{
-            //    logger.Info(LogTemplate, "POST", param1, param2, value);
-            //}
-
-            // PUT api/values/5 
+           // PUT api/values/5 
             public void Put(int id, [FromBody]string value)
             {
             }
@@ -439,40 +403,19 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             }
         }
 
-        private static void StartOwinTest(Action tests)
+        private static void StartOwinTest(Action testsFunc)
         {
             // HttpSelfHostConfiguration 
             //http://www.asp.net/web-api/overview/hosting-aspnet-web-api/use-owin-to-self-host-web-api
 
-
-
-
             // Start OWIN host 
-            using (WebApp.Start<Startup>(url: ws_address))
+            using (WebApp.Start<Startup>(url: WsAddress))
             {
-
-
-                //plain tests for testing call with httpclient
-                //HttpClient client = new HttpClient();
-
-                //{
-                //    var response = client.GetAsync(ws_address + "api/values").Result;
-                //    var result = response.Content.ReadAsStringAsync().Result;
-                //}
-
-                //{
-                //    var response = client.PostAsync(ws_address + "api/values", new StringContent("abc")).Result;
-                //    var result = response.Content.ReadAsStringAsync().Result;
-                //}
-                tests();
-                Thread.Sleep(2000);
-
-                //  Console.WriteLine(response);
-                //   var result = response.Content.ReadAsStringAsync().Result;
-                //    Console.WriteLine(result);
+                testsFunc();
             }
         }
+
+#endif
     }
-
-
+    
 }

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -276,28 +276,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             LogManager.Configuration = configuration;
             var logger = LogManager.GetCurrentClassLogger();
 
-            //            Test Name:	TestWebserviceCall_get
-            //Test FullName:	NLog.UnitTests.Targets.WebServiceTargetTests.TestWebserviceCall_get
-            //Test Source:	x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs : line 293
-            //Test Outcome:	Failed
-            //Test Duration:	0:00:00,463
-
-            //Result Message:	System.Net.ProtocolViolationException : Cannot send a content-body with this verb-type.
-            //Result StackTrace:	
-            //at System.Net.HttpWebRequest.CheckProtocol(Boolean onRequestStream)
-            //   at System.Net.HttpWebRequest.BeginGetRequestStream(AsyncCallback callback, Object state)
-            //   at NLog.Targets.WebServiceTarget.<>c__DisplayClass1.<DoInvoke>b__0(AsyncCallback r) in x:\_GitHub\NLog\src\NLog\Targets\WebServiceTarget.cs:line 151
-            //   at NLog.Targets.WebServiceTarget.DoInvoke(Object[] parameters, AsyncContinuation continuation, HttpWebRequest request, Func`2 beginFunc, Func`2 getStreamFunc) in x:\_GitHub\NLog\src\NLog\Targets\WebServiceTarget.cs:line 218
-            //   at NLog.Targets.WebServiceTarget.DoInvoke(Object[] parameters, AsyncContinuation continuation) in x:\_GitHub\NLog\src\NLog\Targets\WebServiceTarget.cs:line 154
-            //   at NLog.Targets.MethodCallTargetBase.Write(AsyncLogEventInfo logEvent) in x:\_GitHub\NLog\src\NLog\Targets\MethodCallTargetBase.cs:line 79
-            //   at NLog.Targets.Target.WriteAsyncLogEvent(AsyncLogEventInfo logEvent) in x:\_GitHub\NLog\src\NLog\Targets\Target.cs:line 215
-            //   at NLog.LoggerImpl.WriteToTargetWithFilterChain(TargetWithFilterChain targetListHead, LogEventInfo logEvent, AsyncContinuation onException) in x:\_GitHub\NLog\src\NLog\LoggerImpl.cs:line 194
-            //   at NLog.LoggerImpl.Write(Type loggerType, TargetWithFilterChain targets, LogEventInfo logEvent, LogFactory factory) in x:\_GitHub\NLog\src\NLog\LoggerImpl.cs:line 97
-            //   at NLog.Logger.WriteToTargets(LogLevel level, IFormatProvider formatProvider, String message) in x:\_GitHub\NLog\src\NLog\Logger.cs:line 480
-            //   at NLog.Logger.Info(String message) in x:\_GitHub\NLog\src\NLog\Logger1.cs:line 636
-            //   at NLog.UnitTests.Targets.WebServiceTargetTests.<>c__DisplayClassc.<TestWebserviceCall_get>b__b() in x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 326
-            //   at NLog.UnitTests.Targets.WebServiceTargetTests.StartOwinTest(Action tests) in x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 422
-            //   at NLog.UnitTests.Targets.WebServiceTargetTests.TestWebserviceCall_get() in x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 323
+          
 
 
 
@@ -341,7 +320,28 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             LogManager.Configuration = configuration;
             var logger = LogManager.GetCurrentClassLogger();
 
+            //            Test Name:	TestWebserviceCall_get
+            //Test FullName:	NLog.UnitTests.Targets.WebServiceTargetTests.TestWebserviceCall_get
+            //Test Source:	x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs : line 293
+            //Test Outcome:	Failed
+            //Test Duration:	0:00:00,463
 
+            //Result Message:	System.Net.ProtocolViolationException : Cannot send a content-body with this verb-type.
+            //Result StackTrace:	
+            //at System.Net.HttpWebRequest.CheckProtocol(Boolean onRequestStream)
+            //   at System.Net.HttpWebRequest.BeginGetRequestStream(AsyncCallback callback, Object state)
+            //   at NLog.Targets.WebServiceTarget.<>c__DisplayClass1.<DoInvoke>b__0(AsyncCallback r) in x:\_GitHub\NLog\src\NLog\Targets\WebServiceTarget.cs:line 151
+            //   at NLog.Targets.WebServiceTarget.DoInvoke(Object[] parameters, AsyncContinuation continuation, HttpWebRequest request, Func`2 beginFunc, Func`2 getStreamFunc) in x:\_GitHub\NLog\src\NLog\Targets\WebServiceTarget.cs:line 218
+            //   at NLog.Targets.WebServiceTarget.DoInvoke(Object[] parameters, AsyncContinuation continuation) in x:\_GitHub\NLog\src\NLog\Targets\WebServiceTarget.cs:line 154
+            //   at NLog.Targets.MethodCallTargetBase.Write(AsyncLogEventInfo logEvent) in x:\_GitHub\NLog\src\NLog\Targets\MethodCallTargetBase.cs:line 79
+            //   at NLog.Targets.Target.WriteAsyncLogEvent(AsyncLogEventInfo logEvent) in x:\_GitHub\NLog\src\NLog\Targets\Target.cs:line 215
+            //   at NLog.LoggerImpl.WriteToTargetWithFilterChain(TargetWithFilterChain targetListHead, LogEventInfo logEvent, AsyncContinuation onException) in x:\_GitHub\NLog\src\NLog\LoggerImpl.cs:line 194
+            //   at NLog.LoggerImpl.Write(Type loggerType, TargetWithFilterChain targets, LogEventInfo logEvent, LogFactory factory) in x:\_GitHub\NLog\src\NLog\LoggerImpl.cs:line 97
+            //   at NLog.Logger.WriteToTargets(LogLevel level, IFormatProvider formatProvider, String message) in x:\_GitHub\NLog\src\NLog\Logger.cs:line 480
+            //   at NLog.Logger.Info(String message) in x:\_GitHub\NLog\src\NLog\Logger1.cs:line 636
+            //   at NLog.UnitTests.Targets.WebServiceTargetTests.<>c__DisplayClassc.<TestWebserviceCall_get>b__b() in x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 326
+            //   at NLog.UnitTests.Targets.WebServiceTargetTests.StartOwinTest(Action tests) in x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 422
+            //   at NLog.UnitTests.Targets.WebServiceTargetTests.TestWebserviceCall_get() in x:\_GitHub\NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 323
 
             StartOwinTest(() =>
             {

--- a/tests/NLog.UnitTests/packages.config
+++ b/tests/NLog.UnitTests/packages.config
@@ -1,5 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="2.0.2" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="2.0.2" targetFramework="net45" />
+  <package id="Microsoft.Owin.Hosting" version="2.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="StatLight" version="1.6.4375" targetFramework="net40" />
   <package id="xunit" version="1.9.1" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.1" targetFramework="net40" />


### PR DESCRIPTION
Added units tests for WebserviceTarget with REST api. 

- httpGet isn't working and throwing an exception. I will create an issue for that. It is skipped for now. 
Error:

```


 Result Message:	System.Net.ProtocolViolationException : Cannot send a content-body with this verb-type.
 Result StackTrace:	
 at System.Net.HttpWebRequest.CheckProtocol(Boolean onRequestStream)
    at System.Net.HttpWebRequest.BeginGetRequestStream(AsyncCallback callback, Object state)
    at NLog.Targets.WebServiceTarget.<>c__DisplayClass1.<DoInvoke>b__0(AsyncCallback r) in NLog\src\NLog\Targets\WebServiceTarget.cs:line 151
    at NLog.Targets.WebServiceTarget.DoInvoke(Object[] parameters, AsyncContinuation continuation, HttpWebRequest request, Func`2 beginFunc, Func`2 getStreamFunc) in NLog\src\NLog\Targets\WebServiceTarget.cs:line 218
    at NLog.Targets.WebServiceTarget.DoInvoke(Object[] parameters, AsyncContinuation continuation) in NLog\src\NLog\Targets\WebServiceTarget.cs:line 154
    at NLog.Targets.MethodCallTargetBase.Write(AsyncLogEventInfo logEvent) in NLog\src\NLog\Targets\MethodCallTargetBase.cs:line 79
    at NLog.Targets.Target.WriteAsyncLogEvent(AsyncLogEventInfo logEvent) in NLog\src\NLog\Targets\Target.cs:line 215
    at NLog.LoggerImpl.WriteToTargetWithFilterChain(TargetWithFilterChain targetListHead, LogEventInfo logEvent, AsyncContinuation onException) in NLog\src\NLog\LoggerImpl.cs:line 194
    at NLog.LoggerImpl.Write(Type loggerType, TargetWithFilterChain targets, LogEventInfo logEvent, LogFactory factory) in NLog\src\NLog\LoggerImpl.cs:line 97
    at NLog.Logger.WriteToTargets(LogLevel level, IFormatProvider formatProvider, String message) in NLog\src\NLog\Logger.cs:line 480
    at NLog.Logger.Info(String message) in NLog\src\NLog\Logger1.cs:line 636
    at NLog.UnitTests.Targets.WebServiceTargetTests.<>c__DisplayClassc.<TestWebserviceCall_get>b__b() in NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 326
    at NLog.UnitTests.Targets.WebServiceTargetTests.StartOwinTest(Action tests) in NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 422
    at NLog.UnitTests.Targets.WebServiceTargetTests.TestWebserviceCall_get() in NLog\tests\NLog.UnitTests\Targets\WebServiceTargetTests.cs:line 323

      
```

- httpPost is only working with `[FromBody]` which is, ..., akward. Has to do with the "application/x-www-form-urlencoded". Not a lot of people uses "application/x-www-form-urlencoded" with POST to REST. 
- .Net 4.5 Only