### PR TITLE
Fix filetarget: Thread was being aborted

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -663,7 +663,16 @@ namespace NLog.Targets
                             {
                                 while (true)
                                 {
-                                    Thread.Sleep(200);
+                                    try
+                                    {
+                                        Thread.Sleep(200);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        //non-critical, this could be a ThreadAbortException
+                                        InternalLogger.Warn(ex, "Exception in Thread.Sleep, most of the time not an issue.");
+                                    }
+                                   
                                     lock (SyncRoot)
                                         this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
                                 }


### PR DESCRIPTION
Fix filetarget: Thread was being aborted

Thread.Sleep can throw a ThreadAbortException

Fixes https://github.com/NLog/NLog/issues/1385