### PR TITLE
Flush always explicit

### DIFF
--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -373,7 +373,10 @@ namespace NLog.UnitTests
         private static void WriteToFile(string configXML, string path)
         {
             using (StreamWriter fs = File.CreateText(path))
+            {
                 fs.Write(configXML);
+                fs.Flush();
+            }
         }
     }
 }


### PR DESCRIPTION
because reload sometimes fails. (on AppVeyor)