### PR TITLE
added config option for breaking change (Exceptions logging) in NLog 4.0 [WIP]

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -64,6 +64,10 @@ namespace NLog.Config
             this.LoggingRules = new List<LoggingRule>();
         }
 
+        /// <summary>
+        /// Use the old exception log handling of NLog 3.0? 
+        /// </summary>
+        [Obsolete("This option will be removed in NLog 5")]
         public bool ExceptionLoggingOldStyle { get; set; }
 
         /// <summary>

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -64,6 +64,8 @@ namespace NLog.Config
             this.LoggingRules = new List<LoggingRule>();
         }
 
+        public bool ExceptionLoggingOldStyle { get; set; }
+
         /// <summary>
         /// Gets the variables defined in the configuration.
         /// </summary>

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -372,6 +372,7 @@ namespace NLog.Config
             {
                 this.DefaultCultureInfo = CultureInfo.InvariantCulture;
             }
+            this.ExceptionLoggingOldStyle = nlogElement.GetOptionalBooleanAttribute("exceptionLoggingOldStyle", false);
             this.AutoReload = nlogElement.GetOptionalBooleanAttribute("autoReload", false);
             LogManager.ThrowExceptions = nlogElement.GetOptionalBooleanAttribute("throwExceptions", LogManager.ThrowExceptions);
             InternalLogger.LogToConsole = nlogElement.GetOptionalBooleanAttribute("internalLogToConsole", InternalLogger.LogToConsole);

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -372,7 +372,9 @@ namespace NLog.Config
             {
                 this.DefaultCultureInfo = CultureInfo.InvariantCulture;
             }
+#pragma warning disable 618
             this.ExceptionLoggingOldStyle = nlogElement.GetOptionalBooleanAttribute("exceptionLoggingOldStyle", false);
+#pragma warning restore 618
             this.AutoReload = nlogElement.GetOptionalBooleanAttribute("autoReload", false);
             LogManager.ThrowExceptions = nlogElement.GetOptionalBooleanAttribute("throwExceptions", LogManager.ThrowExceptions);
             InternalLogger.LogToConsole = nlogElement.GetOptionalBooleanAttribute("internalLogToConsole", InternalLogger.LogToConsole);

--- a/src/NLog/Internal/LoggerConfiguration.cs
+++ b/src/NLog/Internal/LoggerConfiguration.cs
@@ -44,10 +44,13 @@ namespace NLog.Internal
         /// Initializes a new instance of the <see cref="LoggerConfiguration" /> class.
         /// </summary>
         /// <param name="targetsByLevel">The targets by level.</param>
-        public LoggerConfiguration(TargetWithFilterChain[] targetsByLevel)
+        public LoggerConfiguration(TargetWithFilterChain[] targetsByLevel, bool exceptionLoggingOldStyle = false)
         {
             this.targetsByLevel = targetsByLevel;
+            ExceptionLoggingOldStyle = exceptionLoggingOldStyle;
         }
+
+        public bool ExceptionLoggingOldStyle { get; private set; }
 
         /// <summary>
         /// Gets targets for the specified level.

--- a/src/NLog/Internal/LoggerConfiguration.cs
+++ b/src/NLog/Internal/LoggerConfiguration.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System;
+
 namespace NLog.Internal
 {
     /// <summary>
@@ -44,12 +46,20 @@ namespace NLog.Internal
         /// Initializes a new instance of the <see cref="LoggerConfiguration" /> class.
         /// </summary>
         /// <param name="targetsByLevel">The targets by level.</param>
+        /// <param name="exceptionLoggingOldStyle">  Use the old exception log handling of NLog 3.0? 
+        /// </param>
         public LoggerConfiguration(TargetWithFilterChain[] targetsByLevel, bool exceptionLoggingOldStyle = false)
         {
             this.targetsByLevel = targetsByLevel;
+#pragma warning disable 618
             ExceptionLoggingOldStyle = exceptionLoggingOldStyle;
+#pragma warning restore 618
         }
 
+        /// <summary>
+        /// Use the old exception log handling of NLog 3.0? 
+        /// </summary>
+        [Obsolete("This option will be removed in NLog 5")]
         public bool ExceptionLoggingOldStyle { get; private set; }
 
         /// <summary>

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -306,7 +306,7 @@ namespace NLog
         {
             TargetWithFilterChain[] targetsByLevel = new TargetWithFilterChain[LogLevel.MaxLevel.Ordinal + 1];
             Logger newLogger = new Logger();
-            newLogger.Initialize(string.Empty, new LoggerConfiguration(targetsByLevel), this);
+            newLogger.Initialize(string.Empty, new LoggerConfiguration(targetsByLevel,false), this);
             return newLogger;
         }
 
@@ -726,7 +726,7 @@ namespace NLog
                 InternalLogger.Debug(sb.ToString());
             }
 
-            return new LoggerConfiguration(targetsByLevel);
+            return new LoggerConfiguration(targetsByLevel, configuration != null && configuration.ExceptionLoggingOldStyle);
         }
 
         /// <summary>

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -726,7 +726,9 @@ namespace NLog
                 InternalLogger.Debug(sb.ToString());
             }
 
+#pragma warning disable 618
             return new LoggerConfiguration(targetsByLevel, configuration != null && configuration.ExceptionLoggingOldStyle);
+#pragma warning restore 618
         }
 
         /// <summary>

--- a/src/NLog/Logger.tt
+++ b/src/NLog/Logger.tt
@@ -247,20 +247,24 @@ namespace NLog
         { 
             if (this.Is<#=level#>Enabled)
             {
-
-			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
-
-	            var exceptionCandidate = argument as Exception;		
-                if (exceptionCandidate != null)		
-                {		
+#pragma warning disable 618
+           
+			//todo log also these calls as warning?
+                if (this.configuration.ExceptionLoggingOldStyle)
+#pragma warning restore 618
+                {   
+					var exceptionCandidate = argument as Exception;		
+					if (exceptionCandidate != null)		
+					{		
 				
-				    // ReSharper disable CSharpWarnings::CS0618
-					#pragma warning disable 618
-                    this.<#=level#>(message, exceptionCandidate);	
-					#pragma warning restore 618
-					// ReSharper restore CSharpWarnings::CS0618	
-                    return;		
-                }
+						// ReSharper disable CSharpWarnings::CS0618
+						#pragma warning disable 618
+						this.<#=level#>(message, exceptionCandidate);	
+						#pragma warning restore 618
+						// ReSharper restore CSharpWarnings::CS0618	
+						return;		
+					}
+				}
 
                 this.WriteToTargets(LogLevel.<#=level#>, message, new object[] { argument });
             }

--- a/src/NLog/Logger.tt
+++ b/src/NLog/Logger.tt
@@ -247,6 +247,21 @@ namespace NLog
         { 
             if (this.Is<#=level#>Enabled)
             {
+
+			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
+
+	            var exceptionCandidate = argument as Exception;		
+                if (exceptionCandidate != null)		
+                {		
+				
+				    // ReSharper disable CSharpWarnings::CS0618
+					#pragma warning disable 618
+                    this.<#=level#>(message, exceptionCandidate);	
+					#pragma warning restore 618
+					// ReSharper restore CSharpWarnings::CS0618	
+                    return;		
+                }
+
                 this.WriteToTargets(LogLevel.<#=level#>, message, new object[] { argument });
             }
         }

--- a/src/NLog/Logger1.cs
+++ b/src/NLog/Logger1.cs
@@ -536,17 +536,19 @@ namespace NLog
             {
 
 			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
+                if (this.configuration.ExceptionLoggingOldStyle)
+                {
+                    var exceptionCandidate = argument as Exception;
+                    if (exceptionCandidate != null)
+                    {
 
-	            var exceptionCandidate = argument as Exception;		
-                if (exceptionCandidate != null)		
-                {		
-				
-				    // ReSharper disable CSharpWarnings::CS0618
-					#pragma warning disable 618
-                    this.Debug(message, exceptionCandidate);	
-					#pragma warning restore 618
-					// ReSharper restore CSharpWarnings::CS0618	
-                    return;		
+                        // ReSharper disable CSharpWarnings::CS0618
+#pragma warning disable 618
+                        this.Debug(message, exceptionCandidate);
+#pragma warning restore 618
+                        // ReSharper restore CSharpWarnings::CS0618	
+                        return;
+                    }
                 }
 
                 this.WriteToTargets(LogLevel.Debug, message, new object[] { argument });

--- a/src/NLog/Logger1.cs
+++ b/src/NLog/Logger1.cs
@@ -268,6 +268,21 @@ namespace NLog
         { 
             if (this.IsTraceEnabled)
             {
+
+			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
+
+	            var exceptionCandidate = argument as Exception;		
+                if (exceptionCandidate != null)		
+                {		
+				
+				    // ReSharper disable CSharpWarnings::CS0618
+					#pragma warning disable 618
+                    this.Trace(message, exceptionCandidate);	
+					#pragma warning restore 618
+					// ReSharper restore CSharpWarnings::CS0618	
+                    return;		
+                }
+
                 this.WriteToTargets(LogLevel.Trace, message, new object[] { argument });
             }
         }
@@ -519,6 +534,21 @@ namespace NLog
         { 
             if (this.IsDebugEnabled)
             {
+
+			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
+
+	            var exceptionCandidate = argument as Exception;		
+                if (exceptionCandidate != null)		
+                {		
+				
+				    // ReSharper disable CSharpWarnings::CS0618
+					#pragma warning disable 618
+                    this.Debug(message, exceptionCandidate);	
+					#pragma warning restore 618
+					// ReSharper restore CSharpWarnings::CS0618	
+                    return;		
+                }
+
                 this.WriteToTargets(LogLevel.Debug, message, new object[] { argument });
             }
         }
@@ -770,6 +800,21 @@ namespace NLog
         { 
             if (this.IsInfoEnabled)
             {
+
+			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
+
+	            var exceptionCandidate = argument as Exception;		
+                if (exceptionCandidate != null)		
+                {		
+				
+				    // ReSharper disable CSharpWarnings::CS0618
+					#pragma warning disable 618
+                    this.Info(message, exceptionCandidate);	
+					#pragma warning restore 618
+					// ReSharper restore CSharpWarnings::CS0618	
+                    return;		
+                }
+
                 this.WriteToTargets(LogLevel.Info, message, new object[] { argument });
             }
         }
@@ -1021,6 +1066,21 @@ namespace NLog
         { 
             if (this.IsWarnEnabled)
             {
+
+			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
+
+	            var exceptionCandidate = argument as Exception;		
+                if (exceptionCandidate != null)		
+                {		
+				
+				    // ReSharper disable CSharpWarnings::CS0618
+					#pragma warning disable 618
+                    this.Warn(message, exceptionCandidate);	
+					#pragma warning restore 618
+					// ReSharper restore CSharpWarnings::CS0618	
+                    return;		
+                }
+
                 this.WriteToTargets(LogLevel.Warn, message, new object[] { argument });
             }
         }
@@ -1207,7 +1267,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-		[Obsolete("Use Error(Exception exception, string message, params object[] args) method instead.")]
+		[Obsolete("Use Error(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
         public void Error([Localizable(false)] string message, Exception exception)
         {
             if (this.IsErrorEnabled)
@@ -1272,6 +1332,21 @@ namespace NLog
         { 
             if (this.IsErrorEnabled)
             {
+
+			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
+
+	            var exceptionCandidate = argument as Exception;		
+                if (exceptionCandidate != null)		
+                {		
+				
+				    // ReSharper disable CSharpWarnings::CS0618
+					#pragma warning disable 618
+                    this.Error(message, exceptionCandidate);	
+					#pragma warning restore 618
+					// ReSharper restore CSharpWarnings::CS0618	
+                    return;		
+                }
+
                 this.WriteToTargets(LogLevel.Error, message, new object[] { argument });
             }
         }
@@ -1523,6 +1598,21 @@ namespace NLog
         { 
             if (this.IsFatalEnabled)
             {
+
+			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
+
+	            var exceptionCandidate = argument as Exception;		
+                if (exceptionCandidate != null)		
+                {		
+				
+				    // ReSharper disable CSharpWarnings::CS0618
+					#pragma warning disable 618
+                    this.Fatal(message, exceptionCandidate);	
+					#pragma warning restore 618
+					// ReSharper restore CSharpWarnings::CS0618	
+                    return;		
+                }
+
                 this.WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
             }
         }

--- a/src/NLog/Logger1.cs
+++ b/src/NLog/Logger1.cs
@@ -268,20 +268,24 @@ namespace NLog
         { 
             if (this.IsTraceEnabled)
             {
-
-			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
-
-	            var exceptionCandidate = argument as Exception;		
-                if (exceptionCandidate != null)		
-                {		
+#pragma warning disable 618
+           
+			//todo log also these calls as warning?
+                if (this.configuration.ExceptionLoggingOldStyle)
+#pragma warning restore 618
+                {   
+					var exceptionCandidate = argument as Exception;		
+					if (exceptionCandidate != null)		
+					{		
 				
-				    // ReSharper disable CSharpWarnings::CS0618
-					#pragma warning disable 618
-                    this.Trace(message, exceptionCandidate);	
-					#pragma warning restore 618
-					// ReSharper restore CSharpWarnings::CS0618	
-                    return;		
-                }
+						// ReSharper disable CSharpWarnings::CS0618
+						#pragma warning disable 618
+						this.Trace(message, exceptionCandidate);	
+						#pragma warning restore 618
+						// ReSharper restore CSharpWarnings::CS0618	
+						return;		
+					}
+				}
 
                 this.WriteToTargets(LogLevel.Trace, message, new object[] { argument });
             }
@@ -534,22 +538,24 @@ namespace NLog
         { 
             if (this.IsDebugEnabled)
             {
-
-			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
-                if (this.configuration.ExceptionLoggingOldStyle)
-                {
-                    var exceptionCandidate = argument as Exception;
-                    if (exceptionCandidate != null)
-                    {
-
-                        // ReSharper disable CSharpWarnings::CS0618
 #pragma warning disable 618
-                        this.Debug(message, exceptionCandidate);
+           
+			//todo log also these calls as warning?
+                if (this.configuration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
-                        // ReSharper restore CSharpWarnings::CS0618	
-                        return;
-                    }
-                }
+                {   
+					var exceptionCandidate = argument as Exception;		
+					if (exceptionCandidate != null)		
+					{		
+				
+						// ReSharper disable CSharpWarnings::CS0618
+						#pragma warning disable 618
+						this.Debug(message, exceptionCandidate);	
+						#pragma warning restore 618
+						// ReSharper restore CSharpWarnings::CS0618	
+						return;		
+					}
+				}
 
                 this.WriteToTargets(LogLevel.Debug, message, new object[] { argument });
             }
@@ -802,20 +808,24 @@ namespace NLog
         { 
             if (this.IsInfoEnabled)
             {
-
-			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
-
-	            var exceptionCandidate = argument as Exception;		
-                if (exceptionCandidate != null)		
-                {		
+#pragma warning disable 618
+           
+			//todo log also these calls as warning?
+                if (this.configuration.ExceptionLoggingOldStyle)
+#pragma warning restore 618
+                {   
+					var exceptionCandidate = argument as Exception;		
+					if (exceptionCandidate != null)		
+					{		
 				
-				    // ReSharper disable CSharpWarnings::CS0618
-					#pragma warning disable 618
-                    this.Info(message, exceptionCandidate);	
-					#pragma warning restore 618
-					// ReSharper restore CSharpWarnings::CS0618	
-                    return;		
-                }
+						// ReSharper disable CSharpWarnings::CS0618
+						#pragma warning disable 618
+						this.Info(message, exceptionCandidate);	
+						#pragma warning restore 618
+						// ReSharper restore CSharpWarnings::CS0618	
+						return;		
+					}
+				}
 
                 this.WriteToTargets(LogLevel.Info, message, new object[] { argument });
             }
@@ -1068,20 +1078,24 @@ namespace NLog
         { 
             if (this.IsWarnEnabled)
             {
-
-			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
-
-	            var exceptionCandidate = argument as Exception;		
-                if (exceptionCandidate != null)		
-                {		
+#pragma warning disable 618
+           
+			//todo log also these calls as warning?
+                if (this.configuration.ExceptionLoggingOldStyle)
+#pragma warning restore 618
+                {   
+					var exceptionCandidate = argument as Exception;		
+					if (exceptionCandidate != null)		
+					{		
 				
-				    // ReSharper disable CSharpWarnings::CS0618
-					#pragma warning disable 618
-                    this.Warn(message, exceptionCandidate);	
-					#pragma warning restore 618
-					// ReSharper restore CSharpWarnings::CS0618	
-                    return;		
-                }
+						// ReSharper disable CSharpWarnings::CS0618
+						#pragma warning disable 618
+						this.Warn(message, exceptionCandidate);	
+						#pragma warning restore 618
+						// ReSharper restore CSharpWarnings::CS0618	
+						return;		
+					}
+				}
 
                 this.WriteToTargets(LogLevel.Warn, message, new object[] { argument });
             }
@@ -1334,20 +1348,24 @@ namespace NLog
         { 
             if (this.IsErrorEnabled)
             {
-
-			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
-
-	            var exceptionCandidate = argument as Exception;		
-                if (exceptionCandidate != null)		
-                {		
+#pragma warning disable 618
+           
+			//todo log also these calls as warning?
+                if (this.configuration.ExceptionLoggingOldStyle)
+#pragma warning restore 618
+                {   
+					var exceptionCandidate = argument as Exception;		
+					if (exceptionCandidate != null)		
+					{		
 				
-				    // ReSharper disable CSharpWarnings::CS0618
-					#pragma warning disable 618
-                    this.Error(message, exceptionCandidate);	
-					#pragma warning restore 618
-					// ReSharper restore CSharpWarnings::CS0618	
-                    return;		
-                }
+						// ReSharper disable CSharpWarnings::CS0618
+						#pragma warning disable 618
+						this.Error(message, exceptionCandidate);	
+						#pragma warning restore 618
+						// ReSharper restore CSharpWarnings::CS0618	
+						return;		
+					}
+				}
 
                 this.WriteToTargets(LogLevel.Error, message, new object[] { argument });
             }
@@ -1600,20 +1618,24 @@ namespace NLog
         { 
             if (this.IsFatalEnabled)
             {
-
-			//todo make configurable: exceptionLoggingOldStyle + logexceptionLoggingOldStyle
-
-	            var exceptionCandidate = argument as Exception;		
-                if (exceptionCandidate != null)		
-                {		
+#pragma warning disable 618
+           
+			//todo log also these calls as warning?
+                if (this.configuration.ExceptionLoggingOldStyle)
+#pragma warning restore 618
+                {   
+					var exceptionCandidate = argument as Exception;		
+					if (exceptionCandidate != null)		
+					{		
 				
-				    // ReSharper disable CSharpWarnings::CS0618
-					#pragma warning disable 618
-                    this.Fatal(message, exceptionCandidate);	
-					#pragma warning restore 618
-					// ReSharper restore CSharpWarnings::CS0618	
-                    return;		
-                }
+						// ReSharper disable CSharpWarnings::CS0618
+						#pragma warning disable 618
+						this.Fatal(message, exceptionCandidate);	
+						#pragma warning restore 618
+						// ReSharper restore CSharpWarnings::CS0618	
+						return;		
+					}
+				}
 
                 this.WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
             }

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -406,6 +406,9 @@
       <LastGenOutput>Logger1.cs</LastGenOutput>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(StyleCopTargetsFile)" Condition="Exists('$(StyleCopTargetsFile)')" />
   <Target Name="BeforeBuild">

--- a/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
@@ -225,6 +225,9 @@ namespace NLog.UnitTests.LayoutRenderers
 
             logger.Debug(ex, "Foo");
             AssertDebugLastMessage("debug", "Foo" + newline + ex.ToString());
+
+            logger.Debug( "Foo", ex);
+            AssertDebugLastMessage("debug", "Foo" + newline + ex.ToString());
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
@@ -198,7 +198,7 @@ namespace NLog.UnitTests.LayoutRenderers
         public void MessageWithExceptionTest()
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
-            <nlog>
+            <nlog exceptionLoggingOldStyle='true'>
                 <targets><target name='debug' type='Debug' layout='${message:withException=true}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />


### PR DESCRIPTION
Created option
 ```xml
 <nlog exceptionLoggingOldStyle='true'>
```
API: `LoggingConfiguration.ExceptionLoggingOldStyle` so that we still can use 

```c#
Error("test", new Exception());
```

The preferred, and NLog 4 way:

```c#
Error( new Exception(), "test");
```

and that the `Exception` gets rendered by `${exception}`.

This for updating (partially) to NLog 4.0.

This is forwardcompatible, as you can use the new exception logger methods with this option on.

flow:

1. enabled this option for old code
1. upgrade to nlog 4 step-by-step
1. when done, disable this option