### PR TITLE
Fix HttpGet protocol for WebService

### DIFF
--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -270,7 +270,7 @@ namespace NLog.Targets
                 queryParameters.Append(separator);
                 queryParameters.Append(this.Parameters[i].Name);
                 queryParameters.Append("=");
-                queryParameters.Append(UrlHelper.UrlEncode(Convert.ToString(parameterValues[i], CultureInfo.InvariantCulture), true));
+                queryParameters.Append(UrlHelper.UrlEncode(Convert.ToString(parameterValues[i], CultureInfo.InvariantCulture), false));
                 separator = "&";
             }
 

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -275,6 +275,8 @@ namespace NLog.Targets
             }
 
             var builder = new UriBuilder(this.Url);
+            //append our query string to the URL following 
+            //the recommendations at https://msdn.microsoft.com/en-us/library/system.uribuilder.query.aspx
             if (builder.Query != null && builder.Query.Length > 1)
             {
                 builder.Query = builder.Query.Substring(1) + "&" + queryParameters.ToString();

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -265,15 +265,13 @@ namespace NLog.Targets
             //if the protocol is HttpGet, we need to add the parameters to the query string of the url
             var queryParameters = new StringBuilder();
             string separator = string.Empty;
-            int i = 0;
-            foreach (MethodCallParameter parameter in this.Parameters)
+            for (int i = 0; i < this.Parameters.Count; i++)
             {
                 queryParameters.Append(separator);
-                queryParameters.Append(parameter.Name);
+                queryParameters.Append(this.Parameters[i].Name);
                 queryParameters.Append("=");
                 queryParameters.Append(UrlHelper.UrlEncode(Convert.ToString(parameterValues[i], CultureInfo.InvariantCulture), true));
                 separator = "&";
-                i++;
             }
 
             var builder = new UriBuilder(this.Url);

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -299,8 +299,17 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
         [Fact]
         public void WebserviceTest_restapi_httpget()
         {
+            WebServiceTest_httpget("api/logme");
+        }
 
-
+        [Fact]
+        public void WebServiceTest_restapi_httpget_querystring()
+        {
+            WebServiceTest_httpget("api/logme?paramFromConfig=valueFromConfig");
+        }
+        
+        private void WebServiceTest_httpget(string relativeUrl)
+        {
             var configuration = CreateConfigurationFromString(string.Format(@"
                 <nlog throwExceptions='true' >
                     <targets>
@@ -320,7 +329,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                        
                       </logger>
                     </rules>
-                </nlog>", WsAddress, "api/logme"));
+                </nlog>", WsAddress, relativeUrl));
 
 
             LogManager.Configuration = configuration;
@@ -329,12 +338,9 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             LogMeController.ResetState(1);
 
             StartOwinTest(() =>
-         {
-
-             logger.Info("message 1 with a post");
-         });
-
-
+            {
+                logger.Info("message 1 with a post");
+            });
         }
 
 

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -296,7 +296,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
         /// <summary>
         /// Test the Webservice with REST api -  <see cref="WebServiceProtocol.HttpGet"/>  (only checking for no exception)
         /// </summary>
-        [Fact(Skip = "Not working - ProtocolViolationException - skip for fix later")]
+        [Fact]
         public void WebserviceTest_restapi_httpget()
         {
 


### PR DESCRIPTION
Fixes #701 
Reenables the `WebserviceTest_restapi_httpget` unit test, not sure if other tests are needed.
Not sure either if the `spaceAsPlus` parameter for the `UrlHelper.UrlEncode()` should be true or false