### PR TITLE
Added Option to Specify EOL for NetworkTarget

### DIFF
--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -99,6 +99,7 @@ namespace NLog.Targets
             this.KeepConnection = true;
             this.MaxMessageSize = 65000;
             this.ConnectionCacheSize = 5;
+            this.LineEnding = LineEndingMode.CRLF;
         }
 
         /// <summary>
@@ -146,6 +147,13 @@ namespace NLog.Targets
         /// <docgen category='Layout Options' order='10' />
         [DefaultValue(false)]
         public bool NewLine { get; set; }
+
+        /// <summary>
+        /// Gets or sets the end of line value if a newline is appended at the end of log message <see cref="NewLine"/>.
+        /// </summary>
+        /// <docgen category='Layout Options' order='10' />
+        [DefaultValue("CRLF")]
+        public LineEndingMode LineEnding { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum message size in bytes.
@@ -376,7 +384,7 @@ namespace NLog.Targets
 
             if (this.NewLine)
             {
-                text = this.Layout.Render(logEvent) + "\r\n";
+                text = this.Layout.Render(logEvent) + this.LineEnding.NewLineCharacters;
             }
             else
             {


### PR DESCRIPTION
In some instances, the EOL might need to be something other than
'\r\n' or completely different than the Target's operating system.

This allows the end user to specify the EOL when a NewLine is wanted
between each log message.

Updated the happy path to check for the new EOL and added a new unit test to make sure that the default was set to '\r\n'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1619)
<!-- Reviewable:end -->
