### PR TITLE
ExceptionLayoutRenderer: prevent nullrefexception when exception is null

### DIFF
--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -199,7 +199,14 @@ namespace NLog.LayoutRenderers
 
                     var currentRenderFunction = _renderingfunctions[renderingFormat];
 
-                    currentRenderFunction(sb2, logEvent.Exception);
+                    if (logEvent.Exception != null)
+                    {
+                        currentRenderFunction(sb2, logEvent.Exception);
+                    }
+                    else
+                    {
+                        InternalLogger.Debug("Skipping rendering exception as exception is null");
+                    }
 
                     separator = this.Separator;
                 }


### PR DESCRIPTION
Fixes https://github.com/NLog/NLog/issues/1703

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1751)
<!-- Reviewable:end -->
