### PR TITLE
Thread safe: GetCurrentClassLogger test + fix

### DIFF
--- a/src/NLog/Internal/ObjectGraphScanner.cs
+++ b/src/NLog/Internal/ObjectGraphScanner.cs
@@ -116,7 +116,10 @@ namespace NLog.Internal
                 var enumerable = value as IEnumerable;
                 if (enumerable != null)
                 {
-                    foreach (object element in enumerable)
+                    //cast to list otherwhise possible:  Collection was modified after the enumerator was instantiated.
+                    var elements = enumerable as IList<object> ?? enumerable.Cast<object>().ToList();
+
+                    foreach (object element in elements)
                     {
                         ScanProperties(result, element, level + 1, visitedObjects);
                     }

--- a/tests/NLog.UnitTests/LogManagerTests.cs
+++ b/tests/NLog.UnitTests/LogManagerTests.cs
@@ -390,7 +390,7 @@ namespace NLog.UnitTests
             Assert.Equal(this.GetType().FullName, logger.Name);
         }
 
-#if NET4_0
+#if NET4_0 || NET4_5
         [Fact]
         public void GivenLazyClass_WhenGetCurrentClassLogger_ThenLoggerNameShouldBeCurrentClass()
         {

--- a/tests/NLog.UnitTests/LogManagerTests.cs
+++ b/tests/NLog.UnitTests/LogManagerTests.cs
@@ -31,14 +31,11 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Practices.Unity;
-
 namespace NLog.UnitTests
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Diagnostics;
     using System.IO;
     using Xunit;
@@ -46,6 +43,11 @@ namespace NLog.UnitTests
     using NLog.Config;
     using NLog.Layouts;
     using NLog.Targets;
+
+#if NET4_5
+    using System.Threading.Tasks;
+    using Microsoft.Practices.Unity;
+#endif
 
     public class LogManagerTests : NLogTestBase
     {

--- a/tests/NLog.UnitTests/LogManagerTests.cs
+++ b/tests/NLog.UnitTests/LogManagerTests.cs
@@ -401,19 +401,23 @@ namespace NLog.UnitTests
 #endif
 #if NET4_5
 
+        /// <summary>
+        /// target for <see cref="ThreadSafe_getCurrentClassLogger_test"/>
+        /// </summary>
         private static MemoryQueueTarget mTarget = new MemoryQueueTarget(500);
+        /// <summary>
+        /// target for <see cref="ThreadSafe_getCurrentClassLogger_test"/>
+        /// </summary>
         private static MemoryQueueTarget mTarget2 = new MemoryQueueTarget(500);
 
         /// <summary>
         /// Note: THe problem  can be reproduced when: debugging the unittest + "break when exception is thrown" checked in visual studio.
+        /// 
+        /// https://github.com/NLog/NLog/issues/500
         /// </summary>
         [Fact]
         public void ThreadSafe_getCurrentClassLogger_test()
         {
-
-
-
-
             using (var c = new UnityContainer())
             {
                 var r = Enumerable.Range(1, 100); //reported with 10.
@@ -434,13 +438,12 @@ namespace NLog.UnitTests
                 });
                 mTarget.Layout = @"${date:format=HH\:mm\:ss}|${level:uppercase=true}|${message} ${exception:format=tostring}";
                 mTarget2.Layout = @"${date:format=HH\:mm\:ss}|${level:uppercase=true}|${message} ${exception:format=tostring}";
-
-
-
-
             }
         }
 
+        /// <summary>
+        /// target for <see cref="ThreadSafe_getCurrentClassLogger_test"/>
+        /// </summary>
         [Target("Memory")]
         public sealed class MemoryQueueTarget : TargetWithLayout
         {
@@ -467,6 +470,9 @@ namespace NLog.UnitTests
             }
         }
 
+        /// <summary>
+        /// class for <see cref="ThreadSafe_getCurrentClassLogger_test"/>
+        /// </summary>
         public class ClassA
         {
             private static Logger logger = LogManager.GetCurrentClassLogger();
@@ -476,6 +482,9 @@ namespace NLog.UnitTests
 
             }
         }
+        /// <summary>
+        /// class for <see cref="ThreadSafe_getCurrentClassLogger_test"/>
+        /// </summary>
         public class ClassB
         {
             private static Logger logger = LogManager.GetCurrentClassLogger();
@@ -484,6 +493,9 @@ namespace NLog.UnitTests
                 logger.Info("Hi there B");
             }
         }
+        /// <summary>
+        /// class for <see cref="ThreadSafe_getCurrentClassLogger_test"/>
+        /// </summary>
         public class ClassC
         {
             private static Logger logger = LogManager.GetCurrentClassLogger();
@@ -493,6 +505,9 @@ namespace NLog.UnitTests
 
             }
         }
+        /// <summary>
+        /// class for <see cref="ThreadSafe_getCurrentClassLogger_test"/>
+        /// </summary>
         public class ClassD
         {
             private static Logger logger = LogManager.GetCurrentClassLogger();

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -69,6 +69,15 @@
     <Reference Include="Microsoft.Owin.Hosting">
       <HintPath>..\..\src\packages\Microsoft.Owin.Hosting.2.0.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Practices.Unity">
+      <HintPath>..\..\src\packages\Unity.3.5.1404.0\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.Configuration">
+      <HintPath>..\..\src\packages\Unity.3.5.1404.0\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention">
+      <HintPath>..\..\src\packages\Unity.3.5.1404.0\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\src\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/tests/NLog.UnitTests/packages.config
+++ b/tests/NLog.UnitTests/packages.config
@@ -10,6 +10,7 @@
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="StatLight" version="1.6.4375" targetFramework="net40" />
+  <package id="Unity" version="3.5.1404.0" targetFramework="net45" />
   <package id="xunit" version="1.9.1" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.1" targetFramework="net40" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" targetFramework="net40" />


### PR DESCRIPTION
This seems fixed. Cannot get this error now reproducing (tested + 10 times), and before I could reproduce it almost every-time

closes #500 and #360

note: I could not reproduce the error with *running* the unit test, **only** with debugging:  THe problem  can be reproduced when: debugging the unittest + "break when exception is thrown" checked in visual studio.