### PR TITLE
ConsoleTarget - DetectConsoleAvailable - Disabled by default

### DIFF
--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -90,7 +90,7 @@ namespace NLog.Targets
             this.RowHighlightingRules = new List<ConsoleRowHighlightingRule>();
             this.UseDefaultRowHighlightingRules = true;
             this.PauseLogging = false;
-            this.DetectConsoleAvailable = true;
+            this.DetectConsoleAvailable = false;
         }
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace NLog.Targets
         ///  - Disables console writing if Environment.UserInteractive = False (Windows Service)
         ///  - Disables console writing if Console Standard Input is not available (Non-Console-App)
         /// </summary>
-        [DefaultValue(true)]
+        [DefaultValue(false)]
         public bool DetectConsoleAvailable { get; set; }
 
         /// <summary>

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -103,7 +103,7 @@ namespace NLog.Targets
         ///  - Disables console writing if Environment.UserInteractive = False (Windows Service)
         ///  - Disables console writing if Console Standard Input is not available (Non-Console-App)
         /// </summary>
-        [DefaultValue(true)]
+        [DefaultValue(false)]
         public bool DetectConsoleAvailable { get; set; }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace NLog.Targets
         public ConsoleTarget() : base()
         {
             PauseLogging = false;
-            DetectConsoleAvailable = true;
+            DetectConsoleAvailable = false;
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #1773 

DetectConsoleAvailable fails to handle the situation where the console application stdout is used for file logging, and the console application runs as a Windows Service or within the Task Scheduler.

DetectConsoleAvailable has been designed to disable the console, when the console application is running as windows service. And not for doing the funky chicken with stdout support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1778)
<!-- Reviewable:end -->
