### PR TITLE
Improve unit test performance

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ test_script:
   - tools\CheckSourceCode\NLog.SourceCodeTests.exe no-interactive
   - xunit.console.clr4 "build\bin\Debug\.NET Framework 3.5\NLog.UnitTests.dll" /appveyor /noshadow
   - xunit.console.clr4 "build\bin\Debug\.NET Framework 4.0\NLog.UnitTests.dll" /appveyor /noshadow
-  - xunit.console.clr4 "build\bin\Debug\.NET Framework 4.5\NLog.UnitTests.dll" /appveyor /noshadow
   - nuget.exe install OpenCover -ExcludeVersion
   - OpenCover\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"\"C:\projects\nlog\build\bin\Debug\.NET Framework 4.5\NLog.UnitTests.dll\" -appveyor -noshadow"  -returntargetcode -filter:"+[NLog]* +[NLog.Extended]* -[NLog]JetBrains.Annotations.*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:coverage.xml
   - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -2309,7 +2309,7 @@ namespace NLog.UnitTests.Targets
                     FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive", "{#}." + archiveExtension),
                     ArchiveDateFormat = "yyyy-MM-dd",
-                    ArchiveAboveSize = 1000,
+                    ArchiveAboveSize = 100,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}",
                     MaxArchiveFiles = maxArchiveFiles,
@@ -2320,17 +2320,17 @@ namespace NLog.UnitTests.Targets
 
                 ArchiveFileNameHelper helper = new ArchiveFileNameHelper(Path.Combine(tempPath, "archive"), DateTime.Now.ToString(fileTarget.ArchiveDateFormat), archiveExtension);
 
-                Generate1000BytesLog('a');
+                Generate100BytesLog('a');
 
                 for (int i = 0; i < maxArchiveFiles; i++)
                 {
-                    Generate1000BytesLog('a');
+                    Generate100BytesLog('a');
                     Assert.True(helper.Exists(i), string.Format("file {0} is missing", i));
                 }
 
-                for (int i = maxArchiveFiles; i < 100; i++)
+                for (int i = maxArchiveFiles; i < 21; i++)
                 {
-                    Generate1000BytesLog('b');
+                    Generate100BytesLog('b');
                     var numberToBeRemoved = i - maxArchiveFiles; // number 11, we need to remove 1 etc
                     Assert.True(!helper.Exists(numberToBeRemoved), string.Format("archive file {0} has not been removed! We are created file {1}", numberToBeRemoved, i));
                 }
@@ -2348,6 +2348,15 @@ namespace NLog.UnitTests.Targets
         private void Generate1000BytesLog(char c)
         {
             for (var i = 0; i < 250; ++i)
+            {
+                //3 chars with newlines = 4 bytes
+                logger.Debug(new string(c, 3));
+            }
+        }
+
+        private void Generate100BytesLog(char c)
+        {
+            for (var i = 0; i < 25; ++i)
             {
                 //3 chars with newlines = 4 bytes
                 logger.Debug(new string(c, 3));

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -1789,13 +1789,14 @@ namespace NLog.UnitTests.Targets
 
                 var threadID = Thread.CurrentThread.ManagedThreadId.ToString();
 
-                SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(fileTarget, 1000, AsyncTargetWrapperOverflowAction.Grow)
+                SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(fileTarget, 100, AsyncTargetWrapperOverflowAction.Grow)
                 {
                     Name = "AsyncMultiFileWrite_wrapper"
                 }, LogLevel.Debug);
                 LogManager.ThrowExceptions = true;
 
-                for (var i = 0; i < 250; ++i)
+                var times = 25;
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Trace("@@@");
                     logger.Debug("aaa");
@@ -1810,19 +1811,19 @@ namespace NLog.UnitTests.Targets
                 Assert.False(File.Exists(Path.Combine(tempPath, "Trace.txt")));
 
                 AssertFileContents(Path.Combine(tempPath, "Debug.txt"),
-                    StringRepeat(250, "aaa " + threadID + "\n"), Encoding.UTF8);
+                    StringRepeat(times, "aaa " + threadID + "\n"), Encoding.UTF8);
 
                 AssertFileContents(Path.Combine(tempPath, "Info.txt"),
-                    StringRepeat(250, "bbb " + threadID + "\n"), Encoding.UTF8);
+                    StringRepeat(times, "bbb " + threadID + "\n"), Encoding.UTF8);
 
                 AssertFileContents(Path.Combine(tempPath, "Warn.txt"),
-                    StringRepeat(250, "ccc " + threadID + "\n"), Encoding.UTF8);
+                    StringRepeat(times, "ccc " + threadID + "\n"), Encoding.UTF8);
 
                 AssertFileContents(Path.Combine(tempPath, "Error.txt"),
-                    StringRepeat(250, "ddd " + threadID + "\n"), Encoding.UTF8);
+                    StringRepeat(times, "ddd " + threadID + "\n"), Encoding.UTF8);
 
                 AssertFileContents(Path.Combine(tempPath, "Fatal.txt"),
-                    StringRepeat(250, "eee " + threadID + "\n"), Encoding.UTF8);
+                    StringRepeat(times, "eee " + threadID + "\n"), Encoding.UTF8);
             }
             finally
             {

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -964,7 +964,7 @@ namespace NLog.UnitTests.Targets
                 logger.Debug("123456789");
                 DateTime previousWriteTime = timeSource.Time;
 
-                const int daysToTestLogging = 5;
+                const int daysToTestLogging = 3;
                 const int intervalsPerDay = 24;
                 var loggingInterval = TimeSpan.FromHours(1);
                 for (var i = 0; i < daysToTestLogging * intervalsPerDay; ++i)
@@ -1003,9 +1003,9 @@ namespace NLog.UnitTests.Targets
                 //Setting the Configuration to [null] will result in a 'Dump' of the current log entries
                 LogManager.Configuration = null;
 
-                var files = Directory.GetFiles(archiveFolder).OrderBy(s => s).ToList();
+                var files = Directory.GetFiles(archiveFolder);
                 //the amount of archived files may not exceed the set 'MaxArchiveFiles'
-                Assert.Equal(maxArchiveFiles, files.Count);
+                Assert.Equal(maxArchiveFiles, files.Length);
 
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -652,7 +652,7 @@ namespace NLog.UnitTests.Targets
                 {
                     FileName = logFile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{####}.txt"),
-                    ArchiveAboveSize = 1000,
+                    ArchiveAboveSize = 100,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = ArchiveNumberingMode.Sequence,
                     Layout = "${message}",
@@ -663,36 +663,36 @@ namespace NLog.UnitTests.Targets
 
                 // we emit 5 * 250 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 4 archives
-                Generate1000BytesLog('a');
-                Generate1000BytesLog('b');
-                Generate1000BytesLog('c');
-                Generate1000BytesLog('d');
-                Generate1000BytesLog('e');
+                Generate100BytesLog('a');
+                Generate100BytesLog('b');
+                Generate100BytesLog('c');
+                Generate100BytesLog('d');
+                Generate100BytesLog('e');
 
                 LogManager.Configuration = null;
 
                 AssertFileContents(logFile,
-                    StringRepeat(250, "eee\n"),
+                    StringRepeat(25, "eee\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                    Path.Combine(archiveFolder, "0000.txt"),
-                   StringRepeat(250, "aaa\n"),
+                   StringRepeat(25, "aaa\n"),
                    Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(archiveFolder, "0001.txt"),
-                    StringRepeat(250, "bbb\n"),
+                    StringRepeat(25, "bbb\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(archiveFolder, "0002.txt"),
-                    StringRepeat(250, "ccc\n"),
+                    StringRepeat(25, "ccc\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(archiveFolder, "0003.txt"),
-                    StringRepeat(250, "ddd\n"),
+                    StringRepeat(25, "ddd\n"),
                     Encoding.UTF8);
 
                 Assert.True(!File.Exists(Path.Combine(archiveFolder, "0004.txt")));

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -1875,7 +1875,7 @@ namespace NLog.UnitTests.Targets
         private void FileTarget_ArchiveNumbering_DateAndSequenceTests(bool enableCompression, string fileTxt, string archiveFileName)
         {
             const string archiveDateFormat = "yyyy-MM-dd";
-            const int archiveAboveSize = 1000;
+            const int archiveAboveSize = 100;
 
             var tempPath = ArchiveFileNameHelper.GenerateTempPath();
             Layout logFile = Path.Combine(tempPath, fileTxt);
@@ -1902,11 +1902,11 @@ namespace NLog.UnitTests.Targets
 
                 // we emit 5 * 250 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
-                Generate1000BytesLog('a');
-                Generate1000BytesLog('b');
-                Generate1000BytesLog('c');
-                Generate1000BytesLog('d');
-                Generate1000BytesLog('e');
+                Generate100BytesLog('a');
+                Generate100BytesLog('b');
+                Generate100BytesLog('c');
+                Generate100BytesLog('d');
+                Generate100BytesLog('e');
 
                 string renderedArchiveFileName = archiveFileName.Replace("{#}", DateTime.Now.ToString(archiveDateFormat));
 
@@ -1923,13 +1923,14 @@ namespace NLog.UnitTests.Targets
                 ArchiveFileNameHelper helper = new ArchiveFileNameHelper(tempPath, fileNameWithoutExt, extension);
 
 
+                var times = 25;
                 AssertFileContents(logFileName,
-                    StringRepeat(250, "eee\n"),
+                    StringRepeat(times, "eee\n"),
                     Encoding.UTF8);
 
-                assertFileContents(helper.GetFullPath(1), StringRepeat(250, "bbb\n"), Encoding.UTF8);
-                assertFileContents(helper.GetFullPath(2), StringRepeat(250, "ccc\n"), Encoding.UTF8);
-                assertFileContents(helper.GetFullPath(3), StringRepeat(250, "ddd\n"), Encoding.UTF8);
+                assertFileContents(helper.GetFullPath(1), StringRepeat(times, "bbb\n"), Encoding.UTF8);
+                assertFileContents(helper.GetFullPath(2), StringRepeat(times, "ccc\n"), Encoding.UTF8);
+                assertFileContents(helper.GetFullPath(3), StringRepeat(times, "ddd\n"), Encoding.UTF8);
 
                 Assert.False(helper.Exists(0), "First archive should have been deleted due to max archive count.");
                 Assert.False(helper.Exists(4), "Fifth archive must not have been created yet.");

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -1610,7 +1610,7 @@ namespace NLog.UnitTests.Targets
                 {
                     FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive" + slash + "{####}.txt"),
-                    ArchiveAboveSize = 1000,
+                    ArchiveAboveSize = 100,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = ArchiveNumberingMode.Rolling,
                     Layout = "${message}",
@@ -1621,36 +1621,37 @@ namespace NLog.UnitTests.Targets
 
                 // we emit 5 * 250 * (3 x aaa + \n) bytes
                 // so that we should get a full file + 4 archives
-                Generate1000BytesLog('a');
-                Generate1000BytesLog('b');
-                Generate1000BytesLog('c');
-                Generate1000BytesLog('d');
-                Generate1000BytesLog('e');
+                Generate100BytesLog('a');
+                Generate100BytesLog('b');
+                Generate100BytesLog('c');
+                Generate100BytesLog('d');
+                Generate100BytesLog('e');
 
                 LogManager.Configuration = null;
 
+                var times = 25;
                 AssertFileContents(logFile,
-                    StringRepeat(250, "eee\n"),
+                    StringRepeat(times, "eee\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(tempPath, "archive" + slash + "0000.txt"),
-                    StringRepeat(250, "ddd\n"),
+                    StringRepeat(times, "ddd\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(tempPath, "archive" + slash + "0001.txt"),
-                    StringRepeat(250, "ccc\n"),
+                    StringRepeat(times, "ccc\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(tempPath, "archive" + slash + "0002.txt"),
-                    StringRepeat(250, "bbb\n"),
+                    StringRepeat(times, "bbb\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(tempPath, "archive" + slash + "0003.txt"),
-                    StringRepeat(250, "aaa\n"),
+                    StringRepeat(times, "aaa\n"),
                     Encoding.UTF8);
             }
             finally

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -590,7 +590,7 @@ namespace NLog.UnitTests.Targets
                 {
                     FileName = logFile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{####}.txt"),
-                    ArchiveAboveSize = 1000,
+                    ArchiveAboveSize = 100,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}",
                     MaxArchiveFiles = 3,
@@ -599,33 +599,34 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-                // we emit 5 * 250 *(3 x aaa + \n) bytes
+                // we emit 5 * 25 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
-                Generate1000BytesLog('a');
-                Generate1000BytesLog('b');
-                Generate1000BytesLog('c');
-                Generate1000BytesLog('d');
-                Generate1000BytesLog('e');
+                Generate100BytesLog('a');
+                Generate100BytesLog('b');
+                Generate100BytesLog('c');
+                Generate100BytesLog('d');
+                Generate100BytesLog('e');
 
                 LogManager.Configuration = null;
 
+                var times = 25;
                 AssertFileContents(logFile,
-                    StringRepeat(250, "eee\n"),
+                    StringRepeat(times, "eee\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(archiveFolder, "0001.txt"),
-                    StringRepeat(250, "bbb\n"),
+                    StringRepeat(times, "bbb\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(archiveFolder, "0002.txt"),
-                    StringRepeat(250, "ccc\n"),
+                    StringRepeat(times, "ccc\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(archiveFolder, "0003.txt"),
-                    StringRepeat(250, "ddd\n"),
+                    StringRepeat(times, "ddd\n"),
                     Encoding.UTF8);
                 //0000 should not extists because of MaxArchiveFiles=3
                 Assert.True(!File.Exists(Path.Combine(archiveFolder, "0000.txt")));
@@ -661,7 +662,7 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-                // we emit 5 * 250 *(3 x aaa + \n) bytes
+                // we emit 5 * 25 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 4 archives
                 Generate100BytesLog('a');
                 Generate100BytesLog('b');
@@ -729,7 +730,7 @@ namespace NLog.UnitTests.Targets
                 //e.g. 20150804
                 var archiveFileName = DateTime.Now.ToString("yyyyMMdd");
 
-                // we emit 5 * 250 *(3 x aaa + \n) bytes
+                // we emit 5 * 25 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
                 for (var i = 0; i < 250; ++i)
                 {
@@ -1534,7 +1535,7 @@ namespace NLog.UnitTests.Targets
                     EnableArchiveFileCompression = enableCompression,
 #endif
                     FileName = logFile,
-                    ArchiveAboveSize = 1000,
+                    ArchiveAboveSize = 100,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = ArchiveNumberingMode.Rolling,
                     Layout = "${message}",
@@ -1548,11 +1549,11 @@ namespace NLog.UnitTests.Targets
 
                 // we emit 5 * 250 * (3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
-                Generate1000BytesLog('a');
-                Generate1000BytesLog('b');
-                Generate1000BytesLog('c');
-                Generate1000BytesLog('d');
-                Generate1000BytesLog('e');
+                Generate100BytesLog('a');
+                Generate100BytesLog('b');
+                Generate100BytesLog('c');
+                Generate100BytesLog('d');
+                Generate100BytesLog('e');
 
                 LogManager.Configuration = null;
 
@@ -1563,8 +1564,9 @@ namespace NLog.UnitTests.Targets
  new Action<string, string, Encoding>(AssertFileContents);
 #endif
 
+                var times = 25;
                 AssertFileContents(logFile,
-                    StringRepeat(250, "eee\n"),
+                    StringRepeat(times, "eee\n"),
                     Encoding.UTF8);
 
                 string archiveFileNameFormat = specifyArchiveFileName
@@ -1573,17 +1575,17 @@ namespace NLog.UnitTests.Targets
 
                 assertFileContents(
                     Path.Combine(tempPath, string.Format(archiveFileNameFormat, 0)),
-                    StringRepeat(250, "ddd\n"),
+                    StringRepeat(times, "ddd\n"),
                     Encoding.UTF8);
 
                 assertFileContents(
                     Path.Combine(tempPath, string.Format(archiveFileNameFormat, 1)),
-                    StringRepeat(250, "ccc\n"),
+                    StringRepeat(times, "ccc\n"),
                     Encoding.UTF8);
 
                 assertFileContents(
                     Path.Combine(tempPath, string.Format(archiveFileNameFormat, 2)),
-                    StringRepeat(250, "bbb\n"),
+                    StringRepeat(times, "bbb\n"),
                     Encoding.UTF8);
 
                 Assert.True(!File.Exists(Path.Combine(tempPath, string.Format(archiveFileNameFormat, 3))));
@@ -1902,7 +1904,7 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-                // we emit 5 * 250 *(3 x aaa + \n) bytes
+                // we emit 5 * 25 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
                 Generate100BytesLog('a');
                 Generate100BytesLog('b');
@@ -2345,15 +2347,6 @@ namespace NLog.UnitTests.Targets
                     File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
-            }
-        }
-
-        private void Generate1000BytesLog(char c)
-        {
-            for (var i = 0; i < 250; ++i)
-            {
-                //3 chars with newlines = 4 bytes
-                logger.Debug(new string(c, 3));
             }
         }
 
@@ -3013,7 +3006,7 @@ namespace NLog.UnitTests.Targets
                 {
                     FileName = logfile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{####}.txt"),
-                    ArchiveAboveSize = 1000,
+                    ArchiveAboveSize = 100,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = ArchiveNumberingMode.Sequence,
                     Layout = "${message}",
@@ -3022,38 +3015,39 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 logfile = Path.GetFullPath(logfile);
-                // we emit 5 * 250 *(3 x aaa + \n) bytes
+                // we emit 5 * 25 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 4 archives
-                Generate1000BytesLog('a');
-                Generate1000BytesLog('b');
-                Generate1000BytesLog('c');
-                Generate1000BytesLog('d');
-                Generate1000BytesLog('e');
+                Generate100BytesLog('a');
+                Generate100BytesLog('b');
+                Generate100BytesLog('c');
+                Generate100BytesLog('d');
+                Generate100BytesLog('e');
 
                 LogManager.Configuration = null;
 
+                var times = 25;
                 AssertFileContents(logfile,
-                    StringRepeat(250, "eee\n"),
+                    StringRepeat(times, "eee\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                    Path.Combine(archiveFolder, "0000.txt"),
-                   StringRepeat(250, "aaa\n"),
+                   StringRepeat(times, "aaa\n"),
                    Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(archiveFolder, "0001.txt"),
-                    StringRepeat(250, "bbb\n"),
+                    StringRepeat(times, "bbb\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(archiveFolder, "0002.txt"),
-                    StringRepeat(250, "ccc\n"),
+                    StringRepeat(times, "ccc\n"),
                     Encoding.UTF8);
 
                 AssertFileContents(
                     Path.Combine(archiveFolder, "0003.txt"),
-                    StringRepeat(250, "ddd\n"),
+                    StringRepeat(times, "ddd\n"),
                     Encoding.UTF8);
 
                 Assert.True(!File.Exists(Path.Combine(archiveFolder, "0004.txt")));

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -1017,8 +1017,8 @@ namespace NLog.UnitTests.Targets
                 logger.Debug("1234567890");
                 LogManager.Configuration = null;
 
-                var files2 = Directory.GetFiles(archiveFolder).OrderBy(s => s).ToList();
-                Assert.Equal(maxArchiveFiles, files2.Count);
+                var files2 = Directory.GetFiles(archiveFolder);
+                Assert.Equal(maxArchiveFiles, files2.Length);
 
                 //the oldest file should be deleted
                 Assert.DoesNotContain(files[0], files2);

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -719,7 +719,7 @@ namespace NLog.UnitTests.Targets
                 {
                     FileName = logFile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{####}.txt"),
-                    ArchiveAboveSize = 1000,
+                    ArchiveAboveSize = 100,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}",
                     ArchiveNumbering = ArchiveNumberingMode.Date
@@ -732,24 +732,25 @@ namespace NLog.UnitTests.Targets
 
                 // we emit 5 * 25 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
-                for (var i = 0; i < 250; ++i)
+                var times = 25;
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("aaa");
                 }
 
-                for (var i = 0; i < 250; ++i)
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("bbb");
                 }
-                for (var i = 0; i < 250; ++i)
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("ccc");
                 }
-                for (var i = 0; i < 250; ++i)
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("ddd");
                 }
-                for (var i = 0; i < 250; ++i)
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("eee");
                 }
@@ -759,14 +760,14 @@ namespace NLog.UnitTests.Targets
 
                 //we expect only eee and all other in the archive
                 AssertFileContents(logFile,
-                    StringRepeat(250, "eee\n"),
+                    StringRepeat(times, "eee\n"),
                     Encoding.UTF8);
 
                 //DUNNO what to expected!
                 //try (which fails)
                 AssertFileContents(
                     Path.Combine(archiveFolder, string.Format("{0}.txt", archiveFileName)),
-                   StringRepeat(250, "aaa\n") + StringRepeat(250, "bbb\n") + StringRepeat(250, "ccc\n") + StringRepeat(250, "ddd\n"),
+                   StringRepeat(times, "aaa\n") + StringRepeat(times, "bbb\n") + StringRepeat(times, "ccc\n") + StringRepeat(times, "ddd\n"),
                     Encoding.UTF8);
 
             }
@@ -1547,7 +1548,7 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-                // we emit 5 * 250 * (3 x aaa + \n) bytes
+                // we emit 5 * 25 * (3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
                 Generate100BytesLog('a');
                 Generate100BytesLog('b');
@@ -1621,7 +1622,7 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-                // we emit 5 * 250 * (3 x aaa + \n) bytes
+                // we emit 5 * 25 * (3 x aaa + \n) bytes
                 // so that we should get a full file + 4 archives
                 Generate100BytesLog('a');
                 Generate100BytesLog('b');
@@ -1686,7 +1687,8 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-                for (var i = 0; i < 250; ++i)
+                var times = 25;
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Trace("@@@");
                     logger.Debug("aaa");
@@ -1701,19 +1703,19 @@ namespace NLog.UnitTests.Targets
                 Assert.False(File.Exists(Path.Combine(tempPath, "Trace.txt")));
 
                 AssertFileContents(Path.Combine(tempPath, "Debug.txt"),
-                    StringRepeat(250, "aaa\n"), Encoding.UTF8);
+                    StringRepeat(times, "aaa\n"), Encoding.UTF8);
 
                 AssertFileContents(Path.Combine(tempPath, "Info.txt"),
-                    StringRepeat(250, "bbb\n"), Encoding.UTF8);
+                    StringRepeat(times, "bbb\n"), Encoding.UTF8);
 
                 AssertFileContents(Path.Combine(tempPath, "Warn.txt"),
-                    StringRepeat(250, "ccc\n"), Encoding.UTF8);
+                    StringRepeat(times, "ccc\n"), Encoding.UTF8);
 
                 AssertFileContents(Path.Combine(tempPath, "Error.txt"),
-                    StringRepeat(250, "ddd\n"), Encoding.UTF8);
+                    StringRepeat(times, "ddd\n"), Encoding.UTF8);
 
                 AssertFileContents(Path.Combine(tempPath, "Fatal.txt"),
-                    StringRepeat(250, "eee\n"), Encoding.UTF8);
+                    StringRepeat(times, "eee\n"), Encoding.UTF8);
             }
             finally
             {
@@ -1737,7 +1739,8 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(new BufferingTargetWrapper(fileTarget, 10), LogLevel.Debug);
 
-                for (var i = 0; i < 250; ++i)
+                var times = 25;
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Trace("@@@");
                     logger.Debug("aaa");
@@ -1752,19 +1755,19 @@ namespace NLog.UnitTests.Targets
                 Assert.False(File.Exists(Path.Combine(tempPath, "Trace.txt")));
 
                 AssertFileContents(Path.Combine(tempPath, "Debug.txt"),
-                    StringRepeat(250, "aaa\n"), Encoding.UTF8);
+                    StringRepeat(times, "aaa\n"), Encoding.UTF8);
 
                 AssertFileContents(Path.Combine(tempPath, "Info.txt"),
-                    StringRepeat(250, "bbb\n"), Encoding.UTF8);
+                    StringRepeat(times, "bbb\n"), Encoding.UTF8);
 
                 AssertFileContents(Path.Combine(tempPath, "Warn.txt"),
-                    StringRepeat(250, "ccc\n"), Encoding.UTF8);
+                    StringRepeat(times, "ccc\n"), Encoding.UTF8);
 
                 AssertFileContents(Path.Combine(tempPath, "Error.txt"),
-                    StringRepeat(250, "ddd\n"), Encoding.UTF8);
+                    StringRepeat(times, "ddd\n"), Encoding.UTF8);
 
                 AssertFileContents(Path.Combine(tempPath, "Fatal.txt"),
-                    StringRepeat(250, "eee\n"), Encoding.UTF8);
+                    StringRepeat(times, "eee\n"), Encoding.UTF8);
             }
             finally
             {
@@ -1792,7 +1795,7 @@ namespace NLog.UnitTests.Targets
 
                 var threadID = Thread.CurrentThread.ManagedThreadId.ToString();
 
-                SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(fileTarget, 100, AsyncTargetWrapperOverflowAction.Grow)
+                SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(fileTarget, 10, AsyncTargetWrapperOverflowAction.Grow)
                 {
                     Name = "AsyncMultiFileWrite_wrapper"
                 }, LogLevel.Debug);
@@ -2117,7 +2120,7 @@ namespace NLog.UnitTests.Targets
                 {
                     FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive", "file.txt2"),
-                    ArchiveAboveSize = 1000,
+                    ArchiveAboveSize = 100,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}",
                     MaxArchiveFiles = 1,
@@ -2125,26 +2128,27 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-                // we emit 2 * 250 *(aaa + \n) bytes
+                // we emit 2 * 25 *(aaa + \n) bytes
                 // so that we should get a full file + 1 archives
-                for (var i = 0; i < 250; ++i)
+                var times = 25;
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("aaa");
                 }
-                for (var i = 0; i < 250; ++i)
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("bbb");
                 }
 
                 AssertFileContents(logFile,
-                    StringRepeat(250, "bbb\n"),
+                    StringRepeat(times, "bbb\n"),
                     Encoding.UTF8);
                 AssertFileContents(
                     Path.Combine(tempPath, "archive", "file.txt2"),
-                    StringRepeat(250, "aaa\n"),
+                    StringRepeat(times, "aaa\n"),
                     Encoding.UTF8);
 
-                for (var i = 0; i < 250; ++i)
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("ccc");
                 }
@@ -2152,11 +2156,11 @@ namespace NLog.UnitTests.Targets
                 LogManager.Configuration = null;
 
                 AssertFileContents(logFile,
-                    StringRepeat(250, "ccc\n"),
+                    StringRepeat(times, "ccc\n"),
                     Encoding.UTF8);
                 AssertFileContents(
                     Path.Combine(tempPath, "archive", "file.txt2"),
-                    StringRepeat(250, "bbb\n"),
+                    StringRepeat(times, "bbb\n"),
                     Encoding.UTF8);
             }
             finally
@@ -2179,7 +2183,7 @@ namespace NLog.UnitTests.Targets
                 {
                     FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive", "file.txt2"),
-                    ArchiveAboveSize = 1000,
+                    ArchiveAboveSize = 100,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}",
                     MaxArchiveFiles = 2,
@@ -2187,34 +2191,35 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-                // we emit 3 * 250 *(aaa + \n) bytes
+                // we emit 3 * 25 *(aaa + \n) bytes
                 // so that we should get a full file + 2 archives
-                for (var i = 0; i < 250; ++i)
+                var times = 25;
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("aaa");
                 }
-                for (var i = 0; i < 250; ++i)
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("bbb");
                 }
-                for (var i = 0; i < 250; ++i)
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("ccc");
                 }
 
                 AssertFileContents(logFile,
-                    StringRepeat(250, "ccc\n"),
+                    StringRepeat(times, "ccc\n"),
                     Encoding.UTF8);
                 AssertFileContents(
                     Path.Combine(tempPath, "archive", "file.1.txt2"),
-                    StringRepeat(250, "bbb\n"),
+                    StringRepeat(times, "bbb\n"),
                     Encoding.UTF8);
                 AssertFileContents(
                     Path.Combine(tempPath, "archive", "file.txt2"),
-                    StringRepeat(250, "aaa\n"),
+                    StringRepeat(times, "aaa\n"),
                     Encoding.UTF8);
 
-                for (var i = 0; i < 250; ++i)
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("ddd");
                 }
@@ -2222,15 +2227,15 @@ namespace NLog.UnitTests.Targets
                 LogManager.Configuration = null;
 
                 AssertFileContents(logFile,
-                    StringRepeat(250, "ddd\n"),
+                    StringRepeat(times, "ddd\n"),
                     Encoding.UTF8);
                 AssertFileContents(
                     Path.Combine(tempPath, "archive", "file.2.txt2"),
-                    StringRepeat(250, "ccc\n"),
+                    StringRepeat(times, "ccc\n"),
                     Encoding.UTF8);
                 AssertFileContents(
                     Path.Combine(tempPath, "archive", "file.1.txt2"),
-                    StringRepeat(250, "bbb\n"),
+                    StringRepeat(times, "bbb\n"),
                     Encoding.UTF8);
                 Assert.False(File.Exists(Path.Combine(tempPath, "archive", "file.txt2")));
             }
@@ -2258,7 +2263,7 @@ namespace NLog.UnitTests.Targets
                 {
                     FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "archive", "file.txt2"),
-                    ArchiveAboveSize = 1000,
+                    ArchiveAboveSize = 100,
                     LineEnding = LineEndingMode.LF,
                     Layout = "${message}",
                     MaxArchiveFiles = 2,
@@ -2266,23 +2271,24 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-                // we emit 2 * 250 *(aaa + \n) bytes
+                // we emit 2 * 25 *(aaa + \n) bytes
                 // so that we should get a full file + 1 archive
-                for (var i = 0; i < 250; ++i)
+                var times = 25;
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("aaa");
                 }
-                for (var i = 0; i < 250; ++i)
+                for (var i = 0; i < times; ++i)
                 {
                     logger.Debug("bbb");
                 }
 
                 AssertFileContents(logFile,
-                    StringRepeat(250, "bbb\n"),
+                    StringRepeat(times, "bbb\n"),
                     Encoding.UTF8);
                 AssertFileContents(
                     Path.Combine(tempPath, "archive", "file.11.txt2"),
-                    StringRepeat(250, "aaa\n"),
+                    StringRepeat(times, "aaa\n"),
                     Encoding.UTF8);
                 Assert.True(File.Exists(Path.Combine(tempPath, "archive", "file.10.txt2")));
                 Assert.False(File.Exists(Path.Combine(tempPath, "archive", "file.9.txt2")));

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -499,7 +499,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             var logger = LogManager.GetCurrentClassLogger();
 
             var txt = "message 1 with a JSON POST";
-            var count = 200;
+            var count = 101;
             var context = new LogDocController.TestContext(1, count, false, txt, "info");
 
             StartOwinDocTest(context, () =>
@@ -547,7 +547,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             var logger = LogManager.GetCurrentClassLogger();
 
             var txt = "message 1 with a XML POST";
-            var count = 250;
+            var count = 101;
             var context = new LogDocController.TestContext(1, count, true, txt, "info");
 
             StartOwinDocTest(context, () =>

--- a/tests/NLog.UnitTests/Targets/Wrappers/BufferingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/BufferingTargetWrapperTests.cs
@@ -117,8 +117,6 @@ namespace NLog.UnitTests.Targets.Wrappers
                     flushHit.Set();
                 });
 
-            Thread.Sleep(1000);
-
             flushHit.WaitOne();
             Assert.Null(flushException);
 


### PR DESCRIPTION
Improved test cases speed while not losing quality of test case. 

for example, archiving every 100 bytes is a good as archiving every 1000 bytes. (but 10 times faster)

Also .NET 45 was tested twice.


from 11:50 minutes to 8:14 ~ 30% faster

Should not change code coverage!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1796)
<!-- Reviewable:end -->
