### PR TITLE
Support for configuring target parameters with xml fragments

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -1066,6 +1066,11 @@ namespace NLog.Config
                 return;
             }
 
+            if (this.SetItemFromElement(o, element))
+            {
+                return;
+            }
+
             PropertyHelper.SetPropertyFromString(o, element.LocalName, this.ExpandSimpleVariables(element.Value), this.ConfigurationItemFactory);
         }
 
@@ -1137,6 +1142,25 @@ namespace NLog.Config
             }
 
             return false;
+        }
+
+        private bool SetItemFromElement(object o, NLogXmlElement element)
+        {
+            if (element.Value != null)
+                return false;
+
+            string name = element.LocalName;
+
+            PropertyInfo propInfo;
+            if (!PropertyHelper.TryGetPropertyInfo(o, name, out propInfo))
+            {
+                return false;
+            }
+
+            object item = propInfo.GetValue(o, null);
+            this.ConfigureObjectFromAttributes(item, element, true);
+            this.ConfigureObjectFromElement(item, element);
+            return true;
         }
 
         private void ConfigureObjectFromElement(object targetObject, NLogXmlElement element)


### PR DESCRIPTION
Allow (non-flat) XML config for target parameters.

E.g. 

```xml
 <target type='StructuredDebugTarget'>
                      <name>structuredTgt</name>
                      <layout>${message}</layout>
                      <config platform='any'>
                        <parameter name='param1' />
                      </config>
```

Where `<config>` is a C# class.

Thanks to @luigiberrettini!

Supersedes https://github.com/NLog/NLog/pull/1390

