### PR TITLE
fixed unstable InternalLoggerTests.TimestampTests

### DIFF
--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -45,7 +45,7 @@ using Xunit.Extensions;
 
 namespace NLog.UnitTests.Common
 {
-    public class InternalLoggerTests : NLogTestBase
+    public class InternalLoggerTests : NLogTestBase, IDisposable
     {
         /// <summary>
         /// Test the return values of all Is[Level]Enabled() methods.
@@ -542,5 +542,9 @@ namespace NLog.UnitTests.Common
             }
         }
 #endif
+        public void Dispose()
+        {
+            TimeSource.Current = new FastLocalTimeSource();
+        }
     }
 }

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -38,6 +38,7 @@ using System.Linq;
 using Xunit;
 using NLog.Common;
 using System.Text;
+using NLog.Time;
 #if !SILVERLIGHT 
 using Xunit.Extensions;
 #endif
@@ -332,6 +333,28 @@ namespace NLog.UnitTests.Common
             }
         }
 
+        /// <summary>
+        /// <see cref="TimeSource"/> that returns always the same time,
+        /// passed into object constructor.
+        /// </summary>
+        private class FixedTimeSource : TimeSource
+        {
+            private readonly DateTime _time;
+
+            public FixedTimeSource(DateTime time)
+            {
+                _time = time;
+            }
+
+            public override DateTime Time { get { return _time; } }
+
+            public override DateTime FromSystemTime(DateTime systemTime)
+            {
+                return _time;
+            }
+        }
+
+
         [Fact]
         public void TimestampTests()
         {
@@ -347,6 +370,9 @@ namespace NLog.UnitTests.Common
             // Redirect the console output to a StringWriter.
             Console.SetOut(consoleOutWriter);
 
+            // Set fixed time source to test time output
+            TimeSource.Current = new FixedTimeSource(DateTime.Now);
+
             // Named (based on LogLevel) public methods.
             InternalLogger.Warn("WWW");
             InternalLogger.Error("EEE");
@@ -355,7 +381,7 @@ namespace NLog.UnitTests.Common
             InternalLogger.Debug("DDD");
             InternalLogger.Info("III");
 
-            string expectedDateTime = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+            string expectedDateTime = TimeSource.Current.Time.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
 
             var strings = consoleOutWriter.ToString().Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
             foreach (var str in strings)


### PR DESCRIPTION
Resolves #1067 

Added FixedTimeSource, that will return always the same time (for testing purposes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1739)
<!-- Reviewable:end -->
