### PR TITLE
Support for auto loading UNC paths

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -236,7 +236,7 @@ namespace NLog.Config
             factory.RegisterExtendedItems();
 #if !SILVERLIGHT
 
-            var assemblyLocation = GetNLogAssemblyLocation(nlogAssembly);
+            var assemblyLocation = Path.GetDirectoryName(new Uri(nlogAssembly.CodeBase).LocalPath);
             if (assemblyLocation == null)
             {
                 InternalLogger.Warn("No auto loading because Nlog.dll location is unknown");
@@ -263,19 +263,6 @@ namespace NLog.Config
             return factory;
         }
 
-#if !SILVERLIGHT
-        private static string GetNLogAssemblyLocation(Assembly nlogAssembly)
-        {
-            Uri codeBase = new Uri(nlogAssembly.CodeBase);
-            UriBuilder uri = new UriBuilder(codeBase);
-
-            //UnescapeDataString removes file://
-            string path = Uri.UnescapeDataString(uri.Path);
-            var assemblyLocation = Path.GetDirectoryName(path);
-            return assemblyLocation;
-        }
-
-#endif
         /// <summary>
         /// Registers items in NLog.Extended.dll using late-bound types, so that we don't need a reference to NLog.Extended.dll.
         /// </summary>


### PR DESCRIPTION
Re. #793, the [`GetNLogAssemblyLocation` method](https://github.com/NLog/NLog/blob/master/src/NLog/Config/ConfigurationItemFactory.cs#L267) does not support UNC paths. This can simply be replaced with [`Uri.LocalPath`](https://msdn.microsoft.com/en-us/library/system.uri.localpath(v=vs.110).aspx) which does.