### PR TITLE
Fix configuration usage in `${var}` renderer

### DIFF
--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -127,9 +127,11 @@ namespace NLog.LayoutRenderers
         /// <param name="configuration">The configuration.</param>
         internal void Initialize(LoggingConfiguration configuration)
         {
+            if (this.LoggingConfiguration == null)
+                this.LoggingConfiguration = configuration;
+
             if (!this.isInitialized)
             {
-                this.LoggingConfiguration = configuration;
                 this.isInitialized = true;
                 this.InitializeLayoutRenderer();
             }

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -218,7 +218,7 @@ namespace NLog.Layouts
         {
             return "'" + this.Text + "'";
         }
- 
+
         internal void SetRenderers(LayoutRenderer[] renderers, string text)
         {
             this.Renderers = new ReadOnlyCollection<LayoutRenderer>(renderers);
@@ -241,6 +241,38 @@ namespace NLog.Layouts
             }
 
             this.layoutText = text;
+        }
+
+        /// <summary>
+        /// Initializes the layout.
+        /// </summary>
+        protected override void InitializeLayout()
+        {
+            for (int i = 0; i < this.Renderers.Count; i++)
+            {
+                LayoutRenderer renderer = this.Renderers[i];
+                try
+                {
+                    renderer.Initialize(LoggingConfiguration);
+                }
+                catch (Exception exception)
+                {
+                    //also check IsErrorEnabled, otherwise 'MustBeRethrown' writes it to Error
+
+                    //check for performance
+                    if (InternalLogger.IsWarnEnabled || InternalLogger.IsErrorEnabled)
+                    {
+                        InternalLogger.Warn(exception, "Exception in '{0}.InitializeLayout()'", renderer.GetType().FullName);
+                    }
+
+                    if (exception.MustBeRethrown())
+                    {
+                        throw;
+                    }
+                }
+            }
+
+            base.InitializeLayout();
         }
 
         /// <summary>

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -279,7 +279,9 @@ namespace NLog
 
                     this.config = value;
 
-                    if (this.config != null)
+                    if (this.config == null)
+                        this.configLoaded = false;
+                    else
                     {
                         try
                         {

--- a/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
@@ -115,7 +115,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             LogManager.Configuration.Variables["password"] = "123";
             ILogger logger = LogManager.GetLogger("A");
-
+            // LogManager.ReconfigExistingLoggers();
             logger.Debug("msg");
             var lastMessage = GetDebugLastMessage("debug");
             Assert.Equal("msg and 123==123", lastMessage);
@@ -243,8 +243,9 @@ namespace NLog.UnitTests.LayoutRenderers
         public void null_should_be_ok()
         {
             Layout l = "${var:var1}";
-            LogManager.Configuration = new NLog.Config.LoggingConfiguration();
-            LogManager.Configuration.Variables["var1"] = null;
+            var config = new NLog.Config.LoggingConfiguration();
+            config.Variables["var1"] = null;
+            l.Initialize(config);
             var result = l.Render(LogEventInfo.CreateNullEvent());
             Assert.Equal("", result);
         }
@@ -253,8 +254,9 @@ namespace NLog.UnitTests.LayoutRenderers
         public void null_should_not_use_default()
         {
             Layout l = "${var:var1:default=x}";
-            LogManager.Configuration = new NLog.Config.LoggingConfiguration();
-            LogManager.Configuration.Variables["var1"] = null;
+            var config = new NLog.Config.LoggingConfiguration();
+            config.Variables["var1"] = null;
+            l.Initialize(config);
             var result = l.Render(LogEventInfo.CreateNullEvent());
             Assert.Equal("", result);
         }
@@ -263,8 +265,8 @@ namespace NLog.UnitTests.LayoutRenderers
         public void notset_should_use_default()
         {
             Layout l = "${var:var1:default=x}";
-            LogManager.Configuration = new NLog.Config.LoggingConfiguration();
-
+            var config = new NLog.Config.LoggingConfiguration();
+            l.Initialize(config);
             var result = l.Render(LogEventInfo.CreateNullEvent());
             Assert.Equal("x", result);
         }

--- a/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
@@ -103,7 +103,7 @@ namespace NLog.UnitTests.LayoutRenderers
             <nlog>
                 <variable name='dir' value='{0}' />
                 <targets>
-                    <target name='f' type='file' fileName='${{var:dir}}\test.log' layout='${{message}}' lineEnding='LF' />
+                    <target name='f' type='file' fileName='${{var:dir}}/test.log' layout='${{message}}' lineEnding='LF' />
                 </targets>
                 <rules>
                     <logger name='*' writeTo='f' />

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -234,6 +234,31 @@ namespace NLog.UnitTests
                 </rules>
             </nlog>");
         }
+
+        [Fact]
+        public void ValueWithVariableMustNotCauseInfiniteRecursion()
+        {
+            LogManager.Configuration = null;
+            
+            File.WriteAllText("NLog.config", @"
+            <nlog>
+                <variable name='dir' value='c:\mylogs' />
+                <targets>
+                    <target name='f' type='file' fileName='${var:dir}\test.log' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='f' />
+                </rules>
+            </nlog>");
+            try
+            {
+                LogManager.Configuration.ToString();
+            }
+            finally
+            {
+                File.Delete("NLog.config");
+            }
+        }
         
         [Fact]
         public void EnableAndDisableLogging()


### PR DESCRIPTION
- Fix configuration usage in `${var}` renderer; don't use `LogManager`, that can lead to locks/inifite recursion
- Init layoutrenders correctly inside other layoutrenders
- fix unit tests (if `.render()` is called, call`.Initialize()` first)

fixes https://github.com/NLog/NLog/issues/1381
