### PR TITLE
JsonLayout.AllEventProperties

### DIFF
--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -54,6 +54,8 @@ namespace NLog.Layouts
         {
             this.Attributes = new List<JsonAttribute>();
             this.RenderEmptyObject = true;
+            this.IncludeAllProperties = false;
+            this.ExcludedProperties = new List<string>();
         }
 
         /// <summary>
@@ -72,6 +74,18 @@ namespace NLog.Layouts
         /// Gets or sets the option to render the empty object value {}
         /// </summary>
         public bool RenderEmptyObject { get; set; }
+
+
+        /// <summary>
+        /// Gets or sets the option to include all properties from the log events
+        /// </summary>
+        public bool IncludeAllProperties { get; set; }
+
+        /// <summary>
+        /// List of property names to exclude when IncludeAllProperties is true
+        /// </summary>
+        public IList<string> ExcludedProperties { get; set; }
+
 
         /// <summary>
         /// Formats the log event as a JSON document for writing.

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -337,5 +337,33 @@ namespace NLog.UnitTests.Layouts
             var json = jsonLayout.Render(logEventInfo);
             Assert.Equal("{ \"time\": \"2016-10-30 13:30:55.0000\", \"level\": \"INFO\", \"nested\": { \"message\": \"this is message\", \"exception\": \"test\" } }", json);
         }
+
+
+        [Fact]
+        public void IncludeAllProperties()
+        {
+            var jsonLayout = new JsonLayout()
+            {
+                IncludeAllProperties = true
+            };
+
+            jsonLayout.ExcludedProperties.Add("Excluded");
+
+            var logEventInfo = new LogEventInfo
+            {
+                TimeStamp = new DateTime(2010, 01, 01, 12, 34, 56),
+                Level = LogLevel.Info,
+                Message = "hello, world"
+            };
+
+
+            logEventInfo.Properties.Add("PropA", "ValueA");
+            logEventInfo.Properties.Add("PropB", "ValueB");
+            logEventInfo.Properties.Add("PropC", "ValueC");
+            logEventInfo.Properties.Add("Excluded", "ExcludedValue");
+
+            Assert.Equal("{ \"PropA\": \"ValueA\", \"PropB\": \"ValueB\", \"PropC\": \"ValueC\" }", jsonLayout.Render(logEventInfo));
+
+        }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -356,14 +356,16 @@ namespace NLog.UnitTests.Layouts
                 Message = "hello, world"
             };
 
-
-            logEventInfo.Properties.Add("PropA", "ValueA");
-            logEventInfo.Properties.Add("PropB", "ValueB");
-            logEventInfo.Properties.Add("PropC", "ValueC");
+            logEventInfo.Properties.Add("StringProp", "ValueA");
+            logEventInfo.Properties.Add("IntProp", 123);
+            logEventInfo.Properties.Add("DoubleProp", 123.123);
+            logEventInfo.Properties.Add("BoolProp", true);
+            logEventInfo.Properties.Add("NullProp", null);
             logEventInfo.Properties.Add("Excluded", "ExcludedValue");
 
-            Assert.Equal("{ \"PropA\": \"ValueA\", \"PropB\": \"ValueB\", \"PropC\": \"ValueC\" }", jsonLayout.Render(logEventInfo));
+            Assert.Equal("{ \"StringProp\": \"ValueA\", \"IntProp\": 123, \"DoubleProp\": 123.123, \"BoolProp\": True, \"NullProp\": null }", jsonLayout.Render(logEventInfo));
 
         }
     }
 }
+


### PR DESCRIPTION
Here's an initial attempt at adding "AllEventProperties" functionality to `JsonLayout` as mentioned in issue #1686.  This is the first time I've made a pull request on GitHub. So if I'm not following the proper procedure or conventions let me know.

I have few questions:

1. I'm using a `for each` loop to iterate over the the log event properties, but everywhere else it looks like there's been an effort to use a `for` loop to avoid allocating an Enumerator. There doesn't look like a way to access the items or keys in a dictionary by index though. Is there some other way I could optimize this?

2. `LogEventInfo.Properties` is an `IDictionary<object,object>`. How should the keys be converted into a string property names? Should I just use `ToString()` as I have now? When would the key of a property not be a string?

3. Any ideas on how to handle property values that are collections or objects? I'm guessing we wouldn't want to use reflection to read properties from object values due to the performance hit. However, for my use case I'd like it to be able to identify collection properties and have them returned as an array of values in the JSON rather then "System.Collections.Generic.List`1[System.String]".

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1754)
<!-- Reviewable:end -->
