### PR TITLE
All events layout renderer: added `IncludeCallerInformation` option. 

### DIFF
--- a/tests/NLog.UnitTests/Layouts/AllEventPropertiesLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/Layouts/AllEventPropertiesLayoutRendererTests.cs
@@ -111,7 +111,7 @@ namespace NLog.UnitTests.Layouts
 
 
         [Fact]
-        public void AllEventWithFluent()
+        public void AllEventWithFluent_without_callerInformation()
         {
 
             var configuration = CreateConfigurationFromString(@"
@@ -135,7 +135,6 @@ namespace NLog.UnitTests.Layouts
 
             LogManager.Configuration = configuration;
 
-            // Test=InfoWrite, coolness=200%, a=not b, CallerMemberName=AllEventWithFluent, CallerFilePath=x:\GitHub-304\NLog\tests\NLog.UnitTests\Layouts\AllEventPropertiesLayoutRendererTests.cs, CallerLineNumber=144
             var logger = LogManager.GetCurrentClassLogger();
             logger.Debug()
                 .Message("This is a test fluent message '{0}'.", DateTime.Now.Ticks)
@@ -148,6 +147,48 @@ namespace NLog.UnitTests.Layouts
             base.AssertDebugLastMessage("m","Test=InfoWrite, coolness=200%, a=not b");
             
         }
+
+        [Fact]
+        public void AllEventWithFluent_with_callerInformation()
+        {
+
+            var configuration = CreateConfigurationFromString(@"
+                <nlog throwExceptions='true' >
+                    <targets>
+                        <target type='Debug'
+                                name='m'
+                               layout='${all-event-properties:IncludeCallerInformation=true}'
+                               >
+                           
+     
+                        </target>
+                    </targets>
+                    <rules>
+                      <logger name='*' writeTo='m'>
+                       
+                      </logger>
+                    </rules>
+                </nlog>");
+
+
+            LogManager.Configuration = configuration;
+
+      
+            var logger = LogManager.GetCurrentClassLogger();
+            logger.Debug()
+                .Message("This is a test fluent message '{0}'.", DateTime.Now.Ticks)
+                .Property("Test", "InfoWrite")
+                .Property("coolness", "200%")
+                .Property("a", "not b")
+                .Write();
+
+
+            base.AssertDebugLastMessageContains("m", "CallerMemberName=");
+            base.AssertDebugLastMessageContains("m", "CallerFilePath=");
+            base.AssertDebugLastMessageContains("m", "CallerLineNumber=");
+
+        }
+        
         
         private static LogEventInfo BuildLogEventWithProperties()
         {

--- a/tests/NLog.UnitTests/Layouts/AllEventPropertiesLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/Layouts/AllEventPropertiesLayoutRendererTests.cs
@@ -34,6 +34,7 @@
 using System;
 using System.Text;
 using NLog.LayoutRenderers;
+using NLog.Fluent;
 
 namespace NLog.UnitTests.Layouts
 {
@@ -105,6 +106,47 @@ namespace NLog.UnitTests.Layouts
             var renderer = new AllEventPropertiesLayoutRenderer();
             var ex = Assert.Throws<ArgumentException>(() => renderer.Format = "[key] is [vlue]");
             Assert.Equal("Invalid format: [value] placeholder is missing.", ex.Message);
+        }
+
+
+
+        [Fact]
+        public void AllEventWithFluent()
+        {
+
+            var configuration = CreateConfigurationFromString(@"
+                <nlog throwExceptions='true' >
+                    <targets>
+                        <target type='Debug'
+                                name='m'
+                               layout='${all-event-properties}'
+                               >
+                           
+     
+                        </target>
+                    </targets>
+                    <rules>
+                      <logger name='*' writeTo='m'>
+                       
+                      </logger>
+                    </rules>
+                </nlog>");
+
+
+            LogManager.Configuration = configuration;
+
+            // Test=InfoWrite, coolness=200%, a=not b, CallerMemberName=AllEventWithFluent, CallerFilePath=x:\GitHub-304\NLog\tests\NLog.UnitTests\Layouts\AllEventPropertiesLayoutRendererTests.cs, CallerLineNumber=144
+            var logger = LogManager.GetCurrentClassLogger();
+            logger.Debug()
+                .Message("This is a test fluent message '{0}'.", DateTime.Now.Ticks)
+                .Property("Test", "InfoWrite")
+                .Property("coolness", "200%")
+                .Property("a", "not b")
+                .Write();
+
+
+            base.AssertDebugLastMessage("m","Test=InfoWrite, coolness=200%, a=not b");
+            
         }
         
         private static LogEventInfo BuildLogEventWithProperties()

--- a/tests/NLog.UnitTests/Layouts/AllEventPropertiesLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/Layouts/AllEventPropertiesLayoutRendererTests.cs
@@ -148,6 +148,9 @@ namespace NLog.UnitTests.Layouts
             
         }
 
+        
+#if NET4_5
+
         [Fact]
         public void AllEventWithFluent_with_callerInformation()
         {
@@ -189,6 +192,7 @@ namespace NLog.UnitTests.Layouts
 
         }
         
+#endif
         
         private static LogEventInfo BuildLogEventWithProperties()
         {

--- a/tests/NLog.UnitTests/Layouts/AllEventPropertiesTests.cs
+++ b/tests/NLog.UnitTests/Layouts/AllEventPropertiesTests.cs
@@ -40,7 +40,7 @@ namespace NLog.UnitTests.Layouts
 {
     using Xunit;
 
-    public class AllEventPropertiesLayoutRendererTests : NLogTestBase
+    public class AllEventPropertiesTests : NLogTestBase
     {
         [Fact]
         public void AllParametersAreSetToDefault()

--- a/tests/NLog.UnitTests/NLog.UnitTests.monodevelop.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.monodevelop.csproj
@@ -133,7 +133,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenEmptyTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WhenTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
-    <Compile Include="Layouts\AllEventPropertiesLayoutRendererTests.cs" />
+    <Compile Include="Layouts\AllEventPropertiesTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -162,7 +162,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenEmptyTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WhenTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
-    <Compile Include="Layouts\AllEventPropertiesLayoutRendererTests.cs" />
+    <Compile Include="Layouts\AllEventPropertiesTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -142,7 +142,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenEmptyTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WhenTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
-    <Compile Include="Layouts\AllEventPropertiesLayoutRendererTests.cs" />
+    <Compile Include="Layouts\AllEventPropertiesTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,10 +9,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <ApplicationIcon></ApplicationIcon>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -184,7 +182,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenEmptyTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WhenTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
-    <Compile Include="Layouts\AllEventPropertiesLayoutRendererTests.cs" />
+    <Compile Include="Layouts\AllEventPropertiesTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -161,7 +161,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenEmptyTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WhenTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
-    <Compile Include="Layouts\AllEventPropertiesLayoutRendererTests.cs" />
+    <Compile Include="Layouts\AllEventPropertiesTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />


### PR DESCRIPTION
- added IncludeCallerInformation property (default `false` to be consistent with docs and news post)
- fixes #768 

ready for merge
