### PR TITLE
Support Generic (I)List and (I)Set for Target/Layout/Layout renderers properties

### DIFF
--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -53,7 +53,7 @@ namespace NLog.Layouts
             this.Attributes = new List<JsonAttribute>();
             this.RenderEmptyObject = true;
             this.IncludeAllProperties = false;
-            this.ExcludedProperties = new List<string>();
+            this.ExcludedProperties = new HashSet<string>();
         }
 
         /// <summary>
@@ -81,7 +81,11 @@ namespace NLog.Layouts
         /// <summary>
         /// List of property names to exclude when IncludeAllProperties is true
         /// </summary>
-        public IList<string> ExcludedProperties { get; set; }
+#if NET3_5
+        public HashSet<string> ExcludedProperties { get; set; }
+#else
+        public ISet<string> ExcludedProperties { get; set; }
+#endif
 
         /// <summary>
         /// Formats the log event as a JSON document for writing.

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -551,6 +551,7 @@ namespace NLog.UnitTests.Layouts
         /// <param name="expected"></param>
         [Theory]
         [InlineData("2,3,4", "numbers", "2-3-4")]
+
         [InlineData("a,b,c", "Strings", "a-b-c")]
         [InlineData("a,b,c", "Objects", "a-b-c")]
         [InlineData("a,,b,c", "Strings", "a--b-c")]
@@ -563,6 +564,23 @@ namespace NLog.UnitTests.Layouts
         [InlineData("ASCII,ISO-8859-1, UTF-8", "encodings", "System.Text.ASCIIEncoding-System.Text.Latin1Encoding-System.Text.UTF8Encoding")]
         [InlineData("ASCII,ISO-8859-1,UTF-8", "encodings", "System.Text.ASCIIEncoding-System.Text.Latin1Encoding-System.Text.UTF8Encoding")]
         [InlineData("Value1,Value3,Value2", "FlagEnums", "Value1-Value3-Value2")]
+        [InlineData("2,3,4", "IEnumerableNumber", "2-3-4")]
+        [InlineData("2,3,4", "IListNumber", "2-3-4")]
+        [InlineData("2,3,4", "HashsetNumber", "2-3-4")]
+#if !NET3_5
+        [InlineData("2,3,4", "ISetNumber", "2-3-4")]
+        
+#endif
+        [InlineData("a,b,c", "IEnumerableString", "a-b-c")]
+        [InlineData("a,b,c", "IListString", "a-b-c")]
+        [InlineData("a,b,c", "HashSetString", "a-b-c")]
+#if !NET3_5
+        [InlineData("a,b,c", "ISetString", "a-b-c")]
+        
+#endif
+
+
+
         public void LayoutWithListParamTest(string input, string propname, string expected)
         {
             ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition("layoutrenderer-with-list", typeof(LayoutRendererWithListParam));
@@ -592,6 +610,7 @@ namespace NLog.UnitTests.Layouts
         }
 
 
+
         private class LayoutRendererWithListParam : LayoutRenderer
         {
             public List<double> Doubles { get; set; }
@@ -608,6 +627,25 @@ namespace NLog.UnitTests.Layouts
 
             public List<Encoding> Encodings { get; set; }
 
+            public IEnumerable<string> IEnumerableString { get; set; }
+
+            public IEnumerable<int> IEnumerableNumber { get; set; }
+
+            public IList<string> IListString { get; set; }
+
+            public IList<int> IListNumber { get; set; }
+
+#if !NET3_5
+            public ISet<string> ISetString { get; set; }
+
+            public ISet<int> ISetNumber { get; set; }
+
+#endif
+
+            public HashSet<int> HashSetNumber { get; set; }
+
+            public HashSet<string> HashSetString { get; set; }
+            
             /// <summary>
             /// Renders the specified environmental information and appends it to the specified <see cref="StringBuilder" />.
             /// </summary>
@@ -622,6 +660,20 @@ namespace NLog.UnitTests.Layouts
                 AppendFormattable(builder, Doubles);
                 Append(builder, Encodings);
                 Append(builder, Objects);
+                Append(builder, IEnumerableString);
+                AppendFormattable(builder, IEnumerableNumber);
+                Append(builder, IListString);
+                AppendFormattable(builder, IListNumber);
+#if !NET3_5
+                Append(builder, ISetString);
+                AppendFormattable(builder, ISetNumber);
+        
+#endif
+                Append(builder, HashSetString);
+                AppendFormattable(builder, HashSetNumber);
+
+
+
             }
 
             private void Append<T>(StringBuilder builder, IEnumerable<T> items)


### PR DESCRIPTION
As forcing concrete List is lame, and to promote ISets: 

Support for IList<T>/IEnumerable<T>/List<T>/ISet<T>/HashSet<T> for Target/Layout/Layout renderers properties





### support
Including current support, now supported:

Collections of type: 
  -  `IList<T>` / `IList`
  - `IEnumerable<T>` / `IEnumerable` 
  - `ISet<T>` / `HashSet<T>`

with the following types: 
  - C# built in types (string, int, double, object)
  - enum (use shortname)
  - culture, encoding, Type
  - not supported: Layout

Not supported:
-  Arrays
- Non-generic `List` 
-  Non-gereric `IList`
- Custom class implementing/inheriting from the collection classes/interfaces. (because of performance)


PS: .NET 3.5 has HashSet but not ISet

addition of https://github.com/NLog/NLog/pull/1439


also fixes https://github.com/NLog/NLog/issues/1770

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1782)
<!-- Reviewable:end -->
