### PR TITLE
Performance tweak

### DIFF
--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -268,6 +268,9 @@ namespace NLog
         {
             FilterResult result = FilterResult.Neutral;
 
+            if (filterChain == null || filterChain.Count == 0)
+                return result;
+
             try
             {
                 //Memory profiling pointed out that using a foreach-loop was allocating


### PR DESCRIPTION
if list is empty, skipping creating for loop and stepping into try. 

Seem to have an impact of 2-5% faster when writing a lot to the null target