### PR TITLE
Registering Layout renderers with func (one line needed), easier registering layout/layoutrender/targets

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -58,7 +58,7 @@ namespace NLog.Config
         private readonly IList<object> allFactories;
         private readonly Factory<Target, TargetAttribute> targets;
         private readonly Factory<Filter, FilterAttribute> filters;
-        private readonly Factory<LayoutRenderer, LayoutRendererAttribute> layoutRenderers;
+        private readonly LayoutRendererFactory layoutRenderers;
         private readonly Factory<Layout, LayoutAttribute> layouts;
         private readonly MethodFactory<ConditionMethodsAttribute, ConditionMethodAttribute> conditionMethods;
         private readonly Factory<LayoutRenderer, AmbientPropertyAttribute> ambientProperties;
@@ -73,7 +73,7 @@ namespace NLog.Config
             this.CreateInstance = FactoryHelper.CreateInstance;
             this.targets = new Factory<Target, TargetAttribute>(this);
             this.filters = new Factory<Filter, FilterAttribute>(this);
-            this.layoutRenderers = new Factory<LayoutRenderer, LayoutRendererAttribute>(this);
+            this.layoutRenderers = new LayoutRendererFactory(this);
             this.layouts = new Factory<Layout, LayoutAttribute>(this);
             this.conditionMethods = new MethodFactory<ConditionMethodsAttribute, ConditionMethodAttribute>();
             this.ambientProperties = new Factory<LayoutRenderer, AmbientPropertyAttribute>(this);
@@ -137,6 +137,16 @@ namespace NLog.Config
         public INamedItemFactory<Filter, Type> Filters
         {
             get { return this.filters; }
+        }
+
+        /// <summary>
+        /// gets the <see cref="LayoutRenderer"/> factory
+        /// </summary>
+        /// <remarks>not using <see cref="layoutRenderers"/> due to backwardscomp.</remarks>
+        /// <returns></returns>
+        internal LayoutRendererFactory GetLayoutRenderers()
+        {
+            return this.layoutRenderers;
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/FuncLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/FuncLayoutRenderer.cs
@@ -1,0 +1,84 @@
+// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Text;
+using NLog.Config;
+
+namespace NLog.LayoutRenderers
+{
+    /// <summary>
+    /// A layout renderer which could have different behavior per instance by using a <see cref="Func{TResult}"/>.
+    /// </summary>
+    public class FuncLayoutRenderer : LayoutRenderer
+    {
+        /// <summary>
+        /// Create a new.
+        /// </summary>
+        /// <param name="layoutRendererName">Name without ${}.</param>
+        /// <param name="renderMethod">Method that renders the layout.</param>
+        public FuncLayoutRenderer( string layoutRendererName, Func<LogEventInfo, LoggingConfiguration, object> renderMethod)
+        {
+            RenderMethod = renderMethod;
+            LayoutRendererName = layoutRendererName;
+        }
+
+        /// <summary>
+        /// Name used in config without ${}. E.g. "test" could be used as "${test}".
+        /// </summary>
+        public string LayoutRendererName { get; set; }
+
+        /// <summary>
+        /// Method that renders the layout. 
+        /// </summary>
+        public Func<LogEventInfo, LoggingConfiguration, object> RenderMethod { get; private set; }
+
+        #region Overrides of LayoutRenderer
+
+        /// <summary>
+        /// Renders the specified environmental information and appends it to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="logEvent">Logging event.</param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            if (RenderMethod != null)
+            {
+                builder.Append(RenderMethod(logEvent, LoggingConfiguration));
+            }
+
+        }
+
+        #endregion
+    }
+}

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -255,5 +255,52 @@ namespace NLog.LayoutRenderers
             }
             return culture;
         }
+
+        /// <summary>
+        /// Register a custom layout renderer.
+        /// </summary>
+        /// <remarks>Short-cut for registing to default <see cref="ConfigurationItemFactory"/></remarks>
+        /// <typeparam name="T"> Type of the layout renderer.</typeparam>
+        /// <param name="name"> Name of the layout renderer - without ${}.</param>
+        public static void Register<T>(string name)
+            where T: LayoutRenderer
+        {
+            var layoutRendererType = typeof(T);
+            Register(name, layoutRendererType);
+        }
+
+        /// <summary>
+        /// Register a custom layout renderer.
+        /// </summary>
+        /// <remarks>Short-cut for registing to default <see cref="ConfigurationItemFactory"/></remarks>
+        /// <param name="layoutRendererType"> Type of the layout renderer.</param>
+        /// <param name="name"> Name of the layout renderer - without ${}.</param>
+        public static void Register(string name, Type layoutRendererType)
+        {
+            ConfigurationItemFactory.Default.LayoutRenderers
+                .RegisterDefinition(name, layoutRendererType);
+        }
+
+        /// <summary>
+        /// Register a custom layout renderer with a callback function <paramref name="func"/>. The callback recieves the logEvent.
+        /// </summary>
+        /// <param name="name">Name of the layout renderer - without ${}.</param>
+        /// <param name="func">Callback that returns the value for the layout renderer.</param>
+        public static void Register(string name, Func<LogEventInfo, object> func)
+        {
+            Register(name, (info, configuration) => func(info));
+        }
+
+        /// <summary>
+        /// Register a custom layout renderer with a callback function <paramref name="func"/>. The callback recieves the logEvent and the current configuration.
+        /// </summary>
+        /// <param name="name">Name of the layout renderer - without ${}.</param>
+        /// <param name="func">Callback that returns the value for the layout renderer.</param>
+        public static void Register(string name, Func<LogEventInfo, LoggingConfiguration, object> func)
+        {
+            var layoutRenderer = new FuncLayoutRenderer(name, func);
+            
+            ConfigurationItemFactory.Default.GetLayoutRenderers().RegisterFuncLayout(name, layoutRenderer);
+        }
     }
 }

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System;
+
 namespace NLog.Layouts
 {
     using System.ComponentModel;
@@ -218,5 +220,30 @@ namespace NLog.Layouts
         /// <param name="logEvent">The logging event.</param>
         /// <returns>The rendered layout.</returns>
         protected abstract string GetFormattedMessage(LogEventInfo logEvent);
+
+        /// <summary>
+        /// Register a custom Layout.
+        /// </summary>
+        /// <remarks>Short-cut for registing to default <see cref="ConfigurationItemFactory"/></remarks>
+        /// <typeparam name="T"> Type of the Layout.</typeparam>
+        /// <param name="name"> Name of the Layout.</param>
+        public static void Register<T>(string name)
+            where T : Layout
+        {
+            var layoutRendererType = typeof(T);
+            Register(name, layoutRendererType);
+        }
+
+        /// <summary>
+        /// Register a custom Layout.
+        /// </summary>
+        /// <remarks>Short-cut for registing to default <see cref="ConfigurationItemFactory"/></remarks>
+        /// <param name="layoutType"> Type of the Layout.</param>
+        /// <param name="name"> Name of the Layout.</param>
+        public static void Register(string name, Type layoutType)
+        {
+            ConfigurationItemFactory.Default.Layouts
+                .RegisterDefinition(name, layoutType);
+        }
     }
 }

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -220,6 +220,7 @@
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\ExceptionLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\FileContentsLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\FuncLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorInfoLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorProperty.cs" />
     <Compile Include="LayoutRenderers\GdcLayoutRenderer.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -217,6 +217,7 @@
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\ExceptionLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\FileContentsLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\FuncLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorInfoLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorProperty.cs" />
     <Compile Include="LayoutRenderers\GdcLayoutRenderer.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -230,6 +230,7 @@
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\ExceptionLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\FileContentsLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\FuncLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorInfoLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorProperty.cs" />
     <Compile Include="LayoutRenderers\GdcLayoutRenderer.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -236,6 +236,7 @@
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\ExceptionLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\FileContentsLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\FuncLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorInfoLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorProperty.cs" />
     <Compile Include="LayoutRenderers\GdcLayoutRenderer.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -230,6 +230,7 @@
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\ExceptionLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\FileContentsLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\FuncLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorInfoLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorProperty.cs" />
     <Compile Include="LayoutRenderers\GdcLayoutRenderer.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -230,6 +230,7 @@
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\ExceptionLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\FileContentsLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\FuncLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorInfoLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorProperty.cs" />
     <Compile Include="LayoutRenderers\GdcLayoutRenderer.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -235,6 +235,7 @@
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\ExceptionLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\FileContentsLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\FuncLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorInfoLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorProperty.cs" />
     <Compile Include="LayoutRenderers\GdcLayoutRenderer.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -237,6 +237,7 @@
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\ExceptionLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\FileContentsLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\FuncLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorInfoLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorProperty.cs" />
     <Compile Include="LayoutRenderers\GdcLayoutRenderer.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -234,6 +234,7 @@
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\ExceptionLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\FileContentsLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\FuncLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorInfoLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorProperty.cs" />
     <Compile Include="LayoutRenderers\GdcLayoutRenderer.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -233,6 +233,7 @@
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\ExceptionLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\FileContentsLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\FuncLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorInfoLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorProperty.cs" />
     <Compile Include="LayoutRenderers\GdcLayoutRenderer.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -233,6 +233,7 @@
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\ExceptionLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\FileContentsLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\FuncLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorInfoLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorProperty.cs" />
     <Compile Include="LayoutRenderers\GdcLayoutRenderer.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -258,6 +258,7 @@
     <Compile Include="LayoutRenderers\EventPropertiesLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\ExceptionLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\FileContentsLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\FuncLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorInfoLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\GarbageCollectorProperty.cs" />
     <Compile Include="LayoutRenderers\GdcLayoutRenderer.cs" />

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -603,5 +603,30 @@ namespace NLog.Targets
                 }
             }
         }
+
+        /// <summary>
+        /// Register a custom Target.
+        /// </summary>
+        /// <remarks>Short-cut for registing to default <see cref="ConfigurationItemFactory"/></remarks>
+        /// <typeparam name="T"> Type of the Target.</typeparam>
+        /// <param name="name"> Name of the Target.</param>
+        public static void Register<T>(string name)
+            where T : Target
+        {
+            var layoutRendererType = typeof(T);
+            Register(name, layoutRendererType);
+        }
+
+        /// <summary>
+        /// Register a custom Target.
+        /// </summary>
+        /// <remarks>Short-cut for registing to default <see cref="ConfigurationItemFactory"/></remarks>
+        /// <param name="targetType"> Type of the Target.</param>
+        /// <param name="name"> Name of the Target.</param>
+        public static void Register(string name, Type targetType)
+        {
+            ConfigurationItemFactory.Default.Targets
+                .RegisterDefinition(name, targetType);
+        }
     }
 }

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -34,8 +34,10 @@
 using System.Collections;
 using System.Linq;
 using System.Threading;
+using NLog.LayoutRenderers;
 using System.Xml;
 using NLog.Config;
+using NLog.UnitTests.LayoutRenderers;
 
 #if !SILVERLIGHT
 
@@ -48,6 +50,7 @@ namespace NLog.UnitTests
     using System.Text;
     using Microsoft.CSharp;
     using Xunit;
+    using NLog.Layouts;
     using System.Collections.Generic;
 
     public class ConfigFileLocatorTests : NLogTestBase
@@ -214,6 +217,46 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        void FuncLayoutRendererRegisterTest1()
+        {
+            LayoutRenderer.Register("the-answer", (info) => "42");
+            Layout l = "${the-answer}";
+            var result = l.Render(LogEventInfo.CreateNullEvent());
+            Assert.Equal("42", result);
+
+        }
+        [Fact]
+        void FuncLayoutRendererRegisterTest1WithXML()
+        {
+            LayoutRenderer.Register("the-answer", (info) => "42");
+
+            LogManager.Configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+            
+                <targets>
+                    <target name='debug' type='Debug' layout= '${the-answer}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+            
+            var logger = LogManager.GetCurrentClassLogger();
+            logger.Debug("test1");
+            AssertDebugLastMessage("debug", "42");
+
+        }
+
+        [Fact]
+        void FuncLayoutRendererRegisterTest2()
+        {
+            LayoutRenderer.Register("message-length", (info) => info.Message.Length);
+            Layout l = "${message-length}";
+            var result = l.Render(LogEventInfo.Create(LogLevel.Error, "logger-adhoc", "1234567890"));
+            Assert.Equal("10", result);
+
+        }
+
+        [Fact]
         public void GetCandidateConfigTest()
         {
             Assert.NotNull(XmlLoggingConfiguration.GetCandidateConfigFilePaths());
@@ -251,7 +294,7 @@ namespace NLog.UnitTests
         [Fact]
         public void ResetCandidateConfigTest()
         {
-            
+
             var countBefore = XmlLoggingConfiguration.GetCandidateConfigFilePaths().Count();
             var list = new List<string> { "c:\\global\\temp.config" };
             XmlLoggingConfiguration.SetCandidateConfigFilePaths(list);
@@ -263,6 +306,10 @@ namespace NLog.UnitTests
 
         private string RunTest()
         {
+
+
+
+
             string sourceCode = @"
 using System;
 using System.Reflection;


### PR DESCRIPTION
Easier adding of Layout renderers. 

Just need one line :)

Example

``` c#
//register ${text-fixed}
LayoutRenderer.Register("test-fixed", (info) => "2");

//test
Layout l = "${test-fixed}";
var result = l.Render(LogEventInfo.CreateNullEvent());
Assert.Equal("2", result);
```

Not sure about the name and API 
## real-life example

``` C#
//register ${trace-identifier}
LayoutRenderer.Register("trace-identifier", (info) =>  HttpContext.Current.TraceIdentifier );
```
## Using logEventInfo

``` c#
LayoutRenderer.Register("message-length", (info) => info.Message.Length);
```
- [x] rename AdhocLayoutRenderer to FuncLayoutRenderer and update methods

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1581)

<!-- Reviewable:end -->
