### PR TITLE
Allow overwriting possible nlog configuration file paths

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -59,6 +59,8 @@ namespace NLog.Config
     /// <summary>
     /// A class for configuring NLog through an XML configuration file 
     /// (App.config style or App.nlog style).
+    /// 
+    /// Parsing of the XML file is also implemented in this class.
     /// </summary>
     ///<remarks>This class is thread-safe.<c>.ToList()</c> is used for that purpose.</remarks>
     public class XmlLoggingConfiguration : LoggingConfiguration

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -78,7 +78,7 @@ namespace NLog.Config
         private readonly Dictionary<string, bool> fileMustAutoReloadLookup = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
         private string originalFileName;
-
+        
         private LogFactory logFactory = null;
 
         private ConfigurationItemFactory ConfigurationItemFactory
@@ -225,6 +225,8 @@ namespace NLog.Config
         /// <param name="ignoreErrors">If set to <c>true</c> errors will be ignored during file processing.</param>
         internal XmlLoggingConfiguration(XmlElement element, string fileName, bool ignoreErrors)
         {
+            logFactory = LogManager.LogFactory;
+
             using (var stringReader = new StringReader(element.OuterXml))
             {
                 XmlReader reader = XmlReader.Create(stringReader);
@@ -299,6 +301,32 @@ namespace NLog.Config
         public override LoggingConfiguration Reload()
         {
             return new XmlLoggingConfiguration(this.originalFileName);
+        }
+
+        /// <summary>
+        /// Get file paths (including filename) for the possible NLog config files. 
+        /// </summary>
+        /// <returns>The filepaths to the possible config file</returns>
+        public static IEnumerable<string> GetCandidateConfigFilePaths()
+        {
+            return LogManager.LogFactory.GetCandidateConfigFilePaths();
+        }
+
+        /// <summary>
+        /// Overwrite the paths (including filename) for the possible NLog config files.
+        /// </summary>
+        /// <param name="filePaths">The filepaths to the possible config file</param>
+        public static void SetCandidateConfigFilePaths(IEnumerable<string> filePaths)
+        {
+            LogManager.LogFactory.SetCandidateConfigFilePaths(filePaths);
+        }
+
+        /// <summary>
+        /// Clear the candidate file paths and return to the defaults.
+        /// </summary>
+        public static void ResetCandidateConfigFilePath()
+        {
+            LogManager.LogFactory.ResetCandidateConfigFilePath();
         }
 
         #endregion

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -171,7 +171,8 @@ namespace NLog
                     // Retest the condition as we might have loaded a config.
                     if (this.config == null)
                     {
-                        foreach (string configFile in GetCandidateConfigFileNames())
+                        var configFileNames = CandidateConfigFileNames ?? GetDefaultCandidateConfigFileNames();
+                        foreach (string configFile in configFileNames)
                         {
 #if SILVERLIGHT
                             Uri configFileUri = new Uri(configFile, UriKind.Relative);
@@ -352,6 +353,14 @@ namespace NLog
                 return configuration != null ? configuration.DefaultCultureInfo : null;
             }
         }
+
+        /// <summary>
+        /// Overwrite possible file paths (including filename) for possible NLog config files. 
+        /// When this property is <c>null</c>, the default file paths (<see cref="GetDefaultCandidateConfigFileNames"/> are used.
+        /// 
+        /// </summary>
+        public IList<string> CandidateConfigFileNames { get; set; }
+
 
         private void LogConfigurationInitialized()
         {
@@ -865,13 +874,20 @@ namespace NLog
 #endif
         }
 
-        private static IEnumerable<string> GetCandidateConfigFileNames()
+        /// <summary>
+        /// Get file paths (including filename) for possible NLog config files. 
+        /// 
+        /// <see cref="CandidateConfigFileNames"/> 
+        /// </summary>
+        /// <returns>The filepaths to the possible config file</returns>
+        public static IEnumerable<string> GetDefaultCandidateConfigFileNames()
         {
+           
 #if SILVERLIGHT || __ANDROID__ || __IOS__
             //try.nlog.config is ios/android/silverlight
             yield return "NLog.config";
 #elif !SILVERLIGHT
-            // NLog.config from application directory
+                // NLog.config from application directory
             if (CurrentAppDomain.BaseDirectory != null)
             {
                 yield return Path.Combine(CurrentAppDomain.BaseDirectory, "NLog.config");

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -896,16 +896,13 @@ namespace NLog
 
             if (filePaths != null)
             {
-                foreach (var filePath in filePaths)
-                {
-                    candidateConfigFilePaths.Add(filePath);
-                }
+                candidateConfigFilePaths.AddRange(filePaths);
             }
         }
         /// <summary>
         /// Clear the candidate file paths and return to the defaults.
         /// </summary>
-        public void ClearCandidateConfigFilePath()
+        public void ResetCandidateConfigFilePath()
         {
             candidateConfigFilePaths = null;
         }

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -178,6 +178,15 @@ namespace NLog
         }
 
         /// <summary>
+        /// Overwrite possible file paths (including filename) for possible NLog config files. If this property is set to non-<c>null</c>, the default file paths are not used.
+        /// </summary>
+        public static IList<string> CandidateConfigFileNames
+        {
+            get { return factory.CandidateConfigFileNames; }
+            set { factory.CandidateConfigFileNames = value; }
+        }
+
+        /// <summary>
         /// Gets the logger with the name of the current class.  
         /// </summary>
         /// <returns>The logger.</returns>

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -178,12 +178,29 @@ namespace NLog
         }
 
         /// <summary>
-        /// Overwrite possible file paths (including filename) for possible NLog config files. If this property is set to non-<c>null</c>, the default file paths are not used.
+        /// Get file paths (including filename) for the possible NLog config files. 
         /// </summary>
-        public static IList<string> CandidateConfigFileNames
+        /// <returns>The filepaths to the possible config file</returns>
+        public static IEnumerable<string> GetCandidateConfigFilePaths()
         {
-            get { return factory.CandidateConfigFileNames; }
-            set { factory.CandidateConfigFileNames = value; }
+            return factory.GetCandidateConfigFilePaths();
+        }
+
+        /// <summary>
+        /// Overwrite the paths (including filename) for the possible NLog config files.
+        /// </summary>
+        /// <param name="filePaths">The filepaths to the possible config file</param>
+        public static void SetCandidateConfigFilePaths(IEnumerable<string> filePaths)
+        {
+            factory.SetCandidateConfigFilePaths(filePaths);
+        }
+
+        /// <summary>
+        /// Clear the candidate file paths and return to the defaults.
+        /// </summary>
+        public static void ClearCandidateConfigFilePath()
+        {
+            factory.ClearCandidateConfigFilePath();
         }
 
         /// <summary>

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -198,9 +198,9 @@ namespace NLog
         /// <summary>
         /// Clear the candidate file paths and return to the defaults.
         /// </summary>
-        public static void ClearCandidateConfigFilePath()
+        public static void ResetCandidateConfigFilePath()
         {
-            factory.ClearCandidateConfigFilePath();
+            factory.ResetCandidateConfigFilePath();
         }
 
         /// <summary>

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -178,32 +178,6 @@ namespace NLog
         }
 
         /// <summary>
-        /// Get file paths (including filename) for the possible NLog config files. 
-        /// </summary>
-        /// <returns>The filepaths to the possible config file</returns>
-        public static IEnumerable<string> GetCandidateConfigFilePaths()
-        {
-            return factory.GetCandidateConfigFilePaths();
-        }
-
-        /// <summary>
-        /// Overwrite the paths (including filename) for the possible NLog config files.
-        /// </summary>
-        /// <param name="filePaths">The filepaths to the possible config file</param>
-        public static void SetCandidateConfigFilePaths(IEnumerable<string> filePaths)
-        {
-            factory.SetCandidateConfigFilePaths(filePaths);
-        }
-
-        /// <summary>
-        /// Clear the candidate file paths and return to the defaults.
-        /// </summary>
-        public static void ResetCandidateConfigFilePath()
-        {
-            factory.ResetCandidateConfigFilePath();
-        }
-
-        /// <summary>
         /// Gets the logger with the name of the current class.  
         /// </summary>
         /// <returns>The logger.</returns>

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -247,14 +247,14 @@ namespace NLog.UnitTests
         }
 
         [Fact]
-        public void ClearCandidateConfigTest()
+        public void ResetCandidateConfigTest()
         {
             
             var countBefore = LogManager.GetCandidateConfigFilePaths().Count();
             var list = new List<string> { "c:\\global\\temp.config" };
             LogManager.SetCandidateConfigFilePaths(list);
             Assert.Equal(1, LogManager.GetCandidateConfigFilePaths().Count());
-            LogManager.ClearCandidateConfigFilePath();
+            LogManager.ResetCandidateConfigFilePath();
             Assert.Equal(countBefore, LogManager.GetCandidateConfigFilePaths().Count());
 
         }

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -34,6 +34,8 @@
 using System.Collections;
 using System.Linq;
 using System.Threading;
+using System.Xml;
+using NLog.Config;
 
 #if !SILVERLIGHT
 
@@ -214,8 +216,8 @@ namespace NLog.UnitTests
         [Fact]
         public void GetCandidateConfigTest()
         {
-            Assert.NotNull(LogManager.GetCandidateConfigFilePaths());
-            var candidateConfigFilePaths = LogManager.GetCandidateConfigFilePaths();
+            Assert.NotNull(XmlLoggingConfiguration.GetCandidateConfigFilePaths());
+            var candidateConfigFilePaths = XmlLoggingConfiguration.GetCandidateConfigFilePaths();
             var count = candidateConfigFilePaths.Count();
             Assert.True(count > 0);
 
@@ -227,8 +229,8 @@ namespace NLog.UnitTests
             Assert.Throws<NotSupportedException>(() =>
             {
                 var list = new List<string> { "c:\\global\\temp.config" };
-                LogManager.SetCandidateConfigFilePaths(list);
-                var candidateConfigFilePaths = LogManager.GetCandidateConfigFilePaths();
+                XmlLoggingConfiguration.SetCandidateConfigFilePaths(list);
+                var candidateConfigFilePaths = XmlLoggingConfiguration.GetCandidateConfigFilePaths();
                 var list2 = candidateConfigFilePaths as IList;
                 list2.Add("test");
             });
@@ -238,11 +240,11 @@ namespace NLog.UnitTests
         public void SetCandidateConfigTest()
         {
             var list = new List<string> { "c:\\global\\temp.config" };
-            LogManager.SetCandidateConfigFilePaths(list);
-            Assert.Equal(1, LogManager.GetCandidateConfigFilePaths().Count());
+            XmlLoggingConfiguration.SetCandidateConfigFilePaths(list);
+            Assert.Equal(1, XmlLoggingConfiguration.GetCandidateConfigFilePaths().Count());
             //no side effects
             list.Add("c:\\global\\temp2.config");
-            Assert.Equal(1, LogManager.GetCandidateConfigFilePaths().Count());
+            Assert.Equal(1, XmlLoggingConfiguration.GetCandidateConfigFilePaths().Count());
 
         }
 
@@ -250,12 +252,12 @@ namespace NLog.UnitTests
         public void ResetCandidateConfigTest()
         {
             
-            var countBefore = LogManager.GetCandidateConfigFilePaths().Count();
+            var countBefore = XmlLoggingConfiguration.GetCandidateConfigFilePaths().Count();
             var list = new List<string> { "c:\\global\\temp.config" };
-            LogManager.SetCandidateConfigFilePaths(list);
-            Assert.Equal(1, LogManager.GetCandidateConfigFilePaths().Count());
-            LogManager.ResetCandidateConfigFilePath();
-            Assert.Equal(countBefore, LogManager.GetCandidateConfigFilePaths().Count());
+            XmlLoggingConfiguration.SetCandidateConfigFilePaths(list);
+            Assert.Equal(1, XmlLoggingConfiguration.GetCandidateConfigFilePaths().Count());
+            XmlLoggingConfiguration.ResetCandidateConfigFilePath();
+            Assert.Equal(countBefore, XmlLoggingConfiguration.GetCandidateConfigFilePaths().Count());
 
         }
 

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -64,12 +64,19 @@ namespace NLog.UnitTests
             {
                 //flush all events if needed.
                 LogManager.Configuration.Close();
+                
             }
+
+            if (LogManager.LogFactory != null)
+            {
+                LogManager.LogFactory.ResetCandidateConfigFilePath();
+            }
+
             LogManager.Configuration = null;
             InternalLogger.Reset();
             LogManager.ThrowExceptions = false;
             LogManager.ThrowConfigExceptions = null;
-            LogManager.ResetCandidateConfigFilePath();
+            
         }
 
         protected void AssertDebugCounter(string targetName, int val)

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -69,7 +69,7 @@ namespace NLog.UnitTests
             InternalLogger.Reset();
             LogManager.ThrowExceptions = false;
             LogManager.ThrowConfigExceptions = null;
-            LogManager.ClearCandidateConfigFilePath();
+            LogManager.ResetCandidateConfigFilePath();
         }
 
         protected void AssertDebugCounter(string targetName, int val)

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -69,6 +69,7 @@ namespace NLog.UnitTests
             InternalLogger.Reset();
             LogManager.ThrowExceptions = false;
             LogManager.ThrowConfigExceptions = null;
+            LogManager.ClearCandidateConfigFilePath();
         }
 
         protected void AssertDebugCounter(string targetName, int val)


### PR DESCRIPTION
- [x] `GetDefaultCandidateConfigFileNames` to public
