### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,17 +5,17 @@ test_script:
   - ps: >- 
         .\tests\CreateTestUsers.cmd
 
-        xunit.console.clr4 "build\bin\Debug\.NET Framework 4.0\NLog.UnitTests.dll" /appveyor /noshadow
+        xunit.console.clr4 "build\bin\Debug\.NET Framework 4.0\NLog.UnitTests.dll" /appveyor /noshadow  2> out-null
 
         $success = $?
 
-        xunit.console.clr4 "build\bin\Debug\.NET Framework 4.5\NLog.UnitTests.dll" /appveyor /noshadow
+        xunit.console.clr4 "build\bin\Debug\.NET Framework 4.5\NLog.UnitTests.dll" /appveyor /noshadow 2> out-null
 
         if ( $success ) {
           $success = $?
         }
 
-        xunit.console.clr4 "build\bin\Debug\.NET Framework 3.5\NLog.UnitTests.dll" /appveyor /noshadow
+        xunit.console.clr4 "build\bin\Debug\.NET Framework 3.5\NLog.UnitTests.dll" /appveyor /noshadow 2> out-null
 
         if ( $success ) {
           $success = $?


### PR DESCRIPTION
ignore errors from the console when running xunit. Otherwise we get a "NativeCommandError" and the build stops. (reported broken)

To prevent this:

![image](https://cloud.githubusercontent.com/assets/5808377/9291054/fda1d438-43ab-11e5-9d4c-23c22f3cd1df.png)

See https://ci.appveyor.com/project/Xharze/nlog-134/build/4.0.660

Log
```
xunit.dll:     Version 1.9.1.1600
Test assembly: C:\projects\nlog-134\build\bin\Debug\.NET Framework 3.5\NLog.UnitTests.dll
 
....................................................................................................................................................NLog.UnitTests.Targets.FileTargetTests.ArchiveAboveSizeWithArchiveNumberingModeDa
te_maxfiles_o [SKIP]
   this is not supported, because we cannot create multiple archive files with  ArchiveNumberingMode.Date (for one day)
 
.....................................................................................................................................................................................................................................
.....................................................................................................................................................................................................................................
......................................................NLog.UnitTests.Config.VariableTests.VariablesTest_string_expanding [SKIP]
   It's unclear if this is a bug of a feature. Probably this will a config setting in the feature
 
..............................................................
722 total, 0 failed, 2 skipped, took 51.796 seconds
xunit.console.clr4 : Info Shutting down logging...
At line:8 char:1
+ xunit.console.clr4 "build\bin\Debug\.NET Framework 3.5\NLog.UnitTests.dll" /appv ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (Info Shutting down logging...:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
Info Closing old configuration.
Trace LogFactory.Flush(00:00:15)
Trace Flushing all targets...
Trace ForEachItemInParallel() 0 items
Debug Closing logging configuration...
Trace Closing Debug Target[d1]
Trace Closing '[[${message}]]'
Trace Closing Layout Renderer: ${literal}
Trace Closing Layout Renderer: ${message}
Trace Closing Layout Renderer: ${literal}
Debug Finished closing logging configuration.
Info Logger has been shut down.
 
tests not successfull
```