### PR TITLE
ArchiveFileCompression: auto add `.zip` to compressed filename when archiveName isn't specified 

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1462,7 +1462,7 @@ namespace NLog.Targets
 
             if (this.ArchiveFileName == null)
             {
-                string ext = Path.GetExtension(fileName);
+                string ext = EnableArchiveFileCompression ? ".zip" : Path.GetExtension(fileName);
                 fileNamePattern = Path.ChangeExtension(fileInfo.FullName, ".{#}" + ext);
             }
             else


### PR DESCRIPTION
Fixes #932