### PR TITLE
FileTarget concurrentWrites performance enhancement when used w/o Async-/BufferingWrapper

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -284,7 +284,7 @@ namespace NLog.Internal.FileAppenders
                 this.CreateFileParameters.BufferSize);
         }
 
-        private void UpdateCreationTime()
+        protected void UpdateCreationTime()
         {
             if (File.Exists(this.FileName))
             {

--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -74,7 +74,7 @@ namespace NLog.Internal.FileAppenders
         /// Gets the file creation time.
         /// </summary>
         /// <value>The file creation time. DateTime value must be of UTC kind.</value>
-        public DateTime CreationTime { get; private set; }
+        public DateTime CreationTime { get; protected set; }
 
         /// <summary>
         /// Gets the open time of the file.
@@ -296,7 +296,7 @@ namespace NLog.Internal.FileAppenders
             }
             else
             {
-                File.Create(this.FileName).Dispose();
+                using(File.Create(this.FileName))
                 
 #if !SILVERLIGHT
                 this.CreationTime = DateTime.UtcNow;

--- a/src/NLog/Internal/FileAppenders/ICreateFileParameters.cs
+++ b/src/NLog/Internal/FileAppenders/ICreateFileParameters.cs
@@ -80,7 +80,7 @@ namespace NLog.Internal.FileAppenders
         int BufferSize { get; }
 
         /// <summary>
-        /// Gets or set a value indicating whether a managed file stream is forced, instead of used the native implementation.
+        /// Gets or set a value indicating whether a managed file stream is forced, instead of using the native implementation.
         /// </summary>
         bool ForceManaged { get; }
 
@@ -89,6 +89,13 @@ namespace NLog.Internal.FileAppenders
         /// Gets or sets the file attributes (Windows only).
         /// </summary>
         Win32FileAttributes FileAttributes { get; }
+#endif
+
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+        /// <summary>
+        /// Gets or sets a value indicationg whether file creation calls should be synchronized by a system global mutex.
+        /// </summary>
+        bool PreferMutexLockedFileCreation { get; }
 #endif
     }
 }

--- a/src/NLog/Internal/FileAppenders/UnleashedMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/UnleashedMultiProcessFileAppender.cs
@@ -1,0 +1,194 @@
+// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+
+namespace NLog.Internal.FileAppenders
+{
+    using System;
+    using System.Security;
+    using NLog.Common;
+    using System.Runtime.InteropServices;
+    /// <summary>
+    /// Provides a multiprocess-safe atomic file append while
+    /// keeping the files open.
+    /// </summary>
+    [SecuritySafeCritical]
+    internal class UnleashedMultiProcessFileAppender : BaseFileAppender
+    {
+        public static readonly IFileAppenderFactory TheFactory = new Factory();
+
+        private Microsoft.Win32.SafeHandles.SafeFileHandle _file;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnleashedMultiProcessFileAppender" /> class.
+        /// </summary>
+        /// <param name="fileName">Name of the file.</param>
+        /// <param name="parameters">The parameters.</param>
+        public UnleashedMultiProcessFileAppender(string fileName, ICreateFileParameters parameters) : base(fileName, parameters)
+        {
+            try
+            {
+                CreateAppendOnlyFile(fileName);
+            }
+            catch
+            {
+                if (_file != null)
+                {
+                    if (!_file.IsClosed)
+                        _file.Close();
+                    _file = null;
+                }
+
+                throw;
+            }
+        }
+
+        private void CreateAppendOnlyFile(string fileName)
+        {
+            int fileShare = Win32FileNativeMethods.FILE_SHARE_READ | Win32FileNativeMethods.FILE_SHARE_WRITE;
+
+            if (this.CreateFileParameters.EnableFileDelete)
+            {
+                fileShare |= Win32FileNativeMethods.FILE_SHARE_DELETE;
+            }
+
+            try
+            {
+                // https://blogs.msdn.microsoft.com/oldnewthing/20151127-00/?p=92211/
+                // https://msdn.microsoft.com/en-us/library/ff548289.aspx
+                // If only the FILE_APPEND_DATA and SYNCHRONIZE flags are set, the caller can write only to the end of the file, 
+                // and any offset information about writes to the file is ignored.
+                // However, the file will automatically be extended as necessary for this type of write operation.
+
+                _file = Win32FileNativeMethods.CreateFile(
+                    fileName,
+                    Win32FileNativeMethods.FileAccess.FileAppendData | Win32FileNativeMethods.FileAccess.Synchronize,
+                    fileShare,
+                    IntPtr.Zero,
+                    Win32FileNativeMethods.CreationDisposition.OpenAlways,
+                    this.CreateFileParameters.FileAttributes,
+                    IntPtr.Zero);
+
+                if (_file.IsInvalid)
+                {
+                    Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
+            }
+            catch
+            {
+                if ((_file != null) && (!_file.IsClosed))
+                    _file.Close();
+
+                _file = null;
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Writes the specified bytes.
+        /// </summary>
+        /// <param name="bytes">The bytes to be written.</param>
+        public override void Write(byte[] bytes)
+        {
+            try
+            {
+                uint written;
+                bool success = Win32FileNativeMethods.WriteFile(_file.DangerousGetHandle(), bytes, (uint)bytes.Length, out written, IntPtr.Zero);
+                if (!success || (uint)bytes.Length != written)
+                {
+                    Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
+                FileTouched();
+            }
+            finally
+            {
+            }
+        }
+
+        /// <summary>
+        /// Closes this instance.
+        /// </summary>
+        public override void Close()
+        {
+            InternalLogger.Trace("Closing '{0}'", FileName);
+            if (_file != null && !_file.IsClosed)
+            {
+                _file.Close();
+            }
+
+            _file = null;
+            FileTouched();
+        }
+
+        /// <summary>
+        /// Flushes this instance.
+        /// </summary>
+        public override void Flush()
+        {
+            // do nothing, the file is written directly
+        }
+
+        /// <summary>
+        /// Gets the file info.
+        /// </summary>
+        /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Runtime.InteropServices.SafeHandle.DangerousGetHandle", Justification = "Optimization")]
+        public override FileCharacteristics GetFileCharacteristics()
+        {
+            return FileCharacteristicsHelper.Helper.GetFileCharacteristics(FileName, _file.DangerousGetHandle());
+        }
+        
+        /// <summary>
+        /// Factory class.
+        /// </summary>
+        private class Factory : IFileAppenderFactory
+        {
+            /// <summary>
+            /// Opens the appender for given file name and parameters.
+            /// </summary>
+            /// <param name="fileName">Name of the file.</param>
+            /// <param name="parameters">Creation parameters.</param>
+            /// <returns>
+            /// Instance of <see cref="BaseFileAppender"/> which can be used to write to the file.
+            /// </returns>
+            BaseFileAppender IFileAppenderFactory.Open(string fileName, ICreateFileParameters parameters)
+            {
+                return new UnleashedMultiProcessFileAppender(fileName, parameters);
+            }
+        }
+    }
+}
+
+#endif

--- a/src/NLog/Internal/Win32FileNativeMethods.cs
+++ b/src/NLog/Internal/Win32FileNativeMethods.cs
@@ -53,6 +53,8 @@ namespace NLog.Internal
             GenericWrite = 0x40000000,
             GenericExecute = 0x20000000,
             GenericAll = 0x10000000,
+            Synchronize = 0x00100000,
+            FileAppendData = 0x0004
         }
 
         public enum CreationDisposition : uint
@@ -92,6 +94,11 @@ namespace NLog.Internal
             public uint nFileIndexHigh;
             public uint nFileIndexLow;
         }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool WriteFile(IntPtr hFile, byte[] lpBuffer,
+            uint nNumberOfBytesToWrite, out uint lpNumberOfBytesWritten, IntPtr lpOverlapped);
     }
 }
 

--- a/src/NLog/Internal/Win32FileNativeMethods.cs
+++ b/src/NLog/Internal/Win32FileNativeMethods.cs
@@ -46,6 +46,10 @@ namespace NLog.Internal
         public const int FILE_SHARE_WRITE = 2;
         public const int FILE_SHARE_DELETE = 4;
 
+        // Values returned by Marshal.GetLastWin32Error()
+        public const int NOERROR = 0;
+        public const int ERROR_ALREADY_EXISTS = 183;
+
         [Flags]
         public enum FileAccess : uint
         {

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -146,6 +146,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -146,7 +146,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\WindowsMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -143,7 +143,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\WindowsMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -156,7 +156,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\WindowsMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -162,7 +162,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\WindowsMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -156,7 +156,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\WindowsMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -156,7 +156,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\WindowsMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -161,6 +162,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -162,7 +162,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\WindowsMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -163,7 +163,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\WindowsMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -160,7 +160,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\WindowsMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -159,7 +159,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\WindowsMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -159,7 +159,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\WindowsMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -184,7 +184,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
-    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\WindowsMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -184,6 +184,7 @@
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\UnleashedMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FormatHelper.cs" />

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -864,7 +864,7 @@ namespace NLog.Targets
 #elif __IOS__ || __ANDROID__
                 return MutexMultiProcessFileAppender.TheFactory;
 #else
-                return UnleashedMultiProcessFileAppender.TheFactory;
+                return WindowsMultiProcessFileAppender.TheFactory;
 #endif
             }
             else if (IsArchivingEnabled())

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -859,7 +859,7 @@ namespace NLog.Targets
                 }
                 else
                 {
-                    return UnleashedMultiProcessFileAppender.TheFactory;
+                    return WindowsMultiProcessFileAppender.TheFactory;
                 }
 #elif __IOS__ || __ANDROID__
                 return MutexMultiProcessFileAppender.TheFactory;

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -165,6 +165,8 @@ namespace NLog.Targets
         private bool concurrentWrites;
         private bool keepFileOpen;
 
+        private bool preferMutexLockedFileCreation;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FileTarget" /> class.
         /// </summary>
@@ -645,10 +647,32 @@ namespace NLog.Targets
 
 
         /// <summary>
-        /// Gets or set a value indicating whether a managed file stream is forced, instead of used the native implementation.
+        /// Gets or set a value indicating whether a managed file stream is forced, instead of using the native implementation.
         /// </summary>
         [DefaultValue(false)]
         public bool ForceManaged { get; set; }
+
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+        /// <summary>
+        /// Gets or sets a value indicationg whether file creation calls should be synchronized by a system global mutex.
+        /// </summary>
+        /// [DefaultValue(false)]
+        public bool PreferMutexLockedFileCreation
+        {
+            get
+            {
+                return preferMutexLockedFileCreation;
+            }
+            internal set
+            {
+                preferMutexLockedFileCreation = value;
+                if (IsInitialized)
+                {
+                    RefreshArchiveFilePatternToWatch();
+                }
+            }
+        }
+#endif
 
         /// <summary>
         /// Gets the characters that are appended after each line.
@@ -859,12 +883,16 @@ namespace NLog.Targets
                 }
                 else
                 {
-                    return WindowsMultiProcessFileAppender.TheFactory;
+                    if (!this.PreferMutexLockedFileCreation && !this.ForceManaged && PlatformDetector.IsDesktopWin32)
+                        return WindowsMultiProcessFileAppender.TheFactory;
+                    return MutexMultiProcessFileAppender.TheFactory;
                 }
 #elif __IOS__ || __ANDROID__
                 return MutexMultiProcessFileAppender.TheFactory;
 #else
-                return WindowsMultiProcessFileAppender.TheFactory;
+                if (!this.PreferMutexLockedFileCreation && !this.ForceManaged && PlatformDetector.IsDesktopWin32)
+                    return WindowsMultiProcessFileAppender.TheFactory;
+                return MutexMultiProcessFileAppender.TheFactory;
 #endif
             }
             else if (IsArchivingEnabled())

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -853,19 +853,18 @@ namespace NLog.Targets
 #if SILVERLIGHT
                 return RetryingMultiProcessFileAppender.TheFactory;
 #elif MONO
-                //
-                // mono on Windows uses mutexes, on Unix - special appender
-                //
                 if (PlatformDetector.IsUnix)
                 {
                     return UnixMultiProcessFileAppender.TheFactory;
                 }
                 else
                 {
-                    return MutexMultiProcessFileAppender.TheFactory;
+                    return UnleashedMultiProcessFileAppender.TheFactory;
                 }
-#else
+#elif __IOS__ || __ANDROID__
                 return MutexMultiProcessFileAppender.TheFactory;
+#else
+                return UnleashedMultiProcessFileAppender.TheFactory;
 #endif
             }
             else if (IsArchivingEnabled())

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -165,8 +165,9 @@ namespace NLog.Targets
         private bool concurrentWrites;
         private bool keepFileOpen;
 
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
         private bool preferMutexLockedFileCreation;
-
+#endif
         /// <summary>
         /// Initializes a new instance of the <see cref="FileTarget" /> class.
         /// </summary>

--- a/tests/NLog.UnitTests/ProcessRunner.cs
+++ b/tests/NLog.UnitTests/ProcessRunner.cs
@@ -58,6 +58,9 @@ class C1
     {
         try
         {
+            if (args.Length < 3)
+                throw new Exception(""Usage: Runner.exe \""AssemblyName\"" \""ClassName\"" \""MethodName\"" \""Parameter1...N\"""");
+
             string assemblyName = args[0];
             string className = args[1];
             string methodName = args[2];
@@ -90,6 +93,9 @@ class C1
             options.OutputAssembly = "Runner.exe";
             options.GenerateExecutable = true;
             options.IncludeDebugInformation = true;
+            // To allow debugging the generated Runner.exe we need to keep files.
+            // See http://stackoverflow.com/questions/875723/how-to-debug-break-in-codedom-compiled-code
+            options.TempFiles = new TempFileCollection(Environment.GetEnvironmentVariable("TEMP"), true);
             var results = provider.CompileAssemblyFromSource(options, sourceCode);
             Assert.False(results.Errors.HasWarnings);
             Assert.False(results.Errors.HasErrors);
@@ -121,10 +127,11 @@ class C1
 #endif
             proc.StartInfo.UseShellExecute = false;
             proc.StartInfo.WindowStyle = ProcessWindowStyle.Normal;
-            proc.StartInfo.RedirectStandardInput = false;
-            proc.StartInfo.RedirectStandardOutput = true;
             proc.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
             proc.StartInfo.CreateNoWindow = true;
+            // Hint:
+            // In case we wanna redirect stdout we should drain the redirected pipe continously.
+            // Otherwise Runner.exe's console buffer is full rather fast, leading to a lock within Console.Write(Line).
             proc.Start();
             return proc;
         }

--- a/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
@@ -44,24 +44,27 @@ namespace NLog.UnitTests.Targets
     using NLog.Targets.Wrappers;
     using NLog.Common;
     using Xunit;
-
+    using Xunit.Extensions;
     public class ConcurrentFileTargetTests : NLogTestBase
 	{
         private ILogger logger = LogManager.GetLogger("NLog.UnitTests.Targets.ConcurrentFileTargetTests");
 
-        private void ConfigureSharedFile(string mode)
+        private void ConfigureSharedFile(string mode, string fileName)
         {
+            var modes = mode.Split('|');
+
             FileTarget ft = new FileTarget();
-            ft.FileName = "${basedir}/file.txt";
-            ft.Layout = "${threadname} ${message}";
+            ft.FileName = "${basedir}/" + fileName;
+            ft.Layout = "${message}";
             ft.KeepFileOpen = true;
             ft.OpenFileCacheTimeout = 10;
             ft.OpenFileCacheSize = 1;
             ft.LineEnding = LineEndingMode.LF;
+            ft.PreferMutexLockedFileCreation = modes.Length == 2 && modes[1] == "mutex" ? true : false;
 
-            var name = "ConfigureSharedFile_" + mode + "-wrapper";
-
-            switch (mode)
+            var name = "ConfigureSharedFile_" + mode.Replace('|', '_') + "-wrapper";
+            
+            switch (modes[0])
             {
                 case "async":
                     SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(ft, 100, AsyncTargetWrapperOverflowAction.Grow) { Name = name }, LogLevel.Debug);
@@ -81,28 +84,40 @@ namespace NLog.UnitTests.Targets
             }
         }
 
-        public void Process(string threadName, string numLogsString, string mode)
+        public void Process(string processIndex, string numProcessesString, string numLogsString, string mode)
         {
-            if (threadName != null)
-            {
-                Thread.CurrentThread.Name = threadName;
-            }
+            Thread.CurrentThread.Name = processIndex;
 
-            ConfigureSharedFile(mode);
-            InternalLogger.LogLevel = LogLevel.Trace;
-            InternalLogger.LogToConsole = true;
+            int numProcesses = Convert.ToInt32(numProcessesString);
             int numLogs = Convert.ToInt32(numLogsString);
+            string fileName = MakeFileName(numProcesses, numLogs, mode);
+
+            ConfigureSharedFile(mode, fileName);
+
+            // Having the internal logger enabled would just slow things down, reducing the 
+            // likelyhood for uncovering racing conditions.
+            //InternalLogger.LogLevel = LogLevel.Trace;
+            //InternalLogger.LogToConsole = true;
+
+            string format = processIndex + " {0}";
+            
             for (int i = 0; i < numLogs; ++i)
             {
-                logger.Debug("{0}", i);
+                logger.Debug(format, i);
             }
             
             LogManager.Configuration = null;
         }
 
+        private string MakeFileName(int numProcesses, int numLogs, string mode)
+        {
+            // Having separate filenames for the various tests makes debugging easier.
+            return string.Format("test_{0}_{1}_{2}.txt", numProcesses, numLogs, mode.Replace('|', '_'));
+        }
+
         private void DoConcurrentTest(int numProcesses, int numLogs, string mode)
         {
-            string logFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "file.txt");
+            string logFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, MakeFileName(numProcesses, numLogs, mode));
 
             if (File.Exists(logFile))
                 File.Delete(logFile);
@@ -111,13 +126,20 @@ namespace NLog.UnitTests.Targets
 
             for (int i = 0; i < numProcesses; ++i)
             {
-                processes[i] = ProcessRunner.SpawnMethod(this.GetType(), "Process", i.ToString(), numLogs.ToString(), mode);
+                processes[i] = ProcessRunner.SpawnMethod(
+                    this.GetType(), 
+                    "Process", 
+                    i.ToString(),
+                    numProcesses.ToString(), 
+                    numLogs.ToString(), 
+                    mode);
             }
-            
+
+            // In case we'd like to capture stdout, we would need to drain it continuously.
+            // StandardOutput.ReadToEnd() wont work, since the other processes console only has limited buffer.
             for (int i = 0; i < numProcesses; ++i)
             {
                 processes[i].WaitForExit();
-                string output = processes[i].StandardOutput.ReadToEnd();
                 Assert.Equal(0, processes[i].ExitCode);
                 processes[i].Dispose();
                 processes[i] = null;
@@ -138,7 +160,8 @@ namespace NLog.UnitTests.Targets
                     {
                         int thread = Convert.ToInt32(tokens[0]);
                         int number = Convert.ToInt32(tokens[1]);
-
+                        Assert.True(thread >= 0);
+                        Assert.True(thread < numProcesses);
                         Assert.Equal(maxNumber[thread], number);
                         maxNumber[thread]++;
                     }
@@ -150,35 +173,46 @@ namespace NLog.UnitTests.Targets
             }
         }
 
-        private void DoConcurrentTest(string mode)
+        [Theory]
+        [InlineData(2, 10000, "none")]
+        [InlineData(5, 4000, "none")]
+        [InlineData(10, 2000, "none")]
+        [InlineData(2, 10000, "none|mutex")]
+        [InlineData(5, 4000, "none|mutex")]
+        [InlineData(10, 2000, "none|mutex")]
+        public void SimpleConcurrentTest(int numProcesses, int numLogs, string mode)
         {
-            DoConcurrentTest(2, 10000, mode);
-            DoConcurrentTest(5, 4000, mode);
-            DoConcurrentTest(10, 2000, mode);
+            DoConcurrentTest(numProcesses, numLogs, mode);
         }
 
-        [Fact]
-        public void SimpleConcurrentTest()
+        [Theory]
+        [InlineData("async")]
+        [InlineData("async|mutex")]
+        public void AsyncConcurrentTest(string mode)
         {
-            DoConcurrentTest("none");
+            // Before 2 processes are running into concurrent writes, 
+            // the first process typically already has written couple thousend events.
+            // Thus to have a meaningful test, at least 10K events are required.
+            // Due to the buffering it makes no big difference in runtime, whether we
+            // have 2 process writing 10K events each or couple more processes with even more events.
+            // Runtime is mostly defined by Runner.exe compilation and JITing the first.
+            DoConcurrentTest(5, 50000, mode);
         }
 
-        [Fact]
-        public void AsyncConcurrentTest()
+        [Theory]
+        [InlineData("buffered")]
+        [InlineData("buffered|mutex")]
+        public void BufferedConcurrentTest(string mode)
         {
-            DoConcurrentTest(2, 100, "async");
+            DoConcurrentTest(5, 50000, mode);
         }
 
-        [Fact]
-        public void BufferedConcurrentTest()
+        [Theory]
+        [InlineData("buffered_timed_flush")]
+        [InlineData("buffered_timed_flush|mutex")]
+        public void BufferedTimedFlushConcurrentTest(string mode)
         {
-            DoConcurrentTest(2, 100, "buffered");
-        }
-
-        [Fact]
-        public void BufferedTimedFlushConcurrentTest()
-        {
-            DoConcurrentTest(2, 100, "buffered_timed_flush");
+            DoConcurrentTest(5, 50000, mode);
         }
     }
 }

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -65,13 +65,15 @@ namespace NLog.UnitTests.Targets
                     from concurrentWrites in booleanValues
                     from keepFileOpen in booleanValues
                     from networkWrites in booleanValues
-                    select new object[] { concurrentWrites, keepFileOpen, networkWrites };
+                    from forceManaged in booleanValues
+                    from preferMutexLockedFileCreation in booleanValues
+                    select new object[] { concurrentWrites, keepFileOpen, networkWrites, forceManaged, preferMutexLockedFileCreation };
             }
         }
 
         [Theory]
         [PropertyData("SimpleFileTest_TestParameters")]
-        public void SimpleFileTest(bool concurrentWrites, bool keepFileOpen, bool networkWrites)
+        public void SimpleFileTest(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool forceManaged, bool preferMutexLockedFileCreation)
         {
             var logFile = Path.GetTempFileName();
             try
@@ -84,7 +86,9 @@ namespace NLog.UnitTests.Targets
                     OpenFileCacheTimeout = 0,
                     ConcurrentWrites = concurrentWrites,
                     KeepFileOpen = keepFileOpen,
-                    NetworkWrites = networkWrites
+                    NetworkWrites = networkWrites,
+                    ForceManaged = forceManaged,
+                    PreferMutexLockedFileCreation = preferMutexLockedFileCreation
                 });
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
@@ -850,13 +854,15 @@ namespace NLog.UnitTests.Targets
                     from keepFileOpen in booleanValues
                     from networkWrites in booleanValues
                     from includeSequenceInArchive in booleanValues
-                    select new object[] { timeKind, includeDateInLogFilePath, concurrentWrites, keepFileOpen, networkWrites, includeSequenceInArchive };
+                    from forceManaged in booleanValues
+                    from preferMutexLockedFileCreation in booleanValues
+                    select new object[] { timeKind, includeDateInLogFilePath, concurrentWrites, keepFileOpen, networkWrites, includeSequenceInArchive, forceManaged, preferMutexLockedFileCreation };
             }
         }
 
         [Theory]
         [PropertyData("DateArchive_UsesDateFromCurrentTimeSource_TestParameters")]
-        public void DateArchive_UsesDateFromCurrentTimeSource(DateTimeKind timeKind, bool includeDateInLogFilePath, bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool includeSequenceInArchive)
+        public void DateArchive_UsesDateFromCurrentTimeSource(DateTimeKind timeKind, bool includeDateInLogFilePath, bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool includeSequenceInArchive, bool forceManaged, bool preferMutexLockedFileCreation)
         {
             const string archiveDateFormat = "yyyyMMdd";
             const int maxArchiveFiles = 3;
@@ -885,6 +891,8 @@ namespace NLog.UnitTests.Targets
                     ConcurrentWrites = concurrentWrites,
                     KeepFileOpen = keepFileOpen,
                     NetworkWrites = networkWrites,
+                    ForceManaged = forceManaged,
+                    PreferMutexLockedFileCreation = preferMutexLockedFileCreation
                 });
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
@@ -974,7 +982,9 @@ namespace NLog.UnitTests.Targets
                     where AllowsExternalFileModification(concurrentWrites, keepFileOpen, networkWrites)
                     from includeDateInLogFilePath in booleanValues
                     from includeSequenceInArchive in booleanValues
-                    select new object[] { concurrentWrites, keepFileOpen, networkWrites, includeDateInLogFilePath, includeSequenceInArchive };
+                    from forceManaged in booleanValues
+                    from preferMutexLockedFileCreation in booleanValues
+                    select new object[] { concurrentWrites, keepFileOpen, networkWrites, includeDateInLogFilePath, includeSequenceInArchive, forceManaged, preferMutexLockedFileCreation };
             }
         }
 
@@ -985,7 +995,7 @@ namespace NLog.UnitTests.Targets
 
         [Theory]
         [PropertyData("DateArchive_ArchiveOnceOnly_TestParameters")]
-        public void DateArchive_ArchiveOnceOnly(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool dateInLogFilePath, bool includeSequenceInArchive)
+        public void DateArchive_ArchiveOnceOnly(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool dateInLogFilePath, bool includeSequenceInArchive, bool forceManaged, bool preferMutexLockedFileCreation)
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var logFile = Path.Combine(tempPath, dateInLogFilePath ? "file_${shortdate}.txt" : "file.txt");
@@ -1003,7 +1013,9 @@ namespace NLog.UnitTests.Targets
                     Layout = "${message}",
                     ConcurrentWrites = concurrentWrites,
                     KeepFileOpen = keepFileOpen,
-                    NetworkWrites = networkWrites
+                    NetworkWrites = networkWrites,
+                    ForceManaged = forceManaged,
+                    PreferMutexLockedFileCreation = preferMutexLockedFileCreation
                 });
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
@@ -1118,13 +1130,15 @@ namespace NLog.UnitTests.Targets
                     from includeDateInLogFilePath in booleanValues
                     from includeSequenceInArchive in booleanValues
                     from enableArchiveCompression in booleanValues
-                    select new object[] { concurrentWrites, keepFileOpen, networkWrites, includeDateInLogFilePath, includeSequenceInArchive, enableArchiveCompression };
+                    from forceManaged in booleanValues
+                    from preferMutexLockedFileCreation in booleanValues
+                    select new object[] { concurrentWrites, keepFileOpen, networkWrites, includeDateInLogFilePath, includeSequenceInArchive, enableArchiveCompression, forceManaged, preferMutexLockedFileCreation };
             }
         }
 
         [Theory]
         [PropertyData("DateArchive_AllLoggersTransferToCurrentLogFile_TestParameters")]
-        public void DateArchive_AllLoggersTransferToCurrentLogFile(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool includeDateInLogFilePath, bool includeSequenceInArchive, bool enableArchiveCompression)
+        public void DateArchive_AllLoggersTransferToCurrentLogFile(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool includeDateInLogFilePath, bool includeSequenceInArchive, bool enableArchiveCompression, bool forceManaged, bool preferMutexLockedFileCreation)
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var logfile = Path.Combine(tempPath, includeDateInLogFilePath ? "file_${shortdate}.txt" : "file.txt");
@@ -1147,7 +1161,9 @@ namespace NLog.UnitTests.Targets
                     Layout = "${message}",
                     ConcurrentWrites = concurrentWrites,
                     KeepFileOpen = keepFileOpen,
-                    NetworkWrites = networkWrites
+                    NetworkWrites = networkWrites,
+                    ForceManaged = forceManaged,
+                    PreferMutexLockedFileCreation = preferMutexLockedFileCreation
                 });
                 var logger1Rule = new LoggingRule("logger1", LogLevel.Debug, fileTarget1);
                 config.LoggingRules.Add(logger1Rule);
@@ -1166,7 +1182,9 @@ namespace NLog.UnitTests.Targets
                     Layout = "${message}",
                     ConcurrentWrites = concurrentWrites,
                     KeepFileOpen = keepFileOpen,
-                    NetworkWrites = networkWrites
+                    NetworkWrites = networkWrites,
+                    ForceManaged = forceManaged,
+                    PreferMutexLockedFileCreation = preferMutexLockedFileCreation
                 });
                 var logger2Rule = new LoggingRule("logger2", LogLevel.Debug, fileTarget2);
                 config.LoggingRules.Add(logger2Rule);
@@ -1187,7 +1205,7 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;
                 var files = Directory.GetFiles(archiveFolder);
-                Assert.Equal(1, Directory.GetFiles(archiveFolder).Length);
+                Assert.Equal(1, files.Length);
                 AssertFileContents(currentLogFile, StringRepeat(2, "123456789\n"), Encoding.UTF8);
             }
             finally


### PR DESCRIPTION
When having concurrentWrites/keepFileOpen set to true NLog utilizes a mutex shared with all other processes. Using this synchronization mechanism together with using a FileStream which is auto-flushed during every write is quite costly. This PR improves FileTarget performance by removing the need for using that mutex/FileStream.

On my notebook this gives **30-40% more event writes/sec**.

When FileTarget is used with Async- or BufferingWrapper there's no notable effect.

**Background:**
It is rarely known that when creating/opening a file under Windows with CreateFile(...FILE_APPEND_DATA | SYNCHRONIZE...) that writes are atomically appended, even cross process. See https://blogs.msdn.microsoft.com/oldnewthing/20151127-00/?p=92211/

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1474)

<!-- Reviewable:end -->
