### PR TITLE
Test for async="true" loses current thread identity

### DIFF
--- a/src/NLog/LayoutRenderers/IdentityLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/IdentityLayoutRenderer.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using NLog.Config;
+
 #if !SILVERLIGHT
 
 namespace NLog.LayoutRenderers


### PR DESCRIPTION
fixes #1426 and , see also https://github.com/NLog/NLog/pull/1660

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1692)

<!-- Reviewable:end -->
