### PR TITLE
Load order precedence fix for config files issue #223

### DIFF
--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -158,7 +158,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
-        public void PrecedenceTest()
+		  public void PrecedenceTest()
         {
             var precedence = new[]
                                  {
@@ -168,17 +168,17 @@ namespace NLog.UnitTests
                                              Contents = appConfigContents,
                                              Output = appConfigOutput
                                          },
+												 new
+                                         {
+                                             File = "ConfigFileLocator.exe.nlog",
+                                             Contents = appNLogContents,
+                                             Output = appNLogOutput
+                                         },
                                      new
                                          {
                                              File = "NLog.config",
                                              Contents = nlogConfigContents,
                                              Output = nlogConfigOutput
-                                         },
-                                     new
-                                         {
-                                             File = "ConfigFileLocator.exe.nlog",
-                                             Contents = appNLogContents,
-                                             Output = appNLogOutput
                                          },
                                      new
                                          {
@@ -199,9 +199,9 @@ namespace NLog.UnitTests
             foreach (var p in precedence)
             {
                 output = RunTest();
-                Assert.Equal(p.Output, output);
+					 Assert.Equal(p.Output, output);
                 File.Delete(Path.Combine(_tempDirectory, p.File));
-            }
+            } 
 
             output = RunTest();
             Assert.Equal(missingConfigOutput, output);


### PR DESCRIPTION
The load order precedence of config files in current version of NLog has
a bug and does not follow the documentation. More specific config files,
e.g. program-name.exe.nlog, should be used before using NLog.config.The
method LogFactory.GetCandidateFileNames has been fixed to return the
files in the correct order. The unit test file ConfigFileLocatorTests.cs
has the test PrecedenceTest which has also been updated to match the
same ordering.

fixes  #223

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/959)
<!-- Reviewable:end -->
