### PR TITLE
Fixed DateAndSequence archive numbering mode + bugfix no max archives

### DIFF
--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -342,6 +342,7 @@
     <Compile Include="Targets\DatabaseCommandInfo.cs" />
     <Compile Include="Targets\DatabaseParameterInfo.cs" />
     <Compile Include="Targets\DatabaseTarget.cs" />
+    <Compile Include="Targets\DateAndSequenceArchive.cs" />
     <Compile Include="Targets\DebuggerTarget.cs" />
     <Compile Include="Targets\DebugTarget.cs" />
     <Compile Include="Targets\EventLogTarget.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -345,6 +345,7 @@
     <Compile Include="Targets\DatabaseCommandInfo.cs" />
     <Compile Include="Targets\DatabaseParameterInfo.cs" />
     <Compile Include="Targets\DatabaseTarget.cs" />
+    <Compile Include="Targets\DateAndSequenceArchive.cs" />
     <Compile Include="Targets\DebuggerTarget.cs" />
     <Compile Include="Targets\DebugTarget.cs" />
     <Compile Include="Targets\EventLogTarget.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -339,6 +339,7 @@
     <Compile Include="Targets\DatabaseCommandInfo.cs" />
     <Compile Include="Targets\DatabaseParameterInfo.cs" />
     <Compile Include="Targets\DatabaseTarget.cs" />
+    <Compile Include="Targets\DateAndSequenceArchive.cs" />
     <Compile Include="Targets\DebuggerTarget.cs" />
     <Compile Include="Targets\DebugTarget.cs" />
     <Compile Include="Targets\EventLogTarget.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -342,6 +342,7 @@
     <Compile Include="Targets\DatabaseCommandInfo.cs" />
     <Compile Include="Targets\DatabaseParameterInfo.cs" />
     <Compile Include="Targets\DatabaseTarget.cs" />
+    <Compile Include="Targets\DateAndSequenceArchive.cs" />
     <Compile Include="Targets\DebuggerTarget.cs" />
     <Compile Include="Targets\DebugTarget.cs" />
     <Compile Include="Targets\EventLogTarget.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -346,6 +346,7 @@
     <Compile Include="Targets\DatabaseCommandInfo.cs" />
     <Compile Include="Targets\DatabaseParameterInfo.cs" />
     <Compile Include="Targets\DatabaseTarget.cs" />
+    <Compile Include="Targets\DateAndSequenceArchive.cs" />
     <Compile Include="Targets\DebuggerTarget.cs" />
     <Compile Include="Targets\DebugTarget.cs" />
     <Compile Include="Targets\EventLogTarget.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -345,6 +345,7 @@
     <Compile Include="Targets\DatabaseCommandInfo.cs" />
     <Compile Include="Targets\DatabaseParameterInfo.cs" />
     <Compile Include="Targets\DatabaseTarget.cs" />
+    <Compile Include="Targets\DateAndSequenceArchive.cs" />
     <Compile Include="Targets\DebuggerTarget.cs" />
     <Compile Include="Targets\DebugTarget.cs" />
     <Compile Include="Targets\EventLogTarget.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -345,6 +345,7 @@
     <Compile Include="Targets\DatabaseCommandInfo.cs" />
     <Compile Include="Targets\DatabaseParameterInfo.cs" />
     <Compile Include="Targets\DatabaseTarget.cs" />
+    <Compile Include="Targets\DateAndSequenceArchive.cs" />
     <Compile Include="Targets\DebuggerTarget.cs" />
     <Compile Include="Targets\DebugTarget.cs" />
     <Compile Include="Targets\EventLogTarget.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -344,6 +344,7 @@
     <Compile Include="Targets\DatabaseCommandInfo.cs" />
     <Compile Include="Targets\DatabaseParameterInfo.cs" />
     <Compile Include="Targets\DatabaseTarget.cs" />
+    <Compile Include="Targets\DateAndSequenceArchive.cs" />
     <Compile Include="Targets\DebuggerTarget.cs" />
     <Compile Include="Targets\DebugTarget.cs" />
     <Compile Include="Targets\EventLogTarget.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -344,6 +344,7 @@
     <Compile Include="Targets\DatabaseCommandInfo.cs" />
     <Compile Include="Targets\DatabaseParameterInfo.cs" />
     <Compile Include="Targets\DatabaseTarget.cs" />
+    <Compile Include="Targets\DateAndSequenceArchive.cs" />
     <Compile Include="Targets\DebuggerTarget.cs" />
     <Compile Include="Targets\DebugTarget.cs" />
     <Compile Include="Targets\EventLogTarget.cs" />

--- a/src/NLog/Targets/DateAndSequenceArchive.cs
+++ b/src/NLog/Targets/DateAndSequenceArchive.cs
@@ -35,6 +35,9 @@ namespace NLog.Targets
 {
     using System;
 
+    /// <summary>
+    /// A descriptor for an archive created with the DateAndSequence numbering mode.
+    /// </summary>
     internal class DateAndSequenceArchive
     {
         private readonly string _fileName;
@@ -43,26 +46,43 @@ namespace NLog.Targets
         private readonly int _sequence;
         private readonly string _formattedDate;
 
+        /// <summary>
+        /// The full name of the archive file.
+        /// </summary>
         public string FileName
         {
             get { return _fileName; }
         }
 
+        /// <summary>
+        /// The parsed date contained in the file name.
+        /// </summary>
         public DateTime Date
         {
             get { return _date; }
         }
 
+        /// <summary>
+        /// The parsed sequence number contained in the file name.
+        /// </summary>
         public int Sequence
         {
             get { return _sequence; }
         }
 
-        public bool HasSameArchiveDate(DateTime date)
+        /// <summary>
+        /// Determines whether <paramref name="date"/> produces the same string as the current instance's date once formatted with the current instance's date format.
+        /// </summary>
+        /// <param name="date">The date to compare the current object's date to.</param>
+        /// <returns><c>True</c> if the formatted dates are equal, otherwise <c>False</c>.</returns>
+        public bool HasSameFormattedDate(DateTime date)
         {
             return date.ToString(_dateFormat) == _formattedDate;
         }
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateAndSequenceArchive"/> class.
+        /// </summary>
         public DateAndSequenceArchive(string fileName, DateTime date, string dateFormat, int sequence)
         {
             if (fileName == null) throw new ArgumentNullException("fileName");

--- a/src/NLog/Targets/DateAndSequenceArchive.cs
+++ b/src/NLog/Targets/DateAndSequenceArchive.cs
@@ -40,35 +40,23 @@ namespace NLog.Targets
     /// </summary>
     internal class DateAndSequenceArchive
     {
-        private readonly string _fileName;
-        private readonly DateTime _date;
         private readonly string _dateFormat;
-        private readonly int _sequence;
         private readonly string _formattedDate;
 
         /// <summary>
         /// The full name of the archive file.
         /// </summary>
-        public string FileName
-        {
-            get { return _fileName; }
-        }
+        public string FileName { get; private set; }
 
         /// <summary>
         /// The parsed date contained in the file name.
         /// </summary>
-        public DateTime Date
-        {
-            get { return _date; }
-        }
+        public DateTime Date { get; private set; }
 
         /// <summary>
         /// The parsed sequence number contained in the file name.
         /// </summary>
-        public int Sequence
-        {
-            get { return _sequence; }
-        }
+        public int Sequence { get; private set; }
 
         /// <summary>
         /// Determines whether <paramref name="date"/> produces the same string as the current instance's date once formatted with the current instance's date format.
@@ -88,10 +76,10 @@ namespace NLog.Targets
             if (fileName == null) throw new ArgumentNullException("fileName");
             if (dateFormat == null) throw new ArgumentNullException("dateFormat");
 
-            _date = date;
+            Date = date;
             _dateFormat = dateFormat;
-            _sequence = sequence;
-            _fileName = fileName;
+            Sequence = sequence;
+            FileName = fileName;
             _formattedDate = date.ToString(dateFormat);
         }
     }

--- a/src/NLog/Targets/DateAndSequenceArchive.cs
+++ b/src/NLog/Targets/DateAndSequenceArchive.cs
@@ -1,0 +1,78 @@
+﻿// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Targets
+{
+    using System;
+
+    internal class DateAndSequenceArchive
+    {
+        private readonly string _fileName;
+        private readonly DateTime _date;
+        private readonly string _dateFormat;
+        private readonly int _sequence;
+        private readonly string _formattedDate;
+
+        public string FileName
+        {
+            get { return _fileName; }
+        }
+
+        public DateTime Date
+        {
+            get { return _date; }
+        }
+
+        public int Sequence
+        {
+            get { return _sequence; }
+        }
+
+        public bool HasSameArchiveDate(DateTime date)
+        {
+            return date.ToString(_dateFormat) == _formattedDate;
+        }
+        
+        public DateAndSequenceArchive(string fileName, DateTime date, string dateFormat, int sequence)
+        {
+            if (fileName == null) throw new ArgumentNullException("fileName");
+            if (dateFormat == null) throw new ArgumentNullException("dateFormat");
+
+            _date = date;
+            _dateFormat = dateFormat;
+            _sequence = sequence;
+            _fileName = fileName;
+            _formattedDate = date.ToString(dateFormat);
+        }
+    }
+}

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1020,7 +1020,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// Determines whether a file with a different name from <see cref="fileName"/> is needed to receive <see cref="logEvent"/>.
+        /// Determines whether a file with a different name from <paramref name="fileName"/> is needed to receive <paramref name="logEvent"/>.
         /// </summary>
         private bool IsDaySwitch(string fileName, LogEventInfo logEvent)
         {
@@ -1047,17 +1047,11 @@ namespace NLog.Targets
         /// </remarks>
         private void EnsureArchiveCount(List<string> oldArchiveFileNames)
         {
-            if (this.MaxArchiveFiles == 0) return;
+            if (this.MaxArchiveFiles <= 0) return;
 
             int numberToDelete = oldArchiveFileNames.Count - this.MaxArchiveFiles;
-
-            for (int fileIndex = 0; fileIndex < oldArchiveFileNames.Count; fileIndex++)
+            for (int fileIndex = 0; fileIndex <= numberToDelete; fileIndex++)
             {
-                if (fileIndex > numberToDelete)
-                {
-                    break;
-                }
-
                 File.Delete(oldArchiveFileNames[fileIndex]);
             }
         }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -207,7 +207,7 @@ namespace NLog.Targets
         /// Gets or sets a value specifying the date format to use when archving files.
         /// </summary>
         /// <remarks>
-        /// This option works only when the "ArchiveNumbering" parameter is set to Date.
+        /// This option works only when the "ArchiveNumbering" parameter is set either to Date or DateAndSequence.
         /// </remarks>
         /// <docgen category='Output Options' order='10' />
         [DefaultValue("")]
@@ -1007,11 +1007,8 @@ namespace NLog.Targets
                 return;
             }
 
-            int placeholderFirstPart = baseNamePattern.IndexOf("{#", StringComparison.Ordinal);
-            int placeholderLastPart = baseNamePattern.IndexOf("#}", StringComparison.Ordinal) + 2;
-            int dateTrailerLength = baseNamePattern.Length - placeholderLastPart;
-
-            string fileNameMask = baseNamePattern.Substring(0, placeholderFirstPart) + "*" + baseNamePattern.Substring(placeholderLastPart);
+            FileNameTemplate fileTemplate = new FileNameTemplate(baseNamePattern);
+            string fileNameMask = fileTemplate.ReplacePattern("*");
             string dateFormat = GetDateFormatString(this.ArchiveDateFormat);
 
             string dirName = Path.GetDirectoryName(Path.GetFullPath(pattern));
@@ -1034,82 +1031,25 @@ namespace NLog.Targets
                 isDaySwitch = ts != ts2;
             }
 
-            int nextSequenceNumber = -1;
-
+            int minSequenceLength = fileTemplate.EndAt - fileTemplate.BeginAt - 2;
+            int nextSequenceNumber;
+            DateTime archiveDate = GetArchiveDate(isDaySwitch);
             try
             {
-                var directoryInfo = new DirectoryInfo(dirName);
-#if SILVERLIGHT
-                List<string> files = directoryInfo.EnumerateFiles(fileNameMask).OrderBy(n => n.CreationTime).Select(n => n.FullName).ToList();
-#else
-                List<string> files = directoryInfo.GetFiles(fileNameMask).OrderBy(n => n.CreationTime).Select(n => n.FullName).ToList();
-#endif
+                List<DateAndSequenceArchive> archives = FindDateAndSequenceArchives(dirName, fileName, fileNameMask, minSequenceLength, dateFormat, fileTemplate)
+                    .ToList();
 
-                var filesByDate = new List<ParsedArchiveFileName>();
+                int? lastSequenceNumber = archives
+                    .Where(a => a.HasSameArchiveDate(archiveDate))
+                    .Max(a => (int?) a.Sequence);
+                nextSequenceNumber = (int) (lastSequenceNumber != null ? lastSequenceNumber + 1 : 0);
 
-                //It's possible that the log file itself has a name that will match the archive file mask.
-                var archiveFileCount = files.Count;
-
-                for (int index = 0; index < files.Count; index++)
-                {
-                    //Get the archive file name or empty string if it's null
-                    var unparsedName = files[index];
-                    string archiveFileName = Path.GetFileName(unparsedName) ?? "";
-
-
-                    if (string.IsNullOrEmpty(archiveFileName) ||
-                        archiveFileName.Equals(Path.GetFileName(fileName)))
-                    {
-                        archiveFileCount--;
-                        continue;
-                    }
-
-                    //find date and number part in filename
-                    var indexOfStart = fileNameMask.LastIndexOf('*');
-                    string datePart = archiveFileName.Substring(indexOfStart, dateFormat.Length);
-                    string numberPart = archiveFileName.Substring(indexOfStart + dateFormat.Length + 1,
-                        archiveFileName.Length - dateTrailerLength - (indexOfStart + dateFormat.Length + 1));
-
-                    //parse number part
-                    int num;
-                    try
-                    {
-                        num = Convert.ToInt32(numberPart, CultureInfo.InvariantCulture);
-                    }
-                    catch (FormatException)
-                    {
-                        continue;
-                    }
-
-                    //use for nextSeqNumber if this is the correct day
-                    if (datePart == GetArchiveDate(isDaySwitch).ToString(dateFormat))
-                    {
-                        nextSequenceNumber = Math.Max(nextSequenceNumber, num);
-                    }
-
-                    DateTime fileDate;
-                    //todo what are we checking here?
-                    if (DateTime.TryParseExact(datePart, dateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None,
-                        out fileDate))
-                    {
-                        filesByDate.Add(new ParsedArchiveFileName(unparsedName, fileDate, num));
-                    }
-                }
-
-                //now order the fileNames by date and then number
-
-                filesByDate = filesByDate.OrderBy(f => f.DatePart).ThenBy(f => f.NumberPart).ToList();
-
-                nextSequenceNumber++;
-
-                // Cleanup archive files
-                for (int fileIndex = 0; fileIndex < filesByDate.Count; fileIndex++)
-                {
-                    if (fileIndex > archiveFileCount - this.MaxArchiveFiles)
-                        break;
-
-                    File.Delete(filesByDate[fileIndex].FullName);
-                }
+                var oldArchiveFileNames = archives
+                    .OrderBy(a => a.Date)
+                    .ThenBy(a => a.Sequence)
+                    .Select(a => a.FileName)
+                    .ToList();
+                EnsureArchiveCount(oldArchiveFileNames);
             }
             catch (DirectoryNotFoundException)
             {
@@ -1117,11 +1057,111 @@ namespace NLog.Targets
                 nextSequenceNumber = 0;
             }
 
-            DateTime newFileDate = GetArchiveDate(isDaySwitch);
-            string newFileName = Path.Combine(dirName,
-                fileNameMask.Replace("*", string.Format("{0}.{1}", newFileDate.ToString(dateFormat), nextSequenceNumber)));
+            string paddedSequence = nextSequenceNumber.ToString().PadLeft(minSequenceLength, '0');
+            string newFileNameWithoutPath = fileNameMask.Replace("*",
+                string.Format("{0}.{1}", archiveDate.ToString(dateFormat), paddedSequence));
+            string newFileName = Path.Combine(dirName, newFileNameWithoutPath);
 
             RollArchiveForward(fileName, newFileName, shouldCompress: true);
+        } 
+
+        /// <summary>
+        /// Deletes files among a given list, and stops as soon as the remaining files are fewer than the MaxArchiveFiles setting.
+        /// </summary>
+        /// <remarks>
+        /// Items are deleted in the same order as in <param name="oldArchiveFileNames" />.
+        /// No file is deleted if MaxArchiveFile is equal to zero.
+        /// </remarks>
+        private void EnsureArchiveCount(List<string> oldArchiveFileNames)
+        {
+            if (this.MaxArchiveFiles == 0) return;
+
+            int numberToDelete = oldArchiveFileNames.Count - this.MaxArchiveFiles;
+
+            for (int fileIndex = 0; fileIndex < oldArchiveFileNames.Count; fileIndex++)
+            {
+                if (fileIndex > numberToDelete)
+                {
+                    break;
+                }
+
+                File.Delete(oldArchiveFileNames[fileIndex]);
+            }
+        }
+
+        /// <summary>
+        /// Searches a given directory for archives that comply with the current archive pattern.
+        /// </summary>
+        /// <returns>An enumeration of archive infos, ordered by their file creation date.</returns>
+        private IEnumerable<DateAndSequenceArchive> FindDateAndSequenceArchives(string dirName, string logFileName,
+            string fileNameMask,
+            int minSequenceLength, string dateFormat, FileNameTemplate fileTemplate)
+        {
+            var directoryInfo = new DirectoryInfo(dirName);
+            int archiveFileNameMinLength = fileNameMask.Length + minSequenceLength;
+            var archiveFileNames = GetFiles(directoryInfo, fileNameMask)
+                .Where(n => n.Name.Length >= archiveFileNameMinLength)
+                .OrderBy(n => n.CreationTime)
+                .Select(n => n.FullName);
+
+            foreach (string archiveFileName in archiveFileNames)
+            {
+                //Get the archive file name or empty string if it's null
+                string archiveFileNameWithoutPath = Path.GetFileName(archiveFileName) ?? "";
+
+                DateTime date;
+                int sequence;
+                if (
+                    !TryParseDateAndSequence(archiveFileNameWithoutPath, dateFormat, fileTemplate, out date,
+                        out sequence))
+                {
+                    continue;
+                }
+
+                //It's possible that the log file itself has a name that will match the archive file mask.
+                if (string.IsNullOrEmpty(archiveFileNameWithoutPath) ||
+                    archiveFileNameWithoutPath.Equals(Path.GetFileName(logFileName)))
+                {
+                    continue;
+                }
+
+                yield return new DateAndSequenceArchive(archiveFileName, date, dateFormat, sequence);
+            }
+        }
+
+        private static bool TryParseDateAndSequence(string archiveFileNameWithoutPath, string dateFormat, FileNameTemplate fileTemplate, out DateTime date, out int sequence)
+        {
+            int trailerLength = fileTemplate.Template.Length - fileTemplate.EndAt;
+            int dateAndSequenceIndex = fileTemplate.BeginAt;
+            int dateAndSequenceLength = archiveFileNameWithoutPath.Length - trailerLength - dateAndSequenceIndex;
+            
+            string dateAndSequence = archiveFileNameWithoutPath.Substring(dateAndSequenceIndex, dateAndSequenceLength);
+            int sequenceIndex = dateAndSequence.LastIndexOf('.') + 1;
+
+            string sequencePart = dateAndSequence.Substring(sequenceIndex);
+            if (!Int32.TryParse(sequencePart, NumberStyles.None, CultureInfo.CurrentCulture, out sequence))
+            {
+                date = default(DateTime);
+                return false;
+            }
+
+            string datePart = dateAndSequence.Substring(0, dateAndSequence.Length - sequencePart.Length - 1);
+            if (!DateTime.TryParseExact(datePart, dateFormat, CultureInfo.CurrentCulture, DateTimeStyles.None,
+                out date))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static IEnumerable<FileInfo> GetFiles(DirectoryInfo directoryInfo, string fileNameMask)
+        {
+#if SILVERLIGHT
+            return directoryInfo.EnumerateFiles(fileNameMask);
+#else
+            return directoryInfo.GetFiles(fileNameMask);
+#endif
         }
 
         private static string ReplaceReplaceFileNamePattern(string pattern, string replacementValue)
@@ -1178,10 +1218,11 @@ namespace NLog.Targets
                     }
                 }
 
-                if (this.MaxArchiveFiles != 0)
-                {
-                    for (int fileIndex = 0; fileIndex < filesByDate.Count; fileIndex++)
-                    {
+                /* TODO: The following block could use EnsureArchiveCount, but the behavior is not exactly the same.
+                 * The number of files to delete to "make room" is calculated using 'files.Count' instead of 'filesByDate.Count',
+                 * which I suspect to be a bug, since 'files' can contain filenames that are not actual archives. */
+                if (this.MaxArchiveFiles != 0) {
+                    for (int fileIndex = 0; fileIndex < filesByDate.Count; fileIndex++) {
                         if (fileIndex > files.Count - this.MaxArchiveFiles)
                             break;
 


### PR DESCRIPTION
This PR addresses various issues inherent to the DateAndSequence archive numbering mode :
- The Sequence part wouldn't be padded accordingly ;
- MaxArchiveFiles wouldn't be respected under some circumstances ;
- Using any standard format as ArchiveDateFormat would lead to an ArgumentOutOfRangeException being thrown from a call to String.Substring ;
- Performance improvement by using Int32.TryParse instead of Convert.ToInt32 and exception handling as flow control