### PR TITLE
Autoload fix for ASP.net + better autoloading logging

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -236,10 +236,7 @@ namespace NLog.Config
             factory.RegisterExtendedItems();
 #if !SILVERLIGHT
 
-            var location = !String.IsNullOrEmpty(nlogAssembly.Location)
-                ? nlogAssembly.Location
-                : new Uri(nlogAssembly.CodeBase).LocalPath;
-            var assemblyLocation = Path.GetDirectoryName(location);
+            var assemblyLocation = GetNLogAssemblyLocation(nlogAssembly);
             if (assemblyLocation == null)
             {
                 return factory;
@@ -262,6 +259,17 @@ namespace NLog.Config
             return factory;
         }
 
+#if !SILVERLIGHT
+        private static string GetNLogAssemblyLocation(Assembly nlogAssembly)
+        {
+            var location = !String.IsNullOrEmpty(nlogAssembly.Location)
+                ? nlogAssembly.Location
+                : new Uri(nlogAssembly.CodeBase).LocalPath;
+            var assemblyLocation = Path.GetDirectoryName(location);
+            return assemblyLocation;
+        }
+
+#endif
         /// <summary>
         /// Registers items in NLog.Extended.dll using late-bound types, so that we don't need a reference to NLog.Extended.dll.
         /// </summary>


### PR DESCRIPTION
Tested in MVC application. With `nlogAssembly.Location` we get a path some where in

```
C:\Windows\Microsoft.NET\Framework\v4.0.30319\Temporary ASP.NET Files\....

```
as starting path. Because every `.dll` is in a separate folder in `Temporary ASP.NET Files`, the auto-load didn't work.

This has been resolved with this PR.