### PR TITLE
added unit test: Re-evaluate config  - variables uses old values [WIP]

### DIFF
--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -99,8 +99,8 @@ namespace NLog.UnitTests.Config
         {
             var configuration = new LoggingConfiguration();
             LogManager.Configuration = configuration;
-            
-            Assert.Throws<NotSupportedException>(() =>LogManager.Configuration.Variables);
+
+            Assert.Throws<NotSupportedException>(() => LogManager.Configuration.Variables);
         }
 
         [Fact]
@@ -132,13 +132,13 @@ namespace NLog.UnitTests.Config
 <nlog throwExceptions='true'>
   
   <variable name='filename' value='initVal' />
-  <variable name='logDir' value='${basedir}/logs/${processname}'/>
+
   
   <targets>
     <target type='File' name='FileLog'
-            fileName='${logDir}/${filename}.log'
+            fileName='${filename}.log'
             layout='${longdate} [${uppercase:${level}}] ${message}'
-            archiveFileName='${logDir}/archives/${shortdate}.{#}.log'
+            archiveFileName='/archives/${shortdate}.{#}.log'
             archiveEvery='Day'
             archiveNumbering='Rolling'
             maxArchiveFiles='7'
@@ -157,7 +157,7 @@ namespace NLog.UnitTests.Config
             ReconfigExistingLoggers_checkTarget("initVal");
 
             LogManager.Configuration.Variables["filename"] = "newVal";
- 
+
             LogManager.ReconfigExistingLoggers();
 
             ReconfigExistingLoggers_checkTarget("newVal");
@@ -168,7 +168,7 @@ namespace NLog.UnitTests.Config
             var target = LogManager.Configuration.FindTargetByName("FileLog") as FileTarget;
 
             Assert.NotNull(target);
-            Assert.Equal(string.Format("'${{basedir}}/logs/${{processname}}/{0}.log'", fileName), target.FileName.ToString());
+            Assert.Equal(string.Format("'{0}.log'", fileName), target.FileName.ToString());
         }
     }
 }

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -125,7 +125,7 @@ namespace NLog.UnitTests.Config
 
 
 
-        [Fact]
+        [Fact(Skip = "This is a know issue and will be resolved diffently (due to backwardscomp and we don't prefer special cases in code)")]
         public void ReconfigExistingLoggers_should_use_new_values()
         {
             var configuration = CreateConfigurationFromString(@"


### PR DESCRIPTION
WIP.

Unit test added. Fails and confirms bug in #694
.
The problem: 

- When reading config from XML, we do `ExpandVariables()`, which replaces `"${filename}"` with `"initVal"`. It then makes a `SimpleLayout` with "initVal" (and not aware of "${filename}"`)
-  `LogManager.ReconfigExistingLoggers()` won't do `ExpandVariables()` and have also not the old layout renderer (`${filename}`)

How to solve? Possible solutions:

1. Re-read the XML config. (but already not possible with load config from `string`)
1. keep the layout renderer somewhere. 
1. make variables `ISupportsInitialize` ?  Create `SimpleLayout` aware of layout renderer?

note: we lose information. Also, we lose information when we expand an variable. (same problem, Layout not stored) - also the order of the vars (because they can be depenend of each other), is not stored.