### PR TITLE
JsonLayout - Use StringBuilder instead of string append

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
@@ -35,9 +35,7 @@ namespace NLog.LayoutRenderers.Wrappers
 {
     using System;
     using System.ComponentModel;
-    using System.Globalization;
     using System.Text;
-    using System.Xml;
     using NLog.Config;
 
     /// <summary>
@@ -75,10 +73,33 @@ namespace NLog.LayoutRenderers.Wrappers
 
         private static string DoJsonEscape(string text)
         {
-            var sb = new StringBuilder(text.Length);
-
+            StringBuilder sb = null;
             for (int i = 0; i < text.Length; ++i)
             {
+                char ch = text[i];
+                if (sb == null)
+                {
+                    // Check if we need to upgrade to StringBuilder
+                    if (!NeedsEscaping(ch))
+                    {
+                        switch (ch)
+                        {
+                            case '"':
+                            case '\\':
+                            case '/':
+                                break;
+
+                            default:
+                                continue;   // StringBuilder not needed, yet
+                        }
+                    }
+
+                    // StringBuilder needed
+                    sb = new StringBuilder(text.Length + 4);
+                    for (int j = 0; j < i; ++j)
+                        sb.Append(text[j]);
+                }
+
                 switch (text[i])
                 {
                     case '"':
@@ -128,7 +149,10 @@ namespace NLog.LayoutRenderers.Wrappers
                 }
             }
 
-            return sb.ToString();
+            if (sb != null)
+                return sb.ToString();
+            else
+                return text;
         }
 
         private static bool NeedsEscaping(char ch)

--- a/src/NLog/Layouts/JsonAttribute.cs
+++ b/src/NLog/Layouts/JsonAttribute.cs
@@ -77,11 +77,13 @@ namespace NLog.Layouts
         /// Gets or sets the layout that will be rendered as the attribute's value.
         /// </summary>
         [RequiredParameter]
-        public Layout Layout { get; set; }
+        public Layout Layout { get { return LayoutWrapper.Inner; } set { LayoutWrapper.Inner = value; } }
 
         /// <summary>
         /// Determines wether or not this attribute will be Json encoded.
         /// </summary>
-        public bool Encode { get; set; }
+        public bool Encode { get { return LayoutWrapper.JsonEncode; } set { LayoutWrapper.JsonEncode = value; } }
+
+        internal readonly LayoutRenderers.Wrappers.JsonEncodeLayoutRendererWrapper LayoutWrapper = new LayoutRenderers.Wrappers.JsonEncodeLayoutRendererWrapper();
     }
 }

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -259,6 +259,11 @@ namespace NLog
         }
 
         /// <summary>
+        /// Checks if any per-event context properties (Without allocation)
+        /// </summary>
+        public bool HasProperties { get { return this.properties != null && this.properties.Count > 0; } }
+
+        /// <summary>
         /// Gets the dictionary of per-event context properties.
         /// </summary>
         public IDictionary<object, object> Properties

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -36,9 +36,6 @@ using NLog.Targets;
 namespace NLog.UnitTests.Layouts
 {
     using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.IO;
     using NLog.Layouts;
     using Xunit;
 
@@ -338,9 +335,8 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal("{ \"time\": \"2016-10-30 13:30:55.0000\", \"level\": \"INFO\", \"nested\": { \"message\": \"this is message\", \"exception\": \"test\" } }", json);
         }
 
-
         [Fact]
-        public void IncludeAllProperties()
+        public void IncludeAllJsonProperties()
         {
             var jsonLayout = new JsonLayout()
             {
@@ -359,13 +355,13 @@ namespace NLog.UnitTests.Layouts
             logEventInfo.Properties.Add("StringProp", "ValueA");
             logEventInfo.Properties.Add("IntProp", 123);
             logEventInfo.Properties.Add("DoubleProp", 123.123);
+            logEventInfo.Properties.Add("DecimalProp", 123.123m);
             logEventInfo.Properties.Add("BoolProp", true);
             logEventInfo.Properties.Add("NullProp", null);
             logEventInfo.Properties.Add("Excluded", "ExcludedValue");
 
-            Assert.Equal("{ \"StringProp\": \"ValueA\", \"IntProp\": 123, \"DoubleProp\": 123.123, \"BoolProp\": True, \"NullProp\": null }", jsonLayout.Render(logEventInfo));
+            Assert.Equal("{ \"StringProp\": \"ValueA\", \"IntProp\": 123, \"DoubleProp\": 123.123, \"DecimalProp\": 123.123, \"BoolProp\": True, \"NullProp\": null }", jsonLayout.Render(logEventInfo));
 
         }
     }
 }
-


### PR DESCRIPTION
Reduce memory allocations when using JsonLayout (Includes changes from #1754)
 - Removed unnecessary string append allocations when doing final wrapping in { and } 
 - Skip allocation of StringBuilder when Json value doesn't need to be escaped.
 - Skip allocation of JsonEncodeLayoutRendererWrapper for every log-event (Now cached on JsonAttribute, will also activate initialSize for LayoutRenderer-StringBuilder).
 - Skip allocation of LogEvent.Properties-Dictionary, when it has no properties.
 - Reuse same JsonAttribute for all dynamic attributes found on LogEvent.Properties
 - Faster type-checking for dynamic attributes found on LogEvent.Properties.

If accepted then please merge #1754 first, and then I will correct any merge-conflicts in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1763)
<!-- Reviewable:end -->
