### PR TITLE
NetworkTarget: linkedlist + configure max connections 

### DIFF
--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BaseOutputDirectory Condition=" '$(BaseOutputDirectory)' == '' ">$(MSBuildProjectDirectory)\..\..\build\</BaseOutputDirectory>
@@ -142,8 +142,8 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
@@ -358,6 +358,7 @@
     <Compile Include="Targets\MethodCallTarget.cs" />
     <Compile Include="Targets\MethodCallTargetBase.cs" />
     <Compile Include="Targets\NetworkTarget.cs" />
+    <Compile Include="Targets\NetworkTargetConnectionsOverflowAction.cs" />
     <Compile Include="Targets\NetworkTargetOverflowAction.cs" />
     <Compile Include="Targets\NLogViewerParameterInfo.cs" />
     <Compile Include="Targets\NLogViewerTarget.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BaseOutputDirectory Condition=" '$(BaseOutputDirectory)' == '' ">$(MSBuildProjectDirectory)\..\..\build\</BaseOutputDirectory>
@@ -148,8 +148,8 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
@@ -364,6 +364,7 @@
     <Compile Include="Targets\MethodCallTarget.cs" />
     <Compile Include="Targets\MethodCallTargetBase.cs" />
     <Compile Include="Targets\NetworkTarget.cs" />
+    <Compile Include="Targets\NetworkTargetConnectionsOverflowAction.cs" />
     <Compile Include="Targets\NetworkTargetOverflowAction.cs" />
     <Compile Include="Targets\NLogViewerParameterInfo.cs" />
     <Compile Include="Targets\NLogViewerTarget.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -27,10 +27,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>bin\Debug</OutputPath>
-    <CodeAnalysisRules>
-    </CodeAnalysisRules>
-    <CodeAnalysisRules>
-    </CodeAnalysisRules>
+    <CodeAnalysisRules></CodeAnalysisRules>
+    <CodeAnalysisRules></CodeAnalysisRules>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -360,6 +358,7 @@
     <Compile Include="Targets\MethodCallTarget.cs" />
     <Compile Include="Targets\MethodCallTargetBase.cs" />
     <Compile Include="Targets\NetworkTarget.cs" />
+    <Compile Include="Targets\NetworkTargetConnectionsOverflowAction.cs" />
     <Compile Include="Targets\NetworkTargetOverflowAction.cs" />
     <Compile Include="Targets\NLogViewerParameterInfo.cs" />
     <Compile Include="Targets\NLogViewerTarget.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BaseOutputDirectory Condition=" '$(BaseOutputDirectory)' == '' ">$(MSBuildProjectDirectory)\..\..\build\</BaseOutputDirectory>
@@ -142,8 +142,8 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
@@ -358,6 +358,7 @@
     <Compile Include="Targets\MethodCallTarget.cs" />
     <Compile Include="Targets\MethodCallTargetBase.cs" />
     <Compile Include="Targets\NetworkTarget.cs" />
+    <Compile Include="Targets\NetworkTargetConnectionsOverflowAction.cs" />
     <Compile Include="Targets\NetworkTargetOverflowAction.cs" />
     <Compile Include="Targets\NLogViewerParameterInfo.cs" />
     <Compile Include="Targets\NLogViewerTarget.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,8 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <TargetFrameworkProfile></TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -148,8 +147,8 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
@@ -364,6 +363,7 @@
     <Compile Include="Targets\MethodCallTarget.cs" />
     <Compile Include="Targets\MethodCallTargetBase.cs" />
     <Compile Include="Targets\NetworkTarget.cs" />
+    <Compile Include="Targets\NetworkTargetConnectionsOverflowAction.cs" />
     <Compile Include="Targets\NetworkTargetOverflowAction.cs" />
     <Compile Include="Targets\NLogViewerParameterInfo.cs" />
     <Compile Include="Targets\NLogViewerTarget.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -149,8 +149,8 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
@@ -365,6 +365,7 @@
     <Compile Include="Targets\MethodCallTarget.cs" />
     <Compile Include="Targets\MethodCallTargetBase.cs" />
     <Compile Include="Targets\NetworkTarget.cs" />
+    <Compile Include="Targets\NetworkTargetConnectionsOverflowAction.cs" />
     <Compile Include="Targets\NetworkTargetOverflowAction.cs" />
     <Compile Include="Targets\NLogViewerParameterInfo.cs" />
     <Compile Include="Targets\NLogViewerTarget.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -146,8 +146,8 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
@@ -362,6 +362,7 @@
     <Compile Include="Targets\MethodCallTarget.cs" />
     <Compile Include="Targets\MethodCallTargetBase.cs" />
     <Compile Include="Targets\NetworkTarget.cs" />
+    <Compile Include="Targets\NetworkTargetConnectionsOverflowAction.cs" />
     <Compile Include="Targets\NetworkTargetOverflowAction.cs" />
     <Compile Include="Targets\NLogViewerParameterInfo.cs" />
     <Compile Include="Targets\NLogViewerTarget.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -145,8 +145,8 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
@@ -361,6 +361,7 @@
     <Compile Include="Targets\MethodCallTarget.cs" />
     <Compile Include="Targets\MethodCallTargetBase.cs" />
     <Compile Include="Targets\NetworkTarget.cs" />
+    <Compile Include="Targets\NetworkTargetConnectionsOverflowAction.cs" />
     <Compile Include="Targets\NetworkTargetOverflowAction.cs" />
     <Compile Include="Targets\NLogViewerParameterInfo.cs" />
     <Compile Include="Targets\NLogViewerTarget.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -145,8 +145,8 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
@@ -361,6 +361,7 @@
     <Compile Include="Targets\MethodCallTarget.cs" />
     <Compile Include="Targets\MethodCallTargetBase.cs" />
     <Compile Include="Targets\NetworkTarget.cs" />
+    <Compile Include="Targets\NetworkTargetConnectionsOverflowAction.cs" />
     <Compile Include="Targets\NetworkTargetOverflowAction.cs" />
     <Compile Include="Targets\NLogViewerParameterInfo.cs" />
     <Compile Include="Targets\NLogViewerTarget.cs" />

--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -82,8 +82,8 @@ namespace NLog.Targets
     [Target("Network")]
     public class NetworkTarget : TargetWithLayout
     {
-        private Dictionary<string, NetworkSender> currentSenderCache = new Dictionary<string, NetworkSender>();
-        private List<NetworkSender> openNetworkSenders = new List<NetworkSender>();
+        private Dictionary<string, LinkedListNode<NetworkSender>> currentSenderCache = new Dictionary<string, LinkedListNode<NetworkSender>>();
+        private LinkedList<NetworkSender> openNetworkSenders = new LinkedList<NetworkSender>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NetworkTarget" /> class.
@@ -181,13 +181,13 @@ namespace NLog.Targets
 
             AsyncContinuation continuation =
                 ex =>
+                {
+                    // ignore exception
+                    if (Interlocked.Decrement(ref remainingCount) == 0)
                     {
-                        // ignore exception
-                        if (Interlocked.Decrement(ref remainingCount) == 0)
-                        {
-                            asyncContinuation(null);
-                        }
-                    };
+                        asyncContinuation(null);
+                    }
+                };
 
             lock (this.openNetworkSenders)
             {
@@ -215,7 +215,7 @@ namespace NLog.Targets
         protected override void CloseTarget()
         {
             base.CloseTarget();
-            
+
             lock (this.openNetworkSenders)
             {
                 foreach (var openSender in this.openNetworkSenders)
@@ -239,21 +239,21 @@ namespace NLog.Targets
 
             if (this.KeepConnection)
             {
-                var sender = this.GetCachedNetworkSender(address);
+                var senderNode = this.GetCachedNetworkSender(address);
 
                 this.ChunkedSend(
-                    sender,
+                    senderNode.Value,
                     bytes,
                     ex =>
+                    {
+                        if (ex != null)
                         {
-                            if (ex != null)
-                            {
-                                InternalLogger.Error("Error when sending {0}", ex);
-                                this.ReleaseCachedConnection(sender);
-                            }
+                            InternalLogger.Error("Error when sending {0}", ex);
+                            this.ReleaseCachedConnection(senderNode);
+                        }
 
-                            logEvent.Continuation(ex);
-                        });
+                        logEvent.Continuation(ex);
+                    });
             }
             else
             {
@@ -262,27 +262,44 @@ namespace NLog.Targets
 
                 lock (this.openNetworkSenders)
                 {
-                    this.openNetworkSenders.Add(sender);
+                    var linkedListNode = this.openNetworkSenders.AddLast(sender);
                     this.ChunkedSend(
                         sender,
                         bytes,
                         ex =>
+                        {
+                            lock (this.openNetworkSenders)
                             {
-                                lock (this.openNetworkSenders)
-                                {
-                                    this.openNetworkSenders.Remove(sender);
-                                }
+                                TryRemove(this.openNetworkSenders, linkedListNode);
+                            }
 
-                                if (ex != null)
-                                {
-                                    InternalLogger.Error("Error when sending {0}", ex);
-                                }
+                            if (ex != null)
+                            {
+                                InternalLogger.Error("Error when sending {0}", ex);
+                            }
 
-                                sender.Close(ex2 => { });
-                                logEvent.Continuation(ex);
-                            });
+                            sender.Close(ex2 => { });
+                            logEvent.Continuation(ex);
+                        });
                 }
             }
+        }
+
+        /// <summary>
+        /// Try to remove. 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="list"></param>
+        /// <param name="node"></param>
+        /// <returns>removed something?</returns>
+        private static bool TryRemove<T>(LinkedList<T> list, LinkedListNode<T> node)
+        {
+            if (node == null || list != node.List)
+            {
+                return false;
+            }
+            list.Remove(node);
+            return true;
         }
 
         /// <summary>
@@ -306,31 +323,32 @@ namespace NLog.Targets
             return this.Encoding.GetBytes(text);
         }
 
-        private NetworkSender GetCachedNetworkSender(string address)
+        private LinkedListNode<NetworkSender> GetCachedNetworkSender(string address)
         {
             lock (this.currentSenderCache)
             {
-                NetworkSender sender;
+                LinkedListNode<NetworkSender> senderNode;
 
                 // already have address
-                if (this.currentSenderCache.TryGetValue(address, out sender))
+                if (this.currentSenderCache.TryGetValue(address, out senderNode))
                 {
-                    sender.CheckSocket();
-                    return sender;
+                    senderNode.Value.CheckSocket();
+                    return senderNode;
                 }
 
                 if (this.currentSenderCache.Count >= this.ConnectionCacheSize)
                 {
                     // make room in the cache by closing the least recently used connection
                     int minAccessTime = int.MaxValue;
-                    NetworkSender leastRecentlyUsed = null;
+                    LinkedListNode<NetworkSender> leastRecentlyUsed = null;
 
-                    foreach (var kvp in this.currentSenderCache)
+                    foreach (var pair in this.currentSenderCache)
                     {
-                        if (kvp.Value.LastSendTime < minAccessTime)
+                        var networkSender = pair.Value.Value;
+                        if (networkSender.LastSendTime < minAccessTime)
                         {
-                            minAccessTime = kvp.Value.LastSendTime;
-                            leastRecentlyUsed = kvp.Value;
+                            minAccessTime = networkSender.LastSendTime;
+                            leastRecentlyUsed = pair.Value;
                         }
                     }
 
@@ -340,39 +358,41 @@ namespace NLog.Targets
                     }
                 }
 
-                sender = this.SenderFactory.Create(address, MaxQueueSize);
+                var sender = this.SenderFactory.Create(address, MaxQueueSize);
                 sender.Initialize();
                 lock (this.openNetworkSenders)
                 {
-                    this.openNetworkSenders.Add(sender);
+                    senderNode = this.openNetworkSenders.AddLast(sender);
                 }
 
-                this.currentSenderCache.Add(address, sender);
-                return sender;
+                this.currentSenderCache.Add(address, senderNode);
+                return senderNode;
             }
         }
 
-        private void ReleaseCachedConnection(NetworkSender sender)
+        private void ReleaseCachedConnection(LinkedListNode<NetworkSender> senderNode)
         {
             lock (this.currentSenderCache)
             {
+                var networkSender = senderNode.Value;
                 lock (this.openNetworkSenders)
                 {
-                    if (this.openNetworkSenders.Remove(sender))
+                    
+                    if(TryRemove(this.openNetworkSenders,senderNode))
                     {
                         // only remove it once
-                        sender.Close(ex => { });
+                        networkSender.Close(ex => { });
                     }
                 }
 
-                NetworkSender sender2;
+                LinkedListNode<NetworkSender> sender2;
 
                 // make sure the current sender for this address is the one we want to remove
-                if (this.currentSenderCache.TryGetValue(sender.Address, out sender2))
+                if (this.currentSenderCache.TryGetValue(networkSender.Address, out sender2))
                 {
-                    if (ReferenceEquals(sender, sender2))
+                    if (ReferenceEquals(senderNode, sender2))
                     {
-                        this.currentSenderCache.Remove(sender.Address);
+                        this.currentSenderCache.Remove(networkSender.Address);
                     }
                 }
             }

--- a/src/NLog/Targets/NetworkTargetConnectionsOverflowAction.cs
+++ b/src/NLog/Targets/NetworkTargetConnectionsOverflowAction.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NLog.Targets
+{
+    /// <summary>
+    /// The action to be taken when there are more connections then the max.
+    /// </summary>
+    public enum NetworkTargetConnectionsOverflowAction
+    {
+        /// <summary>
+        /// Just allow it.
+        /// </summary>
+        AllowNewConnnection,
+
+        /// <summary>
+        /// Discard the connection item.
+        /// </summary>
+        DiscardMessage,
+
+        /// <summary>
+        /// Block until there's more room in the queue.
+        /// </summary>
+        Block,
+    }
+}

--- a/src/NLog/Targets/NetworkTargetConnectionsOverflowAction.cs
+++ b/src/NLog/Targets/NetworkTargetConnectionsOverflowAction.cs
@@ -1,3 +1,36 @@
+// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
supersedes https://github.com/NLog/NLog/pull/1018

fixes #902 

- LinkedList instead of List for faster removal
- Handle / configure max connections 

```c#
 /// <summary>
        /// Gets or sets the maximum current connections. 0 = no maximum.
        /// </summary>
        /// <docgen category="Connection Options" order="10"/>
        [DefaultValue(0)]
        public int MaxConnections { get; set; }

        /// <summary>
        /// Gets or sets the action that should be taken if the will be more connections than <see cref="MaxConnections"/>.
        /// </summary>
        /// <docgen category='Layout Options' order='10' />
        public NetworkTargetConnectionsOverflowAction OnConnectionOverflow { get; set; }

```

```c#
        /// <summary>
        /// Just allow it.
        /// </summary>
        AllowNewConnnection,

        /// <summary>
        /// Discard the connection item.
        /// </summary>
        DiscardMessage,

        /// <summary>
        /// Block until there's more room in the queue.
        /// </summary>
        Block,

```