### PR TITLE
Test for: FileTarget fails to write to primary log file when archive files do not match DateAndSequence numbering pattern

### DIFF
--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -2938,8 +2938,69 @@ namespace NLog.UnitTests.Targets
                 }
             }
         }
-    }
 
+        [Fact]
+        public void DontCrashWhenDateAndSequenceDoesntMatchFiles()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "DontCrashWhenDateAndSequenceDoesntMatchFiles-" + Guid.NewGuid());
+            string logFile = Path.Combine(tempDir, "log.txt");
+            try
+            {
+                // set log file access times the same way as when this issue comes up.
+                Directory.CreateDirectory(tempDir);
+                
+                File.WriteAllText(logFile, "some content" + Environment.NewLine);
+                var oldTime = DateTime.Now.AddDays(-2);
+                File.SetCreationTime(logFile, oldTime);
+                File.SetLastWriteTime(logFile, oldTime);
+                File.SetLastAccessTime(logFile, oldTime);
+
+                //write to archive directly
+                var archiveDateFormat = "yyyyMMdd";
+                var archiveFileNamePattern = Path.Combine(tempDir, "log-{#}.txt");
+                var archiveFileName = archiveFileNamePattern.Replace("{#}", oldTime.ToString(archiveDateFormat));
+                File.WriteAllText(archiveFileName, "some archive content");
+
+                LogManager.ThrowExceptions = true;
+
+                // configure nlog
+
+
+                var fileTarget = new FileTarget("file")
+                {
+                    FileName = logFile,
+                    ArchiveEvery = FileArchivePeriod.Day,
+                    ArchiveFileName = "log-{#}.txt",
+                    ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
+                    ArchiveAboveSize = 50000,
+                    MaxArchiveFiles = 7
+                };
+
+                
+                var config = new LoggingConfiguration();
+                config.AddRuleForAllLevels(fileTarget);
+                LogManager.Configuration = config;
+
+                // write
+                var logger = LogManager.GetLogger("DontCrashWhenDateAndSequenceDoesntMatchFiles");
+                logger.Info("Log message");
+
+                LogManager.Flush();
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(logFile))
+                        File.Delete(logFile);
+                    Directory.Delete(tempDir, true);
+                }
+                catch (Exception)
+                {
+                }
+            }
+        }
+    }
 
     public class WrappedFileTargetTests : FileTargetTests
     {


### PR DESCRIPTION
Prove that https://github.com/NLog/NLog/issues/1664 has been fixed.

fixes https://github.com/NLog/NLog/issues/1664

Tested in 4.3.7 and unit test fails there

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1696)
<!-- Reviewable:end -->
