### PR TITLE
LogEventInfo - Hidden StringBuilder-object optimization to avoid LOH

### DIFF
--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -59,5 +59,26 @@ namespace NLog.Internal
             builder.Append(Convert.ToString(o, formatProvider));
         }
 
+        /// <summary>
+        /// Copies content of the builder and appends it to target
+        /// </summary>
+        /// <param name="source">Source of the content</param>
+        /// <param name="target">Destination of the content</param>
+        /// <param name="workBuffer">Helper buffer to perform the copy [optional]</param>
+        public static void CopyToBuilder(this StringBuilder source, StringBuilder target, char[] workBuffer = null)
+        {
+#if !SILVERLIGHT
+            if (workBuffer == null)
+                workBuffer = new char[1024];
+            for (int i = 0; i< source.Length; i += workBuffer.Length)
+            {
+                int charCount = Math.Min(source.Length - i, workBuffer.Length);
+                source.CopyTo(i, workBuffer, 0, charCount);
+                target.Append(workBuffer, 0, charCount);
+            }
+#else
+            builder.Append(_result.ToString());
+#endif
+        }
     }
 }

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -77,7 +77,7 @@ namespace NLog.Internal
                 target.Append(workBuffer, 0, charCount);
             }
 #else
-            builder.Append(_result.ToString());
+            target.Append(source.ToString());
 #endif
         }
     }

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -80,5 +80,14 @@ namespace NLog.Internal
             target.Append(source.ToString());
 #endif
         }
+
+        public static void ClearBuilder(this StringBuilder target)
+        {
+#if NET4 || NET4_5
+            target.Clear();
+#else
+            target.Length = 0;
+#endif
+        }
     }
 }

--- a/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
@@ -74,7 +74,7 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            builder.Append(logEvent.FormattedMessage);
+            logEvent.AppendFormattedMessage(builder, null);
             if (this.WithException && logEvent.Exception != null)
             {
                 builder.Append(this.ExceptionSeparator);

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -260,7 +260,7 @@ namespace NLog
                     if (InternalLogger.IsTraceEnabled)
                         InternalLogger.Trace("LogEvent {0} discarded internal StringBuilder", SequenceID);
                     this.formattedMessage = this.messageBuilder.ToString();
-                    this.messageBuilder.Clear();
+                    StringBuilderExt.ClearBuilder(this.messageBuilder);
                     this.messageBuilder = null;
                 }
                 return this.formattedMessage;
@@ -573,7 +573,7 @@ namespace NLog
             this.formattedMessage = null;
             if (this.messageBuilder != null)
             {
-                this.messageBuilder.Clear();
+                StringBuilderExt.ClearBuilder(this.messageBuilder);
                 this.messageBuilder = null;
             }
         }

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -39,6 +39,7 @@ namespace NLog
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Globalization;
+    using System.Text;
     using System.Threading;
     using NLog.Common;
     using NLog.Internal;
@@ -59,6 +60,7 @@ namespace NLog
 
         private readonly object layoutCacheLock = new object();
 
+        private StringBuilder messageBuilder;
         private string formattedMessage;
         private string message;
         private object[] parameters;
@@ -111,7 +113,6 @@ namespace NLog
         /// <param name="exception">Exception information.</param>
         public LogEventInfo(LogLevel level, string loggerName, IFormatProvider formatProvider, [Localizable(false)] string message, object[] parameters, Exception exception): this()
         {
-            
             this.Level = level;
             this.LoggerName = loggerName;
             this.Message = message;
@@ -254,7 +255,43 @@ namespace NLog
                     this.CalcFormattedMessage();
                 }
 
+                if (this.messageBuilder != null)
+                {
+                    if (InternalLogger.IsTraceEnabled)
+                        InternalLogger.Trace("LogEvent {0} discarded internal StringBuilder", SequenceID);
+                    this.formattedMessage = this.messageBuilder.ToString();
+                    this.messageBuilder.Clear();
+                    this.messageBuilder = null;
+                }
                 return this.formattedMessage;
+            }
+        }
+
+        /// <summary>
+        /// Appends the formatted message to the provided builder
+        /// </summary>
+        /// <param name="builder">Target for the formatted message</param>
+        /// <param name="workBuffer">Work-buffer to perform the copy [optional]</param>
+        internal void AppendFormattedMessage(StringBuilder builder, char[] workBuffer)
+        {
+            if (this.formattedMessage != null)
+            {
+                builder.Append(formattedMessage);
+            }
+            else if (this.messageBuilder != null)
+            {
+                if (this.Parameters == null || this.Parameters.Length == 0)
+                    StringBuilderExt.CopyToBuilder(this.messageBuilder, builder, workBuffer);
+                else
+                    builder.Append(this.FormattedMessage);
+            }
+            else if (this.Parameters == null || this.Parameters.Length == 0)
+            {
+                builder.Append(this.message);
+            }
+            else
+            {
+                builder.Append(this.FormattedMessage);
             }
         }
 
@@ -494,10 +531,26 @@ namespace NLog
         {
             if (this.Parameters == null || this.Parameters.Length == 0)
             {
-                this.formattedMessage = this.Message;
+                if (this.messageBuilder == null)
+                    this.formattedMessage = this.Message;
             }
             else
             {
+                if (this.parameters.Length == 1 && this.message == "{0}" && this.parameters[0] is StringBuilder)
+                {
+                    // Hidden StringBuilder optimization where we clone the StringBuilder to avoid Large-Object-Heap
+                    StringBuilder sb = parameters[0] as StringBuilder;
+                    if (sb.Length > 4096)
+                    {
+                        ResetFormattedMessage();
+                        this.messageBuilder = new StringBuilder(sb.Length);
+                        StringBuilderExt.CopyToBuilder(sb, this.messageBuilder);
+                        this.parameters = null;
+                        this.message = string.Empty;
+                        return;
+                    }
+                }
+
                 try
                 {
                     this.formattedMessage = string.Format(this.FormatProvider ?? CultureInfo.CurrentCulture, this.Message, this.Parameters);
@@ -518,6 +571,11 @@ namespace NLog
         private void ResetFormattedMessage()
         {
             this.formattedMessage = null;
+            if (this.messageBuilder != null)
+            {
+                this.messageBuilder.Clear();
+                this.messageBuilder = null;
+            }
         }
 
         private void InitEventContext()

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -1721,6 +1721,65 @@ namespace NLog.UnitTests
             Assert.Throws<InvalidOperationException>(() => logger.Log(new LogEventInfo()));
         }
 
+        [Fact]
+        public void WhenLoggingStringBuilderSkipLargeObjectHeap()
+        {
+            var config = new LoggingConfiguration();
+            var target = new MyTarget();
+            config.LoggingRules.Add(new LoggingRule("*", LogLevel.Trace, target));
+            LogManager.Configuration = config;
+            var logger = LogManager.GetLogger("A");
+
+            long currentMemory = GC.GetTotalMemory(true);
+            System.Text.StringBuilder sb = new System.Text.StringBuilder(100000);
+            for (int i = 0; i < sb.Capacity ; ++i)
+                sb.Append('a');
+
+            long stringBuilderMemory = GC.GetTotalMemory(true);
+
+            {
+                sb.Clear();
+                for (int i = 0; i < sb.Capacity; ++i)
+                    sb.Append('b');
+                string string1 = sb.ToString();
+                logger.Log(LogLevel.Trace, string1);
+                sb.Clear();
+                target.LastEvent.AppendFormattedMessage(sb, null);
+                Assert.Equal(100000, sb.Length);
+                logger.Log(LogLevel.Trace, string.Empty);   // Clear LastEvent
+            }
+            long string1AllocatedMemory = GC.GetTotalMemory(true);
+
+            {
+                sb.Clear();
+                for (int i = 0; i < sb.Capacity; ++i)
+                    sb.Append('c');
+                string string2 = sb.ToString();
+                logger.Log(LogLevel.Trace, string2);
+                sb.Clear();
+                target.LastEvent.AppendFormattedMessage(sb, null);
+                Assert.Equal(100000, sb.Length);
+                logger.Log(LogLevel.Trace, string.Empty);   // Clear LastEvent
+            }
+
+            long string2AllocatedMemory = GC.GetTotalMemory(true);
+
+            {
+                sb.Clear();
+                for (int i = 0; i < sb.Capacity; ++i)
+                    sb.Append('d');
+                logger.Log(LogLevel.Trace, sb);
+                sb.Clear();
+                target.LastEvent.AppendFormattedMessage(sb, null);
+                Assert.Equal(100000, sb.Length);
+                logger.Log(LogLevel.Trace, string.Empty);   // Clear LastEvent
+            }
+            long noStringAllocatedMemory = GC.GetTotalMemory(true);
+
+            Assert.True((noStringAllocatedMemory - string2AllocatedMemory) < sizeof(char) * 10000);
+        }
+
+
         public abstract class BaseWrapper
         {
             public void Log(string what)

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -1738,12 +1738,12 @@ namespace NLog.UnitTests
             long stringBuilderMemory = GC.GetTotalMemory(true);
 
             {
-                sb.Clear();
+                NLog.Internal.StringBuilderExt.ClearBuilder(sb);
                 for (int i = 0; i < sb.Capacity; ++i)
                     sb.Append('b');
                 string string1 = sb.ToString();
                 logger.Log(LogLevel.Trace, string1);
-                sb.Clear();
+                NLog.Internal.StringBuilderExt.ClearBuilder(sb);
                 target.LastEvent.AppendFormattedMessage(sb, null);
                 Assert.Equal(100000, sb.Length);
                 logger.Log(LogLevel.Trace, string.Empty);   // Clear LastEvent
@@ -1751,12 +1751,12 @@ namespace NLog.UnitTests
             long string1AllocatedMemory = GC.GetTotalMemory(true);
 
             {
-                sb.Clear();
+                NLog.Internal.StringBuilderExt.ClearBuilder(sb);
                 for (int i = 0; i < sb.Capacity; ++i)
                     sb.Append('c');
                 string string2 = sb.ToString();
                 logger.Log(LogLevel.Trace, string2);
-                sb.Clear();
+                NLog.Internal.StringBuilderExt.ClearBuilder(sb);
                 target.LastEvent.AppendFormattedMessage(sb, null);
                 Assert.Equal(100000, sb.Length);
                 logger.Log(LogLevel.Trace, string.Empty);   // Clear LastEvent
@@ -1765,18 +1765,20 @@ namespace NLog.UnitTests
             long string2AllocatedMemory = GC.GetTotalMemory(true);
 
             {
-                sb.Clear();
+                NLog.Internal.StringBuilderExt.ClearBuilder(sb);
                 for (int i = 0; i < sb.Capacity; ++i)
                     sb.Append('d');
                 logger.Log(LogLevel.Trace, sb);
-                sb.Clear();
+                NLog.Internal.StringBuilderExt.ClearBuilder(sb);
                 target.LastEvent.AppendFormattedMessage(sb, null);
                 Assert.Equal(100000, sb.Length);
                 logger.Log(LogLevel.Trace, string.Empty);   // Clear LastEvent
             }
             long noStringAllocatedMemory = GC.GetTotalMemory(true);
 
+#if !SILVERLIGHT
             Assert.True((noStringAllocatedMemory - string2AllocatedMemory) < sizeof(char) * 10000);
+#endif
         }
 
 


### PR DESCRIPTION
Implemented hidden optimization on LogEventInfo that allows a StringBuilder to ride through NLog without allocating string on Large-Object-Heap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1674)
<!-- Reviewable:end -->
