### PR TITLE
More tests inner parse + docs

### DIFF
--- a/src/NLog/Internal/SimpleStringReader.cs
+++ b/src/NLog/Internal/SimpleStringReader.cs
@@ -31,11 +31,16 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+
+
 namespace NLog.Internal
 {
     /// <summary>
     /// Simple character tokenizer.
     /// </summary>
+#if DEBUG
+     [System.Diagnostics.DebuggerDisplay("{CurrentState}")]
+#endif
     internal class SimpleStringReader
     {
         private readonly string text;
@@ -62,6 +67,19 @@ namespace NLog.Internal
         {
             get { return this.text; }
         }
+
+#if DEBUG
+        string CurrentState
+        {
+            get
+            {
+                var current = (char)Peek();
+                var done = Substring(0, Position - 1);
+                var todo = ((Position > text.Length) ? Text.Substring(Position + 1) : "");
+                return string.Format("done: '{0}'.   current: '{1}'.   todo: '{2}'", done, current, todo);
+            }
+        }
+#endif
 
         /// <summary>
         /// Check current char while not changing the position.

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -63,13 +63,13 @@ namespace NLog.Layouts
             {
                 if (isNested)
                 {
-                    //possible escape char \? 
+                    //possible escape char `\` 
                     if (ch == '\\')
                     {
                         sr.Read();
                         var nextChar = sr.Peek();
 
-                        //escape of } en :
+                        //escape chars
                         if (nextChar == '}' || nextChar == ':')
                         {
                             //read next char and append
@@ -86,16 +86,19 @@ namespace NLog.Layouts
 
                     if (ch == '}' || ch == ':')
                     {
-                        //end of innerlayout. } is when double nested inner layout. : when single nested layout
+                        //end of innerlayout. 
+                        // `}` is when double nested inner layout. 
+                        // `:` when single nested layout
                         break;
                     }
                 }
 
                 sr.Read();
 
-                //detect ${
+                //detect `${` (new layout-renderer)
                 if (ch == '$' && sr.Peek() == '{')
                 {
+                    //stach already found layout-renderer.
                     if (literalBuf.Length > 0)
                     {
                         result.Add(new LiteralLayoutRenderer(literalBuf.ToString()));
@@ -477,7 +480,7 @@ namespace NLog.Layouts
 
         private static void MergeLiterals(List<LayoutRenderer> list)
         {
-            for (int i = 0; i + 1 < list.Count;)
+            for (int i = 0; i + 1 < list.Count; )
             {
                 var lr1 = list[i] as LiteralLayoutRenderer;
                 var lr2 = list[i + 1] as LiteralLayoutRenderer;

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -63,13 +63,13 @@ namespace NLog.Layouts
             {
                 if (isNested)
                 {
-                    //escape char? Then allow }, : and \
+                    //possible escape char \? 
                     if (ch == '\\')
                     {
                         sr.Read();
                         var nextChar = sr.Peek();
 
-                        //char that can be escaped.
+                        //escape of } en :
                         if (nextChar == '}' || nextChar == ':')
                         {
                             //read next char and append
@@ -78,7 +78,7 @@ namespace NLog.Layouts
                         }
                         else
                         {
-                            //dont read next char and just append the slash
+                            //dont treat \ as escape char and just read it
                             literalBuf.Append('\\');
                         }
                         continue;
@@ -86,12 +86,14 @@ namespace NLog.Layouts
 
                     if (ch == '}' || ch == ':')
                     {
+                        //end of innerlayout. } is when double nested inner layout. : when single nested layout
                         break;
                     }
                 }
 
                 sr.Read();
 
+                //detect ${
                 if (ch == '$' && sr.Peek() == '{')
                 {
                     if (literalBuf.Length > 0)

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -70,7 +70,7 @@ namespace NLog.Layouts
                         var nextChar = sr.Peek();
 
                         //char that can be escaped.
-                        if (nextChar == '}' || nextChar == ':' || nextChar == '\\')
+                        if (nextChar == '}' || nextChar == ':')
                         {
                             //read next char and append
                             sr.Read();

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenTests.cs
@@ -79,67 +79,6 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
             Assert.Equal("messageYYY", l.Render(le));
         }
 
-        [Fact]
-        public void ComplexWhenWithColonTest_with_workaround()
-        {
-            SimpleLayout l = @"${when:when=1 == 1:Inner=Test${literal:text=\:} Hello}";
-
-            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
-            Assert.Equal("Test: Hello", l.Render(le));
-        }
-
-        [Fact]
-        public void ComplexWhenWithColonTest()
-        {
-            SimpleLayout l = @"${when:when=1 == 1:Inner=Test\: Hello}";
-
-            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
-            Assert.Equal("Test: Hello", l.Render(le));
-        }
-
-        [Fact]
-        public void ComplexWhenWithSlashSingleTest()
-        {
-            SimpleLayout l = @"${when:when=1 == 1:Inner=Test\Hello}";
-
-            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
-            Assert.Equal("Test\\Hello", l.Render(le));
-        }
-
-        [Fact]
-        public void ComplexWhenWithSlashTest()
-        {
-            SimpleLayout l = @"${when:when=1 == 1:Inner=Test\Hello}";
-
-            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
-            Assert.Equal("Test\\Hello", l.Render(le));
-        }
-
-        [Fact]
-        public void ComplexWhenWithBracketsTest()
-        {
-            SimpleLayout l = @"${when:when=1 == 1:Inner=Test{Hello\}}";
-
-            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
-            Assert.Equal("Test{Hello}", l.Render(le));
-        }
-
-
-        [Fact]
-        public void ComplexWhenWithHashTest()
-        {
-            SimpleLayout l = @"${when:when=1 == 1:inner=Log_{#\}.log}";
-
-            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
-            Assert.Equal("Log_{#}.log", l.Render(le));
-        }
-        [Fact]
-        public void ComplexWhenWithHashTest_and_layoutrender()
-        {
-            SimpleLayout l = @"${when:when=1 == 1:inner=${counter}/Log_{#\}.log}";
-
-            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
-            Assert.Equal("1/Log_{#}.log", l.Render(le));
-        }
+       
     }
 }

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -347,5 +347,158 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(@"::", l1.ReplaceWith);
             Assert.Equal(@"(?<!\d[ -]*)(?:(?<digits>\d)[ -]*){8,16}(?=(\d[ -]*){3}(\d)(?![ -]\d))", l1.SearchFor);
         }
+
+
+
+
+        [Fact]
+        public void InnerLayoutWithColonTest_with_workaround()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:Inner=Test${literal:text=\:} Hello}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("Test: Hello", l.Render(le));
+        }
+
+        [Fact]
+        public void InnerLayoutWithColonTest()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:Inner=Test\: Hello}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("Test: Hello", l.Render(le));
+        }
+
+        [Fact]
+        public void InnerLayoutWithSlashSingleTest()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:Inner=Test\Hello}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("Test\\Hello", l.Render(le));
+        }
+
+        [Fact]
+        public void InnerLayoutWithSlashTest()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:Inner=Test\Hello}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("Test\\Hello", l.Render(le));
+        }
+
+        [Fact]
+        public void InnerLayoutWithBracketsTest()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:Inner=Test{Hello\}}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("Test{Hello}", l.Render(le));
+        }
+
+        [Fact]
+        public void InnerLayoutWithBracketsTest2()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:Inner=Test{Hello\\}}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal(@"Test{Hello\}", l.Render(le));
+        }
+
+        [Fact]
+        public void InnerLayoutWithBracketsTest_reverse()
+        {
+            SimpleLayout l = @"${when:Inner=Test{Hello\}:when=1 == 1}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("Test{Hello}", l.Render(le));
+        }
+
+
+
+        [Fact]
+        public void InnerLayoutWithBracketsTest_no_escape()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:Inner=Test{Hello}}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("Test{Hello}", l.Render(le));
+        }
+
+        [Fact]
+        public void InnerLayoutWithHashTest()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:inner=Log_{#\}.log}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("Log_{#}.log", l.Render(le));
+        }
+
+
+
+        [Fact]
+        public void InnerLayoutWithHashTest_need_escape()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:inner=L\}.log}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("L}.log", l.Render(le));
+        }
+
+        [Fact]
+        public void InnerLayoutWithBracketsTest_needEscape()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:inner=\}{.log}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("}{.log", l.Render(le));
+        }
+
+
+        [Fact]
+        public void InnerLayoutWithBracketsTest_needEscape2()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:inner={\}\}{.log}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("{}}{.log", l.Render(le));
+        }
+
+        [Fact]
+        public void InnerLayoutWithBracketsTest_needEscape3()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:inner={\}\}\}.log}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("{}}}.log", l.Render(le));
+        }
+
+        [Fact]
+        public void InnerLayoutWithBracketsTest_needEscape4()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:inner={\}\}\}.log}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("{}}}.log", l.Render(le));
+        }
+
+        [Fact]
+        public void InnerLayoutWithBracketsTest_needEscape5()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:inner=\}{a\}.log}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("}{a}.log", l.Render(le));
+        }
+
+        [Fact]
+        public void InnerLayoutWithHashTest_and_layoutrender()
+        {
+            SimpleLayout l = @"${when:when=1 == 1:inner=${counter}/Log_{#\}.log}";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("1/Log_{#}.log", l.Render(le));
+        }
+
     }
 }


### PR DESCRIPTION
added more unit tests. Moved innerlayout tests from whenTests to simpleLayoutParserTests

Side note:

I tried allowing balanced brackets (e.g. {} doesn't need an escape), but this cannot be done without being fully backwardscompatible