### PR TITLE
PropertiesLayoutRenderer - Check LogEventInfo.HasProperties first

### DIFF
--- a/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
@@ -75,9 +75,8 @@ namespace NLog.LayoutRenderers
         /// 
         /// See https://msdn.microsoft.com/en-us/library/hh534540.aspx
         /// </summary>
-       [DefaultValue(false)] 
-       public bool IncludeCallerInformation { get; set; }
-
+        [DefaultValue(false)]
+        public bool IncludeCallerInformation { get; set; }
 
 #endif
 
@@ -107,30 +106,31 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            bool first = true;
-
-            foreach (var property in GetProperties(logEvent))
+            if (logEvent.HasProperties)
             {
-                if (!first)
+                bool first = true;
+                foreach (var property in GetProperties(logEvent))
                 {
-                    builder.Append(Separator);
+                    if (!first)
+                    {
+                        builder.Append(Separator);
+                    }
+
+                    first = false;
+
+                    var formatProvider = GetFormatProvider(logEvent);
+
+                    var key = Convert.ToString(property.Key, formatProvider);
+                    var value = Convert.ToString(property.Value, formatProvider);
+                    var pair = Format.Replace("[key]", key)
+                                     .Replace("[value]", value);
+
+                    builder.Append(pair);
                 }
-
-                first = false;
-
-                var formatProvider = GetFormatProvider(logEvent);
-
-                var key = Convert.ToString(property.Key, formatProvider);
-                var value = Convert.ToString(property.Value, formatProvider);
-                var pair = Format.Replace("[key]", key)
-                                 .Replace("[value]", value);
-
-                builder.Append(pair);
             }
         }
 
-
-        #if NET4_5
+#if NET4_5
 
         /// <summary>
         /// The names of caller information attributes.
@@ -147,9 +147,8 @@ namespace NLog.LayoutRenderers
         /// Also render the call attributes? (<see cref="CallerMemberNameAttribute"/>,
         /// <see cref="CallerFilePathAttribute"/>, <see cref="CallerLineNumberAttribute"/>). 
         /// </summary>
-        /// 
+        ///
 #endif
-
 
         private IDictionary<object, object> GetProperties(LogEventInfo logEvent)
         {
@@ -157,13 +156,13 @@ namespace NLog.LayoutRenderers
 
             if (this.IncludeCallerInformation)
             {
-                return logEvent.Properties; 
+                return logEvent.Properties;
             }
+            
             //filter CallerInformationAttributeNames
             return logEvent.Properties.Where(p => !CallerInformationAttributeNames.Contains(p.Key)).ToDictionary(p => p.Key, p => p.Value);
 
 #else
-
             return logEvent.Properties;
 #endif
         }

--- a/src/NLog/LayoutRenderers/EventContextLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EventContextLayoutRenderer.cs
@@ -62,7 +62,7 @@ namespace NLog.LayoutRenderers
         {
             object value;
 
-            if (logEvent.Properties.TryGetValue(this.Item, out value))
+            if (logEvent.HasProperties && logEvent.Properties.TryGetValue(this.Item, out value))
             {
                 var formatProvider = GetFormatProvider(logEvent);
                 builder.Append(Convert.ToString(value, formatProvider));

--- a/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
@@ -82,7 +82,7 @@ namespace NLog.LayoutRenderers
         {
             object value;
 
-            if (logEvent.Properties.TryGetValue(this.Item, out value))
+            if (logEvent.HasProperties && logEvent.Properties.TryGetValue(this.Item, out value))
             {
                 var formatProvider = GetFormatProvider(logEvent, Culture);
                 builder.Append(value.ToStringWithOptionalFormat(Format, formatProvider));

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -244,12 +244,15 @@ namespace NLog.LayoutRenderers
                             xtw.WriteEndElement();
 
                             xtw.WriteStartElement("nlog", "properties", dummyNLogNamespace);
-                            foreach (var contextProperty in logEvent.Properties)
+                            if (logEvent.HasProperties)
                             {
-                                xtw.WriteStartElement("nlog", "data", dummyNLogNamespace);
-                                xtw.WriteAttributeSafeString("name", Convert.ToString(contextProperty.Key, CultureInfo.InvariantCulture));
-                                xtw.WriteAttributeSafeString("value", Convert.ToString(contextProperty.Value, CultureInfo.InvariantCulture));
-                                xtw.WriteEndElement();
+                                foreach (var contextProperty in logEvent.Properties)
+                                {
+                                    xtw.WriteStartElement("nlog", "data", dummyNLogNamespace);
+                                    xtw.WriteAttributeSafeString("name", Convert.ToString(contextProperty.Key, CultureInfo.InvariantCulture));
+                                    xtw.WriteAttributeSafeString("value", Convert.ToString(contextProperty.Value, CultureInfo.InvariantCulture));
+                                    xtw.WriteEndElement();
+                                }
                             }
                             xtw.WriteEndElement();
                         }

--- a/src/NLog/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog/Targets/LogReceiverWebServiceTarget.cs
@@ -246,15 +246,18 @@ namespace NLog.Targets
                 {
                     var ev = logEvents[i].LogEvent;
 
-                    // add all event-level property names in 'LayoutNames' collection.
-                    foreach (var prop in ev.Properties)
+                    if (ev.HasProperties)
                     {
-                        string propName = prop.Key as string;
-                        if (propName != null)
+                        // add all event-level property names in 'LayoutNames' collection.
+                        foreach (var prop in ev.Properties)
                         {
-                            if (!networkLogEvents.LayoutNames.Contains(propName))
+                            string propName = prop.Key as string;
+                            if (propName != null)
                             {
-                                networkLogEvents.LayoutNames.Add(propName);
+                                if (!networkLogEvents.LayoutNames.Contains(propName))
+                                {
+                                    networkLogEvents.LayoutNames.Add(propName);
+                                }
                             }
                         }
                     }

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -593,7 +593,7 @@ namespace NLog.Targets
             for (int i = 0; i < logEvent.Parameters.Length; ++i)
             {
                 var logEventParameter = logEvent.Parameters[i] as LogEventInfo;
-                if (logEventParameter != null)
+                if (logEventParameter != null && logEventParameter.HasProperties)
                 {
                     foreach (var key in logEventParameter.Properties.Keys)
                     {


### PR DESCRIPTION
Avoid allocating Properties-Dictionary, when just wanting to read from it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1780)
<!-- Reviewable:end -->
