### PR TITLE
Parse <Variable> before <Include> in XML config

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -546,6 +546,13 @@ namespace NLog.Config
                 this.ParseExtensionsElement(extensionsChild, Path.GetDirectoryName(filePath));
             }
 
+            //then load <variable>
+            var variableChilds = children.Where(child => child.LocalName.Equals("VARIABLE", StringComparison.InvariantCultureIgnoreCase)).ToList();
+            foreach (var variableChild in variableChilds)
+            {
+                this.ParseVariableElement(variableChild);
+            }
+
             //parse all other direct elements
             foreach (var child in children)
             {
@@ -565,7 +572,7 @@ namespace NLog.Config
                         break;
 
                     case "VARIABLE":
-                        this.ParseVariableElement(child);
+                        //already parsed
                         break;
 
                     case "RULES":

--- a/tests/NLog.UnitTests/Config/IncludeTests.cs
+++ b/tests/NLog.UnitTests/Config/IncludeTests.cs
@@ -91,6 +91,58 @@ namespace NLog.UnitTests.Config
             }
         }
 
+
+        [Fact]
+        public void IncludeWithVariablesTest()
+        {
+#if SILVERLIGHT
+            // file is pre-packaged in the XAP
+            string fileToLoad = "ConfigFiles/main.nlog";
+#else
+            string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempPath);
+
+            LogManager.ThrowExceptions = true;
+
+            using (StreamWriter fs = File.CreateText(Path.Combine(tempPath, "included.nlog")))
+            {
+                //note this works because ${var} is also allowed on non-Layouts
+                fs.Write(@"<nlog>
+                    <targets>
+<target name='debug' type='Debug' layout='${layout1}' /></targets>
+            </nlog>");
+            }
+
+            using (StreamWriter fs = File.CreateText(Path.Combine(tempPath, "main.nlog")))
+            {
+                fs.Write(@"<nlog>
+                <include file='included.nlog' />
+                   <variable name='layout1' value='${message}+test' />
+                   <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+            }
+
+            string fileToLoad = Path.Combine(tempPath, "main.nlog");
+#endif
+            try
+            {
+                // load main.nlog from the XAP
+                LogManager.Configuration = new XmlLoggingConfiguration(fileToLoad);
+
+                LogManager.GetLogger("A").Debug("aaa");
+                AssertDebugLastMessage("debug", "aaa+test");
+            }
+            finally
+            {
+#if !SILVERLIGHT
+                if (Directory.Exists(tempPath))
+                    Directory.Delete(tempPath, true);
+#endif
+            }
+        }
+        
         [Fact]
         public void IncludeNotExistingTest()
         {


### PR DESCRIPTION
Parse `<Variable>` before `<Include>` so we can use them in the included files.

TODO not sure, this is maybe a breaking change? (we cannot overwrite a var in a main.config)