### PR TITLE
AsyncTargetWrapper - Change default overflow action to blocking

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
+++ b/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
@@ -42,7 +42,7 @@ namespace NLog.Targets.Wrappers
     /// </summary>
 	internal class AsyncRequestQueue
     {
-        private readonly Queue<AsyncLogEventInfo> logEventInfoQueue = new Queue<AsyncLogEventInfo>();
+        private readonly Queue<AsyncLogEventInfo> logEventInfoQueue = new Queue<AsyncLogEventInfo>(1000);
 
         /// <summary>
         /// Initializes a new instance of the AsyncRequestQueue class.

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -106,7 +106,7 @@ namespace NLog.Targets.Wrappers
         /// </summary>
         /// <param name="wrappedTarget">The wrapped target.</param>
         public AsyncTargetWrapper(Target wrappedTarget)
-            : this(wrappedTarget, 10000, AsyncTargetWrapperOverflowAction.Discard)
+            : this(wrappedTarget, 10000, AsyncTargetWrapperOverflowAction.Block)
         {
         }
 
@@ -118,8 +118,8 @@ namespace NLog.Targets.Wrappers
         /// <param name="overflowAction">The action to be taken when the queue overflows.</param>
         public AsyncTargetWrapper(Target wrappedTarget, int queueLimit, AsyncTargetWrapperOverflowAction overflowAction)
         {
-            this.RequestQueue = new AsyncRequestQueue(10000, AsyncTargetWrapperOverflowAction.Discard);
-            this.TimeToSleepBetweenBatches = 50;
+            this.RequestQueue = new AsyncRequestQueue(10000, overflowAction);
+            this.TimeToSleepBetweenBatches = 0;
             this.BatchSize = 200;
             this.FullBatchSizeWriteLimit = 5;
             this.WrappedTarget = wrappedTarget;
@@ -136,10 +136,10 @@ namespace NLog.Targets.Wrappers
         public int BatchSize { get; set; }
 
         /// <summary>
-        /// Gets or sets the time in milliseconds to sleep between batches.
+        /// Gets or sets the time in milliseconds to sleep between batches (Zero means trigger on new activity)
         /// </summary>
         /// <docgen category='Buffering Options' order='100' />
-        [DefaultValue(50)]
+        [DefaultValue(0)]
         public int TimeToSleepBetweenBatches { get; set; }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace NLog.Targets.Wrappers
         /// exceeds the set limit.
         /// </summary>
         /// <docgen category='Buffering Options' order='100' />
-        [DefaultValue("Discard")]
+        [DefaultValue("Block")]
         public AsyncTargetWrapperOverflowAction OverflowAction
         {
             get { return this.RequestQueue.OnOverflow; }

--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
@@ -50,7 +50,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             var targetWrapper = new AsyncTargetWrapper(myTarget, 300, AsyncTargetWrapperOverflowAction.Grow);
             Assert.Equal(AsyncTargetWrapperOverflowAction.Grow, targetWrapper.OverflowAction);
             Assert.Equal(300, targetWrapper.QueueLimit);
-            Assert.Equal(50, targetWrapper.TimeToSleepBetweenBatches);
+            Assert.Equal(0, targetWrapper.TimeToSleepBetweenBatches);
             Assert.Equal(200, targetWrapper.BatchSize);
         }
 
@@ -63,9 +63,9 @@ namespace NLog.UnitTests.Targets.Wrappers
                 WrappedTarget = myTarget,
             };
 
-            Assert.Equal(AsyncTargetWrapperOverflowAction.Discard, targetWrapper.OverflowAction);
+            Assert.Equal(AsyncTargetWrapperOverflowAction.Block, targetWrapper.OverflowAction);
             Assert.Equal(10000, targetWrapper.QueueLimit);
-            Assert.Equal(50, targetWrapper.TimeToSleepBetweenBatches);
+            Assert.Equal(0, targetWrapper.TimeToSleepBetweenBatches);
             Assert.Equal(200, targetWrapper.BatchSize);
         }
 


### PR DESCRIPTION
Change the default behavior of the AsyncWrapper (**async="true"**):

- Default queue-policy changed from discarding to blocking. Adding the async=true should not change the trusted behavior of the wrapped targets.
- Default timer-interval changed from 50 ms to zero (only trigger timer event on activity). Adding the async=true should not add extra overhead in idle periods (avoid waking up application every 50 ms because of needless timer events).

The combination of **timeToSleepBetweenBatches="0"** + **batchSize="200"** + **fullBatchSizeWriteLimit="5"** makes it easy to write more than 200.000 msgs/sec. Thus diminishing the argument for for having a discard-queue-policy.

See also #1789 and #1652 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1757)
<!-- Reviewable:end -->
