### PR TITLE
Bugfix: useSystemNetMailSettings=false still uses .config settings + feature: PickupDirectoryLocation from nlog.config

### DIFF
--- a/src/NLog/Internal/ISmtpClient.cs
+++ b/src/NLog/Internal/ISmtpClient.cs
@@ -55,6 +55,8 @@ namespace NLog.Internal
         bool EnableSsl { get; set; }
 
         void Send(MailMessage msg);
+
+        string PickupDirectoryLocation { get; set; }
     }
 }
 

--- a/src/NLog/Internal/ISmtpClient.cs
+++ b/src/NLog/Internal/ISmtpClient.cs
@@ -44,18 +44,45 @@ namespace NLog.Internal
     /// </summary>
     internal interface ISmtpClient : IDisposable
     {
+        /// <summary>
+        /// Specifies how outgoing email messages will be handled.
+        /// </summary>
+        SmtpDeliveryMethod DeliveryMethod { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name or IP address of the host used for SMTP transactions.
+        /// </summary>
         string Host { get; set; }
 
+        /// <summary>
+        /// Gets or sets the port used for SMTP transactions.
+        /// </summary>
         int Port { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value that specifies the amount of time after which a synchronous <see cref="Send">Send</see> call times out.
+        /// </summary>
         int Timeout { get; set; }
 
+        /// <summary>
+        /// Gets or sets the credentials used to authenticate the sender.
+        /// </summary>
         ICredentialsByHost Credentials { get; set; }
 
         bool EnableSsl { get; set; }
 
+        /// <summary>
+        /// Sends an e-mail message to an SMTP server for delivery. These methods block while the message is being transmitted.
+        /// </summary>
+        /// <param name="msg">
+        ///   <typeparam>System.Net.Mail.MailMessage
+        ///     <name>MailMessage</name>
+        /// </typeparam> A <see cref="MailMessage">MailMessage</see> that contains the message to send.</param>
         void Send(MailMessage msg);
 
+        /// <summary>
+        /// Gets or sets the folder where applications save mail messages to be processed by the local SMTP server.
+        /// </summary>
         string PickupDirectoryLocation { get; set; }
     }
 }

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -383,7 +383,7 @@ namespace NLog.Targets
         /// </summary>
         /// <param name="lastEvent">last event for username/password</param>
         /// <param name="client">client to set properties on</param>
-        private void ConfigureMailClient(LogEventInfo lastEvent, ISmtpClient client)
+        internal void ConfigureMailClient(LogEventInfo lastEvent, ISmtpClient client)
         {
 
             CheckRequiredParameters();

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -378,7 +378,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// Set propertes of <paramref name="client"/>
+        /// Set properties of <paramref name="client"/>
         /// </summary>
         /// <param name="lastEvent">last event for username/password</param>
         /// <param name="client">client to set properties on</param>
@@ -414,7 +414,7 @@ namespace NLog.Targets
 
         private void CheckRequiredParameters()
         {
-            if (!this.UseSystemNetMailSettings && (this.SmtpServer == null || string.IsNullOrEmpty(this.PickupDirectoryLocation)))
+            if (!this.UseSystemNetMailSettings && this.SmtpServer == null && string.IsNullOrEmpty(this.PickupDirectoryLocation))
             {
                 throw new NLogConfigurationException(
                     string.Format("The MailTarget's '{0}' and '{1}' properties are not set - but needed because useSystemNetMailSettings=false. The email message will not be sent.", "SmtpServer", "PickupDirectoryLocation"));

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -197,7 +197,7 @@ namespace NLog.Targets
         /// <summary>
         /// Gets or sets a value indicating whether SSL (secure sockets layer) should be used when communicating with SMTP server.
         /// </summary>
-        /// <docgen category='SMTP Options' order='14' />
+        /// <docgen category='SMTP Options' order='14' />.
         [DefaultValue(false)]
         public bool EnableSsl { get; set; }
 
@@ -219,6 +219,7 @@ namespace NLog.Targets
         /// Gets or sets the folder where applications save mail messages to be processed by the local SMTP server.
         /// </summary>
         /// <docgen category='SMTP Options' order='17' />
+        [DefaultValue(null)]
         public string PickupDirectoryLocation { get; set; }
 
         /// <summary>
@@ -387,15 +388,23 @@ namespace NLog.Targets
 
             CheckRequiredParameters();
 
+
             var renderedSmtpServer = this.SmtpServer.Render(lastEvent);
-            if (string.IsNullOrEmpty(renderedSmtpServer))
+            if (string.IsNullOrEmpty(renderedSmtpServer) && string.IsNullOrEmpty(this.PickupDirectoryLocation))
             {
-                throw new NLogRuntimeException(string.Format(RequiredPropertyIsEmptyFormat, "SmtpServer"));
+
+                throw new NLogRuntimeException(string.Format(RequiredPropertyIsEmptyFormat,
+                    string.IsNullOrEmpty(renderedSmtpServer) ? "SmtpServer" : "PickupDirectoryLocation"));
             }
+
+
+
+
             client.Host = renderedSmtpServer;
             client.Port = this.SmtpPort;
             client.EnableSsl = this.EnableSsl;
             client.Timeout = this.Timeout;
+            client.PickupDirectoryLocation = this.PickupDirectoryLocation;
 
             if (this.SmtpAuthentication == SmtpAuthenticationMode.Ntlm)
             {

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -216,6 +216,12 @@ namespace NLog.Targets
         public bool UseSystemNetMailSettings { get; set; }
 
         /// <summary>
+        /// Gets or sets the folder where applications save mail messages to be processed by the local SMTP server.
+        /// </summary>
+        /// <docgen category='SMTP Options' order='17' />
+        public string PickupDirectoryLocation { get; set; }
+
+        /// <summary>
         /// Gets or sets the priority used for sending mails.
         /// </summary>
         public Layout Priority { get; set; }
@@ -408,10 +414,10 @@ namespace NLog.Targets
 
         private void CheckRequiredParameters()
         {
-            if (!this.UseSystemNetMailSettings && this.SmtpServer == null)
+            if (!this.UseSystemNetMailSettings && (this.SmtpServer == null || string.IsNullOrEmpty(this.PickupDirectoryLocation)))
             {
                 throw new NLogConfigurationException(
-                    string.Format("The MailTarget's '{0}' property is not set - but needed because useSystemNetMailSettings=false. The email message will not be sent.", "SmtpServer"));
+                    string.Format("The MailTarget's '{0}' and '{1}' properties are not set - but needed because useSystemNetMailSettings=false. The email message will not be sent.", "SmtpServer", "PickupDirectoryLocation"));
             }
         }
 

--- a/tests/NLog.UnitTests/App.config
+++ b/tests/NLog.UnitTests/App.config
@@ -3,4 +3,11 @@
 	<appSettings>
 		<add key="appSettingTestKey" value="appSettingTestValue"/>
 	</appSettings>
+  <system.net>
+    <mailSettings>
+      <smtp deliveryMethod="SpecifiedPickupDirectory">
+        <specifiedPickupDirectory pickupDirectoryLocation="C:\config" />
+      </smtp>
+    </mailSettings>
+  </system.net>
 </configuration>

--- a/tests/NLog.UnitTests/Targets/MailTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MailTargetTests.cs
@@ -765,16 +765,16 @@ namespace NLog.UnitTests.Targets
 
         public class MockMailTarget : MailTarget
         {
-            public MockSmtpClient client;
+            public MockSmtpClient Client;
 
             public MockMailTarget()
             {
-                client = new MockSmtpClient();
+                Client = new MockSmtpClient();
             }
 
             public MockMailTarget(string configPickUpdirectory)
             {
-                client = new MockSmtpClient
+                Client = new MockSmtpClient
                 {
                     PickupDirectoryLocation = configPickUpdirectory
                 };
@@ -786,6 +786,8 @@ namespace NLog.UnitTests.Targets
 
             internal override ISmtpClient CreateSmtpClient()
             {
+                var client = new MockSmtpClient();
+
                 CreatedMocks.Add(client);
 
                 return client;
@@ -794,10 +796,10 @@ namespace NLog.UnitTests.Targets
             public void ConfigureMailClient()
             {
                 if (UseSystemNetMailSettings) return;
-                client.PickupDirectoryLocation = this.PickupDirectoryLocation;
+                Client.PickupDirectoryLocation = this.PickupDirectoryLocation;
             }
 
-            public string SmtpClientPickUpDirectory { get { return client.PickupDirectoryLocation; } }
+            public string SmtpClientPickUpDirectory { get { return Client.PickupDirectoryLocation; } }
         }
 
 

--- a/tests/NLog.UnitTests/Targets/MailTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MailTargetTests.cs
@@ -646,7 +646,7 @@ namespace NLog.UnitTests.Targets
                 Body = "${level} ${logger} ${message}",
                 UseSystemNetMailSettings = true
             };
-           
+
         }
 
         [Fact]
@@ -662,6 +662,45 @@ namespace NLog.UnitTests.Targets
                 UseSystemNetMailSettings = false
             };
             Assert.Throws<NLogConfigurationException>(() => mmt.Initialize(null));
+        }
+
+        /// <summary>
+        /// Test for https://github.com/NLog/NLog/issues/690
+        /// </summary>
+        [Fact]
+        public void MailTarget_UseSystemNetMailSettings_False_Override()
+        {
+            var inConfigVal = @"C:\config";
+            var mmt = new MockMailTarget
+            {
+                From = "foo@bar.com",
+                To = "bar@bar.com",
+                Subject = "Hello from NLog",
+                SmtpPort = 27,
+                Body = "${level} ${logger} ${message}",
+                PickupDirectoryLocation = @"C:\TEMP",
+                UseSystemNetMailSettings = false
+            };
+            mmt.Initialize(null);
+            Assert.NotEqual(mmt.PickupDirectoryLocation, inConfigVal);
+        }
+
+        [Fact]
+        public void MailTarget_UseSystemNetMailSettings_True()
+        {
+            var inConfigVal = @"C:\config";
+            var mmt = new MailTarget
+            {
+                From = "foo@bar.com",
+                To = "bar@bar.com",
+                Subject = "Hello from NLog",
+                Body = "${level} ${logger} ${message}",
+                UseSystemNetMailSettings = true
+            };
+
+            var smtp = new SmtpClient();
+            mmt.Initialize(null);
+            Assert.Equal(mmt.PickupDirectoryLocation, inConfigVal);
         }
 
         [Fact]
@@ -695,15 +734,17 @@ namespace NLog.UnitTests.Targets
                 this.MessagesSent = new List<MailMessage>();
             }
 
-            public string Host { get; set; }
-            public int Port { get; set; }
-            public int Timeout { get; set; }
+            public new string Host { get; set; }
+            public new int Port { get; set; }
+            public new int Timeout { get; set; }
+            public new string PickupDirectoryLocation { get; set; }
 
-            public ICredentialsByHost Credentials { get; set; }
-            public bool EnableSsl { get; set; }
+
+            public new ICredentialsByHost Credentials { get; set; }
+            public new bool EnableSsl { get; set; }
             public List<MailMessage> MessagesSent { get; private set; }
 
-            public void Send(MailMessage msg)
+            public new void Send(MailMessage msg)
             {
                 if (string.IsNullOrEmpty(this.Host))
                 {
@@ -715,10 +756,7 @@ namespace NLog.UnitTests.Targets
                     throw new InvalidOperationException("Some SMTP error.");
                 }
             }
-
-            public string PickupDirectoryLocation { get; set; }
-
-            public void Dispose()
+            public new void Dispose()
             {
             }
         }

--- a/tests/NLog.UnitTests/Targets/MailTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MailTargetTests.cs
@@ -716,6 +716,8 @@ namespace NLog.UnitTests.Targets
                 }
             }
 
+            public string PickupDirectoryLocation { get; set; }
+
             public void Dispose()
             {
             }

--- a/tests/NLog.UnitTests/Targets/MailTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MailTargetTests.cs
@@ -736,6 +736,7 @@ namespace NLog.UnitTests.Targets
                 this.MessagesSent = new List<MailMessage>();
             }
 
+            public SmtpDeliveryMethod DeliveryMethod { get; set; }
             public string Host { get; set; }
             public int Port { get; set; }
             public int Timeout { get; set; }

--- a/tests/NLog.UnitTests/Targets/MailTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MailTargetTests.cs
@@ -666,16 +666,17 @@ namespace NLog.UnitTests.Targets
             Assert.Throws<NLogConfigurationException>(() => mmt.Initialize(null));
         }
 
+
+
         /// <summary>
         /// Test for https://github.com/NLog/NLog/issues/690
         /// </summary>
         [Fact]
-        public void MailTarget_UseSystemNetMailSettings_False_Override()
+        public void MailTarget_UseSystemNetMailSettings_False_Override_ThrowsNLogRuntimeException_if_DeliveryMethodNotSpecified()
         {
             var inConfigVal = @"C:\config";
             var mmt = new MockMailTarget(inConfigVal)
             {
-                SmtpServer = "",
                 From = "foo@bar.com",
                 To = "bar@bar.com",
                 Subject = "Hello from NLog",
@@ -684,8 +685,30 @@ namespace NLog.UnitTests.Targets
                 PickupDirectoryLocation = @"C:\TEMP",
                 UseSystemNetMailSettings = false
             };
+
+            Assert.Throws<NLogRuntimeException>(() => mmt.ConfigureMailClient());
+        }
+
+        /// <summary>
+        /// Test for https://github.com/NLog/NLog/issues/690
+        /// </summary>
+        [Fact]
+        public void MailTarget_UseSystemNetMailSettings_False_Override_DeliveryMethod_SpecifiedDeliveryMethod()
+        {
+            var inConfigVal = @"C:\config";
+            var mmt = new MockMailTarget(inConfigVal)
+            {
+                From = "foo@bar.com",
+                To = "bar@bar.com",
+                Subject = "Hello from NLog",
+                SmtpPort = 27,
+                Body = "${level} ${logger} ${message}",
+                PickupDirectoryLocation = @"C:\TEMP",
+                UseSystemNetMailSettings = false,
+                DeliveryMethod = SmtpDeliveryMethod.SpecifiedPickupDirectory
+            };
             mmt.ConfigureMailClient();
-            Assert.Equal(mmt.PickupDirectoryLocation, mmt.SmtpClientPickUpDirectory);
+            Assert.NotEqual(mmt.PickupDirectoryLocation, inConfigVal);
         }
 
         [Fact]
@@ -766,6 +789,8 @@ namespace NLog.UnitTests.Targets
 
         public class MockMailTarget : MailTarget
         {
+            private const string RequiredPropertyIsEmptyFormat = "After the processing of the MailTarget's '{0}' property it appears to be empty. The email message will not be sent.";
+
             public MockSmtpClient Client;
 
             public MockMailTarget()
@@ -797,7 +822,27 @@ namespace NLog.UnitTests.Targets
             public void ConfigureMailClient()
             {
                 if (UseSystemNetMailSettings) return;
-                Client.PickupDirectoryLocation = this.PickupDirectoryLocation;
+
+                if (this.SmtpServer == null && string.IsNullOrEmpty(this.PickupDirectoryLocation))
+                {
+                    throw new NLogRuntimeException(string.Format(RequiredPropertyIsEmptyFormat, "SmtpServer/PickupDirectoryLocation"));
+                }
+
+                if (this.DeliveryMethod == SmtpDeliveryMethod.Network && this.SmtpServer == null)
+                {
+                    throw new NLogRuntimeException(string.Format(RequiredPropertyIsEmptyFormat, "SmtpServer"));
+                }
+
+                if (this.DeliveryMethod == SmtpDeliveryMethod.SpecifiedPickupDirectory && string.IsNullOrEmpty(this.PickupDirectoryLocation))
+                {
+                    throw new NLogRuntimeException(string.Format(RequiredPropertyIsEmptyFormat, "PickupDirectoryLocation"));
+                }
+
+                if (!string.IsNullOrEmpty(this.PickupDirectoryLocation) && this.DeliveryMethod == SmtpDeliveryMethod.SpecifiedPickupDirectory)
+                {
+                    Client.PickupDirectoryLocation = this.PickupDirectoryLocation;
+                }
+                Client.DeliveryMethod = this.DeliveryMethod;
             }
 
             public string SmtpClientPickUpDirectory { get { return Client.PickupDirectoryLocation; } }


### PR DESCRIPTION
Address [bug/690](https://github.com/NLog/NLog/issues/690), the PickUpDirectory location is exposed in the Mail Target.

However given that the test are using a mock-up for the SMTP class it does not make a lot of sense to create a test for this bug.

@304NotModified the documentation of this property is still pending. I will check the documentation project.