### PR TITLE
autoload NLog.config in assets folder (Xamarin Android)

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -63,6 +63,14 @@ namespace NLog.Config
     ///<remarks>This class is thread-safe.<c>.ToList()</c> is used for that purpose.</remarks>
     public class XmlLoggingConfiguration : LoggingConfiguration
     {
+#if __ANDROID__
+
+        /// <summary>
+        /// Prefix for assets in Xamarin Android
+        /// </summary>
+        internal const string AssetsPrefix = "assets/";
+#endif
+
         #region private fields
 
         private readonly Dictionary<string, bool> fileMustAutoReloadLookup = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
@@ -134,11 +142,10 @@ namespace NLog.Config
                 fileName = fileName.Trim();
 #if __ANDROID__
                 //suport loading config from special assets folder in nlog.config
-                const string assetsPrefix = "assets/";
-                if (fileName.StartsWith(assetsPrefix, StringComparison.OrdinalIgnoreCase))
+                if (fileName.StartsWith(AssetsPrefix, StringComparison.OrdinalIgnoreCase))
                 {
                     //remove prefix
-                    fileName = fileName.Substring(assetsPrefix.Length);
+                    fileName = fileName.Substring(AssetsPrefix.Length);
                     Stream stream = Android.App.Application.Context.Assets.Open(fileName);
                     return XmlReader.Create(stream);
                 }

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -190,6 +190,29 @@ namespace NLog
                         }
                     }
 
+#if __ANDROID__
+                    if (this.config == null)
+                    {
+                        //try nlog.config in assets folder
+                        const string nlogConfigFilename = "NLog.config";
+                        try
+                        {
+                            using (var stream = Android.App.Application.Context.Assets.Open(nlogConfigFilename))
+                            {
+                                if (stream != null)
+                                {
+                                    LoadLoggingConfiguration(XmlLoggingConfiguration.AssetsPrefix + nlogConfigFilename);
+                                }
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            InternalLogger.Trace(e, "no {0} in assets folder", nlogConfigFilename);
+                        }
+
+                    }
+#endif
+
                     if (this.config != null)
                     {
                         try


### PR DESCRIPTION
No need for 

```c#
LogManager.Configuration = new XmlLoggingConfiguration("assets/NLog.config");
```
anymore

- [ ] Update wiki: https://github.com/NLog/NLog/wiki/Configuration-file#xamarin-assets


Related https://github.com/NLog/NLog/issues/1172