### PR TITLE
Control throwing of NLogConfigurationExceptions (LogManager.ThrowConfigExceptions)

### DIFF
--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.Config
 {
+    using Internal;
     using System;
     using System.Collections.Generic;
     using System.Globalization;
@@ -166,7 +167,7 @@ namespace NLog.Config
                 return defaultValue;
             }
 
-            if (string.IsNullOrWhiteSpace(value))
+            if (StringHelpers.IsNullOrWhiteSpace(value))
             {
                 return defaultValue;
             }

--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -153,7 +153,7 @@ namespace NLog.Config
         }
 
         /// <summary>
-        /// Gets the optional boolean attribute value. If whitespace, then returning <paramref name="defaultValue"/>
+        /// Gets the optional boolean attribute value. If whitespace, then returning <c>null</c>.
         /// </summary>
         /// <param name="attributeName">Name of the attribute.</param>
         /// <param name="defaultValue">Default value to return if the attribute is not found.</param>
@@ -164,12 +164,14 @@ namespace NLog.Config
 
             if (!this.AttributeValues.TryGetValue(attributeName, out value))
             {
+                //not defined, don't override default
                 return defaultValue;
             }
 
             if (StringHelpers.IsNullOrWhiteSpace(value))
             {
-                return defaultValue;
+                //not default otherwise no difference between not defined and empty value.
+                return null;
             }
 
             return Convert.ToBoolean(value, CultureInfo.InvariantCulture);

--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -152,6 +152,29 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Gets the optional boolean attribute value. If whitespace, then returning <paramref name="defaultValue"/>
+        /// </summary>
+        /// <param name="attributeName">Name of the attribute.</param>
+        /// <param name="defaultValue">Default value to return if the attribute is not found.</param>
+        /// <returns>Boolean attribute value or default.</returns>
+        public bool? GetOptionalBooleanAttribute(string attributeName, bool? defaultValue)
+        {
+            string value;
+
+            if (!this.AttributeValues.TryGetValue(attributeName, out value))
+            {
+                return defaultValue;
+            }
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return defaultValue;
+            }
+
+            return Convert.ToBoolean(value, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
         /// Gets the optional attribute value.
         /// </summary>
         /// <param name="attributeName">Name of the attribute.</param>

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -515,6 +515,7 @@ namespace NLog.Config
                 this.fileMustAutoReloadLookup[GetFileLookupKey(filePath)] = autoReload;
 
             logFactory.ThrowExceptions = nlogElement.GetOptionalBooleanAttribute("throwExceptions", logFactory.ThrowExceptions);
+            LogManager.ThrowConfigExceptions = nlogElement.GetOptionalBooleanAttribute("throwConfigExceptions", LogManager.ThrowConfigExceptions);
             InternalLogger.LogToConsole = nlogElement.GetOptionalBooleanAttribute("internalLogToConsole", InternalLogger.LogToConsole);
             InternalLogger.LogToConsoleError = nlogElement.GetOptionalBooleanAttribute("internalLogToConsoleError", InternalLogger.LogToConsoleError);
             InternalLogger.LogFile = nlogElement.GetOptionalAttribute("internalLogFile", InternalLogger.LogFile);

--- a/src/NLog/Internal/ExceptionHelper.cs
+++ b/src/NLog/Internal/ExceptionHelper.cs
@@ -96,7 +96,7 @@ namespace NLog.Internal
                 InternalLogger.Log(exception, level, "Error has been raised.");
             }
 
-            var shallRethrow = LogManager.ThrowExceptions || isConfigError;
+            var shallRethrow = LogManager.ThrowExceptions || (LogManager.ThrowConfigExceptions && isConfigError);
             return shallRethrow;
         }
 

--- a/src/NLog/Internal/ExceptionHelper.cs
+++ b/src/NLog/Internal/ExceptionHelper.cs
@@ -88,7 +88,7 @@ namespace NLog.Internal
             }
 
             var isConfigError = exception is NLogConfigurationException;
-                              
+
             //we throw always configuration exceptions (historical)
             if (!exception.IsLoggedToInternalLogger())
             {
@@ -96,7 +96,8 @@ namespace NLog.Internal
                 InternalLogger.Log(exception, level, "Error has been raised.");
             }
 
-            var shallRethrow = LogManager.ThrowExceptions || (LogManager.ThrowConfigExceptions && isConfigError);
+            //if ThrowConfigExceptions == null, use  ThrowExceptions
+            var shallRethrow = isConfigError ? (LogManager.ThrowConfigExceptions ?? LogManager.ThrowExceptions) : LogManager.ThrowExceptions;
             return shallRethrow;
         }
 

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -124,11 +124,23 @@ namespace NLog
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether exceptions should be thrown.
+        /// Gets or sets a value indicating whether exceptions should be thrown. See also <see cref="ThrowConfigExceptions"/>.
         /// </summary>
         /// <value>A value of <c>true</c> if exception should be thrown; otherwise, <c>false</c>.</value>
         /// <remarks>By default exceptions are not thrown under any circumstances.</remarks>
         public bool ThrowExceptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether <see cref="NLogConfigurationException"/> should be thrown.
+        /// </summary>
+        /// <value>A value of <c>true</c> if exception should be thrown; otherwise, <c>false</c>.</value>
+        /// <remarks>
+        /// This option is for backwards-compatiblity.
+        /// By default exceptions are not thrown under any circumstances.
+        /// 
+        /// </remarks>
+        public bool ThrowConfigExceptions { get; set; }
+
 
         /// <summary>
         /// Gets or sets the current logging configuration. After setting this property all

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -132,6 +132,8 @@ namespace NLog
 
         /// <summary>
         /// Gets or sets a value indicating whether <see cref="NLogConfigurationException"/> should be thrown.
+        /// 
+        /// If <c>null</c> then <see cref="ThrowExceptions"/> is used.
         /// </summary>
         /// <value>A value of <c>true</c> if exception should be thrown; otherwise, <c>false</c>.</value>
         /// <remarks>
@@ -139,7 +141,7 @@ namespace NLog
         /// By default exceptions are not thrown under any circumstances.
         /// 
         /// </remarks>
-        public bool ThrowConfigExceptions { get; set; }
+        public bool? ThrowConfigExceptions { get; set; }
 
 
         /// <summary>

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -129,7 +129,7 @@ namespace NLog
         /// By default exceptions are not thrown under any circumstances.
         /// 
         /// </remarks>
-        public static bool ThrowConfigExceptions
+        public static bool? ThrowConfigExceptions
         {
             get { return factory.ThrowConfigExceptions; }
             set { factory.ThrowConfigExceptions = value; }

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -120,6 +120,21 @@ namespace NLog
             set { factory.ThrowExceptions = value; }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether <see cref="NLogConfigurationException"/> should be thrown.
+        /// </summary>
+        /// <value>A value of <c>true</c> if exception should be thrown; otherwise, <c>false</c>.</value>
+        /// <remarks>
+        /// This option is for backwards-compatiblity.
+        /// By default exceptions are not thrown under any circumstances.
+        /// 
+        /// </remarks>
+        public static bool ThrowConfigExceptions
+        {
+            get { return factory.ThrowConfigExceptions; }
+            set { factory.ThrowConfigExceptions = value; }
+        }
+
         internal static IAppDomain CurrentAppDomain
         {
             get { return currentAppDomain ?? (currentAppDomain = AppDomainWrapper.CurrentDomain); }

--- a/tests/NLog.UnitTests/Config/IncludeTests.cs
+++ b/tests/NLog.UnitTests/Config/IncludeTests.cs
@@ -97,6 +97,7 @@ namespace NLog.UnitTests.Config
 #if SILVERLIGHT
             string fileToLoad = "ConfigFiles/referencemissingfile.nlog";
 #else
+            LogManager.ThrowConfigExceptions = true;
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempPath);
 

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -118,6 +118,7 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void NLogConfigurationExceptionShouldThrown_WhenVariableNodeIsWrittenToWrongPlace()
         {
+            LogManager.ThrowConfigExceptions = true;
             const string configurationString_VariableNodeIsInnerTargets =
                     @"<nlog>  
 	                        <targets>

--- a/tests/NLog.UnitTests/GetLoggerTests.cs
+++ b/tests/NLog.UnitTests/GetLoggerTests.cs
@@ -137,10 +137,10 @@ namespace NLog.UnitTests
         [Fact]
         public void InvalidLoggerConfiguration_ThrowsConfigurationException_isTrue()
         {
-            InvalidLoggerConfiguration_ThrowsConfigurationException(true, false);
+            InvalidLoggerConfiguration_ThrowsConfigurationException(true, null);
         }
 
-        private void InvalidLoggerConfiguration_ThrowsConfigurationException(bool throwExceptions, bool throwConfigExceptions)
+        private void InvalidLoggerConfiguration_ThrowsConfigurationException(bool throwExceptions, bool? throwConfigExceptions)
         {
             Assert.Throws<NLogConfigurationException>(() =>
             {

--- a/tests/NLog.UnitTests/GetLoggerTests.cs
+++ b/tests/NLog.UnitTests/GetLoggerTests.cs
@@ -126,25 +126,26 @@ namespace NLog.UnitTests
             }
         }
 
-    
+
         [Fact]
         public void InvalidLoggerConfiguration_ThrowsConfigurationException_isFalse()
         {
-            InvalidLoggerConfiguration_ThrowsConfigurationException(false);
+            InvalidLoggerConfiguration_ThrowsConfigurationException(false, true);
         }
 
 
         [Fact]
         public void InvalidLoggerConfiguration_ThrowsConfigurationException_isTrue()
         {
-            InvalidLoggerConfiguration_ThrowsConfigurationException(true);
+            InvalidLoggerConfiguration_ThrowsConfigurationException(true, false);
         }
 
-        private void InvalidLoggerConfiguration_ThrowsConfigurationException(bool throwExceptions)
+        private void InvalidLoggerConfiguration_ThrowsConfigurationException(bool throwExceptions, bool throwConfigExceptions)
         {
             Assert.Throws<NLogConfigurationException>(() =>
             {
                 LogManager.ThrowExceptions = throwExceptions;
+                LogManager.ThrowConfigExceptions = throwConfigExceptions;
                 LogManager.GetCurrentClassLogger(typeof(InvalidLogger));
             });
 

--- a/tests/NLog.UnitTests/Internal/ExceptionHelperTests.cs
+++ b/tests/NLog.UnitTests/Internal/ExceptionHelperTests.cs
@@ -66,23 +66,26 @@ namespace NLog.UnitTests.Internal
         }
 
         [Theory]
-        [InlineData(typeof(StackOverflowException), true, false)]
-        [InlineData(typeof(StackOverflowException), true, true)]
-        [InlineData(typeof(NLogConfigurationException), true, false)]
-        [InlineData(typeof(NLogConfigurationException), true, true)]
-        [InlineData(typeof(Exception), false, false)]
-        [InlineData(typeof(Exception), true, true)]
-        [InlineData(typeof(ArgumentException), false, false)]
-        [InlineData(typeof(ArgumentException), true, true)]
-        [InlineData(typeof(NullReferenceException), false, false)]
-        [InlineData(typeof(NullReferenceException), true, true)]
-        [InlineData(typeof(ThreadAbortException), true, false)]
-        [InlineData(typeof(ThreadAbortException), true, true)]
-        [InlineData(typeof(OutOfMemoryException), true, false)]
-        [InlineData(typeof(OutOfMemoryException), true, true)]
-        public void MustBeRethrown(Type exceptionType, bool result, bool throwExceptions)
+        [InlineData(typeof(StackOverflowException), true, false, false)]
+        [InlineData(typeof(StackOverflowException), true, true, false)]
+        [InlineData(typeof(NLogConfigurationException), true, true, true)]
+        [InlineData(typeof(NLogConfigurationException), true, false, true)]
+        [InlineData(typeof(NLogConfigurationException), false, true, false)]
+        [InlineData(typeof(NLogConfigurationException), true, false, true)]
+        [InlineData(typeof(Exception), false, false, false)]
+        [InlineData(typeof(Exception), true, true, false)]
+        [InlineData(typeof(ArgumentException), false, false, false)]
+        [InlineData(typeof(ArgumentException), true, true, false)]
+        [InlineData(typeof(NullReferenceException), false, false, false)]
+        [InlineData(typeof(NullReferenceException), true, true, false)]
+        [InlineData(typeof(ThreadAbortException), true, false, false)]
+        [InlineData(typeof(ThreadAbortException), true, true, false)]
+        [InlineData(typeof(OutOfMemoryException), true, false, false)]
+        [InlineData(typeof(OutOfMemoryException), true, true, false)]
+        public void MustBeRethrown(Type exceptionType, bool result, bool throwExceptions, bool throwConfigException)
         {
             LogManager.ThrowExceptions = throwExceptions;
+            LogManager.ThrowConfigExceptions = throwConfigException;
 
             var ex = CreateException(exceptionType);
             Assert.Equal(result, ex.MustBeRethrown());

--- a/tests/NLog.UnitTests/Internal/ExceptionHelperTests.cs
+++ b/tests/NLog.UnitTests/Internal/ExceptionHelperTests.cs
@@ -32,6 +32,7 @@
 // 
 
 #if !SILVERLIGHT
+//no silverlight for xunit InlineData
 
 using System;
 using System.Collections.Generic;
@@ -69,20 +70,30 @@ namespace NLog.UnitTests.Internal
         [InlineData(typeof(StackOverflowException), true, false, false)]
         [InlineData(typeof(StackOverflowException), true, true, false)]
         [InlineData(typeof(NLogConfigurationException), true, true, true)]
-        [InlineData(typeof(NLogConfigurationException), true, false, true)]
         [InlineData(typeof(NLogConfigurationException), false, true, false)]
+        [InlineData(typeof(NLogConfigurationException), true, true, null)]
         [InlineData(typeof(NLogConfigurationException), true, false, true)]
+        [InlineData(typeof(NLogConfigurationException), false, false, false)]
+        [InlineData(typeof(NLogConfigurationException), false, false, null)]
         [InlineData(typeof(Exception), false, false, false)]
+        [InlineData(typeof(Exception), false, false, true)]
+        [InlineData(typeof(Exception), false, false, null)]
         [InlineData(typeof(Exception), true, true, false)]
+        [InlineData(typeof(Exception), true, true, true)]
+        [InlineData(typeof(Exception), true, true, null)]
         [InlineData(typeof(ArgumentException), false, false, false)]
+        [InlineData(typeof(ArgumentException), false, false, true)]
+        [InlineData(typeof(ArgumentException), false, false, null)]
         [InlineData(typeof(ArgumentException), true, true, false)]
+        [InlineData(typeof(ArgumentException), true, true, true)]
+        [InlineData(typeof(ArgumentException), true, true, null)]
         [InlineData(typeof(NullReferenceException), false, false, false)]
         [InlineData(typeof(NullReferenceException), true, true, false)]
         [InlineData(typeof(ThreadAbortException), true, false, false)]
         [InlineData(typeof(ThreadAbortException), true, true, false)]
         [InlineData(typeof(OutOfMemoryException), true, false, false)]
         [InlineData(typeof(OutOfMemoryException), true, true, false)]
-        public void MustBeRethrown(Type exceptionType, bool result, bool throwExceptions, bool throwConfigException)
+        public void MustBeRethrown(Type exceptionType, bool result, bool throwExceptions, bool? throwConfigException)
         {
             LogManager.ThrowExceptions = throwExceptions;
             LogManager.ThrowConfigExceptions = throwConfigException;

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -75,7 +75,7 @@ namespace NLog.UnitTests
         {
             Assert.Equal(msg, GetDebugLastMessage(targetName));
         }
-        
+
         protected void AssertDebugLastMessageContains(string targetName, string msg)
         {
             string debugLastMessage = GetDebugLastMessage(targetName);
@@ -271,11 +271,13 @@ namespace NLog.UnitTests
         {
             private readonly LogLevel globalThreshold;
             private readonly bool throwExceptions;
+            private bool? throwConfigExceptions;
 
             public InternalLoggerScope()
             {
                 this.globalThreshold = LogManager.GlobalThreshold;
                 this.throwExceptions = LogManager.ThrowExceptions;
+                this.throwConfigExceptions = LogManager.ThrowConfigExceptions;
             }
 
             public void Dispose()
@@ -284,8 +286,11 @@ namespace NLog.UnitTests
                     File.Delete(InternalLogger.LogFile);
 
                 InternalLogger.Reset();
+
+                //restore logmanager
                 LogManager.GlobalThreshold = this.globalThreshold;
                 LogManager.ThrowExceptions = this.throwExceptions;
+                LogManager.ThrowConfigExceptions = this.throwConfigExceptions;
             }
         }
     }

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -271,7 +271,7 @@ namespace NLog.UnitTests
         {
             private readonly LogLevel globalThreshold;
             private readonly bool throwExceptions;
-            private bool? throwConfigExceptions;
+            private readonly bool? throwConfigExceptions;
 
             public InternalLoggerScope()
             {

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -677,8 +677,9 @@ Dispose()
         }
 
         [Fact]
-        public void ConnectionStringNameNegativeTest()
+        public void ConnectionStringNameNegativeTest_if_ThrowConfigExceptions()
         {
+            LogManager.ThrowConfigExceptions = true;
             var dt = new DatabaseTarget
             {
                 ConnectionStringName = "MyConnectionString",

--- a/tests/NLog.UnitTests/Targets/MailTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MailTargetTests.cs
@@ -32,8 +32,6 @@
 // 
 
 
-using System.Threading;
-
 #if !SILVERLIGHT
 
 namespace NLog.UnitTests.Targets
@@ -770,7 +768,7 @@ namespace NLog.UnitTests.Targets
             public bool EnableSsl { get; set; }
             public List<MailMessage> MessagesSent { get; private set; }
 
-            public new void Send(MailMessage msg)
+            public void Send(MailMessage msg)
             {
                 if (string.IsNullOrEmpty(this.Host) && string.IsNullOrEmpty(this.PickupDirectoryLocation))
                 {


### PR DESCRIPTION
Added `ThrowConfigExceptions` to control throwing of `NLogConfigurationException`. Before `NLogConfigurationException` where always thrown, which could lead to `System.TypeInitializationException` which is bad and confusing as sending info with the exception is difficult - see [stackoverflow](http://stackoverflow.com/questions/34994470/better-typeinitializationexception-innerexception-is-also-null).

```c#
LogManager.ThrowConfigExceptions  = true | false | null
```
```xml
<nlog throwConfigExceptions="true"|"false"|"">
```

if `ThrowConfigExceptions` is `null` (or empty `string` from XML), then `ThrowExceptions` is used. So `ThrowConfigExceptions` inherits from `ThrowExceptions`.

This isn't fully backwards-compatible, but it is also a bug as we in code and docs is stated "By default exceptions are not thrown under any circumstances.". also this is a good change to include with #1143

With the addition of https://github.com/NLog/NLog/pull/1222, there is no good reason to throw exceptions even with config errors.


