### PR TITLE
Overhaul variables [wip]

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -33,6 +33,7 @@
 
 using System.Globalization;
 using System.Linq;
+using NLog.Layouts;
 
 namespace NLog.Config
 {
@@ -55,11 +56,11 @@ namespace NLog.Config
             new Dictionary<string, Target>(StringComparer.OrdinalIgnoreCase);
 
         private object[] configItems;
-        
+
         /// <summary>
-        /// Variables defined in xml or in API. name is case case insensitive. Not supporting layouts now.
+        /// Variables defined in xml or in API. name is case case insensitive. 
         /// </summary>
-        private readonly Dictionary<string, string> variables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, SimpleLayout> variables = new Dictionary<string, SimpleLayout>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggingConfiguration" /> class.
@@ -72,7 +73,7 @@ namespace NLog.Config
         /// <summary>
         /// Gets the variables defined in the configuration.
         /// </summary>
-        public Dictionary<string, string> Variables
+        public Dictionary<string, SimpleLayout> Variables
         {
             get
             {

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -60,7 +60,7 @@ namespace NLog.Config
         /// <summary>
         /// Variables defined in xml or in API. name is case case insensitive. 
         /// </summary>
-        private readonly Dictionary<string, SimpleLayout> variables = new Dictionary<string, SimpleLayout>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Layout> variables = new Dictionary<string, Layout>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggingConfiguration" /> class.
@@ -73,7 +73,7 @@ namespace NLog.Config
         /// <summary>
         /// Gets the variables defined in the configuration.
         /// </summary>
-        public Dictionary<string, SimpleLayout> Variables
+        public Dictionary<string, Layout> Variables
         {
             get
             {

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -73,7 +73,7 @@ namespace NLog.Config
         /// <summary>
         /// Gets the variables defined in the configuration.
         /// </summary>
-        public Dictionary<string, Layout> Variables
+        public IDictionary<string, Layout> Variables
         {
             get
             {

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -55,6 +55,11 @@ namespace NLog.Config
             new Dictionary<string, Target>(StringComparer.OrdinalIgnoreCase);
 
         private object[] configItems;
+        
+        /// <summary>
+        /// Variables defined in xml or in API. name is case case insensitive. Not supporting layouts now.
+        /// </summary>
+        private readonly Dictionary<string, string> variables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggingConfiguration" /> class.
@@ -67,14 +72,11 @@ namespace NLog.Config
         /// <summary>
         /// Gets the variables defined in the configuration.
         /// </summary>
-        /// <remarks>
-        /// Returns null if not configured using XML configuration.
-        /// </remarks>
-        public virtual Dictionary<string, string> Variables
+        public Dictionary<string, string> Variables
         {
             get
             {
-                throw new NotSupportedException("Variables is only supported in XmlConfiguration");
+                return variables;
             }
         }
 

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -987,7 +987,11 @@ namespace NLog.Config
             // TODO - make this case-insensitive, will probably require a different approach
             foreach (var kvp in this.Variables)
             {
-                output = output.Replace("${" + kvp.Key + "}", kvp.Value);
+                var layout = kvp.Value;
+                //this value is set from xml and that's a string. Because of that, we can use SimpleLayout here.
+                var simpleLayout = layout as SimpleLayout;
+
+                if (simpleLayout != null) output = output.Replace("${" + kvp.Key + "}", simpleLayout.OriginalText);
             }
 
             return output;

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -1061,9 +1061,8 @@ namespace NLog.Config
             {
                 var layout = kvp.Value;
                 //this value is set from xml and that's a string. Because of that, we can use SimpleLayout here.
-                var simpleLayout = layout as SimpleLayout;
 
-                if (simpleLayout != null) output = output.Replace("${" + kvp.Key + "}", simpleLayout.OriginalText);
+                if (layout != null) output = output.Replace("${" + kvp.Key + "}", layout.ToString());
             }
 
             return output;

--- a/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
@@ -1,0 +1,88 @@
+// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+
+namespace NLog.LayoutRenderers
+{
+    using System.Text;
+    using Layouts;
+    using NLog.Config;
+    using NLog.Internal;
+
+    /// <summary>
+    /// The environment variable.
+    /// </summary>
+    [LayoutRenderer("var")]
+    public class VariableLayoutRenderer : LayoutRenderer
+    {
+        /// <summary>
+        /// Gets or sets the name of the NLog variable.
+        /// </summary>
+        /// <docgen category='Rendering Options' order='10' />
+        [RequiredParameter]
+        [DefaultParameter]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default value to be used when the variable is not set.
+        /// </summary>
+        /// <remarks>Not used if Name is <c>null</c></remarks>
+        /// <docgen category='Rendering Options' order='10' />
+        public string Default { get; set; }
+
+        /// <summary>
+        /// Renders the specified environment variable and appends it to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="logEvent">Logging event.</param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            if (this.Name != null)
+            {
+                string value;
+                if(LogManager.Configuration.Variables != null && LogManager.Configuration.Variables.TryGetValue(Name, out value))
+                {
+                    //todo in later stage also layout as values?
+                    builder.Append(value);
+                }
+                else if (Default != null)
+                {
+                    //fallback
+                    builder.Append(Default);
+                }
+            }
+        }
+    }
+}
+
+

--- a/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
@@ -68,7 +68,7 @@ namespace NLog.LayoutRenderers
         {
             if (this.Name != null)
             {
-                SimpleLayout layout;
+                Layout layout;
                 if(LogManager.Configuration.Variables != null && LogManager.Configuration.Variables.TryGetValue(Name, out layout))
                 {
                     //todo in later stage also layout as values?

--- a/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
@@ -35,12 +35,10 @@
 namespace NLog.LayoutRenderers
 {
     using System.Text;
-    using Layouts;
-    using NLog.Config;
-    using NLog.Internal;
+    using Config;
 
     /// <summary>
-    /// The environment variable.
+    /// Render a NLog variable (xml or config)
     /// </summary>
     [LayoutRenderer("var")]
     public class VariableLayoutRenderer : LayoutRenderer
@@ -61,7 +59,7 @@ namespace NLog.LayoutRenderers
         public string Default { get; set; }
 
         /// <summary>
-        /// Renders the specified environment variable and appends it to the specified <see cref="StringBuilder" />.
+        /// Renders the specified variable and appends it to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="logEvent">Logging event.</param>

--- a/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
@@ -31,6 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using NLog.Layouts;
 
 namespace NLog.LayoutRenderers
 {
@@ -67,11 +68,11 @@ namespace NLog.LayoutRenderers
         {
             if (this.Name != null)
             {
-                string value;
-                if(LogManager.Configuration.Variables != null && LogManager.Configuration.Variables.TryGetValue(Name, out value))
+                SimpleLayout layout;
+                if(LogManager.Configuration.Variables != null && LogManager.Configuration.Variables.TryGetValue(Name, out layout))
                 {
                     //todo in later stage also layout as values?
-                    builder.Append(value);
+                    builder.Append(layout.Render(logEvent));
                 }
                 else if (Default != null)
                 {

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -95,6 +95,11 @@ namespace NLog.Layouts
         }
 
         /// <summary>
+        /// Original text before compile to Layout renderes
+        /// </summary>
+        public string OriginalText { get; private set; }
+
+        /// <summary>
         /// Gets or sets the layout text.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -107,6 +112,8 @@ namespace NLog.Layouts
 
             set
             {
+                OriginalText = value;
+
                 LayoutRenderer[] renderers;
                 string txt;
 

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -207,7 +207,7 @@ namespace NLog.Layouts
         /// </returns>
         public override string ToString()
         {
-            return "'" + this.Text + "'";
+            return OriginalText;
         }
 
         internal void SetRenderers(LayoutRenderer[] renderers, string text)

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -254,6 +254,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.mono2.csproj
+++ b/src/NLog/NLog.mono2.csproj
@@ -256,6 +256,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.monodevelop.csproj
+++ b/src/NLog/NLog.monodevelop.csproj
@@ -262,6 +262,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -254,6 +254,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -254,6 +254,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,8 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <TargetFrameworkProfile></TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -216,7 +215,6 @@
     <Compile Include="LayoutRenderers\CounterLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\DateLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\DocumentUriLayoutRenderer.cs" />
-    <Compile Include="LayoutRenderers\VariableLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\EnvironmentLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\EventContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
@@ -260,6 +258,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -216,6 +216,7 @@
     <Compile Include="LayoutRenderers\CounterLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\DateLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\DocumentUriLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\EnvironmentLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\EventContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -260,6 +260,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -257,6 +257,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -256,6 +256,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -256,6 +256,7 @@
     <Compile Include="LayoutRenderers\ThreadNameLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TicksLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\TimeLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\WindowsIdentityLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeLayoutRendererWrapper.cs" />

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -94,14 +94,7 @@ namespace NLog.UnitTests.Config
         }
 #endif
 
-        [Fact]
-        public void None_xml_configuration_throws_not_supported_exception_when_accessing_variables()
-        {
-            var configuration = new LoggingConfiguration();
-            LogManager.Configuration = configuration;
-            
-            Assert.Throws<NotSupportedException>(() =>LogManager.Configuration.Variables);
-        }
+      
 
         [Fact]
         public void Xml_configuration_returns_defined_variables()

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -111,8 +111,8 @@ namespace NLog.UnitTests.Config
 
             LogManager.Configuration = configuration;
 
-            Assert.Equal("[[", LogManager.Configuration.Variables["prefix"].OriginalText);
-            Assert.Equal("]]", LogManager.Configuration.Variables["suffix"].OriginalText);
+            Assert.Equal("[[", LogManager.Configuration.Variables["prefix"].ToString());
+            Assert.Equal("]]", LogManager.Configuration.Variables["suffix"].ToString());
         }
     }
 }

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -111,8 +111,8 @@ namespace NLog.UnitTests.Config
 
             LogManager.Configuration = configuration;
 
-            Assert.Equal("[[", LogManager.Configuration.Variables["prefix"]);
-            Assert.Equal("]]", LogManager.Configuration.Variables["suffix"]);
+            Assert.Equal("[[", LogManager.Configuration.Variables["prefix"].OriginalText);
+            Assert.Equal("]]", LogManager.Configuration.Variables["suffix"].OriginalText);
         }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
@@ -31,12 +31,14 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+#region
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
+
+#endregion
 
 namespace NLog.UnitTests.LayoutRenderers
 {
@@ -52,25 +54,19 @@ namespace NLog.UnitTests.LayoutRenderers
             logger.Debug("msg");
             var lastMessage = GetDebugLastMessage("debug");
             Assert.Equal("msg and admin=realgoodpassword", lastMessage);
-
-
         }
-
-  
 
         [Fact]
         public void Var_from_xml_and_edit()
         {
             CreateConfigFromXml();
-            
+
             LogManager.Configuration.Variables["password"] = "123";
             ILogger logger = LogManager.GetLogger("A");
 
             logger.Debug("msg");
             var lastMessage = GetDebugLastMessage("debug");
             Assert.Equal("msg and admin=123", lastMessage);
-
-
         }
 
         [Fact]
@@ -86,8 +82,6 @@ namespace NLog.UnitTests.LayoutRenderers
                 </rules>
             </nlog>");
 
-
-
             LogManager.Configuration.Variables["user"] = "admin";
             LogManager.Configuration.Variables["password"] = "123";
             ILogger logger = LogManager.GetLogger("A");
@@ -95,11 +89,7 @@ namespace NLog.UnitTests.LayoutRenderers
             logger.Debug("msg");
             var lastMessage = GetDebugLastMessage("debug");
             Assert.Equal("msg and admin=123", lastMessage);
-
-
-
         }
-
 
         [Fact]
         public void Var_default()
@@ -116,16 +106,12 @@ namespace NLog.UnitTests.LayoutRenderers
                 </rules>
             </nlog>");
 
-          
             ILogger logger = LogManager.GetLogger("A");
 
             logger.Debug("msg");
             var lastMessage = GetDebugLastMessage("debug");
             Assert.Equal("msg and admin=unknown", lastMessage);
-
-
         }
-
 
         [Fact]
         public void Var_default_after_clear()
@@ -149,16 +135,12 @@ namespace NLog.UnitTests.LayoutRenderers
             logger.Debug("msg");
             var lastMessage = GetDebugLastMessage("debug");
             Assert.Equal("msg and admin=unknown", lastMessage);
-
-
         }
-
 
         [Fact]
         public void Var_default_after_set_null()
         {
             CreateConfigFromXml();
-
 
             ILogger logger = LogManager.GetLogger("A");
 
@@ -167,16 +149,12 @@ namespace NLog.UnitTests.LayoutRenderers
             logger.Debug("msg");
             var lastMessage = GetDebugLastMessage("debug");
             Assert.Equal("msg and admin=", lastMessage);
-
-
         }
-
 
         [Fact]
         public void Var_default_after_set_emptyString()
         {
             CreateConfigFromXml();
-
 
             ILogger logger = LogManager.GetLogger("A");
 
@@ -185,10 +163,7 @@ namespace NLog.UnitTests.LayoutRenderers
             logger.Debug("msg");
             var lastMessage = GetDebugLastMessage("debug");
             Assert.Equal("msg and admin=", lastMessage);
-
-
         }
-
 
         [Fact]
         public void Var_default_after_xml_emptyString()
@@ -207,13 +182,9 @@ namespace NLog.UnitTests.LayoutRenderers
 
             ILogger logger = LogManager.GetLogger("A");
 
-        
-
             logger.Debug("msg");
             var lastMessage = GetDebugLastMessage("debug");
             Assert.Equal("msg and admin=", lastMessage);
-
-
         }
 
         private void CreateConfigFromXml()
@@ -230,6 +201,5 @@ namespace NLog.UnitTests.LayoutRenderers
                 </rules>
             </nlog>");
         }
-
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
@@ -1,0 +1,235 @@
+﻿// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NLog.UnitTests.LayoutRenderers
+{
+    public class VariableLayoutRendererTests : NLogTestBase
+    {
+        [Fact]
+        public void Var_from_xml()
+        {
+            CreateConfigFromXml();
+
+            ILogger logger = LogManager.GetLogger("A");
+
+            logger.Debug("msg");
+            var lastMessage = GetDebugLastMessage("debug");
+            Assert.Equal("msg and admin=realgoodpassword", lastMessage);
+
+
+        }
+
+  
+
+        [Fact]
+        public void Var_from_xml_and_edit()
+        {
+            CreateConfigFromXml();
+            
+            LogManager.Configuration.Variables["password"] = "123";
+            ILogger logger = LogManager.GetLogger("A");
+
+            logger.Debug("msg");
+            var lastMessage = GetDebugLastMessage("debug");
+            Assert.Equal("msg and admin=123", lastMessage);
+
+
+        }
+
+        [Fact]
+        public void Var_from_api()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+           
+                <targets>
+                    <target name='debug' type='Debug' layout= '${message} and ${var:user}=${var:password}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+
+
+            LogManager.Configuration.Variables["user"] = "admin";
+            LogManager.Configuration.Variables["password"] = "123";
+            ILogger logger = LogManager.GetLogger("A");
+
+            logger.Debug("msg");
+            var lastMessage = GetDebugLastMessage("debug");
+            Assert.Equal("msg and admin=123", lastMessage);
+
+
+
+        }
+
+
+        [Fact]
+        public void Var_default()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+    <variable name='user' value='admin' />
+ 
+            
+                <targets>
+                    <target name='debug' type='Debug' layout= '${message} and ${var:user}=${var:password:default=unknown}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+          
+            ILogger logger = LogManager.GetLogger("A");
+
+            logger.Debug("msg");
+            var lastMessage = GetDebugLastMessage("debug");
+            Assert.Equal("msg and admin=unknown", lastMessage);
+
+
+        }
+
+
+        [Fact]
+        public void Var_default_after_clear()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+    <variable name='user' value='admin' />
+    <variable name='password' value='realgoodpassword' />
+            
+                <targets>
+                    <target name='debug' type='Debug' layout= '${message} and ${var:user}=${var:password:default=unknown}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+
+            LogManager.Configuration.Variables.Remove("password");
+
+            logger.Debug("msg");
+            var lastMessage = GetDebugLastMessage("debug");
+            Assert.Equal("msg and admin=unknown", lastMessage);
+
+
+        }
+
+
+        [Fact]
+        public void Var_default_after_set_null()
+        {
+            CreateConfigFromXml();
+
+
+            ILogger logger = LogManager.GetLogger("A");
+
+            LogManager.Configuration.Variables["password"] = null;
+
+            logger.Debug("msg");
+            var lastMessage = GetDebugLastMessage("debug");
+            Assert.Equal("msg and admin=", lastMessage);
+
+
+        }
+
+
+        [Fact]
+        public void Var_default_after_set_emptyString()
+        {
+            CreateConfigFromXml();
+
+
+            ILogger logger = LogManager.GetLogger("A");
+
+            LogManager.Configuration.Variables["password"] = "";
+
+            logger.Debug("msg");
+            var lastMessage = GetDebugLastMessage("debug");
+            Assert.Equal("msg and admin=", lastMessage);
+
+
+        }
+
+
+        [Fact]
+        public void Var_default_after_xml_emptyString()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+    <variable name='user' value='admin' />
+    <variable name='password' value='' />
+            
+                <targets>
+                    <target name='debug' type='Debug' layout= '${message} and ${var:user}=${var:password}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+
+        
+
+            logger.Debug("msg");
+            var lastMessage = GetDebugLastMessage("debug");
+            Assert.Equal("msg and admin=", lastMessage);
+
+
+        }
+
+        private void CreateConfigFromXml()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+    <variable name='user' value='admin' />
+    <variable name='password' value='realgoodpassword' />
+            
+                <targets>
+                    <target name='debug' type='Debug' layout= '${message} and ${var:user}=${var:password}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+        }
+
+    }
+}

--- a/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
@@ -70,6 +70,53 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
+        public void Var_with_layout_renderers()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+    <variable name='user' value='logger=${logger}' />
+    <variable name='password' value='realgoodpassword' />
+            
+                <targets>
+                    <target name='debug' type='Debug' layout= '${message} and ${var:user}=${var:password}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            LogManager.Configuration.Variables["password"] = "123";
+            ILogger logger = LogManager.GetLogger("A");
+
+            logger.Debug("msg");
+            var lastMessage = GetDebugLastMessage("debug");
+            Assert.Equal("msg and logger=A=123", lastMessage);
+        }
+
+
+        [Fact]
+        public void Var_with_other_var()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+    <variable name='user' value='${var:password}=' />
+    <variable name='password' value='realgoodpassword' />
+            
+                <targets>
+                    <target name='debug' type='Debug' layout= '${message} and ${var:user}=${var:password}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            LogManager.Configuration.Variables["password"] = "123";
+            ILogger logger = LogManager.GetLogger("A");
+
+            logger.Debug("msg");
+            var lastMessage = GetDebugLastMessage("debug");
+            Assert.Equal("msg and 123==123", lastMessage);
+        }
+
+        [Fact]
         public void Var_from_api()
         {
             LogManager.Configuration = CreateConfigurationFromString(@"

--- a/tests/NLog.UnitTests/NLog.UnitTests.monodevelop.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.monodevelop.csproj
@@ -9,8 +9,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -132,6 +131,7 @@
     <Compile Include="LayoutRenderers\SpecialFolderTests.cs" />
     <Compile Include="LayoutRenderers\ThreadNameTests.cs" />
     <Compile Include="LayoutRenderers\TimeTests.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -9,10 +9,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)'==''">v4.0</TargetFrameworkVersion>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <ApplicationIcon></ApplicationIcon>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -21,10 +19,8 @@
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <SignAssembly>true</SignAssembly>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
+    <FileUpgradeFlags></FileUpgradeFlags>
+    <UpgradeBackupLocation></UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -158,6 +154,7 @@
     <Compile Include="LayoutRenderers\SpecialFolderTests.cs" />
     <Compile Include="LayoutRenderers\ThreadNameTests.cs" />
     <Compile Include="LayoutRenderers\TimeTests.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -10,10 +10,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <ApplicationIcon></ApplicationIcon>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -136,6 +134,7 @@
     <Compile Include="LayoutRenderers\SpecialFolderTests.cs" />
     <Compile Include="LayoutRenderers\ThreadNameTests.cs" />
     <Compile Include="LayoutRenderers\TimeTests.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -174,6 +176,7 @@
     <Compile Include="LayoutRenderers\SpecialFolderTests.cs" />
     <Compile Include="LayoutRenderers\ThreadNameTests.cs" />
     <Compile Include="LayoutRenderers\TimeTests.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -152,6 +152,7 @@
     <Compile Include="LayoutRenderers\SpecialFolderTests.cs" />
     <Compile Include="LayoutRenderers\ThreadNameTests.cs" />
     <Compile Include="LayoutRenderers\TimeTests.cs" />
+    <Compile Include="LayoutRenderers\VariableLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\CachedTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\FileSystemNormalizeTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\JsonEncodeTests.cs" />


### PR DESCRIPTION
In the past we could not change the value of a variable, because the variable was rendered while parsing the XML - the old value was lost. (issue #694.). Also, we could not use variables from the API, which was a bit strange.

Both are now fixed, by doing things differently:
- variables can we now  rendered by a layout renderer (`${var:username} `instead of `${username}`)
- the variables can we still set from the XML config, with the same syntax. (e.g.    `<variable name='username' value='admin' />`
- the "old" variables 


Please not:
- The XML is fully backwards-compatible.
- The API isn't, the Variables in config has been changed from `Dictionary<string, string>` to `IDictionary<string, Layout>`. This can not be prevented, without tricks or re-parse every Layout every time.
- This new style won't replace fully the old variables, as I can only be used in Layouts.
- Also the `ToString()` of `Layout`/`SimpleLayout` has been changed. It now returns the original value (before parse). Before it printed the Text in quotes. This was also odd behaviour (because `(Layout) (layout.ToString) == layout`)  (#709)
 

 

- variables are now Layouts
- included new layout rendererer: VariableRenderer
- this will make it easy to change the value of variable on runtime or even remove it
- VariableRenderer has name and default (if not set)

fixed #694.