### PR TITLE
Fix deadlock on Factory

### DIFF
--- a/src/NLog/GDC.cs
+++ b/src/NLog/GDC.cs
@@ -34,6 +34,7 @@
 namespace NLog
 {
     using System;
+    using Config;
 
     /// <summary>
     /// Global Diagnostics Context - used for log4net compatibility.
@@ -56,6 +57,7 @@ namespace NLog
         /// </summary>
         /// <param name="item">Item name.</param>
         /// <returns>The value of <paramref name="item"/>, if defined; otherwise <see cref="String.Empty"/>.</returns>
+        /// <remarks>If the value isn't a <see cref="string"/> already, this call locks the <see cref="LogFactory"/> for reading the <see cref="LoggingConfiguration.DefaultCultureInfo"/> needed for converting to <see cref="string"/>. </remarks>
         public static string Get(string item)
         {
             return GlobalDiagnosticsContext.Get(item);
@@ -67,6 +69,7 @@ namespace NLog
         /// <param name="item">Item name.</param>
         /// <param name="formatProvider"><see cref="IFormatProvider"/> to use when converting the item's value to a string.</param>
         /// <returns>The value of <paramref name="item"/> as a string, if defined; otherwise <see cref="String.Empty"/>.</returns>
+        /// <remarks>If <paramref name="formatProvider"/> is <c>null</c> and the value isn't a <see cref="string"/> already, this call locks the <see cref="LogFactory"/> for reading the <see cref="LoggingConfiguration.DefaultCultureInfo"/> needed for converting to <see cref="string"/>. </remarks>
         public static string Get(string item, IFormatProvider formatProvider) 
         {
             return GlobalDiagnosticsContext.Get(item, formatProvider);

--- a/src/NLog/GlobalDiagnosticsContext.cs
+++ b/src/NLog/GlobalDiagnosticsContext.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using NLog.Internal;
+
 namespace NLog
 {
     using System;
@@ -90,7 +92,7 @@ namespace NLog
         /// <remarks>If <paramref name="formatProvider"/> is <c>null</c> and the value isn't a <see cref="string"/> already, this call locks the <see cref="LogFactory"/> for reading the <see cref="LoggingConfiguration.DefaultCultureInfo"/> needed for converting to <see cref="string"/>. </remarks>
         public static string Get(string item, IFormatProvider formatProvider)
         {
-            return ConvertToString(GetObject(item), formatProvider);
+            return FormatHelper.ConvertToString(GetObject(item), formatProvider);
         }
 
         /// <summary>
@@ -144,31 +146,6 @@ namespace NLog
             {
                 dict.Clear();
             }
-        }
-
-        /// <summary>
-        /// Convert object to string
-        /// </summary>
-        /// <param name="o">value</param>
-        /// <param name="formatProvider">format for conversion.</param>
-        /// <returns></returns>
-        /// <remarks>
-        /// If <paramref name="formatProvider"/> is <c>null</c> and <paramref name="o"/> isn't a <see cref="string"/> already, then the <see cref="LogFactory"/> will get a locked by <see cref="LogManager.Configuration"/>
-        /// </remarks>
-        internal static string ConvertToString(object o, IFormatProvider formatProvider)
-        {
-            // if no IFormatProvider is specified, use the Configuration.DefaultCultureInfo value.
-            if (formatProvider == null && !(o is string))
-            {
-                //variable so only 1 lock is needed
-                //TODO this locks the configuration, which can lead to deadlocks.
-                var loggingConfiguration = LogManager.Configuration;
-                if (loggingConfiguration != null)
-                    formatProvider = loggingConfiguration.DefaultCultureInfo;
-            }
-
-            return Convert.ToString(o, formatProvider);
-
         }
     }
 }

--- a/src/NLog/Internal/FormatHelper.cs
+++ b/src/NLog/Internal/FormatHelper.cs
@@ -54,7 +54,7 @@ namespace NLog.Internal
         {
             if (value == null)
             {
-                return string.Empty;
+                return String.Empty;
             }
 
             if (format == null)
@@ -69,6 +69,31 @@ namespace NLog.Internal
             }
 
             return Convert.ToString(value, formatProvider);
+        }
+
+        /// <summary>
+        /// Convert object to string
+        /// </summary>
+        /// <param name="o">value</param>
+        /// <param name="formatProvider">format for conversion.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <c>null</c> and <paramref name="o"/> isn't a <see cref="string"/> already, then the <see cref="LogFactory"/> will get a locked by <see cref="LogManager.Configuration"/>
+        /// </remarks>
+        internal static string ConvertToString(object o, IFormatProvider formatProvider)
+        {
+            // if no IFormatProvider is specified, use the Configuration.DefaultCultureInfo value.
+            if (formatProvider == null && !(o is string))
+            {
+                //variable so only 1 lock is needed
+                //TODO this locks the configuration, which can lead to deadlocks.
+                var loggingConfiguration = LogManager.Configuration;
+                if (loggingConfiguration != null)
+                    formatProvider = loggingConfiguration.DefaultCultureInfo;
+            }
+
+            return Convert.ToString(o, formatProvider);
+
         }
     }
 }

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using NLog.Config;
 
 namespace NLog.Internal

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NLog.Config;
+
+namespace NLog.Internal
+{
+    /// <summary>
+    /// Helpers for <see cref="StringBuilder"/>, which is used in e.g. layout renderers.
+    /// </summary>
+    internal static class StringBuilderExt
+    {
+        /// <summary>
+        /// Append a value and use formatProvider of <paramref name="logEvent"/> or <paramref name="configuration"/> to convert to string.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="o">value to append.</param>
+        /// <param name="logEvent">current logEvent for FormatProvider.</param>
+        /// <param name="configuration">Configuration for DefaultCultureInfo</param>
+        public static void Append(this StringBuilder builder, object o, LogEventInfo logEvent, LoggingConfiguration configuration)
+        {
+            var formatProvider = logEvent.FormatProvider;
+            if (formatProvider == null && configuration != null)
+            {
+                formatProvider = configuration.DefaultCultureInfo;
+            }
+            builder.Append(Convert.ToString(o, formatProvider));
+        }
+
+    }
+}

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -1,6 +1,37 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
 using System.Text;
 using NLog.Config;
 

--- a/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.LayoutRenderers
 {
+    using System;
     using System.Text;
     using NLog.Config;
 
@@ -57,7 +58,10 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            builder.Append(GlobalDiagnosticsContext.Get(this.Item, logEvent.FormatProvider));
+            //don't use GlobalDiagnosticsContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
+            var o = GlobalDiagnosticsContext.GetObject(this.Item);
+            var formatProvider = logEvent.FormatProvider ?? LoggingConfiguration.DefaultCultureInfo;
+            builder.Append(Convert.ToString(o, formatProvider));
         }
     }
 }

--- a/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
@@ -60,7 +60,11 @@ namespace NLog.LayoutRenderers
         {
             //don't use GlobalDiagnosticsContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
             var o = GlobalDiagnosticsContext.GetObject(this.Item);
-            var formatProvider = logEvent.FormatProvider ?? LoggingConfiguration.DefaultCultureInfo;
+            var formatProvider = logEvent.FormatProvider;
+            if (formatProvider == null && LoggingConfiguration != null)
+            {
+                formatProvider = LoggingConfiguration.DefaultCultureInfo;
+            }
             builder.Append(Convert.ToString(o, formatProvider));
         }
     }

--- a/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
@@ -35,7 +35,8 @@ namespace NLog.LayoutRenderers
 {
     using System;
     using System.Text;
-    using NLog.Config;
+    using Config;
+    using Internal;
 
     /// <summary>
     /// Global Diagnostics Context item. Provided for compatibility with log4net.
@@ -60,12 +61,7 @@ namespace NLog.LayoutRenderers
         {
             //don't use GlobalDiagnosticsContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
             var o = GlobalDiagnosticsContext.GetObject(this.Item);
-            var formatProvider = logEvent.FormatProvider;
-            if (formatProvider == null && LoggingConfiguration != null)
-            {
-                formatProvider = LoggingConfiguration.DefaultCultureInfo;
-            }
-            builder.Append(Convert.ToString(o, formatProvider));
+            builder.Append(o, logEvent, LoggingConfiguration);
         }
     }
 }

--- a/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
@@ -33,9 +33,9 @@
 
 namespace NLog.LayoutRenderers
 {
-    using System;
     using System.Text;
-    using NLog.Config;
+    using Config;
+    using Internal;
 
     /// <summary>
     /// Mapped Diagnostic Context item. Provided for compatibility with log4net.
@@ -60,12 +60,8 @@ namespace NLog.LayoutRenderers
         {
             //don't use MappedDiagnosticsContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
             var o = MappedDiagnosticsContext.GetObject(this.Item);
-            var formatProvider = logEvent.FormatProvider;
-            if (formatProvider == null && LoggingConfiguration != null)
-            {
-                formatProvider = LoggingConfiguration.DefaultCultureInfo;
-            }
-            builder.Append(Convert.ToString(o, formatProvider));
+            
+            builder.Append(o, logEvent, LoggingConfiguration);
         }
     }
 }

--- a/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
@@ -60,7 +60,11 @@ namespace NLog.LayoutRenderers
         {
             //don't use MappedDiagnosticsContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
             var o = MappedDiagnosticsContext.GetObject(this.Item);
-            var formatProvider = logEvent.FormatProvider ?? LoggingConfiguration.DefaultCultureInfo;
+            var formatProvider = logEvent.FormatProvider;
+            if (formatProvider == null && LoggingConfiguration != null)
+            {
+                formatProvider = LoggingConfiguration.DefaultCultureInfo;
+            }
             builder.Append(Convert.ToString(o, formatProvider));
         }
     }

--- a/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
@@ -58,7 +58,10 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            builder.Append(MappedDiagnosticsContext.Get(this.Item, logEvent.FormatProvider));
+            //don't use MappedDiagnosticsContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
+            var o = MappedDiagnosticsContext.GetObject(this.Item);
+            var formatProvider = logEvent.FormatProvider ?? LoggingConfiguration.DefaultCultureInfo;
+            builder.Append(Convert.ToString(o, formatProvider));
         }
     }
 }

--- a/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
@@ -34,9 +34,9 @@
 namespace NLog.LayoutRenderers
 {
 #if NET4_0 || NET4_5
-    using System;
     using System.Text;
     using Config;
+    using Internal;
 
     /// <summary>
     /// Mapped Diagnostic Logical Context item (based on CallContext).
@@ -61,12 +61,7 @@ namespace NLog.LayoutRenderers
         {
             //don't use MappedDiagnosticsLogicalContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
             var o = MappedDiagnosticsLogicalContext.GetObject(this.Item);
-            var formatProvider = logEvent.FormatProvider;
-            if (formatProvider == null && LoggingConfiguration != null)
-            {
-                formatProvider = LoggingConfiguration.DefaultCultureInfo;
-            }
-            builder.Append(Convert.ToString(o, formatProvider));
+            builder.Append(o, logEvent, LoggingConfiguration);
         }
     }
 #endif

--- a/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
@@ -34,8 +34,9 @@
 namespace NLog.LayoutRenderers
 {
 #if NET4_0 || NET4_5
+    using System;
     using System.Text;
-    using NLog.Config;
+    using Config;
 
     /// <summary>
     /// Mapped Diagnostic Logical Context item (based on CallContext).
@@ -58,8 +59,10 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            var message = MappedDiagnosticsLogicalContext.Get(Item);
-            builder.Append(message);
+            //don't use MappedDiagnosticsLogicalContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
+            var o = MappedDiagnosticsLogicalContext.GetObject(this.Item);
+            var formatProvider = logEvent.FormatProvider ?? LoggingConfiguration.DefaultCultureInfo;
+            builder.Append(Convert.ToString(o, formatProvider));
         }
     }
 #endif

--- a/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
@@ -61,7 +61,11 @@ namespace NLog.LayoutRenderers
         {
             //don't use MappedDiagnosticsLogicalContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
             var o = MappedDiagnosticsLogicalContext.GetObject(this.Item);
-            var formatProvider = logEvent.FormatProvider ?? LoggingConfiguration.DefaultCultureInfo;
+            var formatProvider = logEvent.FormatProvider;
+            if (formatProvider == null && LoggingConfiguration != null)
+            {
+                formatProvider = LoggingConfiguration.DefaultCultureInfo;
+            }
             builder.Append(Convert.ToString(o, formatProvider));
         }
     }

--- a/src/NLog/MDC.cs
+++ b/src/NLog/MDC.cs
@@ -34,6 +34,7 @@
 namespace NLog
 {
     using System;
+    using Config;
 
     /// <summary>
     /// Mapped Diagnostics Context - used for log4net compatibility.
@@ -56,6 +57,7 @@ namespace NLog
         /// </summary>
         /// <param name="item">Item name.</param>
         /// <returns>The value of <paramref name="item"/>, if defined; otherwise <see cref="String.Empty"/>.</returns>
+        /// <remarks>If the value isn't a <see cref="string"/> already, this call locks the <see cref="LogFactory"/> for reading the <see cref="LoggingConfiguration.DefaultCultureInfo"/> needed for converting to <see cref="string"/>. </remarks>
         public static string Get(string item)
         {
             return MappedDiagnosticsContext.Get(item);

--- a/src/NLog/MappedDiagnosticsContext.cs
+++ b/src/NLog/MappedDiagnosticsContext.cs
@@ -93,7 +93,7 @@ namespace NLog
         /// <remarks>If <paramref name="formatProvider"/> is <c>null</c> and the value isn't a <see cref="string"/> already, this call locks the <see cref="LogFactory"/> for reading the <see cref="LoggingConfiguration.DefaultCultureInfo"/> needed for converting to <see cref="string"/>. </remarks>
         public static string Get(string item, IFormatProvider formatProvider)
         {
-            return GlobalDiagnosticsContext.ConvertToString(GetObject(item), formatProvider);
+            return FormatHelper.ConvertToString(GetObject(item), formatProvider);
         }
 
         /// <summary>

--- a/src/NLog/MappedDiagnosticsContext.cs
+++ b/src/NLog/MappedDiagnosticsContext.cs
@@ -36,7 +36,8 @@ namespace NLog
     using System;
     using System.Collections.Generic;
 
-    using NLog.Internal;
+    using Config;
+    using Internal;
 
     /// <summary>
     /// Mapped Diagnostics Context - a thread-local structure that keeps a dictionary
@@ -77,6 +78,7 @@ namespace NLog
         /// </summary>
         /// <param name="item">Item name.</param>
         /// <returns>The value of <paramref name="item"/>, if defined; otherwise <see cref="String.Empty"/>.</returns>
+        /// <remarks>If the value isn't a <see cref="string"/> already, this call locks the <see cref="LogFactory"/> for reading the <see cref="LoggingConfiguration.DefaultCultureInfo"/> needed for converting to <see cref="string"/>. </remarks>
         public static string Get(string item)
         {
             return Get(item, null);
@@ -86,8 +88,9 @@ namespace NLog
         /// Gets the current thread MDC named item, as <see cref="string"/>.
         /// </summary>
         /// <param name="item">Item name.</param>
-        /// <param name="formatProvider">The <see cref="IFormatProvider"/> to use when converting a value to a string.</param>
+        /// <param name="formatProvider">The <see cref="IFormatProvider"/> to use when converting a value to a <see cref="string"/>.</param>
         /// <returns>The value of <paramref name="item"/>, if defined; otherwise <see cref="String.Empty"/>.</returns>
+        /// <remarks>If <paramref name="formatProvider"/> is <c>null</c> and the value isn't a <see cref="string"/> already, this call locks the <see cref="LogFactory"/> for reading the <see cref="LoggingConfiguration.DefaultCultureInfo"/> needed for converting to <see cref="string"/>. </remarks>
         public static string Get(string item, IFormatProvider formatProvider)
         {
             return GlobalDiagnosticsContext.ConvertToString(GetObject(item), formatProvider);

--- a/src/NLog/MappedDiagnosticsLogicalContext.cs
+++ b/src/NLog/MappedDiagnosticsLogicalContext.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using NLog.Internal;
+
 namespace NLog
 {
 #if NET4_0 || NET4_5
@@ -87,7 +89,7 @@ namespace NLog
         /// <remarks>If <paramref name="formatProvider"/> is <c>null</c> and the value isn't a <see cref="string"/> already, this call locks the <see cref="LogFactory"/> for reading the <see cref="LoggingConfiguration.DefaultCultureInfo"/> needed for converting to <see cref="string"/>. </remarks>
         public static string Get(string item, IFormatProvider formatProvider)
         {
-            return GlobalDiagnosticsContext.ConvertToString(GetObject(item), formatProvider);
+            return FormatHelper.ConvertToString(GetObject(item), formatProvider);
         }
 
         /// <summary>

--- a/src/NLog/MappedDiagnosticsLogicalContext.cs
+++ b/src/NLog/MappedDiagnosticsLogicalContext.cs
@@ -34,6 +34,7 @@
 namespace NLog
 {
 #if NET4_0 || NET4_5
+    using Config;
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
@@ -71,6 +72,7 @@ namespace NLog
         /// </summary>
         /// <param name="item">Item name.</param>
         /// <returns>The value of <paramref name="item"/>, if defined; otherwise <see cref="String.Empty"/>.</returns>
+        /// <remarks>If the value isn't a <see cref="string"/> already, this call locks the <see cref="LogFactory"/> for reading the <see cref="LoggingConfiguration.DefaultCultureInfo"/> needed for converting to <see cref="string"/>. </remarks>
         public static string Get(string item)
         {
             return Get(item, null);
@@ -82,6 +84,7 @@ namespace NLog
         /// <param name="item">Item name.</param>
         /// <param name="formatProvider">The <see cref="IFormatProvider"/> to use when converting a value to a string.</param>
         /// <returns>The value of <paramref name="item"/>, if defined; otherwise <see cref="String.Empty"/>.</returns>
+        /// <remarks>If <paramref name="formatProvider"/> is <c>null</c> and the value isn't a <see cref="string"/> already, this call locks the <see cref="LogFactory"/> for reading the <see cref="LoggingConfiguration.DefaultCultureInfo"/> needed for converting to <see cref="string"/>. </remarks>
         public static string Get(string item, IFormatProvider formatProvider)
         {
             return GlobalDiagnosticsContext.ConvertToString(GetObject(item), formatProvider);

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -184,6 +184,7 @@
     <Compile Include="Internal\SortHelpers.cs" />
     <Compile Include="Internal\StackTraceUsageUtils.cs" />
     <Compile Include="Internal\StreamHelpers.cs" />
+    <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Internal\SortHelpers.cs" />
     <Compile Include="Internal\StackTraceUsageUtils.cs" />
     <Compile Include="Internal\StreamHelpers.cs" />
+    <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Internal\SortHelpers.cs" />
     <Compile Include="Internal\StackTraceUsageUtils.cs" />
     <Compile Include="Internal\StreamHelpers.cs" />
+    <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -200,6 +200,7 @@
     <Compile Include="Internal\SortHelpers.cs" />
     <Compile Include="Internal\StackTraceUsageUtils.cs" />
     <Compile Include="Internal\StreamHelpers.cs" />
+    <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Internal\SortHelpers.cs" />
     <Compile Include="Internal\StackTraceUsageUtils.cs" />
     <Compile Include="Internal\StreamHelpers.cs" />
+    <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Internal\SortHelpers.cs" />
     <Compile Include="Internal\StackTraceUsageUtils.cs" />
     <Compile Include="Internal\StreamHelpers.cs" />
+    <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -199,6 +200,7 @@
     <Compile Include="Internal\SortHelpers.cs" />
     <Compile Include="Internal\StackTraceUsageUtils.cs" />
     <Compile Include="Internal\StreamHelpers.cs" />
+    <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Internal\SortHelpers.cs" />
     <Compile Include="Internal\StackTraceUsageUtils.cs" />
     <Compile Include="Internal\StreamHelpers.cs" />
+    <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Internal\SortHelpers.cs" />
     <Compile Include="Internal\StackTraceUsageUtils.cs" />
     <Compile Include="Internal\StreamHelpers.cs" />
+    <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Internal\SortHelpers.cs" />
     <Compile Include="Internal\StackTraceUsageUtils.cs" />
     <Compile Include="Internal\StreamHelpers.cs" />
+    <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Internal\SortHelpers.cs" />
     <Compile Include="Internal\StackTraceUsageUtils.cs" />
     <Compile Include="Internal\StreamHelpers.cs" />
+    <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -222,6 +222,7 @@
     <Compile Include="Internal\SortHelpers.cs" />
     <Compile Include="Internal\StackTraceUsageUtils.cs" />
     <Compile Include="Internal\StreamHelpers.cs" />
+    <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NestedDiagnosticsContext.cs
+++ b/src/NLog/NestedDiagnosticsContext.cs
@@ -56,7 +56,7 @@ namespace NLog
         {
             get
             {
-                return GlobalDiagnosticsContext.ConvertToString(TopObject, null);
+                return FormatHelper.ConvertToString(TopObject, null);
             }
         }
 
@@ -117,7 +117,7 @@ namespace NLog
         /// <returns>The top message, which is removed from the stack, as a string value.</returns>
         public static string Pop(IFormatProvider formatProvider)
         {
-            return GlobalDiagnosticsContext.ConvertToString(PopObject(), formatProvider);
+            return FormatHelper.ConvertToString(PopObject(), formatProvider);
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace NLog
         /// <returns>Array of strings.</returns>
         public static string[] GetAllMessages(IFormatProvider formatProvider) 
         {
-            return ThreadStack.Select((o) => GlobalDiagnosticsContext.ConvertToString(o, formatProvider)).ToArray();
+            return ThreadStack.Select((o) => FormatHelper.ConvertToString(o, formatProvider)).ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
- No locking on factory when rendering layout renderers
- Less locking when using GlobalDiagnosticsContext.Get / MappedDiagnosticsContext.Get / MappedDiagnosticsLogicalContext.Get
- added <remarks> for (indirect) locks 
- move ConvertToString from GlobalContext to FormatHelper (internal)
- introduced StringBuilderExt, remove duplicate code (internal)

fixes https://github.com/NLog/NLog/issues/1203