### PR TITLE
LogReceiverWebServiceTarget.CreateLogReceiver()  should be virtual

### DIFF
--- a/src/NLog/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog/Targets/LogReceiverWebServiceTarget.cs
@@ -378,7 +378,8 @@ namespace NLog.Targets
         /// service configuration - binding and endpoint address
         /// </summary>
         /// <returns></returns>
-        protected IWcfLogReceiverClient CreateLogReceiver()
+        /// <remarks>virtual is used by endusers</remarks>
+        protected virtual IWcfLogReceiverClient CreateLogReceiver()
         {
 #pragma warning disable 612, 618
 


### PR DESCRIPTION
`IWcfLogReceiverClient LogReceiverWebServiceTarget.CreateLogReceiver()` should be virtual

fixes #1050

bug as it was a non intended breaking change. 