### PR TITLE
Support for log4jxmlevent on .NET Core

### DIFF
--- a/src/NLog/Internal/Fakeables/IAppDomain.cs
+++ b/src/NLog/Internal/Fakeables/IAppDomain.cs
@@ -32,7 +32,7 @@
 // 
 
 
-#if !NETSTANDARD
+
 
 namespace NLog.Internal.Fakeables
 {
@@ -40,8 +40,11 @@ namespace NLog.Internal.Fakeables
     using System.Collections.Generic;
 
     /// <summary>
-    /// Interface for fakeable the current <see cref="AppDomain"/>. Not fully implemented, please methods/properties as necessary.
+    /// Interface for fakeable the current AppDomain. 
     /// </summary>
+    /// <remarks>
+    /// Not fully implemented, please methods/properties as necessary.
+    /// </remarks>
     public interface IAppDomain
     {
 #if !SILVERLIGHT
@@ -84,4 +87,4 @@ namespace NLog.Internal.Fakeables
 #endif
     }
 }
-#endif
+

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -32,7 +32,8 @@
 // 
 
 
-#if !NETSTANDARD
+using System.Diagnostics;
+
 namespace NLog.LayoutRenderers
 {
     using System;
@@ -60,13 +61,20 @@ namespace NLog.LayoutRenderers
 
         private static readonly string dummyNLogNamespace = "http://nlog-project.org/dummynamespace/" + Guid.NewGuid();
 
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Log4JXmlEventLayoutRenderer" /> class.
         /// </summary>
-        public Log4JXmlEventLayoutRenderer() : this(AppDomainWrapper.CurrentDomain)
+        public Log4JXmlEventLayoutRenderer()
+
+#if NETSTANDARD
+            : this(null)
+#else
+            : this(AppDomainWrapper.CurrentDomain)
+#endif
         {
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Log4JXmlEventLayoutRenderer" /> class.
         /// </summary>
@@ -75,19 +83,26 @@ namespace NLog.LayoutRenderers
             this.IncludeNLogData = true;
             this.NdcItemSeparator = " ";
 
+            SetAppInfo(appDomain);
+
+            this.Parameters = new List<NLogViewerParameterInfo>();
+        }
+
+        private void SetAppInfo(IAppDomain appDomain)
+        {
 #if SILVERLIGHT
             this.AppInfo = "Silverlight Application";
 #elif __IOS__
 			this.AppInfo = "MonoTouch Application";
+#elif NETSTANDARD
+            this.AppInfo = ".NET Standard Application";
 #else
             this.AppInfo = string.Format(
                 CultureInfo.InvariantCulture,
-                "{0}({1})", 
-                appDomain.FriendlyName, 
+                "{0}({1})",
+                appDomain.FriendlyName,
                 ThreadIDHelper.Instance.CurrentProcessID);
 #endif
-
-            this.Parameters = new List<NLogViewerParameterInfo>();
         }
 
         /// <summary>
@@ -240,7 +255,7 @@ namespace NLog.LayoutRenderers
                             xtw.WriteStartElement("nlog", "locationInfo", dummyNLogNamespace);
                             if (type != null)
                             {
-                                xtw.WriteAttributeSafeString("assembly", type.Assembly.FullName);
+                                xtw.WriteAttributeSafeString("assembly", type.GetAssembly().FullName);
                             }
 
                             xtw.WriteEndElement();
@@ -255,7 +270,7 @@ namespace NLog.LayoutRenderers
                             }
                             xtw.WriteEndElement();
                         }
-                        
+
                     }
                 }
 
@@ -307,4 +322,4 @@ namespace NLog.LayoutRenderers
         }
     }
 }
-#endif
+

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -303,7 +303,10 @@ namespace NLog.LayoutRenderers
                 xtw.WriteAttributeSafeString("name", "log4jmachinename");
 
 #if SILVERLIGHT
-            xtw.WriteAttributeSafeString("value", "silverlight");
+                xtw.WriteAttributeSafeString("value", "silverlight");
+#elif NETSTANDARD && !NETSTANDARD1_5
+                // Environment.MachineName is NETSTANDARD1.5+
+                xtw.WriteAttributeSafeString("value", "Net Standard");
 #else
                 xtw.WriteAttributeSafeString("value", Environment.MachineName);
 #endif

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -31,7 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !NETSTANDARD
 namespace NLog.Layouts
 {
     using NLog.LayoutRenderers;
@@ -76,4 +75,3 @@ namespace NLog.Layouts
         }
     }
 }
-#endif

--- a/tests/NLog.UnitTests/LayoutRenderers/Log4JXmlTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Log4JXmlTests.cs
@@ -31,7 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !NETSTANDARD
 
 namespace NLog.UnitTests.LayoutRenderers
 {
@@ -42,6 +41,7 @@ namespace NLog.UnitTests.LayoutRenderers
     using System.Reflection;
     using System.IO;
     using Xunit;
+    using Internal;
 
     public class Log4JXmlTests : NLogTestBase
     {
@@ -113,9 +113,12 @@ namespace NLog.UnitTests.LayoutRenderers
                                 break;
 
                             case "locationInfo":
+#if !NETSTANDARD
                                 Assert.Equal(MethodBase.GetCurrentMethod().DeclaringType.FullName, reader.GetAttribute("class"));
                                 Assert.Equal(MethodBase.GetCurrentMethod().ToString(), reader.GetAttribute("method"));
+#endif
                                 break;
+
 
                             case "properties":
                                 break;
@@ -129,13 +132,15 @@ namespace NLog.UnitTests.LayoutRenderers
                                     case "log4japp":
 #if SILVERLIGHT
                                         Assert.Equal("Silverlight Application", value);
+#elif NETSTANDARD
+                                        Assert.Equal(".NET Standard Application", value);
 #else
                                         Assert.Equal(AppDomain.CurrentDomain.FriendlyName + "(" + Process.GetCurrentProcess().Id + ")", value);
 #endif
                                         break;
 
                                     case "log4jmachinename":
-#if !SILVERLIGHT && !NETSTANDARD
+#if !SILVERLIGHT
                                         Assert.Equal(Environment.MachineName, value);
 #else
                                         Assert.Equal("silverlight", value);
@@ -170,7 +175,7 @@ namespace NLog.UnitTests.LayoutRenderers
                                 break;
 
                             case "locationInfo":
-                                Assert.Equal(this.GetType().Assembly.FullName, reader.GetAttribute("assembly"));
+                                Assert.Equal(GetAssembly(this.GetType()).FullName, reader.GetAttribute("assembly"));
                                 break;
 
                             case "properties":
@@ -190,6 +195,15 @@ namespace NLog.UnitTests.LayoutRenderers
                 }
             }
         }
+
+        private static Assembly GetAssembly(Type type)
+        {
+#if !NETSTANDARD
+            return type.Assembly;
+#else
+            var typeInfo = type.GetTypeInfo();
+            return typeInfo.Assembly;
+#endif
+        }
     }
 }
-#endif


### PR DESCRIPTION
Fixes https://github.com/NLog/NLog/issues/1731

For machinename, NETSTANDARD 1.5+ is needed.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1733)

<!-- Reviewable:end -->
