### PR TITLE
More clear internallog when reading XML config

### DIFF
--- a/src/NLog/Config/Factory.cs
+++ b/src/NLog/Config/Factory.cs
@@ -197,8 +197,20 @@ namespace NLog.Config
             {
                 return result;
             }
+            var message = typeof(TBaseType).Name + " cannot be found: '" + name + "'";
+            if (name != null)
+            {
+                //layouts but also targets
+                if (name.StartsWith("aspnet", StringComparison.OrdinalIgnoreCase) ||
+                    name.StartsWith("iis", StringComparison.OrdinalIgnoreCase))
+                {
+                    //common mistake and probably missing NLog.Web
+                    message += ". Is NLog.Web not included?";
+                }
+            }
 
-            throw new ArgumentException(typeof(TBaseType).Name + " cannot be found: '" + name + "'");
+            
+            throw new ArgumentException(message);
         }
     }
 

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -78,7 +78,7 @@ namespace NLog.Config
         private readonly Dictionary<string, bool> fileMustAutoReloadLookup = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
         private string originalFileName;
-        
+
         private LogFactory logFactory = null;
 
         private ConfigurationItemFactory ConfigurationItemFactory
@@ -421,6 +421,7 @@ namespace NLog.Config
                 InitializeSucceeded = true;
                 this.CheckParsingErrors(content);
                 this.CheckUnusedTargets();
+
             }
             catch (Exception exception)
             {
@@ -430,8 +431,8 @@ namespace NLog.Config
                     throw;
                 }
 
-                var configurationException = new NLogConfigurationException("Exception occurred when loading configuration from " + fileName, exception);
-                InternalLogger.Error(configurationException, "Error in Parsing Configuration File.");
+                var configurationException = new NLogConfigurationException(exception, "Exception when parsing {0}. ", fileName);
+                InternalLogger.Error(configurationException, "Parsing configuration from {0} failed.", fileName);
 
                 if (!ignoreErrors)
                 {
@@ -1152,8 +1153,17 @@ namespace NLog.Config
             {
                 return;
             }
-
-            PropertyHelper.SetPropertyFromString(o, element.LocalName, this.ExpandSimpleVariables(element.Value), this.ConfigurationItemFactory);
+            var value = this.ExpandSimpleVariables(element.Value);
+            try
+            {
+               
+                PropertyHelper.SetPropertyFromString(o, element.LocalName, value, this.ConfigurationItemFactory);
+            }
+            catch (NLogConfigurationException)
+            {
+                InternalLogger.Warn("Error when setting '{0}' from '<{1}>'", element.LocalName, value);
+                throw;
+            }
         }
 
         private bool AddArrayItemFromElement(object o, NLogXmlElement element)
@@ -1197,8 +1207,16 @@ namespace NLog.Config
                 {
                     continue;
                 }
+                try
+                {
+                    PropertyHelper.SetPropertyFromString(targetObject, childName, this.ExpandSimpleVariables(childValue), this.ConfigurationItemFactory);
+                }
+                catch (NLogConfigurationException)
+                {
+                    InternalLogger.Warn("Error when setting '{0}' on attibute '{1}'", childValue, childName);
+                    throw;
+                }
 
-                PropertyHelper.SetPropertyFromString(targetObject, childName, this.ExpandSimpleVariables(childValue), this.ConfigurationItemFactory);
             }
         }
 

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -168,6 +168,8 @@ namespace NLog
                         return this.config;
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+                    //load
+
                     if (this.config == null)
                     {
                         try
@@ -254,6 +256,7 @@ namespace NLog
                             }
 #endif
                             this.config.InitializeAll();
+                            
                             LogConfigurationInitialized();
                         }
                         finally

--- a/src/NLog/NLogConfigurationException.cs
+++ b/src/NLog/NLogConfigurationException.cs
@@ -73,6 +73,18 @@ namespace NLog
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="NLogRuntimeException" /> class.
+        /// </summary>
+        /// <param name="innerException">The inner exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="messageParameters">Parameters for the message</param>
+        [StringFormatMethod("message")]
+        public NLogConfigurationException(Exception innerException, string message, params object[] messageParameters)
+            : base(string.Format(message, messageParameters), innerException)
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="NLogConfigurationException" /> class.
         /// </summary>
         /// <param name="message">The message.</param>


### PR DESCRIPTION
Goals:
- More clear if there are errors
- More clear how many errors
- More clear what exactly failed and what the consequences are

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1585)
<!-- Reviewable:end -->
