### PR TITLE
FileTarget: Use ManualResetEvent instead of Thread.Abort to stop appender-invalidator-thread

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -692,23 +692,18 @@ namespace NLog.Targets
                             {
                                 while (true)
                                 {
-                                    try
-                                    {
-                                        Thread.Sleep(200);
-                                    }
-                                    catch (ThreadAbortException ex)
-                                    {
-                                        //ThreadAbortException will be automatically re-thrown at the end of the try/catch/finally if ResetAbort isn't called.
-                                        Thread.ResetAbort();
-                                        InternalLogger.Trace(ex, "ThreadAbortException in Thread.Sleep");
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        InternalLogger.Warn(ex, "Exception in Thread.Sleep, most of the time not an issue.");
-                                    }
-                                   
+                                    this.fileAppenderCache.LogArchiveWaitHandle.WaitOne();
+
                                     lock (SyncRoot)
+                                    {
+                                        if (!this.fileAppenderCache.LogFileWasArchived)
+                                        {
+                                            // StopAppenderInvalidatorThread() was called.
+                                            break;
+                                        }
+
                                         this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
+                                    }
                                 }
                             }));
                             this.appenderInvalidatorThread.IsBackground = true;
@@ -719,15 +714,23 @@ namespace NLog.Targets
                 else
                 {
                     this.fileAppenderCache.ArchiveFilePatternToWatch = null;
-
-                    if (this.appenderInvalidatorThread != null)
-                    {
-                        this.appenderInvalidatorThread.Abort();
-                        this.appenderInvalidatorThread = null;
-                    }
+                    this.StopAppenderInvalidatorThread();
                 }
             }
 #endif
+        }
+
+        private void StopAppenderInvalidatorThread()
+        {
+            if (this.appenderInvalidatorThread != null)
+            {
+                if (this.fileAppenderCache.LogFileWasArchived)
+                    this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
+
+                this.fileAppenderCache.LogArchiveWaitHandle.Set();
+
+                this.appenderInvalidatorThread = null;
+            }
         }
 
         /// <summary>
@@ -888,11 +891,7 @@ namespace NLog.Targets
                 this.autoClosingTimer = null;
             }
 
-            if (this.appenderInvalidatorThread != null)
-            {
-                this.appenderInvalidatorThread.Abort();
-                this.appenderInvalidatorThread = null;
-            }
+            this.StopAppenderInvalidatorThread();
 
             this.fileAppenderCache.CloseAppenders();
         }
@@ -1225,7 +1224,7 @@ namespace NLog.Targets
                 InternalLogger.Info("Archiving {0} to zip-archive {1}", fileName, archiveFileName);
                 using (var archiveStream = new FileStream(archiveFileName, FileMode.Create))
                 using (var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create))
-                using (var originalFileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite ))
+                using (var originalFileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 {
                     var zipArchiveEntry = archive.CreateEntry(Path.GetFileName(fileName));
                     using (var destination = zipArchiveEntry.Open())
@@ -1233,7 +1232,7 @@ namespace NLog.Targets
                         originalFileStream.CopyTo(destination);
                     }
                 }
-                
+
                 DeleteAndWaitForFileDelete(fileName);
             }
             else


### PR DESCRIPTION
Fix #1415 