### PR TITLE
Add else option to ${when}

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using NLog.Layouts;
+
 namespace NLog.LayoutRenderers.Wrappers
 {
     using NLog.Conditions;
@@ -45,11 +47,18 @@ namespace NLog.LayoutRenderers.Wrappers
     public sealed class WhenLayoutRendererWrapper : WrapperLayoutRendererBase
     {
         /// <summary>
-        /// Gets or sets the condition that must be met for the inner layout to be printed.
+        /// Gets or sets the condition that must be met for the <see cref="WrapperLayoutRendererBase.Inner"/> layout to be printed.
         /// </summary>
         /// <docgen category="Transformation Options" order="10"/>
         [RequiredParameter]
+
         public ConditionExpression When { get; set; }
+
+
+        /// <summary>
+        /// If <see cref="When"/> is not met, print this layout.
+        /// </summary>
+        public Layout Else { get; set; }
 
         /// <summary>
         /// Transforms the output of another layout.
@@ -70,9 +79,12 @@ namespace NLog.LayoutRenderers.Wrappers
         /// </returns>
         protected override string RenderInner(LogEventInfo logEvent)
         {
-            if (true.Equals(this.When.Evaluate(logEvent)))
+            if (this.When == null || true.Equals(this.When.Evaluate(logEvent)))
             {
                 return base.RenderInner(logEvent);
+            }else if (Else != null)
+            {
+                return Else.Render(logEvent);
             }
 
             return string.Empty;

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenTests.cs
@@ -79,6 +79,54 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
             Assert.Equal("messageYYY", l.Render(le));
         }
 
-       
+        [Fact]
+        public void WhenElseCase()
+        {
+            //else cannot be invoked ambiently. First param is inner
+            SimpleLayout l = @"${when:good:when=logger=='logger':else=better}";
+
+            {
+                var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+                Assert.Equal("good", l.Render(le));
+            }
+            {
+                var le = LogEventInfo.Create(LogLevel.Info, "logger1", "message");
+                Assert.Equal("better", l.Render(le));
+            }
+        }
+
+        [Fact]
+        public void WhenElseCase_empty_when()
+        {
+            //else cannot be invoked ambiently. First param is inner
+            SimpleLayout l = @"${when:good:else=better}";
+
+            {
+                var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+                Assert.Equal("good", l.Render(le));
+            }
+            {
+                var le = LogEventInfo.Create(LogLevel.Info, "logger1", "message");
+                Assert.Equal("good", l.Render(le));
+            }
+        }
+
+
+        [Fact]
+        public void WhenElseCase_noIf()
+        {
+            //else cannot be invoked ambiently. First param is inner
+            SimpleLayout l = @"${when:when=logger=='logger':else=better}";
+
+            {
+                var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+                Assert.Equal("", l.Render(le));
+            }
+            {
+                var le = LogEventInfo.Create(LogLevel.Info, "logger1", "message");
+                Assert.Equal("better", l.Render(le));
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Add else option to ${when} to prevent condition duplication.

example: `${when:good:when=logger=='logger':else=better}`

Also handle potential nullref exception

fixes https://github.com/NLog/NLog/issues/1361