### PR TITLE
Fix stacktraceusage with more than 1 rule

### DIFF
--- a/src/NLog/Internal/TargetWithFilterChain.cs
+++ b/src/NLog/Internal/TargetWithFilterChain.cs
@@ -47,6 +47,9 @@ namespace NLog.Internal
     [NLogConfigurationItem]
     internal class TargetWithFilterChain
     {
+        /// <summary>
+        /// cached result as calculating is expensive.
+        /// </summary>
         private StackTraceUsage? _stackTraceUsage;
 
         /// <summary>
@@ -90,12 +93,6 @@ namespace NLog.Internal
 
         internal StackTraceUsage PrecalculateStackTraceUsage()
         {
-            //no need to recalculated as this method is only called once.
-            if (_stackTraceUsage.HasValue)
-            {
-                return _stackTraceUsage.Value;
-            }
-
             var stackTraceUsage = StackTraceUsage.None;
 
             // find all objects which may need stack trace

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -222,7 +222,14 @@ namespace NLog.Layouts
         internal void SetRenderers(LayoutRenderer[] renderers, string text)
         {
             this.Renderers = new ReadOnlyCollection<LayoutRenderer>(renderers);
-            if (this.Renderers.Count == 1 && this.Renderers[0] is LiteralLayoutRenderer)
+
+            if (this.Renderers.Count == 0)
+            {
+                //todo fixedText = null is also used if the text is fixed, but is a empty renderers not fixed?
+                this.fixedText = null;
+                this.StackTraceUsage = StackTraceUsage.None;
+            }
+            else if (this.Renderers.Count == 1 && this.Renderers[0] is LiteralLayoutRenderer)
             {
                 this.fixedText = ((LiteralLayoutRenderer)this.Renderers[0]).Text;
                 this.StackTraceUsage = StackTraceUsage.None;

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -551,6 +551,70 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
 
+        [Fact]
+        public void CheckStackTraceUsageForTwoRules()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets>
+                    <target name='debug' type='Debug' layout='${message}' />
+                    <target name='debug2' type='Debug' layout='${callsite} ${message}' />
+                </targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                    <logger name='*' minlevel='Debug' writeTo='debug2' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("msg");
+            AssertDebugLastMessage("debug2", "NLog.UnitTests.LayoutRenderers.CallSiteTests.CheckStackTraceUsageForTwoRules msg");
+        }
+
+
+        [Fact]
+        public void CheckStackTraceUsageForTwoRules_chained()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets>
+                    <target name='debug' type='Debug' layout='${message}' />
+                    <target name='debug2' type='Debug' layout='${callsite} ${message}' />
+                </targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                    <logger name='*' minlevel='Debug' writeTo='debug,debug2' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("msg");
+            AssertDebugLastMessage("debug2", "NLog.UnitTests.LayoutRenderers.CallSiteTests.CheckStackTraceUsageForTwoRules_chained msg");
+        }
+
+
+        [Fact]
+        public void CheckStackTraceUsageForMultipleRules()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets>
+                    <target name='debug' type='Debug' layout='${message}' />
+                    <target name='debug2' type='Debug' layout='${callsite} ${message}' />
+                </targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                    <logger name='*' minlevel='Debug' writeTo='debug,debug2' />
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("msg");
+            AssertDebugLastMessage("debug2", "NLog.UnitTests.LayoutRenderers.CallSiteTests.CheckStackTraceUsageForMultipleRules msg");
+        }
+
 
         #region Compositio unit test
 


### PR DESCRIPTION
This was broken due to too aggressive caching. 

This was working:

```
<nlog>
   <targets>
       <target name='debug' type='Debug' layout='${message}' />
       <target name='debug2' type='Debug' layout='${callsite} ${message}' />
   </targets>
   <rules>
       <logger name='*' minlevel='Debug' writeTo='debug2' />
       <logger name='*' minlevel='Debug' writeTo='debug' />
   </rules>
</nlog>
```

and this wasn't (nullref in stacktrace renderer, because of maxstacktrace = none)

```
<nlog>
   <targets>
       <target name='debug' type='Debug' layout='${message}' />
       <target name='debug2' type='Debug' layout='${callsite} ${message}' />
   </targets>
   <rules>
       <logger name='*' minlevel='Debug' writeTo='debug' />
       <logger name='*' minlevel='Debug' writeTo='debug2' /> 
   </rules>
</nlog>
```

fixes https://github.com/NLog/NLog/issues/1363