### PR TITLE
FileTarget: Don't throw an exception if a dir is missing when deleting old file on startup

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1959,6 +1959,12 @@ namespace NLog.Targets
                 {
                     File.Delete(fileName);
                 }
+                catch (DirectoryNotFoundException exception)
+                {
+                    //never rethrow this, as this isn't an exceptional case.
+                    InternalLogger.Debug(exception, "Unable to delete old log file '{0}' as directory is missing.", fileName);
+                }
+
                 catch (Exception exception)
                 {
                     InternalLogger.Warn(exception, "Unable to delete old log file '{0}'.", fileName);

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -252,6 +252,25 @@ namespace NLog.UnitTests.Targets
             }
         }
 
+        /// <summary>
+        /// todo not needed to execute twice.
+        /// </summary>
+        [Fact]
+        public void DeleteFileOnStartTest_noExceptionWhenMissing()
+        {
+            LogManager.Configuration = this.CreateConfigurationFromString(@"<nlog throwExceptions='true'>
+    <targets>
+      <target name='file1' encoding='UTF-8' type='File'  deleteOldFileOnStartup='true' fileName='c://temp2/logs/i-dont-exist.log' layout='${message} ' />
+    </targets>
+    <rules>
+      <logger name='*' minlevel='Trace' writeTo='file1' />
+    </rules>
+</nlog>
+");
+            var logger = LogManager.GetCurrentClassLogger();
+            logger.Trace("running test");
+        }
+
 #if NET3_5 || NET4_0 || NET4_5
         public static IEnumerable<object[]> ArchiveFileOnStartTests_TestParameters
         {


### PR DESCRIPTION
Even if throwException is on, this is not any helpful.

fixes https://github.com/NLog/NLog/issues/1605

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1616)
<!-- Reviewable:end -->
