### PR TITLE
Unit test added for Variable node

### DIFF
--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -39,7 +39,6 @@ namespace NLog.UnitTests.Config
     using NLog.Layouts;
     using NLog.Targets;
     using Xunit;
-    using Xunit.Extensions;
 
     public class VariableTests : NLogTestBase
     {

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -114,5 +114,22 @@ namespace NLog.UnitTests.Config
             Assert.Equal("[[", LogManager.Configuration.Variables["prefix"].OriginalText);
             Assert.Equal("]]", LogManager.Configuration.Variables["suffix"].OriginalText);
         }
+
+        [Fact]
+        public void NLogConfigurationExceptionShouldThrown_WhenVariableNodeIsWrittenToWrongPlace()
+        {
+            NLogConfigurationException nlogConfEx = Assert.Throws<NLogConfigurationException>(
+                () => CreateConfigurationFromString(
+                    @"<nlog>  
+	                        <targets>
+			                    <variable name='messageLayout' value='${longdate:universalTime=True}Z | ${message}'/>
+                    			<target name='d1' type='Debug' layout='${messageLayout}' />
+	                        </targets>
+                            <rules>
+			                    <logger name='*' minlevel='Debug' writeTo='d1'/>
+                            </rules>
+                    </nlog>")
+                );
+        }
     }
 }

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -116,8 +116,11 @@ namespace NLog.UnitTests.Config
             Assert.Equal("]]", LogManager.Configuration.Variables["suffix"].OriginalText);
         }
 
-        [Theory]
-        [InlineData(@"<nlog>  
+        [Fact]
+        public void NLogConfigurationExceptionShouldThrown_WhenVariableNodeIsWrittenToWrongPlace()
+        {
+            const string configurationString_VariableNodeIsInnerTargets =
+                    @"<nlog>  
 	                        <targets>
 			                    <variable name='variableOne' value='${longdate:universalTime=True}Z | ${message}'/>
                     			<target name='d1' type='Debug' layout='${variableOne}' />
@@ -125,8 +128,11 @@ namespace NLog.UnitTests.Config
                             <rules>
 			                    <logger name='*' minlevel='Debug' writeTo='d1'/>
                             </rules>
-                    </nlog>")]
-        [InlineData(@"<nlog>  
+                    </nlog>";
+
+
+            const string configurationString_VariableNodeIsAfterTargets =
+                    @"<nlog>  
 	                        <targets>
 			                    <target name='d1' type='Debug' layout='${variableOne}' />
 	                        </targets>
@@ -134,11 +140,14 @@ namespace NLog.UnitTests.Config
                             <rules>
 			                    <logger name='*' minlevel='Debug' writeTo='d1'/>
                             </rules>
-                    </nlog>")]
-        public void NLogConfigurationExceptionShouldThrown_WhenVariableNodeIsWrittenToWrongPlace(string configurationString)
-        {
-            NLogConfigurationException nlogConfEx = Assert.Throws<NLogConfigurationException>(
-                () => CreateConfigurationFromString(configurationString)
+                    </nlog>";
+
+            NLogConfigurationException nlogConfEx_ForInnerTargets = Assert.Throws<NLogConfigurationException>(
+                () => CreateConfigurationFromString(configurationString_VariableNodeIsInnerTargets)
+                );
+
+            NLogConfigurationException nlogConfExForAfterTargets = Assert.Throws<NLogConfigurationException>(
+                () => CreateConfigurationFromString(configurationString_VariableNodeIsAfterTargets)
                 );
         }
     }

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -39,6 +39,7 @@ namespace NLog.UnitTests.Config
     using NLog.Layouts;
     using NLog.Targets;
     using Xunit;
+    using Xunit.Extensions;
 
     public class VariableTests : NLogTestBase
     {
@@ -94,7 +95,7 @@ namespace NLog.UnitTests.Config
         }
 #endif
 
-      
+
 
         [Fact]
         public void Xml_configuration_returns_defined_variables()
@@ -115,20 +116,29 @@ namespace NLog.UnitTests.Config
             Assert.Equal("]]", LogManager.Configuration.Variables["suffix"].OriginalText);
         }
 
-        [Fact]
-        public void NLogConfigurationExceptionShouldThrown_WhenVariableNodeIsWrittenToWrongPlace()
-        {
-            NLogConfigurationException nlogConfEx = Assert.Throws<NLogConfigurationException>(
-                () => CreateConfigurationFromString(
-                    @"<nlog>  
+        [Theory]
+        [InlineData(@"<nlog>  
 	                        <targets>
-			                    <variable name='messageLayout' value='${longdate:universalTime=True}Z | ${message}'/>
-                    			<target name='d1' type='Debug' layout='${messageLayout}' />
+			                    <variable name='variableOne' value='${longdate:universalTime=True}Z | ${message}'/>
+                    			<target name='d1' type='Debug' layout='${variableOne}' />
 	                        </targets>
                             <rules>
 			                    <logger name='*' minlevel='Debug' writeTo='d1'/>
                             </rules>
-                    </nlog>")
+                    </nlog>")]
+        [InlineData(@"<nlog>  
+	                        <targets>
+			                    <target name='d1' type='Debug' layout='${variableOne}' />
+	                        </targets>
+                            <variable name='variableOne' value='${longdate:universalTime=True}Z | ${message}'/>	
+                            <rules>
+			                    <logger name='*' minlevel='Debug' writeTo='d1'/>
+                            </rules>
+                    </nlog>")]
+        public void NLogConfigurationExceptionShouldThrown_WhenVariableNodeIsWrittenToWrongPlace(string configurationString)
+        {
+            NLogConfigurationException nlogConfEx = Assert.Throws<NLogConfigurationException>(
+                () => CreateConfigurationFromString(configurationString)
                 );
         }
     }


### PR DESCRIPTION
This unit test is testing the thrown exception is
NLogConfigurationException or not when variable node is written to wrong
place.

For #1128

Configuration validation will be done at https://github.com/NLog/NLog/issues/1174