### PR TITLE
Pause logging when the race condition occurs in (Colored)Console Target

### DIFF
--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using NLog.Common;
+
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
 
 namespace NLog.Targets
@@ -49,6 +51,23 @@ namespace NLog.Targets
     [Target("ColoredConsole")]
     public sealed class ColoredConsoleTarget : TargetWithLayoutHeaderAndFooter
     {
+        /// <summary>
+        /// Should logging being paused/stopped because of the race condition bug in Console.Writeline?
+        /// </summary>
+        /// <remarks>
+        ///   Console.Out.Writeline / Console.Error.Writeline could throw 'IndexOutOfRangeException', which is a bug. 
+        /// See http://stackoverflow.com/questions/33915790/console-out-and-console-error-race-condition-error-in-a-windows-service-written
+        /// and https://connect.microsoft.com/VisualStudio/feedback/details/2057284/console-out-probable-i-o-race-condition-issue-in-multi-threaded-windows-service
+        ///             
+        /// Full error: 
+        ///   Error during session close: System.IndexOutOfRangeException: Probable I/ O race condition detected while copying memory.
+        ///   The I/ O package is not thread safe by default.In multithreaded applications, 
+        ///   a stream must be accessed in a thread-safe way, such as a thread - safe wrapper returned by TextReader's or 
+        ///   TextWriter's Synchronized methods.This also applies to classes like StreamWriter and StreamReader.
+        /// 
+        /// </remarks>
+        private bool PauseLogging;
+
         private static readonly IList<ConsoleRowHighlightingRule> defaultConsoleRowHighlightingRules = new List<ConsoleRowHighlightingRule>()
         {
             new ConsoleRowHighlightingRule("level == LogLevel.Fatal", ConsoleOutputColor.Red, ConsoleOutputColor.NoChange),
@@ -70,6 +89,7 @@ namespace NLog.Targets
             this.WordHighlightingRules = new List<ConsoleWordHighlightingRule>();
             this.RowHighlightingRules = new List<ConsoleRowHighlightingRule>();
             this.UseDefaultRowHighlightingRules = true;
+            this.PauseLogging = false;
         }
 
         /// <summary>
@@ -167,11 +187,12 @@ namespace NLog.Targets
         /// </summary>
         protected override void InitializeTarget()
         {
+            this.PauseLogging = false;
             base.InitializeTarget();
             if (Header != null)
             {
                 LogEventInfo lei = LogEventInfo.CreateNullEvent();
-                this.Output(lei, Header.Render(lei));
+                this.WriteToOutput(lei, Header.Render(lei));
             }
         }
 
@@ -183,23 +204,28 @@ namespace NLog.Targets
             if (Footer != null)
             {
                 LogEventInfo lei = LogEventInfo.CreateNullEvent();
-                this.Output(lei, Footer.Render(lei));
+                this.WriteToOutput(lei, Footer.Render(lei));
             }
 
             base.CloseTarget();
         }
 
-            /// <summary>
+        /// <summary>
         /// Writes the specified log event to the console highlighting entries
         /// and words based on a set of defined rules.
         /// </summary>
         /// <param name="logEvent">Log event.</param>
         protected override void Write(LogEventInfo logEvent)
         {
-            this.Output(logEvent, this.Layout.Render(logEvent));
+            if (PauseLogging)
+            {
+                //check early for performance
+                return;
+            }
+            this.WriteToOutput(logEvent, this.Layout.Render(logEvent));
         }
 
-        private void Output(LogEventInfo logEvent, string message)
+        private void WriteToOutput(LogEventInfo logEvent, string message)
         {
             ConsoleColor oldForegroundColor = Console.ForegroundColor;
             ConsoleColor oldBackgroundColor = Console.BackgroundColor;
@@ -217,23 +243,34 @@ namespace NLog.Targets
                 if (didChangeBackgroundColor)
                     Console.BackgroundColor = (ConsoleColor)matchingRule.BackgroundColor;
 
-                var consoleStream = this.ErrorStream ? Console.Error : Console.Out;
-                if (this.WordHighlightingRules.Count == 0)
+
+                try
                 {
-                    consoleStream.WriteLine(message);
-                }
-                else
-                {
-                    message = message.Replace("\a", "\a\a");
-                    foreach (ConsoleWordHighlightingRule hl in this.WordHighlightingRules)
+                    var consoleStream = this.ErrorStream ? Console.Error : Console.Out;
+                    if (this.WordHighlightingRules.Count == 0)
                     {
-                        message = hl.ReplaceWithEscapeSequences(message);
+                        consoleStream.WriteLine(message);
                     }
+                    else
+                    {
+                        message = message.Replace("\a", "\a\a");
+                        foreach (ConsoleWordHighlightingRule hl in this.WordHighlightingRules)
+                        {
+                            message = hl.ReplaceWithEscapeSequences(message);
+                        }
 
-                    ColorizeEscapeSequences(consoleStream, message, new ColorPair(Console.ForegroundColor, Console.BackgroundColor), new ColorPair(oldForegroundColor, oldBackgroundColor));
-                    consoleStream.WriteLine();
+                        ColorizeEscapeSequences(consoleStream, message, new ColorPair(Console.ForegroundColor, Console.BackgroundColor), new ColorPair(oldForegroundColor, oldBackgroundColor));
+                        consoleStream.WriteLine();
 
-                    didChangeForegroundColor = didChangeBackgroundColor = true;
+                        didChangeForegroundColor = didChangeBackgroundColor = true;
+                    }
+                }
+                catch (IndexOutOfRangeException ex)
+                {
+                    //this is a bug and therefor stopping logging. For docs, see PauseLogging property
+                    PauseLogging = true;
+                    InternalLogger.Warn(ex, "An IndexOutOfRangeException has been thrown and this is probably due to a race condition." +
+                                            "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets");
                 }
             }
             finally

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -31,6 +31,9 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.IO;
+using NLog.Common;
+
 namespace NLog.Targets
 {
     using System;
@@ -60,6 +63,23 @@ namespace NLog.Targets
     public sealed class ConsoleTarget : TargetWithLayoutHeaderAndFooter
     {
         /// <summary>
+        /// Should logging being paused/stopped because of the race condition bug in Console.Writeline?
+        /// </summary>
+        /// <remarks>
+        ///   Console.Out.Writeline / Console.Error.Writeline could throw 'IndexOutOfRangeException', which is a bug. 
+        /// See http://stackoverflow.com/questions/33915790/console-out-and-console-error-race-condition-error-in-a-windows-service-written
+        /// and https://connect.microsoft.com/VisualStudio/feedback/details/2057284/console-out-probable-i-o-race-condition-issue-in-multi-threaded-windows-service
+        ///             
+        /// Full error: 
+        ///   Error during session close: System.IndexOutOfRangeException: Probable I/ O race condition detected while copying memory.
+        ///   The I/ O package is not thread safe by default.In multithreaded applications, 
+        ///   a stream must be accessed in a thread-safe way, such as a thread - safe wrapper returned by TextReader's or 
+        ///   TextWriter's Synchronized methods.This also applies to classes like StreamWriter and StreamReader.
+        /// 
+        /// </remarks>
+        private bool PauseLogging;
+
+        /// <summary>
         /// Gets or sets a value indicating whether to send the log messages to the standard error instead of the standard output.
         /// </summary>
         /// <docgen category='Console Options' order='10' />
@@ -86,6 +106,7 @@ namespace NLog.Targets
         /// </remarks>
         public ConsoleTarget() : base()
         {
+            PauseLogging = false;
         }
 
         /// <summary>
@@ -105,10 +126,11 @@ namespace NLog.Targets
         /// </summary>
         protected override void InitializeTarget()
         {
+            PauseLogging = false;
             base.InitializeTarget();
             if (Header != null)
             {
-                this.Output(Header.Render(LogEventInfo.CreateNullEvent()));
+                this.WriteToOutput(Header.Render(LogEventInfo.CreateNullEvent()));
             }
         }
 
@@ -119,7 +141,7 @@ namespace NLog.Targets
         {
             if (Footer != null)
             {
-                this.Output(Footer.Render(LogEventInfo.CreateNullEvent()));
+                this.WriteToOutput(Footer.Render(LogEventInfo.CreateNullEvent()));
             }
 
             base.CloseTarget();
@@ -135,23 +157,44 @@ namespace NLog.Targets
         /// </remarks>
         protected override void Write(LogEventInfo logEvent)
         {
-            this.Output(this.Layout.Render(logEvent));
+            if (PauseLogging)
+            {
+                //check early for performance
+                return;
+            }
+
+            this.WriteToOutput(this.Layout.Render(logEvent));
         }
 
         /// <summary>
         /// Write to output
         /// </summary>
         /// <param name="textLine">text to be written.</param>
-        private void Output(string textLine)
+        private void WriteToOutput(string textLine)
         {
-            if (this.Error)
+            if (PauseLogging)
             {
-                Console.Error.WriteLine(textLine);
+                return;
             }
-            else
+
+            var output = GetOutput();
+
+            try
             {
-                Console.Out.WriteLine(textLine);
+                output.WriteLine(textLine);
             }
+            catch (IndexOutOfRangeException ex)
+            {
+                //this is a bug and therefor stopping logging. For docs, see PauseLogging property
+                PauseLogging = true;
+                InternalLogger.Warn(ex, "An IndexOutOfRangeException has been thrown and this is probably due to a race condition." +
+                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets");
+            }
+        }
+
+        private TextWriter GetOutput()
+        {
+            return this.Error ? Console.Error : Console.Out;
         }
     }
 }

--- a/tests/NLog.UnitTests/Config/InternalLoggingTests.cs
+++ b/tests/NLog.UnitTests/Config/InternalLoggingTests.cs
@@ -98,7 +98,7 @@ namespace NLog.UnitTests.Config
             var stringWriter = new StringWriter(sb);
             InternalLogger.LogWriter = stringWriter;
             string wrongFileName = "WRONG/***[]???////WRONG";
-            LogManager.Configuration = this.CreateConfigurationFromString(string.Format(@"<?xml version='1.0' encoding='utf-8' ?>
+            LogManager.Configuration = CreateConfigurationFromString(string.Format(@"<?xml version='1.0' encoding='utf-8' ?>
 <nlog internalLogFile='{0}'
       internalLogLevel='Off'
       throwExceptions='true' >

--- a/tests/NLog.UnitTests/LayoutRenderers/IdentityTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/IdentityTests.cs
@@ -84,7 +84,7 @@ namespace NLog.UnitTests.LayoutRenderers
                             .RegisterDefinition("CSharpEventTarget", typeof(CSharpEventTarget));
 
 
-                LogManager.Configuration = this.CreateConfigurationFromString(@"<?xml version='1.0' encoding='utf-8' ?>
+                LogManager.Configuration = CreateConfigurationFromString(@"<?xml version='1.0' encoding='utf-8' ?>
 <nlog xmlns='http://www.nlog-project.org/schemas/NLog.xsd'
       xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
  

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -64,7 +64,7 @@ namespace NLog.UnitTests
             {
                 //flush all events if needed.
                 LogManager.Configuration.Close();
-                
+
             }
 
             if (LogManager.LogFactory != null)
@@ -76,7 +76,7 @@ namespace NLog.UnitTests
             InternalLogger.Reset();
             LogManager.ThrowExceptions = false;
             LogManager.ThrowConfigExceptions = null;
-            
+
         }
 
         protected void AssertDebugCounter(string targetName, int val)
@@ -311,7 +311,7 @@ namespace NLog.UnitTests
 
 #endif
 
-        protected XmlLoggingConfiguration CreateConfigurationFromString(string configXml)
+        protected static XmlLoggingConfiguration CreateConfigurationFromString(string configXml)
         {
 #if SILVERLIGHT
             XElement element = XElement.Parse(configXml);

--- a/tests/NLog.UnitTests/RegressionTests.cs
+++ b/tests/NLog.UnitTests/RegressionTests.cs
@@ -87,7 +87,7 @@ namespace NLog.UnitTests
         [Fact]
         public void Bug5965StackOverflow()
         {
-            LogManager.Configuration = this.CreateConfigurationFromString(@"
+            LogManager.Configuration = CreateConfigurationFromString(@"
 <nlog xmlns='http://www.nlog-project.org/schemas/NLog.xsd'
       xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
   

--- a/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
@@ -161,6 +161,27 @@ namespace NLog.UnitTests.Targets
                 new string[] { "The Cat Sat At The Bar." });
         }
 
+#if !NET3_5 && !MONO
+
+        [Fact]
+        public void ColoredConsoleRaceCondtionIgnoreTest()
+        {
+            var configXml = @"
+            <nlog throwExceptions='true'>
+                <targets>
+                  <target name='console' type='coloredConsole' layout='${message}' />
+                  <target name='console2' type='coloredConsole' layout='${message}' />
+                  <target name='console3' type='coloredConsole' layout='${message}' />
+                </targets>
+                <rules>
+                  <logger name='*' minlevel='Trace' writeTo='console,console2,console3' />
+                </rules>
+            </nlog>";
+
+            ConsoleTargetTests.ConsoleRaceCondtionIgnoreInnerTest(configXml);
+        }
+#endif
+
 
         private static void AssertOutput(Target target, string message, string[] expectedParts)
         {

--- a/tests/NLog.UnitTests/Targets/ConsoleTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ConsoleTargetTests.cs
@@ -40,6 +40,7 @@ namespace NLog.UnitTests.Targets
     using NLog.Targets;
     using System.Collections.Generic;
     using Xunit;
+    using System.Threading.Tasks;
 
     public class ConsoleTargetTests : NLogTestBase
     {
@@ -71,7 +72,7 @@ namespace NLog.UnitTests.Targets
                 Assert.Equal(6, exceptions.Count);
                 target.Close();
             }
-            finally 
+            finally
             {
                 Console.SetOut(oldConsoleOutWriter);
             }
@@ -125,6 +126,60 @@ namespace NLog.UnitTests.Targets
             string expectedResult = string.Format("-- header --{0}Logger1 message1{0}Logger1 message2{0}Logger1 message3{0}Logger2 message4{0}Logger2 message5{0}Logger1 message6{0}-- footer --{0}", Environment.NewLine);
             Assert.Equal(expectedResult, consoleErrorWriter.ToString());
         }
+
+#if !NET3_5 && !MONO
+
+        [Fact]
+        public void ConsoleRaceCondtionIgnoreTest()
+        {
+            //   Console.Out.Writeline / Console.Error.Writeline could throw 'IndexOutOfRangeException', which is a bug. 
+            // See http://stackoverflow.com/questions/33915790/console-out-and-console-error-race-condition-error-in-a-windows-service-written
+            // and https://connect.microsoft.com/VisualStudio/feedback/details/2057284/console-out-probable-i-o-race-condition-issue-in-multi-threaded-windows-service
+            //             
+            // Full error: 
+            //   Error during session close: System.IndexOutOfRangeException: Probable I/ O race condition detected while copying memory.
+            //   The I/ O package is not thread safe by default.In multithreaded applications, 
+            //   a stream must be accessed in a thread-safe way, such as a thread - safe wrapper returned by TextReader's or 
+            //   TextWriter's Synchronized methods.This also applies to classes like StreamWriter and StreamReader.
+            
+            var oldOut = Console.Out;
+            var oldError = Console.Error;
+
+            try
+            {
+                Console.SetOut(StreamWriter.Null);
+                Console.SetError(StreamWriter.Null);
+
+                LogManager.Configuration = this.CreateConfigurationFromString(@"<nlog>
+    <targets>
+      <target name='console' type='console' layout='${message}' />
+      <target name='consoleError' type='console' layout='${message}'  error='true' />
+    </targets>
+    <rules>
+      <logger name='*' minlevel='Trace' writeTo='console,consoleError' />
+    </rules>
+</nlog>
+");
+                LogManager.ThrowExceptions = true;
+                var logger = LogManager.GetCurrentClassLogger();
+
+
+                Parallel.For(0, 10, new ParallelOptions() { MaxDegreeOfParallelism = 10 }, (_) =>
+                  {
+                      for (int i = 0; i < 100; i++)
+                      {
+                          logger.Trace("test message to the out and error stream");
+                      }
+                  });
+             
+            }
+            finally
+            {
+                Console.SetOut(oldOut);
+                Console.SetError(oldError);
+            }
+        }
+#endif
     }
 }
 

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -313,7 +313,7 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void DeleteFileOnStartTest_noExceptionWhenMissing()
         {
-            LogManager.Configuration = this.CreateConfigurationFromString(@"<nlog throwExceptions='true'>
+            LogManager.Configuration = CreateConfigurationFromString(@"<nlog throwExceptions='true'>
     <targets>
       <target name='file1' encoding='UTF-8' type='File'  deleteOldFileOnStartup='true' fileName='c://temp2/logs/i-dont-exist.log' layout='${message} ' />
     </targets>
@@ -2459,7 +2459,7 @@ namespace NLog.UnitTests.Targets
         {
             try
             {
-                LogManager.Configuration = this.CreateConfigurationFromString(@"<?xml version='1.0' encoding='utf-8' ?>
+                LogManager.Configuration = CreateConfigurationFromString(@"<?xml version='1.0' encoding='utf-8' ?>
 <nlog xmlns='http://www.nlog-project.org/schemas/NLog.xsd'
       xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
  
@@ -2490,7 +2490,7 @@ namespace NLog.UnitTests.Targets
         {
             try
             {
-                LogManager.Configuration = this.CreateConfigurationFromString(@"<?xml version='1.0' encoding='utf-8' ?>
+                LogManager.Configuration = CreateConfigurationFromString(@"<?xml version='1.0' encoding='utf-8' ?>
 <nlog xmlns='http://www.nlog-project.org/schemas/NLog.xsd'
       xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
  


### PR DESCRIPTION
fixes https://github.com/NLog/NLog/issues/1631

   `Console.Out.Writeline` / `Console.Error.Writeline` could throw `IndexOutOfRangeException'` which is a bug. 
 See [Stackoverflow](http://stackoverflow.com/questions/33915790/console-out-and-console-error-race-condition-error-in-a-windows-service-written)
 and [Microsoft connect/bug report](https://connect.microsoft.com/VisualStudio/feedback/details/2057284/console-out-probable-i-o-race-condition-issue-in-multi-threaded-windows-service)
             
 Full error: 

```
   Error during session close: System.IndexOutOfRangeException: Probable I/ O race condition detected while copying memory.
   The I/ O package is not thread safe by default.In multithreaded applications, 
   a stream must be accessed in a thread-safe way, such as a thread - safe wrapper returned by TextReader's or 
   TextWriter's Synchronized methods.This also applies to classes like StreamWriter and StreamReader.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1643)
<!-- Reviewable:end -->
