### PR TITLE
Invalid Layout Should parse partly

### DIFF
--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -37,6 +37,7 @@ namespace NLog.UnitTests.Layouts
     using NLog.LayoutRenderers.Wrappers;
     using NLog.Layouts;
     using NLog.Targets;
+    using System;
     using Xunit;
 
     public class SimpleLayoutParserTests : NLogTestBase
@@ -500,5 +501,24 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal("1/Log_{#}.log", l.Render(le));
         }
 
+        [Fact]
+        public void InvalidLayoutWillParsePartly()
+        {
+            SimpleLayout l = @"aaa ${iDontExist} bbb";
+
+            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            Assert.Equal("aaa  bbb", l.Render(le));
+        }
+
+        [Fact]
+        public void InvalidLayoutWillThrowIfExceptionThrowingIsOn()
+        {
+            LogManager.ThrowConfigExceptions = true;
+            Assert.Throws<ArgumentException>(() =>
+            {
+                SimpleLayout l = @"aaa ${iDontExist} bbb";
+            });
+
+        }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -202,6 +202,7 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void MissingLayoutRendererTest()
         {
+            LogManager.ThrowConfigExceptions = true;
             Assert.Throws<NLogConfigurationException>(() =>
             {
                 SimpleLayout l = "${rot13:${foobar}}";


### PR DESCRIPTION
If we made a typo or forget to include some NLog extensions, there is a change that logging won't work at all! e.g. setting the Message of a filetarget on `{logger} {messagge}` (notice the typo), than the filetarget won't log anything!

This is unneeded and now we are skipping the invalid parts. The invalid parts are replace with an empty string.

If throwExceptions or throwConfigExceptions is `true`, there will be still an error thrown



<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1583)

<!-- Reviewable:end -->
