### PR TITLE
Artifacts and codecov for coreCLR 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,8 @@ before_test:
 after_test:
   - tests\DeleteTestUsers.cmd
 
+artifacts:
+  - path: '**\*.nupkg'
 deploy: off
 # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,3 +16,11 @@ deploy: off
 # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
 cache:
   - packages -> **\packages.config
+
+test_script:
+  - tools\CheckSourceCode\NLog.SourceCodeTests.exe no-interactive
+  - nuget.exe install OpenCover -ExcludeVersion
+  - OpenCover\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"\"C:\projects\nlog\artifacts\Debug\dnx451\NLog.UnitTests.dll\" -appveyor -noshadow"  -returntargetcode -filter:"+[NLog]* +[NLog.Extended]* -[NLog]JetBrains.Annotations.*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:coverage.xml
+  - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
+  - pip install codecov
+  - codecov -f "coverage.xml"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ cache:
   - packages -> **\packages.config
 
 test_script:
-  - tools\CheckSourceCode\NLog.SourceCodeTests.exe no-interactive
+#  - tools\CheckSourceCode\NLog.SourceCodeTests.exe no-interactive
   - nuget.exe install OpenCover -ExcludeVersion
   - OpenCover\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"\"C:\projects\nlog\artifacts\Debug\dnx451\NLog.UnitTests.dll\" -appveyor -noshadow"  -returntargetcode -filter:"+[NLog]* +[NLog.Extended]* -[NLog]JetBrains.Annotations.*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:coverage.xml
   - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"


### PR DESCRIPTION
CoreCLR branch

debug build!

for COReCLR branch. See also #1160

Not working yet due to crash in unit test running for codecov:

```
Task                          Duration            
--------------------------------------------------
Clean                         00:00:00.0095071    
Dnxcore50                     00:01:31.3928177    
Dnx451                        00:01:30.3804337    
net35                         00:01:22.9900511    
sl5                           00:01:17.7625647    
uap10                         00:01:18.4592012    
pack                          00:00:10.7498835    
Default                       00:00:00.0004638    
--------------------------------------------------
Total:                        00:07:11.7449228    
tests\CreateTestUsers.cmd
The command completed successfully.
 
Discovering tests...OK
%xunit20%\xunit.console.x86 "c:\projects\nlog\artifacts\Debug\dnx451\NLog.UnitTests.dll" -appveyor
xUnit.net Console Runner (32-bit .NET 4.0.30319.42000)
System.InvalidOperationException: Unknown test framework: could not find xunit.dll (v1) or xunit.execution.*.dll (v2) in c:\projects\nlog\artifacts\Debug\dnx451
Command exited with code 1
Unregistering Xamarin license...OK
```