### PR TITLE
Fix:  exception is not correctly logged when calling without message [WIP]

### DIFF
--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -527,7 +527,15 @@ namespace NLog
 
         internal void WriteToTargets<T>(LogLevel level, IFormatProvider formatProvider, T value)
         {
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, formatProvider, value)), this.Factory);
+            var logEvent = PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, formatProvider, value));
+            var ex = value as Exception;
+            if (ex != null)
+            {
+                //also record exception
+                logEvent.Exception = ex;
+             
+            }
+            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), logEvent, this.Factory);
         }
 
         [Obsolete("Use WriteToTargets(Exception ex, LogLevel level, IFormatProvider formatProvider, string message, object[] args) method instead.")]

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -132,7 +132,7 @@ namespace NLog.UnitTests.LayoutRenderers
             var debug7Target = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName("debug7");
             Assert.False(string.IsNullOrEmpty(debug7Target.LastMessage));
 
-            AssertDebugLastMessage("debug8", "Test exception*" + typeof(InvalidOperationException).Name);
+            AssertDebugLastMessage("debug8", exceptionMessage + "*" + typeof(InvalidOperationException).Name);
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace NLog.UnitTests.LayoutRenderers
             var debug7Target = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName("debug7");
             Assert.False(string.IsNullOrEmpty(debug7Target.LastMessage));
 
-            AssertDebugLastMessage("debug8", "Test exception*" + typeof(InvalidOperationException).Name);
+            AssertDebugLastMessage("debug8", exceptionMessage + "*" + typeof(InvalidOperationException).Name);
         }
 
 
@@ -507,7 +507,7 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             try
             {
-                GenericClass<int, string, bool>.Method1("aaa", true, null, 42, DateTime.Now);
+                GenericClass<int, string, bool>.Method1("aaa", true, null, 42, DateTime.Now, exceptionMessage);
                 return null;
             }
             catch (Exception exception)
@@ -524,7 +524,7 @@ namespace NLog.UnitTests.LayoutRenderers
                 {
                     try
                     {
-                        GenericClass<int, string, bool>.Method1("aaa", true, null, 42, DateTime.Now);
+                        GenericClass<int, string, bool>.Method1("aaa", true, null, 42, DateTime.Now, exceptionMessage);
                     }
                     catch (Exception exception)
                     {
@@ -551,15 +551,15 @@ namespace NLog.UnitTests.LayoutRenderers
 
         private class GenericClass<TA, TB, TC>
         {
-            internal static List<GenericClass<TA, TB, TC>> Method1(string aaa, bool b, object o, int i, DateTime now)
+            internal static List<GenericClass<TA, TB, TC>> Method1(string aaa, bool b, object o, int i, DateTime now, string exceptionMessage)
             {
-                Method2(aaa, b, o, i, now, null, null);
+                Method2(aaa, b, o, i, now, null, null, exceptionMessage);
                 return null;
             }
 
-            internal static int Method2<T1, T2, T3>(T1 aaa, T2 b, T3 o, int i, DateTime now, Nullable<int> gfff, List<int>[] something)
+            internal static int Method2<T1, T2, T3>(T1 aaa, T2 b, T3 o, int i, DateTime now, Nullable<int> gfff, List<int>[] something, string exceptionMessage)
             {
-                throw new InvalidOperationException("Test exception");
+                throw new InvalidOperationException(exceptionMessage);
             }
         }
     }

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -135,6 +135,53 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug8", "Test exception*" + typeof(InvalidOperationException).Name);
         }
 
+        /// <summary>
+        /// Just wrrite exception, no message argument.
+        /// </summary>
+        [Fact]
+        public void ExceptionWithoutMessageParam()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets>
+                    <target name='debug1' type='Debug' layout='${exception}' />
+                    <target name='debug2' type='Debug' layout='${exception:format=stacktrace}' />
+                    <target name='debug3' type='Debug' layout='${exception:format=type}' />
+                    <target name='debug4' type='Debug' layout='${exception:format=shorttype}' />
+                    <target name='debug5' type='Debug' layout='${exception:format=tostring}' />
+                    <target name='debug6' type='Debug' layout='${exception:format=message}' />
+                    <target name='debug7' type='Debug' layout='${exception:format=method}' />
+                    <target name='debug8' type='Debug' layout='${exception:format=message,shorttype:separator=*}' />
+                    <target name='debug9' type='Debug' layout='${exception:format=data}' />
+                </targets>
+                <rules>
+                    <logger minlevel='Info' writeTo='debug1,debug2,debug3,debug4,debug5,debug6,debug7,debug8,debug9' />
+                </rules>
+            </nlog>");
+
+            const string exceptionMessage = "I don't like nullref exception!";
+            const string exceptionDataKey = "testkey";
+            const string exceptionDataValue = "testvalue";
+            Exception ex = GetExceptionWithStackTrace(exceptionMessage);
+            ex.Data.Add(exceptionDataKey, exceptionDataValue);
+            logger.Error(ex);
+            AssertDebugLastMessage("debug1", exceptionMessage);
+            AssertDebugLastMessage("debug2", ex.StackTrace);
+            AssertDebugLastMessage("debug3", typeof(InvalidOperationException).FullName);
+            AssertDebugLastMessage("debug4", typeof(InvalidOperationException).Name);
+            AssertDebugLastMessage("debug5", ex.ToString());
+            AssertDebugLastMessage("debug6", exceptionMessage);
+            AssertDebugLastMessage("debug9", string.Format(ExceptionDataFormat, exceptionDataKey, exceptionDataValue));
+
+            // each version of the framework produces slightly different information for MethodInfo, so we just 
+            // make sure it's not empty
+            var debug7Target = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName("debug7");
+            Assert.False(string.IsNullOrEmpty(debug7Target.LastMessage));
+
+            AssertDebugLastMessage("debug8", "Test exception*" + typeof(InvalidOperationException).Name);
+        }
+
+
         [Fact]
         public void ExceptionWithoutStackTrace_ObsoleteMethodTest()
         {
@@ -451,6 +498,11 @@ namespace NLog.UnitTests.LayoutRenderers
             </nlog>");
         }
 
+        /// <summary>
+        /// Get an excption with stacktrace by genating a exception
+        /// </summary>
+        /// <param name="exceptionMessage"></param>
+        /// <returns></returns>
         private Exception GetExceptionWithStackTrace(string exceptionMessage)
         {
             try


### PR DESCRIPTION
Added unit test for bug report:  #787.



 Without the message argument it's calling the generic version: 

```c#
error(new Exception("test")
```

will call:

```c#
        public void Error<T>(T value)
        {
            if (this.IsErrorEnabled)
            {
                //LogLevel level, IFormatProvider formatProvider, T value
                this.WriteToTargets(LogLevel.Error, null, value);
            }
        }
```

This method is interpreting the argument as `message`. (which is correct). I'm not sure how to fix this neat - the `Exception` is (again) a special case.

This is not a bug since NLog 4, but we said that since NLog 4 the exception parameter is always the first one. 

N.B.: creating a special method for `Exception`, like `Error(Exception ex)` won't solve it, as this works for `Exeption` but not for the sub classes of `Exception` - those will call the generic version. 

Dunno how to solve this neat. Only thing that come to mind: re-introduce the is Exception quirk which just was removed in NLog 4 (another method).

Also  what should be the result of `Error(ex)` when the `${message}` layout renderer is used? 