### PR TITLE
FileTarget: Archiving not working properly with AsyncWrapper

### DIFF
--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -34,7 +34,6 @@
 namespace NLog.Internal.FileAppenders
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
 
     /// <summary>

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -899,33 +899,6 @@ namespace NLog.Targets
             }
         }
 
-        private void FlushCurrentFileWrites(string currentFileName, LogEventInfo firstLogEvent, MemoryStream ms, List<AsyncContinuation> pendingContinuations)
-        {
-            Exception lastException = null;
-
-            try
-            {
-                if (currentFileName != null)
-                    ProcessLogEvent(firstLogEvent, currentFileName, ms.ToArray());
-            }
-            catch (Exception exception)
-            {
-                if (exception.MustBeRethrown())
-                {
-                    throw;
-                }
-
-                lastException = exception;
-            }
-
-            foreach (AsyncContinuation cont in pendingContinuations)
-            {
-                cont(lastException);
-            }
-
-            pendingContinuations.Clear();
-        }
-
         private void ProcessLogEvent(LogEventInfo logEvent, string fileName, byte[] bytesToWrite)
         {
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
@@ -1004,6 +977,33 @@ namespace NLog.Targets
             int numDigits = lastPart - firstPart - 2;
 
             return pattern.Substring(0, firstPart) + Convert.ToString(value, 10).PadLeft(numDigits, '0') + pattern.Substring(lastPart);
+        }
+
+        private void FlushCurrentFileWrites(string currentFileName, LogEventInfo firstLogEvent, MemoryStream ms, List<AsyncContinuation> pendingContinuations)
+        {
+            Exception lastException = null;
+
+            try
+            {
+                if (currentFileName != null)
+                    ProcessLogEvent(firstLogEvent, currentFileName, ms.ToArray());
+            }
+            catch (Exception exception)
+            {
+                if (exception.MustBeRethrown())
+                {
+                    throw;
+                }
+
+                lastException = exception;
+            }
+
+            foreach (AsyncContinuation cont in pendingContinuations)
+            {
+                cont(lastException);
+            }
+
+            pendingContinuations.Clear();
         }
 
         /// <summary>

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -847,39 +847,8 @@ namespace NLog.Targets
         protected override void Write(LogEventInfo logEvent)
         {
             var fileName = Path.GetFullPath(GetCleanedFileName(logEvent));
-
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-            this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
-#endif
-
             byte[] bytes = this.GetBytesToWrite(logEvent);
-
-            if (this.ShouldAutoArchive(fileName, logEvent, bytes.Length))
-            {
-                this.fileAppenderCache.InvalidateAppender(fileName);
-                this.DoAutoArchive(fileName, logEvent);
-            }
-
-            // Clean up old archives if this is the first time a log record is being written to
-            // this log file and the archiving system is date/time based.
-            if (this.ArchiveNumbering == ArchiveNumberingMode.Date && this.ArchiveEvery != FileArchivePeriod.None && ShouldDeleteOldArchives())
-            {
-                if (!previousFileNames.Contains(fileName))
-                {
-                    if (this.previousFileNames.Count > this.maxLogFilenames)
-                    {
-                        this.previousFileNames.Dequeue();
-                    }
-
-                    string fileNamePattern = this.GetArchiveFileNamePattern(fileName, logEvent);
-                    this.DeleteOldDateArchives(fileNamePattern);
-                    this.previousFileNames.Enqueue(fileName);
-                }
-            }
-
-            this.WriteToFile(fileName, logEvent, bytes, false);
-
-            previousLogEventTimestamp = logEvent.TimeStamp;
+            ProcessLogEvent(logEvent, fileName, bytes);
         }
 
         private string GetCleanedFileName(LogEventInfo logEvent)
@@ -930,6 +899,67 @@ namespace NLog.Targets
             }
         }
 
+        private void FlushCurrentFileWrites(string currentFileName, LogEventInfo firstLogEvent, MemoryStream ms, List<AsyncContinuation> pendingContinuations)
+        {
+            Exception lastException = null;
+
+            try
+            {
+                if (currentFileName != null)
+                    ProcessLogEvent(firstLogEvent, currentFileName, ms.ToArray());
+            }
+            catch (Exception exception)
+            {
+                if (exception.MustBeRethrown())
+                {
+                    throw;
+                }
+
+                lastException = exception;
+            }
+
+            foreach (AsyncContinuation cont in pendingContinuations)
+            {
+                cont(lastException);
+            }
+
+            pendingContinuations.Clear();
+        }
+
+        private void ProcessLogEvent(LogEventInfo logEvent, string fileName, byte[] bytesToWrite)
+        {
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+            this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
+#endif
+
+            if (this.ShouldAutoArchive(fileName, logEvent, bytesToWrite.Length))
+            {
+                this.fileAppenderCache.InvalidateAppender(fileName);
+                this.DoAutoArchive(fileName, logEvent);
+            }
+
+            // Clean up old archives if this is the first time a log record is being written to
+            // this log file and the archiving system is date/time based.
+            if (this.ArchiveNumbering == ArchiveNumberingMode.Date && this.ArchiveEvery != FileArchivePeriod.None && ShouldDeleteOldArchives())
+            {
+                if (!previousFileNames.Contains(fileName))
+                {
+                    if (this.previousFileNames.Count > this.maxLogFilenames)
+                    {
+                        this.previousFileNames.Dequeue();
+                    }
+
+                    string fileNamePattern = this.GetArchiveFileNamePattern(fileName, logEvent);
+                    this.DeleteOldDateArchives(fileNamePattern);
+                    this.previousFileNames.Enqueue(fileName);
+                }
+            }
+
+            this.WriteToFile(fileName, logEvent, bytesToWrite, false);
+
+            previousLogEventTimestamp = logEvent.TimeStamp;
+        }
+
         /// <summary>
         /// Formats the log event for write.
         /// </summary>
@@ -974,41 +1004,6 @@ namespace NLog.Targets
             int numDigits = lastPart - firstPart - 2;
 
             return pattern.Substring(0, firstPart) + Convert.ToString(value, 10).PadLeft(numDigits, '0') + pattern.Substring(lastPart);
-        }
-
-        private void FlushCurrentFileWrites(string currentFileName, LogEventInfo firstLogEvent, MemoryStream ms, List<AsyncContinuation> pendingContinuations)
-        {
-            Exception lastException = null;
-
-            try
-            {
-                if (currentFileName != null)
-                {
-                    if (this.ShouldAutoArchive(currentFileName, firstLogEvent, (int)ms.Length))
-                    {
-                        this.WriteFooterAndUninitialize(currentFileName);
-                        this.DoAutoArchive(currentFileName, firstLogEvent);
-                    }
-
-                    this.WriteToFile(currentFileName, firstLogEvent, ms.ToArray(), false);
-                }
-            }
-            catch (Exception exception)
-            {
-                if (exception.MustBeRethrown())
-                {
-                    throw;
-                }
-
-                lastException = exception;
-            }
-
-            foreach (AsyncContinuation cont in pendingContinuations)
-            {
-                cont(lastException);
-            }
-
-            pendingContinuations.Clear();
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Targets\MemoryTargetTests.cs" />
     <Compile Include="Targets\MessageQueueTargetTests.cs" />
     <Compile Include="Targets\MethodCallTests.cs" />
+    <Compile Include="Targets\Mocks\MockTargetWrapper.cs" />
     <Compile Include="Targets\NetworkTargetTests.cs" />
     <Compile Include="Targets\TargetTests.cs" />
     <Compile Include="Targets\WebServiceTargetTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Targets\MemoryTargetTests.cs" />
     <Compile Include="Targets\MessageQueueTargetTests.cs" />
     <Compile Include="Targets\MethodCallTests.cs" />
+    <Compile Include="Targets\Mocks\MockTargetWrapper.cs" />
     <Compile Include="Targets\NetworkTargetTests.cs" />
     <Compile Include="Targets\TargetTests.cs" />
     <Compile Include="Targets\WebServiceTargetTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Targets\MemoryTargetTests.cs" />
     <Compile Include="Targets\MessageQueueTargetTests.cs" />
     <Compile Include="Targets\MethodCallTests.cs" />
+    <Compile Include="Targets\Mocks\MockTargetWrapper.cs" />
     <Compile Include="Targets\NetworkTargetTests.cs" />
     <Compile Include="Targets\TargetTests.cs" />
     <Compile Include="Targets\WebServiceTargetTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Targets\MemoryTargetTests.cs" />
     <Compile Include="Targets\MessageQueueTargetTests.cs" />
     <Compile Include="Targets\MethodCallTests.cs" />
+    <Compile Include="Targets\Mocks\MockTargetWrapper.cs" />
     <Compile Include="Targets\NetworkTargetTests.cs" />
     <Compile Include="Targets\TargetTests.cs" />
     <Compile Include="Targets\WebServiceTargetTests.cs" />
@@ -275,6 +276,7 @@
       <Name>SampleExtensions.netfx45</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(StyleCopTargetsFile)" Condition="'$(StyleCopTargetsFile)' != ''" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -199,6 +199,7 @@
     <Compile Include="Targets\MemoryTargetTests.cs" />
     <Compile Include="Targets\MessageQueueTargetTests.cs" />
     <Compile Include="Targets\MethodCallTests.cs" />
+    <Compile Include="Targets\Mocks\MockTargetWrapper.cs" />
     <Compile Include="Targets\NetworkTargetTests.cs" />
     <Compile Include="Targets\TargetTests.cs" />
     <Compile Include="Targets\WebServiceTargetTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Targets\MemoryTargetTests.cs" />
     <Compile Include="Targets\MessageQueueTargetTests.cs" />
     <Compile Include="Targets\MethodCallTests.cs" />
+    <Compile Include="Targets\Mocks\MockTargetWrapper.cs" />
     <Compile Include="Targets\NetworkTargetTests.cs" />
     <Compile Include="Targets\TargetTests.cs" />
     <Compile Include="Targets\WebServiceTargetTests.cs" />

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -44,36 +44,17 @@ namespace NLog.UnitTests.Targets
     using Xunit;
     using Xunit.Extensions;
 
+    using Mocks;
     using NLog.Config;
     using NLog.Layouts;
     using NLog.Targets;
     using NLog.Targets.Wrappers;
     using NLog.Time;
-    using NLog.Internal;
-    using NLog.LayoutRenderers;
 
-    public class FileTargetTests : NLogTestBase
+    public abstract class FileTargetTests : NLogTestBase
     {
         private readonly ILogger logger = LogManager.GetLogger("NLog.UnitTests.Targets.FileTargetTests");
-
-        private void GenerateArchives(int count, string archiveDateFormat, string archiveFileName,
-            ArchiveNumberingMode archiveNumbering)
-        {
-            string logFileName = Path.GetTempFileName();
-            const int logFileMaxSize = 1;
-            var ft = new FileTarget
-            {
-                FileName = logFileName,
-                ArchiveFileName = archiveFileName,
-                ArchiveDateFormat = archiveDateFormat,
-                ArchiveNumbering = archiveNumbering,
-                ArchiveAboveSize = logFileMaxSize
-            };
-            SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
-            for (int currentSequenceNumber = 0; currentSequenceNumber < count; currentSequenceNumber++)
-                logger.Debug("Test {0}", currentSequenceNumber);
-        }
-
+        
         public static IEnumerable<object[]> SimpleFileTest_TestParameters
         {
             get
@@ -91,39 +72,39 @@ namespace NLog.UnitTests.Targets
         [PropertyData("SimpleFileTest_TestParameters")]
         public void SimpleFileTest(bool concurrentWrites, bool keepFileOpen, bool networkWrites)
         {
-            var tempFile = Path.GetTempFileName();
+            var logFile = Path.GetTempFileName();
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = SimpleLayout.Escape(tempFile),
+                    FileName = SimpleLayout.Escape(logFile),
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}",
                     OpenFileCacheTimeout = 0,
                     ConcurrentWrites = concurrentWrites,
                     KeepFileOpen = keepFileOpen,
                     NetworkWrites = networkWrites
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
                 logger.Warn("ccc");
                 LogManager.Configuration = null;
-                AssertFileContents(tempFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
+                AssertFileContents(logFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
             }
             finally
             {
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
             }
         }
 
         [Fact]
         public void CsvHeaderTest()
         {
-            var tempFile = Path.GetTempFileName();
+            var logFile = Path.GetTempFileName();
             try
             {
 
@@ -141,43 +122,43 @@ namespace NLog.UnitTests.Targets
                         }
                     };
 
-                    var ft = new FileTarget
+                    var fileTarget = WrapFileTarget(new FileTarget
                     {
-                        FileName = SimpleLayout.Escape(tempFile),
+                        FileName = SimpleLayout.Escape(logFile),
                         LineEnding = LineEndingMode.LF,
                         Layout = layout,
                         OpenFileCacheTimeout = 0,
                         ReplaceFileContentsOnEachWrite = false
-                    };
-                    SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                    });
+                    SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                     logger.Debug("aaa");
                     LogManager.Configuration = null;
                 }
-                AssertFileContents(tempFile, "name;level;message\nNLog.UnitTests.Targets.FileTargetTests;Debug;aaa\nNLog.UnitTests.Targets.FileTargetTests;Debug;aaa\n", Encoding.UTF8);
+                AssertFileContents(logFile, "name;level;message\nNLog.UnitTests.Targets.FileTargetTests;Debug;aaa\nNLog.UnitTests.Targets.FileTargetTests;Debug;aaa\n", Encoding.UTF8);
             }
             finally
             {
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
             }
         }
 
         [Fact]
         public void DeleteFileOnStartTest()
         {
-            var tempFile = Path.GetTempFileName();
+            var logFile = Path.GetTempFileName();
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
                     DeleteOldFileOnStartup = false,
-                    FileName = SimpleLayout.Escape(tempFile),
+                    FileName = SimpleLayout.Escape(logFile),
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}"
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -185,52 +166,52 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;
 
-                AssertFileContents(tempFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
+                AssertFileContents(logFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
 
                 // configure again, without
                 // DeleteOldFileOnStartup
 
-                ft = new FileTarget
+                fileTarget = WrapFileTarget(new FileTarget
                 {
                     DeleteOldFileOnStartup = false,
-                    FileName = SimpleLayout.Escape(tempFile),
+                    FileName = SimpleLayout.Escape(logFile),
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}"
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
                 logger.Warn("ccc");
 
                 LogManager.Configuration = null;
-                AssertFileContents(tempFile, "Debug aaa\nInfo bbb\nWarn ccc\nDebug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
+                AssertFileContents(logFile, "Debug aaa\nInfo bbb\nWarn ccc\nDebug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
 
                 // configure again, this time with
                 // DeleteOldFileOnStartup
 
-                ft = new FileTarget
+                fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = SimpleLayout.Escape(tempFile),
+                    FileName = SimpleLayout.Escape(logFile),
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}",
                     DeleteOldFileOnStartup = true
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 logger.Debug("aaa");
                 logger.Info("bbb");
                 logger.Warn("ccc");
 
                 LogManager.Configuration = null;
-                AssertFileContents(tempFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
+                AssertFileContents(logFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
             }
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
             }
         }
 
@@ -250,21 +231,21 @@ namespace NLog.UnitTests.Targets
 
         private void ArchiveFileOnStartTests(bool enableCompression)
         {
-            var tempFile = Path.GetTempFileName();
+            var logFile = Path.GetTempFileName();
             var tempArchiveFolder = Path.Combine(Path.GetTempPath(), "Archive");
             var archiveExtension = enableCompression ? "zip" : "txt";
             try
             {
                 // Configure first time with ArchiveOldFileOnStartup = false. 
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
                     ArchiveOldFileOnStartup = false,
-                    FileName = SimpleLayout.Escape(tempFile),
+                    FileName = SimpleLayout.Escape(logFile),
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}"
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -272,26 +253,26 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;
 
-                AssertFileContents(tempFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
+                AssertFileContents(logFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
 
                 // Configure second time with ArchiveOldFileOnStartup = false again. 
                 // Expected behavior: Extra content to be appended to the file.
-                ft = new FileTarget
+                fileTarget = WrapFileTarget(new FileTarget
                 {
                     ArchiveOldFileOnStartup = false,
-                    FileName = SimpleLayout.Escape(tempFile),
+                    FileName = SimpleLayout.Escape(logFile),
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}"
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
                 logger.Warn("ccc");
 
                 LogManager.Configuration = null;
-                AssertFileContents(tempFile, "Debug aaa\nInfo bbb\nWarn ccc\nDebug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
+                AssertFileContents(logFile, "Debug aaa\nInfo bbb\nWarn ccc\nDebug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
 
 
                 // Configure third time with ArchiveOldFileOnStartup = true again. 
@@ -300,27 +281,27 @@ namespace NLog.UnitTests.Targets
 
                 var archiveTempName = Path.Combine(tempArchiveFolder, "archive." + archiveExtension);
 
-                ft = new FileTarget
+                fileTarget = WrapFileTarget(new FileTarget
                 {
 #if NET4_5
                     EnableArchiveFileCompression = enableCompression,
 #endif
-                    FileName = SimpleLayout.Escape(tempFile),
+                    FileName = SimpleLayout.Escape(logFile),
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}",
                     ArchiveOldFileOnStartup = true,
                     ArchiveFileName = archiveTempName,
                     ArchiveNumbering = ArchiveNumberingMode.Sequence,
                     MaxArchiveFiles = 1
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 logger.Debug("ddd");
                 logger.Info("eee");
                 logger.Warn("fff");
 
                 LogManager.Configuration = null;
-                AssertFileContents(tempFile, "Debug ddd\nInfo eee\nWarn fff\n", Encoding.UTF8);
+                AssertFileContents(logFile, "Debug ddd\nInfo eee\nWarn fff\n", Encoding.UTF8);
                 Assert.True(File.Exists(archiveTempName));
 
                 var assertFileContents =
@@ -335,8 +316,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempArchiveFolder))
                     Directory.Delete(tempArchiveFolder, true);
             }
@@ -345,36 +326,36 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void ReplaceFileContentsOnEachWriteTest()
         {
-            var tempFile = Path.GetTempFileName();
+            var logFile = Path.GetTempFileName();
             try
             {
-                var fileTarget = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
                     DeleteOldFileOnStartup = false,
-                    FileName = SimpleLayout.Escape(tempFile),
+                    FileName = SimpleLayout.Escape(logFile),
                     ReplaceFileContentsOnEachWrite = true,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}"
-                };
+                });
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("aaa");
-                AssertFileContents(tempFile, "Debug aaa\n", Encoding.UTF8);
+                AssertFileContents(logFile, "Debug aaa\n", Encoding.UTF8);
 
                 logger.Info("bbb");
-                AssertFileContents(tempFile, "Info bbb\n", Encoding.UTF8);
+                AssertFileContents(logFile, "Info bbb\n", Encoding.UTF8);
                 logger.Warn("ccc");
 
-                AssertFileContents(tempFile, "Warn ccc\n", Encoding.UTF8);
+                AssertFileContents(logFile, "Warn ccc\n", Encoding.UTF8);
                 LogManager.Configuration = null;
 
             }
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
             }
         }
 
@@ -382,29 +363,29 @@ namespace NLog.UnitTests.Targets
         public void CreateDirsTest()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}"
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
                 logger.Warn("ccc");
                 LogManager.Configuration = null;
-                AssertFileContents(tempFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
+                AssertFileContents(logFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
             }
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -414,22 +395,22 @@ namespace NLog.UnitTests.Targets
         public void SequentialArchiveTest()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
                 string archiveFolder = Path.Combine(tempPath, "archive");
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{####}.txt"),
                     ArchiveAboveSize = 1000,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}",
                     MaxArchiveFiles = 3,
                     ArchiveNumbering = ArchiveNumberingMode.Sequence
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 // we emit 5 * 250 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
@@ -441,7 +422,7 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;
 
-                AssertFileContents(tempFile,
+                AssertFileContents(logFile,
                     StringRepeat(250, "eee\n"),
                     Encoding.UTF8);
 
@@ -466,8 +447,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -477,22 +458,22 @@ namespace NLog.UnitTests.Targets
         public void SequentialArchiveTest_MaxArchiveFiles_0()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
                 string archiveFolder = Path.Combine(tempPath, "archive");
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{####}.txt"),
                     ArchiveAboveSize = 1000,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = ArchiveNumberingMode.Sequence,
                     Layout = "${message}",
                     MaxArchiveFiles = 0
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 // we emit 5 * 250 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 4 archives
@@ -504,7 +485,7 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;
 
-                AssertFileContents(tempFile,
+                AssertFileContents(logFile,
                     StringRepeat(250, "eee\n"),
                     Encoding.UTF8);
 
@@ -533,8 +514,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -544,21 +525,21 @@ namespace NLog.UnitTests.Targets
         public void ArchiveAboveSizeWithArchiveNumberingModeDate_maxfiles_o()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), "ArchiveEveryCombinedWithArchiveAboveSize_" + Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
                 string archiveFolder = Path.Combine(tempPath, "archive");
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{####}.txt"),
                     ArchiveAboveSize = 1000,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}",
                     ArchiveNumbering = ArchiveNumberingMode.Date
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 //e.g. 20150804
                 var archiveFileName = DateTime.Now.ToString("yyyyMMdd");
@@ -591,7 +572,7 @@ namespace NLog.UnitTests.Targets
 
 
                 //we expect only eee and all other in the archive
-                AssertFileContents(tempFile,
+                AssertFileContents(logFile,
                     StringRepeat(250, "eee\n"),
                     Encoding.UTF8);
 
@@ -606,8 +587,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -617,24 +598,26 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void DeleteArchiveFilesByDate()
         {
+            const int maxArchiveFiles = 3;
+
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
                 string archiveFolder = Path.Combine(tempPath, "archive");
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{#}.txt"),
                     ArchiveAboveSize = 50,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = ArchiveNumberingMode.Date,
                     ArchiveDateFormat = "yyyyMMddHHmmssfff", //make sure the milliseconds are set in the filename
                     Layout = "${message}",
-                    MaxArchiveFiles = 3
-                };
+                    MaxArchiveFiles = maxArchiveFiles
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 //writing 19 times 10 bytes (9 char + linefeed) will result in 3 archive files and 1 current file
                 for (var i = 0; i < 19; ++i)
                 {
@@ -649,17 +632,17 @@ namespace NLog.UnitTests.Targets
 
                 var files = Directory.GetFiles(archiveFolder).OrderBy(s => s);
                 //the amount of archived files may not exceed the set 'MaxArchiveFiles'
-                Assert.Equal(ft.MaxArchiveFiles, files.Count());
+                Assert.Equal(maxArchiveFiles, files.Count());
 
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 //writing just one line of 11 bytes will trigger the cleanup of old archived files
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest file
                 logger.Debug("1234567890");
                 LogManager.Configuration = null;
 
                 var files2 = Directory.GetFiles(archiveFolder).OrderBy(s => s);
-                Assert.Equal(ft.MaxArchiveFiles, files2.Count());
+                Assert.Equal(maxArchiveFiles, files2.Count());
 
                 //the oldest file should be deleted
                 Assert.DoesNotContain(files.ElementAt(0), files2);
@@ -672,8 +655,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -682,23 +665,25 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void DeleteArchiveFilesByDateWithDateName()
         {
+            const int maxArchiveFiles = 3;
+
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "${date:format=yyyyMMddHHmmssfff}.txt");
+            var logFile = Path.Combine(tempPath, "${date:format=yyyyMMddHHmmssfff}.txt");
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "{#}.txt"),
                     ArchiveEvery = FileArchivePeriod.Minute,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = ArchiveNumberingMode.Date,
                     ArchiveDateFormat = "yyyyMMddHHmmssfff", //make sure the milliseconds are set in the filename
                     Layout = "${message}",
-                    MaxArchiveFiles = 3
-                };
-
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                    MaxArchiveFiles = maxArchiveFiles
+                });
+                
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 for (var i = 0; i < 4; ++i)
                 {
                     logger.Debug("123456789");
@@ -710,10 +695,10 @@ namespace NLog.UnitTests.Targets
 
                 var files = Directory.GetFiles(tempPath).OrderBy(s => s);
                 //we expect 3 archive files, plus one current file
-                Assert.Equal(ft.MaxArchiveFiles + 1, files.Count());
+                Assert.Equal(maxArchiveFiles + 1, files.Count());
 
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 //writing 50ms later will trigger the cleanup of old archived files
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest file
                 Thread.Sleep(50);
@@ -721,7 +706,7 @@ namespace NLog.UnitTests.Targets
                 LogManager.Configuration = null;
 
                 var files2 = Directory.GetFiles(tempPath).OrderBy(s => s);
-                Assert.Equal(ft.MaxArchiveFiles + 1, files2.Count());
+                Assert.Equal(maxArchiveFiles + 1, files2.Count());
 
                 //the oldest file should be deleted
                 Assert.DoesNotContain(files.ElementAt(0), files2);
@@ -735,8 +720,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -762,8 +747,11 @@ namespace NLog.UnitTests.Targets
         [PropertyData("DateArchive_UsesDateFromCurrentTimeSource_TestParameters")]
         public void DateArchive_UsesDateFromCurrentTimeSource(DateTimeKind timeKind, bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool includeSequenceInArchive)
         {
+            const string archiveDateFormat = "yyyyMMdd";
+            const int maxArchiveFiles = 3;
+
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logfile = Path.Combine(tempPath, "file.txt");
             var defaultTimeSource = TimeSource.Current;
             try
             {
@@ -773,22 +761,22 @@ namespace NLog.UnitTests.Targets
 
                 string archiveFolder = Path.Combine(tempPath, "archive");
                 string archiveFileNameTemplate = Path.Combine(archiveFolder, "{#}.txt");
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logfile,
                     ArchiveFileName = archiveFileNameTemplate,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = includeSequenceInArchive ? ArchiveNumberingMode.DateAndSequence : ArchiveNumberingMode.Date,
                     ArchiveEvery = FileArchivePeriod.Day,
-                    ArchiveDateFormat = "yyyyMMdd",
+                    ArchiveDateFormat = archiveDateFormat,
                     Layout = "${date:format=O}|${message}",
-                    MaxArchiveFiles = 3,
+                    MaxArchiveFiles = maxArchiveFiles,
                     ConcurrentWrites = concurrentWrites,
                     KeepFileOpen = keepFileOpen,
                     NetworkWrites = networkWrites,
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("123456789");
                 DateTime previousWriteTime = timeSource.Time;
@@ -805,7 +793,7 @@ namespace NLog.UnitTests.Targets
                         // Simulate that previous file write began in previous day and ended on current day.
                         try
                         {
-                            File.SetLastWriteTime(tempFile, timeSource.SystemTime);
+                            File.SetLastWriteTime(logfile, timeSource.SystemTime);
                         }
                         catch { }
                     }
@@ -815,7 +803,7 @@ namespace NLog.UnitTests.Targets
 
                     var dayIsChanged = eventInfo.TimeStamp.Date != previousWriteTime.Date;
                     // ensure new archive is created only when the day part of time is changed
-                    var archiveFileName = archiveFileNameTemplate.Replace("{#}", previousWriteTime.ToString(ft.ArchiveDateFormat) + (includeSequenceInArchive ? ".0" : string.Empty));
+                    var archiveFileName = archiveFileNameTemplate.Replace("{#}", previousWriteTime.ToString(archiveDateFormat) + (includeSequenceInArchive ? ".0" : string.Empty));
                     var archiveExists = File.Exists(archiveFileName);
                     if (dayIsChanged)
                         Assert.True(archiveExists, string.Format("new archive should be created when the day part of {0} time is changed", timeKind));
@@ -831,10 +819,10 @@ namespace NLog.UnitTests.Targets
 
                 var files = Directory.GetFiles(archiveFolder).OrderBy(s => s).ToList();
                 //the amount of archived files may not exceed the set 'MaxArchiveFiles'
-                Assert.Equal(ft.MaxArchiveFiles, files.Count);
+                Assert.Equal(maxArchiveFiles, files.Count);
 
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 //writing one line on a new day will trigger the cleanup of old archived files
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest file
                 timeSource.AddToLocalTime(TimeSpan.FromDays(1));
@@ -842,7 +830,7 @@ namespace NLog.UnitTests.Targets
                 LogManager.Configuration = null;
 
                 var files2 = Directory.GetFiles(archiveFolder).OrderBy(s => s).ToList();
-                Assert.Equal(ft.MaxArchiveFiles, files2.Count);
+                Assert.Equal(maxArchiveFiles, files2.Count);
 
                 //the oldest file should be deleted
                 Assert.DoesNotContain(files[0], files2);
@@ -856,8 +844,8 @@ namespace NLog.UnitTests.Targets
             {
                 TimeSource.Current = defaultTimeSource; // restore default time source
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logfile))
+                    File.Delete(logfile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -888,13 +876,13 @@ namespace NLog.UnitTests.Targets
         public void DateArchive_ArchiveOnceOnly(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool includeSequenceInArchive)
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
                 string archiveFolder = Path.Combine(tempPath, "archive");
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{#}.txt"),
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = includeSequenceInArchive ? ArchiveNumberingMode.DateAndSequence : ArchiveNumberingMode.Date,
@@ -904,13 +892,13 @@ namespace NLog.UnitTests.Targets
                     ConcurrentWrites = concurrentWrites,
                     KeepFileOpen = keepFileOpen,
                     NetworkWrites = networkWrites
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("123456789");
-                File.SetCreationTime(tempFile, File.GetCreationTime(tempFile).AddDays(-1));
-                File.SetLastWriteTime(tempFile, File.GetLastWriteTime(tempFile).AddDays(-1));
+                File.SetCreationTime(logFile, File.GetCreationTime(logFile).AddDays(-1));
+                File.SetLastWriteTime(logFile, File.GetLastWriteTime(logFile).AddDays(-1));
                 // This should archive the log before logging.
                 logger.Debug("123456789");
                 // This must not archive.
@@ -918,7 +906,7 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;
                 File.Equals(1, Directory.GetFiles(archiveFolder).Length);
-                AssertFileContents(tempFile, StringRepeat(2, "123456789\n"), Encoding.UTF8);
+                AssertFileContents(logFile, StringRepeat(2, "123456789\n"), Encoding.UTF8);
             }
             finally
             {
@@ -948,7 +936,7 @@ namespace NLog.UnitTests.Targets
         public void DateArchive_SkipPeriod(DateTimeKind timeKind, FileArchivePeriod archivePeriod, bool includeSequenceInArchive)
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             var defaultTimeSource = TimeSource.Current;
             try
             {
@@ -961,9 +949,9 @@ namespace NLog.UnitTests.Targets
                 }
                 TimeSource.Current = timeSource;
 
-                var ft = new FileTarget
+                var innerFileTarget = new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive/{#}.txt"),
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = includeSequenceInArchive ? ArchiveNumberingMode.DateAndSequence : ArchiveNumberingMode.Date,
@@ -971,13 +959,15 @@ namespace NLog.UnitTests.Targets
                     ArchiveDateFormat = "yyyyMMddHHmm",
                     Layout = "${date:format=O}|${message}",
                 };
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                string archiveDateFormat = innerFileTarget.ArchiveDateFormat;
+                var fileTarget = WrapFileTarget(innerFileTarget);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("1234567890");
                 timeSource.AddToLocalTime(TimeSpan.FromMinutes(1));
                 logger.Debug("1234567890");
                 // The archive file name must be based on the last time the file was written.
-                string archiveFileName = string.Format("{0}.txt", timeSource.Time.ToString(ft.ArchiveDateFormat) + (includeSequenceInArchive ? ".0" : string.Empty));
+                string archiveFileName = string.Format("{0}.txt", timeSource.Time.ToString(archiveDateFormat) + (includeSequenceInArchive ? ".0" : string.Empty));
                 // Effectively update the file's last-write-time.
                 timeSource.AddToSystemTime(TimeSpan.FromMinutes(1));
 
@@ -1026,7 +1016,7 @@ namespace NLog.UnitTests.Targets
                 var config = new LoggingConfiguration();
 
                 string archiveFolder = Path.Combine(tempPath, "archive");
-                var fileTarget1 = new FileTarget
+                var fileTarget1 = WrapFileTarget(new FileTarget
                 {
                     FileName = logfile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{#}.txt"),
@@ -1041,11 +1031,11 @@ namespace NLog.UnitTests.Targets
                     ConcurrentWrites = concurrentWrites,
                     KeepFileOpen = keepFileOpen,
                     NetworkWrites = networkWrites
-                };
+                });
                 var logger1Rule = new LoggingRule("logger1", LogLevel.Debug, fileTarget1);
                 config.LoggingRules.Add(logger1Rule);
 
-                var fileTarget2 = new FileTarget
+                var fileTarget2 = WrapFileTarget(new FileTarget
                 {
                     FileName = logfile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{#}.txt"),
@@ -1060,7 +1050,7 @@ namespace NLog.UnitTests.Targets
                     ConcurrentWrites = concurrentWrites,
                     KeepFileOpen = keepFileOpen,
                     NetworkWrites = networkWrites
-                };
+                });
                 var logger2Rule = new LoggingRule("logger2", LogLevel.Debug, fileTarget2);
                 config.LoggingRules.Add(logger2Rule);
 
@@ -1094,13 +1084,13 @@ namespace NLog.UnitTests.Targets
         public void DeleteArchiveFilesByDate_MaxArchiveFiles_0()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
                 string archiveFolder = Path.Combine(tempPath, "archive");
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{#}.txt"),
                     ArchiveAboveSize = 50,
                     LineEnding = LineEndingMode.LF,
@@ -1108,9 +1098,9 @@ namespace NLog.UnitTests.Targets
                     ArchiveDateFormat = "yyyyMMddHHmmssfff", //make sure the milliseconds are set in the filename
                     Layout = "${message}",
                     MaxArchiveFiles = 0
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 //writing 19 times 10 bytes (9 char + linefeed) will result in 3 archive files and 1 current file
                 for (var i = 0; i < 19; ++i)
                 {
@@ -1130,7 +1120,7 @@ namespace NLog.UnitTests.Targets
 
                 Assert.Equal(3, fileCount);
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 //create 1 new file for archive
                 logger.Debug("1234567890");
                 LogManager.Configuration = null;
@@ -1143,9 +1133,9 @@ namespace NLog.UnitTests.Targets
             {
                 LogManager.Configuration = null;
 
-                if (File.Exists(tempFile))
+                if (File.Exists(logFile))
                 {
-                    File.Delete(tempFile);
+                    File.Delete(logFile);
                 }
 
                 if (Directory.Exists(tempPath))
@@ -1159,13 +1149,13 @@ namespace NLog.UnitTests.Targets
         public void DeleteArchiveFilesByDate_AlteredMaxArchive()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
                 string archiveFolder = Path.Combine(tempPath, "archive");
-                var ft = new FileTarget
+                var innerFileTarget = new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{#}.txt"),
                     ArchiveAboveSize = 50,
                     LineEnding = LineEndingMode.LF,
@@ -1174,8 +1164,9 @@ namespace NLog.UnitTests.Targets
                     Layout = "${message}",
                     MaxArchiveFiles = 5
                 };
+                var fileTarget = WrapFileTarget(innerFileTarget);
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 //writing 29 times 10 bytes (9 char + linefeed) will result in 3 archive files and 1 current file
                 for (var i = 0; i < 29; ++i)
                 {
@@ -1190,19 +1181,19 @@ namespace NLog.UnitTests.Targets
 
                 var files = Directory.GetFiles(archiveFolder).OrderBy(s => s);
                 //the amount of archived files may not exceed the set 'MaxArchiveFiles'
-                Assert.Equal(ft.MaxArchiveFiles, files.Count());
+                Assert.Equal(innerFileTarget.MaxArchiveFiles, files.Count());
 
 
                 //alter the MaxArchivedFiles
-                ft.MaxArchiveFiles = 2;
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                innerFileTarget.MaxArchiveFiles = 2;
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 //writing just one line of 11 bytes will trigger the cleanup of old archived files
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest files
                 logger.Debug("1234567890");
                 LogManager.Configuration = null;
 
                 var files2 = Directory.GetFiles(archiveFolder).OrderBy(s => s);
-                Assert.Equal(ft.MaxArchiveFiles, files2.Count());
+                Assert.Equal(innerFileTarget.MaxArchiveFiles, files2.Count());
 
                 //the oldest files should be deleted
                 Assert.DoesNotContain(files.ElementAt(0), files2);
@@ -1217,8 +1208,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -1228,15 +1219,15 @@ namespace NLog.UnitTests.Targets
         public void RepeatingHeaderTest()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
                 const string header = "Headerline";
 
                 string archiveFolder = Path.Combine(tempPath, "archive");
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{####}.txt"),
                     ArchiveAboveSize = 51,
                     LineEnding = LineEndingMode.LF,
@@ -1244,9 +1235,9 @@ namespace NLog.UnitTests.Targets
                     Layout = "${message}",
                     Header = header,
                     MaxArchiveFiles = 2,
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 for (var i = 0; i < 16; ++i)
                 {
@@ -1255,7 +1246,7 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;
 
-                AssertFileContentsStartsWith(tempFile, header, Encoding.UTF8);
+                AssertFileContentsStartsWith(logFile, header, Encoding.UTF8);
 
                 AssertFileContentsStartsWith(Path.Combine(archiveFolder, "0002.txt"), header, Encoding.UTF8);
 
@@ -1266,8 +1257,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -1294,16 +1285,16 @@ namespace NLog.UnitTests.Targets
         private void RollingArchiveTests(bool enableCompression, bool specifyArchiveFileName)
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             var archiveExtension = enableCompression ? "zip" : "txt";
             try
             {
-                var ft = new FileTarget
+                var innerFileTarget = new FileTarget
                 {
 #if NET4_5
                     EnableArchiveFileCompression = enableCompression,
 #endif
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveAboveSize = 1000,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = ArchiveNumberingMode.Rolling,
@@ -1311,9 +1302,10 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 3
                 };
                 if (specifyArchiveFileName)
-                    ft.ArchiveFileName = Path.Combine(tempPath, "archive", "{####}." + archiveExtension);
-
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                    innerFileTarget.ArchiveFileName = Path.Combine(tempPath, "archive", "{####}." + archiveExtension);
+                var fileTarget = WrapFileTarget(innerFileTarget);
+                
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 // we emit 5 * 250 * (3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
@@ -1332,7 +1324,7 @@ namespace NLog.UnitTests.Targets
  new Action<string, string, Encoding>(AssertFileContents);
 #endif
 
-                AssertFileContents(tempFile,
+                AssertFileContents(logFile,
                     StringRepeat(250, "eee\n"),
                     Encoding.UTF8);
 
@@ -1360,8 +1352,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -1373,21 +1365,21 @@ namespace NLog.UnitTests.Targets
         public void RollingArchiveTest_MaxArchiveFiles_0(string slash)
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive" + slash + "{####}.txt"),
                     ArchiveAboveSize = 1000,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = ArchiveNumberingMode.Rolling,
                     Layout = "${message}",
                     MaxArchiveFiles = 0
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 // we emit 5 * 250 * (3 x aaa + \n) bytes
                 // so that we should get a full file + 4 archives
@@ -1399,7 +1391,7 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;
 
-                AssertFileContents(tempFile,
+                AssertFileContents(logFile,
                     StringRepeat(250, "eee\n"),
                     Encoding.UTF8);
 
@@ -1427,9 +1419,9 @@ namespace NLog.UnitTests.Targets
             {
                 LogManager.Configuration = null;
 
-                if (File.Exists(tempFile))
+                if (File.Exists(logFile))
                 {
-                    File.Delete(tempFile);
+                    File.Delete(logFile);
                 }
 
                 if (Directory.Exists(tempPath))
@@ -1445,14 +1437,14 @@ namespace NLog.UnitTests.Targets
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
                     FileName = Path.Combine(tempPath, "${level}.txt"),
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}"
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 for (var i = 0; i < 250; ++i)
                 {
@@ -1497,14 +1489,14 @@ namespace NLog.UnitTests.Targets
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
                     FileName = Path.Combine(tempPath, "${level}.txt"),
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}"
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(new BufferingTargetWrapper(ft, 10), LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(new BufferingTargetWrapper(fileTarget, 10), LogLevel.Debug);
 
                 for (var i = 0; i < 250; ++i)
                 {
@@ -1549,12 +1541,12 @@ namespace NLog.UnitTests.Targets
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
                     FileName = Path.Combine(tempPath, "${level}.txt"),
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message} ${threadid}"
-                };
+                });
 
                 // this also checks that thread-volatile layouts
                 // such as ${threadid} are properly cached and not recalculated
@@ -1562,7 +1554,7 @@ namespace NLog.UnitTests.Targets
 
                 var threadID = Thread.CurrentThread.ManagedThreadId.ToString();
 
-                SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(ft, 1000, AsyncTargetWrapperOverflowAction.Grow), LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(fileTarget, 1000, AsyncTargetWrapperOverflowAction.Grow), LogLevel.Debug);
                 LogManager.ThrowExceptions = true;
 
                 for (var i = 0; i < 250; ++i)
@@ -1606,35 +1598,10 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
-        public void BatchErrorHandlingTest()
-        {
-            var fileTarget = new FileTarget { FileName = "${logger}", Layout = "${message}" };
-            fileTarget.Initialize(null);
-
-            // make sure that when file names get sorted, the asynchronous continuations are sorted with them as well
-            var exceptions = new List<Exception>();
-            var events = new[]
-            {
-                new LogEventInfo(LogLevel.Info, "file99.txt", "msg1").WithContinuation(exceptions.Add),
-                new LogEventInfo(LogLevel.Info, "", "msg1").WithContinuation(exceptions.Add),
-                new LogEventInfo(LogLevel.Info, "", "msg2").WithContinuation(exceptions.Add),
-                new LogEventInfo(LogLevel.Info, "", "msg3").WithContinuation(exceptions.Add)
-            };
-
-            fileTarget.WriteAsyncLogEvents(events);
-
-            Assert.Equal(4, exceptions.Count);
-            Assert.Null(exceptions[0]);
-            Assert.NotNull(exceptions[1]);
-            Assert.NotNull(exceptions[2]);
-            Assert.NotNull(exceptions[3]);
-        }
-
-        [Fact]
         public void DisposingFileTarget_WhenNotIntialized_ShouldNotThrow()
         {
             var exceptionThrown = false;
-            var fileTarget = new FileTarget();
+            var fileTarget = WrapFileTarget(new FileTarget());
 
             try
             {
@@ -1664,28 +1631,31 @@ namespace NLog.UnitTests.Targets
 
         private void FileTarget_ArchiveNumbering_DateAndSequenceTests(bool enableCompression)
         {
-            var tempPath = ArchiveFilenameHelper.GenerateTempPath();
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            const string archiveDateFormat = "yyyy-MM-dd";
+            const int archiveAboveSize = 1000;
+
+            var tempPath = ArchiveFileNameHelper.GenerateTempPath();
+            var logFile = Path.Combine(tempPath, "file.txt");
             var archiveExtension = enableCompression ? "zip" : "txt";
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
 #if NET4_5
                     EnableArchiveFileCompression = enableCompression,
 #endif
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive", "{#}." + archiveExtension),
-                    ArchiveDateFormat = "yyyy-MM-dd",
-                    ArchiveAboveSize = 1000,
+                    ArchiveDateFormat = archiveDateFormat,
+                    ArchiveAboveSize = archiveAboveSize,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}",
                     MaxArchiveFiles = 3,
                     ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
                     ArchiveEvery = FileArchivePeriod.Day
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 // we emit 5 * 250 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
@@ -1695,7 +1665,7 @@ namespace NLog.UnitTests.Targets
                 Generate1000BytesLog('d');
                 Generate1000BytesLog('e');
 
-                string archiveFilename = DateTime.Now.ToString(ft.ArchiveDateFormat);
+                string archiveFilename = DateTime.Now.ToString(archiveDateFormat);
 
                 LogManager.Configuration = null;
 
@@ -1705,20 +1675,20 @@ namespace NLog.UnitTests.Targets
 #else
                 var assertFileContents = new Action<string, string, Encoding>(AssertFileContents);
 #endif
-                ArchiveFilenameHelper helper = new ArchiveFilenameHelper(Path.Combine(tempPath, "archive"), archiveFilename, archiveExtension);
+                ArchiveFileNameHelper helper = new ArchiveFileNameHelper(Path.Combine(tempPath, "archive"), archiveFilename, archiveExtension);
 
-                AssertFileContents(tempFile,
+                AssertFileContents(logFile,
                     StringRepeat(250, "eee\n"),
                     Encoding.UTF8);
 
                 assertFileContents(helper.GetFullPath(1), StringRepeat(250, "bbb\n"), Encoding.UTF8);
-                AssertFileSize(helper.GetFullPath(1), ft.ArchiveAboveSize);
+                AssertFileSize(helper.GetFullPath(1), archiveAboveSize);
 
                 assertFileContents(helper.GetFullPath(2), StringRepeat(250, "ccc\n"), Encoding.UTF8);
-                AssertFileSize(helper.GetFullPath(2), ft.ArchiveAboveSize);
+                AssertFileSize(helper.GetFullPath(2), archiveAboveSize);
 
                 assertFileContents(helper.GetFullPath(3), StringRepeat(250, "ddd\n"), Encoding.UTF8);
-                AssertFileSize(helper.GetFullPath(3), ft.ArchiveAboveSize);
+                AssertFileSize(helper.GetFullPath(3), archiveAboveSize);
 
                 Assert.False(helper.Exists(0), "First archive should have been deleted due to max archive count.");
                 Assert.False(helper.Exists(4), "Fifth archive must not have been created yet.");
@@ -1726,8 +1696,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -1739,17 +1709,17 @@ namespace NLog.UnitTests.Targets
         public void FileTarget_WithArchiveFileNameEndingInNumberPlaceholder_ShouldArchiveFile(string slash)
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive" + slash + "test.log.{####}"),
                     ArchiveAboveSize = 1000
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 for (var i = 0; i < 100; ++i)
                 {
@@ -1757,14 +1727,14 @@ namespace NLog.UnitTests.Targets
                 }
 
                 LogManager.Configuration = null;
-                Assert.True(File.Exists(tempFile));
+                Assert.True(File.Exists(logFile));
                 Assert.True(File.Exists(Path.Combine(tempPath, "archive" + slash + "test.log.0000")));
             }
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -1774,20 +1744,20 @@ namespace NLog.UnitTests.Targets
         public void FileTarget_InvalidFileNameCorrection()
         {
             var tempFile = Path.GetTempFileName();
-            var invalidTempFile = tempFile + Path.GetInvalidFileNameChars()[0];
+            var invalidLogFileName = tempFile + Path.GetInvalidFileNameChars()[0];
             var expectedCorrectedTempFile = tempFile + "_";
 
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = SimpleLayout.Escape(invalidTempFile),
+                    FileName = SimpleLayout.Escape(invalidLogFileName),
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}",
                     OpenFileCacheTimeout = 0
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Fatal);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Fatal);
 
                 logger.Fatal("aaa");
                 LogManager.Configuration = null;
@@ -1795,8 +1765,8 @@ namespace NLog.UnitTests.Targets
             }
             finally
             {
-                if (File.Exists(invalidTempFile))
-                    File.Delete(invalidTempFile);
+                if (File.Exists(invalidLogFileName))
+                    File.Delete(invalidLogFileName);
                 if (File.Exists(expectedCorrectedTempFile))
                     File.Delete(expectedCorrectedTempFile);
             }
@@ -1814,16 +1784,16 @@ namespace NLog.UnitTests.Targets
                 var archiveFile = Path.Combine(tempPath, "Application{#}.log");
                 var archiveFileMask = "Application*.log";
 
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
                     FileName = logFile,
                     ArchiveFileName = archiveFile,
                     ArchiveAboveSize = 1, //Force immediate archival
                     ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
                     MaxArchiveFiles = 5
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 //Creates 5 archive files.
                 for (int i = 0; i <= 5; i++)
@@ -1859,7 +1829,7 @@ namespace NLog.UnitTests.Targets
             {
                 string archiveFileLayout = Path.Combine(Path.GetDirectoryName(logFile), Path.GetFileNameWithoutExtension(logFile) + "{#}" + Path.GetExtension(logFile));
 
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
                     FileName = logFile,
                     Layout = "${message}",
@@ -1870,10 +1840,9 @@ namespace NLog.UnitTests.Targets
                     ArchiveNumbering = ArchiveNumberingMode.Date,
                     ArchiveDateFormat = "___________yyyyMMddHHmm",
                     MaxArchiveFiles = 10   // Get past the optimization to avoid deleting old files.
-                };
-
-
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                });
+                
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 // Create a file that will match the archive mask pattern but it's not the data format (needs to be shorter that the date format to break).
                 string existingFile = archiveFileLayout.Replace("{#}", "notadate");
@@ -1882,9 +1851,8 @@ namespace NLog.UnitTests.Targets
 
                 logger.Debug("test");
 
-                AssertFileContents(logFile, "test" + ft.NewLineChars, Encoding.UTF8);
+                AssertFileContents(logFile, "test" + LineEndingMode.Default.NewLineCharacters, Encoding.UTF8);
                 Assert.True(File.Exists(existingFile));
-
             }
             finally
             {
@@ -1902,20 +1870,20 @@ namespace NLog.UnitTests.Targets
         public void SingleArchiveFileRollsCorrectly()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive", "file.txt2"),
                     ArchiveAboveSize = 1000,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}",
                     MaxArchiveFiles = 1,
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 // we emit 2 * 250 *(aaa + \n) bytes
                 // so that we should get a full file + 1 archives
@@ -1928,7 +1896,7 @@ namespace NLog.UnitTests.Targets
                     logger.Debug("bbb");
                 }
 
-                AssertFileContents(tempFile,
+                AssertFileContents(logFile,
                     StringRepeat(250, "bbb\n"),
                     Encoding.UTF8);
                 AssertFileContents(
@@ -1943,7 +1911,7 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;
 
-                AssertFileContents(tempFile,
+                AssertFileContents(logFile,
                     StringRepeat(250, "ccc\n"),
                     Encoding.UTF8);
                 AssertFileContents(
@@ -1954,8 +1922,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -1965,20 +1933,20 @@ namespace NLog.UnitTests.Targets
         public void ArchiveFileRollsCorrectly()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive", "file.txt2"),
                     ArchiveAboveSize = 1000,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}",
                     MaxArchiveFiles = 2,
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 // we emit 3 * 250 *(aaa + \n) bytes
                 // so that we should get a full file + 2 archives
@@ -1995,7 +1963,7 @@ namespace NLog.UnitTests.Targets
                     logger.Debug("ccc");
                 }
 
-                AssertFileContents(tempFile,
+                AssertFileContents(logFile,
                     StringRepeat(250, "ccc\n"),
                     Encoding.UTF8);
                 AssertFileContents(
@@ -2014,7 +1982,7 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;
 
-                AssertFileContents(tempFile,
+                AssertFileContents(logFile,
                     StringRepeat(250, "ddd\n"),
                     Encoding.UTF8);
                 AssertFileContents(
@@ -2030,8 +1998,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -2041,24 +2009,24 @@ namespace NLog.UnitTests.Targets
         public void ArchiveFileRollsCorrectly_ExistingArchives()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logFile = Path.Combine(tempPath, "file.txt");
             try
             {
                 Directory.CreateDirectory(Path.Combine(tempPath, "archive"));
                 File.Create(Path.Combine(tempPath, "archive", "file.10.txt2")).Dispose();
                 File.Create(Path.Combine(tempPath, "archive", "file.9.txt2")).Dispose();
 
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive", "file.txt2"),
                     ArchiveAboveSize = 1000,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}",
                     MaxArchiveFiles = 2,
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 // we emit 2 * 250 *(aaa + \n) bytes
                 // so that we should get a full file + 1 archive
@@ -2071,7 +2039,7 @@ namespace NLog.UnitTests.Targets
                     logger.Debug("bbb");
                 }
 
-                AssertFileContents(tempFile,
+                AssertFileContents(logFile,
                     StringRepeat(250, "bbb\n"),
                     Encoding.UTF8);
                 AssertFileContents(
@@ -2084,8 +2052,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -2097,15 +2065,16 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void FileTarget_ArchiveNumbering_remove_correct_order()
         {
-            var tempPath = ArchiveFilenameHelper.GenerateTempPath();
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            const int maxArchiveFiles = 10;
+
+            var tempPath = ArchiveFileNameHelper.GenerateTempPath();
+            var logFile = Path.Combine(tempPath, "file.txt");
             var archiveExtension = "txt";
             try
             {
-                var maxArchiveFiles = 10;
-                var ft = new FileTarget
+                var fileTarget = new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive", "{#}." + archiveExtension),
                     ArchiveDateFormat = "yyyy-MM-dd",
                     ArchiveAboveSize = 1000,
@@ -2115,10 +2084,9 @@ namespace NLog.UnitTests.Targets
                     ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
-
-
-                ArchiveFilenameHelper helper = new ArchiveFilenameHelper(Path.Combine(tempPath, "archive"), DateTime.Now.ToString(ft.ArchiveDateFormat), archiveExtension);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                
+                ArchiveFileNameHelper helper = new ArchiveFileNameHelper(Path.Combine(tempPath, "archive"), DateTime.Now.ToString(fileTarget.ArchiveDateFormat), archiveExtension);
 
                 Generate1000BytesLog('a');
 
@@ -2139,8 +2107,8 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -2159,7 +2127,7 @@ namespace NLog.UnitTests.Targets
         /// Archive file helepr
         /// </summary>
         /// <remarks>TODO rewrite older test</remarks>
-        private class ArchiveFilenameHelper
+        private class ArchiveFileNameHelper
         {
             public string FolderName { get; private set; }
 
@@ -2172,7 +2140,7 @@ namespace NLog.UnitTests.Targets
             /// <summary>
             /// Initializes a new instance of the <see cref="T:System.Object"/> class.
             /// </summary>
-            public ArchiveFilenameHelper(string folderName, string fileName, string ext)
+            public ArchiveFileNameHelper(string folderName, string fileName, string ext)
             {
                 Ext = ext;
                 FileName = fileName;
@@ -2237,6 +2205,24 @@ namespace NLog.UnitTests.Targets
             bool resultArchiveWithExpectedNameExists = File.Exists(expectedArchiveFullName);
 
             Assert.True(resultArchiveWithExpectedNameExists);
+        }
+
+        private void GenerateArchives(int count, string archiveDateFormat, string archiveFileName,
+            ArchiveNumberingMode archiveNumbering)
+        {
+            string logFileName = Path.GetTempFileName();
+            const int logFileMaxSize = 1;
+            var fileTarget = WrapFileTarget(new FileTarget
+            {
+                FileName = logFileName,
+                ArchiveFileName = archiveFileName,
+                ArchiveDateFormat = archiveDateFormat,
+                ArchiveNumbering = archiveNumbering,
+                ArchiveAboveSize = logFileMaxSize
+            });
+            SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+            for (int currentSequenceNumber = 0; currentSequenceNumber < count; currentSequenceNumber++)
+                logger.Debug("Test {0}", currentSequenceNumber);
         }
 
         [Fact]
@@ -2413,9 +2399,7 @@ namespace NLog.UnitTests.Targets
             {
                 dateOffset--;
                 yield return Path.Combine(path, now.AddDays(dateOffset).ToString(dateFormat) + fileExt);
-
             }
-
         }
 
         [Fact]
@@ -2425,15 +2409,15 @@ namespace NLog.UnitTests.Targets
             var fullFilePath = Path.GetFullPath(relativeFileName);
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
                     FileName = fullFilePath,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}",
                     OpenFileCacheTimeout = 0
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -2455,15 +2439,15 @@ namespace NLog.UnitTests.Targets
             var fullFilePath = Path.GetFullPath(relativeFileName);
             try
             {
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
                     FileName = fullFilePath,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}",
                     OpenFileCacheTimeout = 0
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -2482,23 +2466,23 @@ namespace NLog.UnitTests.Targets
         public void RelativeSequentialArchiveTest_MaxArchiveFiles_0()
         {
             var tempPath = Guid.NewGuid().ToString();
-            var tempFile = Path.Combine(tempPath, "file.txt");
+            var logfile = Path.Combine(tempPath, "file.txt");
             try
             {
                 string archiveFolder = Path.Combine(tempPath, "archive");
-                var ft = new FileTarget
+                var fileTarget = WrapFileTarget(new FileTarget
                 {
-                    FileName = tempFile,
+                    FileName = logfile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{####}.txt"),
                     ArchiveAboveSize = 1000,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = ArchiveNumberingMode.Sequence,
                     Layout = "${message}",
                     MaxArchiveFiles = 0
-                };
+                });
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
-                tempFile = Path.GetFullPath(tempFile);
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                logfile = Path.GetFullPath(logfile);
                 // we emit 5 * 250 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 4 archives
                 Generate1000BytesLog('a');
@@ -2509,7 +2493,7 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;
 
-                AssertFileContents(tempFile,
+                AssertFileContents(logfile,
                     StringRepeat(250, "eee\n"),
                     Encoding.UTF8);
 
@@ -2538,11 +2522,57 @@ namespace NLog.UnitTests.Targets
             finally
             {
                 LogManager.Configuration = null;
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
+                if (File.Exists(logfile))
+                    File.Delete(logfile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
+        }
+
+
+        protected abstract Target WrapFileTarget(FileTarget target);
+    }
+
+
+    public class PlainFileTargetTests : FileTargetTests
+    {
+        protected override Target WrapFileTarget(FileTarget target)
+        {
+            return target;
+        }
+
+        [Fact]
+        public void BatchErrorHandlingTest()
+        {
+            var fileTarget = WrapFileTarget(new FileTarget { FileName = "${logger}", Layout = "${message}" });
+            fileTarget.Initialize(null);
+
+            // make sure that when file names get sorted, the asynchronous continuations are sorted with them as well
+            var exceptions = new List<Exception>();
+            var events = new[]
+            {
+                new LogEventInfo(LogLevel.Info, "file99.txt", "msg1").WithContinuation(exceptions.Add),
+                new LogEventInfo(LogLevel.Info, "", "msg1").WithContinuation(exceptions.Add),
+                new LogEventInfo(LogLevel.Info, "", "msg2").WithContinuation(exceptions.Add),
+                new LogEventInfo(LogLevel.Info, "", "msg3").WithContinuation(exceptions.Add)
+            };
+
+            fileTarget.WriteAsyncLogEvents(events);
+
+            Assert.Equal(4, exceptions.Count);
+            Assert.Null(exceptions[0]);
+            Assert.NotNull(exceptions[1]);
+            Assert.NotNull(exceptions[2]);
+            Assert.NotNull(exceptions[3]);
+        }
+    }
+
+
+    public class WrappedFileTargetTests : FileTargetTests
+    {
+        protected override Target WrapFileTarget(FileTarget target)
+        {
+            return new MockTargetWrapper { WrappedTarget = target };
         }
     }
 }

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -341,31 +341,33 @@ namespace NLog.UnitTests.Targets
         {
             const string header = "Headerline", footer = "Footerline";
 
-            var tempFile = Path.GetTempFileName();
+            var logFile = Path.GetTempFileName();
             try
             {
-                var fileTarget = WrapFileTarget(new FileTarget
+                var innerFileTarget = new FileTarget
                 {
                     DeleteOldFileOnStartup = false,
                     FileName = SimpleLayout.Escape(logFile),
                     ReplaceFileContentsOnEachWrite = true,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${level} ${message}"
-                });
+                };
                 if (useHeader)
-                    fileTarget.Header = header;
+                    innerFileTarget.Header = header;
                 if (useFooter)
-                    fileTarget.Footer = footer;
+                    innerFileTarget.Footer = footer;
+                var fileTarget = WrapFileTarget(innerFileTarget);
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-                string headerPart = useHeader ? header + fileTarget.LineEnding.NewLineCharacters : string.Empty;
-                string footerPart = useFooter ? footer + fileTarget.LineEnding.NewLineCharacters : string.Empty;
+                string headerPart = useHeader ? header + LineEndingMode.Default.NewLineCharacters : string.Empty;
+                string footerPart = useFooter ? footer + LineEndingMode.Default.NewLineCharacters : string.Empty;
 
                 logger.Debug("aaa");
                 AssertFileContents(logFile, headerPart + "Debug aaa\n" + footerPart, Encoding.UTF8);
                 logger.Info("bbb");
-                AssertFileContents(logfile, headerPart + "Info bbb\n" + footerPart, Encoding.UTF8);                logger.Warn("ccc");
+                AssertFileContents(logFile, headerPart + "Info bbb\n" + footerPart, Encoding.UTF8);
+                logger.Warn("ccc");
                 AssertFileContents(logFile, headerPart + "Warn ccc\n" + footerPart, Encoding.UTF8);
 
                 LogManager.Configuration = null;

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -360,8 +360,8 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-                string headerPart = useHeader ? header + LineEndingMode.Default.NewLineCharacters : string.Empty;
-                string footerPart = useFooter ? footer + LineEndingMode.Default.NewLineCharacters : string.Empty;
+                string headerPart = useHeader ? header + LineEndingMode.LF.NewLineCharacters : string.Empty;
+                string footerPart = useFooter ? footer + LineEndingMode.LF.NewLineCharacters : string.Empty;
 
                 logger.Debug("aaa");
                 AssertFileContents(logFile, headerPart + "Debug aaa\n" + footerPart, Encoding.UTF8);

--- a/tests/NLog.UnitTests/Targets/Mocks/MockTargetWrapper.cs
+++ b/tests/NLog.UnitTests/Targets/Mocks/MockTargetWrapper.cs
@@ -1,0 +1,54 @@
+﻿// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.Targets.Mocks
+{
+    using NLog.Common;
+    using NLog.Targets;
+    using NLog.Targets.Wrappers;
+
+    [Target("MockWrapper", IsWrapper = true)]
+    public class MockTargetWrapper : WrapperTargetBase
+    {
+        protected override void CloseTarget()
+        {
+            base.CloseTarget();
+            WrappedTarget.Dispose();
+        }
+        
+        protected override void Write(AsyncLogEventInfo logEvent)
+        {
+            WrappedTarget.WriteAsyncLogEvents(logEvent);
+        }
+    }
+}


### PR DESCRIPTION
Augments `FileTargetTests` to run all tests through a wrapper target and fixes all bugs that these tests reveal. 

This should fix #1182, but is to be confirmed.