### PR TITLE
Obsolete attribute doesn't specify the correct replacement

### DIFF
--- a/src/NLog/Logger.tt
+++ b/src/NLog/Logger.tt
@@ -182,7 +182,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-		[Obsolete("Use <#=level#>(LogLevel level, Exception exception, string message, params object[] args) method instead.")]
+		[Obsolete("Use <#=level#>(Exception exception, string message, params object[] args) method instead.")]
         public void <#=level#>([Localizable(false)] string message, Exception exception)
         {
             if (this.Is<#=level#>Enabled)


### PR DESCRIPTION
Calls to `Logger.Error(string, Exception)` were displaying a warning of :

    Use Error(LogLevel level, Exception exception, string message, params object[] args) method instead.

But the correct version to call doesn't contains the LogLevel