### PR TITLE
Internallogger improvements

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -178,7 +178,7 @@ namespace NLog.Targets.Wrappers
         {
             base.InitializeTarget();
             this.RequestQueue.Clear();
-            InternalLogger.Trace("AsyncWrapper: start timer");
+            InternalLogger.Trace("AsyncWrapper '{0}': start timer", Name);
             this.lazyWriterTimer = new Timer(this.ProcessPendingEvents, null, Timeout.Infinite, Timeout.Infinite);
             this.StartLazyWriterTimer();
         }
@@ -245,7 +245,7 @@ namespace NLog.Targets.Wrappers
 
         private void ProcessPendingEvents(object state)
         {
-            InternalLogger.Trace("AsyncWrapper: ProcessPendingEvents");
+            InternalLogger.Trace("AsyncWrapper '{0}': ProcessPendingEvents", Name);
             AsyncContinuation[] continuations;
             lock (this.continuationQueueLock)
             {
@@ -260,7 +260,7 @@ namespace NLog.Targets.Wrappers
 
                 if (this.WrappedTarget == null)
                 {
-                    InternalLogger.Error("AsyncWrapper: WrappedTarget is NULL");
+                    InternalLogger.Error("AsyncWrapper '{0}': WrappedTarget is NULL", Name);
                     return;
                 }
 
@@ -271,7 +271,7 @@ namespace NLog.Targets.Wrappers
                     {
                         count = this.RequestQueue.RequestCount;
                     }
-                    InternalLogger.Trace("AsyncWrapper: Flushing {0} events.", count);
+                    InternalLogger.Trace("AsyncWrapper '{0}': Flushing {1} events.", Name, count);
 
                     if (this.RequestQueue.RequestCount == 0)
                     {
@@ -297,13 +297,13 @@ namespace NLog.Targets.Wrappers
             }
             catch (Exception exception)
             {
-                InternalLogger.Error(exception, "AsyncWrapper: Error in lazy writer timer procedure.");
+                InternalLogger.Error(exception, "AsyncWrapper '{0}': Error in lazy writer timer procedure.", Name);
 
                 if (exception.MustBeRethrown())
                 {
                     throw;
                 }
-                
+
             }
             finally
             {

--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -130,7 +130,7 @@ namespace NLog.Targets.Wrappers
             }
             else
             {
-                InternalLogger.Trace("BufferingWrapper: Flush {0} events async", events.Length);
+                InternalLogger.Trace("BufferingWrapper '{0}': Flush {1} events async", Name, events.Length);
                 this.WrappedTarget.WriteAsyncLogEvents(events, ex => this.WrappedTarget.Flush(asyncContinuation));
             }
         }
@@ -142,7 +142,7 @@ namespace NLog.Targets.Wrappers
         {
             base.InitializeTarget();
             this.buffer = new LogEventInfoBuffer(this.BufferSize, false, 0);
-            InternalLogger.Trace("BufferingWrapper: start timer");
+            InternalLogger.Trace("BufferingWrapper '{0}': start timer", Name);
             this.flushTimer = new Timer(this.FlushCallback, null, -1, -1);
         }
 
@@ -171,7 +171,7 @@ namespace NLog.Targets.Wrappers
             int count = this.buffer.Append(logEvent);
             if (count >= this.BufferSize)
             {
-                InternalLogger.Trace("BufferingWrapper: writing {0} events because of exceeding buffersize ({0}).", BufferSize);
+                InternalLogger.Trace("BufferingWrapper '{0}': writing {1} events because of exceeding buffersize ({0}).", Name, count);
                 AsyncLogEventInfo[] events = this.buffer.GetEventsAndClear();
                 this.WrappedTarget.WriteAsyncLogEvents(events);
             }

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -56,6 +56,11 @@ namespace NLog.UnitTests
         protected NLogTestBase()
         {
             //reset before every test
+            if (LogManager.Configuration != null)
+            {
+                //flush all events if needed.
+                LogManager.Configuration.Close();
+            }
             LogManager.Configuration = null;
             InternalLogger.Reset();
             LogManager.ThrowExceptions = false;

--- a/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
@@ -59,18 +59,20 @@ namespace NLog.UnitTests.Targets
             ft.OpenFileCacheSize = 1;
             ft.LineEnding = LineEndingMode.LF;
 
+            var name = "ConfigureSharedFile_" + mode + "-wrapper";
+
             switch (mode)
             {
                 case "async":
-                    SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(ft, 100, AsyncTargetWrapperOverflowAction.Grow), LogLevel.Debug);
+                    SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(ft, 100, AsyncTargetWrapperOverflowAction.Grow) { Name = name }, LogLevel.Debug);
                     break;
 
                 case "buffered":
-                    SimpleConfigurator.ConfigureForTargetLogging(new BufferingTargetWrapper(ft, 100), LogLevel.Debug);
+                    SimpleConfigurator.ConfigureForTargetLogging(new BufferingTargetWrapper(ft, 100) { Name = name }, LogLevel.Debug);
                     break;
 
                 case "buffered_timed_flush":
-                    SimpleConfigurator.ConfigureForTargetLogging(new BufferingTargetWrapper(ft, 100, 10), LogLevel.Debug);
+                    SimpleConfigurator.ConfigureForTargetLogging(new BufferingTargetWrapper(ft, 100, 10) { Name = name }, LogLevel.Debug);
                     break;
 
                 default:

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -1602,7 +1602,10 @@ namespace NLog.UnitTests.Targets
 
                 var threadID = Thread.CurrentThread.ManagedThreadId.ToString();
 
-                SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(fileTarget, 1000, AsyncTargetWrapperOverflowAction.Grow), LogLevel.Debug);
+                SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(fileTarget, 1000, AsyncTargetWrapperOverflowAction.Grow)
+                {
+                    Name = "AsyncMultiFileWrite_wrapper"
+                }, LogLevel.Debug);
                 LogManager.ThrowExceptions = true;
 
                 for (var i = 0; i < 250; ++i)

--- a/tests/NLog.UnitTests/Targets/LogReceiverWebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/LogReceiverWebServiceTargetTests.cs
@@ -186,7 +186,10 @@ namespace NLog.UnitTests.Targets
             var target = new MyLogReceiverWebServiceTarget();
             target.EndpointAddress = "http://notimportant:9999/";
             target.Initialize(configuration);
-            var asyncTarget = new AsyncTargetWrapper(target);
+            var asyncTarget = new AsyncTargetWrapper(target)
+            {
+                Name = "NoEmptyEventLists_wrapper"
+            };
             asyncTarget.Initialize(configuration);
             asyncTarget.WriteAsyncLogEvents(new[] { LogEventInfo.Create(LogLevel.Info, "logger1", "message1").WithContinuation(ex => { }) });
             Thread.Sleep(1000);

--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
@@ -76,6 +76,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             var targetWrapper = new AsyncTargetWrapper
             {
                 WrappedTarget = myTarget,
+                Name = "AsyncTargetWrapperSyncTest1_Wrapper",
             };
             targetWrapper.Initialize(null);
             myTarget.Initialize(null);
@@ -112,7 +113,7 @@ namespace NLog.UnitTests.Targets.Wrappers
         public void AsyncTargetWrapperAsyncTest1()
         {
             var myTarget = new MyAsyncTarget();
-            var targetWrapper = new AsyncTargetWrapper(myTarget);
+            var targetWrapper = new AsyncTargetWrapper(myTarget) { Name = "AsyncTargetWrapperAsyncTest1_Wrapper" };
             targetWrapper.Initialize(null);
             myTarget.Initialize(null);
             var logEvent = new LogEventInfo();
@@ -144,9 +145,10 @@ namespace NLog.UnitTests.Targets.Wrappers
             var myTarget = new MyAsyncTarget
             {
                 ThrowExceptions = true,
+       
             };
 
-            var targetWrapper = new AsyncTargetWrapper(myTarget);
+            var targetWrapper = new AsyncTargetWrapper(myTarget) {Name = "AsyncTargetWrapperAsyncWithExceptionTest1_Wrapper"};
             targetWrapper.Initialize(null);
             myTarget.Initialize(null);
             var logEvent = new LogEventInfo();
@@ -191,6 +193,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             var targetWrapper = new AsyncTargetWrapper(myTarget)
             {
                 OverflowAction = AsyncTargetWrapperOverflowAction.Grow,
+                Name = "AsyncTargetWrapperFlushTest_Wrapper"
             };
 
             targetWrapper.Initialize(null);
@@ -257,13 +260,13 @@ namespace NLog.UnitTests.Targets.Wrappers
             var myTarget = new MyAsyncTarget
             {
                 ThrowExceptions = true,
-
             };
 
             var targetWrapper = new AsyncTargetWrapper(myTarget)
             {
                 OverflowAction = AsyncTargetWrapperOverflowAction.Grow,
                 TimeToSleepBetweenBatches = 1000,
+                Name = "AsyncTargetWrapperCloseTest_Wrapper",
             };
 
             targetWrapper.Initialize(null);
@@ -283,6 +286,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 OverflowAction = AsyncTargetWrapperOverflowAction.Grow,
                 TimeToSleepBetweenBatches = 500,
                 WrappedTarget = new DebugTarget(),
+                Name = "AsyncTargetWrapperExceptionTest_Wrapper"
             };
 
             LogManager.ThrowExceptions = false;
@@ -300,7 +304,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 },
                 LogLevel.Trace);
 
-                Assert.True(internalLog.Contains("AsyncWrapper: WrappedTarget is NULL"), internalLog);
+            Assert.True(internalLog.Contains("AsyncWrapper 'AsyncTargetWrapperExceptionTest_Wrapper': WrappedTarget is NULL"), internalLog);
         }
 
         [Fact]
@@ -310,6 +314,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             {
                 TimeToSleepBetweenBatches = 2000,
                 WrappedTarget = new DebugTarget(),
+                Name = "FlushingMultipleTimesSimultaneous_Wrapper"
             };
             asyncTarget.Initialize(null);
 


### PR DESCRIPTION
- Log name of AsyncWrapper / BufferingWrapper to InternalLogger. 
- fix count logging of BufferingWrapper 
- improve unit tests


fixes https://github.com/NLog/NLog/issues/1251