### PR TITLE
Bugfix: Rule with level="Off" breaks other rules

### DIFF
--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -225,6 +225,11 @@ namespace NLog.Config
         /// <param name="level">Level to be enabled.</param>
         public void EnableLoggingForLevel(LogLevel level)
         {
+            if (level == LogLevel.Off)
+            {
+                return;
+            }
+
             this.logLevels[level.Ordinal] = true;
         }
 
@@ -247,6 +252,11 @@ namespace NLog.Config
         /// <param name="level">Level to be disabled.</param>
         public void DisableLoggingForLevel(LogLevel level)
         {
+            if (level == LogLevel.Off)
+            {
+                return;
+            }
+
             this.logLevels[level.Ordinal] = false;
         }
 

--- a/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
@@ -463,5 +463,31 @@ namespace NLog.UnitTests.Config
                 }
             }
         }
+                
+        [Fact]
+        public void LoggingRule_LevelOff_NotSetAsActualLogLevel()
+        {
+            LoggingConfiguration c = CreateConfigurationFromString(@"
+            <nlog>
+                <targets>
+                    <target name='l1' type='Debug' layout='${message}' />
+                    <target name='l2' type='Debug' layout='${message}' />
+                </targets>
+
+                <rules>
+                    <logger name='a' level='Off' appendTo='l1' />
+                    <logger name='a' minlevel='Debug' appendTo='l2' />
+                </rules>
+            </nlog>");
+
+            LogManager.Configuration = c;
+            Logger a = LogManager.GetLogger("a");
+
+            Assert.True(c.LoggingRules.Count == 2, "All rules should have been loaded.");
+            Assert.False(c.LoggingRules[0].IsLoggingEnabledForLevel(LogLevel.Off), "Log level Off should always return false.");
+            // The two functions below should not throw an exception.
+            c.LoggingRules[0].EnableLoggingForLevel(LogLevel.Debug);
+            c.LoggingRules[0].DisableLoggingForLevel(LogLevel.Debug);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1509.
When using log level 'Off' it was treated as a normal log level in the 'EnableLoggingForLevel' and 'DisableLoggingForLevel', but no place for it was allocated in the array containing the on/off flags for the different log levels. This array only goes up to 'Fatal' (ordinal 5), which is also max log level. Trying to set the on/off flag for the 'Off' log level (ordinal 6) then resulted in an 'IndexOutOfRangeException'.

The function 'IsLoggingEnabledForLevel' already contained a special case check for the 'Off' log level, so I also added those checks to the 'EnableLoggingForLevel' and 'DisableLoggingForLevel' functions.