### PR TITLE
Merge from 4.2.3 (Improve performance of FileTarget, performance GDC)

### DIFF
--- a/src/NLog/GlobalDiagnosticsContext.cs
+++ b/src/NLog/GlobalDiagnosticsContext.cs
@@ -85,7 +85,7 @@ namespace NLog
         /// <param name="item">Item name.</param>
         /// <param name="formatProvider"><see cref="IFormatProvider"/> to use when converting the item's value to a string.</param>
         /// <returns>The value of <paramref name="item"/> as a string, if defined; otherwise <see cref="String.Empty"/>.</returns>
-        public static string Get(string item, IFormatProvider formatProvider) 
+        public static string Get(string item, IFormatProvider formatProvider)
         {
             return ConvertToString(GetObject(item), formatProvider);
         }
@@ -149,7 +149,8 @@ namespace NLog
             if ((formatProvider == null) && (LogManager.Configuration != null))
                 formatProvider = LogManager.Configuration.DefaultCultureInfo;
 
-            return String.Format(formatProvider, "{0}", o);
+            return Convert.ToString(o, formatProvider);
+
         }
     }
 }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -174,6 +174,7 @@ namespace NLog.Targets
             this.maxLogFilenames = 20;
             this.previousFileNames = new Queue<string>(this.maxLogFilenames);
             this.recentAppenders = FileAppenderCache.Empty;
+            this.CleanupFileName = true;
         }
 
         /// <summary>
@@ -212,6 +213,13 @@ namespace NLog.Targets
                 fileName = value;
             }
         }
+
+        /// <summary>
+        /// Cleanup invalid values in a filename, e.g. slashes in a filename. If set to <c>true</c>, this can impact the performance of massive writes. 
+        /// If set to <c>false</c>, nothing gets written when the filename is wrong.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool CleanupFileName { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to create directories if they do not exist.
@@ -1870,8 +1878,14 @@ namespace NLog.Targets
         /// </summary>
         /// <param name="fileName">The original file name which might contain invalid characters.</param>
         /// <returns>The cleaned up file name without any invalid characters.</returns>
-        private static string CleanupInvalidFileNameChars(string fileName)
+        private string CleanupInvalidFileNameChars(string fileName)
         {
+
+            if (!this.CleanupFileName)
+            {
+                return fileName;
+            }
+
 #if !SILVERLIGHT
 
             var lastDirSeparator = fileName.LastIndexOfAny(DirectorySeparatorChars);

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -493,7 +493,7 @@ namespace NLog.Targets
         /// </remarks>
         public void CleanupInitializedFiles()
         {
-            this.CleanupInitializedFiles(DateTime.Now.AddDays(-FileTarget.InitializedFilesCleanupPeriod));
+            this.CleanupInitializedFiles(DateTime.UtcNow.AddDays(-FileTarget.InitializedFilesCleanupPeriod));
         }
 
         /// <summary>
@@ -1642,11 +1642,13 @@ namespace NLog.Targets
 
             if (!justData)
             {
+                //UtcNow is much faster then .now. This was a bottleneck in writing a lot of files after CPU test.
+                var now = DateTime.UtcNow;
                 if (!this.initializedFiles.ContainsKey(fileName))
                 {
                     ProcessOnStartup(fileName, logEvent);
 
-                    this.initializedFiles[fileName] = DateTime.Now;
+                    this.initializedFiles[fileName] = now;
                     this.initializedFilesCounter++;
                     writeHeader = true;
 
@@ -1657,7 +1659,7 @@ namespace NLog.Targets
                     }
                 }
 
-                this.initializedFiles[fileName] = DateTime.Now;
+                this.initializedFiles[fileName] = now;
             }
 
             return writeHeader;

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -80,11 +80,14 @@ namespace NLog.Targets
         /// </summary>
         private readonly static char[] DirectorySeparatorChars = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
 
+#if !SILVERLIGHT
+
         /// <summary>
         /// Cached invalid filenames char array to avoid memory allocation everytime Path.GetInvalidFileNameChars() is called.
         /// </summary>
         private readonly static char[] InvalidFileNameChars = Path.GetInvalidFileNameChars();
 
+#endif 
         /// <summary>
         /// Holds the initialised files each given time by the <see cref="FileTarget"/> instance. Against each file, the last write time is stored. 
         /// </summary>

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -78,7 +78,7 @@ namespace NLog.Targets
         /// <summary>
         /// Cached directory separator char array to avoid memory allocation on each method call.
         /// </summary>
-        private readonly static char[] DirectorySeparatorChar = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        private readonly static char[] DirectorySeparatorChars = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
 
         /// <summary>
         /// Cached invalid filenames char array to avoid memory allocation everytime Path.GetInvalidFileNameChars() is called.
@@ -1833,7 +1833,7 @@ namespace NLog.Targets
         {
 #if !SILVERLIGHT
 
-            var lastDirSeparator = fileName.LastIndexOfAny(DirectorySeparatorChar);
+            var lastDirSeparator = fileName.LastIndexOfAny(DirectorySeparatorChars);
 
             var fileName1 = fileName.Substring(lastDirSeparator + 1);
             var dirName = lastDirSeparator > 0 ? fileName.Substring(0, lastDirSeparator) : string.Empty;


### PR DESCRIPTION
fixes https://github.com/NLog/NLog/issues/1071

Also released in 4.2.3

Changes:
- Improve file writing when file name has fixed name: no layout renderer in filename. 10 secs instead of 34 sec for 10 million. Sync writing with keepFileOpen="true", AutoFlush="false" and ConcurrentWrites="false".
- Changes the performance of GDC toString 
- Added option `CleanupFileName` on filetarget for faster writing when using dynamic (=non-fixed) file name. Default `true` (backwardscompatible)