### PR TITLE
Console Target Automatic Detect if console is available on Mono

### DIFF
--- a/src/NLog/Internal/PlatformDetector.cs
+++ b/src/NLog/Internal/PlatformDetector.cs
@@ -75,6 +75,14 @@ namespace NLog.Internal
         {
             get { return currentOS == RuntimeOS.Unix; }
         }
+
+        /// <summary>
+        /// Gets a value indicating whether current runtime is Mono-based
+        /// </summary>
+        public static bool IsMono
+        {
+            get { return Type.GetType("Mono.Runtime") != null; }
+        }
         
         private static RuntimeOS GetCurrentRuntimeOS()
         {

--- a/tests/NLog.UnitTests/Internal/PlatformDetectorTests.cs
+++ b/tests/NLog.UnitTests/Internal/PlatformDetectorTests.cs
@@ -31,42 +31,21 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-using System.IO;
-using NLog.Common;
+using NLog.Internal;
+using Xunit;
 
-namespace NLog.Targets
+namespace NLog.UnitTests.Internal
 {
-    internal static class ConsoleTargetHelper
+    public class PlatformDetectorTests : NLogTestBase
     {
-        public static bool IsConsoleAvailable(out string reason)
+        [Fact]
+        public void IsMonoTest()
         {
-            reason = string.Empty;
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !MONO
-            try
-            {
-                if (!Environment.UserInteractive)
-                {
-                    if (Internal.PlatformDetector.IsMono && Console.In is StreamReader)
-                        return true;    // Extra bonus check for Mono, that doesn't support Environment.UserInteractive
-
-                    reason = "Environment.UserInteractive = False";
-                    return false;
-                }
-                else if (Console.OpenStandardInput(1) == Stream.Null)
-                {
-                    reason = "Console.OpenStandardInput = Null";
-                    return false;
-                }
-            }
-            catch (Exception ex)
-            {
-                reason = string.Format("Unexpected exception: {0}:{1}", ex.GetType().Name, ex.Message);
-                InternalLogger.Warn(ex, "Failed to detect whether console is available.");
-                return false;
-            }
+#if MONO
+            Assert.True(PlatformDetector.IsMono);
+#elif NET3_5 || NET4_0 || NET4_5
+            Assert.False(PlatformDetector.IsMono);
 #endif
-            return true;
         }
     }
 }

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
+    <Compile Include="Internal\PlatformDetectorTests.cs" />
     <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
+    <Compile Include="Internal\PlatformDetectorTests.cs" />
     <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
+    <Compile Include="Internal\PlatformDetectorTests.cs" />
     <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
+    <Compile Include="Internal\PlatformDetectorTests.cs" />
     <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
+    <Compile Include="Internal\PlatformDetectorTests.cs" />
     <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Internal\FilePathLayoutTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
+    <Compile Include="Internal\PlatformDetectorTests.cs" />
     <Compile Include="Internal\StringBuilderExtTests.cs" />
     <Compile Include="Internal\StringHelpersTests.cs" />
     <Compile Include="Internal\UrlHelperTests.cs" />


### PR DESCRIPTION
Extended the console detection check to support Mono, that doesn't support Environment.UserInteractive. Attempt to fix #1704 (Not tested)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1706)
<!-- Reviewable:end -->
