### PR TITLE
Resolves Internal Logging With Just Filename

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -452,7 +452,7 @@ namespace NLog.Common
             try
             {
                 string parentDirectory = Path.GetDirectoryName(filename);
-                if (!string.IsNullOrWhiteSpace(parentDirectory))
+                if (!string.IsNullOrEmpty(parentDirectory))
                 {
                     Directory.CreateDirectory(parentDirectory);
                 }

--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -451,7 +451,11 @@ namespace NLog.Common
         {
             try
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(filename));
+                string parentDirectory = Path.GetDirectoryName(filename);
+                if (!string.IsNullOrWhiteSpace(parentDirectory))
+                {
+                    Directory.CreateDirectory(parentDirectory);
+                }
             }
             catch (Exception exception)
             {

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -397,6 +397,57 @@ namespace NLog.UnitTests.Common
                 }
             }
         }
+
+        [Fact]
+        public void CreateFileInCurrentDirectoryTests()
+        {
+            string expected =
+                    "Warn WWW" + Environment.NewLine +
+                    "Error EEE" + Environment.NewLine +
+                    "Fatal FFF" + Environment.NewLine +
+                    "Trace TTT" + Environment.NewLine +
+                    "Debug DDD" + Environment.NewLine +
+                    "Info III" + Environment.NewLine;
+
+            // Store off the previous log file
+            string previousLogFile = InternalLogger.LogFile;
+
+            var tempFileName = Path.GetRandomFileName();
+
+            InternalLogger.LogLevel = LogLevel.Trace;
+            InternalLogger.IncludeTimestamp = false;
+
+            Assert.False(File.Exists(tempFileName));
+
+            // Set the log file, which only has a filename
+            InternalLogger.LogFile = tempFileName;
+
+            try
+            {
+                Assert.False(File.Exists(tempFileName));
+
+                // Invoke Log(LogLevel, string) for every log level.
+                InternalLogger.Log(LogLevel.Warn, "WWW");
+                InternalLogger.Log(LogLevel.Error, "EEE");
+                InternalLogger.Log(LogLevel.Fatal, "FFF");
+                InternalLogger.Log(LogLevel.Trace, "TTT");
+                InternalLogger.Log(LogLevel.Debug, "DDD");
+                InternalLogger.Log(LogLevel.Info, "III");
+
+                AssertFileContents(tempFileName, expected, Encoding.UTF8);
+                Assert.True(File.Exists(tempFileName));
+            }
+            finally
+            {
+                // Reset LogFile to the previous value
+                InternalLogger.LogFile = previousLogFile;
+
+                if (File.Exists(tempFileName))
+                {
+                    File.Delete(tempFileName);
+                }
+            }
+        }
 #endif
     }
 }


### PR DESCRIPTION
When setting the internal logging to just a filename, the create directories method would throw an exception because there was not a parent directory.

To resolve, we needed to check if there was any parent directories to create.  If yes, then create, otherwise, continue on.