### PR TITLE
Reduce memory allocations in Logger.Log by avoiding GetEnumerator.

### DIFF
--- a/src/NLog/Conditions/ConditionMethodExpression.cs
+++ b/src/NLog/Conditions/ConditionMethodExpression.cs
@@ -136,6 +136,8 @@ namespace NLog.Conditions
             sb.Append("(");
 
             string separator = string.Empty;
+
+            //perf: using for-loop to avoid Enumerator memory allocation in foreach-loop.
             for (int i = 0; i < this.MethodParameters.Count; i++)
             {
                 ConditionExpression expr = this.MethodParameters[i];
@@ -158,7 +160,8 @@ namespace NLog.Conditions
             int parameterOffset = this.acceptsLogEvent ? 1 : 0;
 
             var callParameters = new object[this.MethodParameters.Count + parameterOffset];
-            
+
+            //perf: using for-loop to avoid Enumerator memory allocation in foreach-loop.
             for (int i = 0; i < this.MethodParameters.Count; i++)
             {
                 ConditionExpression ce = this.MethodParameters[i];

--- a/src/NLog/Conditions/ConditionMethodExpression.cs
+++ b/src/NLog/Conditions/ConditionMethodExpression.cs
@@ -136,8 +136,9 @@ namespace NLog.Conditions
             sb.Append("(");
 
             string separator = string.Empty;
-            foreach (ConditionExpression expr in this.MethodParameters)
+            for (int i = 0; i < this.MethodParameters.Count; i++)
             {
+                ConditionExpression expr = this.MethodParameters[i];
                 sb.Append(separator);
                 sb.Append(expr);
                 separator = ", ";
@@ -157,10 +158,11 @@ namespace NLog.Conditions
             int parameterOffset = this.acceptsLogEvent ? 1 : 0;
 
             var callParameters = new object[this.MethodParameters.Count + parameterOffset];
-            int i = 0;
-            foreach (ConditionExpression ce in this.MethodParameters)
+            
+            for (int i = 0; i < this.MethodParameters.Count; i++)
             {
-                callParameters[i++ + parameterOffset] = ce.Evaluate(context);
+                ConditionExpression ce = this.MethodParameters[i];
+                callParameters[i + parameterOffset] = ce.Evaluate(context);
             }
 
             if (this.acceptsLogEvent)

--- a/src/NLog/Conditions/ConditionMethodExpression.cs
+++ b/src/NLog/Conditions/ConditionMethodExpression.cs
@@ -137,7 +137,8 @@ namespace NLog.Conditions
 
             string separator = string.Empty;
 
-            //perf: using for-loop to avoid Enumerator memory allocation in foreach-loop.
+            //Memory profiling pointed out that using a foreach-loop was allocating
+            //an Enumerator. Switching to a for-loop avoids the memory allocation.
             for (int i = 0; i < this.MethodParameters.Count; i++)
             {
                 ConditionExpression expr = this.MethodParameters[i];
@@ -161,7 +162,8 @@ namespace NLog.Conditions
 
             var callParameters = new object[this.MethodParameters.Count + parameterOffset];
 
-            //perf: using for-loop to avoid Enumerator memory allocation in foreach-loop.
+            //Memory profiling pointed out that using a foreach-loop was allocating
+            //an Enumerator. Switching to a for-loop avoids the memory allocation.
             for (int i = 0; i < this.MethodParameters.Count; i++)
             {
                 ConditionExpression ce = this.MethodParameters[i];

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -253,7 +253,8 @@ namespace NLog.Layouts
 
             var builder = new StringBuilder(initialSize);
 
-            //perf: using for-loop to avoid Enumerator memory allocation in foreach-loop.
+            //Memory profiling pointed out that using a foreach-loop was allocating
+            //an Enumerator. Switching to a for-loop avoids the memory allocation.
             for (int i = 0; i < this.Renderers.Count; i++)
             {
                 LayoutRenderer renderer = this.Renderers[i];

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -253,6 +253,7 @@ namespace NLog.Layouts
 
             var builder = new StringBuilder(initialSize);
 
+            //perf: using for-loop to avoid Enumerator memory allocation in foreach-loop.
             for (int i = 0; i < this.Renderers.Count; i++)
             {
                 LayoutRenderer renderer = this.Renderers[i];

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -253,8 +253,9 @@ namespace NLog.Layouts
 
             var builder = new StringBuilder(initialSize);
 
-            foreach (LayoutRenderer renderer in this.Renderers)
+            for (int i = 0; i < this.Renderers.Count; i++)
             {
+                LayoutRenderer renderer = this.Renderers[i];
                 try
                 {
                     renderer.Render(builder, logEvent);

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -208,14 +208,15 @@ namespace NLog
         /// <param name="filterChain">The filter chain.</param>
         /// <param name="logEvent">The log event.</param>
         /// <returns>The result of the filter.</returns>
-        private static FilterResult GetFilterResult(IEnumerable<Filter> filterChain, LogEventInfo logEvent)
+        private static FilterResult GetFilterResult(IList<Filter> filterChain, LogEventInfo logEvent)
         {
             FilterResult result = FilterResult.Neutral;
 
             try
             {
-                foreach (Filter f in filterChain)
+                for (int i = 0; i < filterChain.Count; i++)
                 {
+                    Filter f = filterChain[i];
                     result = f.GetFilterResult(logEvent);
                     if (result != FilterResult.Neutral)
                     {

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -214,7 +214,8 @@ namespace NLog
 
             try
             {
-                //perf: using for-loop to avoid Enumerator memory allocation in foreach-loop.
+                //Memory profiling pointed out that using a foreach-loop was allocating
+                //an Enumerator. Switching to a for-loop avoids the memory allocation.
                 for (int i = 0; i < filterChain.Count; i++)
                 {
                     Filter f = filterChain[i];

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -214,6 +214,7 @@ namespace NLog
 
             try
             {
+                //perf: using for-loop to avoid Enumerator memory allocation in foreach-loop.
                 for (int i = 0; i < filterChain.Count; i++)
                 {
                     Filter f = filterChain[i];


### PR DESCRIPTION
I did some memory profiling on the hot path of Logger.Log method and found there are a few simple optimizations that can be done to avoid memory allocations. This is the app I used to log a message 100,000 times:

```c#
        static void Main(string[] args)
        {
            LogManager.Configuration = CreateConfigurationFromString(@"
                <nlog>
                    <targets><target name='debug' type='Debug' layout='${message}' /></targets>
                    <rules>
                        <logger name='*' levels='Debug' writeTo='debug'>
                            <filters>
                                <when condition=""length('${message}') > 100"" action='Ignore' />
                            </filters>
                        </logger>
                    </rules>
                </nlog>");

            var levels = new LogLevel[] { LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal };

            ILogger logger = LogManager.GetLogger("A");
            logger.Log(levels[0], "message");

            Console.WriteLine("Take First snapshot");
            Console.ReadLine();
            
            for (int i = 0; i < 100000; i++)
            {
                foreach (LogLevel level in levels)
                {
                    logger.Log(level, "message");
                }
            }

            Console.WriteLine("Take Last snapshot");
            Console.ReadLine();
        }
```

Here is a screenshot of 3 Enumerator allocations that are targeted in this pull request:

![image](https://cloud.githubusercontent.com/assets/697377/11017622/e720a5e6-8572-11e5-8b08-57a74c919341.png)

These changes remove 4 memory allocations for each Logger.Log call:

![image](https://cloud.githubusercontent.com/assets/697377/11017647/7750b03e-8573-11e5-83d9-bbbf170270fe.png)

The same change can be done to a few more classes:

- [CsvLayout.GetFormattedMessage](https://github.com/NLog/NLog/blob/master/src/NLog/Layouts/CsvLayout.cs#L174)
- [CsvLayout.GetHeader](https://github.com/NLog/NLog/blob/master/src/NLog/Layouts/CsvLayout.cs#L239)
- [JsonLayout.GetFormattedMessage](https://github.com/NLog/NLog/blob/master/src/NLog/Layouts/JsonLayout.cs#L83)

I'll submit another pull request with the changes to the classes above if this one is accepted.