### PR TITLE
Performance: Counter/ProcessId/ThreadId-LayoutRenderer allocations less memory

### DIFF
--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -59,5 +59,69 @@ namespace NLog.Internal
             builder.Append(Convert.ToString(o, formatProvider));
         }
 
+        /// <summary>
+        /// Appends int without using culture, and most importantly without garbage
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="value">value to append</param>
+        public static void AppendInvariant(this StringBuilder builder, int value)
+        {
+            // Deal with negative numbers
+            if (value < 0)
+            {
+                builder.Append('-');
+                uint uint_value = uint.MaxValue - ((uint)value) + 1; //< This is to deal with Int32.MinValue
+                AppendInvariant(builder, uint_value);
+            }
+            else
+            {
+                AppendInvariant(builder, (uint)value);
+            }
+        }
+
+        /// <summary>
+        /// Appends uint without using culture, and most importantly without garbage
+        /// 
+        /// Credits Gavin Pugh  - http://www.gavpugh.com/2010/04/01/xnac-avoiding-garbage-when-working-with-stringbuilder/
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="value">value to append</param>
+        public static void AppendInvariant(this StringBuilder builder, uint value)
+        {
+            if (value == 0)
+            {
+                builder.Append('0');
+                return;
+            }
+            
+            // Calculate length of integer when written out
+            int length = 0;
+            uint length_calc = value;
+
+            do
+            {
+                length_calc /= 10;
+                length++;
+            }
+            while (length_calc > 0);
+
+            // Pad out space for writing.
+            builder.Append('0', length);
+
+            int strpos = builder.Length;
+
+            // We're writing backwards, one character at a time.
+            while (length > 0)
+            {
+                strpos--;
+
+                // Lookup from static char array, to cover hex values too
+                builder[strpos] = charToInt[value % 10];
+
+                value /= 10;
+                length--;
+            }
+        }
+        private static readonly char[] charToInt = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
     }
 }

--- a/src/NLog/LayoutRenderers/CounterLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CounterLayoutRenderer.cs
@@ -96,7 +96,7 @@ namespace NLog.LayoutRenderers
                 this.Value += this.Increment;
             }
 
-            builder.Append(v.ToString(CultureInfo.InvariantCulture));
+            Internal.StringBuilderExt.AppendInvariant(builder, v);
         }
 
         private static int GetNextSequenceValue(string sequenceName, int defaultValue, int increment)

--- a/src/NLog/LayoutRenderers/ProcessIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessIdLayoutRenderer.cs
@@ -35,7 +35,6 @@
 
 namespace NLog.LayoutRenderers
 {
-    using System.Globalization;
     using System.Text;
     using NLog.Config;
     using NLog.Internal;
@@ -55,7 +54,7 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            builder.Append(ThreadIDHelper.Instance.CurrentProcessID.ToString(CultureInfo.InvariantCulture));
+            builder.AppendInvariant(ThreadIDHelper.Instance.CurrentProcessID);
         }
     }
 }

--- a/tests/NLog.UnitTests/Internal/StringBuilderExtTests.cs
+++ b/tests/NLog.UnitTests/Internal/StringBuilderExtTests.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,26 +31,53 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.LayoutRenderers
-{
-    using System.Text;
-    using System.Threading;
+#if !SILVERLIGHT
+//no silverlight for xunit InlineData
 
-    /// <summary>
-    /// The identifier of the current thread.
-    /// </summary>
-    [LayoutRenderer("threadid")]
-    public class ThreadIdLayoutRenderer : LayoutRenderer
+using System.Text;
+using NLog.Internal;
+using Xunit;
+using Xunit.Extensions;
+
+namespace NLog.UnitTests.Internal
+{
+    public class StringBuilderExtTests : NLogTestBase
     {
-        /// <summary>
-        /// Renders the current thread identifier and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(12)]
+        [InlineData(123)]
+        [InlineData(1234)]
+        [InlineData(12345)]
+        [InlineData(123456)]
+        [InlineData(1234567)]
+        [InlineData(12345678)]
+        [InlineData(123456789)]
+        [InlineData(1234567890)]
+        [InlineData(int.MaxValue)]
+        [InlineData(int.MinValue)]
+        void TestAppendInvariant(int input)
         {
-            //no culture needed for ints
-            Internal.StringBuilderExt.AppendInvariant(builder, Thread.CurrentThread.ManagedThreadId);
+            StringBuilder sb = new StringBuilder();
+            StringBuilderExt.AppendInvariant(sb, input);
+            Assert.Equal(input.ToString(System.Globalization.CultureInfo.InvariantCulture), sb.ToString());
+
+            input = 0 - input;
+            sb.Clear();
+            StringBuilderExt.AppendInvariant(sb, input);
+            Assert.Equal(input.ToString(System.Globalization.CultureInfo.InvariantCulture), sb.ToString());
         }
     }
 }
+
+#endif

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
+    <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
+    <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
+    <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -161,6 +163,7 @@
     <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
+    <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
+    <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
+    <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />
     <Compile Include="LayoutRenderers\AppDomainLayoutRendererTests.cs" />


### PR DESCRIPTION
These three renderers are using the invariant culture. - StringBuilder Append without allocation

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1695)
<!-- Reviewable:end -->
