### PR TITLE
Bugfix: Internallogger creates folder, even when turned off.

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -204,6 +204,11 @@ namespace NLog.Common
                 return;
             }
 
+            if (level == LogLevel.Off)
+            {
+                return;
+            }
+
             if (level < LogLevel)
             {
                 return;
@@ -380,7 +385,7 @@ namespace NLog.Common
         {
             try
             {
-                if(InternalLogger.LogLevel == NLog.LogLevel.Off)
+                if (InternalLogger.LogLevel == NLog.LogLevel.Off)
                 {
                     return;
                 }

--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -380,6 +380,11 @@ namespace NLog.Common
         {
             try
             {
+                if(InternalLogger.LogLevel == NLog.LogLevel.Off)
+                {
+                    return;
+                }
+
                 string parentDirectory = Path.GetDirectoryName(filename);
                 if (!string.IsNullOrEmpty(parentDirectory))
                 {

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -416,7 +416,7 @@ namespace NLog.UnitTests.Common
             // Set the log file, which will only create the needed directories
             InternalLogger.LogFile = tempFile;
 
-            Assert.True(Directory.Exists(randomSubDirectory) == shouldCreateDirectory);
+            Assert.Equal(Directory.Exists(randomSubDirectory), shouldCreateDirectory);
 
             try
             {
@@ -424,7 +424,7 @@ namespace NLog.UnitTests.Common
 
                 InternalLogger.Log(LogLevel.FromString(rawLogLevel), "File and Directory created.");
 
-                Assert.True(File.Exists(tempFile) == shouldCreateDirectory);
+                Assert.Equal(File.Exists(tempFile), shouldCreateDirectory);
             }
             finally
             {

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -403,14 +403,6 @@ namespace NLog.UnitTests.Common
         [InlineData("off", false)]
         public void CreateDirectoriesIfNeededTests(string rawLogLevel, bool shouldCreateDirectory)
         {
-            string expected =
-                    "Warn WWW" + Environment.NewLine +
-                    "Error EEE" + Environment.NewLine +
-                    "Fatal FFF" + Environment.NewLine +
-                    "Trace TTT" + Environment.NewLine +
-                    "Debug DDD" + Environment.NewLine +
-                    "Info III" + Environment.NewLine;
-
             var tempPath = Path.GetTempPath();
             var tempFileName = Path.GetRandomFileName();
             var randomSubDirectory = Path.Combine(tempPath, Path.GetRandomFileName());
@@ -430,16 +422,9 @@ namespace NLog.UnitTests.Common
             {
                 Assert.False(File.Exists(tempFile));
 
-                // Invoke Log(LogLevel, string) for every log level.
-                InternalLogger.Log(LogLevel.Warn, "WWW");
-                InternalLogger.Log(LogLevel.Error, "EEE");
-                InternalLogger.Log(LogLevel.Fatal, "FFF");
-                InternalLogger.Log(LogLevel.Trace, "TTT");
-                InternalLogger.Log(LogLevel.Debug, "DDD");
-                InternalLogger.Log(LogLevel.Info, "III");
+                InternalLogger.Log(LogLevel.FromString(rawLogLevel), "File and Directory created.");
 
-                AssertFileContents(tempFile, expected, Encoding.UTF8);
-                Assert.True(File.Exists(tempFile));
+                Assert.True(File.Exists(tempFile) == shouldCreateDirectory);
             }
             finally
             {

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -394,8 +394,17 @@ namespace NLog.UnitTests.Common
         }
 
         [Theory]
-        public void CreateDirectoriesIfNeededTests()
+        [InlineData("trace", true)]
+        [InlineData("debug", true)]
+        [InlineData("info", true)]
+        [InlineData("warn", true)]
+        [InlineData("error", true)]
+        [InlineData("fatal", true)]
+        [InlineData("off", false)]
+        public void CreateDirectoriesIfNeededTests(string rawLogLevel, bool shouldCreateDirectory)
         {
+            var logLevel = LogLevel.FromString(rawLogLevel);
+
             string expected =
                     "Warn WWW" + Environment.NewLine +
                     "Error EEE" + Environment.NewLine +

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -403,8 +403,6 @@ namespace NLog.UnitTests.Common
         [InlineData("off", false)]
         public void CreateDirectoriesIfNeededTests(string rawLogLevel, bool shouldCreateDirectory)
         {
-            var logLevel = LogLevel.FromString(rawLogLevel);
-
             string expected =
                     "Warn WWW" + Environment.NewLine +
                     "Error EEE" + Environment.NewLine +
@@ -413,13 +411,12 @@ namespace NLog.UnitTests.Common
                     "Debug DDD" + Environment.NewLine +
                     "Info III" + Environment.NewLine;
 
-
             var tempPath = Path.GetTempPath();
             var tempFileName = Path.GetRandomFileName();
             var randomSubDirectory = Path.Combine(tempPath, Path.GetRandomFileName());
             string tempFile = Path.Combine(randomSubDirectory, tempFileName);
 
-            InternalLogger.LogLevel = LogLevel.Trace;
+            InternalLogger.LogLevel = LogLevel.FromString(rawLogLevel);
             InternalLogger.IncludeTimestamp = false;
 
             Assert.False(Directory.Exists(randomSubDirectory));
@@ -427,7 +424,7 @@ namespace NLog.UnitTests.Common
             // Set the log file, which will only create the needed directories
             InternalLogger.LogFile = tempFile;
 
-            Assert.True(Directory.Exists(randomSubDirectory));
+            Assert.True(Directory.Exists(randomSubDirectory) == shouldCreateDirectory);
 
             try
             {

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -38,7 +38,9 @@ using System.Linq;
 using Xunit;
 using NLog.Common;
 using System.Text;
+#if !SILVERLIGHT 
 using Xunit.Extensions;
+#endif
 
 namespace NLog.UnitTests.Common
 {

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -38,6 +38,7 @@ using System.Linq;
 using Xunit;
 using NLog.Common;
 using System.Text;
+using Xunit.Extensions;
 
 namespace NLog.UnitTests.Common
 {
@@ -392,8 +393,7 @@ namespace NLog.UnitTests.Common
 
         }
 
-
-        [Fact]
+        [Theory]
         public void CreateDirectoriesIfNeededTests()
         {
             string expected =


### PR DESCRIPTION
Fixes #1229 

When LogLevel is set to "Off" NLog should not create an emtpy folder or try to write a log file to a folder that doesn´t exists.