### PR TITLE
Introduce FileAppenderCache class

### DIFF
--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -43,9 +43,23 @@ namespace NLog.Internal.FileAppenders
         private BaseFileAppender[] appenders;
 
         /// <summary>
-        /// Declares initialise a zero size, empty list of appenders.
+        /// Initializes a new "empty" instance of the <see cref="FileAppenderCache"/> class with zero size and empty
+        /// list of appenders.
         /// </summary>
-        public static readonly FileAppenderCache Empty = new FileAppenderCache(0, null, null);
+        public static readonly FileAppenderCache Empty = new FileAppenderCache();
+
+        /// <summary>
+        /// Initializes a new "empty" instance of the <see cref="FileAppenderCache"/> class with zero size and empty
+        /// list of appenders.
+        /// </summary>
+        private FileAppenderCache()
+        {
+            Size = 0;
+            Factory = null;
+            CreateFileParameters = null;
+
+            appenders = new BaseFileAppender[0];
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FileAppenderCache"/> class.
@@ -85,8 +99,11 @@ namespace NLog.Internal.FileAppenders
         /// It allocates the first slot in the list when the file name does not already in the list and clean up any
         /// unused slots.
         /// </summary>
-        /// <param name="fileName">File name associated with a single appender</param>
-        /// <returns>The allocated appender</returns>
+        /// <param name="fileName">File name associated with a single appender.</param>
+        /// <returns>The allocated appender.</returns>
+        /// <exception cref="NullReferenceException">
+        /// Thrown when <see cref="M:AllocateAppender"/> is called on an <c>Empty</c><see cref="FileAppenderCache"/> instance.
+        /// </exception>
         public BaseFileAppender AllocateAppender(string fileName)
         {
             //

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -1,0 +1,267 @@
+﻿// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal.FileAppenders
+{
+    using System;
+
+    /// <summary>
+    /// Maintains a collection of file appenders usually associated with file targets.
+    /// </summary>
+    internal sealed class FileAppenderCache
+    {
+        private BaseFileAppender[] appenders;
+
+        /// <summary>
+        /// Declares initialise a zero size, empty list of appenders.
+        /// </summary>
+        public static readonly FileAppenderCache Empty = new FileAppenderCache(0, null, null);
+
+        public FileAppenderCache(int size, IFileAppenderFactory appenderFactory, ICreateFileParameters createFileParams)
+        {
+            Size = size;
+            Factory = appenderFactory;
+            CreateFileParameters = createFileParams;
+
+            appenders = new BaseFileAppender[Size];
+        }
+
+        /// <summary>
+        /// Gets the parameters which will be used for creating a file.
+        /// </summary>
+        public ICreateFileParameters CreateFileParameters { get; private set; }
+
+        /// <summary>
+        /// Gets the file appender factory used by all the appenders in this list.
+        /// </summary>
+        public IFileAppenderFactory Factory { get; private set; }
+
+        /// <summary>
+        /// Gets the number of appenders which the list can hold.
+        /// </summary>
+        public int Size { get; private set; }
+
+        /// <summary>
+        /// It allocates the first slot in the list when the file name does not already in the list and clean up any
+        /// unused slots.
+        /// </summary>
+        /// <param name="fileName">File name associated with a single appender</param>
+        /// <returns>The allocated appender</returns>
+        public BaseFileAppender AllocateAppender(string fileName)
+        {
+            //
+            // BaseFileAppender.Write is the most expensive operation here
+            // so the in-memory data structure doesn't have to be 
+            // very sophisticated. It's a table-based LRU, where we move 
+            // the used element to become the first one.
+            // The number of items is usually very limited so the 
+            // performance should be equivalent to the one of the hashtable.
+            //
+
+            BaseFileAppender appenderToWrite = null;
+            int freeSpot = appenders.Length - 1;
+
+            for (int i = 0; i < appenders.Length; ++i)
+            {
+                // Use empty slot in recent appender list, if there is one.
+                if (appenders[i] == null)
+                {
+                    freeSpot = i;
+                    break;
+                }
+
+                if (appenders[i].FileName == fileName)
+                {
+                    // found it, move it to the first place on the list
+                    // (MRU)
+
+                    // file open has a chance of failure
+                    // if it fails in the constructor, we won't modify any data structures
+                    BaseFileAppender app = appenders[i];
+                    for (int j = i; j > 0; --j)
+                    {
+                        appenders[j] = appenders[j - 1];
+                    }
+
+                    appenders[0] = app;
+                    appenderToWrite = app;
+                    break;
+                }
+            }
+
+            if (appenderToWrite == null)
+            {
+                BaseFileAppender newAppender = Factory.Open(fileName, CreateFileParameters);
+
+                if (appenders[freeSpot] != null)
+                {
+                    appenders[freeSpot].Close();
+                    appenders[freeSpot] = null;
+                }
+
+                for (int j = freeSpot; j > 0; --j)
+                {
+                    appenders[j] = appenders[j - 1];
+                }
+
+                appenders[0] = newAppender;
+                appenderToWrite = newAppender;
+            }
+
+            return appenderToWrite;
+        }
+
+        /// <summary>
+        /// Close all the allocated appenders. 
+        /// </summary>
+        public void CloseAppenders()
+        {
+            if (appenders != null)
+            {
+                for (int i = 0; i < appenders.Length; ++i)
+                {
+                    if (appenders[i] == null)
+                    {
+                        break;
+                    }
+
+                    appenders[i].Close();
+                    appenders[i] = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Close the allocated appenders initialised before the supplied time.
+        /// </summary>
+        /// <param name="expireTime">The time which prior the appenders considered expired</param>
+        public void CloseAppenders(DateTime expireTime)
+        {
+            for (int i = 0; i < this.appenders.Length; ++i)
+            {
+                if (this.appenders[i] == null)
+                {
+                    break;
+                }
+
+                if (this.appenders[i].OpenTime < expireTime)
+                {
+                    for (int j = i; j < this.appenders.Length; ++j)
+                    {
+                        if (this.appenders[j] == null)
+                        {
+                            break;
+                        }
+
+                        this.appenders[j].Close();
+                        this.appenders[j] = null;
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Fluch all the allocated appenders. 
+        /// </summary>
+        public void FlushAppenders()
+        {
+            foreach (BaseFileAppender appender in appenders)
+            {
+                if (appender == null)
+                {
+                    break;
+                }
+
+                appender.Flush();
+            }
+        }
+        
+        /// <summary>
+        /// Gets the file info for a particular appender.
+        /// </summary>
+        /// <param name="fileName">The file name associated with a particular appender.</param>
+        /// <param name="lastWriteTime">The last file write time. The value must be of UTC kind.</param>
+        /// <param name="fileLength">Length of the file.</param>
+        /// <returns><see langword="true"/> when the operation succeeded; <see langword="false"/> otherwise.</returns>
+        public bool GetFileInfo(string fileName, out DateTime lastWriteTime, out long fileLength)
+        {
+            foreach (BaseFileAppender appender in appenders)
+            {
+                if (appender == null)
+                {
+                    break;
+                }
+
+                if (appender.FileName == fileName)
+                {
+                    appender.GetFileInfo(out lastWriteTime, out fileLength);
+                    return true;
+                }
+            }
+
+            // Return default values.
+            fileLength = -1;
+            lastWriteTime = DateTime.MinValue;
+            return false;
+        }
+
+        /// <summary>
+        /// Closes the specified appender and removes it from the list. 
+        /// </summary>
+        /// <param name="fileName">File name of the appender to be closed.</param>
+        public void InvalidateAppender(string fileName)
+        {
+            for (int i = 0; i < appenders.Length; ++i)
+            {
+                if (appenders[i] == null)
+                {
+                    break;
+                }
+
+                if (appenders[i].FileName == fileName)
+                {
+                    appenders[i].Close();
+                    for (int j = i; j < appenders.Length - 1; ++j)
+                    {
+                        appenders[j] = appenders[j + 1];
+                    }
+
+                    appenders[appenders.Length - 1] = null;
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -47,6 +47,16 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         public static readonly FileAppenderCache Empty = new FileAppenderCache(0, null, null);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileAppenderCache"/> class.
+        /// </summary>
+        /// <remarks>
+        /// The size of the list should be positive. No validations are performed during initialisation as it is an
+        /// intenal class.
+        /// </remarks>
+        /// <param name="size">Total number of appenders allowed in list.</param>
+        /// <param name="appenderFactory">Factory used to create each appender.</param>
+        /// <param name="createFileParams">Parameters used for creating a file.</param>
         public FileAppenderCache(int size, IFileAppenderFactory appenderFactory, ICreateFileParameters createFileParams)
         {
             Size = size;

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BaseOutputDirectory Condition=" '$(BaseOutputDirectory)' == '' ">$(MSBuildProjectDirectory)\..\..\build\</BaseOutputDirectory>
@@ -145,6 +145,7 @@
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />

--- a/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
+++ b/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
@@ -1,0 +1,226 @@
+﻿// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.Internal.FileAppenders
+{
+    using System;
+    using System.IO;
+    using System.Text;
+
+    using Xunit;
+
+    using NLog.Targets;
+    using NLog.Internal.FileAppenders;
+
+    public class FileAppenderCacheTests : NLogTestBase
+    {
+        [Fact]
+        public void FileAppenderCache_Empty() 
+        {
+            FileAppenderCache cache = FileAppenderCache.Empty;
+            // An empty FileAppenderCache will have Size = 0 as well as Factory and CreateFileParameters parameters equal to null.
+            Assert.True(cache.Size == 0);
+            Assert.Null(cache.Factory);
+            Assert.Null(cache.CreateFileParameters);
+
+        }
+
+        [Fact]
+        public void FileAppenderCache_Construction()
+        {
+            IFileAppenderFactory appenderFactory = SingleProcessFileAppender.TheFactory;
+            ICreateFileParameters fileTarget = new FileTarget();
+            FileAppenderCache cache = new FileAppenderCache(3, appenderFactory, fileTarget);
+
+            Assert.True(cache.Size == 3);
+            Assert.NotNull(cache.Factory);           
+            Assert.NotNull(cache.CreateFileParameters);
+        }
+
+        [Fact]
+        public void FileAppenderCache_Allocate()
+        {
+            // Allocate on an Empty FileAppenderCache.
+            FileAppenderCache emptyCache = FileAppenderCache.Empty;
+            Assert.Throws<NullReferenceException>(() => emptyCache.AllocateAppender("file.txt"));
+
+            // Construct a on non-empty FileAppenderCache.
+            IFileAppenderFactory appenderFactory = SingleProcessFileAppender.TheFactory;
+            ICreateFileParameters fileTarget = new FileTarget();
+            String tempFile = Path.Combine(
+                    Path.GetTempPath(),
+                    Path.Combine(Guid.NewGuid().ToString(), "file.txt")
+            );
+            
+            // Allocate an appender.
+            FileAppenderCache cache = new FileAppenderCache(3, appenderFactory, fileTarget);
+            BaseFileAppender appender = cache.AllocateAppender(tempFile);
+
+            //
+            // Note: Encoding is ASSUMED to be Unicode. There is no explicit reference to which encoding will be used 
+            //      for the file. 
+            //
+
+            // Write, flush the content into the file and release the file.
+            // We need to release the file before invoking AssertFileContents() method.
+            appender.Write(StringToBytes("NLog test string."));
+            appender.Flush();
+            appender.Close();
+            // Verify the appender has been allocated correctly.
+            AssertFileContents(tempFile, "NLog test string.", Encoding.Unicode);
+        }
+
+        [Fact]
+        public void FileAppenderCache_InvalidateAppender()
+        {
+            // Invoke InvalidateAppender() on an Empty FileAppenderCache.
+            FileAppenderCache emptyCache = FileAppenderCache.Empty;
+            emptyCache.InvalidateAppender("file.txt");
+
+            // Construct a on non-empty FileAppenderCache.
+            IFileAppenderFactory appenderFactory = SingleProcessFileAppender.TheFactory;
+            ICreateFileParameters fileTarget = new FileTarget();
+            String tempFile = Path.Combine(
+                    Path.GetTempPath(),
+                    Path.Combine(Guid.NewGuid().ToString(), "file.txt")
+            );
+
+            // Allocate an appender.
+            FileAppenderCache cache = new FileAppenderCache(3, appenderFactory, fileTarget);
+            BaseFileAppender appender = cache.AllocateAppender(tempFile);
+
+            //
+            // Note: Encoding is ASSUMED to be Unicode. There is no explicit reference to which encoding will be used 
+            //      for the file. 
+            //
+
+            // Write, flush the content into the file and release the file. This happens throught the
+            // InvalidateAppender() method. We need to release the file before invoking AssertFileContents() method.
+            appender.Write(StringToBytes("NLog test string."));
+            cache.InvalidateAppender(tempFile);
+            // Verify the appender has been allocated correctly.
+            AssertFileContents(tempFile, "NLog test string.", Encoding.Unicode);
+
+        }
+
+        [Fact]
+        public void FileAppenderCache_CloseAppenders()
+        {
+            // Invoke CloseAppenders() on an Empty FileAppenderCache.
+            FileAppenderCache emptyCache = FileAppenderCache.Empty;
+            emptyCache.CloseAppenders();
+
+            
+            IFileAppenderFactory appenderFactory = SingleProcessFileAppender.TheFactory;
+            ICreateFileParameters fileTarget = new FileTarget();
+            FileAppenderCache cache = new FileAppenderCache(3, appenderFactory, fileTarget);
+            // Invoke CloseAppenders() on non-empty FileAppenderCache - Before allocating any appenders. 
+            cache.CloseAppenders();            
+
+            // Invoke CloseAppenders() on non-empty FileAppenderCache - After allocating N appenders. 
+            cache.AllocateAppender("file1.txt");
+            cache.AllocateAppender("file2.txt");
+            cache.CloseAppenders();
+
+            // Invoke CloseAppenders() on non-empty FileAppenderCache - After allocating N appenders. 
+            cache.AllocateAppender("file1.txt");
+            cache.AllocateAppender("file2.txt");
+            cache.CloseAppenders();
+
+            FileAppenderCache cache2 = new FileAppenderCache(3, appenderFactory, fileTarget);
+            // Invoke CloseAppenders() on non-empty FileAppenderCache - Before allocating any appenders. 
+            cache2.CloseAppenders(DateTime.Now);
+
+            // Invoke CloseAppenders() on non-empty FileAppenderCache - After allocating N appenders. 
+            cache.AllocateAppender("file1.txt");
+            cache.AllocateAppender("file2.txt");
+            cache.CloseAppenders(DateTime.Now);
+        }
+
+        [Fact]
+        public void FileAppenderCache_GetFileInfo()
+        {
+            DateTime lastWriteTime;
+            long fileLength;
+
+            // Invoke GetFileInfo() on an Empty FileAppenderCache.
+            FileAppenderCache emptyCache = FileAppenderCache.Empty;
+            emptyCache.GetFileInfo("file.txt", out lastWriteTime, out fileLength);
+            // Default values will be returned.
+            Assert.True(lastWriteTime == DateTime.MinValue);         
+            Assert.True(fileLength == -1);
+
+            IFileAppenderFactory appenderFactory = SingleProcessFileAppender.TheFactory;
+            ICreateFileParameters fileTarget = new FileTarget();
+            FileAppenderCache cache = new FileAppenderCache(3, appenderFactory, fileTarget);
+            // Invoke GetFileInfo() on non-empty FileAppenderCache - Before allocating any appenders. 
+            cache.GetFileInfo("file.txt", out lastWriteTime, out fileLength);
+            // Default values will be returned.
+            Assert.True(lastWriteTime == DateTime.MinValue);
+            Assert.True(fileLength == -1);
+
+            String tempFile = Path.Combine(
+                    Path.GetTempPath(),
+                    Path.Combine(Guid.NewGuid().ToString(), "file.txt")
+            );
+
+            // Allocate an appender.
+            BaseFileAppender appender = cache.AllocateAppender(tempFile);
+            appender.Write(StringToBytes("NLog test string."));
+
+            //
+            // Note: Encoding is ASSUMED to be Unicode. There is no explicit reference to which encoding will be used 
+            //      for the file. 
+            //
+
+            // File information should be returned.
+            cache.GetFileInfo(tempFile, out lastWriteTime, out fileLength);
+            Assert.False(lastWriteTime == DateTime.MinValue);
+            Assert.True(fileLength == 34);
+
+            // Clean up.
+            appender.Flush();
+            appender.Close();
+        }
+
+        /// <summary>
+        /// Converts a string to byte array.
+        /// </summary>
+        private static byte[] StringToBytes(string text)
+        {
+            byte[] bytes = new byte[sizeof(char) * text.Length];
+            Buffer.BlockCopy(text.ToCharArray(), 0, bytes, 0, bytes.Length);
+            return bytes;
+        }
+    }
+}

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Fluent\LogBuilderTests.cs" />
     <Compile Include="GetLoggerTests.cs" />
     <Compile Include="Internal\EnumHelpersTests.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono2.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono2.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Filters\WhenNotEqualTests.cs" />
     <Compile Include="Fluent\LogBuilderTests.cs" />
     <Compile Include="GetLoggerTests.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="LayoutRenderers\BaseDirTests.cs" />
     <Compile Include="LayoutRenderers\CallSiteTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Fluent\LogBuilderTests.cs" />
     <Compile Include="GetLoggerTests.cs" />
     <Compile Include="Internal\EnumHelpersTests.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Fluent\LogBuilderTests.cs" />
     <Compile Include="GetLoggerTests.cs" />
     <Compile Include="Internal\EnumHelpersTests.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -145,6 +147,7 @@
     <Compile Include="Fluent\LogBuilderTests.cs" />
     <Compile Include="GetLoggerTests.cs" />
     <Compile Include="Internal\EnumHelpersTests.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Fluent\LogBuilderTests.cs" />
     <Compile Include="GetLoggerTests.cs" />
     <Compile Include="Internal\EnumHelpersTests.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Fluent\LogBuilderTests.cs" />
     <Compile Include="GetLoggerTests.cs" />
     <Compile Include="Internal\EnumHelpersTests.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />


### PR DESCRIPTION
Extract the functionality related to file appenders (`BaseFileAppenders`) used within the `FileTarget` class into a new class named `FileAppenderCache`.

This change should improve the code readability and encourage further refactorings. It also re-enforces the Single Responsibility Principle.

The "new" code does not  change the implementation of the functionality related to file appenders. It simply separates it out of the `FileTarget` class.

There are no breaking changes in my knowledge.