### PR TITLE
LogReceiverWebServiceTarget is leaking communication channels

### DIFF
--- a/src/NLog/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog/Targets/LogReceiverWebServiceTarget.cs
@@ -404,10 +404,12 @@ namespace NLog.Targets
             var client = sender as IWcfLogReceiverClient;
             if (client != null && client.State == CommunicationState.Opened)
             {
-                try {
+                try
+                {
                     client.Close();
                 }
-                catch {
+                catch
+                {
                     client.Abort();
                 }
             }

--- a/src/NLog/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog/Targets/LogReceiverWebServiceTarget.cs
@@ -401,10 +401,15 @@ namespace NLog.Targets
 
         private void ClientOnProcessLogMessagesCompleted(object sender, AsyncCompletedEventArgs asyncCompletedEventArgs)
         {
-            var client = sender as WcfLogReceiverClient;
+            var client = sender as IWcfLogReceiverClient;
             if (client != null && client.State == CommunicationState.Opened)
             {
-                client.CloseCommunicationObject();
+                try {
+                    client.Close();
+                }
+                catch {
+                    client.Abort();
+                }
             }
         }
 #endif


### PR DESCRIPTION
After sending log messages over the communication channel, a completion event is raised to close the communication channel. In this event handler the "sender" parameter is cast to the wrong type hence the channel never get closed until the "receive timeout" expire (from the WCF binding, default to 10 minutes)