### PR TITLE
Added constructors with name argument to the target types

### DIFF
--- a/src/NLog.Extended/Targets/MessageQueueTarget.cs
+++ b/src/NLog.Extended/Targets/MessageQueueTarget.cs
@@ -84,6 +84,18 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MessageQueueTarget"/> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public MessageQueueTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets or sets the name of the queue to write to.
         /// </summary>
         /// <remarks>

--- a/src/NLog/Targets/AspResponseTarget.cs
+++ b/src/NLog/Targets/AspResponseTarget.cs
@@ -52,6 +52,28 @@ namespace NLog.Targets
         public bool AddComments { get; set; }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="AspResponseTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        public AspResponseTarget() : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AspResponseTarget"/> class with a name.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public AspResponseTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Outputs the rendered logging event through the <c>OutputDebugString()</c> Win32 API.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>

--- a/src/NLog/Targets/ChainsawTarget.cs
+++ b/src/NLog/Targets/ChainsawTarget.cs
@@ -68,5 +68,14 @@ namespace NLog.Targets
         {
             IncludeNLogData = false;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChainsawTarget"/> class with a name.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public ChainsawTarget(string name) : this()
+        {
+            this.Name = name;
+        }
     }
 }

--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -73,6 +73,18 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ColoredConsoleTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public ColoredConsoleTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the error stream (stderr) should be used instead of the output stream (stdout).
         /// </summary>
         /// <docgen category='Output Options' order='10' />

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -79,6 +79,28 @@ namespace NLog.Targets
 #endif
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ConsoleTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        public ConsoleTarget() : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsoleTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public ConsoleTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Initializes the target.
         /// </summary>
         protected override void InitializeTarget()

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -93,6 +93,15 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="DatabaseTarget" /> class.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public DatabaseTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets or sets the name of the database provider.
         /// </summary>
         /// <remarks>

--- a/src/NLog/Targets/DebugTarget.cs
+++ b/src/NLog/Targets/DebugTarget.cs
@@ -70,6 +70,18 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="DebugTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public DebugTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets the number of times this target has been called.
         /// </summary>
         /// <docgen category='Debugging Options' order='10' />

--- a/src/NLog/Targets/DebuggerTarget.cs
+++ b/src/NLog/Targets/DebuggerTarget.cs
@@ -57,6 +57,28 @@ namespace NLog.Targets
     public sealed class DebuggerTarget : TargetWithLayoutHeaderAndFooter
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="DebuggerTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        public DebuggerTarget() : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DebuggerTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public DebuggerTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Initializes the target.
         /// </summary>
         protected override void InitializeTarget()

--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -90,6 +90,15 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="EventLogTarget"/> class.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public EventLogTarget(string name) : this(AppDomainWrapper.CurrentDomain)
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets or sets the name of the machine on which Event Log service is running.
         /// </summary>
         /// <docgen category='Event Log Options' order='10' />

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -93,7 +93,7 @@ namespace NLog.Targets
         /// </summary>
         /// <remarks>Last write time is store in local time (no UTC).</remarks>
         private readonly Dictionary<string, DateTime> initializedFiles = new Dictionary<string, DateTime>();
-        
+
         private LineEndingMode lineEndingMode = LineEndingMode.Default;
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace NLog.Targets
 
         private bool concurrentWrites;
         private bool keepFileOpen;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FileTarget" /> class.
         /// </summary>
@@ -236,7 +236,7 @@ namespace NLog.Targets
             get { return fileName; }
             set
             {
-              
+
                 fileName = value;
 
                 if (IsInitialized)
@@ -252,24 +252,24 @@ namespace NLog.Targets
 
         private void SetCachedCleanedFileNamed(Layout value)
         {
-                var simpleLayout = value as SimpleLayout;
-                if (simpleLayout != null && simpleLayout.IsFixedText)
-                {
-                    cachedCleanedFileNamed = CleanupInvalidFileNameChars(simpleLayout.FixedText);
-                }
-                else
-                {
-                    //clear cache
-                    cachedCleanedFileNamed = null;
-                }
+            var simpleLayout = value as SimpleLayout;
+            if (simpleLayout != null && simpleLayout.IsFixedText)
+            {
+                cachedCleanedFileNamed = CleanupInvalidFileNameChars(simpleLayout.FixedText);
+            }
+            else
+            {
+                //clear cache
+                cachedCleanedFileNamed = null;
+            }
 
-                fileName = value;
+            fileName = value;
 
-                if (IsInitialized)
-                {
-                    RefreshFileArchive();
-                    RefreshArchiveFilePatternToWatch();
-                }
+            if (IsInitialized)
+            {
+                RefreshFileArchive();
+                RefreshArchiveFilePatternToWatch();
+            }
         }
 
         /// <summary>
@@ -325,9 +325,9 @@ namespace NLog.Targets
                 keepFileOpen = value;
                 if (IsInitialized)
                 {
-                RefreshArchiveFilePatternToWatch();
+                    RefreshArchiveFilePatternToWatch();
+                }
             }
-        }
         }
 
         /// <summary>
@@ -438,9 +438,9 @@ namespace NLog.Targets
                 concurrentWrites = value;
                 if (IsInitialized)
                 {
-                RefreshArchiveFilePatternToWatch();
+                    RefreshArchiveFilePatternToWatch();
+                }
             }
-        }
         }
 
         /// <summary>
@@ -526,9 +526,9 @@ namespace NLog.Targets
                 archiveAboveSize = value;
                 if (IsInitialized)
                 {
-                RefreshArchiveFilePatternToWatch();
+                    RefreshArchiveFilePatternToWatch();
+                }
             }
-        }
         }
 
         /// <summary>
@@ -554,9 +554,9 @@ namespace NLog.Targets
                 archiveEvery = value;
                 if (IsInitialized)
                 {
-                RefreshArchiveFilePatternToWatch();
+                    RefreshArchiveFilePatternToWatch();
+                }
             }
-        }
         }
 
         /// <summary>
@@ -578,10 +578,10 @@ namespace NLog.Targets
                 if (IsInitialized)
                 {
                     //don't call before initialized because this could lead to stackoverflows.
-                RefreshFileArchive();
-                RefreshArchiveFilePatternToWatch();
+                    RefreshFileArchive();
+                    RefreshArchiveFilePatternToWatch();
+                }
             }
-        }
         }
 
         /// <summary>
@@ -622,9 +622,9 @@ namespace NLog.Targets
                 enableArchiveFileCompression = value;
                 if (IsInitialized)
                 {
-                RefreshArchiveFilePatternToWatch();
+                    RefreshArchiveFilePatternToWatch();
+                }
             }
-        }
         }
 #else
         /// <summary>
@@ -714,7 +714,7 @@ namespace NLog.Targets
                                 {
                                     try
                                     {
-                                    Thread.Sleep(200);
+                                        Thread.Sleep(200);
                                     }
                                     catch (ThreadAbortException ex)
                                     {
@@ -726,7 +726,7 @@ namespace NLog.Targets
                                     {
                                         InternalLogger.Warn(ex, "Exception in Thread.Sleep, most of the time not an issue.");
                                     }
-                                   
+
                                     lock (SyncRoot)
                                         this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
                                 }
@@ -858,7 +858,7 @@ namespace NLog.Targets
             else
                 return SingleProcessFileAppender.TheFactory;
         }
-        
+
         private bool IsArchivingEnabled()
         {
             return this.ArchiveAboveSize != FileTarget.ArchiveAboveSizeDisabled || this.ArchiveEvery != FileArchivePeriod.None;
@@ -871,7 +871,7 @@ namespace NLog.Targets
         protected override void InitializeTarget()
         {
             base.InitializeTarget();
-           
+
             SetCachedCleanedFileNamed(FileName);
             RefreshFileArchive();
             this.appenderFactory = GetFileAppenderFactory();
@@ -1070,7 +1070,8 @@ namespace NLog.Targets
             try
             {
                 if (currentFileName != null)
-                    ProcessLogEvent(firstLogEvent, currentFileName, ms.ToArray());            }
+                    ProcessLogEvent(firstLogEvent, currentFileName, ms.ToArray());
+            }
             catch (Exception exception)
             {
                 if (exception.MustBeRethrown())
@@ -1245,7 +1246,7 @@ namespace NLog.Targets
                 InternalLogger.Info("Archiving {0} to zip-archive {1}", fileName, archiveFileName);
                 using (var archiveStream = new FileStream(archiveFileName, FileMode.Create))
                 using (var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create))
-                using (var originalFileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite ))
+                using (var originalFileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 {
                     var zipArchiveEntry = archive.CreateEntry(Path.GetFileName(fileName));
                     using (var destination = zipArchiveEntry.Open())
@@ -1253,7 +1254,7 @@ namespace NLog.Targets
                         originalFileStream.CopyTo(destination);
                     }
                 }
-                
+
                 DeleteAndWaitForFileDelete(fileName);
             }
             else
@@ -1351,7 +1352,7 @@ namespace NLog.Targets
             archiveFileNames.Add(archiveFileName);
             EnsureArchiveCount(archiveFileNames);
         }
-        
+
         /// <summary>
         /// Deletes files among a given list, and stops as soon as the remaining files are fewer than the <see
         /// cref="P:FileTarget.MaxArchiveFiles"/> setting.
@@ -1536,7 +1537,7 @@ namespace NLog.Targets
                 {
                     string archiveFileName = Path.GetFileName(nextFile);
                     int lastIndexOfStar = fileNameMask.LastIndexOf('*');
-          
+
                     if (lastIndexOfStar + dateFormat.Length <= archiveFileName.Length)
                     {
                         string datePart = archiveFileName.Substring(lastIndexOfStar, dateFormat.Length);
@@ -1574,7 +1575,7 @@ namespace NLog.Targets
                     case FileArchivePeriod.Year: formatString = "yyyy"; break;
                     case FileArchivePeriod.Month: formatString = "yyyyMM"; break;
                     default: formatString = "yyyyMMdd"; break;
-                    case FileArchivePeriod.Hour: formatString = "yyyyMMddHH";break;
+                    case FileArchivePeriod.Hour: formatString = "yyyyMMddHH"; break;
                     case FileArchivePeriod.Minute: formatString = "yyyyMMddHHmm"; break;
                 }
             }
@@ -1594,7 +1595,7 @@ namespace NLog.Targets
                 InternalLogger.Trace("Using previous log event time (is more recent)");
                 return previousLogEventTimestamp.Value;
             }
-            
+
             if (PreviousLogOverlappedPeriod(fileCharacteristics, logEvent))
             {
                 InternalLogger.Trace("Using previous log event time (previous log overlapped period)");
@@ -1711,7 +1712,7 @@ namespace NLog.Targets
                 return Path.GetFullPath(archiveFileName);
             }
         }
-        
+
         /// <summary>
         /// Determine if old archive files should be deleted.
         /// </summary>
@@ -1775,7 +1776,7 @@ namespace NLog.Targets
             {
                 return false;
             }
-            
+
             // file creation time is in Utc and logEvent's timestamp is originated from TimeSource.Current,
             // so we should ask the TimeSource to convert file time to TimeSource time:
             DateTime creationTime = TimeSource.Current.FromSystemTime(fileCharacteristics.CreationTimeUtc);
@@ -1881,7 +1882,7 @@ namespace NLog.Targets
                 if (!this.initializedFiles.ContainsKey(fileName))
                 {
                     ProcessOnStartup(fileName, logEvent);
-                    
+
                     this.initializedFiles[fileName] = now;
                     this.initializedFilesCounter++;
                     writeHeader = true;
@@ -2118,7 +2119,7 @@ namespace NLog.Targets
         {
             private readonly Queue<string> archiveFileQueue = new Queue<string>();
             private readonly FileTarget fileTarget;
-            
+
             /// <summary>
             /// Creates an instance of <see cref="DynamicFileArchive"/> class.
             /// </summary>
@@ -2129,7 +2130,7 @@ namespace NLog.Targets
                 this.fileTarget = fileTarget;
                 this.MaxArchiveFileToKeep = maxArchivedFiles;
             }
-            
+
             /// <summary>
             /// Gets or sets the maximum number of archive files that should be kept.
             /// </summary>
@@ -2180,7 +2181,7 @@ namespace NLog.Targets
                 AddToArchive(archiveFileName, fileName, createDirectory);
                 return true;
             }
-            
+
             /// <summary>
             /// Archives the file, either by copying it to a new file system location or by compressing it, and add the file name into the list of archives.
             /// </summary>
@@ -2238,7 +2239,7 @@ namespace NLog.Targets
                 }
             }
 
-            
+
             /// <summary>
             /// Gets the file name for the next archive file by appending a number to the provided
             /// "base"-filename.

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -252,16 +252,24 @@ namespace NLog.Targets
 
         private void SetCachedCleanedFileNamed(Layout value)
         {
-            var simpleLayout = value as SimpleLayout;
-            if (simpleLayout != null && simpleLayout.IsFixedText)
-            {
-                cachedCleanedFileNamed = CleanupInvalidFileNameChars(simpleLayout.FixedText);
-            }
-            else
-            {
-                //clear cache
-                cachedCleanedFileNamed = null;
-            }
+                var simpleLayout = value as SimpleLayout;
+                if (simpleLayout != null && simpleLayout.IsFixedText)
+                {
+                    cachedCleanedFileNamed = CleanupInvalidFileNameChars(simpleLayout.FixedText);
+                }
+                else
+                {
+                    //clear cache
+                    cachedCleanedFileNamed = null;
+                }
+
+                fileName = value;
+
+                if (IsInitialized)
+                {
+                    RefreshFileArchive();
+                    RefreshArchiveFilePatternToWatch();
+                }
         }
 
         /// <summary>
@@ -317,9 +325,9 @@ namespace NLog.Targets
                 keepFileOpen = value;
                 if (IsInitialized)
                 {
-                    RefreshArchiveFilePatternToWatch();
-                }
+                RefreshArchiveFilePatternToWatch();
             }
+        }
         }
 
         /// <summary>
@@ -430,9 +438,9 @@ namespace NLog.Targets
                 concurrentWrites = value;
                 if (IsInitialized)
                 {
-                    RefreshArchiveFilePatternToWatch();
-                }
+                RefreshArchiveFilePatternToWatch();
             }
+        }
         }
 
         /// <summary>
@@ -518,9 +526,9 @@ namespace NLog.Targets
                 archiveAboveSize = value;
                 if (IsInitialized)
                 {
-                    RefreshArchiveFilePatternToWatch();
-                }
+                RefreshArchiveFilePatternToWatch();
             }
+        }
         }
 
         /// <summary>
@@ -546,9 +554,9 @@ namespace NLog.Targets
                 archiveEvery = value;
                 if (IsInitialized)
                 {
-                    RefreshArchiveFilePatternToWatch();
-                }
+                RefreshArchiveFilePatternToWatch();
             }
+        }
         }
 
         /// <summary>
@@ -570,10 +578,10 @@ namespace NLog.Targets
                 if (IsInitialized)
                 {
                     //don't call before initialized because this could lead to stackoverflows.
-                    RefreshFileArchive();
-                    RefreshArchiveFilePatternToWatch();
-                }
+                RefreshFileArchive();
+                RefreshArchiveFilePatternToWatch();
             }
+        }
         }
 
         /// <summary>
@@ -614,9 +622,9 @@ namespace NLog.Targets
                 enableArchiveFileCompression = value;
                 if (IsInitialized)
                 {
-                    RefreshArchiveFilePatternToWatch();
-                }
+                RefreshArchiveFilePatternToWatch();
             }
+        }
         }
 #else
         /// <summary>
@@ -706,7 +714,7 @@ namespace NLog.Targets
                                 {
                                     try
                                     {
-                                        Thread.Sleep(200);
+                                    Thread.Sleep(200);
                                     }
                                     catch (ThreadAbortException ex)
                                     {

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -204,6 +204,18 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="FileTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public FileTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets or sets the name of the file to write to.
         /// </summary>
         /// <remarks>

--- a/src/NLog/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog/Targets/LogReceiverWebServiceTarget.cs
@@ -72,6 +72,15 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="LogReceiverWebServiceTarget"/> class.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public LogReceiverWebServiceTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets or sets the endpoint address.
         /// </summary>
         /// <value>The endpoint address.</value>

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -148,6 +148,18 @@ namespace NLog.Targets
 #endif
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MailTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public MailTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets or sets sender's email address (e.g. joe@domain.com).
         /// </summary>
         /// <docgen category='Message Options' order='10' />

--- a/src/NLog/Targets/MemoryTarget.cs
+++ b/src/NLog/Targets/MemoryTarget.cs
@@ -69,6 +69,18 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public MemoryTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets the list of logs gathered in the <see cref="MemoryTarget"/>.
         /// </summary>
         public IList<string> Logs { get; private set; }

--- a/src/NLog/Targets/MethodCallTarget.cs
+++ b/src/NLog/Targets/MethodCallTarget.cs
@@ -81,6 +81,22 @@ namespace NLog.Targets
         private int NeededParameters { get; set; }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MethodCallTarget" /> class.
+        /// </summary>
+        public MethodCallTarget() : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MethodCallTarget" /> class.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public MethodCallTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Initializes the target.
         /// </summary>
         protected override void InitializeTarget()

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -83,6 +83,18 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="NLogViewerTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public NLogViewerTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to include NLog-specific extensions to log4j schema.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />

--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -102,6 +102,18 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="NetworkTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public NetworkTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets or sets the network address.
         /// </summary>
         /// <remarks>

--- a/src/NLog/Targets/NullTarget.cs
+++ b/src/NLog/Targets/NullTarget.cs
@@ -65,6 +65,28 @@ namespace NLog.Targets
         public bool FormatMessage { get; set; }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="NullTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        public NullTarget() : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NullTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name"></param>
+        public NullTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Does nothing. Optionally it calculates the layout text but
         /// discards the results.
         /// </summary>

--- a/src/NLog/Targets/OutputDebugStringTarget.cs
+++ b/src/NLog/Targets/OutputDebugStringTarget.cs
@@ -60,6 +60,28 @@ namespace NLog.Targets
     public sealed class OutputDebugStringTarget : TargetWithLayout
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="OutputDebugStringTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        public OutputDebugStringTarget() : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutputDebugStringTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public OutputDebugStringTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Outputs the rendered logging event through the <c>OutputDebugString()</c> Win32 API.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>

--- a/src/NLog/Targets/PerformanceCounterTarget.cs
+++ b/src/NLog/Targets/PerformanceCounterTarget.cs
@@ -97,7 +97,7 @@ namespace NLog.Targets
         /// Initializes a new instance of the <see cref="PerformanceCounterTarget" /> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public PerformanceCounterTarget(string name)
+        public PerformanceCounterTarget(string name) : this()
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/PerformanceCounterTarget.cs
+++ b/src/NLog/Targets/PerformanceCounterTarget.cs
@@ -94,6 +94,15 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="PerformanceCounterTarget" /> class.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public PerformanceCounterTarget(string name)
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether performance counter should be automatically created.
         /// </summary>
         /// <docgen category='Performance Counter Options' order='10' />

--- a/src/NLog/Targets/TraceTarget.cs
+++ b/src/NLog/Targets/TraceTarget.cs
@@ -62,6 +62,28 @@ namespace NLog.Targets
     public sealed class TraceTarget : TargetWithLayout
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="TraceTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        public TraceTarget() : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TraceTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public TraceTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Writes the specified logging event to the <see cref="System.Diagnostics.Trace"/> facility.
         /// If the log level is greater than or equal to <see cref="LogLevel.Error"/> it uses the
         /// <see cref="System.Diagnostics.Trace.Fail(string)"/> method, otherwise it uses

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -87,8 +87,15 @@ namespace NLog.Targets
             const bool writeBOM = false;
             this.Encoding = new UTF8Encoding(writeBOM);
             this.IncludeBOM = writeBOM;
+        }
 
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebServiceTarget" /> class.
+        /// </summary>
+        /// <param name="name">Name of the target</param>
+        public WebServiceTarget(string name) : this()
+        {
+            this.Name = name;
         }
 
         /// <summary>

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -87,7 +87,7 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="AsyncTargetWrapper" /> class.
         /// </summary>
         public AsyncTargetWrapper()
-            : this((Target)null)
+            : this(null)
         {
         }
 
@@ -95,8 +95,9 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="AsyncTargetWrapper" /> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public AsyncTargetWrapper(string name)
-            : this()
+        /// <param name="wrappedTarget">The wrapped target.</param>
+        public AsyncTargetWrapper(string name, Target wrappedTarget)
+            : this(wrappedTarget)
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -87,8 +87,18 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="AsyncTargetWrapper" /> class.
         /// </summary>
         public AsyncTargetWrapper()
-            : this(null)
+            : this((Target)null)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncTargetWrapper" /> class.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public AsyncTargetWrapper(string name)
+            : this()
+        {
+            this.Name = name;
         }
 
         /// <summary>

--- a/src/NLog/Targets/Wrappers/AutoFlushTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AutoFlushTargetWrapper.cs
@@ -63,8 +63,21 @@ namespace NLog.Targets.Wrappers
         /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
         /// </remarks>
         public AutoFlushTargetWrapper()
-            : this(null)
+            : this((Target)null)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutoFlushTargetWrapper" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target</param>
+        public AutoFlushTargetWrapper(string name)
+            : this()
+        {
+            this.Name = name;
         }
 
         /// <summary>

--- a/src/NLog/Targets/Wrappers/AutoFlushTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AutoFlushTargetWrapper.cs
@@ -63,7 +63,7 @@ namespace NLog.Targets.Wrappers
         /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
         /// </remarks>
         public AutoFlushTargetWrapper()
-            : this((Target)null)
+            : this(null)
         {
         }
 
@@ -73,9 +73,10 @@ namespace NLog.Targets.Wrappers
         /// <remarks>
         /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
         /// </remarks>
+        /// <param name="wrappedTarget">The wrapped target.</param>
         /// <param name="name">Name of the target</param>
-        public AutoFlushTargetWrapper(string name)
-            : this()
+        public AutoFlushTargetWrapper(string name, Target wrappedTarget)
+            : this(wrappedTarget)
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -52,7 +52,7 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="BufferingTargetWrapper" /> class.
         /// </summary>
         public BufferingTargetWrapper()
-            : this((Target)null)
+            : this(null)
         {
         }
 
@@ -60,8 +60,9 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="BufferingTargetWrapper" /> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public BufferingTargetWrapper(string name)
-            : this()
+        /// <param name="wrappedTarget">The wrapped target.</param>
+        public BufferingTargetWrapper(string name, Target wrappedTarget)
+            : this(wrappedTarget)
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -52,8 +52,18 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="BufferingTargetWrapper" /> class.
         /// </summary>
         public BufferingTargetWrapper()
-            : this(null)
+            : this((Target)null)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BufferingTargetWrapper" /> class.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public BufferingTargetWrapper(string name)
+            : this()
+        {
+            this.Name = name;
         }
 
         /// <summary>

--- a/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
@@ -70,6 +70,16 @@ namespace NLog.Targets.Wrappers
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="FallbackGroupTarget"/> class.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public FallbackGroupTarget(string name)
+            : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="FallbackGroupTarget" /> class.
         /// </summary>
         /// <param name="targets">The targets.</param>

--- a/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
@@ -73,8 +73,9 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="FallbackGroupTarget"/> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public FallbackGroupTarget(string name)
-            : this()
+        /// <param name="targets">The targets.</param>
+        public FallbackGroupTarget(string name, params Target[] targets)
+            : this(targets)
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
@@ -71,6 +71,15 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Initializes a new instance of the <see cref="FilteringTargetWrapper" /> class.
         /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public FilteringTargetWrapper(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilteringTargetWrapper" /> class.
+        /// </summary>
         /// <param name="wrappedTarget">The wrapped target.</param>
         /// <param name="condition">The condition.</param>
         public FilteringTargetWrapper(Target wrappedTarget, ConditionExpression condition)

--- a/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
@@ -72,7 +72,10 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="FilteringTargetWrapper" /> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public FilteringTargetWrapper(string name) : this()
+        /// <param name="wrappedTarget">The wrapped target.</param>
+        /// <param name="condition">The condition.</param>
+        public FilteringTargetWrapper(string name, Target wrappedTarget, ConditionExpression condition)
+            : this(wrappedTarget, condition)
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/ImpersonatingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/ImpersonatingTargetWrapper.cs
@@ -58,7 +58,7 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="ImpersonatingTargetWrapper" /> class.
         /// </summary>
         public ImpersonatingTargetWrapper()
-            : this((Target)null)
+            : this(null)
         {
         }
 
@@ -66,8 +66,9 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="ImpersonatingTargetWrapper" /> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public ImpersonatingTargetWrapper(string name)
-            : this()
+        /// <param name="wrappedTarget">The wrapped target.</param>
+        public ImpersonatingTargetWrapper(string name, Target wrappedTarget)
+            : this(wrappedTarget)
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/ImpersonatingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/ImpersonatingTargetWrapper.cs
@@ -58,8 +58,18 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="ImpersonatingTargetWrapper" /> class.
         /// </summary>
         public ImpersonatingTargetWrapper()
-            : this(null)
+            : this((Target)null)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImpersonatingTargetWrapper" /> class.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public ImpersonatingTargetWrapper(string name)
+            : this()
+        {
+            this.Name = name;
         }
 
         /// <summary>

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -81,6 +81,15 @@ namespace NLog.Targets.Wrappers
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="PostFilteringTargetWrapper" /> class.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public PostFilteringTargetWrapper(string name) : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
         /// Gets or sets the default filter to be applied when no specific rule matches.
         /// </summary>
         /// <docgen category='Filtering Options' order='10' />

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -75,7 +75,7 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Initializes a new instance of the <see cref="PostFilteringTargetWrapper" /> class.
         /// </summary>
-        public PostFilteringTargetWrapper()
+        public PostFilteringTargetWrapper() : this(null)
         {
             this.Rules = new List<FilteringRule>();
         }
@@ -83,8 +83,19 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Initializes a new instance of the <see cref="PostFilteringTargetWrapper" /> class.
         /// </summary>
+        public PostFilteringTargetWrapper(Target wrappedTarget)
+        {
+            this.Rules = new List<FilteringRule>();
+            this.WrappedTarget = wrappedTarget;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PostFilteringTargetWrapper" /> class.
+        /// </summary>
         /// <param name="name">Name of the target.</param>
-        public PostFilteringTargetWrapper(string name) : this()
+        /// <param name="wrappedTarget">The wrapped target.</param>
+        public PostFilteringTargetWrapper(string name, Target wrappedTarget)
+            : this(wrappedTarget)
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/RandomizeGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/RandomizeGroupTarget.cs
@@ -72,6 +72,16 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Initializes a new instance of the <see cref="RandomizeGroupTarget" /> class.
         /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public RandomizeGroupTarget(string name)
+            : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RandomizeGroupTarget" /> class.
+        /// </summary>
         /// <param name="targets">The targets.</param>
         public RandomizeGroupTarget(params Target[] targets)
             : base(targets)

--- a/src/NLog/Targets/Wrappers/RandomizeGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/RandomizeGroupTarget.cs
@@ -73,8 +73,9 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="RandomizeGroupTarget" /> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public RandomizeGroupTarget(string name)
-            : this()
+        /// <param name="targets">The targets.</param>
+        public RandomizeGroupTarget(string name, params Target[] targets)
+             : this(targets)
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/RepeatingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/RepeatingTargetWrapper.cs
@@ -71,7 +71,7 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="RepeatingTargetWrapper" /> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public RepeatingTargetWrapper(string name)
+        public RepeatingTargetWrapper(string name) : this()
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/RepeatingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/RepeatingTargetWrapper.cs
@@ -70,6 +70,15 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Initializes a new instance of the <see cref="RepeatingTargetWrapper" /> class.
         /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public RepeatingTargetWrapper(string name)
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RepeatingTargetWrapper" /> class.
+        /// </summary>
         /// <param name="wrappedTarget">The wrapped target.</param>
         /// <param name="repeatCount">The repeat count.</param>
         public RepeatingTargetWrapper(Target wrappedTarget, int repeatCount)

--- a/src/NLog/Targets/Wrappers/RepeatingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/RepeatingTargetWrapper.cs
@@ -71,7 +71,10 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="RepeatingTargetWrapper" /> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public RepeatingTargetWrapper(string name) : this()
+        /// <param name="wrappedTarget">The wrapped target.</param>
+        /// <param name="repeatCount">The repeat count.</param>
+        public RepeatingTargetWrapper(string name, Target wrappedTarget, int repeatCount) 
+            : this(wrappedTarget, repeatCount)
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
@@ -72,7 +72,7 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="RetryingTargetWrapper" /> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public RetryingTargetWrapper(string name)
+        public RetryingTargetWrapper(string name) : this()
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
@@ -71,6 +71,15 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Initializes a new instance of the <see cref="RetryingTargetWrapper" /> class.
         /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public RetryingTargetWrapper(string name)
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RetryingTargetWrapper" /> class.
+        /// </summary>
         /// <param name="wrappedTarget">The wrapped target.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="retryDelayMilliseconds">The retry delay milliseconds.</param>

--- a/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
@@ -72,7 +72,11 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="RetryingTargetWrapper" /> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public RetryingTargetWrapper(string name) : this()
+        /// <param name="wrappedTarget">The wrapped target.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="retryDelayMilliseconds">The retry delay milliseconds.</param>
+        public RetryingTargetWrapper(string name, Target wrappedTarget, int retryCount, int retryDelayMilliseconds)
+            : this(wrappedTarget, retryCount, retryDelayMilliseconds)
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/RoundRobinGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/RoundRobinGroupTarget.cs
@@ -75,8 +75,9 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="RoundRobinGroupTarget" /> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public RoundRobinGroupTarget(string name)
-            : this()
+        /// <param name="targets">The targets.</param>
+        public RoundRobinGroupTarget(string name, params Target[] targets)
+             : this(targets)
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/RoundRobinGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/RoundRobinGroupTarget.cs
@@ -74,6 +74,16 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Initializes a new instance of the <see cref="RoundRobinGroupTarget" /> class.
         /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public RoundRobinGroupTarget(string name)
+            : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoundRobinGroupTarget" /> class.
+        /// </summary>
         /// <param name="targets">The targets.</param>
         public RoundRobinGroupTarget(params Target[] targets)
             : base(targets)

--- a/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
@@ -72,8 +72,9 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="SplitGroupTarget" /> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public SplitGroupTarget(string name)
-            : this()
+        /// <param name="targets">The targets.</param>
+        public SplitGroupTarget(string name, params Target[] targets)
+             : this(targets)
         {
             this.Name = name;
         }

--- a/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
@@ -71,6 +71,16 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Initializes a new instance of the <see cref="SplitGroupTarget" /> class.
         /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public SplitGroupTarget(string name)
+            : this()
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SplitGroupTarget" /> class.
+        /// </summary>
         /// <param name="targets">The targets.</param>
         public SplitGroupTarget(params Target[] targets)
             : base(targets)

--- a/src/NLogAutoLoadExtension/AutoLoadTarget.cs
+++ b/src/NLogAutoLoadExtension/AutoLoadTarget.cs
@@ -39,6 +39,15 @@ namespace NLogAutloadExtension
     [Target("AutoLoadTarget")]
     public class AutoLoadTarget : Target
     {
+        public AutoLoadTarget() : base()
+        {
+        }
+
+        public AutoLoadTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
         protected override void Write(LogEventInfo logEvent)
         {
             // do nothing

--- a/tests/NLog.UnitTests/Common/LastLogEventListTarget.cs
+++ b/tests/NLog.UnitTests/Common/LastLogEventListTarget.cs
@@ -44,6 +44,15 @@ namespace NLog.UnitTests.Common
     [Target("LastLogEvent")]
     public class LastLogEventListTarget : TargetWithLayout
     {
+        public LastLogEventListTarget() : base()
+        {
+        }
+
+        public LastLogEventListTarget(string name) : this()
+        {
+            this.Name = name;
+        }
+
         /// <summary>
         /// Increases the number of messages.
         /// </summary>

--- a/tests/NLog.UnitTests/Config/TargetConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/TargetConfigurationTests.cs
@@ -615,6 +615,15 @@ namespace NLog.UnitTests.Config
             public Uri UriProperty { get; set; }
 
             public LineEndingMode LineEndingModeProperty { get; set; }
+
+            public MyTarget() : base()
+            {
+            }
+
+            public MyTarget(string name) : this()
+            {
+                this.Name = name;
+            }
         }
 
 
@@ -650,6 +659,15 @@ namespace NLog.UnitTests.Config
             public Layout LayoutProperty { get; set; }
 
             public ConditionExpression ConditionProperty { get; set; }
+
+            public MyNullableTarget() : base()
+            {
+            }
+
+            public MyNullableTarget(string name) : this()
+            {
+                this.Name = name;
+            }
         }
 
         public enum MyEnum

--- a/tests/NLog.UnitTests/LogManagerTests.cs
+++ b/tests/NLog.UnitTests/LogManagerTests.cs
@@ -522,6 +522,16 @@ namespace NLog.UnitTests
         public sealed class MemoryQueueTarget : TargetWithLayout
         {
             private int maxSize;
+
+            public MemoryQueueTarget() : this(1)
+            {
+            }
+
+            public MemoryQueueTarget(string name)
+            {
+                this.Name = name;
+            }
+
             public MemoryQueueTarget(int size)
             {
                 this.Logs = new Queue<string>();

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -1507,6 +1507,11 @@ namespace NLog.UnitTests
                 Layout = "${stacktrace}";
             }
 
+            public MyTarget(string name) : this()
+            {
+                this.Name = name;
+            }
+
             public LogEventInfo LastEvent { get; private set; }
 
             protected override void Write(LogEventInfo logEvent)

--- a/tests/NLog.UnitTests/Targets/LogReceiverWebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/LogReceiverWebServiceTargetTests.cs
@@ -209,6 +209,14 @@ namespace NLog.UnitTests.Targets
             public NLogEvents LastPayload;
             public int SendCount;
 
+            public MyLogReceiverWebServiceTarget() : base()
+            {
+            }
+
+            public MyLogReceiverWebServiceTarget(string name) : base(name)
+            {
+            }
+
             protected internal override bool OnSend(NLogEvents events, IEnumerable<AsyncLogEventInfo> asyncContinuations)
             {
                 this.LastPayload = events;

--- a/tests/NLog.UnitTests/Targets/Mocks/MockTargetWrapper.cs
+++ b/tests/NLog.UnitTests/Targets/Mocks/MockTargetWrapper.cs
@@ -40,6 +40,22 @@ namespace NLog.UnitTests.Targets.Mocks
     [Target("MockWrapper", IsWrapper = true)]
     public class MockTargetWrapper : WrapperTargetBase
     {
+        /// <summary>
+        /// Creates an instance of the <see cref="MockTargetWrapper"/> class.
+        /// </summary>
+        public MockTargetWrapper() : base()
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="MockTargetWrapper"/> class.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        public MockTargetWrapper(string name) : this()
+        {
+            this.Name = name;
+        }
+
         protected override void CloseTarget()
         {
             base.CloseTarget();

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -71,14 +71,14 @@ namespace NLog.UnitTests.Targets
                         {
                             if (pi.CanRead && !pi.Name.Equals("Name"))
                             {
-                                if (pi.GetValue(defaultConstructedTarget) != null && pi.GetValue(namedConstructedTarget) != null)
+                                if (pi.GetValue(defaultConstructedTarget, null) != null && pi.GetValue(namedConstructedTarget, null) != null)
                                 {
-                                    Assert.Equal(pi.GetValue(defaultConstructedTarget), namedConstructedTarget);
+                                    Assert.Equal(pi.GetValue(defaultConstructedTarget, null), namedConstructedTarget);
                                 }
                                 else
                                 {
-                                    Assert.Null(pi.GetValue(defaultConstructedTarget));
-                                    Assert.Null(pi.GetValue(namedConstructedTarget));
+                                    Assert.Null(pi.GetValue(defaultConstructedTarget, null));
+                                    Assert.Null(pi.GetValue(namedConstructedTarget, null));
                                 }
                             }
                         }

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -64,7 +64,7 @@ namespace NLog.UnitTests.Targets
             int neededCheckCount = targetTypes.Count;
             int checkCount = 0;
             Target fileTarget = new FileTarget();
-            Target databaseTarget = new DatabaseTarget();
+            Target memoryTarget = new MemoryTarget();
 
             foreach (Type targetType in targetTypes)
             {
@@ -135,7 +135,7 @@ namespace NLog.UnitTests.Targets
                         neededCheckCount++;
 
                         //multiple targets
-                        var args = new List<object> { fileTarget, databaseTarget };
+                        var args = new List<object> { fileTarget, memoryTarget };
 
                         //specials cases
                    
@@ -144,7 +144,7 @@ namespace NLog.UnitTests.Targets
                         var defaultConstructedTarget = (CompoundTargetBase)Activator.CreateInstance(targetType);
                         defaultConstructedTarget.Name = name;
                         defaultConstructedTarget.Targets.Add(fileTarget);
-                        defaultConstructedTarget.Targets.Add(databaseTarget);
+                        defaultConstructedTarget.Targets.Add(memoryTarget);
 
                         //ctor: target
                         var targetConstructedTarget = (CompoundTargetBase)Activator.CreateInstance(targetType, args.ToArray());

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -65,13 +65,16 @@ namespace NLog.UnitTests.Targets
                         namedConstructedTarget = (Target)Activator.CreateInstance(candidateType, candidateType.ToString());
 
                         // Check that the created targets are the same except for name
-                        foreach (System.Reflection.PropertyInfo pi in (typeof(Target)).GetProperties())
+                        foreach (System.Reflection.PropertyInfo pi in (typeof(Target)).GetProperties(
+                            System.Reflection.BindingFlags.NonPublic |
+                            System.Reflection.BindingFlags.Instance |
+                            System.Reflection.BindingFlags.Static))
                         {
-                            if (pi.CanRead && !pi.Name.Equals("Name"))
+                            if (pi.CanRead && !pi.Name.Equals("Name") && !pi.Name.Equals("SyncRoot"))
                             {
                                 if (pi.GetValue(defaultConstructedTarget, null) != null && pi.GetValue(namedConstructedTarget, null) != null)
                                 {
-                                    Assert.Equal(pi.GetValue(defaultConstructedTarget, null), namedConstructedTarget);
+                                    Assert.Equal(pi.GetValue(defaultConstructedTarget, null), pi.GetValue(namedConstructedTarget, null));
                                 }
                                 else
                                 {

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -47,8 +47,6 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void ConstructorsTest()
         {
-            List<Type> targetTypes = new List<Type>();
-
             foreach (Type candidateType in typeof(Target).Assembly.GetExportedTypes())
             {
                 if (!candidateType.IsAbstract &&

--- a/tests/NLog.UnitTests/Targets/Wrappers/ImpersonatingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/ImpersonatingTargetWrapperTests.cs
@@ -257,6 +257,11 @@ namespace NLog.UnitTests.Targets.Wrappers
                 this.Events = new List<LogEventInfo>();
             }
 
+            public MyTarget(string name) : this()
+            {
+                this.Name = name;
+            }
+
             public List<LogEventInfo> Events { get; set; }
 
             public string ExpectedUser { get; set; }

--- a/tests/NLog.UnitTests/Targets/Wrappers/PostFilteringTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/PostFilteringTargetWrapperTests.cs
@@ -250,6 +250,11 @@ namespace NLog.UnitTests.Targets.Wrappers
                 this.Events = new List<LogEventInfo>();
             }
 
+            public MyTarget(string name) : this()
+            {
+                this.Name = name;
+            }
+
             public List<LogEventInfo> Events { get; set; }
 
             protected override void Write(LogEventInfo logEvent)

--- a/tests/NLog.UnitTests/Targets/Wrappers/RandomizeGroupTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/RandomizeGroupTargetTests.cs
@@ -129,6 +129,15 @@ namespace NLog.UnitTests.Targets.Wrappers
             public int FlushCount { get; private set; }
             public int WriteCount { get; private set; }
 
+            public MyAsyncTarget() : base()
+            {
+            }
+
+            public MyAsyncTarget(string name) : this()
+            {
+                this.Name = name;
+            }
+
             protected override void Write(LogEventInfo logEvent)
             {
                 throw new NotSupportedException();
@@ -169,6 +178,15 @@ namespace NLog.UnitTests.Targets.Wrappers
             public int FlushCount { get; set; }
             public int WriteCount { get; set; }
             public int FailCounter { get; set; }
+
+            public MyTarget() : base()
+            {
+            }
+
+            public MyTarget(string name) : this()
+            {
+                this.Name = name;
+            }
 
             protected override void Write(LogEventInfo logEvent)
             {

--- a/tests/NLog.UnitTests/Targets/Wrappers/RepeatingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/RepeatingTargetWrapperTests.cs
@@ -125,6 +125,11 @@ namespace NLog.UnitTests.Targets.Wrappers
                 this.Events = new List<LogEventInfo>();
             }
 
+            public MyTarget(string name) : this()
+            {
+                this.Name = name;
+            }
+
             public List<LogEventInfo> Events { get; set; }
 
             public bool ThrowExceptions { get; set; }

--- a/tests/NLog.UnitTests/Targets/Wrappers/RetryingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/RetryingTargetWrapperTests.cs
@@ -140,6 +140,11 @@ namespace NLog.UnitTests.Targets.Wrappers
                 this.Events = new List<LogEventInfo>();
             }
 
+            public MyTarget(string name) : this()
+            {
+                this.Name = name;
+            }
+
             public List<LogEventInfo> Events { get; set; }
 
             public int ThrowExceptions { get; set; }

--- a/tests/NLog.UnitTests/Targets/Wrappers/RoundRobinGroupTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/RoundRobinGroupTargetTests.cs
@@ -133,6 +133,15 @@ namespace NLog.UnitTests.Targets.Wrappers
             public int FlushCount { get; private set; }
             public int WriteCount { get; private set; }
 
+            public MyAsyncTarget() : base()
+            {
+            }
+
+            public MyAsyncTarget(string name) : this()
+            {
+                this.Name = name;
+            }
+
             protected override void Write(LogEventInfo logEvent)
             {
                 throw new NotSupportedException();
@@ -173,6 +182,15 @@ namespace NLog.UnitTests.Targets.Wrappers
             public int FlushCount { get; set; }
             public int WriteCount { get; set; }
             public int FailCounter { get; set; }
+
+            public MyTarget() : base()
+            {
+            }
+
+            public MyTarget(string name) : this()
+            {
+                this.Name = name;
+            }
 
             protected override void Write(LogEventInfo logEvent)
             {

--- a/tests/NLog.UnitTests/Targets/Wrappers/SplitGroupTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/SplitGroupTargetTests.cs
@@ -159,6 +159,15 @@ namespace NLog.UnitTests.Targets.Wrappers
             public int FlushCount { get; private set; }
             public int WriteCount { get; private set; }
 
+            public MyAsyncTarget() : base()
+            {
+            }
+
+            public MyAsyncTarget(string name) : this()
+            {
+                this.Name = name;
+            }
+
             protected override void Write(LogEventInfo logEvent)
             {
                 throw new NotSupportedException();
@@ -199,6 +208,11 @@ namespace NLog.UnitTests.Targets.Wrappers
             public MyTarget()
             {
                 this.WrittenEvents = new List<LogEventInfo>();
+            }
+
+            public MyTarget(string name) : this()
+            {
+                this.Name = name;
             }
 
             public int FlushCount { get; set; }

--- a/tests/NLog.UnitTests/Targets/Wrappers/WrapperTargetBaseTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/WrapperTargetBaseTests.cs
@@ -88,10 +88,27 @@ namespace NLog.UnitTests.Targets.Wrappers
 
         public class MyWrapper : WrapperTargetBase
         {
+            public MyWrapper() : base()
+            {
+            }
+
+            public MyWrapper(string name) : this()
+            {
+                this.Name = name;
+            }
         }
 
         public class MyWrappedTarget : Target
         {
+            public MyWrappedTarget() : base()
+            {
+            }
+
+            public MyWrappedTarget(string name) : this()
+            {
+                this.Name = name;
+            }
+
             public int FlushCount { get; set; }
 
             protected override void FlushAsync(AsyncContinuation asyncContinuation)


### PR DESCRIPTION
Added "name" to the constructors of all the Targets.

- For regular targets : added constructor `target(string name)`
- For Wrapper targets:  added constructor `target(string name, params Target target)`
- For Wrapper targets:  added constructor `target(string name, params Target[] targetst)`



supersedes https://github.com/NLog/NLog/pull/1370

fixes #1297

Thanks @flyingcroissant !

