### PR TITLE
Add LimitingTargetWrapper

### DIFF
--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -353,6 +353,7 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
+    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -353,7 +353,6 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
-    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />
@@ -388,6 +387,7 @@
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTarget.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -350,7 +350,6 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
-    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />
@@ -385,6 +384,7 @@
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTarget.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -350,6 +350,7 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
+    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -363,6 +363,7 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
+    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -363,7 +363,6 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
-    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />
@@ -398,6 +397,7 @@
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTarget.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -369,7 +369,6 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
-    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />
@@ -404,6 +403,7 @@
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTarget.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -369,6 +369,7 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
+    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -363,6 +363,7 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
+    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -363,7 +363,6 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
-    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />
@@ -398,6 +397,7 @@
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTarget.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -363,6 +363,7 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
+    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -363,7 +363,6 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
-    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />
@@ -398,6 +397,7 @@
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTarget.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -368,6 +369,7 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
+    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,8 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <TargetFrameworkProfile></TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -369,7 +368,6 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
-    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />
@@ -404,6 +402,7 @@
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTarget.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -370,7 +370,6 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
-    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />
@@ -405,6 +404,7 @@
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTarget.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -370,6 +370,7 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
+    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -367,6 +367,7 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
+    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -367,7 +367,6 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
-    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />
@@ -402,6 +401,7 @@
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTarget.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -366,6 +366,7 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
+    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -366,7 +366,6 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
-    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />
@@ -401,6 +400,7 @@
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTarget.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -366,6 +366,7 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
+    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -366,7 +366,6 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
-    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />
@@ -401,6 +400,7 @@
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTarget.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -391,7 +391,6 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
-    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />
@@ -426,6 +425,7 @@
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTarget.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -391,6 +391,7 @@
     <Compile Include="Targets\FileArchivePeriod.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
+    <Compile Include="Targets\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/Targets/LimitingTargetWrapper.cs
+++ b/src/NLog/Targets/LimitingTargetWrapper.cs
@@ -1,0 +1,175 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Targets.Wrappers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using NLog.Common;
+    using NLog.Time;
+
+
+    /// <summary>
+    /// Limits the number of messages written per timespan to the wrapped target.
+    /// </summary>
+    [Target("LimitingWrapper", IsWrapper = true)]
+    public class LimitingTargetWrapper : WrapperTargetBase
+    {
+        private DateTime firstWriteInInterval;
+        private int writeCount;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LimitingTargetWrapper" /> class.
+        /// </summary>
+        public LimitingTargetWrapper()
+        {
+
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LimitingTargetWrapper" /> class.
+        /// </summary>
+        /// <param name="name">The name of the target.</param>
+        /// <param name="wrappedTarget">The wrapped target.</param>
+        public LimitingTargetWrapper(string name, Target wrappedTarget) 
+            : this(wrappedTarget, 100, TimeSpan.FromHours(1))
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LimitingTargetWrapper" /> class.
+        /// </summary>
+        /// <param name="wrappedTarget">The wrapped target.</param>
+        public LimitingTargetWrapper(Target wrappedTarget) : this(wrappedTarget, 1000, TimeSpan.FromHours(1))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LimitingTargetWrapper" /> class.
+        /// </summary>
+        /// <param name="wrappedTarget">The wrapped target.</param>
+        /// <param name="messageLimit">Maximum number of messages written per interval.</param>
+        /// <param name="interval">Interval in which the maximum number of messages can be written.</param>
+        public LimitingTargetWrapper(Target wrappedTarget, int messageLimit, TimeSpan interval)
+        {
+            this.MessageLimit = messageLimit;
+            this.Interval = interval;
+            this.WrappedTarget = wrappedTarget;
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum allowed number of messages written per <see cref="Interval"/>.
+        /// </summary>
+        /// <remarks>
+        /// Messages received after <see cref="MessageLimit"/> has been reached in the current <see cref="Interval"/> will be discarded.
+        /// </remarks>
+        [DefaultValue(1000)]
+        public int MessageLimit { get; set; }
+
+        /// <summary>
+        /// Gets or sets the interval in which messages will be written up to the <see cref="MessageLimit"/> number of messages.
+        /// </summary>
+        /// <remarks>
+        /// Messages received after <see cref="MessageLimit"/> has been reached in the current <see cref="Interval"/> will be discarded.
+        /// </remarks>
+        [DefaultValue(typeof(TimeSpan), "01:00")]
+        public TimeSpan Interval { get; set; }
+
+        /// <summary>
+        /// Gets the <c>DateTime</c> when the current <see cref="Interval"/> will be reset.
+        /// </summary>
+        public DateTime IntervalResetsAt { get { return firstWriteInInterval + Interval; } }
+
+        /// <summary>
+        /// Gets the number of <see cref="AsyncLogEventInfo"/> written in the current <see cref="Interval"/>.
+        /// </summary>
+        public int MessagesWrittenCount { get { return writeCount;} }
+
+        /// <summary>
+        /// Initializes the target and resets the current Interval and <see cref="MessagesWrittenCount"/>.
+        ///  </summary>
+        protected override void InitializeTarget()
+        {
+            if(this.MessageLimit<=0)
+                throw new NLogConfigurationException("The LimitingTargetWrapper\'s MessageLimit property must be > 0.");
+            if(this.Interval<=TimeSpan.Zero)
+                throw new NLogConfigurationException("The LimitingTargetWrapper\'s property Interval must be > 0.");
+
+            base.InitializeTarget();
+            ResetInterval();
+            InternalLogger.Trace("LimitingTargetWraper '{0}': initialized with MessageLimit={1} and Interval={2}.", Name, MessageLimit, Interval);
+        }
+
+
+        /// <summary>
+        /// Writes log event to the wrapped target if the current <see cref="MessagesWrittenCount"/> is lower than <see cref="MessageLimit"/>.
+        /// If the <see cref="MessageLimit"/> is already reached, no log event will be written to the wrapped target.
+        /// <see cref="MessagesWrittenCount"/> resets when the current <see cref="Interval"/> is expired.
+        /// </summary>
+        /// <param name="logEvent">Log event to be written out.</param>
+        protected override void Write(AsyncLogEventInfo logEvent)
+        {
+            if (IntervalExpired())
+            {
+                ResetInterval();
+                InternalLogger.Debug("LimitingWrapper '{0}': new interval of '{1}' started.", Name, Interval);
+            }
+
+            if (writeCount < MessageLimit)
+            {
+                this.WrappedTarget.WriteAsyncLogEvent(logEvent);
+                writeCount++;
+            }
+            else
+            {
+                logEvent.Continuation(null);
+                InternalLogger.Trace("LimitingWrapper '{0}': discarded event, because MessageLimit of '{1}' was reached.", Name, MessageLimit);
+            }
+        }
+
+        private void ResetInterval()
+        {
+            firstWriteInInterval = TimeSource.Current.Time;
+            writeCount = 0;
+        }
+
+        private bool IntervalExpired()
+        {
+            return TimeSource.Current.Time - firstWriteInInterval > Interval;
+        }
+
+    }
+}

--- a/src/NLog/Targets/LimitingTargetWrapper.cs
+++ b/src/NLog/Targets/LimitingTargetWrapper.cs
@@ -52,9 +52,8 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Initializes a new instance of the <see cref="LimitingTargetWrapper" /> class.
         /// </summary>
-        public LimitingTargetWrapper()
+        public LimitingTargetWrapper():this(null)
         {
-
         }
 
 
@@ -64,7 +63,7 @@ namespace NLog.Targets.Wrappers
         /// <param name="name">The name of the target.</param>
         /// <param name="wrappedTarget">The wrapped target.</param>
         public LimitingTargetWrapper(string name, Target wrappedTarget) 
-            : this(wrappedTarget, 100, TimeSpan.FromHours(1))
+            : this(wrappedTarget, 1000, TimeSpan.FromHours(1))
         {
             this.Name = name;
         }
@@ -73,7 +72,8 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="LimitingTargetWrapper" /> class.
         /// </summary>
         /// <param name="wrappedTarget">The wrapped target.</param>
-        public LimitingTargetWrapper(Target wrappedTarget) : this(wrappedTarget, 1000, TimeSpan.FromHours(1))
+        public LimitingTargetWrapper(Target wrappedTarget)
+            : this(wrappedTarget, 1000, TimeSpan.FromHours(1))
         {
         }
 

--- a/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
@@ -34,7 +34,6 @@
 namespace NLog.Targets.Wrappers
 {
     using System;
-    using System.Collections.Generic;
     using System.ComponentModel;
     using NLog.Common;
     using NLog.Time;

--- a/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
@@ -46,7 +46,6 @@ namespace NLog.Targets.Wrappers
     public class LimitingTargetWrapper : WrapperTargetBase
     {
         private DateTime firstWriteInInterval;
-        private int writeCount;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LimitingTargetWrapper" /> class.
@@ -115,7 +114,7 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Gets the number of <see cref="AsyncLogEventInfo"/> written in the current <see cref="Interval"/>.
         /// </summary>
-        public int MessagesWrittenCount { get { return writeCount;} }
+        public int MessagesWrittenCount { get; private set; }
 
         /// <summary>
         /// Initializes the target and resets the current Interval and <see cref="MessagesWrittenCount"/>.
@@ -141,16 +140,16 @@ namespace NLog.Targets.Wrappers
         /// <param name="logEvent">Log event to be written out.</param>
         protected override void Write(AsyncLogEventInfo logEvent)
         {
-            if (IntervalExpired())
+            if (IsIntervalExpired())
             {
                 ResetInterval();
                 InternalLogger.Debug("LimitingWrapper '{0}': new interval of '{1}' started.", Name, Interval);
             }
 
-            if (writeCount < MessageLimit)
+            if (MessagesWrittenCount < MessageLimit)
             {
                 this.WrappedTarget.WriteAsyncLogEvent(logEvent);
-                writeCount++;
+                MessagesWrittenCount++;
             }
             else
             {
@@ -162,10 +161,10 @@ namespace NLog.Targets.Wrappers
         private void ResetInterval()
         {
             firstWriteInInterval = TimeSource.Current.Time;
-            writeCount = 0;
+            MessagesWrittenCount = 0;
         }
 
-        private bool IntervalExpired()
+        private bool IsIntervalExpired()
         {
             return TimeSource.Current.Time - firstWriteInInterval > Interval;
         }

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapperTests.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\RepeatingTargetWrapperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -224,6 +224,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapperTests.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\RepeatingTargetWrapperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -204,6 +204,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapperTests.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\RepeatingTargetWrapperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -246,6 +246,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapperTests.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\RepeatingTargetWrapperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapperTests.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\RepeatingTargetWrapperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -219,6 +219,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapperTests.cs" />
+    <Compile Include="Targets\Wrappers\LimitingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\RandomizeGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\RepeatingTargetWrapperTests.cs" />

--- a/tests/NLog.UnitTests/Targets/Wrappers/BufferingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/BufferingTargetWrapperTests.cs
@@ -494,7 +494,6 @@ namespace NLog.UnitTests.Targets.Wrappers
                                              };
 
             InitializeTargets(myTarget, bufferingTargetWrapper);
-
             bufferingTargetWrapper.WriteAsyncLogEvent(new LogEventInfo().WithContinuation(_ => { }));
 
             var flushHit = new ManualResetEvent(false);

--- a/tests/NLog.UnitTests/Targets/Wrappers/LimitingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/LimitingTargetWrapperTests.cs
@@ -156,7 +156,27 @@ namespace NLog.UnitTests.Targets.Wrappers
         public void ConstructorWithNoParametersInitialisesDefaultsCorrectly()
         {
             MyTarget wrappedTarget = new MyTarget();
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper();
+
+            Assert.Equal(1000, wrapper.MessageLimit);
+            Assert.Equal(TimeSpan.FromHours(1), wrapper.Interval);
+        }
+
+        [Fact]
+        public void ConstructorWithTargetInitialisesDefaultsCorrectly()
+        {
+            MyTarget wrappedTarget = new MyTarget();
             LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget);
+
+            Assert.Equal(1000, wrapper.MessageLimit);
+            Assert.Equal(TimeSpan.FromHours(1), wrapper.Interval);
+        }
+
+        [Fact]
+        public void ConstructorWithNameInitialisesDefaultsCorrectly()
+        {
+            MyTarget wrappedTarget = new MyTarget();
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper("Wrapper", wrappedTarget);
 
             Assert.Equal(1000, wrapper.MessageLimit);
             Assert.Equal(TimeSpan.FromHours(1), wrapper.Interval);

--- a/tests/NLog.UnitTests/Targets/Wrappers/LimitingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/LimitingTargetWrapperTests.cs
@@ -1,16 +1,46 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading;
-using MyExtensionNamespace;
-using NLog.Common;
-using NLog.Targets;
-using NLog.Targets.Wrappers;
-using NLog.Time;
-using Xunit;
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
 
 namespace NLog.UnitTests.Targets.Wrappers
 {
-    public class LimitingTargetWrapperTests: NLogTestBase
+    using System;
+    using System.Threading;
+    using NLog.Common;
+    using NLog.Targets;
+    using NLog.Targets.Wrappers;
+    using Xunit;
+
+    public class LimitingTargetWrapperTests : NLogTestBase
     {
         [Fact]
         public void WriteMessagesLessThanMessageLimitWritesToWrappedTarget()
@@ -24,7 +54,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             for (int i = 0; i < 5; i++)
             {
                 wrapper.WriteAsyncLogEvent(
-                    new LogEventInfo(LogLevel.Debug, "test", $"Hello {i}").WithContinuation(ex => lastException=ex));
+                    new LogEventInfo(LogLevel.Debug, "test", $"Hello {i}").WithContinuation(ex => lastException = ex));
             }
 
             Assert.Equal(5, wrappedTarget.WriteCount);
@@ -47,7 +77,7 @@ namespace NLog.UnitTests.Targets.Wrappers
         [Fact]
         public void WriteMoreMessagesThanMessageLimitDiscardsExcessMessages()
         {
-            MyTarget wrappedTarget= new MyTarget();
+            MyTarget wrappedTarget = new MyTarget();
             LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget, 5, TimeSpan.FromHours(1));
             InitializeTargets(wrappedTarget, wrapper);
             Exception lastException = null;
@@ -192,7 +222,7 @@ namespace NLog.UnitTests.Targets.Wrappers
         public void InitializeThrowsNLogConfigurationExceptionIfMessageLimitIsSetToZero()
         {
             MyTarget wrappedTarget = new MyTarget();
-            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget) { MessageLimit = 0 };
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget) {MessageLimit = 0};
             wrappedTarget.Initialize(null);
             LogManager.ThrowConfigExceptions = true;
 
@@ -204,7 +234,7 @@ namespace NLog.UnitTests.Targets.Wrappers
         public void InitializeThrowsNLogConfigurationExceptionIfMessageLimitIsSmallerZero()
         {
             MyTarget wrappedTarget = new MyTarget();
-            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget) { MessageLimit = -1 };
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget) {MessageLimit = -1};
             wrappedTarget.Initialize(null);
             LogManager.ThrowConfigExceptions = true;
 
@@ -216,7 +246,7 @@ namespace NLog.UnitTests.Targets.Wrappers
         public void InitializeThrowsNLogConfigurationExceptionIfIntervalIsSmallerZero()
         {
             MyTarget wrappedTarget = new MyTarget();
-            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget) { Interval = TimeSpan.MinValue };
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget) {Interval = TimeSpan.MinValue};
             wrappedTarget.Initialize(null);
             LogManager.ThrowConfigExceptions = true;
 
@@ -228,7 +258,7 @@ namespace NLog.UnitTests.Targets.Wrappers
         public void InitializeThrowsNLogConfigurationExceptionIfIntervalIsZero()
         {
             MyTarget wrappedTarget = new MyTarget();
-            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget) { Interval = TimeSpan.Zero };
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget) {Interval = TimeSpan.Zero};
             wrappedTarget.Initialize(null);
             LogManager.ThrowConfigExceptions = true;
 
@@ -259,6 +289,6 @@ namespace NLog.UnitTests.Targets.Wrappers
             }
 
         }
-        
+
     }
 }

--- a/tests/NLog.UnitTests/Targets/Wrappers/LimitingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/LimitingTargetWrapperTests.cs
@@ -1,0 +1,238 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using MyExtensionNamespace;
+using NLog.Common;
+using NLog.Targets;
+using NLog.Targets.Wrappers;
+using NLog.Time;
+using Xunit;
+
+namespace NLog.UnitTests.Targets.Wrappers
+{
+    public class LimitingTargetWrapperTests: NLogTestBase
+    {
+        [Fact]
+        public void WriteMessagesLessThanMessageLimitWritesToWrappedTarget()
+        {
+            MyTarget wrappedTarget = new MyTarget();
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget, 5, TimeSpan.FromSeconds(1));
+            InitializeTargets(wrappedTarget, wrapper);
+
+            // Write limit number of messages should just write them to the wrappedTarget.
+            for (int i = 0; i < 5; i++)
+            {
+                wrapper.WriteAsyncLogEvent(
+                    new LogEventInfo(LogLevel.Debug, "test", $"Hello {i}").WithContinuation(ex => { }));
+            }
+
+            Assert.Equal(5, wrappedTarget.WriteCount);
+
+            //Let the interval expire to start a new one.
+            Thread.Sleep(1000);
+
+            // Write limit number of messages should just write them to the wrappedTarget.
+            for (int i = 5; i < 10; i++)
+            {
+                wrapper.WriteAsyncLogEvent(
+                    new LogEventInfo(LogLevel.Debug, "test", $"Hello {i}").WithContinuation(ex => { }));
+            }
+
+            // We should have 10 messages (5 from first interval, 5 from second interval).
+            Assert.Equal(10, wrappedTarget.WriteCount);
+        }
+
+        [Fact]
+        public void WriteMoreMessagesThanMessageLimitDiscardsExcessMessages()
+        {
+            MyTarget wrappedTarget= new MyTarget();
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget, 5, TimeSpan.FromHours(1));
+            InitializeTargets(wrappedTarget, wrapper);
+
+            // Write limit number of messages should just write them to the wrappedTarget.
+            for (int i = 0; i < 5; i++)
+            {
+                wrapper.WriteAsyncLogEvent(new LogEventInfo(LogLevel.Debug, "test", $"Hello {i}").WithContinuation(ex => { }));
+            }
+            Assert.Equal(5, wrappedTarget.WriteCount);
+
+            //Additional messages will be discarded, but InternalLogger will write to trace.
+            string internalLog = RunAndCaptureInternalLog(() =>
+            {
+                wrapper.WriteAsyncLogEvent(
+                    new LogEventInfo(LogLevel.Debug, "test", $"Hello {5}").WithContinuation(ex => { }));
+            }, LogLevel.Trace);
+
+            Assert.Equal(5, wrappedTarget.WriteCount);
+            Assert.True(internalLog.Contains("MessageLimit"));
+        }
+
+        [Fact]
+        public void WriteMessageAfterIntervalHasExpiredStartsNewInterval()
+        {
+            MyTarget wrappedTarget = new MyTarget();
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget, 5, TimeSpan.FromSeconds(1));
+            InitializeTargets(wrappedTarget, wrapper);
+
+            wrapper.WriteAsyncLogEvent(
+                new LogEventInfo(LogLevel.Debug, "test", "first interval").WithContinuation(ex => { }));
+
+            //Let the interval expire.
+            Thread.Sleep(1000);
+
+            //Writing a logEvent should start a new Interval. This should be written to InternalLogger.Debug.
+            string internalLog = RunAndCaptureInternalLog(() =>
+            {
+                // We can write 5 messages again since a new interval started.
+                for (int i = 0; i < 5; i++)
+                {
+                    wrapper.WriteAsyncLogEvent(
+                        new LogEventInfo(LogLevel.Debug, "test", $"Hello {i}").WithContinuation(ex => { }));
+                }
+            }, LogLevel.Trace);
+
+            //We should have written 6 messages (1 in first interval and 5 in second interval).
+            Assert.Equal(6, wrappedTarget.WriteCount);
+            Assert.True(internalLog.Contains("new interval"));
+        }
+
+        [Fact]
+        public void TestWritingMessagesOverMultipleIntervals()
+        {
+            MyTarget wrappedTarget = new MyTarget();
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget, 5, TimeSpan.FromSeconds(1));
+            InitializeTargets(wrappedTarget, wrapper);
+            List<Exception> exceptions = new List<Exception>();
+
+            for (int i = 0; i < 10; i++)
+            {
+                wrapper.WriteAsyncLogEvent(
+                    new LogEventInfo(LogLevel.Debug, "test", $"Hello {i}").WithContinuation(exceptions.Add));
+            }
+
+            //Let the interval expire.
+            Thread.Sleep(1000);
+
+            Assert.Equal(5, wrappedTarget.WriteCount);
+            Assert.Equal("Hello 4", wrappedTarget.LastWrittenMessage);
+
+            for (int i = 10; i < 20; i++)
+            {
+                wrapper.WriteAsyncLogEvent(
+                    new LogEventInfo(LogLevel.Debug, "test", $"Hello {i}").WithContinuation(exceptions.Add));
+            }
+            //We should have 10 messages (5 from first, 5 from second interval).
+            Assert.Equal(10, wrappedTarget.WriteCount);
+            Assert.Equal("Hello 14", wrappedTarget.LastWrittenMessage);
+
+            //Let the interval expire.
+            Thread.Sleep(2300);
+
+            for (int i = 20; i < 30; i++)
+            {
+                wrapper.WriteAsyncLogEvent(
+                    new LogEventInfo(LogLevel.Debug, "test", $"Hello {i}").WithContinuation(exceptions.Add));
+            }
+
+            //We should have 15 messages (5 from first, 5 from second, 5 from third interval).
+            Assert.Equal(15, wrappedTarget.WriteCount);
+            Assert.Equal("Hello 24", wrappedTarget.LastWrittenMessage);
+
+            //Let the interval expire.
+            Thread.Sleep(200);
+            for (int i = 30; i < 40; i++)
+            {
+                wrapper.WriteAsyncLogEvent(
+                    new LogEventInfo(LogLevel.Debug, "test", $"Hello {i}").WithContinuation(exceptions.Add));
+            }
+
+            //No more messages shouldve been written, since we are still in the third interval.
+            Assert.Equal(15, wrappedTarget.WriteCount);
+            Assert.Equal("Hello 24", wrappedTarget.LastWrittenMessage);
+            Assert.True(exceptions.TrueForAll(e => e == null));
+        }
+
+        [Fact]
+        public void ConstructorWithNoParametersInitialisesDefaultsCorrectly()
+        {
+            MyTarget wrappedTarget = new MyTarget();
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget);
+
+            Assert.Equal(1000, wrapper.MessageLimit);
+            Assert.Equal(TimeSpan.FromHours(1), wrapper.Interval);
+        }
+
+        [Fact]
+        public void InitializeThrowsNLogConfigurationExceptionIfMessageLimitIsSetToZero()
+        {
+            MyTarget wrappedTarget = new MyTarget();
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget) { MessageLimit = 0 };
+            wrappedTarget.Initialize(null);
+            LogManager.ThrowConfigExceptions = true;
+
+            Assert.Throws<NLogConfigurationException>(() => wrapper.Initialize(null));
+            LogManager.ThrowConfigExceptions = false;
+        }
+
+        [Fact]
+        public void InitializeThrowsNLogConfigurationExceptionIfMessageLimitIsSmallerZero()
+        {
+            MyTarget wrappedTarget = new MyTarget();
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget) { MessageLimit = -1 };
+            wrappedTarget.Initialize(null);
+            LogManager.ThrowConfigExceptions = true;
+
+            Assert.Throws<NLogConfigurationException>(() => wrapper.Initialize(null));
+            LogManager.ThrowConfigExceptions = false;
+        }
+
+        [Fact]
+        public void InitializeThrowsNLogConfigurationExceptionIfIntervalIsSmallerZero()
+        {
+            MyTarget wrappedTarget = new MyTarget();
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget) { Interval = TimeSpan.MinValue };
+            wrappedTarget.Initialize(null);
+            LogManager.ThrowConfigExceptions = true;
+
+            Assert.Throws<NLogConfigurationException>(() => wrapper.Initialize(null));
+            LogManager.ThrowConfigExceptions = false;
+        }
+
+        [Fact]
+        public void InitializeThrowsNLogConfigurationExceptionIfIntervalIsZero()
+        {
+            MyTarget wrappedTarget = new MyTarget();
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget) { Interval = TimeSpan.Zero };
+            wrappedTarget.Initialize(null);
+            LogManager.ThrowConfigExceptions = true;
+
+            Assert.Throws<NLogConfigurationException>(() => wrapper.Initialize(null));
+            LogManager.ThrowConfigExceptions = false;
+        }
+
+
+        private static void InitializeTargets(params Target[] targets)
+        {
+            foreach (Target target in targets)
+            {
+                target.Initialize(null);
+            }
+        }
+
+        private class MyTarget : Target
+        {
+            public int WriteCount { get; private set; }
+            public string LastWrittenMessage { get; private set; }
+
+
+            protected override void Write(AsyncLogEventInfo logEvent)
+            {
+                base.Write(logEvent);
+                LastWrittenMessage = logEvent.LogEvent.FormattedMessage;
+                WriteCount++;
+            }
+
+        }
+        
+    }
+}


### PR DESCRIPTION
So here's my **first ever pull request**!
I implemented the new LimitingTargetWrapper discussed in #1049 with the corresponding tests.
The wrapper limits the messages written per interval to the wrapped target.

Please let me know what you think and of any improvements I can make.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1514)

<!-- Reviewable:end -->
