### PR TITLE
Fix typo in NLog.config

### DIFF
--- a/src/NuGet/NLog.Config/content/NLog.config
+++ b/src/NuGet/NLog.Config/content/NLog.config
@@ -7,7 +7,7 @@
       internalLogLevel="Off" internalLogFile="c:\temp\nlog-internal.log" >
 
 
-  <!-- optional, add some variabeles
+  <!-- optional, add some variables
   https://github.com/nlog/NLog/wiki/Configuration-file#variables
   -->
   <variable name="myvar" value="myvalue"/>


### PR DESCRIPTION
Fix minor typo "variabeles" -> "variables".