### PR TITLE
Improved concurrency when multiple Logger threads are writing to async Target

### DIFF
--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -431,7 +431,7 @@ namespace NLog
         {
             lock (this.layoutCacheLock)
             {
-                if (this.layoutCache == null)
+                if (this.layoutCache == null || this.layoutCache.Count == 0)
                 {
                     value = null;
                     return false;

--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -36,8 +36,7 @@ namespace NLog.Targets.Wrappers
     using System.ComponentModel;
     using System.Threading;
     using NLog.Common;
-    using NLog.Internal;
-
+    
     /// <summary>
     /// A target that buffers log events and sends them in batches to the wrapped target.
     /// </summary>
@@ -177,7 +176,8 @@ namespace NLog.Targets.Wrappers
         /// <param name="logEvent">The log event.</param>
         protected override void Write(AsyncLogEventInfo logEvent)
         {
-            this.WrappedTarget.PrecalculateVolatileLayouts(logEvent.LogEvent);
+            this.MergeEventProperties(logEvent.LogEvent);
+            this.PrecalculateVolatileLayouts(logEvent.LogEvent);
 
             int count = this.buffer.Append(logEvent);
             if (count >= this.BufferSize)


### PR DESCRIPTION
When writing to an async-target, then the Logger is forced to acquire Target.SyncObject-lock and hold it while preparing its LogEventInfo-object for the async-queue. Other Logger-threads writing to the same Target has to wait for this.

Now multiple Logger-threads can post directly to the async-queue without need to aquire and hold the Target.SyncRoot-lock. This means that the lock-held-window is much smaller and thus improves concurrency.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1700)

<!-- Reviewable:end -->
