### PR TITLE
DateLayout - Reduce memory allocation when low time resolution

### DIFF
--- a/src/NLog/LayoutRenderers/ShortDateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ShortDateLayoutRenderer.cs
@@ -94,9 +94,9 @@ namespace NLog.LayoutRenderers
             /// <param name="timestamp">The date to append</param>
             public void AppendDate(StringBuilder builder, DateTime timestamp)
             {
-                if (formattedDate == null || date.Day != timestamp.Day || date.Month != timestamp.Month || date.Year != timestamp.Year)
+                if (formattedDate == null || date != timestamp.Date)
                 {
-                    date = timestamp;
+                    date = timestamp.Date;
                     formattedDate = timestamp.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
                 }
                 builder.Append(formattedDate);


### PR DESCRIPTION
Cache the result of the layout when not using custom formatProvider and format has low time resolution (daily or hourly)

When having hourly log-file-format, then no need to re-format for every log-event.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1746)
<!-- Reviewable:end -->
