### PR TITLE
EventLogTarget.Source layoutable & code improvements to EventLogTarget

### DIFF
--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -119,6 +119,21 @@ namespace NLog.Layouts
                 this.SetRenderers(renderers, txt);
             }
         }
+        /// <summary>
+        /// Is the message fixed? (no Layout renderers used)
+        /// </summary>
+        public bool IsFixedText
+        {
+            get { return this.fixedText != null; }
+        }
+
+        /// <summary>
+        /// Get the fixed text. Only set when <see cref="IsFixedText"/> is <c>true</c>
+        /// </summary>
+        public string FixedText
+        {
+            get { return fixedText; }
+        }
 
         /// <summary>
         /// Gets a collection of <see cref="LayoutRenderer"/> objects that make up this layout.
@@ -211,7 +226,7 @@ namespace NLog.Layouts
         /// <returns>The rendered layout.</returns>
         protected override string GetFormattedMessage(LogEventInfo logEvent)
         {
-            if (this.fixedText != null)
+            if (IsFixedText)
             {
                 return this.fixedText;
             }

--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -151,7 +151,7 @@ namespace NLog.Targets
 
             if (string.IsNullOrEmpty(fixedSource))
             {
-                InternalLogger.Debug("Skipping removing of eventsource because it contains layout renderers");
+                InternalLogger.Debug("Skipping removing of event source because it contains layout renderers");
             }
             else
             {
@@ -174,7 +174,7 @@ namespace NLog.Targets
             {
                 return EventLog.SourceExists(fixedSource, this.MachineName);
             }
-            InternalLogger.Debug("Unclear if eventsource exists because it contains layout renderers");
+            InternalLogger.Debug("Unclear if event source exists because it contains layout renderers");
             return null; //unclear! 
         }
 
@@ -189,12 +189,12 @@ namespace NLog.Targets
 
             if (string.IsNullOrEmpty(fixedSource))
             {
-                InternalLogger.Debug("Skipping creation of eventsource because it contains layout renderers");
+                InternalLogger.Debug("Skipping creation of event source because it contains layout renderers");
             }
             else
             {
-                var s = EventLog.LogNameFromSourceName(fixedSource, this.MachineName);
-                if (!s.Equals(this.Log, StringComparison.CurrentCultureIgnoreCase))
+                var currentSourceName = EventLog.LogNameFromSourceName(fixedSource, this.MachineName);
+                if (!currentSourceName.Equals(this.Log, StringComparison.CurrentCultureIgnoreCase))
                 {
                     this.CreateEventSourceIfNeeded(fixedSource, false);
                 }
@@ -292,9 +292,8 @@ namespace NLog.Targets
             return eventLogInstance ?? (eventLogInstance = new EventLog(this.Log, this.MachineName, this.Source.Render(logEvent)));
         }
 
-
         /// <summary>
-        /// (re-)create a eventsource, if it isn't there. Works only with fixed sourcenames.
+        /// (re-)create a event source, if it isn't there. Works only with fixed sourcenames.
         /// </summary>
         /// <param name="fixedSource">sourcenaam. If source is not fixed (see <see cref="SimpleLayout.IsFixedText"/>, then pass <c>null</c> or emptystring.</param>
         /// <param name="alwaysThrowError">always throw an Exception when there is an error</param>
@@ -303,7 +302,7 @@ namespace NLog.Targets
 
             if (string.IsNullOrEmpty(fixedSource))
             {
-                InternalLogger.Debug("Skipping creation of eventsource because it contains layout renderers");
+                InternalLogger.Debug("Skipping creation of event source because it contains layout renderers");
                 //we can only create event sources if the source is fixed (no layout)
                 return;
 
@@ -344,7 +343,6 @@ namespace NLog.Targets
                 {
                     throw;
                 }
-
               
                 throw;
             }

--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -234,6 +234,11 @@ namespace NLog.Targets
             eventLog.WriteEntry(message, entryType, eventId, category);
         }
 
+        /// <summary>
+        /// Get the entry type for logging the message.
+        /// </summary>
+        /// <param name="logEvent">The logging event - for rendering the <see cref="EntryType"/></param>
+        /// <returns></returns>
         private EventLogEntryType GetEntryType(LogEventInfo logEvent)
         {
             if (this.EntryType != null)
@@ -250,7 +255,6 @@ namespace NLog.Targets
             }
 
             // determine auto
-       
             if (logEvent.Level >= LogLevel.Error)
             {
                 return EventLogEntryType.Error;
@@ -266,7 +270,7 @@ namespace NLog.Targets
         /// <summary>
         /// Get the source, if and only if the source is fixed. 
         /// </summary>
-        /// <returns><c>null</c> when not fixed</returns>
+        /// <returns><c>null</c> when not <see cref="SimpleLayout.IsFixedText"/></returns>
         /// <remarks>Internal for unit tests</remarks>
         internal string GetFixedSource()
         {

--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -298,7 +298,8 @@ namespace NLog.Targets
         /// Get the source, if and only if the source is fixed. 
         /// </summary>
         /// <returns><c>null</c> when not fixed</returns>
-        private string GetFixedSource()
+        /// <remarks>Internal for unit tests</remarks>
+        internal string GetFixedSource()
         {
             if (this.Source == null)
             {

--- a/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
@@ -129,7 +129,8 @@ namespace NLog.UnitTests.Targets
 
             var entries = GetEventRecords(el.Log).TakeWhile(e => e.TimeCreated > loggedNotBefore).ToList();
             //debug-> error
-            EntryExists(entries, testValue, target.Source, eventLogEntryType);
+            var expectedSource = target.GetFixedSource();
+            EntryExists(entries, testValue, expectedSource, eventLogEntryType);
         }
 
         private static void EntryExists(IEnumerable<EventRecord> entries, string expectedValue, string expectedSource, EventLogEntryType expectedEntryType)


### PR DESCRIPTION
- making event source layoutable as requested. Closes #508.
- removed code duplication
- improved docs.
- improved logging to internal logger.

Note: on install/uninstall, the event source is only created / removed when the Source doesn't contain layout renderers. This is needed because we need a `LogEventInfo` when rendering the Layout, and there isn't a `LogEventInfo` when installing/uninstalling. 