### PR TITLE
Check if directory NLog.dll is detected in actually exists

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -244,9 +244,14 @@ namespace NLog.Config
 #if !SILVERLIGHT
 
             var assemblyLocation = Path.GetDirectoryName(new Uri(nlogAssembly.CodeBase).LocalPath);
-            if (assemblyLocation == null || !Directory.Exists(assemblyLocation))
+            if (assemblyLocation == null)
             {
                 InternalLogger.Warn("No auto loading because Nlog.dll location is unknown");
+                return factory;
+            }
+            if (!Directory.Exists(assemblyLocation))
+            {
+                InternalLogger.Warn("No auto loading because Nlog.dll location is not found");
                 return factory;
             }
 

--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -244,7 +244,7 @@ namespace NLog.Config
 #if !SILVERLIGHT
 
             var assemblyLocation = Path.GetDirectoryName(new Uri(nlogAssembly.CodeBase).LocalPath);
-            if (assemblyLocation == null)
+            if (assemblyLocation == null || !Directory.Exists(assemblyLocation))
             {
                 InternalLogger.Warn("No auto loading because Nlog.dll location is unknown");
                 return factory;


### PR DESCRIPTION
Fixes crash when an assembly location is found that doesn't actually exist. 

I believe this happens when using in-memory or bundling loading of the library, as described at https://github.com/NLog/NLog/issues/736#issuecomment-216694452.