### PR TITLE
Fix filetarget: Thread was being aborted (#2)

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -667,9 +667,14 @@ namespace NLog.Targets
                                     {
                                         Thread.Sleep(200);
                                     }
+                                    catch (ThreadAbortException ex)
+                                    {
+                                        //ThreadAbortException will be automatically re-thrown at the end of the try/catch/finally if ResetAbort isn't called.
+                                        Thread.ResetAbort();
+                                        InternalLogger.Trace(ex, "ThreadAbortException in Thread.Sleep");
+                                    }
                                     catch (Exception ex)
                                     {
-                                        //non-critical, this could be a ThreadAbortException
                                         InternalLogger.Warn(ex, "Exception in Thread.Sleep, most of the time not an issue.");
                                     }
                                    


### PR DESCRIPTION
Need for Thread.ResetAbort();

Fixes https://github.com/NLog/NLog/issues/1385

See http://stackoverflow.com/questions/1856286/threadabortexception

Thanks @jonreis!