### PR TITLE
UrlHelper - Added standard support for UTF8 encoding, added support for RFC2396  &  RFC3986

### DIFF
--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -123,5 +123,18 @@ namespace NLog.Internal
             }
         }
         private static readonly char[] charToInt = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+
+        /// <summary>
+        /// Clears the provider StringBuilder
+        /// </summary>
+        /// <param name="builder"></param>
+        public static void ClearBuilder(this StringBuilder builder)
+        {
+#if !SILVERLIGHT && !NET3_5
+            builder.Clear();
+#else
+            builder.Length = 0;
+#endif
+        }
     }
 }

--- a/src/NLog/Internal/UrlHelper.cs
+++ b/src/NLog/Internal/UrlHelper.cs
@@ -33,82 +33,152 @@
 
 namespace NLog.Internal
 {
+    using System;
     using System.Text;
 
     /// <summary>
     /// URL Encoding helper.
     /// </summary>
-    internal class UrlHelper
+    internal static class UrlHelper
     {
-        private static string safeUrlPunctuation = ".()*-_!'";
-        private static string hexChars = "0123456789abcdef";
+        private static readonly char[] hexUpperChars =
+            { '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+        private static readonly char[] hexLowerChars =
+            { '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+
+        [Flags]
+        public enum EscapeEncodingFlag
+        {
+            /// <summary>Use UnreservedMarks instead of ReservedMarks, as specified by chosen RFC</summary>
+            UriString = 1,
+            /// <summary>Use RFC2396 standard (instead of RFC3986)</summary>
+            LegacyRfc2396 = 2,
+            /// <summary>Should use lowercase when doing HEX escaping of special characters</summary>
+            LowerCaseHex = 4,
+            /// <summary>Replace space ' ' with '+' instead of '%20'</summary>
+            SpaceAsPlus = 8,
+            /// <summary>Skip UTF8 encoding, and prefix special characters with '%u'</summary>
+            NLogLegacy = 16 | LegacyRfc2396 | LowerCaseHex | UriString,
+        };
+
+        private const string RFC2396ReservedMarks = @";/?:@&=+$,";
+        private const string RFC3986ReservedMarks = @":/?#[]@!$&'()*+,;=";
+        private const string RFC2396UnreservedMarks = @"-_.!~*'()";
+        private const string RFC3986UnreservedMarks = @"-._~";
 
         /// <summary>
-        /// Url encode and URL
+        /// Url encode an URL
         /// </summary>
         /// <param name="str">URL to be encoded</param>
         /// <param name="spaceAsPlus">space as + or %20? <c>false</c> (%20) is the safe option.</param>
         /// <returns>Encoded url.</returns>
-        internal static string UrlEncode(string str, bool spaceAsPlus)
+        public static string UrlEncode(string str, bool spaceAsPlus)
         {
-            if (str == null) return string.Empty;
+            if (string.IsNullOrEmpty(str))
+                return string.Empty;
 
             StringBuilder result = new StringBuilder(str.Length + 20);
-            for (int i = 0; i < str.Length; ++i)
-            {
-                char ch = str[i];
-
-                if (ch == ' ' && spaceAsPlus)
-                {
-                    result.Append('+');
-                }
-                else if (IsSafeUrlCharacter(ch))
-                {
-                    result.Append(ch);
-                }
-                else if (ch < 256)
-                {
-                    result.Append('%');
-                    result.Append(hexChars[(ch >> 4) & 0xF]);
-                    result.Append(hexChars[(ch >> 0) & 0xF]);
-                }
-                else
-                {
-                    result.Append('%');
-                    result.Append('u');
-                    result.Append(hexChars[(ch >> 12) & 0xF]);
-                    result.Append(hexChars[(ch >> 8) & 0xF]);
-                    result.Append(hexChars[(ch >> 4) & 0xF]);
-                    result.Append(hexChars[(ch >> 0) & 0xF]);
-                }
-            }
-
+            result.Append(str);
+            EscapeEncodingFlag escapeFlags = EscapeEncodingFlag.NLogLegacy;
+            if (spaceAsPlus)
+                escapeFlags |= EscapeEncodingFlag.SpaceAsPlus;
+            EscapeDataEncode(result, escapeFlags);
             return result.ToString();
         }
 
         /// <summary>
-        /// Is this character safe in the URL?
+        /// Escape unicode string data for use in http-requests
         /// </summary>
-        /// <param name="ch">char to test.</param>
-        /// <returns><c>true</c> is safe.</returns>
-        private static bool IsSafeUrlCharacter(char ch)
+        /// <param name="target">unicode string-data to be encoded</param>
+        /// <param name="flags"><see cref="EscapeEncodingFlag"/>s for how to perform the encoding</param>
+        public static void EscapeDataEncode(StringBuilder target, EscapeEncodingFlag flags)
         {
-            if (ch >= 'a' && ch <= 'z')
-            {
-                return true;
-            }
+            if (target.Length == 0)
+                return;
 
-            if (ch >= 'A' && ch <= 'Z')
-            {
-                return true;
-            }
+            bool isUriString = (flags & EscapeEncodingFlag.UriString) == EscapeEncodingFlag.UriString;
+            bool isLegacyRfc2396 = (flags & EscapeEncodingFlag.LegacyRfc2396) == EscapeEncodingFlag.LegacyRfc2396;
+            bool isLowerCaseHex = (flags & EscapeEncodingFlag.LowerCaseHex) == EscapeEncodingFlag.LowerCaseHex;
+            bool isSpaceAsPlus = (flags & EscapeEncodingFlag.SpaceAsPlus) == EscapeEncodingFlag.SpaceAsPlus;
+            bool isNLogLegacy = (flags & EscapeEncodingFlag.NLogLegacy) == EscapeEncodingFlag.NLogLegacy;
 
-            if (ch >= '0' && ch <= '9')
-            {
-                return true;
-            }
+            char[] charArray = null;
+            byte[] byteArray = null;
+            char[] hexChars = isLowerCaseHex ? hexLowerChars : hexUpperChars;
 
-            return safeUrlPunctuation.IndexOf(ch) >= 0;
+            for (int i = 0; i < target.Length; ++i)
+            {
+                char ch = target[i];
+                if (ch >= 'a' && ch <= 'z')
+                    continue;
+                if (ch >= 'A' && ch <= 'Z')
+                    continue;
+                if (ch >= '0' && ch <= '9')
+                    continue;
+                if (isSpaceAsPlus && ch == ' ')
+                {
+                    target[i] = '+';
+                    continue;
+                }
+
+                if (isUriString)
+                {
+                    if (!isLegacyRfc2396 && RFC3986UnreservedMarks.IndexOf(ch) >= 0)
+                        continue;
+                    if (isLegacyRfc2396 && RFC2396UnreservedMarks.IndexOf(ch) >= 0)
+                        continue;
+                }
+                else
+                {
+                    if (!isLegacyRfc2396 && RFC3986ReservedMarks.IndexOf(ch) >= 0)
+                        continue;
+                    if (isLegacyRfc2396 && RFC2396ReservedMarks.IndexOf(ch) >= 0)
+                        continue;
+                }
+
+                if (isNLogLegacy)
+                {
+                    if (ch > 255)
+                    {
+                        target.Insert(i, "%", 5);
+                        target[i] = '%';
+                        target[++i] = 'u';
+                        target[++i] = hexChars[(ch >> 12) & 0xF];
+                        target[++i] = hexChars[(ch >> 8) & 0xF];
+                        target[++i] = hexChars[(ch >> 4) & 0xF];
+                        target[++i] = hexChars[(ch >> 0) & 0xF];
+                    }
+                    else
+                    {
+                        target.Insert(i, "%", 2);
+                        target[i] = '%';
+                        target[++i] = hexChars[(ch >> 4) & 0xF];
+                        target[++i] = hexChars[(ch >> 0) & 0xF];
+                    }
+                    continue;
+                }
+
+                if (charArray == null)
+                    charArray = new char[1];
+                charArray[0] = ch;
+
+                if (byteArray == null)
+                    byteArray = new byte[8];
+
+                // Convert the wide-char into utf8-bytes, and then escape
+                int byteCount = Encoding.UTF8.GetBytes(charArray, 0, 1, byteArray, 0);
+                target.Insert(i, "%", byteCount * 3 - 1);
+                --i;
+                for (int j = 0; j < byteCount; ++j)
+                {
+                    byte byteCh = byteArray[j];
+                    ++i;
+                    target[++i] = hexChars[(byteCh & 0xf0) >> 4];
+                    target[++i] = hexChars[byteCh & 0xf];
+                }
+            }
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/UrlEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/UrlEncodeLayoutRendererWrapper.cs
@@ -59,13 +59,34 @@ namespace NLog.LayoutRenderers.Wrappers
         public bool SpaceAsPlus { get; set; }
 
         /// <summary>
+        /// Gets or sets a value whether escaping be done according to Rfc3986 (Supports Internationalized Resource Identifiers - IRIs)
+        /// </summary>
+        /// <value>A value of <c>true</c> if Rfc3986; otherwise, <c>false</c> for legacy Rfc2396.</value>
+        /// <docgen category='Transformation Options' order='10' />
+        public bool EscapeDataRfc3986 { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value whether escaping be done according to the old NLog style (Very non-standard)
+        /// </summary>
+        /// <value>A value of <c>true</c> if legacy encoding; otherwise, <c>false</c> for standard UTF8 encoding.</value>
+        /// <docgen category='Transformation Options' order='10' />
+        public bool EscapeDataNLogLegacy { get; set; }
+
+        /// <summary>
         /// Transforms the output of another layout.
         /// </summary>
         /// <param name="text">Output to be transform.</param>
         /// <returns>Transformed text.</returns>
         protected override string Transform(string text)
         {
-            return UrlHelper.UrlEncode(text, this.SpaceAsPlus);
+            if (!string.IsNullOrEmpty(text))
+            {
+                UrlHelper.EscapeEncodingFlag encodingFlags = UrlHelper.GetUriStringEncodingFlags(EscapeDataNLogLegacy, SpaceAsPlus, EscapeDataRfc3986);
+                System.Text.StringBuilder sb = new System.Text.StringBuilder(text.Length + 20);
+                UrlHelper.EscapeDataEncode(text, sb, encodingFlags);
+                return sb.ToString();
+            }
+            return string.Empty;
         }
     }
 }

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -272,12 +272,20 @@ namespace NLog.Targets
             //if the protocol is HttpGet, we need to add the parameters to the query string of the url
             var queryParameters = new StringBuilder();
             string separator = string.Empty;
+            StringBuilder sb = null;
             for (int i = 0; i < this.Parameters.Count; i++)
             {
                 queryParameters.Append(separator);
                 queryParameters.Append(this.Parameters[i].Name);
                 queryParameters.Append("=");
-                queryParameters.Append(UrlHelper.UrlEncode(Convert.ToString(parameterValues[i], CultureInfo.InvariantCulture), false));
+                string parameterValue = Convert.ToString(parameterValues[i], CultureInfo.InvariantCulture);
+                if (sb == null)
+                    sb = new StringBuilder(Math.Max(parameterValue.Length + 20, 256));
+                else
+                    StringBuilderExt.ClearBuilder(sb);
+                sb.Append(parameterValue);
+                UrlHelper.EscapeDataEncode(sb, UrlHelper.EscapeEncodingFlag.UriString | UrlHelper.EscapeEncodingFlag.LowerCaseHex);
+                queryParameters.Append(sb.ToString());
                 separator = "&";
             }
 
@@ -372,12 +380,20 @@ namespace NLog.Targets
             var sw = new StreamWriter(ms, this.Encoding);
             sw.Write(string.Empty);
             int i = 0;
+            StringBuilder sb = null;
             foreach (MethodCallParameter parameter in this.Parameters)
             {
                 sw.Write(separator);
                 sw.Write(parameter.Name);
                 sw.Write("=");
-                sw.Write(UrlHelper.UrlEncode(Convert.ToString(parameterValues[i], CultureInfo.InvariantCulture), true));
+                string parameterValue = Convert.ToString(parameterValues[i], CultureInfo.InvariantCulture);
+                if (sb == null)
+                    sb = new StringBuilder(Math.Max(parameterValue.Length + 20, 256));
+                else
+                    StringBuilderExt.ClearBuilder(sb);
+                sb.Append(parameterValue);
+                UrlHelper.EscapeDataEncode(sb, UrlHelper.EscapeEncodingFlag.UriString | UrlHelper.EscapeEncodingFlag.LowerCaseHex | UrlHelper.EscapeEncodingFlag.SpaceAsPlus);
+                sw.Write(sb.ToString());
                 separator = "&";
                 i++;
             }

--- a/tests/NLog.UnitTests/Internal/UrlHelperTests.cs
+++ b/tests/NLog.UnitTests/Internal/UrlHelperTests.cs
@@ -35,10 +35,8 @@
 #if !SILVERLIGHT
 //no silverlight for xunit InlineData
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using NLog.Internal;
+using NLog.Layouts;
 using Xunit;
 using Xunit.Extensions;
 
@@ -53,7 +51,8 @@ namespace NLog.UnitTests.Internal
         [InlineData(null, true, "")]
         [InlineData("ab cd", true,"ab+cd")]
         [InlineData("ab cd", false, "ab%20cd")]
-        [InlineData("ab cd", false, "ab%20cd")]
+        [InlineData("one&two =three", true, "one%26two+%3dthree")]
+        [InlineData("one&two =three", false, "one%26two%20%3dthree")]
         [InlineData(" €;✈ Ĕ  ßß ßß ", true, "+%u20ac%3b%u2708+%u0114++%df%df+%df%df+")] //current implementation, not sure if correct
         [InlineData(" €;✈ Ĕ  ßß ßß ", false, "%20%u20ac%3b%u2708%20%u0114%20%20%df%df%20%df%df%20")] //current implementation, not sure if correct
         [InlineData(".()*-_!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", true, ".()*-_!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")]
@@ -61,7 +60,61 @@ namespace NLog.UnitTests.Internal
         [InlineData("《∠∠⊙⌒∈∽》`````", true, "%u300a%u2220%u2220%u2299%u2312%u2208%u223d%u300b%60%60%60%60%60")] //current implementation, not sure if correct
         public void UrlEncodeTest(string input, bool spaceAsPlus, string result)
         {
-            Assert.Equal(result, UrlHelper.UrlEncode(input, spaceAsPlus));
+            SimpleLayout l = spaceAsPlus ? "${url-encode:escapeDataNLogLegacy=true:${message}}" : "${url-encode:escapeDataNLogLegacy=true:spaceAsPlus=false:${message}}";
+            string urlencoded = l.Render(LogEventInfo.Create(LogLevel.Debug, "logger", input));
+            Assert.Equal(result, urlencoded);
+        }
+
+        [Theory]
+        [InlineData("", true, "")]
+        [InlineData("", false, "")]
+        [InlineData("ab cd", true, "ab+cd")]
+        [InlineData("ab cd", false, "ab%20cd")]
+        [InlineData("one&two =three", true, "one%26two+%3dthree")]
+        [InlineData("one&two =three", false, "one%26two%20%3dthree")]
+        [InlineData(" €;✈ Ĕ  ßß ßß ", true, "+%e2%82%ac%3b%e2%9c%88+%c4%94++%c3%9f%c3%9f+%c3%9f%c3%9f+")]
+        [InlineData(" €;✈ Ĕ  ßß ßß ", false, "%20%e2%82%ac%3b%e2%9c%88%20%c4%94%20%20%c3%9f%c3%9f%20%c3%9f%c3%9f%20")]
+        [InlineData(".()*-_!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", true, ".()*-_!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")]
+        [InlineData(".()*-_!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", false, ".()*-_!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")]
+        [InlineData(@"http://foo:bar@host:123/path?query=key_value+map_value#fragment", true, @"http%3a%2f%2ffoo%3abar%40host%3a123%2fpath%3fquery%3dkey_value%2bmap_value%23fragment")]
+        [InlineData(@"http://foo:bar@host:123/path?query=key_value+map_value#fragment", false, @"http%3a%2f%2ffoo%3abar%40host%3a123%2fpath%3fquery%3dkey_value%2bmap_value%23fragment")]
+        public void EscapeDataEncodeTestRfc2396(string input, bool spaceAsPlus, string result)
+        {
+            System.Text.StringBuilder builder = new System.Text.StringBuilder(input.Length + 20);
+            UrlHelper.EscapeEncodingFlag encodingFlags = UrlHelper.EscapeEncodingFlag.LowerCaseHex | UrlHelper.EscapeEncodingFlag.LegacyRfc2396 | UrlHelper.EscapeEncodingFlag.UriString;
+            if (spaceAsPlus)
+                encodingFlags |= UrlHelper.EscapeEncodingFlag.SpaceAsPlus;
+            UrlHelper.EscapeDataEncode(input, builder, encodingFlags);
+            Assert.Equal(result, builder.ToString());
+            Assert.Equal(input.Replace('+', ' '), DecodeUrlString(builder.ToString()));
+        }
+
+        [Theory]
+        [InlineData("", true, "")]
+        [InlineData("", false, "")]
+        [InlineData("ab cd", true, "ab+cd")]
+        [InlineData("ab cd", false, "ab%20cd")]
+        [InlineData(" €;✈ Ĕ  ßß ßß ", true, "+%E2%82%AC;%E2%9C%88+%C4%94++%C3%9F%C3%9F+%C3%9F%C3%9F+")]
+        [InlineData(" €;✈ Ĕ  ßß ßß ", false, "%20%E2%82%AC;%E2%9C%88%20%C4%94%20%20%C3%9F%C3%9F%20%C3%9F%C3%9F%20")]
+        [InlineData(@"http://foo:bar@host:123/path?query=key_value+map_value#fragment", true, @"http://foo:bar@host:123/path?query=key%5Fvalue+map%5Fvalue#fragment")]
+        [InlineData(@"http://foo:bar@host:123/path?query=key_value+map_value#fragment", false, @"http://foo:bar@host:123/path?query=key%5Fvalue+map%5Fvalue#fragment")] 
+        public void EscapeDataEncodeTestRfc3986(string input, bool spaceAsPlus, string result)
+        {
+            System.Text.StringBuilder builder = new System.Text.StringBuilder(input.Length + 20);
+            UrlHelper.EscapeEncodingFlag encodingFlags = UrlHelper.EscapeEncodingFlag.None;
+            if (spaceAsPlus)
+                encodingFlags |= UrlHelper.EscapeEncodingFlag.SpaceAsPlus;
+            UrlHelper.EscapeDataEncode(input, builder, encodingFlags);
+            Assert.Equal(result, builder.ToString());
+            Assert.Equal(input.Replace('+', ' '), DecodeUrlString(builder.ToString()));
+        }
+
+        private static string DecodeUrlString(string url)
+        {
+            string newUrl;
+            while ((newUrl = System.Uri.UnescapeDataString(url)) != url)
+                url = newUrl;
+            return newUrl.Replace('+', ' ');
         }
     }
 }

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -253,8 +253,6 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
         [Fact]
         public void WebserviceTest_restapi_httppost()
         {
-
-
             var configuration = CreateConfigurationFromString(string.Format(@"
                 <nlog throwExceptions='true'>
                     <targets>
@@ -284,12 +282,22 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
 
 
 
+            LogMeController.ResetState(2);
+
+            var message1 = "message 1 with a post";
+            var message2 = "a b c é k è ï ?";
             StartOwinTest(() =>
             {
 
-                logger.Info("message 1 with a post");
+                logger.Info(message1);
+                logger.Info(message2);
             });
 
+
+            Assert.Equal(LogMeController.CountdownEvent.CurrentCount, 0);
+            Assert.Equal(2, LogMeController.RecievedLogsPostParam1.Count);
+            CheckQueueMessage(message1, LogMeController.RecievedLogsPostParam1);
+            CheckQueueMessage(message2, LogMeController.RecievedLogsPostParam1);
 
         }
 
@@ -299,16 +307,46 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
         [Fact]
         public void WebserviceTest_restapi_httpget()
         {
-            WebServiceTest_httpget("api/logme");
+            var logger = SetUpHttpGetWebservice("api/logme");
+
+            LogMeController.ResetState(2);
+
+            var message1 = "message 1 with a post";
+            var message2 = "a b c é k è ï ?";
+            StartOwinTest(() =>
+            {
+
+                logger.Info(message1);
+                logger.Info(message2);
+            });
+
+
+            Assert.Equal(LogMeController.CountdownEvent.CurrentCount, 0);
+            Assert.Equal(2, LogMeController.RecievedLogsGetParam1.Count);
+            CheckQueueMessage(message1, LogMeController.RecievedLogsGetParam1);
+            CheckQueueMessage(message2, LogMeController.RecievedLogsGetParam1);
         }
 
         [Fact]
         public void WebServiceTest_restapi_httpget_querystring()
         {
-            WebServiceTest_httpget("api/logme?paramFromConfig=valueFromConfig");
+            var logger = SetUpHttpGetWebservice("api/logme?paramFromConfig=valueFromConfig");
+
+            LogMeController.ResetState(1);
+
+            StartOwinTest(() =>
+            {
+
+                logger.Info("another message");
+            });
+
+
+            Assert.Equal(LogMeController.CountdownEvent.CurrentCount, 0);
+            Assert.Equal(1, LogMeController.RecievedLogsGetParam1.Count);
+            CheckQueueMessage("another message", LogMeController.RecievedLogsGetParam1);
         }
-        
-        private void WebServiceTest_httpget(string relativeUrl)
+
+        private static Logger SetUpHttpGetWebservice(string relativeUrl)
         {
             var configuration = CreateConfigurationFromString(string.Format(@"
                 <nlog throwExceptions='true' >
@@ -334,13 +372,13 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
 
             LogManager.Configuration = configuration;
             var logger = LogManager.GetCurrentClassLogger();
+            return logger;
+        }
 
-            LogMeController.ResetState(1);
-
-            StartOwinTest(() =>
-            {
-                logger.Info("message 1 with a post");
-            });
+        private static void CheckQueueMessage(string message1, ConcurrentBag<string> recievedLogsGetParam1)
+        {
+            var success = recievedLogsGetParam1.Contains(message1);
+            Assert.True(success, string.Format("message '{0}' not found", message1));
         }
 
 
@@ -469,7 +507,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             /// Recieved param1 values(post)
             /// </summary>
             public static ConcurrentBag<string> RecievedLogsPostParam1 = new ConcurrentBag<string>();
-      
+
 
             /// <summary>
             /// We need a complex type for modelbinding because of content-type: "application/x-www-form-urlencoded" in <see cref="WebServiceTarget"/>
@@ -494,6 +532,11 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             {
 
                 RecievedLogsGetParam1.Add(param1);
+                if (CountdownEvent != null)
+                {
+                    CountdownEvent.Signal();
+                }
+
                 return new string[] { "value1", "value2" };
             }
 
@@ -519,7 +562,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             /// <summary>
             /// Put
             /// </summary>
-         
+
             public void Put(int id, [FromBody]string value)
             {
             }


### PR DESCRIPTION
Grapped the unit-test from #1725, but implemented the encoding manually so it stays the same independent of dot-net version.

Fixes https://github.com/NLog/NLog/issues/1724

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1735)

<!-- Reviewable:end -->
