### PR TITLE
Don't crash on an invalid (xml) app.config by default

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -170,8 +170,20 @@ namespace NLog
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
                     if (this.config == null)
                     {
-                        // Try to load default configuration.
-                        this.config = XmlLoggingConfiguration.AppConfig;
+                        try
+                        {
+                            // Try to load default configuration.
+                            this.config = XmlLoggingConfiguration.AppConfig;
+                        }
+                        catch (Exception ex)
+                        {
+                            //loading could fail due to an invalid XML file (app.config) etc.
+                            if (ex.MustBeRethrown())
+                            {
+                                throw;
+                            }
+                           
+                        }
                     }
 #endif
                     // Retest the condition as we might have loaded a config.


### PR DESCRIPTION
Fixes https://github.com/NLog/NLog/issues/1772

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1776)
<!-- Reviewable:end -->
