### PR TITLE
Easier api: AddRule methods, fix AllTargets crash, fix IsLevelEnabled(off) crash, refactor internal

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -207,6 +207,94 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Add a rule with min- and maxLevel.
+        /// </summary>
+        /// <param name="minLevel">Minimum log level needed to trigger this rule.</param>
+        /// <param name="maxLevel">Maximum log level needed to trigger this rule.</param>
+        /// <param name="targetName">Name of the target to be written when the rule matches.</param>
+        /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
+        public void AddRule(LogLevel minLevel, LogLevel maxLevel, string targetName, string loggerNamePattern = "*")
+        {
+            var target = FindTargetByName(targetName);
+            if (target == null)
+            {
+                throw new NLogRuntimeException("Target '{0}' not found", targetName);
+            }
+
+            AddRule(minLevel, maxLevel, target, loggerNamePattern);
+        }
+
+        /// <summary>
+        /// Add a rule with min- and maxLevel.
+        /// </summary>
+        /// <param name="minLevel">Minimum log level needed to trigger this rule.</param>
+        /// <param name="maxLevel">Maximum log level needed to trigger this rule.</param>
+        /// <param name="target">Target to be written to when the rule matches.</param>
+        /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
+        public void AddRule(LogLevel minLevel, LogLevel maxLevel, Target target, string loggerNamePattern = "*")
+        {
+            LoggingRules.Add(new LoggingRule(loggerNamePattern, minLevel, maxLevel, target));
+        }
+
+        /// <summary>
+        /// Add a rule for one loglevel.
+        /// </summary>
+        /// <param name="level">log level needed to trigger this rule. </param>
+        /// <param name="targetName">Name of the target to be written when the rule matches.</param>
+        /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
+        public void AddRuleForOneLevel(LogLevel level, string targetName, string loggerNamePattern = "*")
+        {
+            var target = FindTargetByName(targetName);
+            if (target == null)
+            {
+                throw new NLogRuntimeException("Target '{0}' not found", targetName);
+            }
+
+            AddRuleForOneLevel(level, target, loggerNamePattern);
+        }
+
+        /// <summary>
+        /// Add a rule for one loglevel.
+        /// </summary>
+        /// <param name="level">log level needed to trigger this rule. </param>
+        /// <param name="target">Target to be written to when the rule matches.</param>
+        /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
+        public void AddRuleForOneLevel(LogLevel level, Target target, string loggerNamePattern = "*")
+        {
+            var loggingRule = new LoggingRule(loggerNamePattern, target);
+            loggingRule.EnableLoggingForLevel(level);
+            LoggingRules.Add(loggingRule);
+        }
+
+        /// <summary>
+        /// Add a rule for alle loglevels.
+        /// </summary>
+        /// <param name="targetName">Name of the target to be written when the rule matches.</param>
+        /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
+        public void AddRuleForAllLevels(string targetName, string loggerNamePattern = "*")
+        {
+            var target = FindTargetByName(targetName);
+            if (target == null)
+            {
+                throw new NLogRuntimeException("Target '{0}' not found", targetName);
+            }
+
+            AddRuleForAllLevels(target, loggerNamePattern);
+        }
+
+        /// <summary>
+        /// Add a rule for alle loglevels.
+        /// </summary>
+        /// <param name="target">Target to be written to when the rule matches.</param>
+        /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
+        public void AddRuleForAllLevels(Target target, string loggerNamePattern = "*")
+        {
+            var loggingRule = new LoggingRule(loggerNamePattern, target);
+            loggingRule.EnableLoggingForLevels(LogLevel.MinLevel, LogLevel.MaxLevel);
+            LoggingRules.Add(loggingRule);
+        }
+
+        /// <summary>
         /// Called by LogManager when one of the log configuration files changes.
         /// </summary>
         /// <returns>
@@ -329,7 +417,7 @@ namespace NLog.Config
                         throw;
                     }
 
-                   
+
                 }
             }
 

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -247,7 +247,7 @@ namespace NLog.Config
             var target = FindTargetByName(targetName);
             if (target == null)
             {
-                throw new NLogRuntimeException("Target '{0}' not found", targetName);
+                throw new NLogConfigurationException("Target '{0}' not found", targetName);
             }
 
             AddRuleForOneLevel(level, target, loggerNamePattern);

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -56,7 +56,7 @@ namespace NLog.Config
         private readonly IDictionary<string, Target> targets =
             new Dictionary<string, Target>(StringComparer.OrdinalIgnoreCase);
 
-        private object[] configItems;
+        private List<object> configItems = new List<object>();
 
         /// <summary>
         /// Variables defined in xml or in API. name is case case insensitive. 
@@ -129,7 +129,11 @@ namespace NLog.Config
         /// </summary>
         public ReadOnlyCollection<Target> AllTargets
         {
-            get { return this.configItems.OfType<Target>().ToList().AsReadOnly(); }
+            get
+            {
+                var configTargets = this.configItems.OfType<Target>();
+                return configTargets.Concat(targets.Values).ToList().AsReadOnly();
+            }
         }
 
         /// <summary>
@@ -411,7 +415,7 @@ namespace NLog.Config
 
             // initialize all config items starting from most nested first
             // so that whenever the container is initialized its children have already been
-            InternalLogger.Info("Found {0} configuration items", this.configItems.Length);
+            InternalLogger.Info("Found {0} configuration items", this.configItems.Count);
 
             foreach (object o in this.configItems)
             {

--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -64,34 +64,44 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Create a new <see cref="LoggingRule" /> with a <paramref name="minLevel"/> and  <paramref name="maxLevel"/> which writes to <paramref name="target"/>.
+        /// </summary>
+        /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
+        /// <param name="minLevel">Minimum log level needed to trigger this rule.</param>
+        /// <param name="maxLevel">Maximum log level needed to trigger this rule.</param>
+        /// <param name="target">Target to be written to when the rule matches.</param>
+        public LoggingRule(string loggerNamePattern, LogLevel minLevel, LogLevel maxLevel, Target target)
+            : this()
+        {
+            this.LoggerNamePattern = loggerNamePattern;
+            this.Targets.Add(target);
+            EnableLoggingForLevels(minLevel, maxLevel);
+        }
+
+
+
+        /// <summary>
         /// Create a new <see cref="LoggingRule" /> with a <paramref name="minLevel"/> which writes to <paramref name="target"/>.
         /// </summary>
         /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
         /// <param name="minLevel">Minimum log level needed to trigger this rule.</param>
         /// <param name="target">Target to be written to when the rule matches.</param>
         public LoggingRule(string loggerNamePattern, LogLevel minLevel, Target target)
+            : this()
         {
-            this.Filters = new List<Filter>();
-            this.ChildRules = new List<LoggingRule>();
-            this.Targets = new List<Target>();
             this.LoggerNamePattern = loggerNamePattern;
             this.Targets.Add(target);
-            for (int i = minLevel.Ordinal; i <= LogLevel.MaxLevel.Ordinal; ++i)
-            {
-                this.EnableLoggingForLevel(LogLevel.FromOrdinal(i));
-            }
+            EnableLoggingForLevels(minLevel, LogLevel.MaxLevel);
         }
 
         /// <summary>
-        /// Create a (disabled) <see cref="LoggingRule" />. You should call <see cref="EnableLoggingForLevel"/> to enable logging.
+        /// Create a (disabled) <see cref="LoggingRule" />. You should call <see cref="EnableLoggingForLevel"/> or see cref="EnableLoggingForLevels"/> to enable logging.
         /// </summary>
         /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
         /// <param name="target">Target to be written to when the rule matches.</param>
         public LoggingRule(string loggerNamePattern, Target target)
+            : this()
         {
-            this.Filters = new List<Filter>();
-            this.ChildRules = new List<LoggingRule>();
-            this.Targets = new List<Target>();
             this.LoggerNamePattern = loggerNamePattern;
             this.Targets.Add(target);
         }
@@ -219,6 +229,19 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Enables logging for a particular levels between (included) <paramref name="minLevel"/> and <paramref name="maxLevel"/>.
+        /// </summary>
+        /// <param name="minLevel">Minimum log level needed to trigger this rule.</param>
+        /// <param name="maxLevel">Maximum log level needed to trigger this rule.</param>
+        public void EnableLoggingForLevels(LogLevel minLevel, LogLevel maxLevel)
+        {
+            for (int i = minLevel.Ordinal; i <= maxLevel.Ordinal; ++i)
+            {
+                this.EnableLoggingForLevel(LogLevel.FromOrdinal(i));
+            }
+        }
+
+        /// <summary>
         /// Disables logging for a particular level.
         /// </summary>
         /// <param name="level">Level to be disabled.</param>
@@ -296,5 +319,7 @@ namespace NLog.Config
                     return loggerName.IndexOf(this.loggerNameMatchArgument, StringComparison.Ordinal) >= 0;
             }
         }
+
+
     }
 }

--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -287,6 +287,11 @@ namespace NLog.Config
         /// <returns>A value of <see langword="true"/> when the log level is enabled, <see langword="false" /> otherwise.</returns>
         public bool IsLoggingEnabledForLevel(LogLevel level)
         {
+            if (level == LogLevel.Off)
+            {
+                return false;
+            }
+
             return this.logLevels[level.Ordinal];
         }
 

--- a/src/NLog/Internal/ObjectGraphScanner.cs
+++ b/src/NLog/Internal/ObjectGraphScanner.cs
@@ -54,7 +54,7 @@ namespace NLog.Internal
         /// <typeparam name="T">Type of the objects to return.</typeparam>
         /// <param name="rootObjects">The root objects.</param>
         /// <returns>Ordered list of objects implementing T.</returns>
-        public static T[] FindReachableObjects<T>(params object[] rootObjects)
+        public static List<T> FindReachableObjects<T>(params object[] rootObjects)
             where T : class
         {
             InternalLogger.Trace("FindReachableObject<{0}>:", typeof(T));
@@ -66,7 +66,7 @@ namespace NLog.Internal
                 ScanProperties(result, rootObject, 0, visitedObjects);
             }
 
-            return result.ToArray();
+            return result.ToList();
         }
 
         /// <remarks>ISet is not there in .net35, so using HashSet</remarks>

--- a/src/NLog/NLogConfigurationException.cs
+++ b/src/NLog/NLogConfigurationException.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using JetBrains.Annotations;
+
 namespace NLog
 {
     using System;
@@ -56,6 +58,17 @@ namespace NLog
         /// <param name="message">The message.</param>
         public NLogConfigurationException(string message)
             : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NLogRuntimeException" /> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="messageParameters">Parameters for the message</param>
+        [StringFormatMethod("message")]
+        public NLogConfigurationException(string message, params object[] messageParameters)
+            : base(string.Format(message, messageParameters))
         {
         }
 

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -40,6 +40,9 @@ namespace NLog.UnitTests
     using NLog.Config;
     using Xunit;
 
+    /// <summary>
+    /// Test the characteristics of the API. Config of the API is testged in <see cref="NLog.UnitTests.Config.ConfigApiTests"/>
+    /// </summary>
     public class ApiTests : NLogTestBase
     {
         private Type[] allTypes;

--- a/tests/NLog.UnitTests/Config/ConfigApiTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigApiTests.cs
@@ -1,0 +1,185 @@
+﻿// 
+// Copyright (c) 2004-2011 Jaroslaw Kowalski <jaak@jkowalski.net>
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#region
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NLog.Config;
+using NLog.Targets;
+using Xunit;
+
+#endregion
+
+namespace NLog.UnitTests.Config
+{
+    public class ConfigApiTests
+    {
+        [Fact]
+        public void AddTarget_testname()
+        {
+            var config = new LoggingConfiguration();
+            config.AddTarget("name1", new FileTarget { Name = "File" });
+            var allTargets = config.AllTargets;
+            Assert.NotNull(allTargets);
+            Assert.Equal(1, allTargets.Count);
+
+            //maybe confusing, but the name of the target is not changed, only the one of the key.
+            Assert.Equal("File", allTargets.First().Name);
+            Assert.NotNull(config.FindTargetByName<FileTarget>("name1"));
+
+            config.RemoveTarget("name1");
+            allTargets = config.AllTargets;
+            Assert.Equal(0, allTargets.Count);
+        }
+
+        [Fact]
+        public void AddTarget_testname_param()
+        {
+            var config = new LoggingConfiguration();
+            config.AddTarget("name1", new FileTarget { Name = "name2" });
+            var allTargets = config.AllTargets;
+            Assert.NotNull(allTargets);
+            Assert.Equal(1, allTargets.Count);
+
+            //maybe confusing, but the name of the target is not changed, only the one of the key.
+            Assert.Equal("name2", allTargets.First().Name);
+            Assert.NotNull(config.FindTargetByName<FileTarget>("name1"));
+        }
+
+        [Fact]
+        public void AddTarget_testname_fromtarget()
+        {
+            var config = new LoggingConfiguration();
+            config.AddTarget(new FileTarget { Name = "name2" });
+            var allTargets = config.AllTargets;
+            Assert.NotNull(allTargets);
+            Assert.Equal(1, allTargets.Count);
+            Assert.Equal("name2", allTargets.First().Name);
+            Assert.NotNull(config.FindTargetByName<FileTarget>("name2"));
+        }
+
+
+
+        [Fact]
+        public void AddRule_min_max()
+        {
+            var config = new LoggingConfiguration();
+            config.AddTarget(new FileTarget {Name = "File"});
+            config.AddRule(LogLevel.Info, LogLevel.Error, "File", "*a");
+            Assert.NotNull(config.LoggingRules);
+            Assert.Equal(1, config.LoggingRules.Count);
+            var rule1 = config.LoggingRules.FirstOrDefault();
+            Assert.NotNull(rule1);
+            Assert.Equal(false, rule1.Final);
+            Assert.Equal("*a", rule1.LoggerNamePattern);
+            Assert.Equal(false, rule1.IsLoggingEnabledForLevel(LogLevel.Fatal));
+            Assert.Equal(true, rule1.IsLoggingEnabledForLevel(LogLevel.Error));
+            Assert.Equal(true, rule1.IsLoggingEnabledForLevel(LogLevel.Warn));
+            Assert.Equal(true, rule1.IsLoggingEnabledForLevel(LogLevel.Info));
+            Assert.Equal(false, rule1.IsLoggingEnabledForLevel(LogLevel.Debug));
+            Assert.Equal(false, rule1.IsLoggingEnabledForLevel(LogLevel.Trace));
+            Assert.Equal(false, rule1.IsLoggingEnabledForLevel(LogLevel.Off));
+        }
+
+
+        [Fact]
+        public void AddRule_all()
+        {
+            var config = new LoggingConfiguration();
+            config.AddTarget(new FileTarget { Name = "File" });
+            config.AddRuleForAllLevels("File", "*a");
+            Assert.NotNull(config.LoggingRules);
+            Assert.Equal(1, config.LoggingRules.Count);
+            var rule1 = config.LoggingRules.FirstOrDefault();
+            Assert.NotNull(rule1);
+            Assert.Equal(false, rule1.Final);
+            Assert.Equal("*a", rule1.LoggerNamePattern);
+            Assert.Equal(true, rule1.IsLoggingEnabledForLevel(LogLevel.Fatal));
+            Assert.Equal(true, rule1.IsLoggingEnabledForLevel(LogLevel.Error));
+            Assert.Equal(true, rule1.IsLoggingEnabledForLevel(LogLevel.Warn));
+            Assert.Equal(true, rule1.IsLoggingEnabledForLevel(LogLevel.Info));
+            Assert.Equal(true, rule1.IsLoggingEnabledForLevel(LogLevel.Debug));
+            Assert.Equal(true, rule1.IsLoggingEnabledForLevel(LogLevel.Trace));
+            Assert.Equal(false, rule1.IsLoggingEnabledForLevel(LogLevel.Off));
+        }
+
+        [Fact]
+        public void AddRule_onelevel()
+        {
+            var config = new LoggingConfiguration();
+            config.AddTarget(new FileTarget { Name = "File" });
+            config.AddRuleForOneLevel(LogLevel.Error, "File", "*a");
+            Assert.NotNull(config.LoggingRules);
+            Assert.Equal(1, config.LoggingRules.Count);
+            var rule1 = config.LoggingRules.FirstOrDefault();
+            Assert.NotNull(rule1);
+            Assert.Equal(false, rule1.Final);
+            Assert.Equal("*a", rule1.LoggerNamePattern);
+            Assert.Equal(false, rule1.IsLoggingEnabledForLevel(LogLevel.Fatal));
+            Assert.Equal(true, rule1.IsLoggingEnabledForLevel(LogLevel.Error));
+            Assert.Equal(false, rule1.IsLoggingEnabledForLevel(LogLevel.Warn));
+            Assert.Equal(false, rule1.IsLoggingEnabledForLevel(LogLevel.Info));
+            Assert.Equal(false, rule1.IsLoggingEnabledForLevel(LogLevel.Debug));
+            Assert.Equal(false, rule1.IsLoggingEnabledForLevel(LogLevel.Trace));
+            Assert.Equal(false, rule1.IsLoggingEnabledForLevel(LogLevel.Off));
+        }
+
+        [Fact]
+        public void AddRule_with_target()
+        {
+            var config = new LoggingConfiguration();
+            var fileTarget = new FileTarget { Name = "File" };
+            config.AddRuleForOneLevel(LogLevel.Error, fileTarget, "*a");
+            Assert.NotNull(config.LoggingRules);
+            Assert.Equal(1, config.LoggingRules.Count);
+            config.AddTarget(new FileTarget { Name = "File" });
+            var allTargets = config.AllTargets;
+            Assert.NotNull(allTargets);
+            Assert.Equal(1, allTargets.Count);
+            Assert.Equal("File", allTargets.First().Name);
+            Assert.NotNull(config.FindTargetByName<FileTarget>("File"));
+        }
+
+
+        [Fact]
+        public void AddRule_missingtarget()
+        {
+            var config = new LoggingConfiguration();
+
+            Assert.Throws <NLogConfigurationException>(() => config.AddRuleForOneLevel(LogLevel.Error, "File", "*a"));
+
+        }
+    }
+}

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Conditions\ConditionEvaluatorTests.cs" />
     <Compile Include="Conditions\ConditionParserTests.cs" />
     <Compile Include="Config\CaseSensitivityTests.cs" />
+    <Compile Include="Config\ConfigApiTests.cs" />
     <Compile Include="Config\ConfigurationItemFactoryTests.cs" />
     <Compile Include="Config\CultureInfoTests.cs" />
     <Compile Include="Config\ExtensionTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Conditions\ConditionEvaluatorTests.cs" />
     <Compile Include="Conditions\ConditionParserTests.cs" />
     <Compile Include="Config\CaseSensitivityTests.cs" />
+    <Compile Include="Config\ConfigApiTests.cs" />
     <Compile Include="Config\ConfigurationItemFactoryTests.cs" />
     <Compile Include="Config\CultureInfoTests.cs" />
     <Compile Include="Config\ExtensionTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Conditions\ConditionEvaluatorTests.cs" />
     <Compile Include="Conditions\ConditionParserTests.cs" />
     <Compile Include="Config\CaseSensitivityTests.cs" />
+    <Compile Include="Config\ConfigApiTests.cs" />
     <Compile Include="Config\ConfigurationItemFactoryTests.cs" />
     <Compile Include="Config\CultureInfoTests.cs" />
     <Compile Include="Config\ExtensionTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Conditions\ConditionEvaluatorTests.cs" />
     <Compile Include="Conditions\ConditionParserTests.cs" />
     <Compile Include="Config\CaseSensitivityTests.cs" />
+    <Compile Include="Config\ConfigApiTests.cs" />
     <Compile Include="Config\ConfigurationItemFactoryTests.cs" />
     <Compile Include="Config\CultureInfoTests.cs" />
     <Compile Include="Config\ExtensionTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Conditions\ConditionEvaluatorTests.cs" />
     <Compile Include="Conditions\ConditionParserTests.cs" />
     <Compile Include="Config\CaseSensitivityTests.cs" />
+    <Compile Include="Config\ConfigApiTests.cs" />
     <Compile Include="Config\ConfigurationItemFactoryTests.cs" />
     <Compile Include="Config\CultureInfoTests.cs" />
     <Compile Include="Config\ExtensionTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Conditions\ConditionEvaluatorTests.cs" />
     <Compile Include="Conditions\ConditionParserTests.cs" />
     <Compile Include="Config\CaseSensitivityTests.cs" />
+    <Compile Include="Config\ConfigApiTests.cs" />
     <Compile Include="Config\ConfigurationItemFactoryTests.cs" />
     <Compile Include="Config\CultureInfoTests.cs" />
     <Compile Include="Config\ExtensionTests.cs" />


### PR DESCRIPTION
Changes:

- added `AddRule` methods on `LoggingConfiguration`
- added `AddRuleForOneLevel` method  on `LoggingConfiguration`
- added `AddRuleForAllLevels` method  on `LoggingConfiguration`
- `LoggingConfiguration.AllTargets` will now really return all targets
- fix: `.LoggingConfiguration.IsLevelEnabled(off)` was throwing an exception.

Refactor changes:

- moved from Array to List internally for scanProperties.
- added extra ctor for `NLogConfigurationException`
- removed duplicate code


