### PR TITLE
AsyncLogEventInfo getter-property-methods changed into readonly members

### DIFF
--- a/src/NLog/Common/AsyncLogEventInfo.cs
+++ b/src/NLog/Common/AsyncLogEventInfo.cs
@@ -53,12 +53,12 @@ namespace NLog.Common
         /// <summary>
         /// Gets the log event.
         /// </summary>
-        public LogEventInfo LogEvent { get; private set; }
+        public readonly LogEventInfo LogEvent;
 
         /// <summary>
         /// Gets the continuation.
         /// </summary>
-        public AsyncContinuation Continuation { get; internal set; }
+        public readonly AsyncContinuation Continuation;
 
         /// <summary>
         /// Implements the operator ==.

--- a/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
@@ -109,7 +109,7 @@ namespace NLog.Targets.Wrappers
 
             for (int i = 0; i < logEvents.Length; ++i)
             {
-                logEvents[i].Continuation = CountedWrap(logEvents[i].Continuation, this.Targets.Count);
+                logEvents[i] = new AsyncLogEventInfo(logEvents[i].LogEvent, CountedWrap(logEvents[i].Continuation, this.Targets.Count));
             }
 
             foreach (var t in this.Targets)


### PR DESCRIPTION
Replaced syntax-sugar intance-getter-methods with direct readonly intance-member access.

AsyncLogEventInfo  is a public struct so this is a breaking change, even though none are using the setter-method.

Now it is a proper immutable struct :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1722)
<!-- Reviewable:end -->
