### PR TITLE
Move MDLC and TraceActivityId from Contrib

### DIFF
--- a/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
@@ -1,0 +1,66 @@
+// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.LayoutRenderers
+{
+#if NET4_5
+    using System.Text;
+    using NLog.Config;
+
+    /// <summary>
+    /// Mapped Diagnostic Logical Context item (based on CallContext).
+    /// </summary>
+    [LayoutRenderer("mdlc")]
+    public class MdlcLayoutRenderer : LayoutRenderer
+    {
+        /// <summary>
+        /// Gets or sets the name of the item.
+        /// </summary>
+        /// <docgen category='Rendering Options' order='10' />
+        [RequiredParameter]
+        [DefaultParameter]
+        public string Item { get; set; }
+
+        /// <summary>
+        /// Renders the specified MDLC item and appends it to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="logEvent">Logging event.</param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            var message = MappedDiagnosticsLogicalContext.Get(Item);
+            builder.Append(message);
+        }
+    }
+#endif
+}

--- a/src/NLog/LayoutRenderers/TraceActivityIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/TraceActivityIdLayoutRenderer.cs
@@ -1,0 +1,58 @@
+// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.LayoutRenderers
+{
+    using System;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Text;
+
+    /// <summary>
+    /// A renderer that puts into log a System.Diagnostics trace correlation id.
+    /// </summary>
+    [LayoutRenderer("activityid")]
+    public class TraceActivityIdLayoutRenderer : LayoutRenderer
+    {
+        /// <summary>
+        /// Renders the current trace activity ID.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="logEvent">Logging event.</param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            builder.Append(Guid.Empty.Equals(Trace.CorrelationManager.ActivityId) ?
+                String.Empty : Trace.CorrelationManager.ActivityId.ToString("D", CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/src/NLog/MappedDiagnosticsLogicalContext.cs
+++ b/src/NLog/MappedDiagnosticsLogicalContext.cs
@@ -1,0 +1,124 @@
+// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog
+{
+#if NET4_5
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Runtime.Remoting.Messaging;
+
+    /// <summary>
+    /// Async version of Mapped Diagnostics Context - a logical context structure that keeps a dictionary
+    /// of strings and provides methods to output them in layouts.  Allows for maintaining state across
+    /// asynchronous tasks and call contexts.
+    /// Mostly for compatibility with log4net (log4net.ThreadLogicalContext).
+    /// </summary>
+    /// <remarks>
+    /// Ideally, these changes should be incorporated as a new version of the MappedDiagnosticsContext class in the original
+    /// NLog library so that state can be maintained for multiple threads in asynchronous situations.
+    /// </remarks>
+    public static class MappedDiagnosticsLogicalContext
+    {
+        private const string LogicalThreadDictionaryKey = "NLog.AsyncableMappedDiagnosticsContext";
+
+        private static IDictionary<string, string> LogicalThreadDictionary
+        {
+            get
+            {
+                var dictionary = CallContext.LogicalGetData(LogicalThreadDictionaryKey) as ConcurrentDictionary<string, string>;
+                if (dictionary == null)
+                {
+                    dictionary = new ConcurrentDictionary<string, string>();
+                    CallContext.LogicalSetData(LogicalThreadDictionaryKey, dictionary);
+                }
+                return dictionary;
+            }
+        }
+
+        /// <summary>
+        /// Gets the current logical context named item.
+        /// </summary>
+        /// <param name="item">Item name.</param>
+        /// <returns>The item value of string.Empty if the value is not present.</returns>
+        public static string Get(string item)
+        {
+            string value;
+
+            if (!LogicalThreadDictionary.TryGetValue(item, out value))
+            {
+                value = string.Empty;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Sets the current logical context item to the specified value.
+        /// </summary>
+        /// <param name="item">Item name.</param>
+        /// <param name="value">Item value.</param>
+        public static void Set(string item, string value)
+        {
+            LogicalThreadDictionary[item] = value;
+        }
+
+        /// <summary>
+        /// Checks whether the specified item exists in current logical context.
+        /// </summary>
+        /// <param name="item">Item name.</param>
+        /// <returns>A boolean indicating whether the specified item exists in current thread MDC.</returns>
+        public static bool Contains(string item)
+        {
+            return LogicalThreadDictionary.ContainsKey(item);
+        }
+
+        /// <summary>
+        /// Removes the specified item from current logical context.
+        /// </summary>
+        /// <param name="item">Item name.</param>
+        public static void Remove(string item)
+        {
+            LogicalThreadDictionary.Remove(item);
+        }
+
+        /// <summary>
+        /// Clears the content of current logical context.
+        /// </summary>
+        public static void Clear()
+        {
+            LogicalThreadDictionary.Clear();
+        }
+    }
+#endif
+}

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -230,6 +230,7 @@
     <Compile Include="LayoutRenderers\LongDateLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MachineNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
@@ -253,6 +254,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\TraceActivityIdLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />
@@ -315,6 +317,7 @@
     <Compile Include="LogReceiverService\WcfLogReceiverClientFacade.cs" />
     <Compile Include="LogReceiverService\WcfLogReceiverOneWayClient.cs" />
     <Compile Include="MappedDiagnosticsContext.cs" />
+    <Compile Include="MappedDiagnosticsLogicalContext.cs" />
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />

--- a/src/NLog/NLog.mono2.csproj
+++ b/src/NLog/NLog.mono2.csproj
@@ -232,6 +232,7 @@
     <Compile Include="LayoutRenderers\LongDateLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MachineNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
@@ -255,6 +256,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\TraceActivityIdLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />
@@ -317,6 +319,7 @@
     <Compile Include="LogReceiverService\WcfLogReceiverClientFacade.cs" />
     <Compile Include="LogReceiverService\WcfLogReceiverOneWayClient.cs" />
     <Compile Include="MappedDiagnosticsContext.cs" />
+    <Compile Include="MappedDiagnosticsLogicalContext.cs" />
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />

--- a/src/NLog/NLog.monodevelop.csproj
+++ b/src/NLog/NLog.monodevelop.csproj
@@ -234,6 +234,7 @@
     <Compile Include="LayoutRenderers\LongDateLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MachineNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
@@ -257,6 +258,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\TraceActivityIdLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />
@@ -319,6 +321,7 @@
     <Compile Include="LogReceiverService\WcfLogReceiverClientFacade.cs" />
     <Compile Include="LogReceiverService\WcfLogReceiverOneWayClient.cs" />
     <Compile Include="MappedDiagnosticsContext.cs" />
+    <Compile Include="MappedDiagnosticsLogicalContext.cs" />
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -232,6 +232,7 @@
     <Compile Include="LayoutRenderers\LongDateLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MachineNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
@@ -255,6 +256,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\TraceActivityIdLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />
@@ -317,6 +319,7 @@
     <Compile Include="LogReceiverService\WcfLogReceiverClientFacade.cs" />
     <Compile Include="LogReceiverService\WcfLogReceiverOneWayClient.cs" />
     <Compile Include="MappedDiagnosticsContext.cs" />
+    <Compile Include="MappedDiagnosticsLogicalContext.cs" />
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -233,6 +233,7 @@
     <Compile Include="LayoutRenderers\LongDateLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MachineNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
@@ -256,6 +257,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\TraceActivityIdLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />
@@ -318,6 +320,7 @@
     <Compile Include="LogReceiverService\WcfLogReceiverClientFacade.cs" />
     <Compile Include="LogReceiverService\WcfLogReceiverOneWayClient.cs" />
     <Compile Include="MappedDiagnosticsContext.cs" />
+    <Compile Include="MappedDiagnosticsLogicalContext.cs" />
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -238,6 +238,7 @@
     <Compile Include="LayoutRenderers\LongDateLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MachineNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
@@ -261,6 +262,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\TraceActivityIdLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />
@@ -323,6 +325,7 @@
     <Compile Include="LogReceiverService\WcfLogReceiverClientFacade.cs" />
     <Compile Include="LogReceiverService\WcfLogReceiverOneWayClient.cs" />
     <Compile Include="MappedDiagnosticsContext.cs" />
+    <Compile Include="MappedDiagnosticsLogicalContext.cs" />
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -236,6 +236,7 @@
     <Compile Include="LayoutRenderers\LongDateLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MachineNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
@@ -259,6 +260,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\TraceActivityIdLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />
@@ -321,6 +323,7 @@
     <Compile Include="LogReceiverService\WcfLogReceiverClientFacade.cs" />
     <Compile Include="LogReceiverService\WcfLogReceiverOneWayClient.cs" />
     <Compile Include="MappedDiagnosticsContext.cs" />
+    <Compile Include="MappedDiagnosticsLogicalContext.cs" />
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -233,6 +233,7 @@
     <Compile Include="LayoutRenderers\LongDateLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MachineNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
@@ -256,6 +257,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\TraceActivityIdLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />
@@ -318,6 +320,7 @@
     <Compile Include="LogReceiverService\WcfLogReceiverClientFacade.cs" />
     <Compile Include="LogReceiverService\WcfLogReceiverOneWayClient.cs" />
     <Compile Include="MappedDiagnosticsContext.cs" />
+    <Compile Include="MappedDiagnosticsLogicalContext.cs" />
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -232,6 +232,7 @@
     <Compile Include="LayoutRenderers\LongDateLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MachineNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
@@ -255,6 +256,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\TraceActivityIdLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />
@@ -317,6 +319,7 @@
     <Compile Include="LogReceiverService\WcfLogReceiverClientFacade.cs" />
     <Compile Include="LogReceiverService\WcfLogReceiverOneWayClient.cs" />
     <Compile Include="MappedDiagnosticsContext.cs" />
+    <Compile Include="MappedDiagnosticsLogicalContext.cs" />
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -232,6 +232,7 @@
     <Compile Include="LayoutRenderers\LongDateLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MachineNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
@@ -255,6 +256,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\TraceActivityIdLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />
@@ -317,6 +319,7 @@
     <Compile Include="LogReceiverService\WcfLogReceiverClientFacade.cs" />
     <Compile Include="LogReceiverService\WcfLogReceiverOneWayClient.cs" />
     <Compile Include="MappedDiagnosticsContext.cs" />
+    <Compile Include="MappedDiagnosticsLogicalContext.cs" />
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />

--- a/tests/NLog.UnitTests/Contexts/MappedDiagnosticsLogicalContextTests.cs
+++ b/tests/NLog.UnitTests/Contexts/MappedDiagnosticsLogicalContextTests.cs
@@ -1,0 +1,183 @@
+// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.Contexts
+{
+#if NET4_5
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class MappedDiagnosticsLogicalContextTests
+    {
+        public MappedDiagnosticsLogicalContextTests()
+        {
+            MappedDiagnosticsLogicalContext.Clear();
+        }
+
+        [Fact]
+        public void given_no_item_exists_when_getting_item_should_return_empty_string()
+        {
+            Assert.Empty(MappedDiagnosticsLogicalContext.Get("itemThatShouldNotExist"));
+        }
+
+        [Fact]
+        public void given_item_exists_when_getting_item_should_return_item()
+        {
+            const string key = "Key";
+            const string item = "Item";
+            MappedDiagnosticsLogicalContext.Set(key, item);
+
+            Assert.Equal(item, MappedDiagnosticsLogicalContext.Get(key));
+        }
+
+        [Fact]
+        public void given_item_does_not_exist_when_setting_item_should_contain_item()
+        {
+            const string key = "Key";
+            const string item = "Item";
+
+            MappedDiagnosticsLogicalContext.Set(key, item);
+
+            Assert.True(MappedDiagnosticsLogicalContext.Contains(key));
+        }
+
+        [Fact]
+        public void given_item_exists_when_setting_item_should_not_throw()
+        {
+            const string key = "Key";
+            const string item = "Item";
+            MappedDiagnosticsLogicalContext.Set(key, item);
+
+            Assert.DoesNotThrow(() => MappedDiagnosticsLogicalContext.Set(key, item));
+        }
+
+        [Fact]
+        public void given_item_exists_when_setting_item_should_update_item()
+        {
+            const string key = "Key";
+            const string item = "Item";
+            const string newItem = "NewItem";
+            MappedDiagnosticsLogicalContext.Set(key, item);
+
+            MappedDiagnosticsLogicalContext.Set(key, newItem);
+
+            Assert.Equal(newItem, MappedDiagnosticsLogicalContext.Get(key));
+        }
+
+        [Fact]
+        public void given_item_does_not_exist_when_checking_if_context_contains_should_return_false()
+        {
+            Assert.False(MappedDiagnosticsLogicalContext.Contains("keyForItemThatDoesNotExist"));
+        }
+
+        [Fact]
+        public void given_item_exists_when_checking_if_context_contains_should_return_true()
+        {
+            const string key = "Key";
+            MappedDiagnosticsLogicalContext.Set(key, "Item");
+
+            Assert.True(MappedDiagnosticsLogicalContext.Contains(key));
+
+        }
+
+        [Fact]
+        public void given_item_exists_when_removing_item_should_not_contain_item()
+        {
+            const string keyForItemThatShouldExist = "Key";
+            const string itemThatShouldExist = "Item";
+            MappedDiagnosticsLogicalContext.Set(keyForItemThatShouldExist, itemThatShouldExist);
+
+            MappedDiagnosticsLogicalContext.Remove(keyForItemThatShouldExist);
+
+            Assert.False(MappedDiagnosticsLogicalContext.Contains(keyForItemThatShouldExist));
+        }
+
+        [Fact]
+        public void given_item_does_not_exist_when_removing_item_should_not_throw()
+        {
+            const string keyForItemThatShouldExist = "Key";
+            Assert.DoesNotThrow(() => MappedDiagnosticsLogicalContext.Remove(keyForItemThatShouldExist));
+        }
+
+        [Fact]
+        public void given_item_does_not_exist_when_clearing_should_not_throw()
+        {
+            Assert.DoesNotThrow(MappedDiagnosticsLogicalContext.Clear);
+        }
+
+        [Fact]
+        public void given_item_exists_when_clearing_should_not_contain_item()
+        {
+            const string key = "Key";
+            MappedDiagnosticsLogicalContext.Set(key, "Item");
+
+            MappedDiagnosticsLogicalContext.Clear();
+            
+            Assert.False(MappedDiagnosticsLogicalContext.Contains(key));
+        }
+
+        [Fact]
+        public void given_multiple_threads_running_asynchronously_when_setting_and_getting_values_should_return_thread_specific_values()
+        {
+            const string key = "Key";
+            const string valueForLogicalThread1 = "ValueForTask1";
+            const string valueForLogicalThread2 = "ValueForTask2";
+            const string valueForLogicalThread3 = "ValueForTask3";
+
+            var task1 = Task.Factory.StartNew(() =>
+            {
+                MappedDiagnosticsLogicalContext.Set(key, valueForLogicalThread1);
+                return MappedDiagnosticsLogicalContext.Get(key);
+            });
+
+            var task2 = Task.Factory.StartNew(() =>
+            {
+                MappedDiagnosticsLogicalContext.Set(key, valueForLogicalThread2);
+                return MappedDiagnosticsLogicalContext.Get(key);
+            });
+
+            var task3 = Task.Factory.StartNew(() =>
+            {
+                MappedDiagnosticsLogicalContext.Set(key, valueForLogicalThread3);
+                return MappedDiagnosticsLogicalContext.Get(key);
+            });
+
+            Task.WaitAll();
+
+            Assert.Equal(task1.Result, valueForLogicalThread1);
+            Assert.Equal(task2.Result, valueForLogicalThread2);
+            Assert.Equal(task3.Result, valueForLogicalThread3);
+        }
+    }
+#endif
+}

--- a/tests/NLog.UnitTests/LayoutRenderers/MdlcLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/MdlcLayoutRendererTests.cs
@@ -1,0 +1,90 @@
+// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.LayoutRenderers
+{
+#if NET4_5
+    using System.Xml.Linq;
+    using NLog.Config;
+    using NLog.LayoutRenderers;
+    using NLog.Targets;
+    using Xunit;
+
+    public class MdlcLayoutRendererTests
+    {
+        private static DebugTarget _target;
+
+        public MdlcLayoutRendererTests()
+        {
+            ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition("mdlc", typeof(MdlcLayoutRenderer));
+
+            const string configXml = @"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${mdlc:Item=myitem}${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>";
+
+            var element = XElement.Parse(configXml);
+            var config = new XmlLoggingConfiguration(element.CreateReader(), null);
+            LogManager.Configuration = config;
+
+            _target = LogManager.Configuration.FindTargetByName("debug") as DebugTarget;
+
+            MappedDiagnosticsLogicalContext.Clear();
+        }
+
+        [Fact]
+        public void given_item_does_not_exist_when_rendering_item_and_message_should_render_only_message()
+        {
+            const string message = "message";
+            LogManager.GetLogger("A").Debug(message);
+            Assert.Equal(message, _target.LastMessage);
+        }
+
+        [Fact]
+        public void given_item_exists_when_rendering_item_and_message_should_render_item_and_message()
+        {
+            const string message = "message";
+            const string key = "myitem";
+            const string item = "item";
+
+            MappedDiagnosticsLogicalContext.Set(key, item);
+            LogManager.GetLogger("A").Debug(message);
+
+            Assert.Equal(item + message, _target.LastMessage);
+        }
+    }
+#endif
+}

--- a/tests/NLog.UnitTests/NLog.UnitTests.monodevelop.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.monodevelop.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ConfigFileLocatorTests.cs" />
     <Compile Include="Contexts\GlobalDiagnosticsContextTests.cs" />
     <Compile Include="Contexts\MappedDiagnosticsContextTests.cs" />
+    <Compile Include="Contexts\MappedDiagnosticsLogicalContextTests.cs" />
     <Compile Include="Contexts\NestedDiagnosticsContextTests.cs" />
     <Compile Include="Filters\APITests.cs" />
     <Compile Include="Filters\ConditionBasedFilterTests.cs" />
@@ -115,6 +116,7 @@
     <Compile Include="LayoutRenderers\LogLevelTests.cs" />
     <Compile Include="LayoutRenderers\LongDateTests.cs" />
     <Compile Include="LayoutRenderers\MDCTests.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
     <Compile Include="LayoutRenderers\RegistryTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -112,6 +112,7 @@
     <Compile Include="ConfigFileLocatorTests.cs" />
     <Compile Include="Contexts\GlobalDiagnosticsContextTests.cs" />
     <Compile Include="Contexts\MappedDiagnosticsContextTests.cs" />
+    <Compile Include="Contexts\MappedDiagnosticsLogicalContextTests.cs" />
     <Compile Include="Contexts\NestedDiagnosticsContextTests.cs" />
     <Compile Include="Filters\APITests.cs" />
     <Compile Include="Filters\ConditionBasedFilterTests.cs" />
@@ -144,6 +145,7 @@
     <Compile Include="LayoutRenderers\LogLevelTests.cs" />
     <Compile Include="LayoutRenderers\LongDateTests.cs" />
     <Compile Include="LayoutRenderers\MDCTests.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
     <Compile Include="LayoutRenderers\RegistryTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -92,6 +92,7 @@
     <Compile Include="ConfigFileLocatorTests.cs" />
     <Compile Include="Contexts\GlobalDiagnosticsContextTests.cs" />
     <Compile Include="Contexts\MappedDiagnosticsContextTests.cs" />
+    <Compile Include="Contexts\MappedDiagnosticsLogicalContextTests.cs" />
     <Compile Include="Contexts\NestedDiagnosticsContextTests.cs" />
     <Compile Include="Filters\APITests.cs" />
     <Compile Include="Filters\ConditionBasedFilterTests.cs" />
@@ -124,6 +125,7 @@
     <Compile Include="LayoutRenderers\LogLevelTests.cs" />
     <Compile Include="LayoutRenderers\LongDateTests.cs" />
     <Compile Include="LayoutRenderers\MDCTests.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
     <Compile Include="LayoutRenderers\RegistryTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -134,6 +134,7 @@
     <Compile Include="ConfigFileLocatorTests.cs" />
     <Compile Include="Contexts\GlobalDiagnosticsContextTests.cs" />
     <Compile Include="Contexts\MappedDiagnosticsContextTests.cs" />
+    <Compile Include="Contexts\MappedDiagnosticsLogicalContextTests.cs" />
     <Compile Include="Contexts\NestedDiagnosticsContextTests.cs" />
     <Compile Include="Filters\APITests.cs" />
     <Compile Include="Filters\ConditionBasedFilterTests.cs" />
@@ -166,6 +167,7 @@
     <Compile Include="LayoutRenderers\LogLevelTests.cs" />
     <Compile Include="LayoutRenderers\LongDateTests.cs" />
     <Compile Include="LayoutRenderers\MDCTests.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
     <Compile Include="LayoutRenderers\RegistryTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -111,6 +111,7 @@
     <Compile Include="ConfigFileLocatorTests.cs" />
     <Compile Include="Contexts\GlobalDiagnosticsContextTests.cs" />
     <Compile Include="Contexts\MappedDiagnosticsContextTests.cs" />
+    <Compile Include="Contexts\MappedDiagnosticsLogicalContextTests.cs" />
     <Compile Include="Contexts\NestedDiagnosticsContextTests.cs" />
     <Compile Include="Filters\APITests.cs" />
     <Compile Include="Filters\ConditionBasedFilterTests.cs" />
@@ -143,6 +144,7 @@
     <Compile Include="LayoutRenderers\LogLevelTests.cs" />
     <Compile Include="LayoutRenderers\LongDateTests.cs" />
     <Compile Include="LayoutRenderers\MDCTests.cs" />
+    <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
     <Compile Include="LayoutRenderers\RegistryTests.cs" />


### PR DESCRIPTION
MDLC can only be used in .NET 4.5