### PR TITLE
Add CompoundLayout

### DIFF
--- a/src/NLog/Layouts/CompoundLayout.cs
+++ b/src/NLog/Layouts/CompoundLayout.cs
@@ -42,8 +42,6 @@ namespace NLog.Layouts
     /// A layout containing one or more nested layouts.
     /// </summary>
     [Layout("CompoundLayout")]
-    [ThreadAgnostic]
-    [AppDomainFixedOutput]
     public class CompoundLayout : Layout
     {
         /// <summary>

--- a/src/NLog/Layouts/CompoundLayout.cs
+++ b/src/NLog/Layouts/CompoundLayout.cs
@@ -1,0 +1,77 @@
+// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+
+namespace NLog.Layouts
+{
+    using Config;
+    using System.Collections.Generic;
+    using System.Text;
+
+    /// <summary>
+    /// A layout containig a nested layouts.
+    /// </summary>
+    [Layout("CompoundLayout")]
+    [ThreadAgnostic]
+    [AppDomainFixedOutput]
+    public class CompoundLayout : Layout
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompoundLayout"/> class.
+        /// </summary>
+        public CompoundLayout()
+        {
+            Layouts = new List<Layout>();
+        }
+
+        /// <summary>
+        /// Gets the array of inner layouts.
+        /// </summary>
+        /// <docgen category='CSV Options' order='10' />
+        [ArrayParameter(typeof(Layout), "layout")]
+        public IList<Layout> Layouts { get; private set; }
+
+        /// <summary>
+        /// Formats the log event relying on inner layouts.
+        /// </summary>
+        /// <param name="logEvent">The log event to be formatted.</param>
+        /// <returns>A string representation of the log event.</returns>
+        protected override string GetFormattedMessage(LogEventInfo logEvent)
+        {
+            var sb = new StringBuilder();
+            foreach (var layout in Layouts)
+                sb.Append(layout.Render(logEvent));
+            return sb.ToString();
+        }
+    }
+}

--- a/src/NLog/Layouts/CompoundLayout.cs
+++ b/src/NLog/Layouts/CompoundLayout.cs
@@ -60,6 +60,16 @@ namespace NLog.Layouts
         public IList<Layout> Layouts { get; private set; }
 
         /// <summary>
+        /// Initializes the layout.
+        /// </summary>
+        protected override void InitializeLayout()
+        {
+            base.InitializeLayout();
+            foreach (var layout in Layouts)
+                layout.Initialize(this.LoggingConfiguration);
+        }
+
+            /// <summary>
         /// Formats the log event relying on inner layouts.
         /// </summary>
         /// <param name="logEvent">The log event to be formatted.</param>
@@ -70,6 +80,16 @@ namespace NLog.Layouts
             foreach (var layout in Layouts)
                 sb.Append(layout.Render(logEvent));
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Closes the layout.
+        /// </summary>
+        protected override void CloseLayout()
+        {
+            foreach (var layout in Layouts)
+                layout.Close();
+            base.CloseLayout();
         }
     }
 }

--- a/src/NLog/Layouts/CompoundLayout.cs
+++ b/src/NLog/Layouts/CompoundLayout.cs
@@ -39,7 +39,7 @@ namespace NLog.Layouts
     using System.Text;
 
     /// <summary>
-    /// A layout containig a nested layouts.
+    /// A layout containing one or more nested layouts.
     /// </summary>
     [Layout("CompoundLayout")]
     [ThreadAgnostic]
@@ -55,7 +55,7 @@ namespace NLog.Layouts
         }
 
         /// <summary>
-        /// Gets the array of inner layouts.
+        /// Gets the inner layouts.
         /// </summary>
         /// <docgen category='CSV Options' order='10' />
         [ArrayParameter(typeof(Layout), "layout")]

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -276,6 +276,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -273,6 +273,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -286,6 +286,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -292,6 +292,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -286,6 +286,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -286,6 +286,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -302,6 +303,7 @@
     <Compile Include="Layouts\LayoutParser.cs" />
     <Compile Include="Layouts\LayoutWithHeaderAndFooter.cs" />
     <Compile Include="Layouts\Log4JXmlEventLayout.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\SimpleLayout.cs" />
     <Compile Include="LogEventInfo.cs" />
     <Compile Include="LogFactory.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -293,6 +293,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -290,6 +290,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -289,6 +289,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -289,6 +289,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -314,6 +314,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />

--- a/tests/NLog.UnitTests/LayoutRenderers/IdentityTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/IdentityTests.cs
@@ -79,7 +79,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             try
             {
-               
+
                 ConfigurationItemFactory.Default.Targets
                             .RegisterDefinition("CSharpEventTarget", typeof(CSharpEventTarget));
 
@@ -121,10 +121,10 @@ namespace NLog.UnitTests.LayoutRenderers
 
                      target.EventWritten += (logevent, rendered1, asyncThreadId1) =>
                     {
-                        continuationHit.Set();
                         rendered = rendered1;
                         asyncThreadId = asyncThreadId1;
                         lastLogEvent = logevent;
+                        continuationHit.Set();
                     };
 
 
@@ -139,10 +139,10 @@ namespace NLog.UnitTests.LayoutRenderers
                     //should be written in another thread.
                     Assert.NotEqual(threadId, asyncThreadId);
 
-                   
+
                     Assert.Equal("auth:CustomAuth:SOMEDOMAIN\\SomeUser", rendered);
-                  
-                 
+
+
 
                 }
                 finally

--- a/tests/NLog.UnitTests/Layouts/CompoundLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/CompoundLayoutTests.cs
@@ -1,0 +1,135 @@
+// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using NLog.Targets;
+
+namespace NLog.UnitTests.Layouts
+{
+    using NLog.Layouts;
+    using System;
+    using Xunit;
+
+    public class CompoundLayoutTests : NLogTestBase
+    {
+        [Fact]
+        public void CodeCompoundLayoutIsRenderedCorrectly()
+        {
+            var compoundLayout = new CompoundLayout
+            {
+                Layouts =
+                {
+                    new SimpleLayout("Long date - ${longdate}"),
+                    new SimpleLayout("|Before| "),
+                    new JsonLayout
+                    {
+                        Attributes =
+                        {
+                            new JsonAttribute("short date", "${shortdate}"),
+                            new JsonAttribute("message", "${message}"),
+                        }
+                    },
+                    new SimpleLayout(" |After|"),
+                    new SimpleLayout("Last - ${level}")
+                }
+            };
+
+            var logEventInfo = new LogEventInfo
+            {
+                TimeStamp = new DateTime(2010, 01, 20, 12, 34, 56),
+                Level = LogLevel.Info,
+                Message = "hello, world"
+            };
+
+            const string expected = "Long date - 2010-01-20 12:34:56.0000|Before| { \"short date\": \"2010-01-20\", \"message\": \"hello, world\" } |After|Last - Info";
+            var actual = compoundLayout.Render(logEventInfo);
+            Assert.Equal(expected, actual);
+        }
+
+
+        [Fact]
+        public void XmlCompoundLayoutIsRenderedCorrectly()
+        {
+            const string configXml = @"
+<nlog>
+  <targets>
+    <target name='compoundFile' type='File' fileName='log.txt'>
+      <layout type='CompoundLayout'>
+        <layout type='SimpleLayout' text='Long date - ${longdate}' />
+        <layout type='SimpleLayout' text='|Before| ' />
+        <layout type='JsonLayout'>
+          <attribute name='short date' layout='${shortdate}' />
+          <attribute name='message' layout='${message}' />
+        </layout>
+        <layout type='SimpleLayout' text=' |After|' />
+        <layout type='SimpleLayout' text='Last - ${level}' />
+      </layout>
+    </target>
+  </targets>
+  <rules>
+  </rules>
+</nlog>
+";
+
+            var config = CreateConfigurationFromString(configXml);
+
+            Assert.NotNull(config);
+            var target = config.FindTargetByName<FileTarget>("compoundFile");
+            Assert.NotNull(target);
+            var compoundLayout = target.Layout as CompoundLayout;
+            Assert.NotNull(compoundLayout);
+            var layouts = compoundLayout.Layouts;
+            Assert.NotNull(layouts);
+            Assert.Equal(5, layouts.Count);
+            Assert.Equal(typeof(SimpleLayout), layouts[0].GetType());
+            Assert.Equal(typeof(SimpleLayout), layouts[1].GetType());
+            var innerJsonLayout = (JsonLayout)layouts[2];
+            Assert.Equal(typeof(JsonLayout), innerJsonLayout.GetType());
+            Assert.Equal(2, innerJsonLayout.Attributes.Count);
+            Assert.Equal("'${shortdate}'", innerJsonLayout.Attributes[0].Layout.ToString());
+            Assert.Equal("'${message}'", innerJsonLayout.Attributes[1].Layout.ToString());
+            Assert.Equal(typeof(SimpleLayout), layouts[3].GetType());
+            Assert.Equal(typeof(SimpleLayout), layouts[4].GetType());
+
+            var logEventInfo = new LogEventInfo
+            {
+                TimeStamp = new DateTime(2010, 01, 20, 12, 34, 56),
+                Level = LogLevel.Info,
+                Message = "hello, world"
+            };
+
+            const string expected = "Long date - 2010-01-20 12:34:56.0000|Before| { \"short date\": \"2010-01-20\", \"message\": \"hello, world\" } |After|Last - Info";
+            var actual = compoundLayout.Render(logEventInfo);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -156,6 +156,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
     <Compile Include="Layouts\AllEventPropertiesTests.cs" />
+    <Compile Include="Layouts\CompoundLayoutTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -185,6 +185,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
     <Compile Include="Layouts\AllEventPropertiesTests.cs" />
+    <Compile Include="Layouts\CompoundLayoutTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -165,6 +165,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
     <Compile Include="Layouts\AllEventPropertiesTests.cs" />
+    <Compile Include="Layouts\CompoundLayoutTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -208,6 +208,7 @@
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
     <Compile Include="Layouts\AllEventPropertiesTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
+    <Compile Include="Layouts\CompoundLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />
     <Compile Include="Layouts\SimpleLayoutParserTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -178,6 +178,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
     <Compile Include="Layouts\AllEventPropertiesTests.cs" />
+    <Compile Include="Layouts\CompoundLayoutTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -180,6 +180,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
     <Compile Include="Layouts\AllEventPropertiesTests.cs" />
+    <Compile Include="Layouts\CompoundLayoutTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />


### PR DESCRIPTION
As per issue #1543 I added a CompoundLayout Layout to make it possible to use multiple nested heterogeneous layouts and create complex log entries.

Take as an example the following configuration:
```xml
<nlog>
  <targets>
    <target name='file' type='File' fileName='log.txt'>
      <layout type='CompoundLayout'>
        <layout type='SimpleLayout' text="myAmazingText: " />
        <layout type='JsonLayout'>
          <attribute name='time' layout='${longdate}' />
          <attribute name='level' layout='${level:upperCase=true}'/>
          <attribute name='nested' encode='false'  >
            <layout type='JsonLayout'>
              <attribute name='message' layout='${message}' />
              <attribute name='exception' layout='${exception}' />
            </layout>
          </attribute>
        </layout>
      </layout>
    </target>
  </targets>
  <rules>
  </rules>
</nlog>
```

Log entries would be like this:
```json
myAmazingText: { "time": "2016-10-30 13:30:55.0000", "level": "INFO", "nested": { "message": "this is message", "exception": "test" } }
```