### PR TITLE
Fix parse of inner layout

### DIFF
--- a/src/NLog/Internal/SimpleStringReader.cs
+++ b/src/NLog/Internal/SimpleStringReader.cs
@@ -50,13 +50,23 @@ namespace NLog.Internal
             this.Position = 0;
         }
 
+        /// <summary>
+        /// Current position in <see cref="Text"/>
+        /// </summary>
         internal int Position { get; set; }
 
+        /// <summary>
+        /// Full text to be parsed
+        /// </summary>
         internal string Text
         {
             get { return this.text; }
         }
 
+        /// <summary>
+        /// Check current char while not changing the position.
+        /// </summary>
+        /// <returns></returns>
         internal int Peek()
         {
             if (this.Position < this.text.Length)
@@ -67,6 +77,10 @@ namespace NLog.Internal
             return -1;
         }
 
+        /// <summary>
+        /// Read the current char and change position
+        /// </summary>
+        /// <returns></returns>
         internal int Read()
         {
             if (this.Position < this.text.Length)
@@ -77,9 +91,15 @@ namespace NLog.Internal
             return -1;
         }
 
-        internal string Substring(int p0, int p1)
+        /// <summary>
+        /// Get the substring of the <see cref="Text"/>
+        /// </summary>
+        /// <param name="startIndex"></param>
+        /// <param name="endIndex"></param>
+        /// <returns></returns>
+        internal string Substring(int startIndex, int endIndex)
         {
-            return this.text.Substring(p0, p1 - p0);
+            return this.text.Substring(startIndex, endIndex - startIndex);
         }
     }
 }

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -61,9 +61,33 @@ namespace NLog.Layouts
 
             while ((ch = sr.Peek()) != -1)
             {
-                if (isNested && (ch == '}' || ch == ':'))
+                if (isNested)
                 {
-                    break;
+                    //escape char? Then allow }, : and \
+                    if (ch == '\\')
+                    {
+                        sr.Read();
+                        var nextChar = sr.Peek();
+
+                        //char that can be escaped.
+                        if (nextChar == '}' || nextChar == ':' || nextChar == '\\')
+                        {
+                            //read next char and append
+                            sr.Read();
+                            literalBuf.Append((char)nextChar);
+                        }
+                        else
+                        {
+                            //dont read next char and just append the slash
+                            literalBuf.Append('\\');
+                        }
+                        continue;
+                    }
+
+                    if (ch == '}' || ch == ':')
+                    {
+                        break;
+                    }
                 }
 
                 sr.Read();

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenTests.cs
@@ -67,7 +67,7 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
             var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
             Assert.Equal("messageYYY", l.Render(le));
         }
-        
+
         [Fact]
         public void ComplexWhenTest2()
         {
@@ -106,13 +106,31 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
             Assert.Equal("Test\\Hello", l.Render(le));
         }
 
-                [Fact]
+        [Fact]
         public void ComplexWhenWithBracketsTest()
         {
             SimpleLayout l = @"${when:when=1 == 1:Inner=Test{Hello\}}";
 
             var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
             Assert.Equal("Test{Hello}", l.Render(le));
+        }
+
+
+        [Fact]
+        public void ComplexWhenWithHashTest()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:inner=Log_{#\}.log}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("Log_{#}.log", l.Render(le));
+        }
+        [Fact]
+        public void ComplexWhenWithHashTest_and_layoutrender()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:inner=${counter}/Log_{#\}.log}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("1/Log_{#}.log", l.Render(le));
         }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenTests.cs
@@ -80,12 +80,39 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
         }
 
         [Fact]
-        public void ComplexWhenWithColonTest()
+        public void ComplexWhenWithColonTest_with_workaround()
         {
             SimpleLayout l = @"${when:when=1 == 1:Inner=Test${literal:text=\:} Hello}";
 
             var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
             Assert.Equal("Test: Hello", l.Render(le));
+        }
+
+        [Fact]
+        public void ComplexWhenWithColonTest()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:Inner=Test\: Hello}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("Test: Hello", l.Render(le));
+        }
+
+        [Fact]
+        public void ComplexWhenWithSlashTest()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:Inner=Test\\Hello}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("Test\\Hello", l.Render(le));
+        }
+
+                [Fact]
+        public void ComplexWhenWithBracketsTest()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:Inner=Test{Hello\}}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("Test{Hello}", l.Render(le));
         }
     }
 }


### PR DESCRIPTION
Parse of inner layout was not always correct working. Escaping of colon and bracket was only with hack (`${literal:text=\:}`) possible. This is now fixed. It does still need an escape with `\`. The work around is also still working.

fixes https://github.com/NLog/NLog/issues/444 and https://github.com/NLog/NLog/issues/914

Working examples:

- `${when:when=1 == 1:Inner=Test\: Hello}`
- `${when:when=1 == 1:Inner=Test\\Hello}`
- `${when:when=1 == 1:Inner=Test{Hello\}}`

We need to escape `:`, `\` and `}` in an inner layout because: 

- `:` because it's a value separator.
- `\` because it's the separator
- `}` because it's the end of the layout

Fixes https://github.com/NLog/NLog/issues/914 confirmed with unit tests ("ComplexWhenWithHashTest" fails with master)