### PR TITLE
Fix Xamarin obsolete warning/error & Support Android 4.4

### DIFF
--- a/src/NLog/Internal/MySmtpClient.cs
+++ b/src/NLog/Internal/MySmtpClient.cs
@@ -40,7 +40,13 @@ namespace NLog.Internal
     /// <summary>
     /// Supports mocking of SMTP Client code.
     /// </summary>
+    /// <remarks>
+    /// Disabled Error CS0618  'SmtpClient' is obsolete: 'SmtpClient and its network of types are poorly designed,
+    ///  we strongly recommend you use https://github.com/jstedfast/MailKit and https://github.com/jstedfast/MimeKit instead'	
+    /// </remarks>
+#pragma warning disable 618
     internal class MySmtpClient : SmtpClient, ISmtpClient
+#pragma warning restore 618
     {
 #if NET3_5 || MONO
         /// <summary>

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -14,8 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -409,7 +409,9 @@
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <ItemGroup>
     <None Include="Logger.tt">


### PR DESCRIPTION
- Fix Obsolete warning (which was reported as error): CS0618  'SmtpClient' is obsolete: 'SmtpClient and its network of types are poorly designed,  we strongly recommend you use https://github.com/jstedfast/MailKit and https://github.com/jstedfast/MimeKit instead'
- Support Android 4.4 (was first 5.0)

Fixes https://github.com/NLog/NLog/issues/1527