### PR TITLE
FIxed ArchiveOldFileOnStartup with layout renderer used in ArchiveFileName

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -674,7 +674,7 @@ namespace NLog.Targets
                 this.DoAutoArchive(fileName, logEvent);
             }
 
-            this.WriteToFile(fileName, bytes, false);
+            this.WriteToFile(fileName, logEvent, bytes, false);
         }
 
         /// <summary>
@@ -779,7 +779,7 @@ namespace NLog.Targets
                         this.DoAutoArchive(currentFileName, firstLogEvent);
                     }
 
-                    this.WriteToFile(currentFileName, ms.ToArray(), false);
+                    this.WriteToFile(currentFileName, firstLogEvent, ms.ToArray(), false);
                 }
             }
             catch (Exception exception)
@@ -1528,7 +1528,7 @@ namespace NLog.Targets
             */
         }
 
-        private void WriteToFile(string fileName, byte[] bytes, bool justData)
+        private void WriteToFile(string fileName, LogEventInfo logEvent, byte[] bytes, bool justData)
         {
             if (this.ReplaceFileContentsOnEachWrite)
             {
@@ -1536,7 +1536,7 @@ namespace NLog.Targets
                 return;
             }
 
-            bool writeHeader = InitializeFile(fileName, justData);
+            bool writeHeader = InitializeFile(fileName, logEvent, justData);
             BaseFileAppender appender = AllocateFileAppender(fileName);
 
             if (writeHeader)
@@ -1552,7 +1552,7 @@ namespace NLog.Targets
             }
         }
 
-        private bool InitializeFile(string fileName, bool justData)
+        private bool InitializeFile(string fileName, LogEventInfo logEvent, bool justData)
         {
             bool writeHeader = false;
 
@@ -1560,7 +1560,7 @@ namespace NLog.Targets
             {
                 if (!this.initializedFiles.ContainsKey(fileName))
                 {
-                    ProcessOnStartup(fileName);
+                    ProcessOnStartup(fileName, logEvent);
 
                     this.initializedFiles[fileName] = DateTime.Now;
                     this.initializedFilesCounter++;
@@ -1586,20 +1586,20 @@ namespace NLog.Targets
             {
                 if (File.Exists(fileName))
                 {
-                    this.WriteToFile(fileName, footerBytes, true);
+                    this.WriteToFile(fileName, null, footerBytes, true);
                 }
             }
 
             this.initializedFiles.Remove(fileName);
         }
 
-        private void ProcessOnStartup(string fileName)
+        private void ProcessOnStartup(string fileName, LogEventInfo logEvent)
         {
             if (this.ArchiveOldFileOnStartup)
             {
                 try
                 {
-                    this.DoAutoArchive(fileName, null);
+                    this.DoAutoArchive(fileName, logEvent);
                 }
                 catch (Exception exception)
                 {


### PR DESCRIPTION
Addresses an issue where ArchiveOldFileOnStartup would constantly fail if part of the archive file name contains a layout renderer (nullref).
This PR obsoletes PR #769