### PR TITLE
Fix FileTarget on Xamarin: Remove mutex usage for Xamarin 'cause of runtime exceptions

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -31,7 +31,14 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+#if !SILVERLIGHT && !__ANDROID__ && !__IOS__
+// Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) 
+#define SupportsMutex
+#endif
+
 using System.Security;
+
+
 
 namespace NLog.Internal.FileAppenders
 {
@@ -41,7 +48,7 @@ namespace NLog.Internal.FileAppenders
     using NLog.Common;
     using NLog.Internal;
     using System.Threading;
-#if !SILVERLIGHT
+#if SupportsMutex
     using System.Security.AccessControl;
     using System.Security.Principal;
     using System.Security.Cryptography;
@@ -68,7 +75,8 @@ namespace NLog.Internal.FileAppenders
             this.OpenTime = DateTime.UtcNow; // to be consistent with timeToKill in FileTarget.AutoClosingTimerCallback
             this.LastWriteTime = DateTime.MinValue;
             this.CaptureLastWriteTime = createParameters.CaptureLastWriteTime;
-#if !SILVERLIGHT
+#if SupportsMutex
+           
             this.ArchiveMutex = CreateArchiveMutex();
 #endif
         }
@@ -174,7 +182,7 @@ namespace NLog.Internal.FileAppenders
             this.LastWriteTime = dateTime;
         }
 
-#if !SILVERLIGHT
+#if SupportsMutex
         /// <summary>
         /// Creates a mutually-exclusive lock for archiving files.
         /// </summary>

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -31,6 +31,11 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+#if !SILVERLIGHT && !__ANDROID__ && !__IOS__
+// Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) so the BaseFileAppender class now throws an exception in the constructor.
+#define SupportsMutex
+#endif
+
 namespace NLog.Internal.FileAppenders
 {
     using System;
@@ -301,7 +306,7 @@ namespace NLog.Internal.FileAppenders
             return null;
         }
 
-#if !SILVERLIGHT
+#if SupportsMutex
         public Mutex GetArchiveMutex(string fileName)
         {
             var appender = GetAppender(fileName);

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -31,7 +31,12 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !__ANDROID__ && !__IOS__
+// Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) so the BaseFileAppender class now throws an exception in the constructor.
+#define SupportsMutex
+#endif
+
+#if SupportsMutex
 
 namespace NLog.Internal.FileAppenders
 {

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -31,6 +31,11 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+#if !SILVERLIGHT && !__ANDROID__ && !__IOS__
+// Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) so the BaseFileAppender class now throws an exception in the constructor.
+#define SupportsMutex
+#endif
+
 using System.Security;
 
 namespace NLog.Internal.FileAppenders
@@ -121,7 +126,7 @@ namespace NLog.Internal.FileAppenders
             return null;
         }
 
-#if !SILVERLIGHT
+#if SupportsMutex
         /// <summary>
         /// Creates a mutually-exclusive lock for archiving files.
         /// </summary>

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -31,6 +31,11 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+#if !SILVERLIGHT && !__ANDROID__ && !__IOS__
+// Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) so the BaseFileAppender class now throws an exception in the constructor.
+#define SupportsMutex
+#endif
+
 namespace NLog.Targets
 {
     using System;
@@ -879,7 +884,7 @@ namespace NLog.Targets
             }
             else if (this.ConcurrentWrites)
             {
-#if SILVERLIGHT
+#if !SupportsMutex
                 return RetryingMultiProcessFileAppender.TheFactory;
 #elif MONO
 //
@@ -1778,7 +1783,7 @@ namespace NLog.Targets
             var archiveFile = this.GetArchiveFileName(fileName, ev, upcomingWriteSize);
             if (!string.IsNullOrEmpty(archiveFile))
             {
-#if !SILVERLIGHT
+#if SupportsMutex
                 Mutex archiveMutex = this.fileAppenderCache.GetArchiveMutex(fileName);
                 try
                 {
@@ -1802,7 +1807,7 @@ namespace NLog.Targets
                 }
                 finally
                 {
-#if !SILVERLIGHT
+#if SupportsMutex
                     if (archiveMutex != null)
                         archiveMutex.ReleaseMutex();
 #endif


### PR DESCRIPTION
Fixes https://github.com/NLog/NLog/issues/1666

> Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1676)
<!-- Reviewable:end -->
