### PR TITLE
Fix monodevelop build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,27 +36,28 @@ TOOLS=build/bin/Tools
 OUTPUT_DIR=build/bin/$(CONFIG)/Mono\ 2.x
 MONO_LIB_DIR=$(shell pkg-config --variable=libdir mono)/mono/4.0
 XBUILD=xbuild /nologo
+SOLUTION=monodevelop
 
 buildnlog:
-	$(XBUILD) src/NLog.Extended/NLog.Extended.monodevelop.csproj /p:Configuration=$(CONFIG)
+	$(XBUILD) src/NLog.Extended/NLog.Extended.$(SOLUTION).csproj /p:Configuration=$(CONFIG)
 
 buildtests:
-	$(XBUILD) tests/NLog.UnitTests/NLog.UnitTests.monodevelop.csproj /p:Configuration=$(CONFIG)  
+	$(XBUILD) tests/NLog.UnitTests/NLog.UnitTests.$(SOLUTION).csproj /p:Configuration=$(CONFIG)
 
 makexsdtool:
-	$(XBUILD) tools/MakeNLogXSD/MakeNLogXSD.csproj /p:Configuration=$(CONFIG)  
+	$(XBUILD) tools/MakeNLogXSD/MakeNLogXSD.csproj /p:Configuration=$(CONFIG)
 
 dumpapitool:
-	$(XBUILD) tools/DumpApiXml/DumpApiXml.csproj /p:Configuration=$(CONFIG)  
+	$(XBUILD) tools/DumpApiXml/DumpApiXml.csproj /p:Configuration=$(CONFIG)
 
 mergeapitool:
-	$(XBUILD) tools/MergeApiXml/MergeApiXml.csproj /p:Configuration=$(CONFIG)  
+	$(XBUILD) tools/MergeApiXml/MergeApiXml.csproj /p:Configuration=$(CONFIG)
 
 builddocpagestool:
-	$(XBUILD) tools/BuildDocPages/BuildDocPages.csproj /p:Configuration=$(CONFIG)  
+	$(XBUILD) tools/BuildDocPages/BuildDocPages.csproj /p:Configuration=$(CONFIG)
 
 syncprojectitemstool:
-	$(XBUILD) tools/SyncProjectItems/SyncProjectItems.csproj /p:Configuration=$(CONFIG)  
+	$(XBUILD) tools/SyncProjectItems/SyncProjectItems.csproj /p:Configuration=$(CONFIG)
 
 syncprojectitems: syncprojectitemstool
 	(cd src/NLog && mono ../../build/bin/Tools/SyncProjectItems.exe ProjectFileInfo.xml)
@@ -70,7 +71,7 @@ dumpapi: dumpapitool mergeapitool buildnlog
 
 builddocpages: builddocpagestool
 	(cd build/bin/$(CONFIG) && mono ../Tools/BuildDocPages.exe "NLogMerged.api.xml" "../../../tools/WebsiteFiles/style.xsl" "Website/generated" "../../.." html web)
- 
+
 xsd: makexsdtool
 	(cd $(OUTPUT_DIR) && mono ../../Tools/MakeNLogXSD.exe -api API/NLog.api -out NLog.mono2.xsd -xmlns http://www.nlog-project.org/schemas/NLog.mono2.xsd)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ As the current NLog team is a small team, we cannot fix every bug or implement e
 
 If you like to start with a small task, thent the following GitHub issues are nice to start with:
 
-- If you like to work with Mono: [#648](https://github.com/NLog/NLog/issues/648)
 - These issues would be great if it get fixed (and unit tested):  [#302](https://github.com/NLog/NLog/issues/302)
 - If you like to create a layout renderer (small task): [#86](https://github.com/NLog/NLog/issues/86)
 - If you good in writing English or just like writing English:  [#520](https://github.com/NLog/NLog/issues/520)

--- a/src/NLog.Extended/NLog.Extended.monodevelop.csproj
+++ b/src/NLog.Extended/NLog.Extended.monodevelop.csproj
@@ -4,14 +4,14 @@
     <BaseOutputDirectory Condition=" '$(BaseOutputDirectory)' == '' ">$(MSBuildProjectDirectory)\..\..\build\</BaseOutputDirectory>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{F801A1F9-1024-4446-BF9E-A923137340B8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NLog</RootNamespace>
     <AssemblyName>NLog.Extended</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
@@ -25,6 +25,8 @@
     <WarningLevel>4</WarningLevel>
     <OutputPath>bin\Debug</OutputPath>
     <NoStdLib>true</NoStdLib>
+    <IntermediateOutputPath>$(BaseOutputDirectory)obj\$(Configuration)\Mono 2.x</IntermediateOutputPath>
+    <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,6 +37,8 @@
     <WarningLevel>4</WarningLevel>
     <OutputPath>bin\Release</OutputPath>
     <NoStdLib>true</NoStdLib>
+    <IntermediateOutputPath>$(BaseOutputDirectory)obj\$(Configuration)\Mono 2.x</IntermediateOutputPath>
+    <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <NoStdLib>true</NoStdLib>

--- a/src/NLog/NLog.mono2.csproj
+++ b/src/NLog/NLog.mono2.csproj
@@ -405,7 +405,7 @@
       <Compile Include="$(BuildInfoFile)" />
     </ItemGroup>
   </Target>
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <ItemGroup>
     <None Include="Logger.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/NLog/NLog.monodevelop.csproj
+++ b/src/NLog/NLog.monodevelop.csproj
@@ -4,7 +4,7 @@
     <BaseOutputDirectory Condition=" '$(BaseOutputDirectory)' == '' ">$(MSBuildProjectDirectory)\..\..\build\</BaseOutputDirectory>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{E7AB20BF-6920-442A-B876-CC05BC5CEC79}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <NoWarn>0419</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -26,6 +26,8 @@
     <WarningLevel>4</WarningLevel>
     <OutputPath>bin\Debug</OutputPath>
     <NoStdLib>true</NoStdLib>
+    <IntermediateOutputPath>$(BaseOutputDirectory)obj\$(Configuration)\Mono 2.x</IntermediateOutputPath>
+    <DocumentationFile>$(OutputPath)\NLog.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,6 +38,8 @@
     <WarningLevel>4</WarningLevel>
     <OutputPath>bin\Release</OutputPath>
     <NoStdLib>true</NoStdLib>
+    <IntermediateOutputPath>$(BaseOutputDirectory)obj\$(Configuration)\Mono 2.x</IntermediateOutputPath>
+    <DocumentationFile>$(OutputPath)\NLog.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <NoStdLib>true</NoStdLib>

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -408,5 +408,5 @@
       <Compile Include="$(BuildInfoFile)" />
     </ItemGroup>
   </Target>
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
 </Project>

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -413,5 +413,5 @@
       <Compile Include="$(BuildInfoFile)" />
     </ItemGroup>
   </Target>
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
 </Project>

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -681,7 +681,7 @@ namespace NLog.Targets
         /// Writes the specified array of logging events to a file specified in the FileName
         /// parameter.
         /// </summary>
-        /// <param name="logEvents">An array of <see cref="LogEventInfo "/> objects.</param>
+        /// <param name="logEvents">An array of <see cref="AsyncLogEventInfo"/> objects.</param>
         /// <remarks>
         /// This function makes use of the fact that the events are batched by sorting
         /// the requests by filename. This optimizes the number of open/close calls

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono2.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono2.csproj
@@ -166,5 +166,5 @@
     <ProjectReference Include="..\SampleExtensions\SampleExtensions.mono2.csproj" />
   </ItemGroup>
   <Import Project="..\..\src\Mono.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
 </Project>

--- a/tests/NLog.UnitTests/NLog.UnitTests.monodevelop.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.monodevelop.csproj
@@ -3,13 +3,14 @@
   <PropertyGroup>
     <BaseOutputDirectory Condition=" '$(BaseOutputDirectory)' == '' ">$(MSBuildProjectDirectory)\..\..\build\</BaseOutputDirectory>
     <ProjectType>Local</ProjectType>
-    <ProductVersion>9.0.30729</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{FE0A3713-E9A8-41F0-89FA-C1126F8FB6A8}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <OutputPath>bin\Debug</OutputPath>
     <NoStdLib>true</NoStdLib>
+    <IntermediateOutputPath>$(BaseOutputDirectory)obj\$(Configuration)\Mono 2.x</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <BaseAddress>285212672</BaseAddress>
@@ -44,6 +46,7 @@
     <ErrorReport>prompt</ErrorReport>
     <OutputPath>bin\Release</OutputPath>
     <NoStdLib>true</NoStdLib>
+    <IntermediateOutputPath>$(BaseOutputDirectory)obj\$(Configuration)\Mono 2.x</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <NoStdLib>true</NoStdLib>
@@ -61,7 +64,12 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="nunit.framework, Version=2.4.8.0, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77" />
+    <Reference Include="xunit">
+      <HintPath>..\..\src\packages\xunit.1.9.1\lib\net20\xunit.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.extensions">
+      <HintPath>..\..\src\packages\xunit.extensions.1.9.1\lib\net20\xunit.extensions.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -264,5 +264,5 @@
   </ItemGroup>
   <Import Project="$(StyleCopTargetsFile)" Condition="'$(StyleCopTargetsFile)' != ''" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
 </Project>

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -223,5 +223,5 @@
   </ItemGroup>
   <Import Project="$(StyleCopTargetsFile)" Condition="'$(StyleCopTargetsFile)' != ''" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
 </Project>

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -266,5 +266,5 @@
   </ItemGroup>
   <Import Project="$(StyleCopTargetsFile)" Condition="'$(StyleCopTargetsFile)' != ''" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
 </Project>

--- a/tests/SampleExtensions/SampleExtensions.monodevelop.csproj
+++ b/tests/SampleExtensions/SampleExtensions.monodevelop.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{C480452F-7E14-443D-906D-7E021ABAA107A}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -12,7 +12,7 @@
     <AssemblyName>SampleExtensions</AssemblyName>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>bin\Debug</OutputPath>
+    <IntermediateOutputPath>$(BaseOutputDirectory)obj\$(Configuration)\Mono 2.x</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>bin\Release</OutputPath>
+    <IntermediateOutputPath>$(BaseOutputDirectory)obj\$(Configuration)\Mono 2.x</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <NoConfig>true</NoConfig>


### PR DESCRIPTION
We move the .NET target version to 4.5 and add the references
to the xunit packages.

Open the sln file with monodevelop first so it can restore the
nuget packages before calling make.

fix #648

@akoeplinger do you have maybe some further suggestions?
This is just a quick fix to get what we can compile NLog with monodevelop.
I dropped 3.5, because that is under mono considered to be ancient and mostly never used.