### PR TITLE
Allow comma separated values (List) for Layout Renderers

### DIFF
--- a/src/NLog/Internal/StringSplitter.cs
+++ b/src/NLog/Internal/StringSplitter.cs
@@ -1,0 +1,533 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#region
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+#endregion
+
+namespace NLog.Internal
+{
+    /// <summary>
+    /// Split a string
+    /// </summary>
+    internal static class StringSplitter
+    {
+        /// <summary>
+        /// Split string with escape. The escape char is the same as the splitchar
+        /// </summary>
+        /// <param name="text"></param>
+        /// <param name="splitChar">split char. escaped also with this char</param>
+        /// <returns></returns>
+        public static IEnumerable<string> SplitWithSelfEscape(this string text, char splitChar)
+        {
+            return SplitWithSelfEscape2(text, splitChar);
+        }
+
+        /// <summary>
+        /// Split string with escape
+        /// </summary>
+        /// <param name="text"></param>
+        /// <param name="splitChar"></param>
+        /// <param name="escapeChar"></param>
+        /// <returns></returns>
+        public static IEnumerable<string> SplitWithEscape(this string text, char splitChar, char escapeChar)
+        {
+            if (splitChar == escapeChar)
+            {
+                return SplitWithSelfEscape2(text, splitChar);
+            }
+
+            return SplitWithEscape2(text, splitChar, escapeChar);
+        }
+
+
+        private static IEnumerable<string> SplitWithEscape2(string text, char splitChar, char escapeChar)
+        {
+            if (!string.IsNullOrEmpty(text))
+            {
+                var prevWasEscape = false;
+                int i;
+                var sb = new StringBuilder();
+                for (i = 0; i < text.Length; i++)
+                {
+                    var c = text[i];
+
+                    //prev not escaped, then check splitchar
+                    var isSplitChar = c == splitChar;
+                    if (prevWasEscape)
+                    {
+                        if (isSplitChar)
+                        {
+                            //overwrite escapechar
+                            if (sb.Length > 0)
+                                sb.Length--;
+                            sb.Append(c);
+                            //if splitchar ==escapechar, then in this case it's used as split
+                            prevWasEscape = false;
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                            prevWasEscape = c == escapeChar;
+                        }
+                    }
+                    else
+                    {
+                        if (isSplitChar)
+                        {
+                            var part = sb.ToString();
+                            //reset
+                            sb.Length = 0;
+                            yield return part;
+                            if (text.Length - 1 == i)
+                            {
+                                //done
+                                yield return string.Empty;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                            prevWasEscape = c == escapeChar;
+                        }
+                    }
+                }
+                var lastPart = GetLastPart(sb);
+                if (lastPart != null)
+                {
+                    yield return lastPart;
+                }
+            }
+        }
+
+        private static IEnumerable<string> SplitWithSelfEscape2(string text, char splitAndEscapeChar)
+        {
+            if (!string.IsNullOrEmpty(text))
+            {
+                var prevWasEscape = false;
+                int i;
+                var sb = new StringBuilder();
+                //if same, handle different
+                for (i = 0; i < text.Length; i++)
+                {
+                    var c = text[i];
+                    var isSplitAndEscape = c == splitAndEscapeChar;
+                    var isLastChar = i == text.Length - 1;
+                    if (prevWasEscape)
+                    {
+                        if (isSplitAndEscape)
+                        {
+                            prevWasEscape = false;
+                        }
+                        else
+                        {
+                            //if prevWasEscape, always appended so length >0
+                            //if (sb.Length > 0) 
+                            sb.Length--;
+                            var part = sb.ToString();
+                            //reset
+                            sb.Length = 0;
+                            prevWasEscape = false;
+                            sb.Append(c);
+                            yield return part;
+                        }
+                    }
+                    else
+                    {
+                        if (isLastChar && isSplitAndEscape)
+                        {
+                            var part = sb.ToString();
+                            sb.Length = 0;
+                            yield return part;
+                            yield return string.Empty;
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                            if (isSplitAndEscape)
+                            {
+                                prevWasEscape = true;
+                            }
+                        }
+                    }
+                }
+                var lastPart = GetLastPart(sb);
+                if (lastPart != null)
+                {
+                    yield return lastPart;
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Split a string, optional quoted value
+        /// </summary>
+        /// <param name="text">Text to split</param>
+        /// <param name="splitChar">Character to split the <paramref name="text" /></param>
+        /// <param name="quoteChar">Quote character</param>
+        /// <param name="escapeChar">
+        /// Escape for the <paramref name="quoteChar" />, not escape for the <paramref name="splitChar" />
+        /// , use quotes for that.
+        /// </param>
+        /// <returns></returns>
+        public static IEnumerable<string> SplitQuoted(this string text, char splitChar, char quoteChar, char escapeChar)
+        {
+            if (!string.IsNullOrEmpty(text))
+            {
+                if (splitChar == quoteChar)
+                {
+                    throw new NotSupportedException("Quote character should different from split character");
+                }
+
+
+                if (splitChar == escapeChar)
+                {
+                    throw new NotSupportedException("Escape character should different from split character");
+                }
+
+                if (quoteChar == escapeChar)
+                {
+                    return SplitSelfQuoted2(text, splitChar, quoteChar);
+                }
+
+
+                return SplitQuoted2(text, splitChar, quoteChar, escapeChar);
+            }
+            return new List<string>();
+        }
+
+        private static IEnumerable<string> SplitSelfQuoted2(string text, char splitChar, char quoteAndEscapeChar)
+        {
+            var inQuotedMode = false;
+            int i;
+            var sb = new StringBuilder();
+            var isNewPart = true;
+
+            for (i = 0; i < text.Length; i++)
+            {
+                var c = text[i];
+
+                //prev not escaped, then check splitchar
+                var isSplitChar = c == splitChar;
+                var isQuoteAndEscapeChar = c == quoteAndEscapeChar;
+                var isLastChar = i == text.Length - 1;
+
+                if (isNewPart)
+                {
+                    //now only quote for quotemode accepted
+                    isNewPart = false;
+                    isQuoteAndEscapeChar = c == quoteAndEscapeChar;
+
+                    if (isQuoteAndEscapeChar)
+                    {
+                        //escape of the quote, if the quote is after this.
+                        if (isLastChar)
+                        {
+                            //done
+                            sb.Append(c);
+                            break;
+                        }
+                        i++;
+                        c = text[i];
+
+                        if (c == quoteAndEscapeChar)
+                        {
+                            sb.Append(quoteAndEscapeChar);
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                            inQuotedMode = true;
+                        }
+                    }
+                    else if (isSplitChar)
+                    {
+                        //end of part
+
+                        var part = sb.ToString();
+                        //reset
+                        sb.Length = 0;
+                        //  isInPart = false;
+                        yield return part;
+
+                        if (isLastChar)
+                        {
+                            //done
+                            yield return string.Empty;
+                            break;
+                        }
+
+                        isNewPart = true;
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+                }
+
+                else if (inQuotedMode)
+                {
+                    if (isQuoteAndEscapeChar)
+                    {
+                        //skip escapechar
+                        i++;
+                        //    isInPart = false;
+                        inQuotedMode = false;
+                        var part = sb.ToString();
+                        //reset
+                        sb.Length = 0;
+                        yield return part;
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+                }
+                else
+                {
+                    if (isSplitChar)
+                    {
+                        //end of part
+
+                        var part = sb.ToString();
+                        //reset
+                        sb.Length = 0;
+                        //  isInPart = false;
+                        yield return part;
+
+                        if (isLastChar)
+                        {
+                            //done
+                            yield return string.Empty;
+                            break;
+                        }
+
+                        isNewPart = true;
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+                }
+            }
+
+            var lastPart = GetLastPart(sb);
+            if (inQuotedMode)
+            {
+                //append quote back
+                lastPart = quoteAndEscapeChar + lastPart;
+            }
+
+            if (lastPart != null)
+            {
+                yield return lastPart;
+            }
+        }
+
+        private static IEnumerable<string> SplitQuoted2(string text, char splitChar, char quoteChar, char escapeChar)
+        {
+            var inQuotedMode = false;
+            int i;
+            var sb = new StringBuilder();
+            var isNewPart = true;
+
+            var prevIsEscape = false;
+            for (i = 0; i < text.Length; i++)
+            {
+                var c = text[i];
+
+                //prev not escaped, then check splitchar
+                var isSplitChar = c == splitChar;
+                var isQuoteChar = c == quoteChar;
+                var isEscapeChar = c == escapeChar;
+                var isLastChar = i == text.Length - 1;
+
+
+                if (isNewPart)
+                {
+                    isNewPart = false;
+                    isQuoteChar = c == quoteChar;
+                    isEscapeChar = c == escapeChar;
+
+                    if (isEscapeChar)
+                    {
+                        //escape of the quote, if the quote is after this.
+
+                        if (isLastChar)
+                        {
+                            //done
+                            sb.Append(c);
+                            break;
+                        }
+
+                        i++;
+
+                        c = text[i];
+                        if (c == quoteChar)
+                        {
+                            sb.Append(quoteChar);
+                        }
+                        else
+                        {
+                            sb.Append(escapeChar);
+                            sb.Append(c);
+                        }
+                    }
+                    else if (isSplitChar)
+                    {
+                        //end of part
+
+                        var part = sb.ToString();
+                        //reset
+                        sb.Length = 0;
+                        yield return part;
+
+                        if (isLastChar)
+                        {
+                            //done
+                            yield return string.Empty;
+                            break;
+                        }
+
+                        isNewPart = true;
+                    }
+
+                    else if (isQuoteChar)
+                    {
+                        //skip quoteChar
+                        if (sb.Length > 0)
+                            sb.Length--;
+                        //isInPart = true;
+                        inQuotedMode = true;
+                        //todo check escape quoteChar
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+                }
+
+                else if (inQuotedMode)
+                {
+                    if (isQuoteChar)
+                    {
+                        if (prevIsEscape)
+
+                        {
+                            //skip escapechar
+
+                            if (sb.Length > 0)
+                                sb.Length--;
+
+                            //todo skip escape 
+                            sb.Append(c);
+                            break;
+                        }
+
+
+                        //skip quoteChar
+                        i++;
+                        //    isInPart = false;
+                        inQuotedMode = false;
+                        var part = sb.ToString();
+                        //reset
+                        sb.Length = 0;
+                        yield return part;
+                    }
+
+                    else
+                    {
+                        prevIsEscape = isEscapeChar;
+
+                        sb.Append(c);
+                    }
+                }
+                else
+                {
+                    if (isSplitChar)
+                    {
+                        //end of part
+
+                        var part = sb.ToString();
+                        //reset
+                        sb.Length = 0;
+                        yield return part;
+
+                        if (isLastChar)
+                        {
+                            //done
+                            yield return string.Empty;
+                            break;
+                        }
+
+                        isNewPart = true;
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+                }
+            }
+
+            var lastPart = GetLastPart(sb);
+            if (inQuotedMode)
+            {
+                //append quote back
+                lastPart = quoteChar + lastPart;
+            }
+
+            if (lastPart != null)
+            {
+                yield return lastPart;
+            }
+        }
+
+        private static string GetLastPart(StringBuilder sb)
+        {
+            var length = sb.Length;
+            if (length > 0)
+            {
+                var lastPart = sb.ToString();
+                return lastPart;
+            }
+            return null;
+        }
+    }
+}

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -190,6 +190,7 @@
     <Compile Include="Internal\StreamHelpers.cs" />
     <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="Internal\StringSplitter.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Internal\StreamHelpers.cs" />
     <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="Internal\StringSplitter.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -200,6 +200,7 @@
     <Compile Include="Internal\StreamHelpers.cs" />
     <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="Internal\StringSplitter.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -206,6 +206,7 @@
     <Compile Include="Internal\StreamHelpers.cs" />
     <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="Internal\StringSplitter.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -200,6 +200,7 @@
     <Compile Include="Internal\StreamHelpers.cs" />
     <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="Internal\StringSplitter.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -200,6 +200,7 @@
     <Compile Include="Internal\StreamHelpers.cs" />
     <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="Internal\StringSplitter.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -205,6 +205,7 @@
     <Compile Include="Internal\StreamHelpers.cs" />
     <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="Internal\StringSplitter.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Internal\StreamHelpers.cs" />
     <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="Internal\StringSplitter.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -204,6 +204,7 @@
     <Compile Include="Internal\StreamHelpers.cs" />
     <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="Internal\StringSplitter.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Internal\StreamHelpers.cs" />
     <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="Internal\StringSplitter.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Internal\StreamHelpers.cs" />
     <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="Internal\StringSplitter.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Internal\StreamHelpers.cs" />
     <Compile Include="Internal\StringBuilderExt.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="Internal\StringSplitter.cs" />
     <Compile Include="Internal\TargetWithFilterChain.cs" />
     <Compile Include="Internal\ThreadIDHelper.cs" />
     <Compile Include="Internal\ThreadLocalStorageHelper.cs" />

--- a/tests/NLog.UnitTests/Internal/StringSplitterTests.cs
+++ b/tests/NLog.UnitTests/Internal/StringSplitterTests.cs
@@ -1,0 +1,195 @@
+// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if !SILVERLIGHT
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NLog.Internal;
+using Xunit;
+using Xunit.Extensions;
+
+namespace NLog.UnitTests.Internal
+{
+    public class StringSplitterTests
+    {
+        private const char SingleQuote = '\'';
+        private const char Backslash = '\\';
+
+        [Theory]
+
+        [InlineData("abc", ';', "abc")]
+        [InlineData("  abc", ';', "  abc")]
+        [InlineData(null, ';', "")]
+        [InlineData("", ';', "")]
+        [InlineData(";", ';', ",")]
+        [InlineData("a;", ';', "a,")]
+        [InlineData("a; ", ';', "a, ")]
+        [InlineData("   ", ';', "   ")]
+        [InlineData(@"a;b;;c", ';', @"a,b;c")]
+        [InlineData(@"a;b;;;;c", ';', @"a,b;;c")]
+        [InlineData(@"a;;b", ';', @"a;b")]
+        [InlineData(@"abc", ';', @"abc")]
+        [InlineData(@"a'b'c''d", SingleQuote, @"a,b,c'd")]
+        [InlineData(@"'a", SingleQuote, @",a")]
+
+        void SplitStringWithSelfEscape(string input, char splitCharAndEscapeChar, string output)
+        {
+
+            //also test SplitWithSelfEscape
+            var strings = StringSplitter.SplitWithSelfEscape(input, splitCharAndEscapeChar).ToArray();
+            var result = string.Join(",", strings);
+            Assert.Equal(output, result);
+
+
+            SplitStringWithEscape2(input, splitCharAndEscapeChar, splitCharAndEscapeChar, output);
+        }
+
+
+        [Theory]
+        [InlineData("abc", "abc")]
+        [InlineData("  abc", "  abc")]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("   ", "   ")]
+        [InlineData(@"a;b;c", "a,b,c")]
+        [InlineData(@"a;b;c;", "a,b,c,")]
+        [InlineData(@"a;", "a,")]
+        [InlineData(@";", ",")]
+        [InlineData(@"a;b;c;", "a,b,c,")]
+        [InlineData(@";a;b;c", ",a,b,c")]
+        [InlineData(@"a;;b;c;", "a,,b,c,")]
+        [InlineData(@"a\b;c", @"a\b,c")]
+        [InlineData(@"a;b;c\", @"a,b,c\")]
+        [InlineData(@"a;b;c\;", @"a,b,c;")]
+        [InlineData(@"a;b;c\;;", @"a,b,c;,")]
+        [InlineData(@"a\;b;c", @"a;b,c")]
+        [InlineData(@"a\;b\;c", @"a;b;c")]
+        [InlineData(@"a\;b\;c;d", @"a;b;c,d")]
+        [InlineData(@"a\;b\;c;d", @"a;b;c,d")]
+        [InlineData(@"a\;b;c\;d", @"a;b,c;d")]
+        [InlineData(@"abc\;", @"abc;")]
+        void SplitStringWithEscape(string input, string output)
+        {
+            SplitStringWithEscape2(input, ';', Backslash, output);
+        }
+
+        [InlineData(@"abc", ';', ',', "abc")]
+        void SplitStringWithEscape2(string input, char splitChar, char escapeChar, string output)
+        {
+            var strings = StringSplitter.SplitWithEscape(input, splitChar, escapeChar).ToArray();
+            var result = string.Join(",", strings);
+            Assert.Equal(output, result);
+        }
+
+        /// <summary>
+        /// Tests with ; as separator, quoted and escaped with '
+        /// </summary>
+        [Theory]
+        [InlineData(@";", @",")]
+        [InlineData(@";;", @",,")]
+        [InlineData(@"a;", @"a,")]
+        [InlineData(@"a;''b;c", "a,'b,c")]
+        [InlineData(@"a;''b;c'", "a,'b,c'")]
+        [InlineData(@"abc", "abc")]
+        [InlineData(@"abc'", "abc'")]
+        [InlineData(@"''abc'", "'abc'")]
+        [InlineData(@"'abc'", "abc")]
+        [InlineData(@"'ab;c'", "ab;c")]
+        [InlineData(@"'ab\c'", @"ab\c")]
+        [InlineData(@"'", @"'")]
+        [InlineData(@"'a", @"'a")]
+        [InlineData(@"a'", @"a'")]
+        [InlineData(@"\", @"\")]
+        [InlineData(@"a\", @"a\")]
+        [InlineData(@"\b", @"\b")]
+
+        private void SplitStringWithQuotes_selfQuoted(string input, string output)
+        {
+            SplitStringWithQuotes(input, ';', SingleQuote, SingleQuote, output);
+        }
+
+        /// <summary>
+        /// Tests with ; as separator, quoted with single quote and escaped with backslash
+        /// </summary>
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData(@"\", @"\")]
+        [InlineData(@"'", @"'")]
+        [InlineData(@"' ", @"' ")]
+        [InlineData(@"a'", "a'")]
+        [InlineData(@" ' ", @" ' ")]
+        [InlineData(@" ; ", @" , ")]
+        [InlineData(@";", @",")]
+        [InlineData(@";;", @",,")]
+        [InlineData(@"abc", "abc")]
+        [InlineData(@"abc;", "abc,")]
+        [InlineData(@"abc'", "abc'")]
+        [InlineData(@"abc\", @"abc\")]
+        [InlineData(@"abc\\", @"abc\\")]
+        [InlineData(@"abc\b", @"abc\b")]
+        [InlineData(@"a;b;c", "a,b,c")]
+        [InlineData(@"a;'b;c'", "a,b;c")]
+        [InlineData(@"a;'b;c", "a,'b;c")]
+        [InlineData(@"a;b'c;d", "a,b'c,d")]
+        [InlineData(@"a;\'b;c", "a,'b,c")]
+        [InlineData(@"\b", @"\b")]
+        [InlineData(@"'\'", @"''")]
+        [InlineData(@"'\''", @"''")]   //todo check case
+        [InlineData(@"'\\'", @"'\'")]  //todo check case
+
+        private void SplitStringWithQuotes_escaped(string input, string output)
+        {
+            SplitStringWithQuotes(input, ';', SingleQuote, Backslash, output);
+        }
+
+        void SplitStringWithQuotes(string input, char splitChar, char quoteChar, char escapeChar, string output)
+        {
+            var strings = StringSplitter.SplitQuoted(input, splitChar, quoteChar, escapeChar).ToArray();
+            var result = string.Join(",", strings);
+            Assert.Equal(output, result);
+        }
+
+        [Theory]
+        [InlineData(';', ';', Backslash)]
+        [InlineData(';', Backslash, ';')]
+        void SplitStringNotSupported(char splitChar, char quoteChar, char escapeChar)
+        {
+            Assert.Throws<NotSupportedException>(() => StringSplitter.SplitQuoted("dont care", splitChar, quoteChar, escapeChar));
+        }
+    }
+}
+#endif

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -7,8 +7,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -118,6 +117,7 @@
     <Compile Include="Internal\SortHelpersTests.cs" />
     <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
+    <Compile Include="Internal\StringSplitterTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\AppSettingTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -9,10 +9,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)'==''">v4.0</TargetFrameworkVersion>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <ApplicationIcon></ApplicationIcon>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -21,10 +19,8 @@
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <SignAssembly>true</SignAssembly>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
+    <FileUpgradeFlags></FileUpgradeFlags>
+    <UpgradeBackupLocation></UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -150,6 +146,7 @@
     <Compile Include="Internal\SortHelpersTests.cs" />
     <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
+    <Compile Include="Internal\StringSplitterTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\AppSettingTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -10,10 +10,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <ApplicationIcon></ApplicationIcon>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -128,6 +126,7 @@
     <Compile Include="Internal\SortHelpersTests.cs" />
     <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
+    <Compile Include="Internal\StringSplitterTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\AppSettingTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,10 +9,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <ApplicationIcon></ApplicationIcon>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -168,6 +166,7 @@
     <Compile Include="Internal\SortHelpersTests.cs" />
     <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
+    <Compile Include="Internal\StringSplitterTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\AppSettingTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -17,8 +17,7 @@
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <SilverlightApplication>true</SilverlightApplication>
-    <SupportedCultures>
-    </SupportedCultures>
+    <SupportedCultures></SupportedCultures>
     <XapOutputs>true</XapOutputs>
     <SilverlightVersion>$(TargetFrameworkVersion)</SilverlightVersion>
     <GenerateSilverlightManifest>true</GenerateSilverlightManifest>
@@ -32,18 +31,15 @@
     <OutOfBrowserSettingsFile>Properties\OutOfBrowserSettings.xml</OutOfBrowserSettingsFile>
     <UsePlatformExtensions>false</UsePlatformExtensions>
     <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
-    <LinkedServerProject>
-    </LinkedServerProject>
+    <LinkedServerProject></LinkedServerProject>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkIdentifier>Silverlight</TargetFrameworkIdentifier>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
+    <FileUpgradeFlags></FileUpgradeFlags>
+    <UpgradeBackupLocation></UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -143,6 +139,7 @@
     <Compile Include="Internal\SortHelpersTests.cs" />
     <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
+    <Compile Include="Internal\StringSplitterTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\AppSettingTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -17,8 +17,7 @@
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <SilverlightApplication>true</SilverlightApplication>
-    <SupportedCultures>
-    </SupportedCultures>
+    <SupportedCultures></SupportedCultures>
     <XapOutputs>true</XapOutputs>
     <SilverlightVersion>$(TargetFrameworkVersion)</SilverlightVersion>
     <GenerateSilverlightManifest>true</GenerateSilverlightManifest>
@@ -32,8 +31,7 @@
     <OutOfBrowserSettingsFile>Properties\OutOfBrowserSettings.xml</OutOfBrowserSettingsFile>
     <UsePlatformExtensions>false</UsePlatformExtensions>
     <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
-    <LinkedServerProject>
-    </LinkedServerProject>
+    <LinkedServerProject></LinkedServerProject>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkIdentifier>Silverlight</TargetFrameworkIdentifier>
@@ -143,6 +141,7 @@
     <Compile Include="Internal\SortHelpersTests.cs" />
     <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
+    <Compile Include="Internal\StringSplitterTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\AppSettingTests.cs" />


### PR DESCRIPTION
Support voor comma separated list,

e.g.

supported:
- Generic List (`List<T>`), with the following types: 
  - C# built in types (string, int, double, object)
  - enum (use shortname)
  - culture, encoding, Type
  - not supported: Layout

Not supported:
-  Arrays
- Non-generic `List` 
-  `IList<T>` / `IList`
- `IEnumerable<T>` / `IEnumerable` 

Example:

```
${layoutrenderer-with-list:enums=Ignore, Neutral, ignore}
```

``` c#
[LayoutRenderer("layoutrenderer-with-list")]
public class LayoutRendererWithListParam : LayoutRenderer
{
    public List<FilterResult> Enums { get; set; }
   protected override void Append(StringBuilder builder, LogEventInfo logEvent)
   {
       ...
   }
}
```

TO DO
- [x] escape comma -> backtick
-  [x] replace escape with optional quoted
- [x] add unit test for multiple enum

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1439)

<!-- Reviewable:end -->
