### PR TITLE
Correct race condition in AsyncTargetWrapperExceptionTest

### DIFF
--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
@@ -294,11 +294,10 @@ namespace NLog.UnitTests.Targets.Wrappers
                 () =>
                 {
                     targetWrapper.WriteAsyncLogEvent(LogEventInfo.CreateNullEvent().WithContinuation(ex => { }));
-                    Thread.Sleep(1000);
+                    targetWrapper.Close();
                 },
                 LogLevel.Trace);
 
-            targetWrapper.Close();
             Assert.True(internalLog.StartsWith("Error Error in lazy writer timer procedure: System.NullReferenceException", StringComparison.Ordinal), internalLog);
         }
 


### PR DESCRIPTION
Modify AsyncTargetWrapperExceptionTest to avoid race condition with AsyncWrapper thread timer.