### PR TITLE
FileTarget: Fix Footer for archiving.

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -188,7 +188,7 @@ namespace NLog.Targets
             this.OpenFileCacheTimeout = -1;
             this.OpenFileCacheSize = 5;
             this.CreateDirs = true;
-            this.fileArchive = new DynamicFileArchive(MaxArchiveFiles);
+            this.fileArchive = new DynamicFileArchive(this, MaxArchiveFiles);
             this.ForceManaged = false;
             this.ArchiveDateFormat = string.Empty;
 
@@ -711,7 +711,7 @@ namespace NLog.Targets
             // Uninitialize the files.
             foreach (string fileName in filesToUninitialize)
             {
-                this.WriteFooterAndUninitialize(fileName);
+                this.UninitializeFile(fileName);
             }
         }
 
@@ -820,7 +820,7 @@ namespace NLog.Targets
 
             foreach (string fileName in new List<string>(this.initializedFiles.Keys))
             {
-                this.WriteFooterAndUninitialize(fileName);
+                this.UninitializeFile(fileName);
             }
 
             if (this.autoClosingTimer != null)
@@ -855,10 +855,7 @@ namespace NLog.Targets
             byte[] bytes = this.GetBytesToWrite(logEvent);
 
             if (this.ShouldAutoArchive(fileName, logEvent, bytes.Length))
-            {
-                this.fileAppenderCache.InvalidateAppender(fileName);
                 this.DoAutoArchive(fileName, logEvent);
-            }
 
             // Clean up old archives if this is the first time a log record is being written to
             // this log file and the archiving system is date/time based.
@@ -985,10 +982,7 @@ namespace NLog.Targets
                 if (currentFileName != null)
                 {
                     if (this.ShouldAutoArchive(currentFileName, firstLogEvent, (int)ms.Length))
-                    {
-                        this.WriteFooterAndUninitialize(currentFileName);
                         this.DoAutoArchive(currentFileName, firstLogEvent);
-                    }
 
                     this.WriteToFile(currentFileName, firstLogEvent, ms.ToArray(), false);
                 }
@@ -1058,22 +1052,21 @@ namespace NLog.Targets
             string newFileName = ReplaceNumberPattern(pattern, archiveNumber);
             RollArchivesForward(newFileName, pattern, archiveNumber + 1);
 
-            var shouldCompress = archiveNumber == 0;
-            try
-            {
-                RollArchiveForward(fileName, newFileName, shouldCompress);
-            }
-            catch (IOException)
-            {
-                // TODO: Check the value of CreateDirs property before creating directories.
-                string dir = Path.GetDirectoryName(newFileName);
-                if (!Directory.Exists(dir))
-                {
-                    Directory.CreateDirectory(dir);
-                }
+            if (archiveNumber == 0)
+                ArchiveFile(fileName, newFileName);
+            else
+                RollArchiveForward(fileName, newFileName);
+        }
 
-                RollArchiveForward(fileName, newFileName, shouldCompress);
-            }
+        /// <summary>
+        /// Moves the archive file to the specified file name.
+        /// </summary>
+        /// <param name="existingFileName">The archive file to move.</param>
+        /// <param name="newFileName">The destination file name.</param>
+        private void RollArchiveForward(string existingFileName, string newFileName)
+        {
+            InternalLogger.Info("Roll archive {0} to {1}", existingFileName, newFileName);
+            File.Move(existingFileName, newFileName);
         }
 
         /// <summary>
@@ -1146,24 +1139,24 @@ namespace NLog.Targets
             }
 
             string newFileName = ReplaceNumberPattern(pattern, nextNumber);
-            RollArchiveForward(fileName, newFileName, allowCompress: true);
+            ArchiveFile(fileName, newFileName);
         }
 
         /// <summary>
-        /// Creates an archive copy of source file either by compressing it or moving to a new location in the file
-        /// system. Which action will be used is determined by the value of <paramref name="enableCompression"/> parameter.
+        /// Archives fileName to archiveFileName.
         /// </summary>
         /// <param name="fileName">File name to be archived.</param>
         /// <param name="archiveFileName">Name of the archive file.</param>
-        /// <param name="enableCompression">Enables file compression</param>
-        private static void ArchiveFile(string fileName, string archiveFileName, bool enableCompression)
+        private void ArchiveFile(string fileName, string archiveFileName)
         {
+            UninitializeFile(fileName);
+
             string archiveFolderPath = Path.GetDirectoryName(archiveFileName);
             if (!Directory.Exists(archiveFolderPath))
                 Directory.CreateDirectory(archiveFolderPath);
 
 #if NET4_5
-            if (enableCompression)
+            if (EnableArchiveFileCompression)
             {
                 InternalLogger.Info("Archiving {0} to zip-archive {1}", fileName, archiveFileName);
                 using (var archiveStream = new FileStream(archiveFileName, FileMode.Create))
@@ -1201,26 +1194,6 @@ namespace NLog.Targets
                     currentFileInfo = new FileInfo(fileName);
                 }
                 while ((currentFileInfo.Exists) && (currentFileInfo.CreationTime == originalFileCreationTime));
-            }
-        }
-
-        private void RollArchiveForward(string existingFileName, string archiveFileName, bool allowCompress)
-        {
-            ArchiveFile(existingFileName, archiveFileName, allowCompress && EnableArchiveFileCompression);
-
-            string fileName = Path.GetFileName(existingFileName);
-            if (fileName == null) { return; }
-
-            // When the file has been moved, the original filename is 
-            // no longer one of the initializedFiles. The initializedFilesCounter
-            // should be left alone, the amount is still valid.
-            if (this.initializedFiles.ContainsKey(fileName))
-            {
-                this.initializedFiles.Remove(fileName);
-            }
-            else if (this.initializedFiles.ContainsKey(existingFileName))
-            {
-                this.initializedFiles.Remove(existingFileName);
             }
         }
 
@@ -1290,7 +1263,7 @@ namespace NLog.Targets
                 string.Format("{0}.{1}", archiveDate.ToString(dateFormat), paddedSequence));
             string archiveFileName = Path.Combine(dirName, archiveFileNameWithoutPath);
 
-            RollArchiveForward(fileName, archiveFileName, allowCompress: true);
+            ArchiveFile(fileName, archiveFileName);
             archiveFileNames.Add(archiveFileName);
             EnsureArchiveCount(archiveFileNames);
         }
@@ -1437,7 +1410,7 @@ namespace NLog.Targets
             if (dirName != null)
             {
                 string archiveFileName = Path.Combine(dirName, fileNameMask.Replace("*", archiveDate.ToString(dateFormat)));
-                RollArchiveForward(fileName, archiveFileName, allowCompress: true);
+                ArchiveFile(fileName, archiveFileName);
             }
 
             DeleteOldDateArchives(pattern);
@@ -1579,7 +1552,7 @@ namespace NLog.Targets
 
             if (!ContainsFileNamePattern(fileNamePattern))
             {
-                if (fileArchive.Archive(fileNamePattern, fileInfo.FullName, CreateDirs, EnableArchiveFileCompression))
+                if (fileArchive.Archive(fileNamePattern, fileInfo.FullName, CreateDirs))
                 {
                     if (this.initializedFiles.ContainsKey(fileInfo.FullName))
                     {
@@ -1823,10 +1796,22 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// Writes the file footer and uninitialise the file in <see cref="FileTarget"/> instance internal structures.
+        /// Writes the file footer and uninitialises the file in <see cref="FileTarget"/> instance internal structures.
         /// </summary>
-        /// <param name="fileName">File name to be written.</param>
-        private void WriteFooterAndUninitialize(string fileName)
+        /// <param name="fileName">File name to close.</param>
+        private void UninitializeFile(string fileName)
+        {
+            WriteFooter(fileName);
+
+            this.fileAppenderCache.InvalidateAppender(fileName);
+            this.initializedFiles.Remove(fileName);
+        }
+
+        /// <summary>
+        /// Writes the footer information to a file.
+        /// </summary>
+        /// <param name="fileName">The file path to write to.</param>
+        private void WriteFooter(string fileName)
         {
             byte[] footerBytes = this.GetFooterBytes();
             if (footerBytes != null)
@@ -1836,9 +1821,6 @@ namespace NLog.Targets
                     this.WriteToFile(fileName, null, footerBytes, true);
                 }
             }
-
-            this.fileAppenderCache.InvalidateAppender(fileName);
-            this.initializedFiles.Remove(fileName);
         }
 
         /// <summary>
@@ -2026,20 +2008,24 @@ namespace NLog.Targets
         private class DynamicFileArchive
         {
             private readonly Queue<string> archiveFileQueue = new Queue<string>();
+            private readonly FileTarget fileTarget;
             
             /// <summary>
             /// Creates an instance of <see cref="DynamicFileArchive"/> class.
             /// </summary>
+            /// <param name="fileTarget">The file target instance whose files to archive.</param>
             /// <param name="maxArchivedFiles">Maximum number of archive files to be kept.</param>
-            public DynamicFileArchive(int maxArchivedFiles)
+            public DynamicFileArchive(FileTarget fileTarget, int maxArchivedFiles)
             {
+                this.fileTarget = fileTarget;
                 this.MaxArchiveFileToKeep = maxArchivedFiles;
             }
 
             /// <summary>
             /// Creates an instance of <see cref="DynamicFileArchive"/> class.
             /// </summary>
-            public DynamicFileArchive() : this(-1) { }
+            /// <param name="fileTarget">The file target instance whose files to archive.</param>
+            public DynamicFileArchive(FileTarget fileTarget) : this(fileTarget, -1) { }
 
             /// <summary>
             /// Gets or sets the maximum number of archive files that should be kept.
@@ -2071,10 +2057,9 @@ namespace NLog.Targets
             /// <param name="archiveFileName">File name of the archive</param>
             /// <param name="fileName">Original file name</param>
             /// <param name="createDirectory">Create a directory, if it does not exist</param>
-            /// <param name="enableCompression">Enables file compression</param>
             /// <returns><see langword="true"/> if the file has been moved successfully; <see langword="false"/> otherwise.</returns>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-            public bool Archive(string archiveFileName, string fileName, bool createDirectory, bool enableCompression)
+            public bool Archive(string archiveFileName, string fileName, bool createDirectory)
             {
                 if (MaxArchiveFileToKeep < 1)
                 {
@@ -2089,7 +2074,7 @@ namespace NLog.Targets
                 }
 
                 DeleteOldArchiveFiles();
-                AddToArchive(archiveFileName, fileName, createDirectory, enableCompression);
+                AddToArchive(archiveFileName, fileName, createDirectory);
                 return true;
             }
             
@@ -2099,15 +2084,14 @@ namespace NLog.Targets
             /// <param name="archiveFileName">Target file name.</param>
             /// <param name="fileName">Original file name.</param>
             /// <param name="createDirectory">Create a directory, if it does not exist.</param>
-            /// <param name="enableCompression">Enables file compression.</param>
-            private void AddToArchive(string archiveFileName, string fileName, bool createDirectory, bool enableCompression)
+            private void AddToArchive(string archiveFileName, string fileName, bool createDirectory)
             {
                 if (archiveFileQueue.Count != 0)
                     archiveFileName = GetNextArchiveFileName(archiveFileName);
 
                 try
                 {
-                    ArchiveFile(fileName, archiveFileName, enableCompression);
+                    fileTarget.ArchiveFile(fileName, archiveFileName);
                     archiveFileQueue.Enqueue(archiveFileName);
                 }
                 catch (Exception ex)

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -60,30 +60,29 @@ namespace NLog.UnitTests
             LogManager.ThrowExceptions = false;
         }
 
-        public void AssertDebugCounter(string targetName, int val)
+        protected void AssertDebugCounter(string targetName, int val)
         {
             Assert.Equal(val, GetDebugTarget(targetName).Counter);
         }
 
-        public void AssertDebugLastMessage(string targetName, string msg)
+        protected void AssertDebugLastMessage(string targetName, string msg)
         {
             Assert.Equal(msg, GetDebugLastMessage(targetName));
         }
-
-
-        public void AssertDebugLastMessageContains(string targetName, string msg)
+        
+        protected void AssertDebugLastMessageContains(string targetName, string msg)
         {
             string debugLastMessage = GetDebugLastMessage(targetName);
             Assert.True(debugLastMessage.Contains(msg),
                 string.Format("Expected to find '{0}' in last message value on '{1}', but found '{2}'", msg, targetName, debugLastMessage));
         }
 
-        public string GetDebugLastMessage(string targetName)
+        protected string GetDebugLastMessage(string targetName)
         {
             return GetDebugLastMessage(targetName, LogManager.Configuration);
         }
 
-        public string GetDebugLastMessage(string targetName, LoggingConfiguration configuration)
+        protected string GetDebugLastMessage(string targetName, LoggingConfiguration configuration)
         {
             return GetDebugTarget(targetName, configuration).LastMessage;
         }
@@ -93,18 +92,18 @@ namespace NLog.UnitTests
             return GetDebugTarget(targetName, LogManager.Configuration);
         }
 
-        public NLog.Targets.DebugTarget GetDebugTarget(string targetName, LoggingConfiguration configuration)
+        protected NLog.Targets.DebugTarget GetDebugTarget(string targetName, LoggingConfiguration configuration)
         {
             var debugTarget = (NLog.Targets.DebugTarget)configuration.FindTargetByName(targetName);
             Assert.NotNull(debugTarget);
             return debugTarget;
         }
 
-        public void AssertFileContentsStartsWith(string fileName, string contents, Encoding encoding)
+        protected void AssertFileContentsStartsWith(string fileName, string contents, Encoding encoding)
         {
             FileInfo fi = new FileInfo(fileName);
             if (!fi.Exists)
-                Assert.True(true, "File '" + fileName + "' doesn't exist.");
+                Assert.True(false, "File '" + fileName + "' doesn't exist.");
 
             byte[] encodedBuf = encoding.GetBytes(contents);
             Assert.True(encodedBuf.Length <= fi.Length);
@@ -120,27 +119,22 @@ namespace NLog.UnitTests
             }
         }
 
-        public void AssertFileSize(string filename, long expectedSize)
+        protected void AssertFileContentsEndsWith(string fileName, string contents, Encoding encoding)
         {
-            var fi = new FileInfo(filename);
+            if (!File.Exists(fileName))
+                Assert.True(false, "File '" + fileName + "' doesn't exist.");
 
-            if (!fi.Exists)
-            {
-                Assert.True(true, string.Format("File \"{0}\" doesn't exist.", filename));
-            }
-
-            if (fi.Length != expectedSize)
-            {
-                Assert.True(true, string.Format("Filesize of \"{0}\" unequals {1}.", filename, expectedSize));
-            }
+            string fileText = File.ReadAllText(fileName, encoding);
+            Assert.True(fileText.Length >= contents.Length);
+            Assert.Equal(contents, fileText.Substring(fileText.Length - contents.Length));
         }
 
 #if NET4_5
-        public void AssertZipFileContents(string fileName, string contents, Encoding encoding)
+        protected void AssertZipFileContents(string fileName, string contents, Encoding encoding)
         {
             FileInfo fi = new FileInfo(fileName);
             if (!fi.Exists)
-                Assert.True(true, "File '" + fileName + "' doesn't exist.");
+                Assert.True(false, "File '" + fileName + "' doesn't exist.");
 
             byte[] encodedBuf = encoding.GetBytes(contents);
             using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
@@ -163,7 +157,7 @@ namespace NLog.UnitTests
         }
 #endif
 
-        public void AssertFileContents(string fileName, string contents, Encoding encoding)
+        protected void AssertFileContents(string fileName, string contents, Encoding encoding)
         {
             FileInfo fi = new FileInfo(fileName);
             if (!fi.Exists)
@@ -183,7 +177,7 @@ namespace NLog.UnitTests
             }
         }
 
-        public void AssertFileContains(string fileName, string contentToCheck, Encoding encoding)
+        protected void AssertFileContains(string fileName, string contentToCheck, Encoding encoding)
         {
             if (contentToCheck.Contains(Environment.NewLine))
                 Assert.True(false, "Please use only single line string to check.");
@@ -205,7 +199,7 @@ namespace NLog.UnitTests
             Assert.True(false, "File doesn't contains '" + contentToCheck + "'");
         }
 
-        public string StringRepeat(int times, string s)
+        protected string StringRepeat(int times, string s)
         {
             StringBuilder sb = new StringBuilder(s.Length * times);
             for (int i = 0; i < times; ++i)


### PR DESCRIPTION
The Footer property did not add the footer to archive files. Header is added to each archive, so one expects the footer to work the same way. 