### PR TITLE
Fixed reference for Siverlight (broken and fixed in 4.0.1)

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -48,6 +48,10 @@ namespace NLog.Config
     using NLog.Targets;
     using NLog.Targets.Wrappers;
     using NLog.Time;
+#if SILVERLIGHT
+// ReSharper disable once RedundantUsingDirective
+    using System.Windows;
+#endif
 
     /// <summary>
     /// A class for configuring NLog through an XML configuration file 


### PR DESCRIPTION
Fixed reference, was broken due to #754

Note: Was not broken in 4.0 (but trunk for 4.0.1)