### PR TITLE
ColoredConsoleTarget performance improvements.

### DIFF
--- a/src/NLog/LogLevel.cs
+++ b/src/NLog/LogLevel.cs
@@ -37,10 +37,13 @@ namespace NLog
 {
     using System;
     using NLog.Internal;
+    using System.ComponentModel;
+    using System.Globalization;
 
     /// <summary>
     /// Defines available log levels.
     /// </summary>
+    [TypeConverter(typeof(LogLevelConverter))]
     public sealed class LogLevel : IComparable, IEquatable<LogLevel>
     {
         /// <summary>
@@ -405,6 +408,40 @@ namespace NLog
 
             LogLevel level = (LogLevel)obj;
             return this.Ordinal - level.Ordinal;
+        }
+    }
+
+
+    internal class LogLevelConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return (sourceType == typeof(string)) || (sourceType == typeof(int)) || (base.CanConvertFrom(context, sourceType));
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string)
+                return LogLevel.FromString((string)value);
+            if (value is int)
+                return LogLevel.FromOrdinal((int)value);
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return (destinationType == typeof(string)) || (destinationType == typeof(int)) || (base.CanConvertTo(context, destinationType));
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+                return value.ToString();
+            if (destinationType == typeof(int))
+                return ((LogLevel)value).Ordinal;
+
+            return base.ConvertTo(context, culture, value, destinationType);
         }
     }
 }

--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -189,6 +189,7 @@ namespace NLog.Targets
 
         private void Output(LogEventInfo logEvent, string message)
         {
+            var consoleStream = this.ErrorStream ? Console.Error : Console.Out;
             ConsoleColor oldForegroundColor = Console.ForegroundColor;
             ConsoleColor oldBackgroundColor = Console.BackgroundColor;
 
@@ -239,7 +240,7 @@ namespace NLog.Targets
                     message = hl.ReplaceWithEscapeSequences(message);
                 }
 
-                ColorizeEscapeSequences(this.ErrorStream ? Console.Error : Console.Out, message, new ColorPair(Console.ForegroundColor, Console.BackgroundColor), new ColorPair(oldForegroundColor, oldBackgroundColor));
+                ColorizeEscapeSequences(consoleStream, message, new ColorPair(Console.ForegroundColor, Console.BackgroundColor), new ColorPair(oldForegroundColor, oldBackgroundColor));
             }
             finally
             {
@@ -247,14 +248,7 @@ namespace NLog.Targets
                 Console.BackgroundColor = oldBackgroundColor;
             }
 
-            if (this.ErrorStream)
-            {
-                Console.Error.WriteLine();
-            }
-            else
-            {
-                Console.WriteLine();
-            }
+            consoleStream.WriteLine();
         }
 
         private static void ColorizeEscapeSequences(

--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -187,6 +187,76 @@ namespace NLog.Targets
             this.Output(logEvent, this.Layout.Render(logEvent));
         }
 
+        private void Output(LogEventInfo logEvent, string message)
+        {
+            ConsoleColor oldForegroundColor = Console.ForegroundColor;
+            ConsoleColor oldBackgroundColor = Console.BackgroundColor;
+
+            try
+            {
+                ConsoleRowHighlightingRule matchingRule = null;
+
+                foreach (ConsoleRowHighlightingRule cr in this.RowHighlightingRules)
+                {
+                    if (cr.CheckCondition(logEvent))
+                    {
+                        matchingRule = cr;
+                        break;
+                    }
+                }
+
+                if (this.UseDefaultRowHighlightingRules && matchingRule == null)
+                {
+                    foreach (ConsoleRowHighlightingRule cr in defaultConsoleRowHighlightingRules)
+                    {
+                        if (cr.CheckCondition(logEvent))
+                        {
+                            matchingRule = cr;
+                            break;
+                        }
+                    }
+                }
+
+                if (matchingRule == null)
+                {
+                    matchingRule = ConsoleRowHighlightingRule.Default;
+                }
+
+                if (matchingRule.ForegroundColor != ConsoleOutputColor.NoChange)
+                {
+                    Console.ForegroundColor = (ConsoleColor)matchingRule.ForegroundColor;
+                }
+
+                if (matchingRule.BackgroundColor != ConsoleOutputColor.NoChange)
+                {
+                    Console.BackgroundColor = (ConsoleColor)matchingRule.BackgroundColor;
+                }
+
+                message = message.Replace("\a", "\a\a");
+
+                foreach (ConsoleWordHighlightingRule hl in this.WordHighlightingRules)
+                {
+                    message = hl.ReplaceWithEscapeSequences(message);
+                }
+
+                ColorizeEscapeSequences(this.ErrorStream ? Console.Error : Console.Out, message, new ColorPair(Console.ForegroundColor, Console.BackgroundColor), new ColorPair(oldForegroundColor, oldBackgroundColor));
+            }
+            finally
+            {
+                Console.ForegroundColor = oldForegroundColor;
+                Console.BackgroundColor = oldBackgroundColor;
+            }
+
+            if (this.ErrorStream)
+            {
+                Console.Error.WriteLine();
+            }
+            else
+            {
+                Console.WriteLine();
+            }
+        }
+
         private static void ColorizeEscapeSequences(
             TextWriter output,
             string message,
@@ -282,76 +352,6 @@ namespace NLog.Targets
             if (p0 < message.Length)
             {
                 output.Write(message.Substring(p0));
-            }
-        }
-
-        private void Output(LogEventInfo logEvent, string message)
-        {
-            ConsoleColor oldForegroundColor = Console.ForegroundColor;
-            ConsoleColor oldBackgroundColor = Console.BackgroundColor;
-
-            try
-            {
-                ConsoleRowHighlightingRule matchingRule = null;
-
-                foreach (ConsoleRowHighlightingRule cr in this.RowHighlightingRules)
-                {
-                    if (cr.CheckCondition(logEvent))
-                    {
-                        matchingRule = cr;
-                        break;
-                    }
-                }
-
-                if (this.UseDefaultRowHighlightingRules && matchingRule == null)
-                {
-                    foreach (ConsoleRowHighlightingRule cr in defaultConsoleRowHighlightingRules)
-                    {
-                        if (cr.CheckCondition(logEvent))
-                        {
-                            matchingRule = cr;
-                            break;
-                        }
-                    }
-                }
-
-                if (matchingRule == null)
-                {
-                    matchingRule = ConsoleRowHighlightingRule.Default;
-                }
-
-                if (matchingRule.ForegroundColor != ConsoleOutputColor.NoChange)
-                {
-                    Console.ForegroundColor = (ConsoleColor)matchingRule.ForegroundColor;
-                }
-
-                if (matchingRule.BackgroundColor != ConsoleOutputColor.NoChange)
-                {
-                    Console.BackgroundColor = (ConsoleColor)matchingRule.BackgroundColor;
-                }
-
-                message = message.Replace("\a", "\a\a");
-
-                foreach (ConsoleWordHighlightingRule hl in this.WordHighlightingRules)
-                {
-                    message = hl.ReplaceWithEscapeSequences(message);
-                }
-
-                ColorizeEscapeSequences(this.ErrorStream ? Console.Error : Console.Out, message, new ColorPair(Console.ForegroundColor, Console.BackgroundColor), new ColorPair(oldForegroundColor, oldBackgroundColor));
-            }
-            finally
-            {
-                Console.ForegroundColor = oldForegroundColor;
-                Console.BackgroundColor = oldBackgroundColor;
-            }
-
-            if (this.ErrorStream)
-            {
-                Console.Error.WriteLine();
-            }
-            else
-            {
-                Console.WriteLine();
             }
         }
 

--- a/src/NLog/Targets/ConsoleRowHighlightingRule.cs
+++ b/src/NLog/Targets/ConsoleRowHighlightingRule.cs
@@ -80,10 +80,16 @@ namespace NLog.Targets
         public static ConsoleRowHighlightingRule Default { get; private set; }
 
         /// <summary>
+        /// Gets or sets the log level that will select the specified foreground and background color.
+        /// This parameter overrides the condition parameter when set.
+        /// </summary>
+        /// <docgen category='Rule Matching Options' order='10' />
+        public LogLevel LogLevel { get; set; }
+
+        /// <summary>
         /// Gets or sets the condition that must be met in order to set the specified foreground and background color.
         /// </summary>
         /// <docgen category='Rule Matching Options' order='10' />
-        [RequiredParameter]
         public ConditionExpression Condition { get; set; }
 
         /// <summary>
@@ -112,6 +118,9 @@ namespace NLog.Targets
         /// </returns>
         public bool CheckCondition(LogEventInfo logEvent)
         {
+            if (this.LogLevel != null)
+                return logEvent.Level == this.LogLevel;
+
             if (this.Condition == null)
             {
                 return true;

--- a/src/NLog/Targets/ConsoleWordHighlightingRule.cs
+++ b/src/NLog/Targets/ConsoleWordHighlightingRule.cs
@@ -97,9 +97,23 @@ namespace NLog.Targets
         public bool IgnoreCase { get; set; }
 
         /// <summary>
+        /// Gets or sets the foreground color.
+        /// </summary>
+        /// <docgen category='Formatting Options' order='10' />
+        [DefaultValue("NoChange")]
+        public ConsoleOutputColor ForegroundColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the background color.
+        /// </summary>
+        /// <docgen category='Formatting Options' order='10' />
+        [DefaultValue("NoChange")]
+        public ConsoleOutputColor BackgroundColor { get; set; }
+
+        /// <summary>
         /// Gets the compiled regular expression that matches either Text or Regex property.
         /// </summary>
-        public Regex CompiledRegex
+        private Regex CompiledRegex
         {
             get
             {
@@ -116,7 +130,7 @@ namespace NLog.Targets
                         }
                     }
 
-                    RegexOptions regexOptions = RegexOptions.Compiled;
+                    RegexOptions regexOptions = RegexOptions.None;
                     if (this.IgnoreCase)
                     {
                         regexOptions |= RegexOptions.IgnoreCase;
@@ -129,21 +143,7 @@ namespace NLog.Targets
             }
         }
 
-        /// <summary>
-        /// Gets or sets the foreground color.
-        /// </summary>
-        /// <docgen category='Formatting Options' order='10' />
-        [DefaultValue("NoChange")]
-        public ConsoleOutputColor ForegroundColor { get; set; }
-
-        /// <summary>
-        /// Gets or sets the background color.
-        /// </summary>
-        /// <docgen category='Formatting Options' order='10' />
-        [DefaultValue("NoChange")]
-        public ConsoleOutputColor BackgroundColor { get; set; }
-
-        internal string MatchEvaluator(Match m)
+        private string MatchEvaluator(Match m)
         {
             StringBuilder result = new StringBuilder();
 


### PR DESCRIPTION
Fixes #980 

Added the `LogLevel` property to `ConsoleRowHighlightingRule` as a faster alternative to the existing `Condition` property. 