### PR TITLE
refs #1498 keeping variables during configuration reload

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -580,5 +580,22 @@ namespace NLog.Config
             }
             return items.ToList();
         }
+
+        /// <summary>
+        /// Copies missing variables and variables with an empty value, from provided dictionary, 
+        /// into current configuration variables dictionary.
+        /// </summary>
+        /// <param name="newVariables">New variables dictionary</param>
+        internal void MergeVariables(IDictionary<string, SimpleLayout> newVariables)
+        {
+            foreach (var variableKey in newVariables.Keys)
+            {
+                if (!this.Variables.ContainsKey(variableKey) 
+                    || string.IsNullOrEmpty(this.Variables[variableKey].OriginalText))
+                {
+                    Variables[variableKey] = newVariables[variableKey];
+                }
+            }
+        }
     }
 }

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -582,19 +582,14 @@ namespace NLog.Config
         }
 
         /// <summary>
-        /// Copies missing variables and variables with an empty value, from provided dictionary, 
-        /// into current configuration variables dictionary.
+        /// Copies all variables from provided dictionary into current configuration variables. 
         /// </summary>
-        /// <param name="newVariables">New variables dictionary</param>
-        internal void MergeVariables(IDictionary<string, SimpleLayout> newVariables)
+        /// <param name="masterVariables">Master variables dictionary</param>
+        internal void CopyVariables(IDictionary<string, SimpleLayout> masterVariables)
         {
-            foreach (var variableKey in newVariables.Keys)
+            foreach (var variable in masterVariables)
             {
-                if (!this.Variables.ContainsKey(variableKey) 
-                    || string.IsNullOrEmpty(this.Variables[variableKey].OriginalText))
-                {
-                    Variables[variableKey] = newVariables[variableKey];
-                }
+                this.Variables[variable.Key] = variable.Value;
             }
         }
     }

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -583,6 +583,7 @@ namespace NLog.Config
 
             logFactory.ThrowExceptions = nlogElement.GetOptionalBooleanAttribute("throwExceptions", logFactory.ThrowExceptions);
             logFactory.ThrowConfigExceptions = nlogElement.GetOptionalBooleanAttribute("throwConfigExceptions", logFactory.ThrowConfigExceptions);
+            logFactory.KeepVariablesOnReload = nlogElement.GetOptionalBooleanAttribute("keepVariablesOnReload", logFactory.KeepVariablesOnReload);
             InternalLogger.LogToConsole = nlogElement.GetOptionalBooleanAttribute("internalLogToConsole", InternalLogger.LogToConsole);
             InternalLogger.LogToConsoleError = nlogElement.GetOptionalBooleanAttribute("internalLogToConsoleError", InternalLogger.LogToConsoleError);
             InternalLogger.LogFile = nlogElement.GetOptionalAttribute("internalLogFile", InternalLogger.LogFile);

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -149,6 +149,12 @@ namespace NLog
         /// </remarks>
         public bool? ThrowConfigExceptions { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether Variables should be kept on configuration reload.
+        /// Default value - false.
+        /// </summary>
+        public bool KeepVariablesOnReload { get; set; }
+
 
         /// <summary>
         /// Gets or sets the current logging configuration. After setting this property all
@@ -728,7 +734,10 @@ namespace NLog
 
                     if (newConfig != null)
                     {
-                        newConfig.MergeVariables(this.Configuration.Variables);
+                        if (this.KeepVariablesOnReload)
+                        {
+                            newConfig.CopyVariables(this.Configuration.Variables);
+                        }
                         this.Configuration = newConfig;
                         if (this.ConfigurationReloaded != null)
                         {

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -728,6 +728,7 @@ namespace NLog
 
                     if (newConfig != null)
                     {
+                        newConfig.MergeVariables(this.Configuration.Variables);
                         this.Configuration = newConfig;
                         if (this.ConfigurationReloaded != null)
                         {

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -135,6 +135,16 @@ namespace NLog
             set { factory.ThrowConfigExceptions = value; }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether Variables should be kept on configuration reload.
+        /// Default value - false.
+        /// </summary>
+        public static bool KeepVariablesOnReload
+        {
+            get { return factory.KeepVariablesOnReload; }
+            set { factory.KeepVariablesOnReload = value; }
+        }
+
         internal static IAppDomain CurrentAppDomain
         {
             get { return currentAppDomain ?? (currentAppDomain = AppDomainWrapper.CurrentDomain); }

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using Xunit.Extensions;
+
 #if !SILVERLIGHT && !MONO
 namespace NLog.UnitTests.Config
 {
@@ -479,9 +481,6 @@ namespace NLog.UnitTests.Config
             }
         }
 
-        /// <summary>
-        /// Empty and missing variables shoud be taken from current configuration on config reload.
-        /// </summary>
         [Fact]
         public void TestKeepVariablesOnReload()
         {
@@ -513,13 +512,15 @@ namespace NLog.UnitTests.Config
             }
         }
 
-        [Fact]
-        public void TestResetVariablesOnReload()
+        [Theory]
+        [InlineData("")]
+        [InlineData("keepVariablesOnReload='false'")]
+        public void TestResetVariablesOnReload(string keepVariablesAttr)
         {
-            string config = @"<nlog autoReload='true'>
+            string config = string.Format(@"<nlog autoReload='true' {0}>
                                 <variable name='var1' value='' />
                                 <variable name='var2' value='keep_value' />
-                            </nlog>";
+                            </nlog>", keepVariablesAttr);
 
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempPath);

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -39,7 +39,6 @@ namespace NLog.UnitTests.Config
     using System.IO;
     using System.Threading;
     using Xunit;
-    using Xunit.Extensions;
 
     public class ReloadTests : NLogTestBase
     {
@@ -511,12 +510,10 @@ namespace NLog.UnitTests.Config
             }
         }
 
-        [Theory]
-        [InlineData("")]
-        [InlineData("keepVariablesOnReload='false'")]
+        [Fact]
         public void TestResetVariablesOnReload(string keepVariablesAttr)
         {
-            string config = string.Format(@"<nlog autoReload='true' {0}>
+            string config = string.Format(@"<nlog autoReload='true' keepVariablesOnReload='false'>
                                 <variable name='var1' value='' />
                                 <variable name='var2' value='keep_value' />
                             </nlog>", keepVariablesAttr);

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -31,7 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-
 #if !SILVERLIGHT && !MONO
 namespace NLog.UnitTests.Config
 {
@@ -41,7 +40,6 @@ namespace NLog.UnitTests.Config
     using System.Threading;
     using Xunit;
     using Xunit.Extensions;
-
 
     public class ReloadTests : NLogTestBase
     {

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -514,7 +514,7 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
-        public void TestReplacedVariablesOnReload()
+        public void TestResetVariablesOnReload()
         {
             string config = @"<nlog autoReload='true'>
                                 <variable name='var1' value='' />

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -511,12 +511,12 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
-        public void TestResetVariablesOnReload(string keepVariablesAttr)
+        public void TestResetVariablesOnReload()
         {
-            string config = string.Format(@"<nlog autoReload='true' keepVariablesOnReload='false'>
+            string config = @"<nlog autoReload='true' keepVariablesOnReload='false'>
                                 <variable name='var1' value='' />
                                 <variable name='var2' value='keep_value' />
-                            </nlog>", keepVariablesAttr);
+                            </nlog>";
 
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempPath);

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -31,7 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using Xunit.Extensions;
 
 #if !SILVERLIGHT && !MONO
 namespace NLog.UnitTests.Config
@@ -41,6 +40,8 @@ namespace NLog.UnitTests.Config
     using System.IO;
     using System.Threading;
     using Xunit;
+    using Xunit.Extensions;
+
 
     public class ReloadTests : NLogTestBase
     {


### PR DESCRIPTION
fixes #1498 

On configuration reload - variables with empty values/missing variables are taken from current configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1769)
<!-- Reviewable:end -->
