### PR TITLE
Databasetarget: restored 'UseTransactions' and print warning if used

### DIFF
--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -177,7 +177,6 @@ namespace NLog.Targets
         /// This option was removed in NLog 4.0 because the logging code always runs outside of transaction. 
         /// This ensures that the log gets written to the database if you rollback the main transaction because of an error and want to log the error.
         /// </remarks>
-        [DefaultValue(false)]
         [Obsolete("Obsolete - value will be ignored - logging code always runs outside of transaction. Will be removed in NLog 6.")]
         public bool? UseTransactions { get; set; }
 

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -167,6 +167,21 @@ namespace NLog.Targets
         public bool KeepConnection { get; set; }
 
         /// <summary>
+        /// Obsolete - value will be ignored! The logging code always runs outside of transaction. 
+        /// 
+        /// Gets or sets a value indicating whether to use database transactions. 
+        /// Some data providers require this.
+        /// </summary>
+        /// <docgen category='Connection Options' order='10' />
+        /// <remarks>
+        /// This option was removed in NLog 4.0 because the logging code always runs outside of transaction. 
+        /// This ensures that the log gets written to the database if you rollback the main transaction because of an error and want to log the error.
+        /// </remarks>
+        [DefaultValue(false)]
+        [Obsolete("Obsolete - value will be ignored - logging code always runs outside of transaction. Will be removed in NLog 6.")]
+        public bool? UseTransactions { get; set; }
+
+        /// <summary>
         /// Gets or sets the database host name. If the ConnectionString is not provided
         /// this value will be used to construct the "Server=" part of the
         /// connection string.
@@ -296,6 +311,13 @@ namespace NLog.Targets
         protected override void InitializeTarget()
         {
             base.InitializeTarget();
+
+#pragma warning disable 618
+            if (UseTransactions.HasValue)
+#pragma warning restore 618
+            {
+                InternalLogger.Warn("UseTransactions is obsolete and will not be used - will be removed in NLog 6");
+            }
 
             bool foundProvider = false;
 

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -31,11 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.IO;
-using NLog.Common;
-using NLog.Config;
-using Xunit.Extensions;
-
 #if !SILVERLIGHT
 
 namespace NLog.UnitTests.Targets
@@ -47,8 +42,12 @@ namespace NLog.UnitTests.Targets
     using System.Data;
     using System.Data.Common;
     using System.Globalization;
+    using System.IO;
+    using NLog.Common;
+    using NLog.Config;
     using NLog.Targets;
     using Xunit;
+    using Xunit.Extensions;
 
     public class DatabaseTargetTests : NLogTestBase
     {


### PR DESCRIPTION
Because just removing (in NLog 4.0 this happened), without obsolete is really bad.

fixes https://github.com/NLog/NLog/issues/1023

Will be removed in NLog 6.