### PR TITLE
Fix threadsafe issue of GetLogger / GetCurrentClassLogger (+improve performance) 

### DIFF
--- a/src/NLog/Internal/TargetWithFilterChain.cs
+++ b/src/NLog/Internal/TargetWithFilterChain.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Linq;
+
 namespace NLog.Internal
 {
     using System.Collections.Generic;
@@ -43,8 +45,8 @@ namespace NLog.Internal
     /// whether logging should happen.
     /// </summary>
     [NLogConfigurationItem]
-	internal class TargetWithFilterChain
-	{
+    internal class TargetWithFilterChain
+    {
         private StackTraceUsage stackTraceUsage = StackTraceUsage.None;
 
         /// <summary>
@@ -92,19 +94,10 @@ namespace NLog.Internal
 
             // find all objects which may need stack trace
             // and determine maximum
-            foreach (var item in ObjectGraphScanner.FindReachableObjects<IUsesStackTrace>(this))
+            // only the target can have IUsesStackTrace
+            if (Target != null)
             {
-                var stu = item.StackTraceUsage;
-
-                if (stu > this.stackTraceUsage)
-                {
-                    this.stackTraceUsage = stu;
-
-                    if (this.stackTraceUsage >= StackTraceUsage.Max)
-                    {
-                        break;
-                    }
-                }
+                this.stackTraceUsage = Target.GetAllLayouts().OfType<IUsesStackTrace>().DefaultIfEmpty().Max(usage => usage == null ? StackTraceUsage.None : usage.StackTraceUsage);
             }
         }
     }

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -50,6 +50,7 @@ namespace NLog.Targets
     {
         private object lockObject = new object();
         private List<Layout> allLayouts;
+        private bool scannedForLayouts;
         private Exception initializeException;
 
         /// <summary>
@@ -75,6 +76,20 @@ namespace NLog.Targets
         /// Gets a value indicating whether the target has been initialized.
         /// </summary>
         protected bool IsInitialized { get; private set; }
+
+        /// <summary>
+        /// Get all used layouts in this target.
+        /// </summary>
+        /// <returns></returns>
+        internal List<Layout> GetAllLayouts()
+        {
+
+            if (!scannedForLayouts)
+            {
+                FindAllLayouts();
+            }
+            return allLayouts;
+        }
 
         /// <summary>
         /// Initializes this instance.
@@ -397,8 +412,15 @@ namespace NLog.Targets
         /// </summary>
         protected virtual void InitializeTarget()
         {
+            //rescan as amount layouts can be changed.
+            FindAllLayouts();
+        }
+
+        private void FindAllLayouts()
+        {
             this.allLayouts = new List<Layout>(ObjectGraphScanner.FindReachableObjects<Layout>(this));
             InternalLogger.Trace("{0} has {1} layouts", this, this.allLayouts.Count);
+            this.scannedForLayouts = true;
         }
 
         /// <summary>


### PR DESCRIPTION
another try for https://github.com/NLog/NLog/issues/1262

Fix PrecalculateStackTraceUsage for threadsafe  issues in objectscaner.FindReachableObjects