### PR TITLE
Handle duplicate attributes (error or using first occurence)

### DIFF
--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -222,20 +222,20 @@ namespace NLog.Config
         }
 
         /// <summary>
-        /// Try to get all errors occured during xml parsing.
-        /// A return value indicates whether there any error.
+        /// Returns all errors occured during xml parsing.
+        /// If there is no errors - returns null.
         /// </summary>
-        /// <param name="errors">Array of error messages</param>
-        public bool TryGetParsingErrors(out string[] errors)
+        public string GetParsingErrors()
         {
-            errors = GetParsingErrors().ToArray();
-            return errors.Any();
+            var errors = GetParsingErrorsInternal().ToArray();
+            if (errors.Length == 0) return null;
+            return string.Join(Environment.NewLine, errors);
         }
 
         /// <summary>
         /// Returns all parsing errors from current and all child elements.
         /// </summary>
-        private IEnumerable<string> GetParsingErrors()
+        private IEnumerable<string> GetParsingErrorsInternal()
         {
             foreach (var parsingError in _parsingErrors)
             {
@@ -244,7 +244,7 @@ namespace NLog.Config
 
             foreach (var childElement in this.Children)
             {
-                foreach (var parsingError in childElement.GetParsingErrors())
+                foreach (var parsingError in childElement.GetParsingErrorsInternal())
                 {
                     yield return parsingError;
                 }

--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -225,10 +225,10 @@ namespace NLog.Config
         /// Try to get all errors occured during xml parsing.
         /// A return value indicates whether there any error.
         /// </summary>
-        /// <param name="errors">List of errors</param>
-        public bool TryGetParsingErrors(out IEnumerable<string> errors)
+        /// <param name="errors">Array of error messages</param>
+        public bool TryGetParsingErrors(out string[] errors)
         {
-            errors = GetParsingErrors().ToList();
+            errors = GetParsingErrors().ToArray();
             return errors.Any();
         }
 

--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -222,20 +222,9 @@ namespace NLog.Config
         }
 
         /// <summary>
-        /// Returns all errors occured during xml parsing.
-        /// If there is no errors - returns null.
-        /// </summary>
-        public string GetParsingErrors()
-        {
-            var errors = GetParsingErrorsInternal().ToArray();
-            if (errors.Length == 0) return null;
-            return string.Join(Environment.NewLine, errors);
-        }
-
-        /// <summary>
         /// Returns all parsing errors from current and all child elements.
         /// </summary>
-        private IEnumerable<string> GetParsingErrorsInternal()
+        public IEnumerable<string> GetParsingErrors()
         {
             foreach (var parsingError in _parsingErrors)
             {
@@ -244,7 +233,7 @@ namespace NLog.Config
 
             foreach (var childElement in this.Children)
             {
-                foreach (var parsingError in childElement.GetParsingErrorsInternal())
+                foreach (var parsingError in childElement.GetParsingErrors())
                 {
                     yield return parsingError;
                 }

--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -238,7 +238,7 @@ namespace NLog.Config
                     yield return parsingError;
                 }
             }
-        } 
+        }
 
         private void Parse(XmlReader reader)
         {
@@ -262,7 +262,7 @@ namespace NLog.Config
                 while (reader.MoveToNextAttribute());
                 reader.MoveToElement();
             }
-            
+
             this.LocalName = reader.LocalName;
 
             if (!reader.IsEmptyElement)

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -453,7 +453,7 @@ namespace NLog.Config
         /// <param name="rootContentElement">Root NLog configuration xml element</param>
         private void CheckParsingErrors(NLogXmlElement rootContentElement)
         {
-            IEnumerable<string> errors;
+            string[] errors;
             if(rootContentElement.TryGetParsingErrors(out errors))
             {
                 if (LogManager.ThrowConfigExceptions ?? LogManager.ThrowExceptions)

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -419,7 +419,6 @@ namespace NLog.Config
                     this.ParseTopLevel(content, null, autoReloadDefault: false);
                 }
                 InitializeSucceeded = true;
-
                 this.CheckUnusedTargets();
 
             }
@@ -508,6 +507,8 @@ namespace NLog.Config
                     this.ParseNLogElement(content, filePath, autoReloadDefault);
                     break;
             }
+
+            content.AssertNoParsingErrors();
         }
 
         /// <summary>

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -419,8 +419,8 @@ namespace NLog.Config
                     this.ParseTopLevel(content, null, autoReloadDefault: false);
                 }
                 InitializeSucceeded = true;
+                this.CheckParsingErrors(content);
                 this.CheckUnusedTargets();
-
             }
             catch (Exception exception)
             {
@@ -441,6 +441,33 @@ namespace NLog.Config
                     }
                 }
 
+            }
+        }
+
+        /// <summary>
+        /// Checks whether any error during XML configuration parsing has occured.
+        /// If there are any and <c>ThrowConfigExceptions</c> or <c>ThrowExceptions</c>
+        /// setting is enabled - throws <c>NLogConfigurationException</c>, otherwise
+        /// just write an internal log at Warn level.
+        /// </summary>
+        /// <param name="rootContentElement">Root NLog configuration xml element</param>
+        private void CheckParsingErrors(NLogXmlElement rootContentElement)
+        {
+            IEnumerable<string> errors;
+            if(rootContentElement.TryGetParsingErrors(out errors))
+            {
+                if (LogManager.ThrowConfigExceptions ?? LogManager.ThrowExceptions)
+                {
+                    string exceptionMessage = string.Join(Environment.NewLine, errors);
+                    throw new NLogConfigurationException(exceptionMessage);
+                }
+                else
+                {
+                    foreach (var error in errors)
+                    {
+                        InternalLogger.Log(LogLevel.Warn, error);
+                    }
+                }
             }
         }
 
@@ -507,8 +534,6 @@ namespace NLog.Config
                     this.ParseNLogElement(content, filePath, autoReloadDefault);
                     break;
             }
-
-            content.AssertNoParsingErrors();
         }
 
         /// <summary>

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -453,17 +453,20 @@ namespace NLog.Config
         /// <param name="rootContentElement">Root NLog configuration xml element</param>
         private void CheckParsingErrors(NLogXmlElement rootContentElement)
         {
-            var parsingErrors = rootContentElement.GetParsingErrors();
-            if(!string.IsNullOrEmpty(parsingErrors))
+            var parsingErrors = rootContentElement.GetParsingErrors().ToArray();
+            if(!parsingErrors.Any())
             {
                 if (LogManager.ThrowConfigExceptions ?? LogManager.ThrowExceptions)
                 {
-                    throw new NLogConfigurationException(parsingErrors);
+                    string exceptionMessage = string.Join(Environment.NewLine, parsingErrors);
+                    throw new NLogConfigurationException(exceptionMessage);
                 }
                 else
                 {
-                    InternalLogger.Log(LogLevel.Warn, parsingErrors);
-
+                    foreach (var parsingError in parsingErrors)
+                    {
+                        InternalLogger.Log(LogLevel.Warn, parsingError);
+                    }
                 }
             }
         }

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -454,7 +454,7 @@ namespace NLog.Config
         private void CheckParsingErrors(NLogXmlElement rootContentElement)
         {
             var parsingErrors = rootContentElement.GetParsingErrors().ToArray();
-            if(!parsingErrors.Any())
+            if(parsingErrors.Any())
             {
                 if (LogManager.ThrowConfigExceptions ?? LogManager.ThrowExceptions)
                 {

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -453,20 +453,17 @@ namespace NLog.Config
         /// <param name="rootContentElement">Root NLog configuration xml element</param>
         private void CheckParsingErrors(NLogXmlElement rootContentElement)
         {
-            string[] errors;
-            if(rootContentElement.TryGetParsingErrors(out errors))
+            var parsingErrors = rootContentElement.GetParsingErrors();
+            if(!string.IsNullOrEmpty(parsingErrors))
             {
                 if (LogManager.ThrowConfigExceptions ?? LogManager.ThrowExceptions)
                 {
-                    string exceptionMessage = string.Join(Environment.NewLine, errors);
-                    throw new NLogConfigurationException(exceptionMessage);
+                    throw new NLogConfigurationException(parsingErrors);
                 }
                 else
                 {
-                    foreach (var error in errors)
-                    {
-                        InternalLogger.Log(LogLevel.Warn, error);
-                    }
+                    InternalLogger.Log(LogLevel.Warn, parsingErrors);
+
                 }
             }
         }

--- a/tests/NLog.UnitTests/Config/DuplicateConfigurationAttributeTests.cs
+++ b/tests/NLog.UnitTests/Config/DuplicateConfigurationAttributeTests.cs
@@ -1,0 +1,118 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.Config
+{
+    using Xunit;
+
+
+    public class DuplicateConfigurationAttributeTests : NLogTestBase
+    {
+        [Fact]
+        public void ShouldWriteLogsOnDuplicateAttributeTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog>
+                    <targets><target name='debug' type='debug' layout='${message}' /></targets>
+                    <rules>
+                        <logger name='*' minlevel='info' minLevel='info' appendto='debug'>
+                            <filters>
+                                <whencontains layout='${message}' substring='msg' action='ignore' />
+                            </filters>
+                        </logger>
+                    </rules>
+                </nlog>");
+
+            var logger = LogManager.GetLogger("A");
+            string expectedMesssage = "some message";
+            logger.Info(expectedMesssage);
+            var actualMessage = this.GetDebugLastMessage("debug");
+            Assert.Equal(expectedMesssage, actualMessage);
+        }
+
+        [Fact]
+        public void ShoudWriteToInternalLogOnDuplicateAttributeTest()
+        {
+            var internalLog = RunAndCaptureInternalLog(() =>
+            {
+                LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog>
+                    <targets><target name='debug' type='debug' layout='${message}' /></targets>
+                    <rules>
+                        <logger name='*' minlevel='info' minLevel='trace' appendto='debug'>
+                            <filters>
+                                <whencontains layout='${message}' substring='msg' action='ignore' />
+                            </filters>
+                        </logger>
+                    </rules>
+                </nlog>");
+            }, LogLevel.Error);
+
+            Assert.True(internalLog.Contains("NLog.NLogConfigurationException: Duplicate attribute detected. Attribute name: [minLevel]. Duplicate value:[trace], Current value:[info]"), internalLog);
+        }
+
+        [Fact]
+        public void ShoudThrowExceptionOnDuplicateAttributeWhenOptionIsEnabledTest()
+        {
+            Assert.Throws<NLogConfigurationException>(() =>
+            {
+                LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog throwExceptions='true'>
+                    <targets><target name='debug' type='debug' layout='${message}' /></targets>
+                    <rules>
+                        <logger name='*' minlevel='info' minLevel='info' appendto='debug'>
+                            <filters>
+                                <whencontains layout='${message}' substring='msg' action='ignore' />
+                            </filters>
+                        </logger>
+                    </rules>
+                </nlog>");
+            });
+
+            Assert.Throws<NLogConfigurationException>(() =>
+            {
+                LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog throwConfigExceptions='true'>
+                    <targets><target name='debug' type='debug' layout='${message}' /></targets>
+                    <rules>
+                        <logger name='*' minlevel='info' minLevel='info' appendto='debug'>
+                            <filters>
+                                <whencontains layout='${message}' substring='msg' action='ignore' />
+                            </filters>
+                        </logger>
+                    </rules>
+                </nlog>");
+            });
+        }
+    }
+}

--- a/tests/NLog.UnitTests/Config/DuplicateConfigurationAttributeTests.cs
+++ b/tests/NLog.UnitTests/Config/DuplicateConfigurationAttributeTests.cs
@@ -71,14 +71,15 @@ namespace NLog.UnitTests.Config
                     <rules>
                         <logger name='*' minlevel='info' minLevel='trace' appendto='debug'>
                             <filters>
-                                <whencontains layout='${message}' substring='msg' action='ignore' />
+                                <whencontains layout='${message}' substring='msg' Substring='msg1' action='ignore' />
                             </filters>
                         </logger>
                     </rules>
                 </nlog>");
             }, LogLevel.Error);
 
-            Assert.True(internalLog.Contains("NLog.NLogConfigurationException: Duplicate attribute detected. Attribute name: [minLevel]. Duplicate value:[trace], Current value:[info]"), internalLog);
+            Assert.True(internalLog.Contains("Duplicate attribute detected. Attribute name: [minLevel]. Duplicate value:[trace], Current value:[info]"), internalLog);
+            Assert.True(internalLog.Contains("Duplicate attribute detected. Attribute name: [Substring]. Duplicate value:[msg1], Current value:[msg]"), internalLog);
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -252,7 +252,4 @@
       <Name>SampleExtensions.mono</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
 </Project>

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -7,7 +7,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -83,6 +84,7 @@
     <Compile Include="Config\ConfigApiTests.cs" />
     <Compile Include="Config\ConfigurationItemFactoryTests.cs" />
     <Compile Include="Config\CultureInfoTests.cs" />
+    <Compile Include="Config\DuplicateConfigurationAttributeTests.cs" />
     <Compile Include="Config\ExtensionTests.cs" />
     <Compile Include="Config\IncludeTests.cs" />
     <Compile Include="Config\InternalLoggingTests.cs" />
@@ -249,5 +251,8 @@
       <Project>{5CCB56C3-4A6E-4C11-960B-2877099F52CE}</Project>
       <Name>SampleExtensions.mono</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)'==''">v4.0</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -19,8 +21,10 @@
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <SignAssembly>true</SignAssembly>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <FileUpgradeFlags></FileUpgradeFlags>
-    <UpgradeBackupLocation></UpgradeBackupLocation>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -112,6 +116,7 @@
     <Compile Include="Config\ConfigApiTests.cs" />
     <Compile Include="Config\ConfigurationItemFactoryTests.cs" />
     <Compile Include="Config\CultureInfoTests.cs" />
+    <Compile Include="Config\DuplicateConfigurationAttributeTests.cs" />
     <Compile Include="Config\ExtensionTests.cs" />
     <Compile Include="Config\IncludeTests.cs" />
     <Compile Include="Config\InternalLoggingTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -10,8 +10,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -92,6 +94,7 @@
     <Compile Include="Config\ConfigApiTests.cs" />
     <Compile Include="Config\ConfigurationItemFactoryTests.cs" />
     <Compile Include="Config\CultureInfoTests.cs" />
+    <Compile Include="Config\DuplicateConfigurationAttributeTests.cs" />
     <Compile Include="Config\ExtensionTests.cs" />
     <Compile Include="Config\IncludeTests.cs" />
     <Compile Include="Config\InternalLoggingTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Config\ConfigApiTests.cs" />
     <Compile Include="Config\ConfigurationItemFactoryTests.cs" />
     <Compile Include="Config\CultureInfoTests.cs" />
+    <Compile Include="Config\DuplicateConfigurationAttributeTests.cs" />
     <Compile Include="Config\ExtensionTests.cs" />
     <Compile Include="Config\IncludeTests.cs" />
     <Compile Include="Config\InternalLoggingTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl4.csproj
@@ -17,7 +17,8 @@
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <SilverlightApplication>true</SilverlightApplication>
-    <SupportedCultures></SupportedCultures>
+    <SupportedCultures>
+    </SupportedCultures>
     <XapOutputs>true</XapOutputs>
     <SilverlightVersion>$(TargetFrameworkVersion)</SilverlightVersion>
     <GenerateSilverlightManifest>true</GenerateSilverlightManifest>
@@ -31,15 +32,18 @@
     <OutOfBrowserSettingsFile>Properties\OutOfBrowserSettings.xml</OutOfBrowserSettingsFile>
     <UsePlatformExtensions>false</UsePlatformExtensions>
     <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
-    <LinkedServerProject></LinkedServerProject>
+    <LinkedServerProject>
+    </LinkedServerProject>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkIdentifier>Silverlight</TargetFrameworkIdentifier>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <FileUpgradeFlags></FileUpgradeFlags>
-    <UpgradeBackupLocation></UpgradeBackupLocation>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -105,6 +109,7 @@
     <Compile Include="Config\ConfigApiTests.cs" />
     <Compile Include="Config\ConfigurationItemFactoryTests.cs" />
     <Compile Include="Config\CultureInfoTests.cs" />
+    <Compile Include="Config\DuplicateConfigurationAttributeTests.cs" />
     <Compile Include="Config\ExtensionTests.cs" />
     <Compile Include="Config\IncludeTests.cs" />
     <Compile Include="Config\InternalLoggingTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.sl5.csproj
@@ -17,7 +17,8 @@
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <SilverlightApplication>true</SilverlightApplication>
-    <SupportedCultures></SupportedCultures>
+    <SupportedCultures>
+    </SupportedCultures>
     <XapOutputs>true</XapOutputs>
     <SilverlightVersion>$(TargetFrameworkVersion)</SilverlightVersion>
     <GenerateSilverlightManifest>true</GenerateSilverlightManifest>
@@ -31,7 +32,8 @@
     <OutOfBrowserSettingsFile>Properties\OutOfBrowserSettings.xml</OutOfBrowserSettingsFile>
     <UsePlatformExtensions>false</UsePlatformExtensions>
     <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
-    <LinkedServerProject></LinkedServerProject>
+    <LinkedServerProject>
+    </LinkedServerProject>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkIdentifier>Silverlight</TargetFrameworkIdentifier>
@@ -107,6 +109,7 @@
     <Compile Include="Config\ConfigApiTests.cs" />
     <Compile Include="Config\ConfigurationItemFactoryTests.cs" />
     <Compile Include="Config\CultureInfoTests.cs" />
+    <Compile Include="Config\DuplicateConfigurationAttributeTests.cs" />
     <Compile Include="Config\ExtensionTests.cs" />
     <Compile Include="Config\IncludeTests.cs" />
     <Compile Include="Config\InternalLoggingTests.cs" />


### PR DESCRIPTION
Resolves #1659 .
1. Logger now can write logs when config has duplicate attributes (first occurence is taken)
2. If throwExceptions or throwConfigExceptions option is on - exception is thrown.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1732)

<!-- Reviewable:end -->
