### PR TITLE
Layout processinfo with support for custom Format-string

### DIFF
--- a/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
@@ -40,8 +40,8 @@ namespace NLog.LayoutRenderers
     using System.Diagnostics;
     using System.Reflection;
     using System.Text;
-    using NLog.Common;
     using NLog.Config;
+    using NLog.Internal;
 
     /// <summary>
     /// The information about the running process.
@@ -52,8 +52,6 @@ namespace NLog.LayoutRenderers
         private Process process;
 
         private PropertyInfo propertyInfo;
-
-        private MethodInfo propertyToString;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProcessInfoLayoutRenderer" /> class.
@@ -89,19 +87,6 @@ namespace NLog.LayoutRenderers
             }
 
             this.process = Process.GetCurrentProcess();
-
-            if (!string.IsNullOrEmpty(Format))
-            {
-                object value = this.propertyInfo.GetValue(this.process, null);
-                if (value != null)
-                {
-                    propertyToString = value.GetType().GetMethod("ToString", new[] { typeof(string), typeof(IFormatProvider) });
-                    if (propertyToString == null)
-                    {
-                        InternalLogger.Info("Layout {processinfo} property {0} does not support formatting {1}", this.propertyInfo, Format);
-                    }
-                }
-            }
         }
 
         /// <summary>
@@ -129,10 +114,7 @@ namespace NLog.LayoutRenderers
             {
                 var formatProvider = GetFormatProvider(logEvent);
                 var value = this.propertyInfo.GetValue(this.process, null);
-                if (value != null && this.propertyToString != null)
-                    builder.Append(this.propertyToString.Invoke(value, new object[] { this.Format, formatProvider }));
-                else
-                    builder.Append(Convert.ToString(value, formatProvider));
+                builder.Append(value.ToStringWithOptionalFormat(this.Format, formatProvider));
             }
         }
     }

--- a/tests/NLog.UnitTests/Config/CultureInfoTests.cs
+++ b/tests/NLog.UnitTests/Config/CultureInfoTests.cs
@@ -148,23 +148,31 @@ namespace NLog.UnitTests.Config
 
 
 #if !MONO
-        [Fact(Skip = "TimeSpan tostring isn't culture aware in .NET?")]
+        [Fact]
         public void ProcessInfoLayoutRendererCultureTest()
         {
             string cultureName = "de-DE";
-            string expected = ",";   // decimal comma as separator for ticks
+            string expected = ".";   // dot as date separator (01.10.2008)
 
             var logEventInfo = CreateLogEventInfo(cultureName);
 
             var renderer = new ProcessInfoLayoutRenderer();
-            renderer.Property = ProcessInfoProperty.TotalProcessorTime;
+            renderer.Property = ProcessInfoProperty.StartTime;
+            renderer.Format = "d";
             string output = renderer.Render(logEventInfo);
 
             Assert.Contains(expected, output);
-            Assert.DoesNotContain(".", output);
+            Assert.DoesNotContain("/", output);
+            Assert.DoesNotContain("-", output);
+
+            var renderer2 = new ProcessInfoLayoutRenderer();
+            renderer2.Property = ProcessInfoProperty.BasePriority;
+            renderer2.Format = "d";
+            output = renderer2.Render(logEventInfo);
+            Assert.True(output.Length >= 1);
+            Assert.True("012345678".IndexOf(output[0]) > 0);
         }
 #endif
-
 
         [Fact]
         public void AllEventPropRendererCultureTest()


### PR DESCRIPTION
Makes it possible to make a filename like this:

> fileName="c:/temp/Log/test1-${processinfo:property=StartTime:format=yyyy-MM-dd_HHmmss}.log"

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1752)
<!-- Reviewable:end -->
