### PR TITLE
Alternate fix for #730

### DIFF
--- a/src/NLog/Internal/Win32FileNativeMethods.cs
+++ b/src/NLog/Internal/Win32FileNativeMethods.cs
@@ -65,7 +65,7 @@ namespace NLog.Internal
         }
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern IntPtr CreateFile(
+        public static extern Microsoft.Win32.SafeHandles.SafeFileHandle CreateFile(
             string lpFileName,
             FileAccess dwDesiredAccess,
             int dwShareMode,


### PR DESCRIPTION
Modify Win32FileNativeMethods.CreateFile to return SafeFileHandle rather than IntPtr and adjust callsite to ensure the returned handle is not leaked.

Issue #730