### PR TITLE
ASP.NET 5 integration (NLog.Framework.logging)

### DIFF
--- a/NLogAdapter.cs
+++ b/NLogAdapter.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Logging;
+using NLog;
+using System;
+
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace NLog.Asp
+{
+    public class NLogAdapter : ILogger
+    {
+        private NLog.ILogger logger;
+
+        public NLogAdapter(string loggerName)
+        {
+            logger = LogManager.GetLogger(loggerName);
+        }
+
+        public IDisposable BeginScopeImpl(object state)
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Verbose:
+                    return logger.IsTraceEnabled;
+                case LogLevel.Debug:
+                    return logger.IsDebugEnabled;
+                case LogLevel.Information:
+                    return logger.IsInfoEnabled;
+                case LogLevel.Warning:
+                    return logger.IsWarnEnabled;
+                case LogLevel.Error:
+                    return logger.IsErrorEnabled;
+                case LogLevel.Critical:
+                    return logger.IsFatalEnabled;
+                default:
+                    throw new ArgumentException($"Unknown log level {logLevel}.", nameof(logLevel));
+            }
+        }
+
+        public void Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+            string message = null;
+            if (null != formatter)
+            {
+                message = formatter(state, exception);
+            }
+            else
+            {
+                message = LogFormatter.Formatter(state, exception);
+            }
+            switch (logLevel)
+            {
+                case LogLevel.Verbose:
+                    logger.Trace(exception, message);
+                    break;
+                case LogLevel.Debug:
+                    logger.Debug(exception, message);
+                    break;
+                case LogLevel.Information:
+                    logger.Info(exception, message);
+                    break;
+                case LogLevel.Warning:
+                    logger.Warn(exception, message);
+                    break;
+                case LogLevel.Error:
+                    logger.Error(exception, message);
+                    break;
+                case LogLevel.Critical:
+                    logger.Fatal(exception, message);
+                    break;
+                default:
+                    logger.Warn($"Encountered unknown log level {logLevel}, writing out as Info.");
+                    logger.Info(exception, message);
+                    break;
+            }
+        }
+    }
+}

--- a/NLogProvider.cs
+++ b/NLogProvider.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+
+namespace NLog.Asp
+{
+    public class NLogProvider : ILoggerProvider
+    {
+        private IDictionary<string, ILogger> loggers = new Dictionary<string, ILogger>();
+
+        public ILogger CreateLogger(string name)
+        {
+            if (!loggers.ContainsKey(name))
+            {
+                lock (loggers)
+                {
+                    // Have to check again since another thread may have gotten the lock first.
+                    if (!loggers.ContainsKey(name))
+                    {
+                        loggers[name] = new NLogAdapter(name);
+                    }
+                }
+            }
+            return loggers[name];
+        }
+
+        public void Dispose()
+        {
+            loggers.Clear();
+            loggers = null;
+        }
+    }
+}

--- a/src/NLog/NLogAspExtensions.cs
+++ b/src/NLog/NLogAspExtensions.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNet.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.PlatformAbstractions;
+using System.IO;
+
+namespace NLog.Asp
+{
+    public static class NLogAspExtensions
+    {
+        public static void ConfigureNLog(this IHostingEnvironment env, string configFileRelativePath)
+        {
+            NLog.LogManager.Configuration = new NLog.Config.XmlLoggingConfiguration(Path.Combine(Directory.GetParent(env.WebRootPath).ToString(), configFileRelativePath), true);
+        }
+
+        public static void ConfigureNLog(this IApplicationEnvironment appEnv, string configFileRelativePath)
+        {
+            NLog.LogManager.Configuration = new NLog.Config.XmlLoggingConfiguration(Path.Combine(appEnv.ApplicationBasePath, configFileRelativePath), true);
+        }
+
+        public static void AddNLog(this ILoggerFactory loggerFactory)
+        {
+            loggerFactory.AddProvider(new NLogProvider());
+        }
+    }
+}


### PR DESCRIPTION
Usage:

Add namespace NLog.Asp to Startup class.
Add these lines to Configure method of Startup class:

        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
        {
            loggerFactory.MinimumLevel = LogLevel.Verbose;
            loggerFactory.AddConsole();
            loggerFactory.AddDebug();
            loggerFactory.AddNLog();
            ....
            ....
       }

NLog automatically finds the config file. Also the user can define it himself with a relative path:
env.ConfigureNLog("NLog.config"); (env =====>IHostEnvironment)
or
appEnv.ConfigureNLog("NLog.config"); (appEnv =====>IApplicationEnvironment)