### PR TITLE
FIx (xml-) config classes for thread-safe issues

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -62,6 +62,7 @@ namespace NLog.Config
     /// A class for configuring NLog through an XML configuration file 
     /// (App.config style or App.nlog style).
     /// </summary>
+    ///<remarks>This class is thread-safe.<c>.ToList()</c> is used for that purpose.</remarks>
     public class XmlLoggingConfiguration : LoggingConfiguration
     {
         #region private fields
@@ -193,7 +194,8 @@ namespace NLog.Config
             }
             set
             {
-                foreach (string nextFile in this.fileMustAutoReloadLookup.Keys.ToList())
+                var autoReloadFiles = this.fileMustAutoReloadLookup.Keys.ToList();
+                foreach (string nextFile in autoReloadFiles)
                     this.fileMustAutoReloadLookup[nextFile] = value;
             }
         }
@@ -422,9 +424,10 @@ namespace NLog.Config
             InternalLogger.Trace("ParseConfigurationElement");
             configurationElement.AssertName("configuration");
 
-            foreach (var el in configurationElement.Elements("nlog"))
+            var nlogElements = configurationElement.Elements("nlog").ToList();
+            foreach (var nlogElement in nlogElements)
             {
-                this.ParseNLogElement(el, filePath, autoReloadDefault);
+                this.ParseNLogElement(nlogElement, filePath, autoReloadDefault);
             }
         }
 
@@ -458,10 +461,10 @@ namespace NLog.Config
             InternalLogger.LogLevel = LogLevel.FromString(nlogElement.GetOptionalAttribute("internalLogLevel", InternalLogger.LogLevel.Name));
             LogManager.GlobalThreshold = LogLevel.FromString(nlogElement.GetOptionalAttribute("globalThreshold", LogManager.GlobalThreshold.Name));
 
-            var children = nlogElement.Children;
+            var children = nlogElement.Children.ToList();
 
             //first load the extensions, as the can be used in other elements (targets etc)
-            var extensionsChilds = children.Where(child => child.LocalName.Equals("EXTENSIONS", StringComparison.InvariantCultureIgnoreCase));
+            var extensionsChilds = children.Where(child => child.LocalName.Equals("EXTENSIONS", StringComparison.InvariantCultureIgnoreCase)).ToList();
             foreach (var extensionsChild in extensionsChilds)
             {
                 this.ParseExtensionsElement(extensionsChild, Path.GetDirectoryName(filePath));
@@ -514,7 +517,8 @@ namespace NLog.Config
             InternalLogger.Trace("ParseRulesElement");
             rulesElement.AssertName("rules");
 
-            foreach (var loggerElement in rulesElement.Elements("logger"))
+            var loggerElements = rulesElement.Elements("logger").ToList();
+            foreach (var loggerElement in loggerElements)
             {
                 this.ParseLoggerElement(loggerElement, rulesCollection);
             }
@@ -577,11 +581,11 @@ namespace NLog.Config
                 levelString = CleanSpaces(levelString);
 
                 string[] tokens = levelString.Split(',');
-                foreach (string s in tokens)
+                foreach (string token in tokens)
                 {
-                    if (!string.IsNullOrEmpty(s))
+                    if (!string.IsNullOrEmpty(token))
                     {
-                        LogLevel level = LogLevel.FromString(s);
+                        LogLevel level = LogLevel.FromString(token);
                         rule.EnableLoggingForLevel(level);
                     }
                 }
@@ -609,7 +613,8 @@ namespace NLog.Config
                 }
             }
 
-            foreach (var child in loggerElement.Children)
+            var children = loggerElement.Children.ToList();
+            foreach (var child in children)
             {
                 switch (child.LocalName.ToUpper(CultureInfo.InvariantCulture))
                 {
@@ -630,7 +635,8 @@ namespace NLog.Config
         {
             filtersElement.AssertName("filters");
 
-            foreach (var filterElement in filtersElement.Children)
+            var children = filtersElement.Children.ToList();
+            foreach (var filterElement in children)
             {
                 string name = filterElement.LocalName;
 
@@ -658,7 +664,8 @@ namespace NLog.Config
             NLogXmlElement defaultWrapperElement = null;
             var typeNameToDefaultTargetParameters = new Dictionary<string, NLogXmlElement>();
 
-            foreach (var targetElement in targetsElement.Children)
+            var children = targetsElement.Children.ToList();
+            foreach (var targetElement in children)
             {
                 string name = targetElement.LocalName;
                 string typeAttributeVal = StripOptionalNamespacePrefix(targetElement.GetOptionalAttribute("type", null));
@@ -722,7 +729,8 @@ namespace NLog.Config
 
             this.ConfigureObjectFromAttributes(target, targetElement, true);
 
-            foreach (var childElement in targetElement.Children)
+            var children = targetElement.Children.ToList();
+            foreach (var childElement in children)
             {
                 string name = childElement.LocalName;
 
@@ -812,7 +820,8 @@ namespace NLog.Config
         {
             extensionsElement.AssertName("extensions");
 
-            foreach (var addElement in extensionsElement.Elements("add"))
+            var addElements = extensionsElement.Elements("add").ToList();
+            foreach (var addElement in addElements)
             {
                 string prefix = addElement.GetOptionalAttribute("prefix", null);
 
@@ -891,8 +900,6 @@ namespace NLog.Config
                             throw new NLogConfigurationException("Error loading extensions: " + assemblyName, exception);
                         }
                     }
-
-                    continue;
                 }
             }
         }
@@ -1013,7 +1020,8 @@ namespace NLog.Config
 
         private void ConfigureObjectFromAttributes(object targetObject, NLogXmlElement element, bool ignoreType)
         {
-            foreach (var kvp in element.AttributeValues)
+            var attributeValues = element.AttributeValues.ToList();
+            foreach (var kvp in attributeValues)
             {
                 string childName = kvp.Key;
                 string childValue = kvp.Value;
@@ -1058,7 +1066,8 @@ namespace NLog.Config
 
         private void ConfigureObjectFromElement(object targetObject, NLogXmlElement element)
         {
-            foreach (var child in element.Children)
+            var children = element.Children.ToList();
+            foreach (var child in children)
             {
                 this.SetPropertyFromElement(targetObject, child);
             }
@@ -1105,7 +1114,8 @@ namespace NLog.Config
             string output = input;
 
             // TODO - make this case-insensitive, will probably require a different approach
-            foreach (var kvp in this.Variables)
+            var variables = this.Variables.ToList();
+            foreach (var kvp in variables)
             {
                 var layout = kvp.Value;
                 //this value is set from xml and that's a string. Because of that, we can use SimpleLayout here.

--- a/src/NLog/Internal/ObjectGraphScanner.cs
+++ b/src/NLog/Internal/ObjectGraphScanner.cs
@@ -61,7 +61,8 @@ namespace NLog.Internal
             var result = new List<T>();
             var visitedObjects = new Dictionary<object, int>();
 
-            foreach (var rootObject in rootObjects)
+            var rootObjectsList = rootObjects.ToList();
+            foreach (var rootObject in rootObjectsList)
             {
                 ScanProperties(result, rootObject, 0, visitedObjects);
             }
@@ -100,7 +101,8 @@ namespace NLog.Internal
                 InternalLogger.Trace("{0}Scanning {1} '{2}'", new string(' ', level), o.GetType().Name, o);
             }
 
-            foreach (PropertyInfo prop in PropertyHelper.GetAllReadableProperties(o.GetType()))
+            var allReadableProperties = PropertyHelper.GetAllReadableProperties(o.GetType()).ToList();
+            foreach (PropertyInfo prop in allReadableProperties)
             {
                 if (prop.PropertyType.IsPrimitive || prop.PropertyType.IsEnum || prop.PropertyType == typeof(string) || prop.IsDefined(typeof(NLogConfigurationIgnorePropertyAttribute), true))
                 {

--- a/src/NLog/Internal/ObjectGraphScanner.cs
+++ b/src/NLog/Internal/ObjectGraphScanner.cs
@@ -59,7 +59,7 @@ namespace NLog.Internal
         {
             InternalLogger.Trace("FindReachableObject<{0}>:", typeof(T));
             var result = new List<T>();
-            var visitedObjects = new Dictionary<object, int>();
+            var visitedObjects = new HashSet<object>();
 
             var rootObjectsList = rootObjects.ToList();
             foreach (var rootObject in rootObjectsList)
@@ -70,7 +70,7 @@ namespace NLog.Internal
             return result.ToArray();
         }
 
-        private static void ScanProperties<T>(List<T> result, object o, int level, Dictionary<object, int> visitedObjects)
+        private static void ScanProperties<T>(List<T> result, object o, int level, HashSet<object> visitedObjects)
             where T : class
         {
             if (o == null)
@@ -78,18 +78,21 @@ namespace NLog.Internal
                 return;
             }
 
+            //cheaper call then getType and isDefined
+            if (visitedObjects.Contains(o))
+            {
+                return;
+            }
+
+
             var type = o.GetType();
             if (!type.IsDefined(typeof(NLogConfigurationItemAttribute), true))
             {
                 return;
             }
 
-            if (visitedObjects.ContainsKey(o))
-            {
-                return;
-            }
-
-            visitedObjects.Add(o, 0);
+        
+            visitedObjects.Add(o);
 
             var t = o as T;
             if (t != null)

--- a/src/NLog/Internal/ObjectGraphScanner.cs
+++ b/src/NLog/Internal/ObjectGraphScanner.cs
@@ -78,7 +78,8 @@ namespace NLog.Internal
                 return;
             }
 
-            if (!o.GetType().IsDefined(typeof(NLogConfigurationItemAttribute), true))
+            var type = o.GetType();
+            if (!type.IsDefined(typeof(NLogConfigurationItemAttribute), true))
             {
                 return;
             }
@@ -98,10 +99,10 @@ namespace NLog.Internal
 
             if (InternalLogger.IsTraceEnabled)
             {
-                InternalLogger.Trace("{0}Scanning {1} '{2}'", new string(' ', level), o.GetType().Name, o);
+                InternalLogger.Trace("{0}Scanning {1} '{2}'", new string(' ', level), type.Name, o);
             }
 
-            var allReadableProperties = PropertyHelper.GetAllReadableProperties(o.GetType()).ToList();
+            var allReadableProperties = PropertyHelper.GetAllReadableProperties(type).ToList();
             foreach (PropertyInfo prop in allReadableProperties)
             {
                 if (prop.PropertyType.IsPrimitive || prop.PropertyType.IsEnum || prop.PropertyType == typeof(string) || prop.IsDefined(typeof(NLogConfigurationIgnorePropertyAttribute), true))


### PR DESCRIPTION
Replacing foreach with for, for thread-safe usage

`For` forces uses to use lists.

(also `for` is most of the time more performant)

fixes https://github.com/NLog/NLog/issues/1153