### PR TITLE
Fix: LogFactoryTests remove Windows specific values

### DIFF
--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -229,7 +229,8 @@ namespace NLog.UnitTests
                 new FileInfo(originalFilePath).Delete();
                 new FileInfo(newFilePath).Delete();
 
-                WriteToFile(GetValidXml(), originalFilePath);
+                string targetLogFile = Path.Combine(tempPath, @"log.txt");
+                WriteToFile(GetValidXml(targetLogFile), originalFilePath);
 
                 //event for async testing
                 var counterEvent = new CountdownEvent(1);
@@ -287,7 +288,8 @@ namespace NLog.UnitTests
 
                 var tempPathFile = Path.Combine(tempPath, "main.nlog");
 
-                WriteToFile(GetValidXml(), tempPathFile);
+                string targetLogFile = Path.Combine(tempPath, @"log.txt");
+                WriteToFile(GetValidXml(targetLogFile), tempPathFile);
 
                 //event for async testing
                 var counterEvent = new CountdownEvent(1);
@@ -302,16 +304,17 @@ namespace NLog.UnitTests
                         counterEvent.Signal();
                 };
 
-                Test_if_reload_success(@"c:\temp\log.txt");
+                Test_if_reload_success(targetLogFile);
 
-                WriteToFile(GetValidXml(@"c:\temp\log2.txt"), tempPathFile);
+                string targetLogFile2 = Path.Combine(tempPath, @"log2.txt");
+                WriteToFile(GetValidXml(targetLogFile2), tempPathFile);
 
                 //test after signal
                 counterEvent.Wait(3000);
                 //we need some extra time for completion
                 Thread.Sleep(1000);
 
-                Test_if_reload_success(@"c:\temp\log2.txt");
+                Test_if_reload_success(targetLogFile2);
 
             }
             finally
@@ -331,7 +334,8 @@ namespace NLog.UnitTests
 
                 var tempPathFile = Path.Combine(tempPath, "main.nlog");
 
-                WriteToFile(GetValidXml(), tempPathFile);
+                string targetLogFile = Path.Combine(tempPath, @"log.txt");
+                WriteToFile(GetValidXml(targetLogFile), tempPathFile);
 
                 //event for async testing
                 var counterEvent = new CountdownEvent(1);
@@ -341,7 +345,7 @@ namespace NLog.UnitTests
 
                 LogManager.ConfigurationReloaded += SignalCounterEvent1(counterEvent);
 
-                Test_if_reload_success(@"c:\temp\log.txt");
+                Test_if_reload_success(targetLogFile);
 
 
                 //set invalid, set valid
@@ -363,7 +367,8 @@ namespace NLog.UnitTests
                 var counterEvent2 = new CountdownEvent(1);
                 LogManager.ConfigurationReloaded += (sender, e) => SignalCounterEvent(counterEvent2);
 
-                WriteToFile(GetValidXml(@"c:\temp\log2.txt"), tempPathFile);
+                string targetLogFile2 = Path.Combine(tempPath, @"log2.txt");
+                WriteToFile(GetValidXml(targetLogFile2), tempPathFile);
 
                 counterEvent2.Wait(5000);
                 //we need some extra time for completion
@@ -374,7 +379,7 @@ namespace NLog.UnitTests
                     throw new Exception("failed to reload - 2");
                 }
 
-                Test_if_reload_success(@"c:\temp\log2.txt");
+                Test_if_reload_success(targetLogFile2);
 
             }
             finally
@@ -397,7 +402,7 @@ namespace NLog.UnitTests
             }
         }
 
-        private static string GetValidXml(string fileName = @"c:\temp\log.txt")
+        private static string GetValidXml(string fileName)
         {
             return
                 string.Format(@"<?xml version=""1.0"" encoding=""utf-8"" ?>


### PR DESCRIPTION
Fixed some of the tests in LogFactoryTests class which they were using Windows specific temporary directory location i.e. C:\temp. Now the temp directories are created through managed code.