### PR TITLE
[WIP] Improve FileTarget performance

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -110,11 +110,6 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         public abstract void Close();
 
-        /// <summary>
-        /// Gets the file info.
-        /// </summary>
-        /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
-        public abstract FileCharacteristics GetFileCharacteristics();
         public abstract DateTime? GetFileCreationTimeUtc();
         public abstract DateTime? GetFileLastWriteTimeUtc();
         public abstract long? GetFileLength();

--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -62,7 +62,10 @@ namespace NLog.Internal.FileAppenders
             this.FileName = fileName;
             this.OpenTime = DateTime.UtcNow; // to be consistent with timeToKill in FileTarget.AutoClosingTimerCallback
             this.LastWriteTime = DateTime.MinValue;
+            this.CaptureLastWriteTime = createParameters.CaptureLastWriteTime;
         }
+
+        protected bool CaptureLastWriteTime { get;  private set; }
 
         /// <summary>
         /// Gets the path of the file, including file extension.
@@ -140,7 +143,10 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         protected void FileTouched()
         {
-            FileTouched(DateTime.UtcNow);
+            if (CaptureLastWriteTime)
+            {
+                FileTouched(DateTime.UtcNow);
+            }
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -115,6 +115,9 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
         public abstract FileCharacteristics GetFileCharacteristics();
+        public abstract DateTime? GetFileCreationTimeUtc();
+        public abstract DateTime? GetFileLastWriteTimeUtc();
+        public abstract long? GetFileLength();
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.

--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -62,7 +62,10 @@ namespace NLog.Internal.FileAppenders
             var fileInfo = new FileInfo(fileName);
             if (fileInfo.Exists)
             {
-                FileTouched(fileInfo.GetLastWriteTimeUtc());
+                if (CaptureLastWriteTime)
+                {
+                    FileTouched(fileInfo.GetLastWriteTimeUtc());
+                }
                 this.currentFileLength = fileInfo.Length;
             }
             else

--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -131,7 +131,10 @@ namespace NLog.Internal.FileAppenders
 
             this.currentFileLength += bytes.Length;
             this.file.Write(bytes, 0, bytes.Length);
-            FileTouched();
+            if (CaptureLastWriteTime)
+            {
+                FileTouched();
+            }
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -31,6 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System;
 using System.Security;
 
 namespace NLog.Internal.FileAppenders
@@ -110,6 +111,21 @@ namespace NLog.Internal.FileAppenders
         public override FileCharacteristics GetFileCharacteristics()
         {
             return new FileCharacteristics(this.CreationTime, this.LastWriteTime, this.currentFileLength);
+        }
+
+        public override DateTime? GetFileCreationTimeUtc()
+        {
+            return this.CreationTime;
+        }
+
+        public override DateTime? GetFileLastWriteTimeUtc()
+        {
+            return this.LastWriteTime;
+        }
+
+        public override long? GetFileLength()
+        {
+            return this.currentFileLength;
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -100,15 +100,6 @@ namespace NLog.Internal.FileAppenders
             FileTouched();
         }
 
-        /// <summary>
-        /// Gets the file info.
-        /// </summary>
-        /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
-        public override FileCharacteristics GetFileCharacteristics()
-        {
-            return new FileCharacteristics(this.CreationTime, this.LastWriteTime, this.currentFileLength);
-        }
-
         public override DateTime? GetFileCreationTimeUtc()
         {
             return this.CreationTime;

--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -62,11 +62,7 @@ namespace NLog.Internal.FileAppenders
             var fileInfo = new FileInfo(fileName);
             if (fileInfo.Exists)
             {
-#if !SILVERLIGHT
-                FileTouched(fileInfo.LastWriteTimeUtc);
-#else
-                FileTouched(fileInfo.LastWriteTime);
-#endif
+                FileTouched(fileInfo.GetLastWriteTimeUtc());
                 this.currentFileLength = fileInfo.Length;
             }
             else

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -307,25 +307,6 @@ namespace NLog.Internal.FileAppenders
             }
         }
 
-        /// <summary>
-        /// Gets the file info for a particular appender.
-        /// </summary>
-        /// <param name="fileName">The file name associated with a particular appender.</param>
-        /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
-        public FileCharacteristics GetFileCharacteristics(string fileName)
-        {
-            foreach (BaseFileAppender appender in appenders)
-            {
-                if (appender == null)
-                    break;
-
-                if (appender.FileName == fileName)
-                    return appender.GetFileCharacteristics();
-            }
-
-            return null;
-        }
-
         private BaseFileAppender GetAppender(string fileName)
         {
             foreach (BaseFileAppender appender in appenders)

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -208,36 +208,16 @@ namespace NLog.Internal.FileAppenders
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
                 if (!string.IsNullOrEmpty(archiveFilePatternToWatch))
                 {
-                    var archiveFilePatternToWatchPath = GetFullPathForPattern(archiveFilePatternToWatch);
-
-                    string directoryPath = Path.GetDirectoryName(archiveFilePatternToWatchPath);
+                    string directoryPath = Path.GetDirectoryName(archiveFilePatternToWatch);
                     if (!Directory.Exists(directoryPath))
                         Directory.CreateDirectory(directoryPath);
 
-                    externalFileArchivingWatcher.Watch(archiveFilePatternToWatchPath);
+                    externalFileArchivingWatcher.Watch(archiveFilePatternToWatch);
                 }
 #endif
             }
 
             return appenderToWrite;
-        }
-
-        /// <summary>
-        /// Get fullpath for a relative file pattern,  e.g *.log 
-        /// <see cref="Path.GetFullPath"/> crashes on patterns: ArgumentException: Illegal characters in path.
-        /// </summary>
-        /// <param name="pattern"></param>
-        /// <returns></returns>
-        private static string GetFullPathForPattern(string pattern)
-        {
-            string filePattern = Path.GetFileName(pattern);
-            string dir = pattern.Substring(0, pattern.Length - filePattern.Length);
-            // Get absolute path (root+relative)
-            if (string.IsNullOrEmpty(dir))
-            {
-                dir = ".";
-            }
-            return Path.Combine(Path.GetFullPath(dir), filePattern);
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -351,11 +351,7 @@ namespace NLog.Internal.FileAppenders
                 var fileInfo = new FileInfo(filePath);
                 if (fileInfo.Exists)
                 {
-#if !SILVERLIGHT
-                    return fileInfo.CreationTimeUtc;
-#else
-                    return fileInfo.CreationTime;
-#endif
+                    return fileInfo.GetCreationTimeUtc();
                 }
             }
 
@@ -373,11 +369,7 @@ namespace NLog.Internal.FileAppenders
                 var fileInfo = new FileInfo(filePath);
                 if (fileInfo.Exists)
                 {
-#if !SILVERLIGHT
-                    return fileInfo.LastWriteTimeUtc;
-#else
-                    return fileInfo.LastWriteTime;
-#endif
+                    return fileInfo.GetLastWriteTimeUtc();
                 }
             }
 

--- a/src/NLog/Internal/FileAppenders/ICreateFileParameters.cs
+++ b/src/NLog/Internal/FileAppenders/ICreateFileParameters.cs
@@ -90,5 +90,10 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         Win32FileAttributes FileAttributes { get; }
 #endif
+
+        /// <summary>
+        /// Should we capture the last write time of a file?
+        /// </summary>
+        bool CaptureLastWriteTime { get; }
     }
 }

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -161,23 +161,27 @@ namespace NLog.Internal.FileAppenders
 
         public override DateTime? GetFileCreationTimeUtc()
         {
-            //todo
-            throw new NotImplementedException();
-          //  return this.CreationTime;
+           
+            var fileChars = GetFileCharacteristics();
+            return fileChars.CreationTimeUtc;
         }
 
         public override DateTime? GetFileLastWriteTimeUtc()
         {
-            //todo
-            throw new NotImplementedException();
-          //  return this.LastWriteTime;
+            var fileChars = GetFileCharacteristics();
+            return fileChars.LastWriteTimeUtc;
         }
 
         public override long? GetFileLength()
         {
-            //todo
-            throw new NotImplementedException();
-            //return this.currentFileLength;
+            var fileChars = GetFileCharacteristics();
+            return fileChars.FileLength;
+        }
+
+        private FileCharacteristics GetFileCharacteristics()
+        {
+            //todo not efficient to read all the whole FileCharacteristics and then using one property
+            return FileCharacteristicsHelper.Helper.GetFileCharacteristics(FileName, this.fileStream.SafeFileHandle.DangerousGetHandle());
         }
 
         private static Mutex CreateSharableMutex(string name)

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -168,6 +168,28 @@ namespace NLog.Internal.FileAppenders
             return FileCharacteristicsHelper.Helper.GetFileCharacteristics(FileName, this.fileStream.SafeFileHandle.DangerousGetHandle());
         }
 
+
+        public override DateTime? GetFileCreationTimeUtc()
+        {
+            //todo
+            throw new NotImplementedException();
+          //  return this.CreationTime;
+        }
+
+        public override DateTime? GetFileLastWriteTimeUtc()
+        {
+            //todo
+            throw new NotImplementedException();
+          //  return this.LastWriteTime;
+        }
+
+        public override long? GetFileLength()
+        {
+            //todo
+            throw new NotImplementedException();
+            //return this.currentFileLength;
+        }
+
         private static Mutex CreateSharableMutex(string name)
         {
             // Creates a mutex sharable by more than one process

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -158,16 +158,6 @@ namespace NLog.Internal.FileAppenders
             // do nothing, the stream is always flushed
         }
 
-        /// <summary>
-        /// Gets the file info.
-        /// </summary>
-        /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Runtime.InteropServices.SafeHandle.DangerousGetHandle", Justification = "Optimization")]
-        public override FileCharacteristics GetFileCharacteristics()
-        {
-            return FileCharacteristicsHelper.Helper.GetFileCharacteristics(FileName, this.fileStream.SafeFileHandle.DangerousGetHandle());
-        }
-
 
         public override DateTime? GetFileCreationTimeUtc()
         {

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -121,7 +121,10 @@ namespace NLog.Internal.FileAppenders
                 this.fileStream.Seek(0, SeekOrigin.End);
                 this.fileStream.Write(bytes, 0, bytes.Length);
                 this.fileStream.Flush();
-                FileTouched();
+                if (CaptureLastWriteTime)
+                {
+                    FileTouched();
+                }
             }
             finally
             {

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -95,11 +95,7 @@ namespace NLog.Internal.FileAppenders
             FileInfo fileInfo = new FileInfo(FileName);
             if (fileInfo.Exists)
             {
-#if !SILVERLIGHT
-                return new FileCharacteristics(fileInfo.CreationTimeUtc, fileInfo.LastWriteTimeUtc, fileInfo.Length);
-#else
-                return new FileCharacteristics(fileInfo.CreationTime, fileInfo.LastWriteTime, fileInfo.Length);
-#endif
+                return new FileCharacteristics(fileInfo.GetCreationTimeUtc(), fileInfo.GetLastWriteTimeUtc(), fileInfo.Length);
             }
             else
                 return null;
@@ -111,11 +107,7 @@ namespace NLog.Internal.FileAppenders
             FileInfo fileInfo = new FileInfo(FileName);
             if (fileInfo.Exists)
             {
-#if !SILVERLIGHT
-                return fileInfo.CreationTimeUtc;
-#else
-                return fileInfo.CreationTime;
-#endif
+                return fileInfo.GetCreationTimeUtc();
             }
             return null;
         }
@@ -125,11 +117,7 @@ namespace NLog.Internal.FileAppenders
             FileInfo fileInfo = new FileInfo(FileName);
             if (fileInfo.Exists)
             {
-#if !SILVERLIGHT
-                return fileInfo.LastWriteTimeUtc;
-#else
-                return  fileInfo.LastWriteTime;
-#endif
+                return fileInfo.GetLastWriteTimeUtc();
             }
             return null;
         }
@@ -139,11 +127,7 @@ namespace NLog.Internal.FileAppenders
             FileInfo fileInfo = new FileInfo(FileName);
             if (fileInfo.Exists)
             {
-#if !SILVERLIGHT
                 return fileInfo.Length;
-#else
-                return  fileInfo.Length;
-#endif
             }
             return null;
         }

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -67,7 +67,10 @@ namespace NLog.Internal.FileAppenders
                 fileStream.Write(bytes, 0, bytes.Length);
             }
 
-            FileTouched();
+            if (CaptureLastWriteTime)
+            {
+                FileTouched();
+            }
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -105,6 +105,49 @@ namespace NLog.Internal.FileAppenders
                 return null;
         }
 
+
+        public override DateTime? GetFileCreationTimeUtc()
+        {
+            FileInfo fileInfo = new FileInfo(FileName);
+            if (fileInfo.Exists)
+            {
+#if !SILVERLIGHT
+                return fileInfo.CreationTimeUtc;
+#else
+                return fileInfo.CreationTime;
+#endif
+            }
+            return null;
+        }
+
+        public override DateTime? GetFileLastWriteTimeUtc()
+        {
+            FileInfo fileInfo = new FileInfo(FileName);
+            if (fileInfo.Exists)
+            {
+#if !SILVERLIGHT
+                return fileInfo.LastWriteTimeUtc;
+#else
+                return  fileInfo.LastWriteTime;
+#endif
+            }
+            return null;
+        }
+
+        public override long? GetFileLength()
+        {
+            FileInfo fileInfo = new FileInfo(FileName);
+            if (fileInfo.Exists)
+            {
+#if !SILVERLIGHT
+                return fileInfo.Length;
+#else
+                return  fileInfo.Length;
+#endif
+            }
+            return null;
+        }
+
         /// <summary>
         /// Factory class.
         /// </summary>

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -86,21 +86,6 @@ namespace NLog.Internal.FileAppenders
             // nothing to do
         }
 
-        /// <summary>
-        /// Gets the file info.
-        /// </summary>
-        /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
-        public override FileCharacteristics GetFileCharacteristics()
-        {
-            FileInfo fileInfo = new FileInfo(FileName);
-            if (fileInfo.Exists)
-            {
-                return new FileCharacteristics(fileInfo.GetCreationTimeUtc(), fileInfo.GetLastWriteTimeUtc(), fileInfo.Length);
-            }
-            else
-                return null;
-        }
-
 
         public override DateTime? GetFileCreationTimeUtc()
         {

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -83,7 +83,10 @@ namespace NLog.Internal.FileAppenders
             }
 
             this.file.Write(bytes, 0, bytes.Length);
-            FileTouched();
+            if (CaptureLastWriteTime)
+            {
+                FileTouched();
+            }
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -31,6 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System;
 using System.Security;
 
 namespace NLog.Internal.FileAppenders
@@ -122,6 +123,22 @@ namespace NLog.Internal.FileAppenders
         public override FileCharacteristics GetFileCharacteristics()
         {
             return file == null ? null : new FileCharacteristics(CreationTime, LastWriteTime, file.Length);
+        }
+
+        public override DateTime? GetFileCreationTimeUtc()
+        {
+            return this.CreationTime;
+        }
+
+        public override DateTime? GetFileLastWriteTimeUtc()
+        {
+            return this.LastWriteTime;
+        }
+
+        public override long? GetFileLength()
+        {
+            if (file == null) return null;
+            return file.Length;
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -112,15 +112,6 @@ namespace NLog.Internal.FileAppenders
             this.file = null;
         }
 
-        /// <summary>
-        /// Gets the file info.
-        /// </summary>
-        /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
-        public override FileCharacteristics GetFileCharacteristics()
-        {
-            return file == null ? null : new FileCharacteristics(CreationTime, LastWriteTime, file.Length);
-        }
-
         public override DateTime? GetFileCreationTimeUtc()
         {
             return this.CreationTime;

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -56,14 +56,17 @@ namespace NLog.Internal.FileAppenders
         /// <param name="parameters">The parameters.</param>
         public SingleProcessFileAppender(string fileName, ICreateFileParameters parameters) : base(fileName, parameters)
         {
-            var fileInfo = new FileInfo(fileName);
-            if (fileInfo.Exists)
+            if (CaptureLastWriteTime)
             {
-                FileTouched(fileInfo.GetLastWriteTimeUtc());
-            }
-            else
-            {
-                FileTouched();
+                var fileInfo = new FileInfo(fileName);
+                if (fileInfo.Exists)
+                {
+                    FileTouched(fileInfo.GetLastWriteTimeUtc());
+                }
+                else
+                {
+                    FileTouched();
+                }
             }
             this.file = CreateFileStream(false);
         }

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -59,11 +59,7 @@ namespace NLog.Internal.FileAppenders
             var fileInfo = new FileInfo(fileName);
             if (fileInfo.Exists)
             {
-#if !SILVERLIGHT
-                FileTouched(fileInfo.LastWriteTimeUtc);
-#else
-                FileTouched(fileInfo.LastWriteTime);
-#endif
+                FileTouched(fileInfo.GetLastWriteTimeUtc());
             }
             else
             {

--- a/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
@@ -119,15 +119,33 @@ namespace NLog.Internal.FileAppenders
             this.file = null;
         }
 
+        public override DateTime? GetFileCreationTimeUtc()
+        {
+            FileInfo fileInfo = new FileInfo(FileName);
+            if (!fileInfo.Exists)
+                return null;
+            return fileInfo.CreationTime;
+        }
+
+        public override DateTime? GetFileLastWriteTimeUtc()
+        {
+            FileInfo fileInfo = new FileInfo(FileName);
+            if (!fileInfo.Exists)
+                return null;
+            return fileInfo.LastWriteTime;
+        }
+
+        public override long? GetFileLength()
+        {
+            FileInfo fileInfo = new FileInfo(FileName);
+            if (!fileInfo.Exists)
+                return null;
+            return fileInfo.Length;
+        }
+
         public override void Flush()
         {
             // do nothing, the stream is always flushed
-        }
-
-        public override FileCharacteristics GetFileCharacteristics()
-        {
-            FileInfo fileInfo = new FileInfo(FileName);
-            return fileInfo.Exists ? new FileCharacteristics(fileInfo.CreationTime, fileInfo.LastWriteTime, fileInfo.Length) : null;
         }
     }
 }

--- a/src/NLog/Internal/FileInfoExt.cs
+++ b/src/NLog/Internal/FileInfoExt.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NLog.Internal
+{
+    internal static class FileInfoExt
+    {
+        public static DateTime GetLastWriteTimeUtc(this FileInfo fileInfo)
+        {
+#if !SILVERLIGHT
+            return fileInfo.LastWriteTimeUtc;
+#else
+            return fileInfo.LastWriteTime;
+#endif
+        }
+        public static DateTime GetCreationTimeUtc(this FileInfo fileInfo)
+        {
+#if !SILVERLIGHT
+            return fileInfo.CreationTimeUtc;
+#else
+            return fileInfo.CreationTime;
+#endif
+        }
+
+    }
+}

--- a/src/NLog/Internal/FileInfoExt.cs
+++ b/src/NLog/Internal/FileInfoExt.cs
@@ -1,10 +1,38 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NLog.Layouts;
 
 namespace NLog.Internal
 {

--- a/src/NLog/Internal/FileInfoExt.cs
+++ b/src/NLog/Internal/FileInfoExt.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NLog.Layouts;
 
 namespace NLog.Internal
 {
@@ -25,6 +26,8 @@ namespace NLog.Internal
             return fileInfo.CreationTime;
 #endif
         }
+
+       
 
     }
 }

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -105,7 +105,7 @@ namespace NLog.Internal
                         if (cleanupInvalidChars)
                         {
                             //clean first
-                            cleanedFixedResult = CleanupInvalidFileName(cleanedFixedResult);
+                            cleanedFixedResult = CleanupInvalidFilePath(cleanedFixedResult);
                         }
                     }
 
@@ -156,7 +156,7 @@ namespace NLog.Internal
             var result = _layout.Render(logEvent);
             if (_cleanupInvalidChars)
             {
-                return CleanupInvalidFileName(result);
+                return CleanupInvalidFilePath(result);
             }
             return result;
         }
@@ -249,46 +249,46 @@ namespace NLog.Internal
             return FilePathKind.Unknown;
         }
 
-        private static string CleanupInvalidFileName(string fileName)
+        private static string CleanupInvalidFilePath(string filePath)
         {
 #if !SILVERLIGHT
-            if (StringHelpers.IsNullOrWhiteSpace(fileName))
+            if (StringHelpers.IsNullOrWhiteSpace(filePath))
             {
-                return fileName;
+                return filePath;
             }
 
 
-            var lastDirSeparator = fileName.LastIndexOfAny(DirectorySeparatorChars);
+            var lastDirSeparator = filePath.LastIndexOfAny(DirectorySeparatorChars);
 
-            var fileName1 = fileName.Substring(lastDirSeparator + 1);
+            var fileName = filePath.Substring(lastDirSeparator + 1);
             //keep the / in the dirname, because dirname could be c:/ and combine of c: and file name won't work well.
-            var dirName = lastDirSeparator > 0 ? fileName.Substring(0, lastDirSeparator + 1) : String.Empty;
+            var dirName = lastDirSeparator > 0 ? filePath.Substring(0, lastDirSeparator + 1) : String.Empty;
 
-            char[] fileName1Chars = null;
+            char[] fileNameChars = null;
 
-            for (int i = 0; i < fileName1.Length; i++)
+            for (int i = 0; i < fileName.Length; i++)
             {
-                if (InvalidFileNameChars.Contains(fileName1[i]))
+                if (InvalidFileNameChars.Contains(fileName[i]))
                 {
                     //delay char[] creation until first invalid char
                     //is found to avoid memory allocation.
-                    if (fileName1Chars == null)
-                        fileName1Chars = fileName1.ToCharArray();
-                    fileName1Chars[i] = '_';
+                    if (fileNameChars == null)
+                        fileNameChars = fileName.ToCharArray();
+                    fileNameChars[i] = '_';
                 }
             }
 
             //only if an invalid char was replaced do we create a new string.
-            if (fileName1Chars != null)
+            if (fileNameChars != null)
             {
-                fileName1 = new string(fileName1Chars);
-                return Path.Combine(dirName, fileName1);
+                fileName = new string(fileNameChars);
+                return Path.Combine(dirName, fileName);
             }
-            return fileName;
+            return filePath;
 
 
 #else
-            return fileName;
+            return filePath;
 #endif
         }
     }

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -85,6 +85,12 @@ namespace NLog.Internal
             _filePathKind = filePathKind;
             _cleanupInvalidChars = cleanupInvalidChars;
 
+            if (_layout == null)
+            {
+                _filePathKind = FilePathKind.Unknown;
+                return;
+            }
+
             //do we have to the the layout?
             if (cleanupInvalidChars || _filePathKind == FilePathKind.Unknown)
             {

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -112,7 +112,7 @@ namespace NLog.Internal
                     //detect absolute
                     if (_filePathKind == FilePathKind.Unknown)
                     {
-                        _filePathKind = DetectFilePathKind(pathLayout2, !isFixedText);
+                        _filePathKind = DetectFilePathKind(pathLayout2);
                     }
                 }
                 else
@@ -200,14 +200,15 @@ namespace NLog.Internal
                 return FilePathKind.Unknown;
             }
 
-            var containsLayoutRenderers = !pathLayout2.IsFixedText;
-
-            return DetectFilePathKind(pathLayout2, containsLayoutRenderers);
+            return DetectFilePathKind(pathLayout2);
         }
 
-        private static FilePathKind DetectFilePathKind(SimpleLayout pathLayout2, bool containsLayoutRenderers)
+        private static FilePathKind DetectFilePathKind(SimpleLayout pathLayout)
         {
-            var path = pathLayout2.OriginalText;
+            var isFixedText = pathLayout.IsFixedText;
+
+            //nb: ${basedir} has already been rewritten in the SimpleLayout.compile
+            var path = isFixedText ? pathLayout.FixedText : pathLayout.Text;
 
             if (path != null)
             {
@@ -230,17 +231,6 @@ namespace NLog.Internal
                         var secondChar = path[1];
                         if (secondChar == Path.VolumeSeparatorChar)
                             return FilePathKind.Absolute;
-
-                        //starts with template-character, and not ${basedir}
-                        if (containsLayoutRenderers && firstChar == '$' && secondChar == '{')
-                        {
-                            if (path.StartsWith("${basedir}", StringComparison.OrdinalIgnoreCase))
-                            {
-                                return FilePathKind.Absolute;
-                            }
-                            //unknown what this will render
-                            return FilePathKind.Unknown;
-                        }
                     }
 
                     //not a layout renderer, but text

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -127,6 +127,11 @@ namespace NLog.Internal
             {
                 return cleanedFixedResult;
             }
+            if (_layout == null)
+            {
+                return null;
+            }
+
             var result = _layout.Render(logEvent);
             if (_cleanupInvalidChars)
             {
@@ -138,6 +143,11 @@ namespace NLog.Internal
         public string GetAsAbsolutePath(LogEventInfo logEvent)
         {
             var rendered = Render(logEvent);
+            if (string.IsNullOrEmpty(rendered))
+            {
+                return rendered;
+            }
+
             if (_filePathKind == FilePathKind.Absolute)
             {
                 return rendered;

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -234,8 +234,9 @@ namespace NLog.Internal
                             return FilePathKind.Absolute;
 
                     }
-                    if (!isFixedText)
+                    if (!isFixedText && path.StartsWith("${", StringComparison.OrdinalIgnoreCase))
                     {
+                        //if first part is a layout, then unknown
                         return FilePathKind.Unknown;
                     }
 

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -43,7 +43,7 @@ namespace NLog.Internal
     /// <summary>
     /// A layout that represents a filePath. 
     /// </summary>
-    internal class FilePathLayout
+    internal class FilePathLayout : IRenderable
     {
         /// <summary>
         /// Cached directory separator char array to avoid memory allocation on each method call.
@@ -142,7 +142,7 @@ namespace NLog.Internal
         /// </summary>
         /// <param name="logEvent">The log event.</param>
         /// <returns>String representation of a layout.</returns>
-        private string Render(LogEventInfo logEvent)
+        private string GetCleanedFileName(LogEventInfo logEvent)
         {
             if (cleanedFixedResult != null)
             {
@@ -161,9 +161,9 @@ namespace NLog.Internal
             return result;
         }
 
-        public string GetAsAbsolutePath(LogEventInfo logEvent)
+        public string Render(LogEventInfo logEvent)
         {
-            var rendered = Render(logEvent);
+            var rendered = GetCleanedFileName(logEvent);
             if (String.IsNullOrEmpty(rendered))
             {
                 return rendered;

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -247,7 +247,7 @@ namespace NLog.Internal
         private static string CleanupInvalidFileName(string fileName)
         {
 #if !SILVERLIGHT
-            if (String.IsNullOrWhiteSpace(fileName))
+            if (StringHelpers.IsNullOrWhiteSpace(fileName))
             {
                 return fileName;
             }

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NLog.Internal.Fakeables;
+using NLog.LayoutRenderers;
+using NLog.Layouts;
+using NLog.Targets;
+
+namespace NLog.Internal
+{
+    /// <summary>
+    /// A layout that represents a filePath. 
+    /// </summary>
+    internal class FilePathLayout : IRenderable
+    {
+        private Layout _layout;
+
+        private bool? _isAbsolute;
+
+        /// <summary>
+        /// not null when <see cref="_isAbsolute"/> == <c>false</c>
+        /// </summary>
+        private string _baseDir;
+
+        /// <summary>
+        /// non null is fixed,
+        /// </summary>
+        private string cleanedFixedResult;
+
+        private bool _cleanupInvalidChars;
+
+        //TODO onInit maken
+        /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+        public FilePathLayout(Layout layout, bool cleanupInvalidChars, bool? isAbsoluteAlready)
+        {
+            _layout = layout;
+
+            _isAbsolute = isAbsoluteAlready;
+
+            _cleanupInvalidChars = cleanupInvalidChars;
+
+            if (cleanupInvalidChars || isAbsoluteAlready == null)
+            {
+                //check if fixed 
+                var pathLayout2 = layout as SimpleLayout;
+                if (pathLayout2 != null)
+                {
+                    var isFixedText = pathLayout2.IsFixedText;
+                    if (isFixedText)
+                    {
+                        cleanedFixedResult = pathLayout2.FixedText;
+                        if (cleanupInvalidChars)
+                        {
+                            //clean first
+                            cleanedFixedResult = FileTarget.CleanupInvalidFileNameChars2(cleanedFixedResult);
+                        }
+                    }
+
+                    //detect absolute
+                    if (isAbsoluteAlready == null)
+                    {
+                        _isAbsolute = IsAbsolutePath(pathLayout2, !isFixedText);
+                    }
+                }
+                else
+                {
+                    _isAbsolute = null;
+                }
+            }
+
+            if (_isAbsolute == false)
+            {
+                _baseDir = AppDomainWrapper.CurrentDomain.BaseDirectory;
+            }
+
+        }
+
+        public Layout GetLayout()
+        {
+            return _layout;
+        }
+
+        #region Implementation of IRenderable
+
+        /// <summary>
+        /// Render, as cleaned if requested.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <returns>String representation of a layout.</returns>
+        public string Render(LogEventInfo logEvent)
+        {
+            if (cleanedFixedResult != null)
+            {
+                return cleanedFixedResult;
+            }
+            var result = _layout.Render(logEvent);
+            if (_cleanupInvalidChars)
+            {
+                return FileTarget.CleanupInvalidFileNameChars2(result);
+            }
+            return result;
+        }
+
+        public string RenderAsAbsolutePath(LogEventInfo logEvent)
+        {
+            var rendered = Render(logEvent);
+            if (_isAbsolute == true)
+            {
+                return rendered;
+            }
+            else if (_isAbsolute == false)
+            {
+                return Path.Combine(_baseDir, rendered);
+                //use basedir, faster than Path.GetFullPath
+            }
+            else
+            {
+                //unknown, use slow method
+                return Path.GetFullPath(rendered);
+            }
+        }
+
+        #endregion
+
+
+        /// <summary>
+        /// Is this (templated/invalid) path an absolute, relative or unknown?
+        /// </summary>
+        /// <returns> <c>true</c> for absolute, <c>false</c> for relative, <c>null</c> for unknown </returns>
+        internal static bool? IsAbsolutePath(Layout pathLayout)
+        {
+            var pathLayout2 = pathLayout as SimpleLayout;
+            if (pathLayout2 == null)
+            {
+                return null;
+            }
+
+            var containsLayoutRenderers = !pathLayout2.IsFixedText;
+
+            return IsAbsolutePath(pathLayout2, containsLayoutRenderers);
+        }
+
+        private static bool? IsAbsolutePath(SimpleLayout pathLayout2, bool containsLayoutRenderers)
+        {
+            var path = pathLayout2.OriginalText;
+            const bool absolute = true;
+            const bool relative = false;
+
+            if (path != null)
+            {
+                path = path.TrimStart();
+
+                int length = path.Length;
+                if (length >= 1)
+                {
+                    var firstChar = path[0];
+                    if (firstChar == Path.DirectorySeparatorChar || firstChar == Path.AltDirectorySeparatorChar)
+                        return absolute;
+                    if (firstChar == '.') //. and ..
+                    {
+                        return relative;
+                    }
+
+
+                    if (length >= 2)
+                    {
+                        var secondChar = path[1];
+                        if (secondChar == Path.VolumeSeparatorChar)
+                            return absolute;
+
+                        //starts with template-character, and not ${basedir}
+                        if (containsLayoutRenderers && firstChar == '$' && secondChar == '{')
+                        {
+                            if (path.StartsWith("${basedir}", StringComparison.OrdinalIgnoreCase))
+                            {
+                                return absolute;
+                            }
+                            //unknown what this will render
+                            return null;
+                        }
+                    }
+
+                    //not a layout renderer, but text
+                    return relative;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -32,13 +32,8 @@
 // 
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NLog.Internal.Fakeables;
-using NLog.LayoutRenderers;
 using NLog.Layouts;
 using NLog.Targets;
 
@@ -47,16 +42,18 @@ namespace NLog.Internal
     /// <summary>
     /// A layout that represents a filePath. 
     /// </summary>
-    internal class FilePathLayout 
+    internal class FilePathLayout
     {
         private Layout _layout;
 
         private FilePathKind _filePathKind;
 
+#if !SILVERLIGHT
         /// <summary>
         /// not null when <see cref="_filePathKind"/> == <c>false</c>
         /// </summary>
         private string _baseDir;
+#endif
 
         /// <summary>
         /// non null is fixed,
@@ -102,11 +99,13 @@ namespace NLog.Internal
                     _filePathKind = FilePathKind.Unknown;
                 }
             }
+#if !SILVERLIGHT
 
             if (_filePathKind == FilePathKind.Relative)
             {
                 _baseDir = AppDomainWrapper.CurrentDomain.BaseDirectory;
             }
+#endif
 
         }
 
@@ -143,16 +142,16 @@ namespace NLog.Internal
             {
                 return rendered;
             }
-            else if (_filePathKind == FilePathKind.Relative)
+#if !SILVERLIGHT
+            if (_filePathKind == FilePathKind.Relative)
             {
                 return Path.Combine(_baseDir, rendered);
                 //use basedir, faster than Path.GetFullPath
             }
-            else
-            {
-                //unknown, use slow method
-                return Path.GetFullPath(rendered);
-            }
+#endif
+            //unknown, use slow method
+            return Path.GetFullPath(rendered);
+
         }
 
         #endregion

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -191,18 +191,19 @@ namespace NLog.Internal
         /// <summary>
         /// Is this (templated/invalid) path an absolute, relative or unknown?
         /// </summary>
-        /// <returns> <c>true</c> for absolute, <c>false</c> for relative, <c>null</c> for unknown </returns>
         internal static FilePathKind DetectFilePathKind(Layout pathLayout)
         {
-            var pathLayout2 = pathLayout as SimpleLayout;
-            if (pathLayout2 == null)
+            var simpleLayout = pathLayout as SimpleLayout;
+            if (simpleLayout == null)
             {
                 return FilePathKind.Unknown;
             }
 
-            return DetectFilePathKind(pathLayout2);
+            return DetectFilePathKind(simpleLayout);
         }
-
+        /// <summary>
+        /// Is this (templated/invalid) path an absolute, relative or unknown?
+        /// </summary>
         private static FilePathKind DetectFilePathKind(SimpleLayout pathLayout)
         {
             var isFixedText = pathLayout.IsFixedText;
@@ -231,7 +232,13 @@ namespace NLog.Internal
                         var secondChar = path[1];
                         if (secondChar == Path.VolumeSeparatorChar)
                             return FilePathKind.Absolute;
+
                     }
+                    if (!isFixedText)
+                    {
+                        return FilePathKind.Unknown;
+                    }
+
 
                     //not a layout renderer, but text
                     return FilePathKind.Relative;

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -1,4 +1,37 @@
-﻿using System;
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -230,7 +230,8 @@ namespace NLog.Internal
                     if (length >= 2)
                     {
                         var secondChar = path[1];
-                        if (secondChar == Path.VolumeSeparatorChar)
+                        //on unix VolumeSeparatorChar == DirectorySeparatorChar
+                        if (Path.VolumeSeparatorChar != Path.DirectorySeparatorChar && secondChar == Path.VolumeSeparatorChar)
                             return FilePathKind.Absolute;
 
                     }

--- a/src/NLog/Internal/PortableFileCharacteristicsHelper.cs
+++ b/src/NLog/Internal/PortableFileCharacteristicsHelper.cs
@@ -52,11 +52,7 @@ namespace NLog.Internal
             var fileInfo = new FileInfo(fileName);
             if (fileInfo.Exists)
             {
-#if !SILVERLIGHT
-                return new FileCharacteristics(fileInfo.CreationTimeUtc, fileInfo.LastWriteTimeUtc, fileInfo.Length);
-#else
-                return new FileCharacteristics(fileInfo.CreationTime, fileInfo.LastWriteTime, fileInfo.Length);
-#endif
+                return new FileCharacteristics(fileInfo.GetCreationTimeUtc(), fileInfo.GetLastWriteTimeUtc(), fileInfo.Length);
             }
             else
                 return null;

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -118,12 +118,19 @@ namespace NLog.Layouts
 
                 LayoutRenderer[] renderers;
                 string txt;
-
-                renderers = LayoutParser.CompileLayout(
-                    this.configurationItemFactory,
-                    new SimpleStringReader(value),
-                    false,
-                    out txt);
+                if (value == null)
+                {
+                    renderers = new LayoutRenderer[0];
+                    txt = string.Empty;
+                }
+                else
+                {
+                    renderers = LayoutParser.CompileLayout(
+                       this.configurationItemFactory,
+                       new SimpleStringReader(value),
+                       false,
+                       out txt);
+                }
 
                 this.SetRenderers(renderers, txt);
             }
@@ -163,6 +170,8 @@ namespace NLog.Layouts
         /// <returns>A <see cref="SimpleLayout"/> object.</returns>
         public static implicit operator SimpleLayout(string text)
         {
+            if (text == null) return null;
+
             return new SimpleLayout(text);
         }
 

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -148,6 +148,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -352,6 +354,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -145,6 +145,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -349,6 +351,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -158,6 +158,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -362,6 +364,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -164,6 +164,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -368,6 +370,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -158,6 +158,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -362,6 +364,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -158,6 +158,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -362,6 +364,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -370,6 +370,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,8 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <TargetFrameworkProfile></TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -294,6 +293,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />
@@ -305,7 +305,6 @@
     <Compile Include="Layouts\LayoutParser.cs" />
     <Compile Include="Layouts\LayoutWithHeaderAndFooter.cs" />
     <Compile Include="Layouts\Log4JXmlEventLayout.cs" />
-    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\SimpleLayout.cs" />
     <Compile Include="LogEventInfo.cs" />
     <Compile Include="LogFactory.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
     <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -165,6 +165,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -369,6 +371,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -162,6 +162,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -366,6 +368,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -161,6 +161,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -365,6 +367,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -161,6 +161,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -365,6 +367,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -186,6 +186,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -390,6 +392,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/Targets/FilePathKind.cs
+++ b/src/NLog/Targets/FilePathKind.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NLog.Targets
+{
+    /// <summary>
+    /// Type of filepath
+    /// </summary>
+    public enum FilePathKind : byte
+    {
+        /// <summary>
+        /// Detect of relative or absolute
+        /// </summary>
+        Unknown,
+        /// <summary>
+        /// Relative path
+        /// </summary>
+        Relative,
+
+        /// <summary>
+        /// Absolute path
+        /// </summary>
+        /// <remarks>Best for performance</remarks>
+        Absolute
+    }
+}

--- a/src/NLog/Targets/FilePathKind.cs
+++ b/src/NLog/Targets/FilePathKind.cs
@@ -1,8 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
 
 namespace NLog.Targets
 {

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1637,14 +1637,14 @@ namespace NLog.Targets
 
             InternalLogger.Trace("Calculating archive date. Last write time: {0}; Previous log event time: {1}", lastWriteTime, previousLogEventTimestamp);
 
-            bool previousLogIsMoreRecent = (previousLogEventTimestamp.HasValue) && (previousLogEventTimestamp.Value > lastWriteTime);
+            bool previousLogIsMoreRecent = previousLogEventTimestamp.HasValue && (previousLogEventTimestamp.Value > lastWriteTime);
             if (previousLogIsMoreRecent)
             {
                 InternalLogger.Trace("Using previous log event time (is more recent)");
                 return previousLogEventTimestamp.Value;
             }
 
-            if (PreviousLogOverlappedPeriod(logEvent, lastWriteTimeUtc.Value))
+            if (previousLogEventTimestamp.HasValue && PreviousLogOverlappedPeriod(logEvent, lastWriteTime))
             {
                 InternalLogger.Trace("Using previous log event time (previous log overlapped period)");
                 return previousLogEventTimestamp.Value;
@@ -1654,13 +1654,13 @@ namespace NLog.Targets
             return lastWriteTime;
         }
 
-        private bool PreviousLogOverlappedPeriod(LogEventInfo logEvent, DateTime lastWriteTimeUtc)
+        private bool PreviousLogOverlappedPeriod(LogEventInfo logEvent, DateTime lastWrite)
         {
             if (!previousLogEventTimestamp.HasValue)
                 return false;
 
             string formatString = GetArchiveDateFormatString(string.Empty);
-            string lastWriteTimeString = TimeSource.Current.FromSystemTime(lastWriteTimeUtc).ToString(formatString, CultureInfo.InvariantCulture);
+            string lastWriteTimeString = lastWrite.ToString(formatString, CultureInfo.InvariantCulture);
             string logEventTimeString = logEvent.TimeStamp.ToString(formatString, CultureInfo.InvariantCulture);
 
             if (lastWriteTimeString != logEventTimeString)

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -75,7 +75,7 @@ namespace NLog.Targets
         /// </summary>
         private const int ArchiveAboveSizeDisabled = -1;
 
-       
+
         /// <summary>
         /// Holds the initialised files each given time by the <see cref="FileTarget"/> instance. Against each file, the last write time is stored. 
         /// </summary>
@@ -939,19 +939,12 @@ namespace NLog.Targets
             }
         }
 
-        internal string GetCleanedFileName(LogEventInfo logEvent)
-        {		
-            if (this.fileName == null)		
-            {		
-                return null;		
-            }
-            return this.fileName.GetAsAbsolutePath(logEvent);
-        }
 
-    /// <summary>
-    /// Closes the file(s) opened for writing.
-    /// </summary>
-    protected override void CloseTarget()
+
+        /// <summary>
+        /// Closes the file(s) opened for writing.
+        /// </summary>
+        protected override void CloseTarget()
         {
             base.CloseTarget();
 
@@ -982,6 +975,15 @@ namespace NLog.Targets
             var fileName = this.GetCleanedFileName(logEvent);
             byte[] bytes = this.GetBytesToWrite(logEvent);
             ProcessLogEvent(logEvent, fileName, bytes);
+        }
+
+        internal string GetCleanedFileName(LogEventInfo logEvent)
+        {
+            if (this.fileName == null)
+            {
+                return null;
+            }
+            return this.fileName.GetAsAbsolutePath(logEvent);
         }
 
         /// <summary>
@@ -1026,6 +1028,8 @@ namespace NLog.Targets
                 }
             }
         }
+
+
 
         private void ProcessLogEvent(LogEventInfo logEvent, string fileName, byte[] bytesToWrite)
         {

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -377,7 +377,21 @@ namespace NLog.Targets
         /// <docgen category='Output Options' order='10' />
         [Advanced]
         public Win32FileAttributes FileAttributes { get; set; }
+
+
 #endif
+
+        /// <summary>
+        /// Should we capture the last write time of a file?
+        /// </summary>
+        bool ICreateFileParameters.CaptureLastWriteTime
+        {
+            get
+            {
+                return ArchiveNumbering == ArchiveNumberingMode.Date ||
+                       ArchiveNumbering == ArchiveNumberingMode.DateAndSequence;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the line ending mode.

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -123,12 +123,12 @@ namespace NLog.Targets
         /// <summary>
         /// The filename as target
         /// </summary>
-        private FilePathLayout fileName;
+        private FilePathLayout fullFileName;
 
         /// <summary>
         /// The archive file name as target
         /// </summary>
-        private FilePathLayout archiveFileName;
+        private FilePathLayout fullarchiveFileName;
 
         private FileArchivePeriod archiveEvery;
         private long archiveAboveSize;
@@ -230,14 +230,14 @@ namespace NLog.Targets
         {
             get
             {
-                if (fileName == null) return null;
+                if (fullFileName == null) return null;
 
-                return fileName.GetLayout();
+                return fullFileName.GetLayout();
             }
             set
             {
 
-                fileName = CreateFileNameLayout(value);
+                fullFileName = CreateFileNameLayout(value);
 
                 if (IsInitialized)
                 {
@@ -270,8 +270,8 @@ namespace NLog.Targets
             set
             {
                 _cleanupFileName = value;
-                fileName = CreateFileNameLayout(FileName);
-                archiveFileName = CreateFileNameLayout(ArchiveFileName);
+                fullFileName = CreateFileNameLayout(FileName);
+                fullarchiveFileName = CreateFileNameLayout(ArchiveFileName);
             }
         }
 
@@ -288,7 +288,7 @@ namespace NLog.Targets
             {
 
                 _fileNameKind = value;
-                fileName = CreateFileNameLayout(FileName);
+                fullFileName = CreateFileNameLayout(FileName);
             }
         }
 
@@ -595,7 +595,7 @@ namespace NLog.Targets
             set
             {
                 _archiveFileKind = value;
-                archiveFileName = CreateFileNameLayout(ArchiveFileName);
+                fullarchiveFileName = CreateFileNameLayout(ArchiveFileName);
             }
         }
 
@@ -613,13 +613,13 @@ namespace NLog.Targets
         {
             get
             {
-                if (archiveFileName == null) return null;
+                if (fullarchiveFileName == null) return null;
 
-                return archiveFileName.GetLayout();
+                return fullarchiveFileName.GetLayout();
             }
             set
             {
-                archiveFileName = CreateFileNameLayout(value);
+                fullarchiveFileName = CreateFileNameLayout(value);
                 if (IsInitialized)
                 {
                     //don't call before initialized because this could lead to stackoverflows.
@@ -972,18 +972,18 @@ namespace NLog.Targets
         /// <param name="logEvent">The logging event.</param>
         protected override void Write(LogEventInfo logEvent)
         {
-            var fileName = this.GetCleanedFileName(logEvent);
+            var fullFileName = this.GetCleanedFileName(logEvent);
             byte[] bytes = this.GetBytesToWrite(logEvent);
-            ProcessLogEvent(logEvent, fileName, bytes);
+            ProcessLogEvent(logEvent, fullFileName, bytes);
         }
 
         internal string GetCleanedFileName(LogEventInfo logEvent)
         {
-            if (this.fileName == null)
+            if (this.fullFileName == null)
             {
                 return null;
             }
-            return this.fileName.GetAsAbsolutePath(logEvent);
+            return this.fullFileName.Render(logEvent);
         }
 
         /// <summary>
@@ -1740,7 +1740,7 @@ namespace NLog.Targets
         /// <returns>A string with a pattern that will match the archive filenames</returns>
         private string GetArchiveFileNamePattern(string fileName, LogEventInfo eventInfo)
         {
-            if (this.archiveFileName == null)
+            if (this.fullarchiveFileName == null)
             {
                 string ext = EnableArchiveFileCompression ? ".zip" : Path.GetExtension(fileName);
                 return Path.ChangeExtension(fileName, ".{#}" + ext);
@@ -1750,7 +1750,7 @@ namespace NLog.Targets
                 //The archive file name is given. There are two possibilities
                 //(1) User supplied the Filename with pattern
                 //(2) User supplied the normal filename
-                string archiveFileName = this.archiveFileName.GetAsAbsolutePath(eventInfo);
+                string archiveFileName = this.fullarchiveFileName.Render(eventInfo);
                 return archiveFileName;
             }
         }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -2026,6 +2026,9 @@ namespace NLog.Targets
         /// <param name="appender">File appender associated with the file.</param>
         private void WriteHeader(BaseFileAppender appender)
         {
+            //performance: cheap check before checking file info 
+            if (Header == null) return;
+
             //todo replace with hasWritten?
             var length = appender.GetFileLength();
             //  Write header only on empty files or if file info cannot be obtained.
@@ -2053,7 +2056,7 @@ namespace NLog.Targets
             {
                 return null;
             }
-
+            //todo remove 
             string renderedText = layout.Render(LogEventInfo.CreateNullEvent()) + this.NewLineChars;
             return this.TransformBytes(this.Encoding.GetBytes(renderedText));
         }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -2117,6 +2117,11 @@ namespace NLog.Targets
         internal static string CleanupInvalidFileNameChars2(string fileName)
         {
 #if !SILVERLIGHT
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return fileName;
+            }
+
 
             var lastDirSeparator = fileName.LastIndexOfAny(DirectorySeparatorChars);
 

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -2071,12 +2071,16 @@ namespace NLog.Targets
         /// <returns>The cleaned up file name without any invalid characters.</returns>
         private string CleanupInvalidFileNameChars(string fileName)
         {
-
             if (!this.CleanupFileName)
             {
                 return fileName;
             }
 
+            return CleanupInvalidFileNameChars2(fileName);
+        }
+
+        internal static string CleanupInvalidFileNameChars2(string fileName)
+        {
 #if !SILVERLIGHT
 
             var lastDirSeparator = fileName.LastIndexOfAny(DirectorySeparatorChars);

--- a/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
+++ b/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
@@ -173,13 +173,18 @@ namespace NLog.UnitTests.Internal.FileAppenders
         {
             // Invoke GetFileCharacteristics() on an Empty FileAppenderCache.
             FileAppenderCache emptyCache = FileAppenderCache.Empty;
-            Assert.Null(emptyCache.GetFileCharacteristics("file.txt"));
+            Assert.Null(emptyCache.GetFileCreationTimeUtc("file.txt", false));
+            Assert.Null(emptyCache.GetFileLastWriteTimeUtc("file.txt", false));
+            Assert.Null(emptyCache.GetFileLength("file.txt", false));
 
             IFileAppenderFactory appenderFactory = SingleProcessFileAppender.TheFactory;
             ICreateFileParameters fileTarget = new FileTarget();
             FileAppenderCache cache = new FileAppenderCache(3, appenderFactory, fileTarget);
             // Invoke GetFileCharacteristics() on non-empty FileAppenderCache - Before allocating any appenders. 
-            Assert.Null(cache.GetFileCharacteristics("file.txt"));
+            Assert.Null(emptyCache.GetFileCreationTimeUtc("file.txt", false));
+            Assert.Null(emptyCache.GetFileLastWriteTimeUtc("file.txt", false));
+            Assert.Null(emptyCache.GetFileLength("file.txt", false));
+
 
             String tempFile = Path.Combine(
                     Path.GetTempPath(),
@@ -196,10 +201,16 @@ namespace NLog.UnitTests.Internal.FileAppenders
             //
 
             // File information should be returned.
-            var fileCharacteristics = cache.GetFileCharacteristics(tempFile);
-            Assert.NotNull(fileCharacteristics);
-            Assert.NotEqual(DateTime.MinValue, fileCharacteristics.CreationTimeUtc);
-            Assert.Equal(34, fileCharacteristics.FileLength);
+           
+            var fileCreationTimeUtc = cache.GetFileCreationTimeUtc(tempFile, false);
+            Assert.NotNull(fileCreationTimeUtc);
+            Assert.True(fileCreationTimeUtc > DateTime.UtcNow.AddMinutes(-2),"creationtime is wrong");
+
+            var fileLastWriteTimeUtc = cache.GetFileLastWriteTimeUtc(tempFile, false);
+            Assert.NotNull(fileLastWriteTimeUtc);
+            Assert.True(fileLastWriteTimeUtc > DateTime.UtcNow.AddMinutes(-2), "lastwrite is wrong");
+
+            Assert.Equal(34, cache.GetFileLength(tempFile, false));
 
             // Clean up.
             appender.Flush();

--- a/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
+++ b/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
@@ -178,7 +178,8 @@ namespace NLog.UnitTests.Internal.FileAppenders
             Assert.Null(emptyCache.GetFileLength("file.txt", false));
 
             IFileAppenderFactory appenderFactory = SingleProcessFileAppender.TheFactory;
-            ICreateFileParameters fileTarget = new FileTarget();
+            ICreateFileParameters fileTarget = new FileTarget() {ArchiveNumbering = ArchiveNumberingMode.Date};
+           
             FileAppenderCache cache = new FileAppenderCache(3, appenderFactory, fileTarget);
             // Invoke GetFileCharacteristics() on non-empty FileAppenderCache - Before allocating any appenders. 
             Assert.Null(emptyCache.GetFileCreationTimeUtc("file.txt", false));

--- a/tests/NLog.UnitTests/Internal/FilePathLayoutTests.cs
+++ b/tests/NLog.UnitTests/Internal/FilePathLayoutTests.cs
@@ -1,0 +1,79 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using NLog.Layouts;
+
+#if !SILVERLIGHT //xunit2
+
+namespace NLog.UnitTests.Internal
+{
+    using NLog.Targets;
+
+    using Xunit;
+    using Xunit.Extensions;
+    using NLog.Internal;
+
+    public class FilePathLayoutTests : NLogTestBase
+    {
+        [Theory]
+        [InlineData(@"", FilePathKind.Unknown)]
+        [InlineData(@" ", FilePathKind.Unknown)]
+        [InlineData(null, FilePathKind.Unknown)]
+        [InlineData(@"d:\test.log", FilePathKind.Absolute)]
+        [InlineData(@"d:\test", FilePathKind.Absolute)]
+        [InlineData(@" d:\test", FilePathKind.Absolute)]
+        [InlineData(@" d:\ test", FilePathKind.Absolute)]
+        [InlineData(@" d:\ test", FilePathKind.Absolute)]
+        [InlineData(@" d:\ test\a", FilePathKind.Absolute)]
+        [InlineData(@"\ test\a", FilePathKind.Absolute)]
+        [InlineData(@"\\test\a", FilePathKind.Absolute)]
+        [InlineData(@"test.log", FilePathKind.Relative)]
+        [InlineData(@"test", FilePathKind.Relative)]
+        [InlineData(@" test.log ", FilePathKind.Relative)]
+        [InlineData(@" test.log ", FilePathKind.Relative)]
+        [InlineData(@".test.log ", FilePathKind.Relative)]
+        [InlineData(@"..test.log ", FilePathKind.Relative)]
+        [InlineData(@" .. test.log ", FilePathKind.Relative)]
+        [InlineData(@"${basedir}\test.log ", FilePathKind.Absolute)]
+        [InlineData(@"${BASEDIR}\test.log ", FilePathKind.Absolute)]
+        [InlineData(@"${BASEDIR}\test ", FilePathKind.Absolute)]
+        public void DetectFilePathKind(string path, FilePathKind expected)
+        {
+            Layout layout = path;
+            var result = FilePathLayout.DetectFilePathKind(layout);
+            Assert.Equal(expected, result);
+        }
+
+    }
+}
+#endif

--- a/tests/NLog.UnitTests/Internal/FilePathLayoutTests.cs
+++ b/tests/NLog.UnitTests/Internal/FilePathLayoutTests.cs
@@ -50,10 +50,11 @@ namespace NLog.UnitTests.Internal
         [InlineData(@" ", FilePathKind.Unknown)]
         [InlineData(null, FilePathKind.Unknown)]
 #if !MONO 
+
+        //no forwardslash on mono
         [InlineData(@"d:\test.log", FilePathKind.Absolute)]
         [InlineData(@"d:\test", FilePathKind.Absolute)]
         [InlineData(@" d:\test", FilePathKind.Absolute)]
-        [InlineData(@" d:\ test", FilePathKind.Absolute)]
         [InlineData(@" d:\ test", FilePathKind.Absolute)]
         [InlineData(@" d:\ test\a", FilePathKind.Absolute)]
         [InlineData(@"\\test\a", FilePathKind.Absolute)]
@@ -66,7 +67,6 @@ namespace NLog.UnitTests.Internal
 
         [InlineData(@"test.log", FilePathKind.Relative)]
         [InlineData(@"test", FilePathKind.Relative)]
-        [InlineData(@" test.log ", FilePathKind.Relative)]
         [InlineData(@" test.log ", FilePathKind.Relative)]
         [InlineData(@" a/test.log ", FilePathKind.Relative)]
 

--- a/tests/NLog.UnitTests/Internal/FilePathLayoutTests.cs
+++ b/tests/NLog.UnitTests/Internal/FilePathLayoutTests.cs
@@ -63,13 +63,13 @@ namespace NLog.UnitTests.Internal
 #endif
 
         [InlineData(@"/ test\a", FilePathKind.Absolute)]
-       
+
         [InlineData(@"test.log", FilePathKind.Relative)]
         [InlineData(@"test", FilePathKind.Relative)]
         [InlineData(@" test.log ", FilePathKind.Relative)]
         [InlineData(@" test.log ", FilePathKind.Relative)]
         [InlineData(@" a/test.log ", FilePathKind.Relative)]
-      
+
         [InlineData(@".test.log ", FilePathKind.Relative)]
         [InlineData(@"..test.log ", FilePathKind.Relative)]
         [InlineData(@" .. test.log ", FilePathKind.Relative)]
@@ -84,6 +84,12 @@ namespace NLog.UnitTests.Internal
         [InlineData(@"${BASEDIR}/test ", FilePathKind.Absolute)]
         [InlineData(@"${BASEDIR}/test ", FilePathKind.Absolute)]
         [InlineData(@"${level}/test ", FilePathKind.Unknown)]
+        [InlineData(@" ${level}/test ", FilePathKind.Unknown)]
+        [InlineData(@" 
+${level}/test ", FilePathKind.Unknown)]
+        [InlineData(@"dir 
+${level}/test ", FilePathKind.Relative)]
+        [InlineData(@"dir${level}/test ", FilePathKind.Relative)]
         public void DetectFilePathKind(string path, FilePathKind expected)
         {
             Layout layout = path;

--- a/tests/NLog.UnitTests/Internal/FilePathLayoutTests.cs
+++ b/tests/NLog.UnitTests/Internal/FilePathLayoutTests.cs
@@ -49,24 +49,32 @@ namespace NLog.UnitTests.Internal
         [InlineData(@"", FilePathKind.Unknown)]
         [InlineData(@" ", FilePathKind.Unknown)]
         [InlineData(null, FilePathKind.Unknown)]
+#if !MONO 
         [InlineData(@"d:\test.log", FilePathKind.Absolute)]
         [InlineData(@"d:\test", FilePathKind.Absolute)]
         [InlineData(@" d:\test", FilePathKind.Absolute)]
         [InlineData(@" d:\ test", FilePathKind.Absolute)]
         [InlineData(@" d:\ test", FilePathKind.Absolute)]
         [InlineData(@" d:\ test\a", FilePathKind.Absolute)]
+#endif
         [InlineData(@"\ test\a", FilePathKind.Absolute)]
+        [InlineData(@"/ test\a", FilePathKind.Absolute)]
         [InlineData(@"\\test\a", FilePathKind.Absolute)]
+        [InlineData(@"\\test/a", FilePathKind.Absolute)]
         [InlineData(@"test.log", FilePathKind.Relative)]
         [InlineData(@"test", FilePathKind.Relative)]
         [InlineData(@" test.log ", FilePathKind.Relative)]
         [InlineData(@" test.log ", FilePathKind.Relative)]
+        [InlineData(@" a/test.log ", FilePathKind.Relative)]
+        [InlineData(@" a\test.log ", FilePathKind.Relative)]
         [InlineData(@".test.log ", FilePathKind.Relative)]
         [InlineData(@"..test.log ", FilePathKind.Relative)]
         [InlineData(@" .. test.log ", FilePathKind.Relative)]
         [InlineData(@"${basedir}\test.log ", FilePathKind.Absolute)]
         [InlineData(@"${BASEDIR}\test.log ", FilePathKind.Absolute)]
         [InlineData(@"${BASEDIR}\test ", FilePathKind.Absolute)]
+        [InlineData(@"${BASEDIR}\test ", FilePathKind.Absolute)]
+        [InlineData(@"${level}\test ", FilePathKind.Unknown)]
         public void DetectFilePathKind(string path, FilePathKind expected)
         {
             Layout layout = path;

--- a/tests/NLog.UnitTests/Internal/FilePathLayoutTests.cs
+++ b/tests/NLog.UnitTests/Internal/FilePathLayoutTests.cs
@@ -56,17 +56,20 @@ namespace NLog.UnitTests.Internal
         [InlineData(@" d:\ test", FilePathKind.Absolute)]
         [InlineData(@" d:\ test", FilePathKind.Absolute)]
         [InlineData(@" d:\ test\a", FilePathKind.Absolute)]
-#endif
-        [InlineData(@"\ test\a", FilePathKind.Absolute)]
-        [InlineData(@"/ test\a", FilePathKind.Absolute)]
         [InlineData(@"\\test\a", FilePathKind.Absolute)]
         [InlineData(@"\\test/a", FilePathKind.Absolute)]
+        [InlineData(@"\ test\a", FilePathKind.Absolute)]
+        [InlineData(@" a\test.log ", FilePathKind.Relative)]
+#endif
+
+        [InlineData(@"/ test\a", FilePathKind.Absolute)]
+       
         [InlineData(@"test.log", FilePathKind.Relative)]
         [InlineData(@"test", FilePathKind.Relative)]
         [InlineData(@" test.log ", FilePathKind.Relative)]
         [InlineData(@" test.log ", FilePathKind.Relative)]
         [InlineData(@" a/test.log ", FilePathKind.Relative)]
-        [InlineData(@" a\test.log ", FilePathKind.Relative)]
+      
         [InlineData(@".test.log ", FilePathKind.Relative)]
         [InlineData(@"..test.log ", FilePathKind.Relative)]
         [InlineData(@" .. test.log ", FilePathKind.Relative)]
@@ -75,6 +78,12 @@ namespace NLog.UnitTests.Internal
         [InlineData(@"${BASEDIR}\test ", FilePathKind.Absolute)]
         [InlineData(@"${BASEDIR}\test ", FilePathKind.Absolute)]
         [InlineData(@"${level}\test ", FilePathKind.Unknown)]
+
+        [InlineData(@"${basedir}/test.log ", FilePathKind.Absolute)]
+        [InlineData(@"${BASEDIR}/test.log ", FilePathKind.Absolute)]
+        [InlineData(@"${BASEDIR}/test ", FilePathKind.Absolute)]
+        [InlineData(@"${BASEDIR}/test ", FilePathKind.Absolute)]
+        [InlineData(@"${level}/test ", FilePathKind.Unknown)]
         public void DetectFilePathKind(string path, FilePathKind expected)
         {
             Layout layout = path;

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Internal\EnumHelpersTests.cs" />
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
+    <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Internal\EnumHelpersTests.cs" />
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
+    <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Internal\EnumHelpersTests.cs" />
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
+    <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,10 +9,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <ApplicationIcon></ApplicationIcon>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -207,8 +205,8 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
     <Compile Include="Layouts\AllEventPropertiesTests.cs" />
-    <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\CompoundLayoutTests.cs" />
+    <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />
     <Compile Include="Layouts\SimpleLayoutParserTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,10 +9,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <ApplicationIcon></ApplicationIcon>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -208,8 +206,8 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
     <Compile Include="Layouts\AllEventPropertiesTests.cs" />
-    <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\CompoundLayoutTests.cs" />
+    <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />
     <Compile Include="Layouts\SimpleLayoutParserTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -157,6 +159,7 @@
     <Compile Include="Internal\EnumHelpersTests.cs" />
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
+    <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
@@ -205,8 +208,8 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
     <Compile Include="Layouts\AllEventPropertiesTests.cs" />
-    <Compile Include="Layouts\CompoundLayoutTests.cs" />
     <Compile Include="Layouts\CsvLayoutTests.cs" />
+    <Compile Include="Layouts\CompoundLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />
     <Compile Include="Layouts\SimpleLayoutParserTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Internal\EnumHelpersTests.cs" />
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
+    <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Internal\EnumHelpersTests.cs" />
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
+    <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -2715,7 +2715,7 @@ namespace NLog.UnitTests.Targets
             var filePathLayout = new FilePathLayout(invalidFileName,true, FilePathKind.Absolute);
 
 
-            var path = filePathLayout.GetAsAbsolutePath(LogEventInfo.CreateNullEvent());
+            var path = filePathLayout.Render(LogEventInfo.CreateNullEvent());
             Assert.Equal(expectedFileName, path);
         }
 

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -46,6 +46,7 @@ namespace NLog.UnitTests.Targets
 
     using Mocks;
     using NLog.Config;
+    using NLog.Internal;
     using NLog.Layouts;
     using NLog.Targets;
     using NLog.Targets.Wrappers;
@@ -2710,7 +2711,11 @@ namespace NLog.UnitTests.Targets
             //CleanupFileName is default true;
             var fileTarget = new FileTarget();
             fileTarget.FileName = invalidFileName;
-            var path = fileTarget.GetCleanedFileName(LogEventInfo.CreateNullEvent());
+
+            var filePathLayout = new FilePathLayout(invalidFileName,true, FilePathKind.Absolute);
+
+
+            var path = filePathLayout.GetAsAbsolutePath(LogEventInfo.CreateNullEvent());
             Assert.Equal(expectedFileName, path);
         }
 


### PR DESCRIPTION
Fixes https://github.com/NLog/NLog-Performance-tests/issues/1

## Steps:

- [x] Replace `GetFileCharacteristics` with three methods: `GetFileCreationTimeUtc`, `GetFileLastWriteTimeUtc` and `GetFileLength`
- [ ] Remove `FileCharacteristics` class (failed)
- [x] Improve amount of calls to `GetFileCreationTimeUtc`, `GetFileLastWriteTimeUtc` and `GetFileLength`
- [x] Double check that `new FileInfo` isn't done in too many places
- [x] Improve `Path.GetFullPath()` usage (cache, on setter etc), make it optional?
- [x] Optimize / remove `FileTouched`
- [x] Tell `BaseFileAppender` if we need `LastWriteTime` (saves stuff)
- [x] Cleanup silverlight stuff (add helpers)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1593)
<!-- Reviewable:end -->
