### PR TITLE
Use Assembly.DefinedTypes for .NET Core.

### DIFF
--- a/src/NLog/Internal/ReflectionHelpers.cs
+++ b/src/NLog/Internal/ReflectionHelpers.cs
@@ -65,7 +65,7 @@ namespace NLog.Internal
             try
             {
 #if DNX
-                return new Type[0];
+                return assembly.DefinedTypes.Select(typeinfo => typeinfo.AsType()).ToArray();
 #else
                 return assembly.GetTypes();
 #endif
@@ -323,7 +323,7 @@ namespace NLog.Internal
 
 #endif
 
-#if !UWP10  && !WINDOWS_PHONE
+#if !UWP10 && !WINDOWS_PHONE
         public static string GetLocation(this Assembly assembly)
         {
             return assembly.Location;


### PR DESCRIPTION
`Assembly.GetTypes()` is not supported on .NET Core.  The recommended replacement is the property `Assembly.DefinedTypes` according to http://dotnetstatus.azurewebsites.net.

Related to https://github.com/NLog/NLog/issues/641. 