### PR TITLE
Change Event Context call to Event properties

### DIFF
--- a/examples/ExtendingLoggers/LoggerWrapper/Program.cs
+++ b/examples/ExtendingLoggers/LoggerWrapper/Program.cs
@@ -59,9 +59,9 @@ namespace LoggerWrapper
 
             //
             // set event-specific context parameter
-            // this context parameter can be retrieved using ${event-context:EventID}
+            // this context parameter can be retrieved using ${event-properties:EventID}
             //
-            logEvent.Context["EventID"] = eventID;
+            logEvent.Properties["EventID"] = eventID;
 
             // 
             // Call the Log() method. It is important to pass typeof(MyLogger) as the


### PR DESCRIPTION
Line 62, change {$event-context:EventID} to {$event-properties:EventID}
Line 64, change logEvent.Context to logEvent.Properties

Reason: Context is deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1781)
<!-- Reviewable:end -->
