### PR TITLE
Add AllLevels and AllLoggingLevels to LogLevel.cs.

### DIFF
--- a/src/NLog/LogLevel.cs
+++ b/src/NLog/LogLevel.cs
@@ -87,10 +87,10 @@ namespace NLog
 
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "Type is immutable")]
-        private static readonly LogLevel[] allLevels = { Trace, Debug, Info, Warn, Error, Fatal, Off };
+        private static readonly IList<LogLevel> allLevels = new List<LogLevel> { Trace, Debug, Info, Warn, Error, Fatal, Off };
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "Type is immutable")]
-        private static readonly LogLevel[] allLoggingLevels = {Trace, Debug, Info, Warn, Error, Fatal};
+        private static readonly IList<LogLevel> allLoggingLevels = new List<LogLevel> {Trace, Debug, Info, Warn, Error, Fatal};
 
         /// <summary>
         /// All log levels. (Trace, Debug, Info, Warn, Error, Fatal, Off)

--- a/src/NLog/LogLevel.cs
+++ b/src/NLog/LogLevel.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Collections.Generic;
+
 namespace NLog
 {
     using System;
@@ -82,6 +84,24 @@ namespace NLog
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "Type is immutable")]
         public static readonly LogLevel Off = new LogLevel("Off", 6);
+
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "Type is immutable")]
+        private static readonly LogLevel[] allLevels = { Trace, Debug, Info, Warn, Error, Fatal, Off };
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "Type is immutable")]
+        private static readonly LogLevel[] allLoggingLevels = {Trace, Debug, Info, Warn, Error, Fatal};
+
+        /// <summary>
+        /// All log levels. (Trace, Debug, Info, Warn, Error, Fatal, Off)
+        /// </summary>
+        public static IEnumerable<LogLevel> AllLevels { get { return allLevels; } }
+
+        /// <summary>
+        /// All log levels that can be used to log events (excludes Off). (Trace, Debug, Info, Warn, Error, Fatal)
+        /// </summary>
+        public static IEnumerable<LogLevel> AllLoggingLevels { get { return allLoggingLevels; } }
+
 
         private readonly int ordinal;
         private readonly string name;


### PR DESCRIPTION
This is mostly for presentation purposes, which might be out of scope.  I just find it convenient with type safe enums like LogLevel to have a built-in enumerable of all possible values.  Makes it easier to create query filters etc. without having to hardcode anything.