### PR TITLE
Fix find calling method on stack trace

### DIFF
--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -117,11 +117,11 @@ namespace NLog
                 return 0;
             var intermediate = stackFrames.Select((f, i) => new {index = i, frame = f});
             intermediate = intermediate.SkipWhile(p => IsNonUserStackFrame(p.frame.GetMethod(), loggerType));
-            var last = intermediate.SkipWhile(p => !IsNonUserStackFrame(p.frame.GetMethod(), loggerType)).FirstOrDefault();
+            var last = intermediate.FirstOrDefault();
 
             if (last != null && last.index > 0)
             {
-                return last.index - 1;
+                return last.index;
             }
             return 0;
 
@@ -160,7 +160,7 @@ namespace NLog
             // skip stack frame if the method declaring type assembly is from hidden assemblies list
             if (SkipAssembly(assembly)) return true;
             // or if that type is the loggerType or one of its subtypes
-            var isNonUserStackFrame = declaringType != null && (loggerType != declaringType && loggerType.IsAssignableFrom(declaringType));
+            var isNonUserStackFrame = (declaringType != null && (loggerType != declaringType && loggerType.IsAssignableFrom(declaringType)));
             return isNonUserStackFrame;
         }
 

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -116,11 +116,11 @@ namespace NLog
                 return 0;
             var intermediate = stackFrames.Select((f, i) => new {index = i, frame = f});
             //find until logger type
-            intermediate = intermediate.SkipWhile(p => !IsLoggerType(p.frame.GetMethod(), loggerType));
+            intermediate = intermediate.SkipWhile(p => !IsLoggerType(p.frame, loggerType));
             //skip to next
             intermediate = intermediate.Skip(1);
             //skip while in "skip" assemlbl
-            intermediate = intermediate.SkipWhile(p => SkipAssembly(p.frame.GetMethod()));
+            intermediate = intermediate.SkipWhile(p => SkipAssembly(p.frame));
             var last = intermediate.FirstOrDefault();
 
             if (last != null)
@@ -134,10 +134,11 @@ namespace NLog
         /// <summary>
         /// Assembly to skip?
         /// </summary>
-        /// <param name="method">get asselmby from this method.</param>
-        /// <returns></returns>
-        private static bool SkipAssembly(MethodBase method)
+        /// <param name="frame">Find assembly via this frame. </param>
+        /// <returns><c>true</c>, we should skip.</returns>
+        private static bool SkipAssembly(StackFrame frame)
         {
+            var method = frame.GetMethod();
             var assembly = method.DeclaringType != null ? method.DeclaringType.Assembly : method.Module.Assembly;
             // skip stack frame if the method declaring type assembly is from hidden assemblies list
             return SkipAssembly(assembly);
@@ -146,12 +147,13 @@ namespace NLog
         /// <summary>
         /// Is this the type of the logger?
         /// </summary>
-        /// <param name="methodBase">get type of this method.</param>
+        /// <param name="frame">get type of this logger in this frame.</param>
         /// <param name="loggerType">Type of the logger.</param>
         /// <returns></returns>
-        private static bool IsLoggerType(MethodBase methodBase, Type loggerType)
+        private static bool IsLoggerType(StackFrame frame, Type loggerType)
         {
-            Type declaringType = methodBase.DeclaringType;
+            var method = frame.GetMethod();
+            Type declaringType = method.DeclaringType;
             var isLoggerType = declaringType != null && loggerType == declaringType;
             return isLoggerType;
         }

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -114,18 +114,21 @@ namespace NLog
         {
             int? firstUserFrame = null;
 
-                for (int i = 0; i < stackTrace.FrameCount; ++i)
-                {
-                    StackFrame frame = stackTrace.GetFrame(i);
-                    MethodBase mb = frame.GetMethod();
+            for (int i = 0; i < stackTrace.FrameCount; ++i)
+            {
+                StackFrame frame = stackTrace.GetFrame(i);
+                MethodBase mb = frame.GetMethod();
                 if (IsNonUserStackFrame(mb, loggerType))
-                        firstUserFrame = i + 1;
-                    else if (firstUserFrame != null)
+                    firstUserFrame = i + 1;
+                else if (firstUserFrame != null)
+                {
+                    //first usercode
                     return firstUserFrame.Value;
                 }
+            }
 
             return 0;
-                    }
+        }
 
         /// <summary>
         ///  Defines whether a stack frame belongs to non-user code
@@ -141,7 +144,7 @@ namespace NLog
         {
             var declaringType = method.DeclaringType;
             // get assembly by declaring type or by module for global methods
-            var assembly = declaringType != null ? declaringType.Assembly : method.Module.Assembly; 
+            var assembly = declaringType != null ? declaringType.Assembly : method.Module.Assembly;
             // skip stack frame if the method declaring type assembly is from hidden assemblies list
             if (SkipAssembly(assembly)) return true;
             // or if that type is the loggerType or one of its subtypes

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -107,7 +107,7 @@ namespace NLog
         ///  Finds first user stack frame in a stack trace
         /// </summary>
         /// <param name="stackTrace">The stack trace of the logging method invocation</param>
-        /// <param name="loggerType">Type of the logger or logger wrapper</param>
+        /// <param name="loggerType">Type of the logger or logger wrapper. This is still Logger if it's a subclass of Logger.</param>
         /// <returns>Index of the first user stack frame or 0 if all stack frames are non-user</returns>
         private static int FindCallingMethodOnStackTrace([NotNull] StackTrace stackTrace, [NotNull] Type loggerType)
         {
@@ -134,7 +134,7 @@ namespace NLog
         /// <summary>
         /// Assembly to skip?
         /// </summary>
-        /// <param name="method"></param>
+        /// <param name="method">get asselmby from this method.</param>
         /// <returns></returns>
         private static bool SkipAssembly(MethodBase method)
         {
@@ -146,14 +146,13 @@ namespace NLog
         /// <summary>
         /// Is this the type of the logger?
         /// </summary>
-        /// <param name="methodBase"></param>
-        /// <param name="loggerType"></param>
+        /// <param name="methodBase">get type of this method.</param>
+        /// <param name="loggerType">Type of the logger.</param>
         /// <returns></returns>
         private static bool IsLoggerType(MethodBase methodBase, Type loggerType)
         {
             Type declaringType = methodBase.DeclaringType;
-            var isLoggerType = declaringType != null && (loggerType == declaringType);
-                //TODO not needed?|| loggerType.IsAssignableFrom(declaringType));
+            var isLoggerType = declaringType != null && loggerType == declaringType;
             return isLoggerType;
         }
 

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -518,6 +518,86 @@ namespace NLog.UnitTests.LayoutRenderers
 
 
         }
+
+
+        #region Compositio unit test
+
+        [Fact]
+        public void When_WrappedInCompsition_Ignore_Wrapper_Methods_In_Callstack()
+        {
+
+            //namespace en name of current method
+            const string currentMethodFullName = "NLog.UnitTests.LayoutRenderers.CallSiteTests.When_WrappedInCompsition_Ignore_Wrapper_Methods_In_Callstack";
+
+            LogManager.Configuration = CreateConfigurationFromString(@"
+           <nlog>
+               <targets><target name='debug' type='Debug' layout='${callsite}|${message}' /></targets>
+               <rules>
+                   <logger name='*' levels='Warn' writeTo='debug' />
+               </rules>
+           </nlog>");
+
+            var logger = LogManager.GetLogger("A");
+            logger.Warn("direct");
+            AssertDebugLastMessage("debug", string.Format("{0}|direct", currentMethodFullName));
+
+            CompositeWrapper wrappedLogger = new CompositeWrapper();
+            wrappedLogger.Log("wrapped");
+            AssertDebugLastMessage("debug", string.Format("{0}|wrapped", currentMethodFullName));
+
+        }
+
+
+
+        public class CompositeWrapper
+        {
+            private readonly MyWrapper wrappedLogger;
+            public CompositeWrapper()
+            {
+                wrappedLogger = new MyWrapper();
+            }
+            public void Log(string what)
+            {
+                wrappedLogger.Log(typeof(CompositeWrapper), what);
+            }
+        }
+
+        public abstract class BaseWrapper
+        {
+            public void Log(string what)
+            {
+                InternalLog(typeof(BaseWrapper), what);
+            }
+
+            public void Log(Type type, string what) //overloaded with type for composition
+            {
+                InternalLog(type, what);
+            }
+
+            protected abstract void InternalLog(Type type, string what);
+        }
+
+        public class MyWrapper : BaseWrapper
+        {
+            private readonly ILogger wrapperLogger;
+
+            public MyWrapper()
+            {
+                wrapperLogger = LogManager.GetLogger("WrappedLogger");
+            }
+
+            protected override void InternalLog(Type type, string what) //added type for composition
+            {
+                LogEventInfo info = new LogEventInfo(LogLevel.Warn, wrapperLogger.Name, what);
+
+                // Provide BaseWrapper as wrapper type.
+                // Expected: UserStackFrame should point to the method that calls a 
+                // method of BaseWrapper.
+                wrapperLogger.Log(type, info);
+            }
+        }
+
+        #endregion
     }
 
 }


### PR DESCRIPTION
Fixed https://github.com/NLog/NLog/issues/1070

TODO:

- [x] check if `loggerType.IsAssignableFrom(declaringType));` isn't needed. Not sure