### PR TITLE
Reduce Memory Allocations in LongDateLayoutRenderer

### DIFF
--- a/src/NLog/LayoutRenderers/LongDateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LongDateLayoutRenderer.cs
@@ -67,7 +67,7 @@ namespace NLog.LayoutRenderers
                 dt = dt.ToUniversalTime();
             }
 
-            builder.Append(dt.Year);
+            Append4DigitsZeroPadded(builder, dt.Year);
             builder.Append('-');
             Append2DigitsZeroPadded(builder, dt.Month);
             builder.Append('-');


### PR DESCRIPTION
Removes a memory allocation inside StringBuilder when doing **number.ToString()** we can simply reuse existing method to remove allocation.