### PR TITLE
Reduce memory allocations in Logger.Log when using CsvLayout and JsonLayout

### DIFF
--- a/src/NLog/Layouts/CsvLayout.cs
+++ b/src/NLog/Layouts/CsvLayout.cs
@@ -169,16 +169,16 @@ namespace NLog.Layouts
             }
 
             var sb = new StringBuilder();
-            bool first = true;
 
-            foreach (CsvColumn col in this.Columns)
+            //Memory profiling pointed out that using a foreach-loop was allocating
+            //an Enumerator. Switching to a for-loop avoids the memory allocation.
+            for (int i = 0; i < this.Columns.Count; i++)
             {
-                if (!first)
+                CsvColumn col = this.Columns[i];
+                if (i != 0)
                 {
                     sb.Append(this.actualColumnDelimiter);
                 }
-
-                first = false;
 
                 bool useQuoting;
                 string text = col.Layout.Render(logEvent);
@@ -234,16 +234,15 @@ namespace NLog.Layouts
         {
             var sb = new StringBuilder();
 
-            bool first = true;
-
-            foreach (CsvColumn col in this.Columns)
+            //Memory profiling pointed out that using a foreach-loop was allocating
+            //an Enumerator. Switching to a for-loop avoids the memory allocation.
+            for (int i = 0; i < this.Columns.Count; i++)
             {
-                if (!first)
+                CsvColumn col = this.Columns[i];
+                if (i != 0)
                 {
                     sb.Append(this.actualColumnDelimiter);
                 }
-
-                first = false;
 
                 bool useQuoting;
                 string text = col.Name;

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -80,8 +80,11 @@ namespace NLog.Layouts
             AppendIf(!this.SuppressSpaces, sb, " ");
             bool first = true;
 
-            foreach (var col in this.Attributes)
+            //Memory profiling pointed out that using a foreach-loop was allocating
+            //an Enumerator. Switching to a for-loop avoids the memory allocation.
+            for (int i = 0; i < this.Attributes.Count; i++)
             {
+                var col = this.Attributes[i];
                 jsonWrapper.Inner = col.Layout;
                 jsonWrapper.JsonEncode = col.Encode;
                 string text = jsonWrapper.Render(logEvent);


### PR DESCRIPTION
Continuation of #1020. This time targeting CsvLayout and JsonLayout. This is the sample app used:

            LogManager.Configuration = CreateConfigurationFromString(@"
                <nlog>
	                <targets>
		                <target name='debugCsv' type='Debug'>
			                <layout type='CsvLayout'>
                                <column name='message' layout='${message}' />
				                <withHeader>true</withHeader>
			                </layout>
		                </target>
                        <target name='debugJson' type='Debug'>
                            <layout type='JsonLayout'>
                                <attribute name='message' layout='${message}' />
	                        </layout>
                        </target>
	                </targets>
	                <rules>
		                <logger name='*' levels='Debug' writeTo='debugCsv'></logger>
                        <logger name='*' levels='Debug' writeTo='debugJson'></logger>
	                </rules>
                </nlog>
            ");

            var levels = new LogLevel[] { LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal };

            ILogger logger = LogManager.GetLogger("A");
            logger.Log(levels[0], "message");

            Console.WriteLine("Take First snapshot");
            Console.ReadLine();
            
            for (int i = 0; i < 100000; i++)
            {
                foreach (LogLevel level in levels)
                {
                    logger.Log(level, "message");
                }
            }

            Console.WriteLine("Take Last snapshot");
            Console.ReadLine();

Here is a screenshot of the GetEnumerator allocations for CsvLayout and JsonLayout:

![image](https://cloud.githubusercontent.com/assets/697377/11053682/31855dc4-8731-11e5-990a-56c42ec1d482.png)

Now gone after the changes:

![image](https://cloud.githubusercontent.com/assets/697377/11053691/43177d10-8731-11e5-8a74-b3275559ea67.png)
