### PR TITLE
Overhaul ExceptionLayoutRenderer

### DIFF
--- a/src/NLog/Config/ExceptionRenderingFormat.cs
+++ b/src/NLog/Config/ExceptionRenderingFormat.cs
@@ -45,14 +45,9 @@ namespace NLog.Config
     public enum ExceptionRenderingFormat
     {
         /// <summary>
-        /// This is for internal NLog Library usage. This is required we would a default value in switch cases. 
-        /// </summary>
-        NotSet = -1,
-        /// <summary>
         /// Appends the Message of an Exception to the specified target.
         /// </summary>
         Message = 0,
-
         /// <summary>
         /// Appends the type of an Exception to the specified target.
         /// </summary>

--- a/src/NLog/Config/ExceptionRenderingFormat.cs
+++ b/src/NLog/Config/ExceptionRenderingFormat.cs
@@ -1,4 +1,38 @@
-﻿using System;
+﻿// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/NLog/Config/ExceptionRenderingFormat.cs
+++ b/src/NLog/Config/ExceptionRenderingFormat.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NLog.Config
+{
+    /// <summary>
+    /// Format of the excpetion output to the specific target.
+    /// </summary>
+    public enum ExceptionRenderingFormat
+    {
+        /// <summary>
+        /// This is for internal NLog Library usage. This is required we would a default value in switch cases. 
+        /// </summary>
+        NotSet = -1,
+        /// <summary>
+        /// Appends the Message of an Exception to the specified target.
+        /// </summary>
+        Message = 0,
+
+        /// <summary>
+        /// Appends the type of an Exception to the specified target.
+        /// </summary>
+        Type = 1,
+        /// <summary>
+        /// Appends the short type of an Exception to the specified target.
+        /// </summary>
+        ShortType = 2,
+        /// <summary>
+        /// Appends the result of calling ToString() on an Exception to the specified target.
+        /// </summary>
+        ToString = 3,
+        /// <summary>
+        /// Appends the method name from Exception's stack trace to the specified target.
+        /// </summary>
+        Method = 4,
+        /// <summary>
+        /// Appends the stack trace from an Exception to the specified target.
+        /// </summary>
+        StackTrace = 5,
+        /// <summary>
+        /// Appends the contents of an Exception's Data property to the specified target.
+        /// </summary>
+        Data = 6
+    }
+}

--- a/src/NLog/Config/ExceptionRenderingFormat.cs
+++ b/src/NLog/Config/ExceptionRenderingFormat.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace NLog.Config
 {

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -52,16 +52,7 @@ namespace NLog.LayoutRenderers
     {
         private string format;
         private string innerFormat = string.Empty;
-        private static readonly Dictionary<ExceptionRenderingFormat, Action<StringBuilder, Exception>> _renderingfunctions = new Dictionary<ExceptionRenderingFormat, Action<StringBuilder, Exception>>() 
-                                                                                                    {
-                                                                                                        {ExceptionRenderingFormat.Message, AppendMessage}, 
-                                                                                                        {ExceptionRenderingFormat.Type, AppendType},
-                                                                                                        {ExceptionRenderingFormat.ShortType, AppendShortType},
-                                                                                                        {ExceptionRenderingFormat.ToString, AppendToString},
-                                                                                                        {ExceptionRenderingFormat.Method, AppendMethod},
-                                                                                                        {ExceptionRenderingFormat.StackTrace, AppendStackTrace},
-                                                                                                        {ExceptionRenderingFormat.Data, AppendData}
-                                                                                                    };
+        private readonly Dictionary<ExceptionRenderingFormat, Action<StringBuilder, Exception>> _renderingfunctions;
 
         private static readonly Dictionary<String, ExceptionRenderingFormat> _formatsMapping = new Dictionary<string, ExceptionRenderingFormat>(StringComparer.OrdinalIgnoreCase)
                                                                                                     {
@@ -83,6 +74,17 @@ namespace NLog.LayoutRenderers
             this.Separator = " ";
             this.InnerExceptionSeparator = EnvironmentHelper.NewLine;
             this.MaxInnerExceptionLevel = 0;
+
+            _renderingfunctions = new Dictionary<ExceptionRenderingFormat, Action<StringBuilder, Exception>>() 
+                                                                                                    {
+                                                                                                        {ExceptionRenderingFormat.Message, AppendMessage}, 
+                                                                                                        {ExceptionRenderingFormat.Type, AppendType},
+                                                                                                        {ExceptionRenderingFormat.ShortType, AppendShortType},
+                                                                                                        {ExceptionRenderingFormat.ToString, AppendToString},
+                                                                                                        {ExceptionRenderingFormat.Method, AppendMethod},
+                                                                                                        {ExceptionRenderingFormat.StackTrace, AppendStackTrace},
+                                                                                                        {ExceptionRenderingFormat.Data, AppendData}
+                                                                                                    };
         }
 
         /// <summary>
@@ -225,7 +227,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="ex">The exception containing the Message to append.</param>        
-        private static void AppendMessage(StringBuilder sb, Exception ex)
+        protected virtual void AppendMessage(StringBuilder sb, Exception ex)
         {
             try
             {
@@ -248,7 +250,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="ex">The Exception whose method name should be appended.</param>        
-        private static void AppendMethod(StringBuilder sb, Exception ex)
+        protected virtual void AppendMethod(StringBuilder sb, Exception ex)
         {
 #if SILVERLIGHT
             sb.Append(ParseMethodNameFromStackTrace(ex.StackTrace));
@@ -265,7 +267,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="ex">The Exception whose stack trace should be appended.</param>        
-        private static void AppendStackTrace(StringBuilder sb, Exception ex)
+        protected virtual void AppendStackTrace(StringBuilder sb, Exception ex)
         {
             sb.Append(ex.StackTrace);
         }
@@ -275,7 +277,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="ex">The Exception whose call to ToString() should be appended.</param>       
-        private static void AppendToString(StringBuilder sb, Exception ex)
+        protected virtual void AppendToString(StringBuilder sb, Exception ex)
         {
             sb.Append(ex.ToString());
         }
@@ -285,7 +287,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="ex">The Exception whose type should be appended.</param>        
-        private static void AppendType(StringBuilder sb, Exception ex)
+        protected virtual void AppendType(StringBuilder sb, Exception ex)
         {
             sb.Append(ex.GetType().FullName);
         }
@@ -295,7 +297,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="ex">The Exception whose short type should be appended.</param>
-        private static void AppendShortType(StringBuilder sb, Exception ex)
+        protected virtual void AppendShortType(StringBuilder sb, Exception ex)
         {
             sb.Append(ex.GetType().Name);
         }
@@ -305,7 +307,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="ex">The Exception whose Data property elements should be appended.</param>
-        private static void AppendData(StringBuilder sb, Exception ex)
+        protected virtual void AppendData(StringBuilder sb, Exception ex)
         {
             string separator = string.Empty;
             foreach (var key in ex.Data.Keys)

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -52,9 +52,16 @@ namespace NLog.LayoutRenderers
     {
         private string format;
         private string innerFormat = string.Empty;
-        private ExceptionDataTarget[] exceptionDataTargets;
-        private ExceptionDataTarget[] innerExceptionDataTargets;
-        
+        private Dictionary<ExceptionRenderingFormat, Action<StringBuilder, Exception>> _functions = new Dictionary<ExceptionRenderingFormat, Action<StringBuilder, Exception>>() {
+                                                                                                        {ExceptionRenderingFormat.Message, AppendMessage}, 
+                                                                                                        {ExceptionRenderingFormat.Type, AppendType},
+                                                                                                        {ExceptionRenderingFormat.ShortType, AppendShortType},
+                                                                                                        {ExceptionRenderingFormat.ToString, AppendToString},
+                                                                                                        {ExceptionRenderingFormat.Method, AppendMethod},
+                                                                                                        {ExceptionRenderingFormat.StackTrace, AppendStackTrace},
+                                                                                                        {ExceptionRenderingFormat.Data, AppendData}
+                                                                                                    };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ExceptionLayoutRenderer" /> class.
         /// </summary>
@@ -65,8 +72,6 @@ namespace NLog.LayoutRenderers
             this.InnerExceptionSeparator = EnvironmentHelper.NewLine;
             this.MaxInnerExceptionLevel = 0;
         }
-
-        private delegate void ExceptionDataTarget(StringBuilder sb, Exception ex);
 
         /// <summary>
         /// Gets or sets the format of the output. Must be a comma-separated list of exception
@@ -85,7 +90,7 @@ namespace NLog.LayoutRenderers
             set
             {
                 this.format = value;
-                this.exceptionDataTargets = CompileFormat(value);
+                Formats = CompileFormat(value);
             }
         }
 
@@ -105,7 +110,7 @@ namespace NLog.LayoutRenderers
             set
             {
                 this.innerFormat = value;
-                this.innerExceptionDataTargets = CompileFormat(value);
+                InnerFormats = CompileFormat(value);
             }
         }
 
@@ -131,6 +136,26 @@ namespace NLog.LayoutRenderers
         public string InnerExceptionSeparator { get; set; }
 
         /// <summary>
+        ///  Gets the formats of the output of inner exceptions to be rendered in target.
+        /// </summary>
+        /// <docgen category='Rendering Options' order='10' />
+        public List<ExceptionRenderingFormat> Formats
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        ///  Gets the formats of the output to be rendered in target.
+        /// </summary>
+        /// <docgen category='Rendering Options' order='10' />
+        public List<ExceptionRenderingFormat> InnerFormats
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
         /// Renders the specified exception information and appends it to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
@@ -142,13 +167,13 @@ namespace NLog.LayoutRenderers
                 var sb2 = new StringBuilder(128);
                 string separator = string.Empty;
 
-                foreach (ExceptionDataTarget targetRenderFunc in this.exceptionDataTargets)
+                foreach (ExceptionRenderingFormat renderingFormat in this.Formats)
                 {
                     sb2.Append(separator);
-                    targetRenderFunc(sb2, logEvent.Exception);
+                    _functions[renderingFormat](sb2, logEvent.Exception);
+
                     separator = this.Separator;
                 }
-
                 Exception currentException = logEvent.Exception.InnerException;
                 int currentLevel = 0;
                 while (currentException != null && currentLevel < this.MaxInnerExceptionLevel)
@@ -157,10 +182,10 @@ namespace NLog.LayoutRenderers
                     sb2.Append(this.InnerExceptionSeparator);
 
                     separator = string.Empty;
-                    foreach (ExceptionDataTarget targetRenderFunc in this.innerExceptionDataTargets ?? this.exceptionDataTargets)
+                    foreach (ExceptionRenderingFormat renderingFormat in this.InnerFormats ?? this.Formats)
                     {
                         sb2.Append(separator);
-                        targetRenderFunc(sb2, currentException);
+                        _functions[renderingFormat](sb2, currentException);
                         separator = this.Separator;
                     }
 
@@ -176,8 +201,8 @@ namespace NLog.LayoutRenderers
         /// Appends the Message of an Exception to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="ex">The exception containing the Message to append.</param>
-        protected virtual void AppendMessage(StringBuilder sb, Exception ex)
+        /// <param name="ex">The exception containing the Message to append.</param>        
+        private static void AppendMessage(StringBuilder sb, Exception ex)
         {
             try
             {
@@ -199,8 +224,8 @@ namespace NLog.LayoutRenderers
         /// Appends the method name from Exception's stack trace to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="ex">The Exception whose method name should be appended.</param>
-        protected virtual void AppendMethod(StringBuilder sb, Exception ex)
+        /// <param name="ex">The Exception whose method name should be appended.</param>        
+        private static void AppendMethod(StringBuilder sb, Exception ex)
         {
 #if SILVERLIGHT
             sb.Append(ParseMethodNameFromStackTrace(ex.StackTrace));
@@ -216,8 +241,8 @@ namespace NLog.LayoutRenderers
         /// Appends the stack trace from an Exception to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="ex">The Exception whose stack trace should be appended.</param>
-        protected virtual void AppendStackTrace(StringBuilder sb, Exception ex)
+        /// <param name="ex">The Exception whose stack trace should be appended.</param>        
+        private static void AppendStackTrace(StringBuilder sb, Exception ex)
         {
             sb.Append(ex.StackTrace);
         }
@@ -226,8 +251,8 @@ namespace NLog.LayoutRenderers
         /// Appends the result of calling ToString() on an Exception to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="ex">The Exception whose call to ToString() should be appended.</param>
-        protected virtual void AppendToString(StringBuilder sb, Exception ex)
+        /// <param name="ex">The Exception whose call to ToString() should be appended.</param>       
+        private static void AppendToString(StringBuilder sb, Exception ex)
         {
             sb.Append(ex.ToString());
         }
@@ -236,8 +261,8 @@ namespace NLog.LayoutRenderers
         /// Appends the type of an Exception to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="ex">The Exception whose type should be appended.</param>
-        protected virtual void AppendType(StringBuilder sb, Exception ex)
+        /// <param name="ex">The Exception whose type should be appended.</param>        
+        private static void AppendType(StringBuilder sb, Exception ex)
         {
             sb.Append(ex.GetType().FullName);
         }
@@ -247,7 +272,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="ex">The Exception whose short type should be appended.</param>
-        protected virtual void AppendShortType(StringBuilder sb, Exception ex)
+        private static void AppendShortType(StringBuilder sb, Exception ex)
         {
             sb.Append(ex.GetType().Name);
         }
@@ -257,7 +282,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="ex">The Exception whose Data property elements should be appended.</param>
-        protected virtual void AppendData(StringBuilder sb, Exception ex)
+        private static void AppendData(StringBuilder sb, Exception ex)
         {
             string separator = string.Empty;
             foreach (var key in ex.Data.Keys)
@@ -268,52 +293,54 @@ namespace NLog.LayoutRenderers
             }
         }
 
-        private ExceptionDataTarget[] CompileFormat(string formatSpecifier)
+        /// <summary>
+        /// Split the string and then compile into list of Rendering formats.
+        /// </summary>
+        /// <param name="formatSpecifier"></param>
+        /// <returns></returns>
+        private List<ExceptionRenderingFormat> CompileFormat(string formatSpecifier)
         {
+            List<ExceptionRenderingFormat> formats = new List<ExceptionRenderingFormat>();
             string[] parts = formatSpecifier.Replace(" ", string.Empty).Split(',');
-            var dataTargets = new List<ExceptionDataTarget>();
 
             foreach (string s in parts)
             {
+                ExceptionRenderingFormat renderingFormat;
+
                 switch (s.ToUpper(CultureInfo.InvariantCulture))
                 {
                     case "MESSAGE":
-                        dataTargets.Add(AppendMessage);
+                        renderingFormat = ExceptionRenderingFormat.Message;
                         break;
-
                     case "TYPE":
-                        dataTargets.Add(AppendType);
+                        renderingFormat = ExceptionRenderingFormat.Type;
                         break;
-
                     case "SHORTTYPE":
-                        dataTargets.Add(AppendShortType);
+                        renderingFormat = ExceptionRenderingFormat.ShortType;
                         break;
-
                     case "TOSTRING":
-                        dataTargets.Add(AppendToString);
+                        renderingFormat = ExceptionRenderingFormat.ToString;
                         break;
-
                     case "METHOD":
-                        dataTargets.Add(AppendMethod);
+                        renderingFormat = ExceptionRenderingFormat.Method;
                         break;
-
                     case "STACKTRACE":
-                        dataTargets.Add(AppendStackTrace);
+                        renderingFormat = ExceptionRenderingFormat.StackTrace;
                         break;
-
                     case "DATA":
-                        dataTargets.Add(AppendData);
+                        renderingFormat = ExceptionRenderingFormat.Data;
                         break;
-
                     default:
                         InternalLogger.Warn("Unknown exception data target: {0}", s);
+                        renderingFormat = ExceptionRenderingFormat.NotSet;
                         break;
                 }
+                if (renderingFormat != ExceptionRenderingFormat.NotSet)
+                    formats.Add(renderingFormat);
+
             }
-
-            return dataTargets.ToArray();
+            return formats;
         }
-
 #if SILVERLIGHT
         /// <summary>
         /// Find name of method on stracktrace.

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Config\ConfigurationItemCreator.cs" />
     <Compile Include="Config\ConfigurationItemFactory.cs" />
     <Compile Include="Config\DefaultParameterAttribute.cs" />
+    <Compile Include="Config\ExceptionRenderingFormat.cs" />
     <Compile Include="Config\Factory.cs" />
     <Compile Include="Config\IFactory.cs" />
     <Compile Include="Config\IInstallable.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Config\ConfigurationItemCreator.cs" />
     <Compile Include="Config\ConfigurationItemFactory.cs" />
     <Compile Include="Config\DefaultParameterAttribute.cs" />
+    <Compile Include="Config\ExceptionRenderingFormat.cs" />
     <Compile Include="Config\Factory.cs" />
     <Compile Include="Config\IFactory.cs" />
     <Compile Include="Config\IInstallable.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Config\ConfigurationItemCreator.cs" />
     <Compile Include="Config\ConfigurationItemFactory.cs" />
     <Compile Include="Config\DefaultParameterAttribute.cs" />
+    <Compile Include="Config\ExceptionRenderingFormat.cs" />
     <Compile Include="Config\Factory.cs" />
     <Compile Include="Config\IFactory.cs" />
     <Compile Include="Config\IInstallable.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Config\ConfigurationItemCreator.cs" />
     <Compile Include="Config\ConfigurationItemFactory.cs" />
     <Compile Include="Config\DefaultParameterAttribute.cs" />
+    <Compile Include="Config\ExceptionRenderingFormat.cs" />
     <Compile Include="Config\Factory.cs" />
     <Compile Include="Config\IFactory.cs" />
     <Compile Include="Config\IInstallable.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Config\ConfigurationItemCreator.cs" />
     <Compile Include="Config\ConfigurationItemFactory.cs" />
     <Compile Include="Config\DefaultParameterAttribute.cs" />
+    <Compile Include="Config\ExceptionRenderingFormat.cs" />
     <Compile Include="Config\Factory.cs" />
     <Compile Include="Config\IFactory.cs" />
     <Compile Include="Config\IInstallable.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Config\ConfigurationItemCreator.cs" />
     <Compile Include="Config\ConfigurationItemFactory.cs" />
     <Compile Include="Config\DefaultParameterAttribute.cs" />
+    <Compile Include="Config\ExceptionRenderingFormat.cs" />
     <Compile Include="Config\Factory.cs" />
     <Compile Include="Config\IFactory.cs" />
     <Compile Include="Config\IInstallable.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -96,6 +97,7 @@
     <Compile Include="Config\ConfigurationItemCreator.cs" />
     <Compile Include="Config\ConfigurationItemFactory.cs" />
     <Compile Include="Config\DefaultParameterAttribute.cs" />
+    <Compile Include="Config\ExceptionRenderingFormat.cs" />
     <Compile Include="Config\Factory.cs" />
     <Compile Include="Config\IFactory.cs" />
     <Compile Include="Config\IInstallable.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Config\ConfigurationItemCreator.cs" />
     <Compile Include="Config\ConfigurationItemFactory.cs" />
     <Compile Include="Config\DefaultParameterAttribute.cs" />
+    <Compile Include="Config\ExceptionRenderingFormat.cs" />
     <Compile Include="Config\Factory.cs" />
     <Compile Include="Config\IFactory.cs" />
     <Compile Include="Config\IInstallable.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Config\ConfigurationItemCreator.cs" />
     <Compile Include="Config\ConfigurationItemFactory.cs" />
     <Compile Include="Config\DefaultParameterAttribute.cs" />
+    <Compile Include="Config\ExceptionRenderingFormat.cs" />
     <Compile Include="Config\Factory.cs" />
     <Compile Include="Config\IFactory.cs" />
     <Compile Include="Config\IInstallable.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Config\ConfigurationItemCreator.cs" />
     <Compile Include="Config\ConfigurationItemFactory.cs" />
     <Compile Include="Config\DefaultParameterAttribute.cs" />
+    <Compile Include="Config\ExceptionRenderingFormat.cs" />
     <Compile Include="Config\Factory.cs" />
     <Compile Include="Config\IFactory.cs" />
     <Compile Include="Config\IInstallable.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Config\ConfigurationItemCreator.cs" />
     <Compile Include="Config\ConfigurationItemFactory.cs" />
     <Compile Include="Config\DefaultParameterAttribute.cs" />
+    <Compile Include="Config\ExceptionRenderingFormat.cs" />
     <Compile Include="Config\Factory.cs" />
     <Compile Include="Config\IFactory.cs" />
     <Compile Include="Config\IInstallable.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Config\ConfigurationItemCreator.cs" />
     <Compile Include="Config\ConfigurationItemFactory.cs" />
     <Compile Include="Config\DefaultParameterAttribute.cs" />
+    <Compile Include="Config\ExceptionRenderingFormat.cs" />
     <Compile Include="Config\Factory.cs" />
     <Compile Include="Config\IFactory.cs" />
     <Compile Include="Config\IInstallable.cs" />

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -622,14 +622,14 @@ namespace NLog.UnitTests.LayoutRenderers
             // Obsolete method requires testing until completely removed.
             logger.ErrorException("msg", ex);
             AssertDebugLastMessage("debug1", "InvalidOperationException Wrapper2" + EnvironmentHelper.NewLine +
-                "InvalidOperationException Wrapper1" + EnvironmentHelper.NewLine +
-                "InvalidOperationException Test exception");
+                "Wrapper1" + EnvironmentHelper.NewLine +
+                "Test exception");
 #pragma warning restore 0618
 
             logger.Error(ex, "msg");
             AssertDebugLastMessage("debug1", "InvalidOperationException Wrapper2" + EnvironmentHelper.NewLine +
-                "InvalidOperationException Wrapper1" + EnvironmentHelper.NewLine +
-                "InvalidOperationException Test exception");
+                "Wrapper1" + EnvironmentHelper.NewLine +
+                "Test exception");
 
             var t = (DebugTarget)LogManager.Configuration.AllTargets[0];
             var elr = ((SimpleLayout)t.Layout).Renderers[0] as ExceptionLayoutRenderer;
@@ -638,7 +638,7 @@ namespace NLog.UnitTests.LayoutRenderers
             Assert.Equal(ExceptionRenderingFormat.ShortType, elr.Formats[0]);
             Assert.Equal(ExceptionRenderingFormat.Message, elr.Formats[1]);
 
-            Assert.Equal(ExceptionRenderingFormat.Message, elr.Formats[0]);
+            Assert.Equal(ExceptionRenderingFormat.Message, elr.InnerFormats[0]);
         }
     }
 }


### PR DESCRIPTION
* Added enums so that the API can set with enums instead of strings.
* Converted all delegates to action delegates.

fixes #1016