### PR TITLE
Improved config example

### DIFF
--- a/src/NuGet/NLog.Config/content/NLog.config
+++ b/src/NuGet/NLog.Config/content/NLog.config
@@ -1,15 +1,31 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd"
+      autoReload="true"
+      throwExceptions="false"
+      internalLogLevel="Off" internalLogFile="c:\temp\nlog-internal.log" >
+
+
+  <!-- optional, add some variabeles
+  https://github.com/nlog/NLog/wiki/Configuration-file#variables
+  -->
+  <variable name="myvar" value="myvalue"/>
 
   <!-- 
   See https://github.com/nlog/nlog/wiki/Configuration-file 
   for information on customizing logging rules and outputs.
    -->
   <targets>
-    <!-- add your targets here -->
-    
+
+    <!-- 
+    add your targets here 
+    See https://github.com/nlog/NLog/wiki/Targets for possible targets.
+    See https://github.com/nlog/NLog/wiki/Layout-Renderers for the possible layout renderers.
+    -->
+
     <!--
+    Writing events to the a file with the date in the filename. 
     <target xsi:type="File" name="f" fileName="${basedir}/logs/${shortdate}.log"
             layout="${longdate} ${uppercase:${level}} ${message}" />
     -->
@@ -17,9 +33,10 @@
 
   <rules>
     <!-- add your logging rules here -->
-    
+
     <!--
-    <logger name="*" minlevel="Trace" writeTo="f" />
+    Write all events with minimal level of Debug (So Debug, Info, Warn, Error and Fatal, but not Trace)  to "f"
+    <logger name="*" minlevel="Debug" writeTo="f" />
     -->
   </rules>
 </nlog>


### PR DESCRIPTION
Improved init example, for the [nlog.config package](https://www.nuget.org/packages/NLog.Config/)
- more documentation, more links
- better defaults (not throwExceptions, internal logging visible)
- XML schemalocation added (because visual studio not always found the
xsd)

This is done. Comments are welcome!