### PR TITLE
Updated appveyor.yml (unit test CMD)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,13 @@
 version: 4.0.{build}
 build_script:
   - Msbuild.exe src/NLog.proj /verbosity:minimal /t:BuildTests /p:BuildSL5=true /p:BuildSL4=true /p:BuildNetFX35=true /p:BuildNetFX40=true /p:BuildNetFX45=true
+
+before_test:
+  - .\tests\CreateTestUsers.cmd
 test_script:
-  - ps: >- 
-        .\tests\CreateTestUsers.cmd
-
-        xunit.console.clr4 "build\bin\Debug\.NET Framework 4.0\NLog.UnitTests.dll" /appveyor /noshadow  2> out-null
-
-        $success = $?
-
-        xunit.console.clr4 "build\bin\Debug\.NET Framework 4.5\NLog.UnitTests.dll" /appveyor /noshadow 2> out-null
-
-        if ( $success ) {
-          $success = $?
-        }
-
-        xunit.console.clr4 "build\bin\Debug\.NET Framework 3.5\NLog.UnitTests.dll" /appveyor /noshadow 2> out-null
-
-        if ( $success ) {
-          $success = $?
-        }
-
-        if ( -not $success) {
-           throw "tests not successfull"
-        }
-
-        .\tests\DeleteTestUsers.cmd
+  - xunit.console.clr4 "build\bin\Debug\.NET Framework 4.0\NLog.UnitTests.dll" /appveyor /noshadow
+  - xunit.console.clr4 "build\bin\Debug\.NET Framework 4.5\NLog.UnitTests.dll" /appveyor /noshadow
+  - xunit.console.clr4 "build\bin\Debug\.NET Framework 3.5\NLog.UnitTests.dll" /appveyor /noshadow
+after_test:
+  - .\tests\DeleteTestUsers.cmd
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ build_script:
 before_test:
   - .\tests\CreateTestUsers.cmd
 test_script:
+  - xunit.console.clr4 "build\bin\Debug\.NET Framework 3.5\NLog.UnitTests.dll" /appveyor /noshadow
   - xunit.console.clr4 "build\bin\Debug\.NET Framework 4.0\NLog.UnitTests.dll" /appveyor /noshadow
   - xunit.console.clr4 "build\bin\Debug\.NET Framework 4.5\NLog.UnitTests.dll" /appveyor /noshadow
-  - xunit.console.clr4 "build\bin\Debug\.NET Framework 3.5\NLog.UnitTests.dll" /appveyor /noshadow
 after_test:
   - .\tests\DeleteTestUsers.cmd
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ build_script:
 before_test:
   - .\tests\CreateTestUsers.cmd
 test_script:
-  - xunit.console.clr4 "build\bin\Debug\.NET Framework 3.5\NLog.UnitTests.dll" /appveyor /noshadow
   - xunit.console.clr4 "build\bin\Debug\.NET Framework 4.0\NLog.UnitTests.dll" /appveyor /noshadow
   - xunit.console.clr4 "build\bin\Debug\.NET Framework 4.5\NLog.UnitTests.dll" /appveyor /noshadow
+  - xunit.console.clr4 "build\bin\Debug\.NET Framework 3.5\NLog.UnitTests.dll" /appveyor /noshadow
 after_test:
   - .\tests\DeleteTestUsers.cmd
 deploy: off


### PR DESCRIPTION
unit test without powershell, because we have some issues for weeks with crashing unit tests (but none of the tests failed...)

The unstable powershell unit test seems to be trigger by:

1. Enabling Silverlight builds
1. AppDomain.Shutdown / unload events
1. bad luck....