### PR TITLE
AsyncTargetWrapper - Allow TimeToSleepBetweenBatches = 0

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
+++ b/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
@@ -85,18 +85,8 @@ namespace NLog.Targets.Wrappers
         /// action is taken as specified by <see cref="OnOverflow"/>.
         /// </summary>
         /// <param name="logEventInfo">The log event info.</param>
-        public void Enqueue(AsyncLogEventInfo logEventInfo)
-        {
-            EnqueueCheckWasEmpty(logEventInfo);
-        }
-
-        /// <summary>
-        /// Enqueues another item. If the queue is overflown the appropriate
-        /// action is taken as specified by <see cref="OnOverflow"/>.
-        /// </summary>
-        /// <param name="logEventInfo">The log event info.</param>
         /// <returns>Queue was empty before enqueue</returns>
-        public bool EnqueueCheckWasEmpty(AsyncLogEventInfo logEventInfo)
+        public bool Enqueue(AsyncLogEventInfo logEventInfo)
         {
             lock (this)
             {

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -302,7 +302,7 @@ namespace NLog.Targets.Wrappers
         {
             this.MergeEventProperties(logEvent.LogEvent);
             this.PrecalculateVolatileLayouts(logEvent.LogEvent);
-            bool queueWasEmpty = this.RequestQueue.EnqueueCheckWasEmpty(logEvent);
+            bool queueWasEmpty = this.RequestQueue.Enqueue(logEvent);
             if (queueWasEmpty && TimeToSleepBetweenBatches <= 0)
                 StartInstantWriterTimer();
         }


### PR DESCRIPTION
Better than using 1ms that uses Timer-Threads even when nothing to process. Also when not having enabled high-resolution-timers, then 1 ms can become 15 ms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1669)
<!-- Reviewable:end -->
