### PR TITLE
fixed culture dependent tests

### DIFF
--- a/tests/NLog.UnitTests/Config/CultureInfoTests.cs
+++ b/tests/NLog.UnitTests/Config/CultureInfoTests.cs
@@ -63,7 +63,7 @@ namespace NLog.UnitTests.Config
             try
             {
                 // set the current thread culture to be definitely different from the InvariantCulture
-                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE", false);
 
                 var configurationTemplate = @"<nlog useInvariantCulture='{0}'>
 <targets>
@@ -226,12 +226,12 @@ namespace NLog.UnitTests.Config
             }
             catch (Exception ex)
             {
-                Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
-                Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+                Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US", false);
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US", false);
                 logger.Error(ex, "");
 
-                Thread.CurrentThread.CurrentUICulture = new CultureInfo("de-DE");
-                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+                Thread.CurrentThread.CurrentUICulture = new CultureInfo("de-DE", false);
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE", false);
                 logger.Error(ex, "");
 
                 Assert.Equal(2, target.Logs.Count);

--- a/tests/NLog.UnitTests/Config/CultureInfoTests.cs
+++ b/tests/NLog.UnitTests/Config/CultureInfoTests.cs
@@ -63,7 +63,7 @@ namespace NLog.UnitTests.Config
             try
             {
                 // set the current thread culture to be definitely different from the InvariantCulture
-                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE", false);
+                Thread.CurrentThread.CurrentCulture = GetCultureInfo("de-DE");
 
                 var configurationTemplate = @"<nlog useInvariantCulture='{0}'>
 <targets>

--- a/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
+++ b/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
@@ -476,7 +476,7 @@ namespace NLog.UnitTests.Fluent
         public void LogBuilder_message_cultureTest()
         {
 
-            LogManager.Configuration.DefaultCultureInfo = new CultureInfo("en-us");
+            LogManager.Configuration.DefaultCultureInfo = new CultureInfo("en-US", false);
 
             _logger.Debug()
              .Message("Message with {0} {1} {2} {3}", 4.1, 4.001, new DateTime(2016, 12, 31), true)
@@ -484,7 +484,7 @@ namespace NLog.UnitTests.Fluent
             AssertDebugLastMessage("t2", "Message with 4.1 4.001 12/31/2016 12:00:00 AM True");
 
             _logger.Debug()
-           .Message(new CultureInfo("nl-nl"), "Message with {0} {1} {2} {3}", 4.1, 4.001, new DateTime(2016, 12, 31), true)
+           .Message(new CultureInfo("nl-nl", false), "Message with {0} {1} {2} {3}", 4.1, 4.001, new DateTime(2016, 12, 31), true)
            .Write();
             AssertDebugLastMessage("t2", "Message with 4,1 4,001 31-12-2016 00:00:00 True");
         }

--- a/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
+++ b/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
@@ -476,7 +476,7 @@ namespace NLog.UnitTests.Fluent
         public void LogBuilder_message_cultureTest()
         {
 
-            LogManager.Configuration.DefaultCultureInfo = new CultureInfo("en-US", false);
+            LogManager.Configuration.DefaultCultureInfo = GetCultureInfo("en-US");
 
             _logger.Debug()
              .Message("Message with {0} {1} {2} {3}", 4.1, 4.001, new DateTime(2016, 12, 31), true)
@@ -484,7 +484,7 @@ namespace NLog.UnitTests.Fluent
             AssertDebugLastMessage("t2", "Message with 4.1 4.001 12/31/2016 12:00:00 AM True");
 
             _logger.Debug()
-           .Message(new CultureInfo("nl-nl", false), "Message with {0} {1} {2} {3}", 4.1, 4.001, new DateTime(2016, 12, 31), true)
+           .Message(GetCultureInfo("nl-nl"), "Message with {0} {1} {2} {3}", 4.1, 4.001, new DateTime(2016, 12, 31), true)
            .Write();
             AssertDebugLastMessage("t2", "Message with 4,1 4,001 31-12-2016 00:00:00 True");
         }

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -45,7 +45,7 @@ namespace NLog.UnitTests
     using System.Threading;
     public class LoggerTests : NLogTestBase
     {
-        private CultureInfo NLCulture = new CultureInfo("nl-nl", false);
+        private CultureInfo NLCulture = GetCultureInfo("nl-nl");
 
         [Fact]
         public void TraceTest()

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -45,7 +45,7 @@ namespace NLog.UnitTests
     using System.Threading;
     public class LoggerTests : NLogTestBase
     {
-        private CultureInfo NLCulture = new CultureInfo("nl-nl");
+        private CultureInfo NLCulture = new CultureInfo("nl-nl", false);
 
         [Fact]
         public void TraceTest()
@@ -1313,6 +1313,8 @@ namespace NLog.UnitTests
 
                 var logger = LogManager.GetLogger("A");
 
+                //set current UI culture as invariant to receive exception messages in EN
+                Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
                 var argException = new ArgumentException("arg1 is obvious wrong", "arg1");
 
                 LogManager.Configuration.DefaultCultureInfo = CultureInfo.InvariantCulture;
@@ -1485,8 +1487,9 @@ namespace NLog.UnitTests
 
                 var logger = LogManager.GetLogger("A");
 
+                //set current UI culture as invariant to receive exception messages in EN
+                Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
                 var argException = new ArgumentException("arg1 is obvious wrong", "arg1");
-
                 LogManager.Configuration.DefaultCultureInfo = CultureInfo.InvariantCulture;
 
                 logger.ConditionalDebug("message");

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -40,7 +40,7 @@ namespace NLog.UnitTests
     using NLog.Common;
     using System.IO;
     using System.Text;
-
+    using System.Globalization;
     using NLog.Layouts;
     using NLog.Config;
     using NLog.Targets;
@@ -352,6 +352,24 @@ namespace NLog.UnitTests
             action();
 
             return stringWriter.ToString();
+        }
+
+        /// <summary>
+        /// Creates <see cref="CultureInfo"/> instance for test purposes
+        /// </summary>
+        /// <param name="cultureName">Culture name to create</param>
+        /// <remarks>
+        /// Creates <see cref="CultureInfo"/> instance with non-userOverride
+        /// flag to provide expected results when running tests in different
+        /// system cultures(with overriden culture options)
+        /// </remarks>
+        protected static CultureInfo GetCultureInfo(string cultureName)
+        {
+#if SILVERLIGHT
+            return new CultureInfo(cultureName);
+#else
+            return new CultureInfo(cultureName, false);
+#endif
         }
 
         public delegate void SyncAction();


### PR DESCRIPTION
On environments with system culture different from US some tests are failing.

1. Now passing useUserOverride = false, when creating ```new CultureInfo``` in tests. User can override DateTimeFormat for specific Culture, because of this some asserts in a tests are failed.

2. In ConditionalTraceTest and ConditionalDebugTest setting ```Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;``` for receiving exceptions messages in english (as test expects)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1726)
<!-- Reviewable:end -->
