### PR TITLE
Assure automatic re-configuration after configuration change

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -129,7 +129,9 @@ namespace NLog
         public bool ThrowExceptions { get; set; }
 
         /// <summary>
-        /// Gets or sets the current logging configuration.
+        /// Gets or sets the current logging configuration. After setting this property all
+        /// existing loggers will be re-configured, so that there is no need to call <see cref="ReconfigExistingLoggers" />
+        /// manually.
         /// </summary>
         public LoggingConfiguration Configuration
         {


### PR DESCRIPTION
Currently it is just an implementation detail, but if you add this note to the specification, there is no need to call unnecessarily ReconfigExistingLoggers() after updating the configuration.