### PR TITLE
Issue #550 - Use file creation time instead of last write time

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -61,7 +61,7 @@ namespace NLog.Internal.FileAppenders
             this.CreateFileParameters = createParameters;
             this.FileName = fileName;
             this.OpenTime = DateTime.UtcNow; // to be consistent with timeToKill in FileTarget.AutoClosingTimerCallback
-            this.LastWriteTime = DateTime.MinValue;
+            this.CreationTime = DateTime.MinValue;
         }
 
         /// <summary>
@@ -71,10 +71,13 @@ namespace NLog.Internal.FileAppenders
         public string FileName { get; private set; }
 
         /// <summary>
-        /// Gets the last write time.
+        /// Gets the file creation time.
         /// </summary>
-        /// <value>The last write time. DateTime value must be of UTC kind.</value>
-        public DateTime LastWriteTime { get; private set; }
+        /// <value>The file creation time. DateTime value must be of UTC kind.</value>
+        public DateTime CreationTime
+        {
+           get; private set;
+        }
 
         /// <summary>
         /// Gets the open time of the file.
@@ -107,10 +110,10 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Gets the file info.
         /// </summary>
-        /// <param name="lastWriteTime">The last file write time. The value must be of UTC kind.</param>
+        /// <param name="creationTime">The file creation time. The value must be of UTC kind.</param>
         /// <param name="fileLength">Length of the file in bytes.</param>
         /// <returns>True if the operation succeeded, false otherwise.</returns>
-        public abstract bool GetFileInfo(out DateTime lastWriteTime, out long fileLength);
+        public abstract bool GetFileInfo(out DateTime creationTime, out long fileLength);
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
@@ -131,24 +134,6 @@ namespace NLog.Internal.FileAppenders
             {
                 this.Close();
             }
-        }
-
-        /// <summary>
-        /// Records the last write time for a file.
-        /// </summary>
-        protected void FileTouched()
-        {
-            // always use system time in UTC to be consistent with FileInfo.LastWriteTimeUtc
-            this.LastWriteTime = DateTime.UtcNow;
-        }
-
-        /// <summary>
-        /// Records the last write time for a file to be specific date.
-        /// </summary>
-        /// <param name="dateTime">Date and time when the last write occurred. The value must be of UTC kind.</param>
-        protected void FileTouched(DateTime dateTime)
-        {
-            this.LastWriteTime = dateTime;
         }
 
         /// <summary>
@@ -263,6 +248,8 @@ namespace NLog.Internal.FileAppenders
                 fileShare |= FileShare.Delete;
             }
 
+            UpdateCreationTime();
+
 #if !SILVERLIGHT && !MONO && !__IOS__ && !__ANDROID__
             try
             {
@@ -283,6 +270,23 @@ namespace NLog.Internal.FileAppenders
                 FileAccess.Write,
                 fileShare,
                 this.CreateFileParameters.BufferSize);
+        }
+
+        /// <summary>
+        /// If the file exists retrieve the creation time, otherwise create a new log file and set the creation time.
+        /// </summary>
+        private void UpdateCreationTime()
+        {
+           if( !File.Exists(this.FileName) )
+           {
+              this.CreationTime = DateTime.UtcNow;
+              File.Create(this.FileName).Dispose();
+              File.SetCreationTimeUtc(this.FileName, this.CreationTime);
+           }
+           else
+           {
+              this.CreationTime = File.GetCreationTimeUtc(this.FileName);
+           }
         }
     }
 }

--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -280,12 +280,18 @@ namespace NLog.Internal.FileAppenders
            if( !File.Exists(this.FileName) )
            {
               this.CreationTime = DateTime.UtcNow;
+#if !SILVERLIGHT
               File.Create(this.FileName).Dispose();
               File.SetCreationTimeUtc(this.FileName, this.CreationTime);
-           }
-           else
+#endif
+         }
+         else
            {
+#if !SILVERLIGHT
               this.CreationTime = File.GetCreationTimeUtc(this.FileName);
+#else
+              this.CreationTime = File.GetCreationTime( this.FileName );
+#endif
            }
         }
     }

--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -62,16 +62,10 @@ namespace NLog.Internal.FileAppenders
             var fi = new FileInfo(fileName);
             if (fi.Exists)
             {
-#if !SILVERLIGHT
-                this.FileTouched(fi.LastWriteTimeUtc);
-#else
-                this.FileTouched(fi.LastWriteTime);
-#endif
                 this.currentFileLength = fi.Length;
             }
             else
             {
-                this.FileTouched();
                 this.currentFileLength = 0;
             }
 
@@ -101,18 +95,17 @@ namespace NLog.Internal.FileAppenders
             }
 
             this.file.Flush();
-            this.FileTouched();
         }
 
         /// <summary>
         /// Gets the file info.
         /// </summary>
-        /// <param name="lastWriteTime">The last file write time. The value must be of UTC kind.</param>
+        /// <param name="creationTime">The file creation time. The value must be of UTC kind.</param>
         /// <param name="fileLength">Length of the file.</param>
         /// <returns>True if the operation succeeded, false otherwise.</returns>
-        public override bool GetFileInfo(out DateTime lastWriteTime, out long fileLength)
+        public override bool GetFileInfo(out DateTime creationTime, out long fileLength)
         {
-            lastWriteTime = this.LastWriteTime;
+            creationTime = this.CreationTime;
             fileLength = this.currentFileLength;
             return true;
         }
@@ -130,7 +123,6 @@ namespace NLog.Internal.FileAppenders
 
             this.currentFileLength += bytes.Length;
             this.file.Write(bytes, 0, bytes.Length);
-            this.FileTouched();
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -239,10 +239,10 @@ namespace NLog.Internal.FileAppenders
         /// Gets the file info for a particular appender.
         /// </summary>
         /// <param name="fileName">The file name associated with a particular appender.</param>
-        /// <param name="lastWriteTime">The last file write time. The value must be of UTC kind.</param>
+        /// <param name="creationTime">The file creation time. The value must be of UTC kind.</param>
         /// <param name="fileLength">Length of the file.</param>
         /// <returns><see langword="true"/> when the operation succeeded; <see langword="false"/> otherwise.</returns>
-        public bool GetFileInfo(string fileName, out DateTime lastWriteTime, out long fileLength)
+        public bool GetFileInfo(string fileName, out DateTime creationTime, out long fileLength)
         {
             foreach (BaseFileAppender appender in appenders)
             {
@@ -253,14 +253,14 @@ namespace NLog.Internal.FileAppenders
 
                 if (appender.FileName == fileName)
                 {
-                    appender.GetFileInfo(out lastWriteTime, out fileLength);
+                    appender.GetFileInfo(out creationTime, out fileLength);
                     return true;
                 }
             }
 
             // Return default values.
             fileLength = -1;
-            lastWriteTime = DateTime.MinValue;
+            creationTime = DateTime.MinValue;
             return false;
         }
 

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -121,7 +121,6 @@ namespace NLog.Internal.FileAppenders
                 this.file.Seek(0, SeekOrigin.End);
                 this.file.Write(bytes, 0, bytes.Length);
                 this.file.Flush();
-                FileTouched();
             }
             finally
             {
@@ -147,7 +146,6 @@ namespace NLog.Internal.FileAppenders
 
             this.mutex = null;
             this.file = null;
-            FileTouched();
         }
 
         /// <summary>
@@ -161,15 +159,15 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Gets the file info.
         /// </summary>
-        /// <param name="lastWriteTime">The last file write time. The value must be of UTC kind.</param>
+        /// <param name="creationTime">The file creation time. The value must be of UTC kind.</param>
         /// <param name="fileLength">Length of the file.</param>
         /// <returns>
         /// True if the operation succeeded, false otherwise.
         /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Runtime.InteropServices.SafeHandle.DangerousGetHandle", Justification = "Optimization")]
-        public override bool GetFileInfo(out DateTime lastWriteTime, out long fileLength)
+        public override bool GetFileInfo(out DateTime creationTime, out long fileLength)
         {
-            return FileInfoHelper.Helper.GetFileInfo(FileName, this.file.SafeFileHandle.DangerousGetHandle(), out lastWriteTime, out fileLength);
+            return FileInfoHelper.Helper.GetFileInfo(FileName, this.file.SafeFileHandle.DangerousGetHandle(), out creationTime, out fileLength);
         }
 
         private static Mutex CreateSharableMutex(string name)

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -66,8 +66,6 @@ namespace NLog.Internal.FileAppenders
             {
                 fileStream.Write(bytes, 0, bytes.Length);
             }
-
-            FileTouched();
         }
 
         /// <summary>
@@ -89,28 +87,28 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Gets the file info.
         /// </summary>
-        /// <param name="lastWriteTime">The last file write time. The value must be of UTC kind.</param>
+        /// <param name="creationTime">The file creation time. The value must be of UTC kind.</param>
         /// <param name="fileLength">Length of the file.</param>
         /// <returns>
         /// True if the operation succeeded, false otherwise.
         /// </returns>
-        public override bool GetFileInfo(out DateTime lastWriteTime, out long fileLength)
+        public override bool GetFileInfo(out DateTime creationTime, out long fileLength)
         {
             FileInfo fi = new FileInfo(FileName);
             if (fi.Exists)
             {
                 fileLength = fi.Length;
 #if !SILVERLIGHT
-                lastWriteTime = fi.LastWriteTimeUtc;
+                creationTime = fi.CreationTimeUtc;
 #else
-                lastWriteTime = fi.LastWriteTime;
+                creationTime = fi.CreationTime;
 #endif
                 return true;
             }
             else
             {
                 fileLength = -1;
-                lastWriteTime = DateTime.MinValue;
+                creationTime = DateTime.MinValue;
                 return false;
             }
         }

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -56,19 +56,6 @@ namespace NLog.Internal.FileAppenders
         /// <param name="parameters">The parameters.</param>
         public SingleProcessFileAppender(string fileName, ICreateFileParameters parameters) : base(fileName, parameters)
         {
-            var fi = new FileInfo(fileName);
-            if (fi.Exists)
-            {
-#if !SILVERLIGHT
-                this.FileTouched(fi.LastWriteTimeUtc);
-#else
-                this.FileTouched(fi.LastWriteTime);
-#endif
-            }
-            else
-            {
-                this.FileTouched();
-            }
             this.file = CreateFileStream(false);
         }
 
@@ -84,7 +71,6 @@ namespace NLog.Internal.FileAppenders
             }
 
             this.file.Write(bytes, 0, bytes.Length);
-            FileTouched();
         }
 
         /// <summary>
@@ -98,7 +84,6 @@ namespace NLog.Internal.FileAppenders
             }
 
             this.file.Flush();
-            FileTouched();
         }
 
         /// <summary>
@@ -119,22 +104,22 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Gets the file info.
         /// </summary>
-        /// <param name="lastWriteTime">The last file write time. The value must be of UTC kind.</param>
+        /// <param name="creationTime">The file creation time. The value must be of UTC kind.</param>
         /// <param name="fileLength">Length of the file.</param>
         /// <returns>
         /// True if the operation succeeded, false otherwise.
         /// </returns>
-        public override bool GetFileInfo(out DateTime lastWriteTime, out long fileLength)
+        public override bool GetFileInfo(out DateTime creationTime, out long fileLength)
         {
             if (file != null)
             {
-                lastWriteTime = LastWriteTime;
+                creationTime = CreationTime;
                 fileLength = file.Length;
                 return true;
             }
             else
             {
-                lastWriteTime = new DateTime();
+                creationTime = new DateTime();
                 fileLength = 0;
                 return false;
             }

--- a/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
@@ -108,7 +108,6 @@ namespace NLog.Internal.FileAppenders
             if (this.file == null)
                 return;
             this.file.Write(bytes, 0, bytes.Length);
-            FileTouched();
         }
 
         public override void Close()
@@ -118,7 +117,6 @@ namespace NLog.Internal.FileAppenders
             InternalLogger.Trace("Closing '{0}'", FileName);
             this.file.Close();
             this.file = null;
-            FileTouched();
         }
 
         public override void Flush()
@@ -126,19 +124,19 @@ namespace NLog.Internal.FileAppenders
             // do nothing, the stream is always flushed
         }
 
-        public override bool GetFileInfo(out DateTime lastWriteTime, out long fileLength)
+        public override bool GetFileInfo(out DateTime creationTime, out long fileLength)
         {
             FileInfo fi = new FileInfo(FileName);
             if (fi.Exists)
             {
                 fileLength = fi.Length;
-                lastWriteTime = fi.LastWriteTime;
+                creationTime = fi.CreationTime;
                 return true;
             }
             else
             {
                 fileLength = -1;
-                lastWriteTime = DateTime.MinValue;
+                creationTime = DateTime.MinValue;
                 return false;
             }
         }

--- a/src/NLog/Internal/FileInfoHelper.cs
+++ b/src/NLog/Internal/FileInfoHelper.cs
@@ -67,9 +67,9 @@ namespace NLog.Internal
         /// </summary>
         /// <param name="fileName">Name of the file.</param>
         /// <param name="fileHandle">The file handle.</param>
-        /// <param name="lastWriteTime">The last write time of the file in UTC.</param>
+        /// <param name="creationTime">The file creation time. The value must be of UTC kind.</param>
         /// <param name="fileLength">Length of the file.</param>
         /// <returns>A value of <c>true</c> if file information was retrieved successfully, <c>false</c> otherwise.</returns>
-        public abstract bool GetFileInfo(string fileName, IntPtr fileHandle, out DateTime lastWriteTime, out long fileLength);
+        public abstract bool GetFileInfo(string fileName, IntPtr fileHandle, out DateTime creationTime, out long fileLength);
     }
 }

--- a/src/NLog/Internal/PortableFileInfoHelper.cs
+++ b/src/NLog/Internal/PortableFileInfoHelper.cs
@@ -46,28 +46,28 @@ namespace NLog.Internal
         /// </summary>
         /// <param name="fileName">Name of the file.</param>
         /// <param name="fileHandle">The file handle.</param>
-        /// <param name="lastWriteTime">The last write time of the file in UTC.</param>
+        /// <param name="creationTime">The file creation time. The value must be of UTC kind.</param>
         /// <param name="fileLength">Length of the file.</param>
         /// <returns>
         /// A value of <c>true</c> if file information was retrieved successfully, <c>false</c> otherwise.
         /// </returns>
-        public override bool GetFileInfo(string fileName, IntPtr fileHandle, out DateTime lastWriteTime, out long fileLength)
+        public override bool GetFileInfo(string fileName, IntPtr fileHandle, out DateTime creationTime, out long fileLength)
         {
             FileInfo fi = new FileInfo(fileName);
             if (fi.Exists)
             {
                 fileLength = fi.Length;
 #if !SILVERLIGHT
-                lastWriteTime = fi.LastWriteTimeUtc;
+                creationTime = fi.CreationTimeUtc;
 #else
-                lastWriteTime = fi.LastWriteTime;
+                creationTime = fi.CreationTime;
 #endif
                 return true;
             }
             else
             {
                 fileLength = -1;
-                lastWriteTime = DateTime.MinValue;
+                creationTime = DateTime.MinValue;
                 return false;
             }
         }

--- a/src/NLog/Internal/Win32FileInfoHelper.cs
+++ b/src/NLog/Internal/Win32FileInfoHelper.cs
@@ -47,24 +47,24 @@ namespace NLog.Internal
         /// </summary>
         /// <param name="fileName">Name of the file.</param>
         /// <param name="fileHandle">The file handle.</param>
-        /// <param name="lastWriteTime">The last write time of the file in UTC.</param>
+        /// <param name="creationTime">The file creation time. The value must be of UTC kind.</param>
         /// <param name="fileLength">Length of the file.</param>
         /// <returns>
         /// A value of <c>true</c> if file information was retrieved successfully, <c>false</c> otherwise.
         /// </returns>
-        public override bool GetFileInfo(string fileName, IntPtr fileHandle, out DateTime lastWriteTime, out long fileLength)
+        public override bool GetFileInfo(string fileName, IntPtr fileHandle, out DateTime creationTime, out long fileLength)
         {
             Win32FileNativeMethods.BY_HANDLE_FILE_INFORMATION fi;
 
             if (Win32FileNativeMethods.GetFileInformationByHandle(fileHandle, out fi))
             {
-                lastWriteTime = DateTime.FromFileTimeUtc(fi.ftLastWriteTime);
+                creationTime = DateTime.FromFileTimeUtc(fi.ftCreationTime);
                 fileLength = fi.nFileSizeLow + (((long)fi.nFileSizeHigh) << 32);
                 return true;
             }
             else
             {
-                lastWriteTime = DateTime.MinValue;
+                creationTime = DateTime.MinValue;
                 fileLength = -1;
                 return false;
             }

--- a/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
+++ b/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
@@ -170,23 +170,23 @@ namespace NLog.UnitTests.Internal.FileAppenders
         [Fact]
         public void FileAppenderCache_GetFileInfo()
         {
-            DateTime lastWriteTime;
+            DateTime creationTime;
             long fileLength;
 
             // Invoke GetFileInfo() on an Empty FileAppenderCache.
             FileAppenderCache emptyCache = FileAppenderCache.Empty;
-            emptyCache.GetFileInfo("file.txt", out lastWriteTime, out fileLength);
+            emptyCache.GetFileInfo("file.txt", out creationTime, out fileLength);
             // Default values will be returned.
-            Assert.True(lastWriteTime == DateTime.MinValue);         
+            Assert.True(creationTime == DateTime.MinValue);         
             Assert.True(fileLength == -1);
 
             IFileAppenderFactory appenderFactory = SingleProcessFileAppender.TheFactory;
             ICreateFileParameters fileTarget = new FileTarget();
             FileAppenderCache cache = new FileAppenderCache(3, appenderFactory, fileTarget);
             // Invoke GetFileInfo() on non-empty FileAppenderCache - Before allocating any appenders. 
-            cache.GetFileInfo("file.txt", out lastWriteTime, out fileLength);
+            cache.GetFileInfo("file.txt", out creationTime, out fileLength);
             // Default values will be returned.
-            Assert.True(lastWriteTime == DateTime.MinValue);
+            Assert.True(creationTime == DateTime.MinValue);
             Assert.True(fileLength == -1);
 
             String tempFile = Path.Combine(
@@ -204,8 +204,8 @@ namespace NLog.UnitTests.Internal.FileAppenders
             //
 
             // File information should be returned.
-            cache.GetFileInfo(tempFile, out lastWriteTime, out fileLength);
-            Assert.False(lastWriteTime == DateTime.MinValue);
+            cache.GetFileInfo(tempFile, out creationTime, out fileLength);
+            Assert.False(creationTime == DateTime.MinValue);
             Assert.True(fileLength == 34);
 
             // Clean up.


### PR DESCRIPTION
FileTarget modified to use file creation time instead of last write time for archival. This is a proposed solution for Issue #550. 

I am not sure if the solution proposed in BaseFileAppender (UpdateCreationTime method) is the most elegant solution, however if the file doesn't exist, I have to create it to be able to set the creation time. If the filestream is opened by TryCreateFileStream, it's not always possible to set the creation time due to FileShare settings. 