### PR TITLE
[WIP] Improve FileTarget performance #2

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -62,7 +62,10 @@ namespace NLog.Internal.FileAppenders
             this.FileName = fileName;
             this.OpenTime = DateTime.UtcNow; // to be consistent with timeToKill in FileTarget.AutoClosingTimerCallback
             this.LastWriteTime = DateTime.MinValue;
+            this.CaptureLastWriteTime = createParameters.CaptureLastWriteTime;
         }
+
+        protected bool CaptureLastWriteTime { get;  private set; }
 
         /// <summary>
         /// Gets the path of the file, including file extension.
@@ -142,7 +145,10 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         protected void FileTouched()
         {
-            FileTouched(DateTime.UtcNow);
+            if (CaptureLastWriteTime)
+            {
+                FileTouched(DateTime.UtcNow);
+            }
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -116,6 +116,7 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Gets the file info.
         /// </summary>
+        /// <remarks>This is an expensive call</remarks>
         /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
         public abstract FileCharacteristics GetFileCharacteristics();
 

--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -31,6 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System;
 using System.Security;
 
 namespace NLog.Internal.FileAppenders
@@ -61,11 +62,10 @@ namespace NLog.Internal.FileAppenders
             var fileInfo = new FileInfo(fileName);
             if (fileInfo.Exists)
             {
-#if !SILVERLIGHT
-                FileTouched(fileInfo.LastWriteTimeUtc);
-#else
-                FileTouched(fileInfo.LastWriteTime);
-#endif
+                if (CaptureLastWriteTime)
+                {
+                    FileTouched(fileInfo.GetLastWriteTimeUtc());
+                }
                 this.currentFileLength = fileInfo.Length;
             }
             else

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -290,6 +290,7 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Gets the file info for a particular appender.
         /// </summary>
+        /// <remarks>This is an expensive call</remarks>
         /// <param name="fileName">The file name associated with a particular appender.</param>
         /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
         public FileCharacteristics GetFileCharacteristics(string fileName)

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -89,7 +89,7 @@ namespace NLog.Internal.FileAppenders
             if ((e.ChangeType & WatcherChangeTypes.Created) == WatcherChangeTypes.Created)
                 logFileWasArchived = true;
         }
-        
+
         /// <summary>
         /// The archive file path pattern that is used to detect when archiving occurs.
         /// </summary>
@@ -208,36 +208,16 @@ namespace NLog.Internal.FileAppenders
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
                 if (!string.IsNullOrEmpty(archiveFilePatternToWatch))
                 {
-                    var archiveFilePatternToWatchPath = GetFullPathForPattern(archiveFilePatternToWatch);
-
-                    string directoryPath = Path.GetDirectoryName(archiveFilePatternToWatchPath);
+                    string directoryPath = Path.GetDirectoryName(archiveFilePatternToWatch);
                     if (!Directory.Exists(directoryPath))
                         Directory.CreateDirectory(directoryPath);
 
-                    externalFileArchivingWatcher.Watch(archiveFilePatternToWatchPath);
+                    externalFileArchivingWatcher.Watch(archiveFilePatternToWatch);
                 }
 #endif
             }
 
             return appenderToWrite;
-        }
-
-        /// <summary>
-        /// Get fullpath for a relative file pattern,  e.g *.log 
-        /// <see cref="Path.GetFullPath"/> crashes on patterns: ArgumentException: Illegal characters in path.
-        /// </summary>
-        /// <param name="pattern"></param>
-        /// <returns></returns>
-        private static string GetFullPathForPattern(string pattern)
-        {
-            string filePattern = Path.GetFileName(pattern);
-            string dir = pattern.Substring(0, pattern.Length - filePattern.Length);
-            // Get absolute path (root+relative)
-            if (string.IsNullOrEmpty(dir))
-            {
-                dir = ".";
-            }
-            return  Path.Combine(Path.GetFullPath(dir), filePattern);
         }
 
         /// <summary>
@@ -329,8 +309,8 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Closes the specified appender and removes it from the list. 
         /// </summary>
-        /// <param name="fileName">File name of the appender to be closed.</param>
-        public void InvalidateAppender(string fileName)
+        /// <param name="filePath">File name of the appender to be closed.</param>
+        public void InvalidateAppender(string filePath)
         {
             for (int i = 0; i < appenders.Length; ++i)
             {
@@ -339,7 +319,7 @@ namespace NLog.Internal.FileAppenders
                     break;
                 }
 
-                if (appenders[i].FileName == fileName)
+                if (appenders[i].FileName == filePath)
                 {
                     CloseAppender(appenders[i]);
                     for (int j = i; j < appenders.Length - 1; ++j)

--- a/src/NLog/Internal/FileAppenders/ICreateFileParameters.cs
+++ b/src/NLog/Internal/FileAppenders/ICreateFileParameters.cs
@@ -90,5 +90,10 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         Win32FileAttributes FileAttributes { get; }
 #endif
+
+        /// <summary>
+        /// Should we capture the last write time of a file?
+        /// </summary>
+        bool CaptureLastWriteTime { get; }
     }
 }

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -95,14 +95,9 @@ namespace NLog.Internal.FileAppenders
             FileInfo fileInfo = new FileInfo(FileName);
             if (fileInfo.Exists)
             {
-#if !SILVERLIGHT
-                return new FileCharacteristics(fileInfo.CreationTimeUtc, fileInfo.LastWriteTimeUtc, fileInfo.Length);
-#else
-                return new FileCharacteristics(fileInfo.CreationTime, fileInfo.LastWriteTime, fileInfo.Length);
-#endif
+                return fileInfo.GetCreationTimeUtc();
             }
-            else
-                return null;
+            return null;
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -95,7 +95,7 @@ namespace NLog.Internal.FileAppenders
             FileInfo fileInfo = new FileInfo(FileName);
             if (fileInfo.Exists)
             {
-                return fileInfo.GetCreationTimeUtc();
+                return new FileCharacteristics(fileInfo.GetCreationTimeUtc(), fileInfo.GetLastWriteTimeUtc(), fileInfo.Length);
             }
             return null;
         }

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -31,6 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System;
 using System.Security;
 
 namespace NLog.Internal.FileAppenders
@@ -55,18 +56,17 @@ namespace NLog.Internal.FileAppenders
         /// <param name="parameters">The parameters.</param>
         public SingleProcessFileAppender(string fileName, ICreateFileParameters parameters) : base(fileName, parameters)
         {
-            var fileInfo = new FileInfo(fileName);
-            if (fileInfo.Exists)
+            if (CaptureLastWriteTime)
             {
-#if !SILVERLIGHT
-                FileTouched(fileInfo.LastWriteTimeUtc);
-#else
-                FileTouched(fileInfo.LastWriteTime);
-#endif
-            }
-            else
-            {
-                FileTouched();
+                var fileInfo = new FileInfo(fileName);
+                if (fileInfo.Exists)
+                {
+                    FileTouched(fileInfo.GetLastWriteTimeUtc());
+                }
+                else
+                {
+                    FileTouched();
+                }
             }
             this.file = CreateFileStream(false);
         }

--- a/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
@@ -129,7 +129,7 @@ namespace NLog.Internal.FileAppenders
             FileInfo fileInfo = new FileInfo(FileName);
             return fileInfo.Exists ? new FileCharacteristics(fileInfo.CreationTime, fileInfo.LastWriteTime, fileInfo.Length) : null;
         }
-        }
-        }
+    }
+}
 
 #endif

--- a/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
@@ -129,7 +129,7 @@ namespace NLog.Internal.FileAppenders
             FileInfo fileInfo = new FileInfo(FileName);
             return fileInfo.Exists ? new FileCharacteristics(fileInfo.CreationTime, fileInfo.LastWriteTime, fileInfo.Length) : null;
         }
-    }
-}
+        }
+        }
 
 #endif

--- a/src/NLog/Internal/FileInfoExt.cs
+++ b/src/NLog/Internal/FileInfoExt.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,31 +31,31 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System;
+using System.IO;
+
 namespace NLog.Internal
 {
-    using System;
-    using System.IO;
-
-    /// <summary>
-    /// Portable implementation of <see cref="FileCharacteristicsHelper"/>.
-    /// </summary>
-    internal class PortableFileCharacteristicsHelper : FileCharacteristicsHelper
+    internal static class FileInfoExt
     {
-        /// <summary>
-        /// Gets the information about a file.
-        /// </summary>
-        /// <param name="fileName">Name of the file.</param>
-        /// <param name="fileHandle">The file handle.</param>
-        /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
-        public override FileCharacteristics GetFileCharacteristics(string fileName, IntPtr fileHandle)
+        public static DateTime GetLastWriteTimeUtc(this FileInfo fileInfo)
         {
-            var fileInfo = new FileInfo(fileName);
-            if (fileInfo.Exists)
-            {
-                return new FileCharacteristics(fileInfo.GetCreationTimeUtc(), fileInfo.GetLastWriteTimeUtc(), fileInfo.Length);
-            }
-            else
-                return null;
+#if !SILVERLIGHT
+            return fileInfo.LastWriteTimeUtc;
+#else
+            return fileInfo.LastWriteTime;
+#endif
         }
+        public static DateTime GetCreationTimeUtc(this FileInfo fileInfo)
+        {
+#if !SILVERLIGHT
+            return fileInfo.CreationTimeUtc;
+#else
+            return fileInfo.CreationTime;
+#endif
+        }
+
+       
+
     }
 }

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -1,0 +1,294 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using NLog.Internal.Fakeables;
+using NLog.Layouts;
+using NLog.Targets;
+
+namespace NLog.Internal
+{
+    /// <summary>
+    /// A layout that represents a filePath. 
+    /// </summary>
+    internal class FilePathLayout : IRenderable
+    {
+        /// <summary>
+        /// Cached directory separator char array to avoid memory allocation on each method call.
+        /// </summary>
+        private readonly static char[] DirectorySeparatorChars = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
+#if !SILVERLIGHT
+
+        /// <summary>
+        /// Cached invalid filenames char array to avoid memory allocation everytime Path.GetInvalidFileNameChars() is called.
+        /// </summary>
+        private readonly static HashSet<char> InvalidFileNameChars = new HashSet<char>(Path.GetInvalidFileNameChars());
+
+#endif 
+
+        private Layout _layout;
+
+        private FilePathKind _filePathKind;
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// not null when <see cref="_filePathKind"/> == <c>false</c>
+        /// </summary>
+        private string _baseDir;
+#endif
+
+        /// <summary>
+        /// non null is fixed,
+        /// </summary>
+        private string cleanedFixedResult;
+
+        private bool _cleanupInvalidChars;
+
+        //TODO onInit maken
+        /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+        public FilePathLayout(Layout layout, bool cleanupInvalidChars, FilePathKind filePathKind)
+        {
+            _layout = layout;
+            _filePathKind = filePathKind;
+            _cleanupInvalidChars = cleanupInvalidChars;
+
+            if (_layout == null)
+            {
+                _filePathKind = FilePathKind.Unknown;
+                return;
+            }
+
+            //do we have to the the layout?
+            if (cleanupInvalidChars || _filePathKind == FilePathKind.Unknown)
+            {
+                //check if fixed 
+                var pathLayout2 = layout as SimpleLayout;
+                if (pathLayout2 != null)
+                {
+                    var isFixedText = pathLayout2.IsFixedText;
+                    if (isFixedText)
+                    {
+                        cleanedFixedResult = pathLayout2.FixedText;
+                        if (cleanupInvalidChars)
+                        {
+                            //clean first
+                            cleanedFixedResult = CleanupInvalidFileName(cleanedFixedResult);
+                        }
+                    }
+
+                    //detect absolute
+                    if (_filePathKind == FilePathKind.Unknown)
+                    {
+                        _filePathKind = DetectFilePathKind(pathLayout2);
+                    }
+                }
+                else
+                {
+                    _filePathKind = FilePathKind.Unknown;
+                }
+            }
+#if !SILVERLIGHT
+
+            if (_filePathKind == FilePathKind.Relative)
+            {
+                _baseDir = AppDomainWrapper.CurrentDomain.BaseDirectory;
+            }
+#endif
+
+        }
+
+        public Layout GetLayout()
+        {
+            return _layout;
+        }
+
+        #region Implementation of IRenderable
+
+        /// <summary>
+        /// Render, as cleaned if requested.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <returns>String representation of a layout.</returns>
+        private string GetCleanedFileName(LogEventInfo logEvent)
+        {
+            if (cleanedFixedResult != null)
+            {
+                return cleanedFixedResult;
+            }
+            if (_layout == null)
+            {
+                return null;
+            }
+
+            var result = _layout.Render(logEvent);
+            if (_cleanupInvalidChars)
+            {
+                return CleanupInvalidFileName(result);
+            }
+            return result;
+        }
+
+        public string Render(LogEventInfo logEvent)
+        {
+            var rendered = GetCleanedFileName(logEvent);
+            if (String.IsNullOrEmpty(rendered))
+            {
+                return rendered;
+            }
+
+            if (_filePathKind == FilePathKind.Absolute)
+            {
+                return rendered;
+            }
+#if !SILVERLIGHT
+            if (_filePathKind == FilePathKind.Relative)
+            {
+                return Path.Combine(_baseDir, rendered);
+                //use basedir, faster than Path.GetFullPath
+            }
+#endif
+            //unknown, use slow method
+            return Path.GetFullPath(rendered);
+
+        }
+
+        #endregion
+
+
+        /// <summary>
+        /// Is this (templated/invalid) path an absolute, relative or unknown?
+        /// </summary>
+        internal static FilePathKind DetectFilePathKind(Layout pathLayout)
+        {
+            var simpleLayout = pathLayout as SimpleLayout;
+            if (simpleLayout == null)
+            {
+                return FilePathKind.Unknown;
+            }
+
+            return DetectFilePathKind(simpleLayout);
+        }
+        /// <summary>
+        /// Is this (templated/invalid) path an absolute, relative or unknown?
+        /// </summary>
+        private static FilePathKind DetectFilePathKind(SimpleLayout pathLayout)
+        {
+            var isFixedText = pathLayout.IsFixedText;
+
+            //nb: ${basedir} has already been rewritten in the SimpleLayout.compile
+            var path = isFixedText ? pathLayout.FixedText : pathLayout.Text;
+
+            if (path != null)
+            {
+                path = path.TrimStart();
+
+                int length = path.Length;
+                if (length >= 1)
+                {
+                    var firstChar = path[0];
+                    if (firstChar == Path.DirectorySeparatorChar || firstChar == Path.AltDirectorySeparatorChar)
+                        return FilePathKind.Absolute;
+                    if (firstChar == '.') //. and ..
+                    {
+                        return FilePathKind.Relative;
+                    }
+
+
+                    if (length >= 2)
+                    {
+                        var secondChar = path[1];
+                        if (secondChar == Path.VolumeSeparatorChar)
+                            return FilePathKind.Absolute;
+
+                    }
+                    if (!isFixedText && path.StartsWith("${", StringComparison.OrdinalIgnoreCase))
+                    {
+                        //if first part is a layout, then unknown
+                        return FilePathKind.Unknown;
+                    }
+
+
+                    //not a layout renderer, but text
+                    return FilePathKind.Relative;
+                }
+            }
+            return FilePathKind.Unknown;
+        }
+
+        private static string CleanupInvalidFileName(string fileName)
+        {
+#if !SILVERLIGHT
+            if (StringHelpers.IsNullOrWhiteSpace(fileName))
+            {
+                return fileName;
+            }
+
+
+            var lastDirSeparator = fileName.LastIndexOfAny(DirectorySeparatorChars);
+
+            var fileName1 = fileName.Substring(lastDirSeparator + 1);
+            //keep the / in the dirname, because dirname could be c:/ and combine of c: and file name won't work well.
+            var dirName = lastDirSeparator > 0 ? fileName.Substring(0, lastDirSeparator + 1) : String.Empty;
+
+            char[] fileName1Chars = null;
+
+            for (int i = 0; i < fileName1.Length; i++)
+            {
+                if (InvalidFileNameChars.Contains(fileName1[i]))
+                {
+                    //delay char[] creation until first invalid char
+                    //is found to avoid memory allocation.
+                    if (fileName1Chars == null)
+                        fileName1Chars = fileName1.ToCharArray();
+                    fileName1Chars[i] = '_';
+                }
+            }
+
+            //only if an invalid char was replaced do we create a new string.
+            if (fileName1Chars != null)
+            {
+                fileName1 = new string(fileName1Chars);
+                return Path.Combine(dirName, fileName1);
+            }
+            return fileName;
+
+
+#else
+            return fileName;
+#endif
+        }
+    }
+}

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -118,12 +118,19 @@ namespace NLog.Layouts
 
                 LayoutRenderer[] renderers;
                 string txt;
-
-                renderers = LayoutParser.CompileLayout(
-                    this.configurationItemFactory,
-                    new SimpleStringReader(value),
-                    false,
-                    out txt);
+                if (value == null)
+                {
+                    renderers = new LayoutRenderer[0];
+                    txt = string.Empty;
+                }
+                else
+                {
+                    renderers = LayoutParser.CompileLayout(
+                       this.configurationItemFactory,
+                       new SimpleStringReader(value),
+                       false,
+                       out txt);
+                }
 
                 this.SetRenderers(renderers, txt);
             }
@@ -163,6 +170,8 @@ namespace NLog.Layouts
         /// <returns>A <see cref="SimpleLayout"/> object.</returns>
         public static implicit operator SimpleLayout(string text)
         {
+            if (text == null) return null;
+
             return new SimpleLayout(text);
         }
 

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -148,6 +148,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -352,6 +354,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -145,6 +145,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -349,6 +351,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -158,6 +158,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -362,6 +364,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -164,6 +164,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -368,6 +370,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -158,6 +158,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -362,6 +364,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -158,6 +158,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -362,6 +364,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,8 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <TargetFrameworkProfile></TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -164,6 +163,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -292,6 +293,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
+    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />
     <Compile Include="Layouts\CsvColumnDelimiterMode.cs" />
     <Compile Include="Layouts\CsvLayout.cs" />
@@ -303,7 +305,6 @@
     <Compile Include="Layouts\LayoutParser.cs" />
     <Compile Include="Layouts\LayoutWithHeaderAndFooter.cs" />
     <Compile Include="Layouts\Log4JXmlEventLayout.cs" />
-    <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\SimpleLayout.cs" />
     <Compile Include="LogEventInfo.cs" />
     <Compile Include="LogFactory.cs" />
@@ -368,6 +369,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -165,6 +165,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -369,6 +371,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -162,6 +162,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -366,6 +368,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -161,6 +161,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -365,6 +367,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -161,6 +161,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -365,6 +367,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -186,6 +186,8 @@
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileCharacteristics.cs" />
     <Compile Include="Internal\FileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\FileInfoExt.cs" />
+    <Compile Include="Internal\FilePathLayout.cs" />
     <Compile Include="Internal\FormatHelper.cs" />
     <Compile Include="Internal\IConfigurationManager.cs" />
     <Compile Include="Internal\IRenderable.cs" />
@@ -390,6 +392,7 @@
     <Compile Include="Targets\EventLogTarget.cs" />
     <Compile Include="Targets\EventLogTargetOverflowAction.cs" />
     <Compile Include="Targets\FileArchivePeriod.cs" />
+    <Compile Include="Targets\FilePathKind.cs" />
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />

--- a/src/NLog/Targets/FilePathKind.cs
+++ b/src/NLog/Targets/FilePathKind.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,31 +31,26 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.Internal
+namespace NLog.Targets
 {
-    using System;
-    using System.IO;
-
     /// <summary>
-    /// Portable implementation of <see cref="FileCharacteristicsHelper"/>.
+    /// Type of filepath
     /// </summary>
-    internal class PortableFileCharacteristicsHelper : FileCharacteristicsHelper
+    public enum FilePathKind : byte
     {
         /// <summary>
-        /// Gets the information about a file.
+        /// Detect of relative or absolute
         /// </summary>
-        /// <param name="fileName">Name of the file.</param>
-        /// <param name="fileHandle">The file handle.</param>
-        /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
-        public override FileCharacteristics GetFileCharacteristics(string fileName, IntPtr fileHandle)
-        {
-            var fileInfo = new FileInfo(fileName);
-            if (fileInfo.Exists)
-            {
-                return new FileCharacteristics(fileInfo.GetCreationTimeUtc(), fileInfo.GetLastWriteTimeUtc(), fileInfo.Length);
-            }
-            else
-                return null;
-        }
+        Unknown,
+        /// <summary>
+        /// Relative path
+        /// </summary>
+        Relative,
+
+        /// <summary>
+        /// Absolute path
+        /// </summary>
+        /// <remarks>Best for performance</remarks>
+        Absolute
     }
 }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1643,7 +1643,7 @@ namespace NLog.Targets
                 return previousLogEventTimestamp.Value;
             }
 
-            if (previousLogEventTimestamp.HasValue && PreviousLogOverlappedPeriod(logEvent, fileCharacteristics.LastWriteTimeUtc))
+            if (previousLogEventTimestamp.HasValue && PreviousLogOverlappedPeriod(logEvent, lastWriteTime))
             {
                 InternalLogger.Trace("Using previous log event time (previous log overlapped period)");
                 return previousLogEventTimestamp.Value;
@@ -1653,13 +1653,13 @@ namespace NLog.Targets
             return lastWriteTime;
         }
 
-        private bool PreviousLogOverlappedPeriod(LogEventInfo logEvent, DateTime lastWriteTimeUtc)
+        private bool PreviousLogOverlappedPeriod(LogEventInfo logEvent, DateTime lastWriteTime)
         {
             if (!previousLogEventTimestamp.HasValue)
                 return false;
 
             string formatString = GetArchiveDateFormatString(string.Empty);
-            string lastWriteTimeString = TimeSource.Current.FromSystemTime(lastWriteTimeUtc).ToString(formatString, CultureInfo.InvariantCulture);
+            string lastWriteTimeString = lastWriteTime.ToString(formatString, CultureInfo.InvariantCulture);
             string logEventTimeString = logEvent.TimeStamp.ToString(formatString, CultureInfo.InvariantCulture);
 
             if (lastWriteTimeString != logEventTimeString)

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1807,7 +1807,7 @@ namespace NLog.Targets
                 return fileName;
             }
             
-            var fileLength = fileCharacteristics?.FileLength;
+            var fileLength = fileCharacteristics != null ? fileCharacteristics.FileLength : (long?) null;
             string fileToArchive = fileLength != null ? fileName : previousLogFileName;
             return fileToArchive;
         }
@@ -1833,7 +1833,7 @@ namespace NLog.Targets
                 return null;
             }
 
-            var length = fileCharacteristics?.FileLength;
+            var length = fileCharacteristics != null ? fileCharacteristics.FileLength : (long?) null;
             if (length == null)
             {
                 return null;
@@ -1869,7 +1869,7 @@ namespace NLog.Targets
                 return null;
             }
 
-            var creationTimeUtc = fileCharacteristics?.CreationTimeUtc;
+            var creationTimeUtc = fileCharacteristics != null ? fileCharacteristics.CreationTimeUtc : (DateTime?) null;
             if (creationTimeUtc == null)
             {
                 return null;
@@ -2127,7 +2127,7 @@ namespace NLog.Targets
             if (Header == null) return;
 
             //todo replace with hasWritten?
-            var length = appender.GetFileCharacteristics()?.FileLength;
+            var length = appender.GetFileCharacteristics() != null ? appender.GetFileCharacteristics().FileLength : (long?) null;
             //  Write header only on empty files or if file info cannot be obtained.
             if (length == null || length == 0)
             {

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -75,19 +75,7 @@ namespace NLog.Targets
         /// </summary>
         private const int ArchiveAboveSizeDisabled = -1;
 
-        /// <summary>
-        /// Cached directory separator char array to avoid memory allocation on each method call.
-        /// </summary>
-        private readonly static char[] DirectorySeparatorChars = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
 
-#if !SILVERLIGHT
-
-        /// <summary>
-        /// Cached invalid filenames char array to avoid memory allocation everytime Path.GetInvalidFileNameChars() is called.
-        /// </summary>
-        private readonly static HashSet<char> InvalidFileNameChars = new HashSet<char>(Path.GetInvalidFileNameChars());
-
-#endif 
         /// <summary>
         /// Holds the initialised files each given time by the <see cref="FileTarget"/> instance. Against each file, the last write time is stored. 
         /// </summary>
@@ -135,22 +123,17 @@ namespace NLog.Targets
         /// <summary>
         /// The filename as target
         /// </summary>
-        private Layout fileName;
+        private FilePathLayout fullFileName;
 
         /// <summary>
         /// The archive file name as target
         /// </summary>
-        private Layout archiveFileName;
+        private FilePathLayout fullarchiveFileName;
 
         private FileArchivePeriod archiveEvery;
         private long archiveAboveSize;
 
         private bool enableArchiveFileCompression;
-
-        /// <summary>
-        /// The filename if <see cref="FileName"/> is a fixed string
-        /// </summary>
-        private string cachedCleanedFileNamed;
 
         /// <summary>
         /// The date of the previous log event.
@@ -164,6 +147,9 @@ namespace NLog.Targets
 
         private bool concurrentWrites;
         private bool keepFileOpen;
+        private bool _cleanupFileName;
+        private FilePathKind _fileNameKind;
+        private FilePathKind _archiveFileKind;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FileTarget" /> class.
@@ -242,16 +228,19 @@ namespace NLog.Targets
         [RequiredParameter]
         public Layout FileName
         {
-            get { return fileName; }
+            get
+            {
+                if (fullFileName == null) return null;
+
+                return fullFileName.GetLayout();
+            }
             set
             {
 
-                fileName = value;
+                fullFileName = CreateFileNameLayout(value);
 
                 if (IsInitialized)
                 {
-                    SetCachedCleanedFileNamed(value);
-
                     //don't call before initialized because this could lead to stackoverflows.
                     RefreshFileArchive();
                     RefreshArchiveFilePatternToWatch();
@@ -259,34 +248,49 @@ namespace NLog.Targets
             }
         }
 
-        private void SetCachedCleanedFileNamed(Layout value)
+        private FilePathLayout CreateFileNameLayout(Layout value)
         {
-            var simpleLayout = value as SimpleLayout;
-            if (simpleLayout != null && simpleLayout.IsFixedText)
-            {
-                cachedCleanedFileNamed = CleanupInvalidFileNameChars(simpleLayout.FixedText);
-            }
-            else
-            {
-                //clear cache
-                cachedCleanedFileNamed = null;
-            }
+            if (value == null)
+                return null;
 
-            fileName = value;
-
-            if (IsInitialized)
-            {
-                RefreshFileArchive();
-                RefreshArchiveFilePatternToWatch();
-            }
+            return new FilePathLayout(value, CleanupFileName, FileNameKind);
         }
+
 
         /// <summary>
         /// Cleanup invalid values in a filename, e.g. slashes in a filename. If set to <c>true</c>, this can impact the performance of massive writes. 
         /// If set to <c>false</c>, nothing gets written when the filename is wrong.
         /// </summary>
         [DefaultValue(true)]
-        public bool CleanupFileName { get; set; }
+        public bool CleanupFileName
+
+
+        {
+            get { return _cleanupFileName; }
+            set
+            {
+                _cleanupFileName = value;
+                fullFileName = CreateFileNameLayout(FileName);
+                fullarchiveFileName = CreateFileNameLayout(ArchiveFileName);
+            }
+        }
+
+        /// <summary>
+        /// Is the  <see cref="FileName"/> an absolute or relative path?
+        /// </summary>
+        [DefaultValue(FilePathKind.Unknown)]
+        public FilePathKind FileNameKind
+
+
+        {
+            get { return _fileNameKind; }
+            set
+            {
+
+                _fileNameKind = value;
+                fullFileName = CreateFileNameLayout(FileName);
+            }
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether to create directories if they do not exist.
@@ -364,7 +368,21 @@ namespace NLog.Targets
         /// <docgen category='Output Options' order='10' />
         [Advanced]
         public Win32FileAttributes FileAttributes { get; set; }
+
+
 #endif
+
+        /// <summary>
+        /// Should we capture the last write time of a file?
+        /// </summary>
+        bool ICreateFileParameters.CaptureLastWriteTime
+        {
+            get
+            {
+                return ArchiveNumbering == ArchiveNumberingMode.Date ||
+                       ArchiveNumbering == ArchiveNumberingMode.DateAndSequence;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the line ending mode.
@@ -569,6 +587,19 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Is the  <see cref="ArchiveFileName"/> an absolute or relative path?
+        /// </summary>
+        public FilePathKind ArchiveFileKind
+        {
+            get { return _archiveFileKind; }
+            set
+            {
+                _archiveFileKind = value;
+                fullarchiveFileName = CreateFileNameLayout(ArchiveFileName);
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the name of the file to be used for an archive.
         /// </summary>
         /// <remarks>
@@ -580,10 +611,15 @@ namespace NLog.Targets
         /// <docgen category='Archival Options' order='10' />
         public Layout ArchiveFileName
         {
-            get { return archiveFileName; }
+            get
+            {
+                if (fullarchiveFileName == null) return null;
+
+                return fullarchiveFileName.GetLayout();
+            }
             set
             {
-                archiveFileName = value;
+                fullarchiveFileName = CreateFileNameLayout(value);
                 if (IsInitialized)
                 {
                     //don't call before initialized because this could lead to stackoverflows.
@@ -664,7 +700,7 @@ namespace NLog.Targets
         private void RefreshFileArchive()
         {
             var nullEvent = LogEventInfo.CreateNullEvent();
-            string fileNamePattern = GetArchiveFileNamePattern(GetCleanedFileName(nullEvent), nullEvent);
+            string fileNamePattern = GetArchiveFileNamePattern(GetFullFileName(nullEvent), nullEvent);
             if (fileNamePattern == null)
             {
                 InternalLogger.Debug("no RefreshFileArchive because fileName is NULL");
@@ -706,10 +742,11 @@ namespace NLog.Targets
                 if (mustWatchArchiving)
                 {
                     var nullEvent = LogEventInfo.CreateNullEvent();
-                    string fileNamePattern = GetArchiveFileNamePattern(GetCleanedFileName(nullEvent), nullEvent);
+                    string fileNamePattern = GetArchiveFileNamePattern(GetFullFileName(nullEvent), nullEvent);
                     if (!string.IsNullOrEmpty(fileNamePattern))
                     {
                         fileNamePattern = Path.Combine(Path.GetDirectoryName(fileNamePattern), ReplaceFileNamePattern(fileNamePattern, "*"));
+                        //fileNamePattern is absolute
                         this.fileAppenderCache.ArchiveFilePatternToWatch = fileNamePattern;
 
                         if ((EnableArchiveFileCompression) && (this.appenderInvalidatorThread == null))
@@ -887,7 +924,6 @@ namespace NLog.Targets
         {
             base.InitializeTarget();
 
-            SetCachedCleanedFileNamed(FileName);
             RefreshFileArchive();
             this.appenderFactory = GetFileAppenderFactory();
 
@@ -903,6 +939,8 @@ namespace NLog.Targets
                     this.OpenFileCacheTimeout * 1000);
             }
         }
+
+
 
         /// <summary>
         /// Closes the file(s) opened for writing.
@@ -935,18 +973,23 @@ namespace NLog.Targets
         /// <param name="logEvent">The logging event.</param>
         protected override void Write(LogEventInfo logEvent)
         {
-            var fileName = Path.GetFullPath(GetCleanedFileName(logEvent));
+            var fullFileName = this.GetFullFileName(logEvent);
             byte[] bytes = this.GetBytesToWrite(logEvent);
-            ProcessLogEvent(logEvent, fileName, bytes);
+            ProcessLogEvent(logEvent, fullFileName, bytes);
         }
 
-        internal string GetCleanedFileName(LogEventInfo logEvent)
+        /// <summary>
+        /// Get full filename (=absolute) and cleaned if needed.
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns></returns>
+        internal string GetFullFileName(LogEventInfo logEvent)
         {
-            if (this.FileName == null)
+            if (this.fullFileName == null)
             {
                 return null;
             }
-            return cachedCleanedFileNamed ?? CleanupInvalidFileNameChars(this.FileName.Render(logEvent));
+            return this.fullFileName.Render(logEvent);
         }
 
         /// <summary>
@@ -961,14 +1004,14 @@ namespace NLog.Targets
         /// </remarks>
         protected override void Write(AsyncLogEventInfo[] logEvents)
         {
-            var buckets = logEvents.BucketSort(c => this.FileName.Render(c.LogEvent));
+            var buckets = logEvents.BucketSort(c => this.GetFullFileName(c.LogEvent));
             using (var ms = new MemoryStream())
             {
                 var pendingContinuations = new List<AsyncContinuation>();
 
                 foreach (var bucket in buckets)
                 {
-                    string fileName = Path.GetFullPath(CleanupInvalidFileNameChars(bucket.Key));
+                    string fileName = bucket.Key;
 
                     ms.SetLength(0);
                     ms.Position = 0;
@@ -992,19 +1035,23 @@ namespace NLog.Targets
             }
         }
 
+
+
         private void ProcessLogEvent(LogEventInfo logEvent, string fileName, byte[] bytesToWrite)
         {
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
             this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
 #endif
-
-            string fileToArchive = this.GetFileCharacteristics(fileName) != null ? fileName : previousLogFileName;
-            if (this.ShouldAutoArchive(fileToArchive, logEvent, bytesToWrite.Length))
-                this.DoAutoArchive(fileToArchive, logEvent);
+            var archiveFile = this.GetAutoArchiveFileName(fileName, logEvent, bytesToWrite.Length);
+            if (!string.IsNullOrEmpty(archiveFile))
+            {
+                this.DoAutoArchive(archiveFile, logEvent);
+            }
 
             // Clean up old archives if this is the first time a log record is being written to
             // this log file and the archiving system is date/time based.
-            if (this.ArchiveNumbering == ArchiveNumberingMode.Date && this.ArchiveEvery != FileArchivePeriod.None && ShouldDeleteOldArchives())
+            if (this.ArchiveNumbering == ArchiveNumberingMode.Date && this.ArchiveEvery != FileArchivePeriod.None &&
+                ShouldDeleteOldArchives())
             {
                 if (!previousFileNames.Contains(fileName))
                 {
@@ -1583,19 +1630,20 @@ namespace NLog.Targets
 
         private DateTime GetArchiveDate(string fileName, LogEventInfo logEvent)
         {
-            var fileCharacteristics = GetFileCharacteristics(fileName);
+            var fileCharacteristics = this.fileAppenderCache.GetFileCharacteristics(fileName);
+
             var lastWriteTime = TimeSource.Current.FromSystemTime(fileCharacteristics.LastWriteTimeUtc);
 
             InternalLogger.Trace("Calculating archive date. Last write time: {0}; Previous log event time: {1}", lastWriteTime, previousLogEventTimestamp);
 
-            bool previousLogIsMoreRecent = (previousLogEventTimestamp.HasValue) && (previousLogEventTimestamp.Value > lastWriteTime);
+            bool previousLogIsMoreRecent = previousLogEventTimestamp.HasValue && (previousLogEventTimestamp.Value > lastWriteTime);
             if (previousLogIsMoreRecent)
             {
                 InternalLogger.Trace("Using previous log event time (is more recent)");
                 return previousLogEventTimestamp.Value;
             }
 
-            if (PreviousLogOverlappedPeriod(fileCharacteristics, logEvent))
+            if (previousLogEventTimestamp.HasValue && PreviousLogOverlappedPeriod(logEvent, fileCharacteristics.LastWriteTimeUtc))
             {
                 InternalLogger.Trace("Using previous log event time (previous log overlapped period)");
                 return previousLogEventTimestamp.Value;
@@ -1605,13 +1653,13 @@ namespace NLog.Targets
             return lastWriteTime;
         }
 
-        private bool PreviousLogOverlappedPeriod(FileCharacteristics fileCharacteristics, LogEventInfo logEvent)
+        private bool PreviousLogOverlappedPeriod(LogEventInfo logEvent, DateTime lastWriteTimeUtc)
         {
             if (!previousLogEventTimestamp.HasValue)
                 return false;
 
             string formatString = GetArchiveDateFormatString(string.Empty);
-            string lastWriteTimeString = TimeSource.Current.FromSystemTime(fileCharacteristics.LastWriteTimeUtc).ToString(formatString, CultureInfo.InvariantCulture);
+            string lastWriteTimeString = TimeSource.Current.FromSystemTime(lastWriteTimeUtc).ToString(formatString, CultureInfo.InvariantCulture);
             string logEventTimeString = logEvent.TimeStamp.ToString(formatString, CultureInfo.InvariantCulture);
 
             if (lastWriteTimeString != logEventTimeString)
@@ -1696,7 +1744,7 @@ namespace NLog.Targets
         /// <returns>A string with a pattern that will match the archive filenames</returns>
         private string GetArchiveFileNamePattern(string fileName, LogEventInfo eventInfo)
         {
-            if (this.ArchiveFileName == null)
+            if (this.fullarchiveFileName == null)
             {
                 string ext = EnableArchiveFileCompression ? ".zip" : Path.GetExtension(fileName);
                 return Path.ChangeExtension(fileName, ".{#}" + ext);
@@ -1706,9 +1754,8 @@ namespace NLog.Targets
                 //The archive file name is given. There are two possibilities
                 //(1) User supplied the Filename with pattern
                 //(2) User supplied the normal filename
-                string archiveFileName = this.ArchiveFileName.Render(eventInfo);
-                archiveFileName = CleanupInvalidFileNameChars(archiveFileName);
-                return Path.GetFullPath(archiveFileName);
+                string archiveFileName = this.fullarchiveFileName.Render(eventInfo);
+                return archiveFileName;
             }
         }
 
@@ -1727,12 +1774,42 @@ namespace NLog.Targets
         /// <param name="fileName">File name to be written.</param>
         /// <param name="ev">Log event that the <see cref="FileTarget"/> instance is currently processing.</param>
         /// <param name="upcomingWriteSize">The size in bytes of the next chunk of data to be written in the file.</param>
-        /// <returns><see langword="true"/> when archiving should be executed; <see langword="false"/> otherwise.</returns>
-        private bool ShouldAutoArchive(string fileName, LogEventInfo ev, int upcomingWriteSize)
+        /// <returns>Filename to archive. If <c>null</c>, then nothing to archive.</returns>
+        private string GetAutoArchiveFileName(string fileName, LogEventInfo ev, int upcomingWriteSize)
         {
-            return (fileName != null) &&
-                (ShouldAutoArchiveBasedOnFileSize(fileName, upcomingWriteSize) ||
-                ShouldAutoArchiveBasedOnTime(fileName, ev));
+            var hasFileName = !(fileName == null && previousLogFileName == null);
+            if (hasFileName)
+            {
+                return GetAutoArchiveFileNameBasedOnFileSize(fileName, upcomingWriteSize) ??
+                       GetAutoArchiveFileNameBasedOnTime(fileName, ev);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the correct filename to archive
+        /// </summary>
+        /// <returns></returns>
+        private string GetFileForArchiving(string fileName, out FileCharacteristics fileCharacteristics)
+        {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                fileCharacteristics = !string.IsNullOrEmpty(previousLogFileName) ? this.fileAppenderCache.GetFileCharacteristics(previousLogFileName) : null;
+                return previousLogFileName;
+            }
+
+            fileCharacteristics = !string.IsNullOrEmpty(fileName) ? this.fileAppenderCache.GetFileCharacteristics(fileName) : null;
+
+            if (string.IsNullOrEmpty(previousLogFileName) || fileName == previousLogFileName)
+            {
+                //no difference between both, or previous is empyt
+                return fileName;
+            }
+            
+            var fileLength = fileCharacteristics?.FileLength;
+            string fileToArchive = fileLength != null ? fileName : previousLogFileName;
+            return fileToArchive;
         }
 
         /// <summary>
@@ -1740,21 +1817,35 @@ namespace NLog.Targets
         /// </summary>
         /// <param name="fileName">File name to be written.</param>
         /// <param name="upcomingWriteSize">The size in bytes of the next chunk of data to be written in the file.</param>
-        /// <returns><see langword="true"/> when archiving should be executed; <see langword="false"/> otherwise.</returns>
-        private bool ShouldAutoArchiveBasedOnFileSize(string fileName, int upcomingWriteSize)
+        /// <returns>Filename to archive. If <c>null</c>, then nothing to archive.</returns>
+        private string GetAutoArchiveFileNameBasedOnFileSize(string fileName, int upcomingWriteSize)
         {
             if (this.ArchiveAboveSize == FileTarget.ArchiveAboveSizeDisabled)
             {
-                return false;
+                return null;
             }
 
-            var fileCharacteristics = this.GetFileCharacteristics(fileName);
-            if (fileCharacteristics == null)
+            FileCharacteristics fileCharacteristics;
+            fileName = GetFileForArchiving(fileName, out fileCharacteristics);
+
+            if (fileName == null)
             {
-                return false;
+                return null;
             }
 
-            return fileCharacteristics.FileLength + upcomingWriteSize > this.ArchiveAboveSize;
+            var length = fileCharacteristics?.FileLength;
+            if (length == null)
+            {
+                return null;
+            }
+
+            var shouldArchive = length.Value + upcomingWriteSize > this.ArchiveAboveSize;
+            if (shouldArchive)
+            {
+                return fileName;
+            }
+            return null;
+
         }
 
         /// <summary>
@@ -1762,28 +1853,42 @@ namespace NLog.Targets
         /// </summary>
         /// <param name="fileName">File name to be written.</param>
         /// <param name="logEvent">Log event that the <see cref="FileTarget"/> instance is currently processing.</param>
-        /// <returns><see langword="true"/> when archiving should be executed; <see langword="false"/> otherwise.</returns>
-        private bool ShouldAutoArchiveBasedOnTime(string fileName, LogEventInfo logEvent)
+        /// <returns>Filename to archive. If <c>null</c>, then nothing to archive.</returns>
+        private string GetAutoArchiveFileNameBasedOnTime(string fileName, LogEventInfo logEvent)
         {
             if (this.ArchiveEvery == FileArchivePeriod.None)
             {
-                return false;
+                return null;
             }
 
-            var fileCharacteristics = this.GetFileCharacteristics(fileName);
-            if (fileCharacteristics == null)
+            FileCharacteristics fileCharacteristics;
+            fileName = GetFileForArchiving(fileName, out fileCharacteristics);
+
+            if (fileName == null)
             {
-                return false;
+                return null;
+            }
+
+            var creationTimeUtc = fileCharacteristics?.CreationTimeUtc;
+            if (creationTimeUtc == null)
+            {
+                return null;
             }
 
             // file creation time is in Utc and logEvent's timestamp is originated from TimeSource.Current,
             // so we should ask the TimeSource to convert file time to TimeSource time:
-            DateTime creationTime = TimeSource.Current.FromSystemTime(fileCharacteristics.CreationTimeUtc);
+
+            DateTime creationTime = TimeSource.Current.FromSystemTime(creationTimeUtc.Value);
             string formatString = GetArchiveDateFormatString(string.Empty);
             string fileCreated = creationTime.ToString(formatString, CultureInfo.InvariantCulture);
             string logEventRecorded = logEvent.TimeStamp.ToString(formatString, CultureInfo.InvariantCulture);
 
-            return fileCreated != logEventRecorded;
+            var shouldArchive = fileCreated != logEventRecorded;
+            if (shouldArchive)
+            {
+                return fileName;
+            }
+            return null;
         }
 
         private void AutoClosingTimerCallback(object state)
@@ -2018,9 +2123,13 @@ namespace NLog.Targets
         /// <param name="appender">File appender associated with the file.</param>
         private void WriteHeader(BaseFileAppender appender)
         {
-            FileCharacteristics fileCharacteristics = appender.GetFileCharacteristics();
+            //performance: cheap check before checking file info 
+            if (Header == null) return;
+
+            //todo replace with hasWritten?
+            var length = appender.GetFileCharacteristics()?.FileLength;
             //  Write header only on empty files or if file info cannot be obtained.
-            if ((fileCharacteristics == null) || (fileCharacteristics.FileLength == 0))
+            if (length == null || length == 0)
             {
                 byte[] headerBytes = this.GetHeaderBytes();
                 if (headerBytes != null)
@@ -2030,30 +2139,6 @@ namespace NLog.Targets
             }
         }
 
-        /// <summary>
-        /// Returns the length of a specified file and the last time it has been written. File appender is queried before the file system.  
-        /// </summary>
-        /// <param name="filePath">File which the information are requested.</param>
-        /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
-        private FileCharacteristics GetFileCharacteristics(string filePath)
-        {
-            var fileCharacteristics = this.fileAppenderCache.GetFileCharacteristics(filePath);
-            if (fileCharacteristics != null)
-                return fileCharacteristics;
-
-            var fileInfo = new FileInfo(filePath);
-            if (fileInfo.Exists)
-            {
-#if !SILVERLIGHT
-                fileCharacteristics = new FileCharacteristics(fileInfo.CreationTimeUtc, fileInfo.LastWriteTimeUtc, fileInfo.Length);
-#else
-                fileCharacteristics = new FileCharacteristics(fileInfo.CreationTime, fileInfo.LastWriteTime, fileInfo.Length);
-#endif
-                return fileCharacteristics;
-            }
-
-            return null;
-        }
 
         /// <summary>
         /// The sequence of <see langword="byte"/> to be written in a file after applying any formating and any
@@ -2068,61 +2153,9 @@ namespace NLog.Targets
             {
                 return null;
             }
-
+            //todo remove 
             string renderedText = layout.Render(LogEventInfo.CreateNullEvent()) + this.NewLineChars;
             return this.TransformBytes(this.Encoding.GetBytes(renderedText));
-        }
-
-        /// <summary>
-        /// Replaces any invalid characters found in the <paramref name="fileName"/> with underscore i.e _ character.
-        /// Invalid characters are defined by .NET framework and they returned by <see
-        /// cref="M:System.IO.Path.GetInvalidFileNameChars"/> method.
-        /// <para>Note: not implemented in Silverlight</para>
-        /// </summary>
-        /// <param name="fileName">The original file name which might contain invalid characters.</param>
-        /// <returns>The cleaned up file name without any invalid characters.</returns>
-        private string CleanupInvalidFileNameChars(string fileName)
-        {
-
-            if (!this.CleanupFileName)
-            {
-                return fileName;
-            }
-
-#if !SILVERLIGHT
-
-            var lastDirSeparator = fileName.LastIndexOfAny(DirectorySeparatorChars);
-
-            var fileName1 = fileName.Substring(lastDirSeparator + 1);
-            //keep the / in the dirname, because dirname could be c:/ and combine of c: and file name won't work well.
-            var dirName = lastDirSeparator > 0 ? fileName.Substring(0, lastDirSeparator + 1) : string.Empty;
-
-            char[] fileName1Chars = null;
-
-            for (int i = 0; i < fileName1.Length; i++)
-            {
-                if (InvalidFileNameChars.Contains(fileName1[i]))
-                {
-                    //delay char[] creation until first invalid char
-                    //is found to avoid memory allocation.
-                    if (fileName1Chars == null)
-                        fileName1Chars = fileName1.ToCharArray();
-                    fileName1Chars[i] = '_';
-                }
-            }
-
-            //only if an invalid char was replaced do we create a new string.
-            if (fileName1Chars != null)
-            {
-                fileName1 = new string(fileName1Chars);
-                return Path.Combine(dirName, fileName1);
-            }
-            return fileName;
-
-
-#else
-            return fileName;
-#endif
         }
 
 

--- a/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
+++ b/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
@@ -173,13 +173,19 @@ namespace NLog.UnitTests.Internal.FileAppenders
         {
             // Invoke GetFileCharacteristics() on an Empty FileAppenderCache.
             FileAppenderCache emptyCache = FileAppenderCache.Empty;
-            Assert.Null(emptyCache.GetFileCharacteristics("file.txt"));
+            Assert.Null(emptyCache.GetFileCreationTimeUtc("file.txt", false));
+            Assert.Null(emptyCache.GetFileLastWriteTimeUtc("file.txt", false));
+            Assert.Null(emptyCache.GetFileLength("file.txt", false));
 
             IFileAppenderFactory appenderFactory = SingleProcessFileAppender.TheFactory;
-            ICreateFileParameters fileTarget = new FileTarget();
+            ICreateFileParameters fileTarget = new FileTarget() {ArchiveNumbering = ArchiveNumberingMode.Date};
+           
             FileAppenderCache cache = new FileAppenderCache(3, appenderFactory, fileTarget);
             // Invoke GetFileCharacteristics() on non-empty FileAppenderCache - Before allocating any appenders. 
-            Assert.Null(cache.GetFileCharacteristics("file.txt"));
+            Assert.Null(emptyCache.GetFileCreationTimeUtc("file.txt", false));
+            Assert.Null(emptyCache.GetFileLastWriteTimeUtc("file.txt", false));
+            Assert.Null(emptyCache.GetFileLength("file.txt", false));
+
 
             String tempFile = Path.Combine(
                     Path.GetTempPath(),
@@ -196,10 +202,16 @@ namespace NLog.UnitTests.Internal.FileAppenders
             //
 
             // File information should be returned.
-            var fileCharacteristics = cache.GetFileCharacteristics(tempFile);
-            Assert.NotNull(fileCharacteristics);
-            Assert.NotEqual(DateTime.MinValue, fileCharacteristics.CreationTimeUtc);
-            Assert.Equal(34, fileCharacteristics.FileLength);
+           
+            var fileCreationTimeUtc = cache.GetFileCreationTimeUtc(tempFile, false);
+            Assert.NotNull(fileCreationTimeUtc);
+            Assert.True(fileCreationTimeUtc > DateTime.UtcNow.AddMinutes(-2),"creationtime is wrong");
+
+            var fileLastWriteTimeUtc = cache.GetFileLastWriteTimeUtc(tempFile, false);
+            Assert.NotNull(fileLastWriteTimeUtc);
+            Assert.True(fileLastWriteTimeUtc > DateTime.UtcNow.AddMinutes(-2), "lastwrite is wrong");
+
+            Assert.Equal(34, cache.GetFileLength(tempFile, false));
 
             // Clean up.
             appender.Flush();

--- a/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
+++ b/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
@@ -173,19 +173,13 @@ namespace NLog.UnitTests.Internal.FileAppenders
         {
             // Invoke GetFileCharacteristics() on an Empty FileAppenderCache.
             FileAppenderCache emptyCache = FileAppenderCache.Empty;
-            Assert.Null(emptyCache.GetFileCreationTimeUtc("file.txt", false));
-            Assert.Null(emptyCache.GetFileLastWriteTimeUtc("file.txt", false));
-            Assert.Null(emptyCache.GetFileLength("file.txt", false));
+            Assert.Null(emptyCache.GetFileCharacteristics("file.txt"));
 
             IFileAppenderFactory appenderFactory = SingleProcessFileAppender.TheFactory;
-            ICreateFileParameters fileTarget = new FileTarget() {ArchiveNumbering = ArchiveNumberingMode.Date};
-           
+            ICreateFileParameters fileTarget = new FileTarget();
             FileAppenderCache cache = new FileAppenderCache(3, appenderFactory, fileTarget);
             // Invoke GetFileCharacteristics() on non-empty FileAppenderCache - Before allocating any appenders. 
-            Assert.Null(emptyCache.GetFileCreationTimeUtc("file.txt", false));
-            Assert.Null(emptyCache.GetFileLastWriteTimeUtc("file.txt", false));
-            Assert.Null(emptyCache.GetFileLength("file.txt", false));
-
+            Assert.Null(cache.GetFileCharacteristics("file.txt"));
 
             String tempFile = Path.Combine(
                     Path.GetTempPath(),
@@ -202,16 +196,10 @@ namespace NLog.UnitTests.Internal.FileAppenders
             //
 
             // File information should be returned.
-           
-            var fileCreationTimeUtc = cache.GetFileCreationTimeUtc(tempFile, false);
-            Assert.NotNull(fileCreationTimeUtc);
-            Assert.True(fileCreationTimeUtc > DateTime.UtcNow.AddMinutes(-2),"creationtime is wrong");
-
-            var fileLastWriteTimeUtc = cache.GetFileLastWriteTimeUtc(tempFile, false);
-            Assert.NotNull(fileLastWriteTimeUtc);
-            Assert.True(fileLastWriteTimeUtc > DateTime.UtcNow.AddMinutes(-2), "lastwrite is wrong");
-
-            Assert.Equal(34, cache.GetFileLength(tempFile, false));
+            var fileCharacteristics = cache.GetFileCharacteristics(tempFile);
+            Assert.NotNull(fileCharacteristics);
+            Assert.NotEqual(DateTime.MinValue, fileCharacteristics.CreationTimeUtc);
+            Assert.Equal(34, fileCharacteristics.FileLength);
 
             // Clean up.
             appender.Flush();

--- a/tests/NLog.UnitTests/Internal/FilePathLayoutTests.cs
+++ b/tests/NLog.UnitTests/Internal/FilePathLayoutTests.cs
@@ -1,0 +1,102 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using NLog.Layouts;
+
+#if !SILVERLIGHT //xunit2
+
+namespace NLog.UnitTests.Internal
+{
+    using NLog.Targets;
+
+    using Xunit;
+    using Xunit.Extensions;
+    using NLog.Internal;
+
+    public class FilePathLayoutTests : NLogTestBase
+    {
+        [Theory]
+        [InlineData(@"", FilePathKind.Unknown)]
+        [InlineData(@" ", FilePathKind.Unknown)]
+        [InlineData(null, FilePathKind.Unknown)]
+#if !MONO 
+        [InlineData(@"d:\test.log", FilePathKind.Absolute)]
+        [InlineData(@"d:\test", FilePathKind.Absolute)]
+        [InlineData(@" d:\test", FilePathKind.Absolute)]
+        [InlineData(@" d:\ test", FilePathKind.Absolute)]
+        [InlineData(@" d:\ test", FilePathKind.Absolute)]
+        [InlineData(@" d:\ test\a", FilePathKind.Absolute)]
+        [InlineData(@"\\test\a", FilePathKind.Absolute)]
+        [InlineData(@"\\test/a", FilePathKind.Absolute)]
+        [InlineData(@"\ test\a", FilePathKind.Absolute)]
+        [InlineData(@" a\test.log ", FilePathKind.Relative)]
+#endif
+
+        [InlineData(@"/ test\a", FilePathKind.Absolute)]
+
+        [InlineData(@"test.log", FilePathKind.Relative)]
+        [InlineData(@"test", FilePathKind.Relative)]
+        [InlineData(@" test.log ", FilePathKind.Relative)]
+        [InlineData(@" test.log ", FilePathKind.Relative)]
+        [InlineData(@" a/test.log ", FilePathKind.Relative)]
+
+        [InlineData(@".test.log ", FilePathKind.Relative)]
+        [InlineData(@"..test.log ", FilePathKind.Relative)]
+        [InlineData(@" .. test.log ", FilePathKind.Relative)]
+        [InlineData(@"${basedir}\test.log ", FilePathKind.Absolute)]
+        [InlineData(@"${BASEDIR}\test.log ", FilePathKind.Absolute)]
+        [InlineData(@"${BASEDIR}\test ", FilePathKind.Absolute)]
+        [InlineData(@"${BASEDIR}\test ", FilePathKind.Absolute)]
+        [InlineData(@"${level}\test ", FilePathKind.Unknown)]
+
+        [InlineData(@"${basedir}/test.log ", FilePathKind.Absolute)]
+        [InlineData(@"${BASEDIR}/test.log ", FilePathKind.Absolute)]
+        [InlineData(@"${BASEDIR}/test ", FilePathKind.Absolute)]
+        [InlineData(@"${BASEDIR}/test ", FilePathKind.Absolute)]
+        [InlineData(@"${level}/test ", FilePathKind.Unknown)]
+        [InlineData(@" ${level}/test ", FilePathKind.Unknown)]
+        [InlineData(@" 
+${level}/test ", FilePathKind.Unknown)]
+        [InlineData(@"dir 
+${level}/test ", FilePathKind.Relative)]
+        [InlineData(@"dir${level}/test ", FilePathKind.Relative)]
+        public void DetectFilePathKind(string path, FilePathKind expected)
+        {
+            Layout layout = path;
+            var result = FilePathLayout.DetectFilePathKind(layout);
+            Assert.Equal(expected, result);
+        }
+
+    }
+}
+#endif

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Internal\EnumHelpersTests.cs" />
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
+    <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Internal\EnumHelpersTests.cs" />
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
+    <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Internal\EnumHelpersTests.cs" />
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
+    <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,10 +9,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <ApplicationIcon></ApplicationIcon>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -159,6 +157,7 @@
     <Compile Include="Internal\EnumHelpersTests.cs" />
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
+    <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
@@ -207,8 +206,8 @@
     <Compile Include="LayoutRenderers\Wrappers\WrapLineTests.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeTests.cs" />
     <Compile Include="Layouts\AllEventPropertiesTests.cs" />
-    <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\CompoundLayoutTests.cs" />
+    <Compile Include="Layouts\CsvLayoutTests.cs" />
     <Compile Include="Layouts\JsonLayoutTests.cs" />
     <Compile Include="Layouts\SimpleLayoutOutputTests.cs" />
     <Compile Include="Layouts\SimpleLayoutParserTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Internal\EnumHelpersTests.cs" />
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
+    <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Internal\EnumHelpersTests.cs" />
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
+    <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -46,6 +46,7 @@ namespace NLog.UnitTests.Targets
 
     using Mocks;
     using NLog.Config;
+    using NLog.Internal;
     using NLog.Layouts;
     using NLog.Targets;
     using NLog.Targets.Wrappers;
@@ -2690,19 +2691,31 @@ namespace NLog.UnitTests.Targets
         public void TestFilenameCleanup()
         {
             var invalidChars = Path.GetInvalidFileNameChars();
-            var invalidFileName = "";
+            var invalidFileName = Path.DirectorySeparatorChar.ToString();
             var expectedFileName = "";
-            for (int i = 0; i < invalidFileName.Count(); i++)
+            for (int i = 0; i < invalidChars.Count(); i++)
             {
-                var invalidChar = invalidFileName[i];
-                invalidFileName += i + invalidChar;
+                var invalidChar = invalidChars[i];
+                if (invalidChar == Path.DirectorySeparatorChar || invalidChar == Path.AltDirectorySeparatorChar)
+                {
+                    //ignore, won't used in cleanup (but for find filename in path)
+                    continue;
+                }
+
+                invalidFileName += i + invalidChar.ToString();
                 //underscore is used for clean
                 expectedFileName += i + "_";
             }
+            //under mono this the invalid chars is sometimes only 1 char (so min width 2)
+            Assert.True(invalidFileName.Length >= 2);
             //CleanupFileName is default true;
             var fileTarget = new FileTarget();
             fileTarget.FileName = invalidFileName;
-            var path = fileTarget.GetCleanedFileName(LogEventInfo.CreateNullEvent());
+
+            var filePathLayout = new FilePathLayout(invalidFileName,true, FilePathKind.Absolute);
+
+
+            var path = filePathLayout.Render(LogEventInfo.CreateNullEvent());
             Assert.Equal(expectedFileName, path);
         }
 


### PR DESCRIPTION
Fixes https://github.com/NLog/NLog-Performance-tests/issues/1, supersedes https://github.com/NLog/NLog/pull/1593

## Steps:

- [x] Improve amount of calls to `GetFileCharacteristics`,
- [x] Improve `Path.GetFullPath()` usage (cache, on setter etc), make it optional?
- [x] Optimize / remove `FileTouched`
- [x] Tell `BaseFileAppender` if we need `LastWriteTime` (saves stuff)
- [x] Cleanup silverlight stuff (add helpers)


Changes with https://github.com/NLog/NLog/pull/1593:

- keep GetFileCharacteristics for less big change
- changes after review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1613)
<!-- Reviewable:end -->
