### PR TITLE
FileTarget: Fix continuous archiving bug.

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -279,12 +279,13 @@ namespace NLog.Internal.FileAppenders
             else
             {
                 File.Create(this.FileName).Dispose();
+                
 #if !SILVERLIGHT
                 this.CreationTime = DateTime.UtcNow;
+                // Set the file's creation time to avoid being thwarted by Windows' Tunneling capabilities (https://support.microsoft.com/en-us/kb/172190).
                 File.SetCreationTimeUtc(this.FileName, this.CreationTime);
 #else
-                this.CreationTime = DateTime.Now;
-                File.SetCreationTime(this.FileName, this.CreationTime);
+                this.CreationTime = File.GetCreationTime(this.FileName);
 #endif
             }
         }

--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -268,14 +268,25 @@ namespace NLog.Internal.FileAppenders
 
         private void UpdateCreationTime()
         {
-            if (!File.Exists(this.FileName))
-                File.Create(this.FileName).Dispose();
-
+            if (File.Exists(this.FileName))
+            {
 #if !SILVERLIGHT
-            this.CreationTime = File.GetCreationTimeUtc(this.FileName);
+                this.CreationTime = File.GetCreationTimeUtc(this.FileName);
 #else
-            this.CreationTime = File.GetCreationTime(this.FileName);
+                this.CreationTime = File.GetCreationTime(this.FileName);
 #endif
+            }
+            else
+            {
+                File.Create(this.FileName).Dispose();
+#if !SILVERLIGHT
+                this.CreationTime = DateTime.UtcNow;
+                File.SetCreationTimeUtc(this.FileName, this.CreationTime);
+#else
+                this.CreationTime = DateTime.Now;
+                File.SetCreationTime(this.FileName, this.CreationTime);
+#endif
+            }
         }
     }
 }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -658,10 +658,15 @@ namespace NLog.Targets
                 return MutexMultiProcessFileAppender.TheFactory;
 #endif
             }
-            else if (this.ArchiveAboveSize != FileTarget.ArchiveAboveSizeDisabled || this.ArchiveEvery != FileArchivePeriod.None)
-                return CountingSingleProcessFileAppender.TheFactory;
-            else
+            else if (IsArchivingEnabled())
                 return SingleProcessFileAppender.TheFactory;
+            else
+                return CountingSingleProcessFileAppender.TheFactory;
+        }
+
+        private bool IsArchivingEnabled()
+        {
+            return this.ArchiveAboveSize == FileTarget.ArchiveAboveSizeDisabled && this.ArchiveEvery == FileArchivePeriod.None;
         }
 
         /// <summary>

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -634,71 +634,34 @@ namespace NLog.Targets
             {
                 return RetryingMultiProcessFileAppender.TheFactory;
             }
-            else
+            else if (this.NetworkWrites)
             {
-                if (this.ArchiveAboveSize != FileTarget.ArchiveAboveSizeDisabled || this.ArchiveEvery != FileArchivePeriod.None)
-                {
-                    if (this.NetworkWrites)
-                    {
-                        return RetryingMultiProcessFileAppender.TheFactory;
-                    }
-                    else if (this.ConcurrentWrites)
-                    {
+                return RetryingMultiProcessFileAppender.TheFactory;
+            }
+            else if (this.ConcurrentWrites)
+            {
 #if SILVERLIGHT
-                        return RetryingMultiProcessFileAppender.TheFactory;
+                return RetryingMultiProcessFileAppender.TheFactory;
 #elif MONO
-                        //
-                        // mono on Windows uses mutexes, on Unix - special appender
-                        //
-                        if (PlatformDetector.IsUnix)
-                        {
-                            return UnixMultiProcessFileAppender.TheFactory;
-                        }
-                        else
-                        {
-                            return MutexMultiProcessFileAppender.TheFactory;
-                        }
-#else
-                        return MutexMultiProcessFileAppender.TheFactory;
-#endif
-                    }
-                    else
-                    {
-                        return CountingSingleProcessFileAppender.TheFactory;
-                    }
+                //
+                // mono on Windows uses mutexes, on Unix - special appender
+                //
+                if (PlatformDetector.IsUnix)
+                {
+                    return UnixMultiProcessFileAppender.TheFactory;
                 }
                 else
                 {
-                    if (this.NetworkWrites)
-                    {
-                        return RetryingMultiProcessFileAppender.TheFactory;
-                    }
-                    else if (this.ConcurrentWrites)
-                    {
-#if SILVERLIGHT
-                        return RetryingMultiProcessFileAppender.TheFactory;
-#elif MONO
-                        //
-                        // mono on Windows uses mutexes, on Unix - special appender
-                        //
-                        if (PlatformDetector.IsUnix)
-                        {
-                            return UnixMultiProcessFileAppender.TheFactory;
-                        }
-                        else
-                        {
-                            return MutexMultiProcessFileAppender.TheFactory;
-                        }
-#else
-                        return MutexMultiProcessFileAppender.TheFactory;
-#endif
-                    }
-                    else
-                    {
-                        return SingleProcessFileAppender.TheFactory;
-                    }
+                    return MutexMultiProcessFileAppender.TheFactory;
                 }
+#else
+                return MutexMultiProcessFileAppender.TheFactory;
+#endif
             }
+            else if (this.ArchiveAboveSize != FileTarget.ArchiveAboveSizeDisabled || this.ArchiveEvery != FileArchivePeriod.None)
+                return CountingSingleProcessFileAppender.TheFactory;
+            else
+                return SingleProcessFileAppender.TheFactory;
         }
 
         /// <summary>
@@ -752,9 +715,7 @@ namespace NLog.Targets
         protected override void Write(LogEventInfo logEvent)
         {
             var fileName = GetCleanedFileName(logEvent);
-
-
-
+            
             byte[] bytes = this.GetBytesToWrite(logEvent);
 
             if (this.ShouldAutoArchive(fileName, logEvent, bytes.Length))

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -74,8 +74,22 @@ namespace NLog.UnitTests.Targets
                 logger.Debug("Test {0}", currentSequenceNumber);
         }
 
-        [Fact]
-        public void SimpleFileTest1()
+        public static IEnumerable<object[]> SimpleFileTest_TestParameters
+        {
+            get
+            {
+                var booleanValues = new[] { true, false };
+                return
+                    from concurrentWrites in booleanValues
+                    from keepFileOpen in booleanValues
+                    from networkWrites in booleanValues
+                    select new object[] { concurrentWrites, keepFileOpen, networkWrites };
+            }
+        }
+        
+        [Theory]
+        [PropertyData("SimpleFileTest_TestParameters")]
+        public void SimpleFileTest(bool concurrentWrites, bool keepFileOpen, bool networkWrites)
         {
             var tempFile = Path.GetTempFileName();
             try
@@ -85,7 +99,10 @@ namespace NLog.UnitTests.Targets
                                         FileName = SimpleLayout.Escape(tempFile),
                                         LineEnding = LineEndingMode.LF,
                                         Layout = "${level} ${message}",
-                                        OpenFileCacheTimeout = 0
+                                        OpenFileCacheTimeout = 0,
+                                        ConcurrentWrites = concurrentWrites,
+                                        KeepFileOpen = keepFileOpen,
+                                        NetworkWrites = networkWrites
                                     };
 
                 SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
@@ -358,7 +375,7 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
-        public void SequentialArchiveTest1()
+        public void SequentialArchiveTest()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var tempFile = Path.Combine(tempPath, "file.txt");
@@ -420,7 +437,7 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
-        public void SequentialArchiveTest1_MaxArchiveFiles_0()
+        public void SequentialArchiveTest_MaxArchiveFiles_0()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var tempFile = Path.Combine(tempPath, "file.txt");
@@ -486,7 +503,6 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact(Skip = "this is not supported, because we cannot create multiple archive files with  ArchiveNumberingMode.Date (for one day)")]
-
         public void ArchiveAboveSizeWithArchiveNumberingModeDate_maxfiles_o()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), "ArchiveEveryCombinedWithArchiveAboveSize_" + Guid.NewGuid().ToString());

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -686,7 +686,7 @@ namespace NLog.UnitTests.Targets
                     Directory.Delete(tempPath, true);
             }
         }
-
+        
         public static IEnumerable<object[]> DateArchive_UsesDateFromCurrentTimeSource_TestParameters
         {
             get
@@ -702,8 +702,7 @@ namespace NLog.UnitTests.Targets
                     select new object[] { timeKind, concurrentWrites, keepFileOpen, networkWrites, includeSequenceInArchive };
             }
         }
-
-
+        
         [Theory]
         [PropertyData("DateArchive_UsesDateFromCurrentTimeSource_TestParameters")]
         public void DateArchive_UsesDateFromCurrentTimeSource(DateTimeKind timeKind, bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool includeSequenceInArchive)
@@ -804,6 +803,72 @@ namespace NLog.UnitTests.Targets
                 LogManager.Configuration = null;
                 if (File.Exists(tempFile))
                     File.Delete(tempFile);
+                if (Directory.Exists(tempPath))
+                    Directory.Delete(tempPath, true);
+            }
+        }
+
+        public static IEnumerable<object[]> DateArchive_ArchiveOnceOnly_TestParameters
+        {
+            get
+            {
+                var booleanValues = new[] { true, false };
+                return
+                    from concurrentWrites in booleanValues
+                    from keepFileOpen in booleanValues
+                    from networkWrites in booleanValues
+                    from includeSequenceInArchive in booleanValues
+                    where AllowsExternalFileModification(concurrentWrites, keepFileOpen, networkWrites)
+                    select new object[] { concurrentWrites, keepFileOpen, networkWrites, includeSequenceInArchive };
+            }
+        }
+
+        private static bool AllowsExternalFileModification(bool concurrentWrites, bool keepFileOpen, bool networkWrites)
+        {
+            return (concurrentWrites) || (!keepFileOpen) || (networkWrites);
+        }
+
+        [Theory]
+        [PropertyData("DateArchive_ArchiveOnceOnly_TestParameters")]
+        public void DateArchive_ArchiveOnceOnly(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool includeSequenceInArchive)
+        {
+            var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var tempFile = Path.Combine(tempPath, "file.txt");
+            try
+            {
+                var archiveFileNameTemplate = Path.Combine(tempPath, "archive/{#}.txt");
+                var ft = new FileTarget
+                {
+                    FileName = tempFile,
+                    ArchiveFileName = archiveFileNameTemplate,
+                    LineEnding = LineEndingMode.LF,
+                    ArchiveNumbering = includeSequenceInArchive ? ArchiveNumberingMode.DateAndSequence : ArchiveNumberingMode.Date,
+                    ArchiveEvery = FileArchivePeriod.Day,
+                    ArchiveDateFormat = "yyyyMMdd",
+                    Layout = "${message}",
+                    ConcurrentWrites = concurrentWrites,
+                    KeepFileOpen = keepFileOpen,
+                    NetworkWrites = networkWrites
+                };
+                
+                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+
+                logger.Debug("123456789");
+                File.SetCreationTime(tempFile, File.GetCreationTime(tempFile).AddDays(-1));
+                File.SetLastWriteTime(tempFile, File.GetLastWriteTime(tempFile).AddDays(-1));
+                // This should archive the log before logging.
+                logger.Debug("123456789");
+                // This must not archive.
+                logger.Debug("123456789");
+
+                LogManager.Configuration = null;
+                string archivePath = Path.Combine(tempPath, "archive");
+                File.Equals(1, Directory.GetFiles(archivePath).Length);
+                AssertFileContents(tempFile, StringRepeat(2, "123456789\n"), Encoding.UTF8);
+            }
+            finally
+            {
+                LogManager.Configuration = null;
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }


### PR DESCRIPTION
Fixes #1124 

The bug manifested since we were archiving based on the log file's creation time, but it seems to be caused by a strange anomaly with the Windows file system:  
When we archive, the log file is moved to the archive file path. However, when the new log file is created, it ends up having the same creation time of the old log file (which is now archived). 

[Others have observed this behavior](http://stackoverflow.com/questions/33227149/after-deleting-file-and-re-creating-file-not-change-creation-date-in-windows), and it turns out is caused by the [Windows NT Tunneling](https://support.microsoft.com/en-us/kb/172190) capabilities which is meant to facilitate the safe saving mechanism of MS-DOS programs.

The fix is to manually set the creation time of the file when it is created.