### PR TITLE
don't require ProviderName attribute when using <connectionStrings> (app.config etc)

### DIFF
--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -329,18 +329,24 @@ namespace NLog.Targets
                 }
 
                 this.ConnectionString = SimpleLayout.Escape(cs.ConnectionString);
-                this.ProviderFactory = DbProviderFactories.GetFactory(cs.ProviderName);
-                foundProvider = true;
+                if (!string.IsNullOrEmpty(cs.ProviderName))
+                {
+                    this.ProviderFactory = DbProviderFactories.GetFactory(cs.ProviderName);
+                    foundProvider = true;
+                }
+            
             }
 
             if (!foundProvider)
             {
                 foreach (DataRow row in DbProviderFactories.GetFactoryClasses().Rows)
                 {
-                    if ((string)row["InvariantName"] == this.DBProvider)
+                    var invariantname = (string)row["InvariantName"];
+                    if (invariantname == this.DBProvider)
                     {
                         this.ProviderFactory = DbProviderFactories.GetFactory(this.DBProvider);
                         foundProvider = true;
+                        break;
                     }
                 }
             }

--- a/tests/NLog.UnitTests/App.config
+++ b/tests/NLog.UnitTests/App.config
@@ -3,10 +3,6 @@
 	<appSettings>
 		<add key="appSettingTestKey" value="appSettingTestValue"/>
 	</appSettings>
-  <connectionStrings>
-    <add name="test_connectionstring_without_providerName" connectionString="some connectionstring"/>
-    <add name="test_connectionstring_with_providerName" connectionString="some connectionstring" providerName="System.Data.SqlClient"/>
-  </connectionStrings>
   <system.net>
     <mailSettings>
       <smtp deliveryMethod="SpecifiedPickupDirectory">

--- a/tests/NLog.UnitTests/App.config
+++ b/tests/NLog.UnitTests/App.config
@@ -3,6 +3,10 @@
 	<appSettings>
 		<add key="appSettingTestKey" value="appSettingTestValue"/>
 	</appSettings>
+  <connectionStrings>
+    <add name="test_connectionstring_without_providerName" connectionString="some connectionstring"/>
+    <add name="test_connectionstring_with_providerName" connectionString="some connectionstring" providerName="System.Data.SqlClient"/>
+  </connectionStrings>
   <system.net>
     <mailSettings>
       <smtp deliveryMethod="SpecifiedPickupDirectory">

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -7,7 +7,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -211,6 +212,7 @@
     <Content Include="Properties\WMAppManifest.xml" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="NLogTests.snk" />
     <None Include="NLog.UnitTests.dll.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -769,6 +769,11 @@ Dispose()
                 ConnectionStringName = "test_connectionstring_with_providerName",
                 CommandText = "notimportant",
             };
+            databaseTarget.ConnectionStringsSettings = new ConnectionStringSettingsCollection()
+            {
+                new ConnectionStringSettings("test_connectionstring_without_providerName","some connectionstring"),
+                new ConnectionStringSettings("test_connectionstring_with_providerName","some connectionstring","System.Data.SqlClient"),
+            };
 
             databaseTarget.Initialize(null);
             Assert.NotNull(databaseTarget.ProviderFactory);
@@ -785,6 +790,12 @@ Dispose()
                 ConnectionStringName = "test_connectionstring_without_providerName",
                 CommandText = "notimportant",
                 DBProvider = "System.Data.SqlClient"
+            };
+
+            databaseTarget.ConnectionStringsSettings = new ConnectionStringSettingsCollection()
+            {
+                new ConnectionStringSettings("test_connectionstring_without_providerName","some connectionstring"),
+                new ConnectionStringSettings("test_connectionstring_with_providerName","some connectionstring","System.Data.SqlClient"),
             };
 
             databaseTarget.Initialize(null);

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -348,7 +348,7 @@ Dispose()
                     new DatabaseParameterInfo("msg", "${message}"),
                     new DatabaseParameterInfo("lvl", "${level}"),
                     new DatabaseParameterInfo("lg", "${logger}")
-                        
+
                 }
             };
 
@@ -759,10 +759,43 @@ Dispose()
             Assert.Equal(typeof(System.Data.Odbc.OdbcConnection), dt.ConnectionType);
         }
 
+        [Fact]  
+        public void GetProviderNameFromAppConfig()
+        {
+            LogManager.ThrowExceptions = true;
+            var databaseTarget = new DatabaseTarget()
+            {
+                Name = "myTarget",
+                ConnectionStringName = "test_connectionstring_with_providerName",
+                CommandText = "notimportant",
+            };
+
+            databaseTarget.Initialize(null);
+            Assert.NotNull(databaseTarget.ProviderFactory);
+            Assert.Equal(typeof(System.Data.SqlClient.SqlClientFactory), databaseTarget.ProviderFactory.GetType());
+        }
+
+        [Fact]
+        public void DontRequireProviderNameInAppConfig()
+        {
+            LogManager.ThrowExceptions = true;
+            var databaseTarget = new DatabaseTarget()
+            {
+                Name = "myTarget",
+                ConnectionStringName = "test_connectionstring_without_providerName",
+                CommandText = "notimportant",
+                DBProvider = "System.Data.SqlClient"
+            };
+
+            databaseTarget.Initialize(null);
+            Assert.NotNull(databaseTarget.ProviderFactory);
+            Assert.Equal(typeof(System.Data.SqlClient.SqlClientFactory), databaseTarget.ProviderFactory.GetType());
+        }
+
         [Theory]
-        [InlineData("usetransactions='false'",true)]
-        [InlineData("usetransactions='true'",true)]
-        [InlineData("",false)]
+        [InlineData("usetransactions='false'", true)]
+        [InlineData("usetransactions='true'", true)]
+        [InlineData("", false)]
         public void WarningForObsoleteUseTransactions(string property, bool printWarning)
         {
             LoggingConfiguration c = CreateConfigurationFromString(string.Format(@"


### PR DESCRIPTION
Fixes https://github.com/NLog/NLog/issues/1115

Before was needed:

```
<add name="test_connectionstring_with_providerName" connectionString="some connectionstring" 

providerName="System.Data.SqlClient" <-----------------

/>
```

even if "DBProvider" was set. E.g. 
 
```
                databaseTarget .DBProvider = "System.Data.SqlClient"
 
```