### PR TITLE
FIxed ArchiveOldFileOnStartup with DateAndSequential archive numbering mode

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -985,7 +985,7 @@ namespace NLog.Targets
 
             DateTime lastWriteTime;
             long fileLength;
-            if (this.GetFileInfo(fileName, out lastWriteTime, out fileLength))
+            if (logEvent != null && this.GetFileInfo(fileName, out lastWriteTime, out fileLength))
             {
                 string formatString = GetDateFormatString(string.Empty);
                 string ts = lastWriteTime.ToString(formatString, CultureInfo.InvariantCulture);


### PR DESCRIPTION
A nullref in the FileTarget.DateAndSequentialArchive method would consistently prevent ArchiveOldFileOnStartup from working when used along with this archive numbering mode.
Thus, the behavior was exactly the same as if ArchiveOldFileOnStartup were disabled.