### PR TITLE
Remove test dependency on locale

### DIFF
--- a/tests/NLog.UnitTests/LayoutRenderers/LongDateTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/LongDateTests.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Globalization;
+
 namespace NLog.UnitTests.LayoutRenderers
 {
     using NLog.LayoutRenderers;
@@ -67,7 +69,7 @@ namespace NLog.UnitTests.LayoutRenderers
             dt.UniversalTime = true;
             
             var ei = new LogEventInfo(LogLevel.Info, "logger", "msg");
-            Assert.Equal(ei.TimeStamp.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffff"), dt.Render(ei));
+            Assert.Equal(ei.TimeStamp.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffff", CultureInfo.InvariantCulture), dt.Render(ei));
         }
 
         [Fact]
@@ -77,7 +79,7 @@ namespace NLog.UnitTests.LayoutRenderers
             dt.UniversalTime = false;
             
             var ei = new LogEventInfo(LogLevel.Info, "logger", "msg");
-            Assert.Equal(ei.TimeStamp.ToString("yyyy-MM-dd HH:mm:ss.ffff"), dt.Render(ei));
+            Assert.Equal(ei.TimeStamp.ToString("yyyy-MM-dd HH:mm:ss.ffff", CultureInfo.InvariantCulture), dt.Render(ei));
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/LayoutRenderers/TimeTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/TimeTests.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Globalization;
+
 namespace NLog.UnitTests.LayoutRenderers
 {
     using NLog.LayoutRenderers;
@@ -45,7 +47,7 @@ namespace NLog.UnitTests.LayoutRenderers
             dt.UniversalTime = true;
 
             var ei = new LogEventInfo(LogLevel.Info, "logger", "msg");
-            Assert.Equal(ei.TimeStamp.ToUniversalTime().ToString("HH:mm:ss.ffff"), dt.Render(ei));
+            Assert.Equal(ei.TimeStamp.ToUniversalTime().ToString("HH:mm:ss.ffff", CultureInfo.InvariantCulture), dt.Render(ei));
         }
 
         [Fact]
@@ -55,7 +57,7 @@ namespace NLog.UnitTests.LayoutRenderers
             dt.UniversalTime = false;
 
             var ei = new LogEventInfo(LogLevel.Info, "logger", "msg");
-            Assert.Equal(ei.TimeStamp.ToString("HH:mm:ss.ffff"), dt.Render(ei));
+            Assert.Equal(ei.TimeStamp.ToString("HH:mm:ss.ffff", CultureInfo.InvariantCulture), dt.Render(ei));
         }
         
         [Fact]


### PR DESCRIPTION
Since some tests were not working because relying on a specific locale I fixed them.

**NLog version**
4.3.0

**Work arounds**
None

**Config when implemented**
No changes