### PR TITLE
Coloredconsole not compiled regex by default

### DIFF
--- a/src/NLog/Targets/ConsoleWordHighlightingRule.cs
+++ b/src/NLog/Targets/ConsoleWordHighlightingRule.cs
@@ -200,7 +200,14 @@ namespace NLog.Targets
         {
             if (CompileRegex)
             {
-                return this.CompiledRegex.Replace(message, this.MatchEvaluator);
+                var regex = this.CompiledRegex;
+                if (regex == null)
+                {
+                    //empty regex so nothing todo
+                    return message;
+                }
+
+                return regex.Replace(message, this.MatchEvaluator);
             }
             //use regex cache
             var expression = GetRegexExpression();

--- a/src/NLog/Targets/ConsoleWordHighlightingRule.cs
+++ b/src/NLog/Targets/ConsoleWordHighlightingRule.cs
@@ -177,7 +177,7 @@ namespace NLog.Targets
         /// <returns></returns>
         private string MatchEvaluator(Match m)
         {
-            StringBuilder result = new StringBuilder();
+            StringBuilder result = new StringBuilder(m.Value.Length + 5);
 
             result.Append('\a');
             result.Append((char)((int)this.ForegroundColor + 'A'));

--- a/src/NLog/Targets/ConsoleWordHighlightingRule.cs
+++ b/src/NLog/Targets/ConsoleWordHighlightingRule.cs
@@ -129,6 +129,12 @@ namespace NLog.Targets
                 if (this.compiledRegex == null)
                 {
                     var regexpression = GetRegexExpression();
+                    if (regexpression == null)
+                    {
+                        //we can't build an empty regex
+                        return null;
+                    }
+
                     var regexOptions = GetRegexOptions(RegexOptions.Compiled);
                     this.compiledRegex = new Regex(regexpression, regexOptions);
                 }

--- a/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
@@ -41,26 +41,33 @@ namespace NLog.UnitTests.Targets
     using System.Linq;
     using NLog.Targets;
     using Xunit;
+    using Xunit.Extensions;
 
     public class ColoredConsoleTargetTests : NLogTestBase
     {
-        [Fact]
-        public void WordHighlightingTextTest()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WordHighlightingTextTest(bool compileRegex)
         {
             var target = new ColoredConsoleTarget { Layout = "${logger} ${message}" };
             target.WordHighlightingRules.Add(
                 new ConsoleWordHighlightingRule
                 {
                     ForegroundColor = ConsoleOutputColor.Red,
-                    Text = "at"
+                    Text = "at",
+                    CompileRegex = compileRegex
+
                 });
             
             AssertOutput(target, "The Cat Sat At The Bar.", 
                 new string[] { "The C", "at", " S", "at", " At The Bar." });
         }
 
-        [Fact]
-        public void WordHighlightingTextIgnoreCase()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WordHighlightingTextIgnoreCase(bool compileRegex)
         {
             var target = new ColoredConsoleTarget { Layout = "${logger} ${message}" };
             target.WordHighlightingRules.Add(
@@ -68,15 +75,19 @@ namespace NLog.UnitTests.Targets
                 {
                     ForegroundColor = ConsoleOutputColor.Red,
                     Text = "at",
-                    IgnoreCase = true
+                    IgnoreCase = true,
+                    CompileRegex = compileRegex
                 });
 
             AssertOutput(target, "The Cat Sat At The Bar.",
                 new string[] { "The C", "at", " S", "at", " ", "At", " The Bar." });
         }
 
-        [Fact]
-        public void WordHighlightingTextWholeWords()
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WordHighlightingTextWholeWords(bool compileRegex)
         {
             var target = new ColoredConsoleTarget { Layout = "${logger} ${message}" };
             target.WordHighlightingRules.Add(
@@ -84,22 +95,26 @@ namespace NLog.UnitTests.Targets
                 {
                     ForegroundColor = ConsoleOutputColor.Red,
                     Text = "at",
-                    WholeWords = true
+                    WholeWords = true,
+                    CompileRegex = compileRegex
                 });
 
             AssertOutput(target, "The cat sat at the bar.",
                 new string[] { "The cat sat ", "at", " the bar." });
         }
-        
-        [Fact]
-        public void WordHighlightingRegex()
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WordHighlightingRegex(bool compileRegex)
         {
             var target = new ColoredConsoleTarget { Layout = "${logger} ${message}" };
             target.WordHighlightingRules.Add(
                 new ConsoleWordHighlightingRule
                 {
                     ForegroundColor = ConsoleOutputColor.Red,
-                    Regex = "\\wat"
+                    Regex = "\\wat",
+                    CompileRegex = compileRegex
                 });
 
             AssertOutput(target, "The cat sat at the bar.",
@@ -107,7 +122,7 @@ namespace NLog.UnitTests.Targets
         }
 
 
-        private void AssertOutput(Target target, string message, string[] expectedParts)
+        private static void AssertOutput(Target target, string message, string[] expectedParts)
         {
             var consoleOutWriter = new PartsWriter();
             TextWriter oldConsoleOutWriter = Console.Out;

--- a/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
@@ -59,8 +59,8 @@ namespace NLog.UnitTests.Targets
                     CompileRegex = compileRegex
 
                 });
-            
-            AssertOutput(target, "The Cat Sat At The Bar.", 
+
+            AssertOutput(target, "The Cat Sat At The Bar.",
                 new string[] { "The C", "at", " S", "at", " At The Bar." });
         }
 
@@ -195,7 +195,7 @@ namespace NLog.UnitTests.Targets
                 Values = new List<string>();
             }
 
-            public List<string> Values { get; private set; } 
+            public List<string> Values { get; private set; }
 
             public override void Write(string value)
             {

--- a/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
@@ -121,6 +121,46 @@ namespace NLog.UnitTests.Targets
                 new string[] { "The ", "cat", " ", "sat", " at the bar." });
         }
 
+        /// <summary>
+        /// With or wihout CompileRegex, CompileRegex is never null, even if not used when CompileRegex=false. (needed for backwardscomp)
+        /// </summary>
+        /// <param name="compileRegex"></param>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CompiledRegexPropertyNotNull(bool compileRegex)
+        {
+            var rule = new ConsoleWordHighlightingRule
+            {
+                ForegroundColor = ConsoleOutputColor.Red,
+                Regex = "\\wat",
+                CompileRegex = compileRegex
+            };
+
+            Assert.NotNull(rule.CompiledRegex);
+        }
+
+
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DonRemoveIfRegexIsEmpty(bool compileRegex)
+        {
+            var target = new ColoredConsoleTarget { Layout = "${logger} ${message}" };
+            target.WordHighlightingRules.Add(
+                new ConsoleWordHighlightingRule
+                {
+                    ForegroundColor = ConsoleOutputColor.Red,
+                    Text = null,
+                    IgnoreCase = true,
+                    CompileRegex = compileRegex
+                });
+
+            AssertOutput(target, "The Cat Sat At The Bar.",
+                new string[] { "The Cat Sat At The Bar." });
+        }
+
 
         private static void AssertOutput(Target target, string message, string[] expectedParts)
         {


### PR DESCRIPTION
- Added `CompileRegex` option, `false` by default. If `false` the Regex Cache is used.
- Some small performance improvements

fixes https://github.com/NLog/NLog/issues/764