### PR TITLE
Bugfix: <extensions> needs to be the first element in the config

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -211,9 +211,9 @@ namespace NLog.Config
         }
 
         #endregion
-       
+
         #region public methods
-        
+
         /// <summary>
         /// Re-reads the original configuration file and returns the new <see cref="LoggingConfiguration" /> object.
         /// </summary>
@@ -252,6 +252,14 @@ namespace NLog.Config
             return s;
         }
 
+        /// <summary>
+        /// Remove the namespace (before :)
+        /// </summary>
+        /// <example>
+        /// x:a, will be a
+        /// </example>
+        /// <param name="attributeValue"></param>
+        /// <returns></returns>
         private static string StripOptionalNamespacePrefix(string attributeValue)
         {
             if (attributeValue == null)
@@ -361,6 +369,11 @@ namespace NLog.Config
 
         #region parse methods
 
+        /// <summary>
+        /// Parse the root
+        /// </summary>
+        /// <param name="content"></param>
+        /// <param name="baseDirectory">path to directory of config file.</param>
         private void ParseTopLevel(NLogXmlElement content, string baseDirectory)
         {
             content.AssertName("nlog", "configuration");
@@ -377,6 +390,11 @@ namespace NLog.Config
             }
         }
 
+        /// <summary>
+        /// Parse {configuration} xml element.
+        /// </summary>
+        /// <param name="configurationElement"></param>
+        /// <param name="baseDirectory">path to directory of config file.</param>
         private void ParseConfigurationElement(NLogXmlElement configurationElement, string baseDirectory)
         {
             InternalLogger.Trace("ParseConfigurationElement");
@@ -388,6 +406,11 @@ namespace NLog.Config
             }
         }
 
+        /// <summary>
+        /// Parse {NLog} xml element.
+        /// </summary>
+        /// <param name="nlogElement"></param>
+        /// <param name="baseDirectory"></param>
         private void ParseNLogElement(NLogXmlElement nlogElement, string baseDirectory)
         {
             InternalLogger.Trace("ParseNLogElement");

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -61,11 +61,17 @@ namespace NLog.Config
     /// </summary>
     public class XmlLoggingConfiguration : LoggingConfiguration
     {
+        #region private fields
+
         private readonly ConfigurationItemFactory configurationItemFactory = ConfigurationItemFactory.Default;
         private readonly Dictionary<string, bool> visitedFile = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, string> variables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         private string originalFileName;
+
+        #endregion
+
+        #region contructors
 
         /// <summary>
         /// Initializes a new instance of the <see cref="XmlLoggingConfiguration" /> class.
@@ -145,6 +151,9 @@ namespace NLog.Config
             }
         }
 #endif
+        #endregion
+
+        #region public properties
 
 #if !SILVERLIGHT
         /// <summary>
@@ -201,6 +210,10 @@ namespace NLog.Config
             }
         }
 
+        #endregion
+       
+        #region public methods
+        
         /// <summary>
         /// Re-reads the original configuration file and returns the new <see cref="LoggingConfiguration" /> object.
         /// </summary>
@@ -209,6 +222,8 @@ namespace NLog.Config
         {
             return new XmlLoggingConfiguration(this.originalFileName);
         }
+
+        #endregion
 
         private static bool IsTargetElement(string name)
         {
@@ -337,6 +352,8 @@ namespace NLog.Config
 
             this.ParseTopLevel(new NLogXmlElement(fileName), Path.GetDirectoryName(fileName));
         }
+
+        #region parse methods
 
         private void ParseTopLevel(NLogXmlElement content, string baseDirectory)
         {
@@ -872,6 +889,8 @@ namespace NLog.Config
             InternalLogger.Info("Selecting time source {0}", newTimeSource);
             TimeSource.Current = newTimeSource;
         }
+
+        #endregion
 
         private void SetPropertyFromElement(object o, NLogXmlElement element)
         {

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -410,7 +410,7 @@ namespace NLog.Config
         /// Parse {NLog} xml element.
         /// </summary>
         /// <param name="nlogElement"></param>
-        /// <param name="baseDirectory"></param>
+        /// <param name="baseDirectory">path to directory of config file.</param>
         private void ParseNLogElement(NLogXmlElement nlogElement, string baseDirectory)
         {
             InternalLogger.Trace("ParseNLogElement");
@@ -474,6 +474,11 @@ namespace NLog.Config
             }
         }
 
+        /// <summary>
+        /// Parse {Rules} xml element
+        /// </summary>
+        /// <param name="rulesElement"></param>
+        /// <param name="rulesCollection">Rules are added to this parameter.</param>
         private void ParseRulesElement(NLogXmlElement rulesElement, IList<LoggingRule> rulesCollection)
         {
             InternalLogger.Trace("ParseRulesElement");
@@ -485,6 +490,11 @@ namespace NLog.Config
             }
         }
 
+        /// <summary>
+        /// Parse {Logger} xml element
+        /// </summary>
+        /// <param name="loggerElement"></param>
+        /// <param name="rulesCollection">Rules are added to this parameter.</param>
         private void ParseLoggerElement(NLogXmlElement loggerElement, IList<LoggingRule> rulesCollection)
         {
             loggerElement.AssertName("logger");

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -431,7 +431,7 @@ namespace NLog.Config
             var children = nlogElement.Children;
 
             //first load the extensions, as the can be used in other elements (targets etc)
-            var extensionsChilds = children.Where(el => el.LocalName.Equals("EXTENSIONS", StringComparison.InvariantCultureIgnoreCase));
+            var extensionsChilds = children.Where(child => child.LocalName.Equals("EXTENSIONS", StringComparison.InvariantCultureIgnoreCase));
             foreach (var extensionsChild in extensionsChilds)
             {
                 this.ParseExtensionsElement(extensionsChild, baseDirectory);

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -240,7 +240,13 @@ namespace NLog.Config
                    || name.Equals("compound-target-ref", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static string CleanWhitespace(string s)
+        /// <summary>
+        /// Remove all spaces, also in between text. 
+        /// </summary>
+        /// <param name="s">text</param>
+        /// <returns>text without spaces</returns>
+        /// <remarks>Tabs and other whitespace is not removed!</remarks>
+        private static string CleanSpaces(string s)
         {
             s = s.Replace(" ", string.Empty); // get rid of the whitespace
             return s;
@@ -505,7 +511,7 @@ namespace NLog.Config
             }
             else if (loggerElement.AttributeValues.TryGetValue("levels", out levelString))
             {
-                levelString = CleanWhitespace(levelString);
+                levelString = CleanSpaces(levelString);
 
                 string[] tokens = levelString.Split(',');
                 foreach (string s in tokens)

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -391,37 +391,38 @@ namespace NLog.Config
                 this.ParseExtensionsElement(extensionsChild, baseDirectory);
             }
 
-            foreach (var el in children)
+            //parse all other direct elements
+            foreach (var child in children)
             {
-                switch (el.LocalName.ToUpper(CultureInfo.InvariantCulture))
+                switch (child.LocalName.ToUpper(CultureInfo.InvariantCulture))
                 {
                     case "EXTENSIONS":
                         //already parsed
                         break;
 
                     case "INCLUDE":
-                        this.ParseIncludeElement(el, baseDirectory);
+                        this.ParseIncludeElement(child, baseDirectory);
                         break;
 
                     case "APPENDERS":
                     case "TARGETS":
-                        this.ParseTargetsElement(el);
+                        this.ParseTargetsElement(child);
                         break;
 
                     case "VARIABLE":
-                        this.ParseVariableElement(el);
+                        this.ParseVariableElement(child);
                         break;
 
                     case "RULES":
-                        this.ParseRulesElement(el, this.LoggingRules);
+                        this.ParseRulesElement(child, this.LoggingRules);
                         break;
 
                     case "TIME":
-                        this.ParseTimeElement(el);
+                        this.ParseTimeElement(child);
                         break;
 
                     default:
-                        InternalLogger.Warn("Skipping unknown node: {0}", el.LocalName);
+                        InternalLogger.Warn("Skipping unknown node: {0}", child.LocalName);
                         break;
                 }
             }

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -232,6 +232,54 @@ namespace NLog.UnitTests.Config
             Assert.Equal("MyExtensionNamespace.WhenFooFilter", configuration.LoggingRules[0].Filters[0].GetType().FullName);
         }
 
+
+        [Fact]
+        public void ExtensionTest_extensions_not_top_and_used()
+        {
+            Assert.NotNull(typeof(FooLayout));
+
+            var configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+    
+    <targets>
+        <target name='t' type='MyTarget' />
+        <target name='d1' type='Debug' layout='${foo}' />
+        <target name='d2' type='Debug'>
+            <layout type='FooLayout' x='1'>
+            </layout>
+        </target>
+    </targets>
+
+    <rules>
+      <logger name='*' writeTo='t'>
+        <filters>
+           <whenFoo x='44' action='Ignore' />
+        </filters>
+      </logger>
+    </rules>
+
+<extensions>
+        <add assemblyFile='" + this.extensionAssemblyFullPath1 + @"' />
+    </extensions>
+
+</nlog>");
+
+            Target myTarget = configuration.FindTargetByName("t");
+            Assert.Equal("MyExtensionNamespace.MyTarget", myTarget.GetType().FullName);
+
+            var d1Target = (DebugTarget)configuration.FindTargetByName("d1");
+            var layout = d1Target.Layout as SimpleLayout;
+            Assert.NotNull(layout);
+            Assert.Equal(1, layout.Renderers.Count);
+            Assert.Equal("MyExtensionNamespace.FooLayoutRenderer", layout.Renderers[0].GetType().FullName);
+
+            var d2Target = (DebugTarget)configuration.FindTargetByName("d2");
+            Assert.Equal("MyExtensionNamespace.FooLayout", d2Target.Layout.GetType().FullName);
+
+            Assert.Equal(1, configuration.LoggingRules[0].Filters.Count);
+            Assert.Equal("MyExtensionNamespace.WhenFooFilter", configuration.LoggingRules[0].Filters[0].GetType().FullName);
+        }
+
         [Fact]
         public void CustomXmlNamespaceTest()
         {


### PR DESCRIPTION
fixes #302

added some comments and `#regions`. 

The bug was confirmed with an unit test (and fixed).