### PR TITLE
Issue 730: Correct detection of an invalid file handle returned from …

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -222,12 +222,13 @@ namespace NLog.Internal.FileAppenders
                 this.CreateFileParameters.FileAttributes, 
                 IntPtr.Zero);
 
-            if (handle.ToInt32() == -1)
+            var safeHandle = new Microsoft.Win32.SafeHandles.SafeFileHandle(handle, true);
+            
+            if (safeHandle.IsInvalid)
             {
                 Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
             }
 
-            var safeHandle = new Microsoft.Win32.SafeHandles.SafeFileHandle(handle, true);
             var returnValue = new FileStream(safeHandle, FileAccess.Write, this.CreateFileParameters.BufferSize);
             returnValue.Seek(0, SeekOrigin.End);
             return returnValue;


### PR DESCRIPTION
…Win32 CreateFile API to be compatible with 32 & 64 bit systems.

SafeFileHandle was already being used to manage the lifetime of the created file. It also has a IsInvalid property that handles detection of an invalid handle via an IntPtr for both 32 & 64-bit systems.