### PR TITLE
Fix: {$processtime} has incorrect milliseconds formatting

### DIFF
--- a/src/NLog/LayoutRenderers/ProcessTimeLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessTimeLayoutRenderer.cs
@@ -53,6 +53,16 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             TimeSpan ts = logEvent.TimeStamp.ToUniversalTime() - LogEventInfo.ZeroDate;
+            WritetTimestamp(builder, ts);
+        }
+
+        /// <summary>
+        /// Write timestamp to builder with format hh:mm:ss:fff
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="ts"></param>
+        internal static void WritetTimestamp(StringBuilder builder, TimeSpan ts)
+        {
             if (ts.Hours < 10)
             {
                 builder.Append('0');
@@ -74,19 +84,23 @@ namespace NLog.LayoutRenderers
 
             builder.Append(ts.Seconds);
             builder.Append('.');
-            if (ts.Milliseconds < 1000)
-            {
-                builder.Append('0');
-            }
 
             if (ts.Milliseconds < 100)
             {
                 builder.Append('0');
-            }
 
-            if (ts.Milliseconds < 10)
-            {
-                builder.Append('0');
+                if (ts.Milliseconds < 10)
+                {
+                    builder.Append('0');
+
+                    if (ts.Milliseconds < 0)
+                    {
+                        //don't write negative times. This is probably an accuracy problem (accuracy is by default 16ms, see https://github.com/NLog/NLog/wiki/Time-Source)
+                        builder.Append('0');
+                        return;
+                        
+                    }
+                }
             }
 
             builder.Append(ts.Milliseconds);

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -131,6 +131,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
+    <Compile Include="LayoutRenderers\ProcessTimeLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\RegistryTests.cs" />
     <Compile Include="LayoutRenderers\Rot13Tests.cs" />
     <Compile Include="LayoutRenderers\ShortDateTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -155,6 +155,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
+    <Compile Include="LayoutRenderers\ProcessTimeLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\RegistryTests.cs" />
     <Compile Include="LayoutRenderers\Rot13Tests.cs" />
     <Compile Include="LayoutRenderers\ShortDateTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -135,6 +135,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
+    <Compile Include="LayoutRenderers\ProcessTimeLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\RegistryTests.cs" />
     <Compile Include="LayoutRenderers\Rot13Tests.cs" />
     <Compile Include="LayoutRenderers\ShortDateTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -177,6 +177,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
+    <Compile Include="LayoutRenderers\ProcessTimeLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\RegistryTests.cs" />
     <Compile Include="LayoutRenderers\Rot13Tests.cs" />
     <Compile Include="LayoutRenderers\ShortDateTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -153,6 +153,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
+    <Compile Include="LayoutRenderers\ProcessTimeLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\RegistryTests.cs" />
     <Compile Include="LayoutRenderers\Rot13Tests.cs" />
     <Compile Include="LayoutRenderers\ShortDateTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -155,6 +155,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
+    <Compile Include="LayoutRenderers\ProcessTimeLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\RegistryTests.cs" />
     <Compile Include="LayoutRenderers\Rot13Tests.cs" />
     <Compile Include="LayoutRenderers\ShortDateTests.cs" />

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -213,11 +213,24 @@ namespace NLog.UnitTests
             return sb.ToString();
         }
 
-        protected void AssertLayoutRendererOutput(Layout l, string expected)
+        /// <summary>
+        /// Render layout <paramref name="layout"/> with dummy <see cref="LogEventInfo" />and compare result with <paramref name="expected"/>.
+        /// </summary>
+        protected static void AssertLayoutRendererOutput(Layout layout, string expected)
         {
-            l.Initialize(null);
-            string actual = l.Render(LogEventInfo.Create(LogLevel.Info, "loggername", "message"));
-            l.Close();
+            var logEventInfo = LogEventInfo.Create(LogLevel.Info, "loggername", "message");
+
+            AssertLayoutRendererOutput(layout, logEventInfo, expected);
+        }
+
+        /// <summary>
+        /// Render layout <paramref name="layout"/> with <paramref name="logEventInfo"/> and compare result with <paramref name="expected"/>.
+        /// </summary>
+        protected static void AssertLayoutRendererOutput(Layout layout, LogEventInfo logEventInfo, string expected)
+        {
+            layout.Initialize(null);
+            string actual = layout.Render(logEventInfo);
+            layout.Close();
             Assert.Equal(expected, actual);
         }
 


### PR DESCRIPTION
Fix milliseconds bug, fix negative time bug, add unit tests

Including small performance improvement. 

fixes https://github.com/NLog/NLog/issues/1284
