### PR TITLE
Bugfix: Throw configException when registering invalid extension assembly/type.

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -406,7 +406,7 @@ namespace NLog.Config
 
                 if (!ignoreErrors)
                 {
-                    if (exception.MustBeRethrown())
+                    if (configurationException.MustBeRethrown())
                     {
                         throw configurationException;
                     }
@@ -915,35 +915,18 @@ namespace NLog.Config
                 string assemblyFile = addElement.GetOptionalAttribute("assemblyFile", null);
                 if (assemblyFile != null)
                 {
-                    try
-                    {
 #if SILVERLIGHT && !WINDOWS_PHONE
-                                var si = Application.GetResourceStream(new Uri(assemblyFile, UriKind.Relative));
-                                var assemblyPart = new AssemblyPart();
-                                Assembly asm = assemblyPart.Load(si.Stream);
+                    var si = Application.GetResourceStream(new Uri(assemblyFile, UriKind.Relative));
+                    var assemblyPart = new AssemblyPart();
+                    Assembly asm = assemblyPart.Load(si.Stream);
 #else
 
-                        string fullFileName = Path.Combine(baseDirectory, assemblyFile);
-                        InternalLogger.Info("Loading assembly file: {0}", fullFileName);
+                    string fullFileName = Path.Combine(baseDirectory, assemblyFile);
+                    InternalLogger.Info("Loading assembly file: {0}", fullFileName);
 
-                        Assembly asm = Assembly.LoadFrom(fullFileName);
+                    Assembly asm = Assembly.LoadFrom(fullFileName);
 #endif
-                        this.ConfigurationItemFactory.RegisterItemsFromAssembly(asm, prefix);
-                    }
-                    catch (Exception exception)
-                    {
-                        if (exception.MustBeRethrownImmediately())
-                        {
-                            throw;
-                        }
-
-                        InternalLogger.Error(exception, "Error loading extensions.");
-
-                        if (exception.MustBeRethrown())
-                        {
-                            throw new NLogConfigurationException("Error loading extensions: " + assemblyFile, exception);
-                        }
-                    }
+                    this.ConfigurationItemFactory.RegisterItemsFromAssembly(asm, prefix);
 
                     continue;
                 }
@@ -951,34 +934,17 @@ namespace NLog.Config
                 string assemblyName = addElement.GetOptionalAttribute("assembly", null);
                 if (assemblyName != null)
                 {
-                    try
-                    {
-                        InternalLogger.Info("Loading assembly name: {0}", assemblyName);
+                   
+                    InternalLogger.Info("Loading assembly name: {0}", assemblyName);
 #if SILVERLIGHT && !WINDOWS_PHONE
-                        var si = Application.GetResourceStream(new Uri(assemblyName + ".dll", UriKind.Relative));
-                        var assemblyPart = new AssemblyPart();
-                        Assembly asm = assemblyPart.Load(si.Stream);
+                    var si = Application.GetResourceStream(new Uri(assemblyName + ".dll", UriKind.Relative));
+                    var assemblyPart = new AssemblyPart();
+                    Assembly asm = assemblyPart.Load(si.Stream);
 #else
-                        Assembly asm = Assembly.Load(assemblyName);
+                    Assembly asm = Assembly.Load(assemblyName);
 #endif
 
-                        this.ConfigurationItemFactory.RegisterItemsFromAssembly(asm, prefix);
-                    }
-                    catch (Exception exception)
-                    {
-
-                        if (exception.MustBeRethrownImmediately())
-                        {
-                            throw;
-                        }
-
-                        InternalLogger.Error(exception, "Error loading extensions.");
-
-                        if (exception.MustBeRethrown())
-                        {
-                            throw new NLogConfigurationException("Error loading extensions: " + assemblyName, exception);
-                        }
-                    }
+                    this.ConfigurationItemFactory.RegisterItemsFromAssembly(asm, prefix);
                 }
             }
         }

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -286,8 +286,8 @@ namespace NLog.UnitTests.Config
             var configXml = @"
 <nlog throwConfigExceptions='true'>
     <extensions>
-        <add type='some_type_that_doesnt_exist'/>
-    </extensions>
+                <add type='some_type_that_doesnt_exist'/>
+</extensions>
 </nlog>";
             Assert.Throws<NLogConfigurationException>(()=>CreateConfigurationFromString(configXml));
         }
@@ -303,6 +303,56 @@ namespace NLog.UnitTests.Config
 </nlog>";
             Assert.Throws<NLogConfigurationException>(() => CreateConfigurationFromString(configXml));
         }
+
+        [Fact]
+        public void ExtensionShouldThrowNLogConfiguratonExceptionWhenRegisteringInvalidAssemblyFile()
+        {
+            var configXml = @"
+<nlog throwConfigExceptions='true'>
+    <extensions>
+                <add assemblyfile='some_file_that_doesnt_exist'/>
+</extensions>
+</nlog>";
+            Assert.Throws<NLogConfigurationException>(() => CreateConfigurationFromString(configXml));
+        }
+
+        [Fact]
+        public void ExtensionShouldNotThrowWhenRegisteringInvalidTypeIfThrowConfigExceptionsFalse()
+        {
+            var configXml = @"
+<nlog throwConfigExceptions='false'>
+    <extensions>
+                <add type='some_type_that_doesnt_exist'/>
+                <add assembly='NLog'/>
+</extensions>
+</nlog>";
+            CreateConfigurationFromString(configXml);
+        }
+
+        [Fact]
+        public void ExtensionShouldNotThrowWhenRegisteringInvalidAssemblyIfThrowConfigExceptionsFalse()
+        {
+            var configXml = @"
+<nlog throwConfigExceptions='false'>
+    <extensions>
+        <add assembly='some_assembly_that_doesnt_exist'/>
+    </extensions>
+</nlog>";
+            CreateConfigurationFromString(configXml);
+        }
+
+        [Fact]
+        public void ExtensionShouldNotThrowWhenRegisteringInvalidAssemblyFileIfThrowConfigExceptionsFalse()
+        {
+            var configXml = @"
+<nlog throwConfigExceptions='false'>
+    <extensions>
+                <add assemblyfile='some_file_that_doesnt_exist'/>
+</extensions>
+</nlog>";
+            CreateConfigurationFromString(configXml);
+        }
+
 
         [Fact]
         public void CustomXmlNamespaceTest()

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -281,6 +281,30 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        public void ExtensionShouldThrowNLogConfiguratonExceptionWhenRegisteringInvalidType()
+        {
+            var configXml = @"
+<nlog throwConfigExceptions='true'>
+    <extensions>
+        <add type='some_type_that_doesnt_exist'/>
+    </extensions>
+</nlog>";
+            Assert.Throws<NLogConfigurationException>(()=>CreateConfigurationFromString(configXml));
+        }
+
+        [Fact]
+        public void ExtensionShouldThrowNLogConfiguratonExceptionWhenRegisteringInvalidAssembly()
+        {
+            var configXml = @"
+<nlog throwConfigExceptions='true'>
+    <extensions>
+        <add assembly='some_assembly_that_doesnt_exist'/>
+    </extensions>
+</nlog>";
+            Assert.Throws<NLogConfigurationException>(() => CreateConfigurationFromString(configXml));
+        }
+
+        [Fact]
         public void CustomXmlNamespaceTest()
         {
             var configuration = CreateConfigurationFromString(@"

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -63,25 +63,17 @@ namespace NLog.UnitTests
         [Fact]
         public void InvalidXMLConfiguration_DoesNotThrowErrorWhen_ThrowExceptionFlagIsNotSet()
         {
-            Boolean ExceptionThrown = false;
-            try
-            {
-                LogManager.ThrowExceptions = false;
 
-                LogManager.Configuration = CreateConfigurationFromString(@"
+            LogManager.ThrowExceptions = false;
+
+            LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog internalLogToConsole='IamNotBooleanValue'>
                 <targets><target type='MethodCall' name='test' methodName='Throws' className='NLog.UnitTests.LogFactoryTests, NLog.UnitTests.netfx40' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeto='test'></logger>
                 </rules>
             </nlog>");
-            }
-            catch (Exception)
-            {
-                ExceptionThrown = true;
-            }
 
-            Assert.False(ExceptionThrown);
 
         }
 
@@ -239,7 +231,7 @@ namespace NLog.UnitTests
         public void ValueWithVariableMustNotCauseInfiniteRecursion()
         {
             LogManager.Configuration = null;
-            
+
             File.WriteAllText("NLog.config", @"
             <nlog>
                 <variable name='dir' value='c:\mylogs' />
@@ -259,7 +251,7 @@ namespace NLog.UnitTests
                 File.Delete("NLog.config");
             }
         }
-        
+
         [Fact]
         public void EnableAndDisableLogging()
         {

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -68,6 +68,7 @@ namespace NLog.UnitTests
             LogManager.Configuration = null;
             InternalLogger.Reset();
             LogManager.ThrowExceptions = false;
+            LogManager.ThrowConfigExceptions = null;
         }
 
         protected void AssertDebugCounter(string targetName, int val)


### PR DESCRIPTION
Fixes #1508. Supersedes https://github.com/NLog/NLog/pull/1517