### PR TITLE
FileTarget: performance improvement: 10-70% faster, less garbage collecting (3-4 times less) by reusing buffers

### DIFF
--- a/src/NLog/Common/AsyncLogEventInfo.cs
+++ b/src/NLog/Common/AsyncLogEventInfo.cs
@@ -58,7 +58,7 @@ namespace NLog.Common
         /// <summary>
         /// Gets the continuation.
         /// </summary>
-        public AsyncContinuation Continuation { get; internal set; }
+        public AsyncContinuation Continuation { get; private set; }
 
         /// <summary>
         /// Implements the operator ==.

--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -102,7 +102,12 @@ namespace NLog.Internal.FileAppenders
         /// Writes the specified bytes.
         /// </summary>
         /// <param name="bytes">The bytes.</param>
-        public abstract void Write(byte[] bytes);
+        public void Write(byte[] bytes)
+        {
+            Write(bytes, 0, bytes.Length);
+        }
+
+        public abstract void Write(byte[] bytes, int offset, int count);
 
         /// <summary>
         /// Flushes this instance.

--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -149,16 +149,18 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Writes the specified bytes to a file.
         /// </summary>
-        /// <param name="bytes">The bytes to be written.</param>
-        public override void Write(byte[] bytes)
+        /// <param name="bytes">The bytes array.</param>
+        /// <param name="offset">The bytes array offset.</param>
+        /// <param name="count">The number of bytes.</param>
+        public override void Write(byte[] bytes, int offset, int count)
         {
             if (this.file == null)
             {
                 return;
             }
 
-            this.currentFileLength += bytes.Length;
-            this.file.Write(bytes, 0, bytes.Length);
+            this.currentFileLength += count;
+            this.file.Write(bytes, offset, count);
 
             if (CaptureLastWriteTime)
             {

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -100,8 +100,10 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Writes the specified bytes.
         /// </summary>
-        /// <param name="bytes">The bytes to be written.</param>
-        public override void Write(byte[] bytes)
+        /// <param name="bytes">The bytes array.</param>
+        /// <param name="offset">The bytes array offset.</param>
+        /// <param name="count">The number of bytes.</param>
+        public override void Write(byte[] bytes, int offset, int count)
         {
             if (this.mutex == null || this.fileStream == null)
             {
@@ -122,7 +124,7 @@ namespace NLog.Internal.FileAppenders
             try
             {
                 this.fileStream.Seek(0, SeekOrigin.End);
-                this.fileStream.Write(bytes, 0, bytes.Length);
+                this.fileStream.Write(bytes, offset, count);
                 this.fileStream.Flush();
                 if (CaptureLastWriteTime)
                 {

--- a/src/NLog/Internal/FileAppenders/NullAppender.cs
+++ b/src/NLog/Internal/FileAppenders/NullAppender.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,48 +31,67 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.LayoutRenderers.Wrappers
+using System;
+
+namespace NLog.Internal.FileAppenders
 {
-    using System.Text;
-    using NLog.Config;
-    using NLog.Layouts;
-
     /// <summary>
-    /// Outputs alternative layout when the inner layout produces empty result.
+    /// Appender used to discard data for the FileTarget.
+    /// Used mostly for testing entire stack except the actual writing to disk.
+    /// Throws away all data.
     /// </summary>
-    [LayoutRenderer("whenEmpty")]
-    [AmbientProperty("WhenEmpty")]
-    [ThreadAgnostic]
-    public sealed class WhenEmptyLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    internal class NullAppender : BaseFileAppender
     {
-        /// <summary>
-        /// Gets or sets the layout to be rendered when original layout produced empty result.
-        /// </summary>
-        /// <docgen category="Transformation Options" order="10"/>
-        [RequiredParameter]
-        public Layout WhenEmpty { get; set; }
+        public static readonly IFileAppenderFactory TheFactory = new Factory();
 
-        /// <summary>
-        /// Transforms the output of another layout.
-        /// </summary>
-        /// <param name="target">Output to be transform.</param>
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        public NullAppender(string fileName, ICreateFileParameters createParameters) : base(fileName, createParameters)
         {
         }
 
-        /// <summary>
-        /// Renders the inner layout contents.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
-        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        public override void Close()
         {
-            base.RenderFormattedMessage(logEvent, target);
-            if (target.Length > 0)
-                return;
+        }
 
-            // render WhenEmpty when the inner layout was empty
-            this.WhenEmpty.RenderAppendBuilder(logEvent, target);
+        public override void Flush()
+        {
+        }
+
+        public override DateTime? GetFileCreationTimeUtc()
+        {
+            return DateTime.UtcNow;
+        }
+
+        public override DateTime? GetFileLastWriteTimeUtc()
+        {
+            return DateTime.UtcNow;
+        }
+
+        public override long? GetFileLength()
+        {
+            return 0;
+        }
+
+        public override void Write(byte[] bytes, int offset, int count)
+        {
+        }
+ 
+        /// <summary>
+        /// Factory class.
+        /// </summary>
+        private class Factory : IFileAppenderFactory
+        {
+            /// <summary>
+            /// Opens the appender for given file name and parameters.
+            /// </summary>
+            /// <param name="fileName">Name of the file.</param>
+            /// <param name="parameters">Creation parameters.</param>
+            /// <returns>
+            /// Instance of <see cref="BaseFileAppender"/> which can be used to write to the file.
+            /// </returns>
+            BaseFileAppender IFileAppenderFactory.Open(string fileName, ICreateFileParameters parameters)
+            {
+                return new NullAppender(fileName, parameters);
+            }
         }
     }
 }

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -64,12 +64,14 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Writes the specified bytes.
         /// </summary>
-        /// <param name="bytes">The bytes.</param>
-        public override void Write(byte[] bytes)
+        /// <param name="bytes">The bytes array.</param>
+        /// <param name="offset">The bytes array offset.</param>
+        /// <param name="count">The number of bytes.</param>
+        public override void Write(byte[] bytes, int offset, int count)
         {
             using (FileStream fileStream = CreateFileStream(false))
             {
-                fileStream.Write(bytes, 0, bytes.Length);
+                fileStream.Write(bytes, offset, count);
             }
 
             if (CaptureLastWriteTime)

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -75,16 +75,18 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Writes the specified bytes.
         /// </summary>
-        /// <param name="bytes">The bytes.</param>
-        public override void Write(byte[] bytes)
+        /// <param name="bytes">The bytes array.</param>
+        /// <param name="offset">The bytes array offset.</param>
+        /// <param name="count">The number of bytes.</param>
+        public override void Write(byte[] bytes, int offset, int count)
         {
             if (this.file == null)
             {
                 return;
             }
 
-            this.file.Write(bytes, 0, bytes.Length);
-            
+            this.file.Write(bytes, offset, count);
+
             if (CaptureLastWriteTime)
             {
                 FileTouched();

--- a/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
@@ -66,9 +66,9 @@ namespace NLog.Internal.FileAppenders
 
         public static readonly IFileAppenderFactory TheFactory = new Factory();
 
-        public class Factory : IFileAppenderFactory
+        private class Factory : IFileAppenderFactory
         {
-            public BaseFileAppender Open(string fileName, ICreateFileParameters parameters)
+            BaseFileAppender IFileAppenderFactory.Open(string fileName, ICreateFileParameters parameters)
             {
                 return new UnixMultiProcessFileAppender(fileName, parameters);
             }
@@ -102,12 +102,17 @@ namespace NLog.Internal.FileAppenders
             }
         }
 
-        public override void Write(byte[] bytes)
+        /// <summary>
+        /// Writes the specified bytes.
+        /// </summary>
+        /// <param name="bytes">The bytes array.</param>
+        /// <param name="offset">The bytes array offset.</param>
+        /// <param name="count">The number of bytes.</param>
+        public override void Write(byte[] bytes, int offset, int count)
         {
             if (this.file == null)
                 return;
-
-            this.file.Write(bytes, 0, bytes.Length);
+            this.file.Write(bytes, offset, count);
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
@@ -153,12 +153,14 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Writes the specified bytes.
         /// </summary>
-        /// <param name="bytes">The bytes to be written.</param>
-        public override void Write(byte[] bytes)
+        /// <param name="bytes">The bytes array.</param>
+        /// <param name="offset">The bytes array offset.</param>
+        /// <param name="count">The number of bytes.</param>
+        public override void Write(byte[] bytes, int offset, int count)
         {
             if (fileStream != null)
             {
-                fileStream.Write(bytes, 0, bytes.Length);
+                fileStream.Write(bytes, offset, count);
 
                 if (CaptureLastWriteTime)
                 {

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -152,8 +152,9 @@ namespace NLog.Internal
         /// Render the raw filename from Layout
         /// </summary>
         /// <param name="logEvent">The log event.</param>
+        /// <param name="reusableBuilder">StringBuilder to minimize allocations [optional].</param>
         /// <returns>String representation of a layout.</returns>
-        private string GetRenderedFileName(LogEventInfo logEvent)
+        private string GetRenderedFileName(LogEventInfo logEvent, System.Text.StringBuilder reusableBuilder = null)
         {
             if (cleanedFixedResult != null)
             {
@@ -165,7 +166,33 @@ namespace NLog.Internal
                 return null;
             }
 
-            return _layout.Render(logEvent);
+            if (reusableBuilder != null)
+            {
+                _layout.RenderAppendBuilder(logEvent, reusableBuilder);
+
+                if (_cachedPrevRawFileName != null && _cachedPrevRawFileName.Length == reusableBuilder.Length)
+                {
+                    // If old filename matches the newly rendered, then no need to call StringBuilder.ToString()
+                    for (int i = 0; i < _cachedPrevRawFileName.Length; ++i)
+                    {
+                        if (_cachedPrevRawFileName[i] != reusableBuilder[i])
+                        {
+                            _cachedPrevRawFileName = null;
+                            break;
+                        }
+                    }
+                    if (_cachedPrevRawFileName != null)
+                        return _cachedPrevRawFileName;
+                }
+
+                _cachedPrevRawFileName = reusableBuilder.ToString();
+                _cachedPrevCleanFileName = null;
+                return _cachedPrevRawFileName;
+            }
+            else
+            {
+                return _layout.Render(logEvent);
+            }
         }
 
         /// <summary>
@@ -201,7 +228,12 @@ namespace NLog.Internal
 
         public string Render(LogEventInfo logEvent)
         {
-            var rawFileName = GetRenderedFileName(logEvent);
+            return RenderWithBuilder(logEvent);
+        }
+
+        internal string RenderWithBuilder(LogEventInfo logEvent, System.Text.StringBuilder reusableBuilder = null)
+        { 
+            var rawFileName = GetRenderedFileName(logEvent, reusableBuilder);
             if (string.IsNullOrEmpty(rawFileName))
             {
                 return rawFileName;

--- a/src/NLog/Internal/ReusableAsyncLogEventList.cs
+++ b/src/NLog/Internal/ReusableAsyncLogEventList.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,48 +31,59 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.LayoutRenderers.Wrappers
+using System;
+using System.Collections.Generic;
+using NLog.Common;
+
+namespace NLog.Internal
 {
-    using System.Text;
-    using NLog.Config;
-    using NLog.Layouts;
-
     /// <summary>
-    /// Outputs alternative layout when the inner layout produces empty result.
+    /// Controls a single allocated AsyncLogEventInfo-List for reuse (only one active user)
     /// </summary>
-    [LayoutRenderer("whenEmpty")]
-    [AmbientProperty("WhenEmpty")]
-    [ThreadAgnostic]
-    public sealed class WhenEmptyLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    internal class ReusableAsyncLogEventList
     {
-        /// <summary>
-        /// Gets or sets the layout to be rendered when original layout produced empty result.
-        /// </summary>
-        /// <docgen category="Transformation Options" order="10"/>
-        [RequiredParameter]
-        public Layout WhenEmpty { get; set; }
+        private IList<AsyncLogEventInfo> _list;
 
-        /// <summary>
-        /// Transforms the output of another layout.
-        /// </summary>
-        /// <param name="target">Output to be transform.</param>
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        /// <summary>Empty handle when <see cref="Targets.Target.OptimizeBufferReuse"/> is disabled</summary>
+        public readonly LockList None = default(LockList);
+
+        public ReusableAsyncLogEventList(int capacity)
         {
+            _list = new List<AsyncLogEventInfo>(capacity);
         }
 
         /// <summary>
-        /// Renders the inner layout contents.
+        /// Creates handle to the reusable AsyncLogEventInfo-List for active usage
         /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
-        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        /// <returns>Handle to the reusable item, that can release it again</returns>
+        public LockList Allocate()
         {
-            base.RenderFormattedMessage(logEvent, target);
-            if (target.Length > 0)
-                return;
+            return new LockList(this);
+        }
 
-            // render WhenEmpty when the inner layout was empty
-            this.WhenEmpty.RenderAppendBuilder(logEvent, target);
+        public struct LockList : IDisposable
+        {
+            /// <summary>
+            /// Access the AsyncLogEventInfo[]-buffer acquired
+            /// </summary>
+            public readonly IList<AsyncLogEventInfo> Result;
+            private readonly ReusableAsyncLogEventList _owner;
+
+            public LockList(ReusableAsyncLogEventList owner)
+            {
+                Result = owner._list;
+                owner._list = null;
+                _owner = owner;
+            }
+
+            public void Dispose()
+            {
+                if (Result != null)
+                {
+                    Result.Clear();
+                    _owner._list = Result;
+                }
+            }
         }
     }
 }

--- a/src/NLog/Internal/ReusableBufferCreator.cs
+++ b/src/NLog/Internal/ReusableBufferCreator.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,48 +31,56 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.LayoutRenderers.Wrappers
+using System;
+
+namespace NLog.Internal
 {
-    using System.Text;
-    using NLog.Config;
-    using NLog.Layouts;
-
     /// <summary>
-    /// Outputs alternative layout when the inner layout produces empty result.
+    /// Controls a single allocated char[]-buffer for reuse (only one active user)
     /// </summary>
-    [LayoutRenderer("whenEmpty")]
-    [AmbientProperty("WhenEmpty")]
-    [ThreadAgnostic]
-    public sealed class WhenEmptyLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    internal class ReusableBufferCreator
     {
-        /// <summary>
-        /// Gets or sets the layout to be rendered when original layout produced empty result.
-        /// </summary>
-        /// <docgen category="Transformation Options" order="10"/>
-        [RequiredParameter]
-        public Layout WhenEmpty { get; set; }
+        private char[] _buffer;
 
-        /// <summary>
-        /// Transforms the output of another layout.
-        /// </summary>
-        /// <param name="target">Output to be transform.</param>
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        /// <summary>Empty handle when <see cref="Targets.Target.OptimizeBufferReuse"/> is disabled</summary>
+        public readonly LockBuffer None = default(LockBuffer);
+
+        public ReusableBufferCreator(int capacity)
         {
+            _buffer = new char[capacity];
         }
 
         /// <summary>
-        /// Renders the inner layout contents.
+        /// Creates handle to the reusable char[]-buffer for active usage
         /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
-        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        /// <returns>Handle to the reusable item, that can release it again</returns>
+        public LockBuffer Allocate()
         {
-            base.RenderFormattedMessage(logEvent, target);
-            if (target.Length > 0)
-                return;
+            return new LockBuffer(this);
+        }
 
-            // render WhenEmpty when the inner layout was empty
-            this.WhenEmpty.RenderAppendBuilder(logEvent, target);
+        public struct LockBuffer : IDisposable
+        {
+            /// <summary>
+            /// Access the char[]-buffer acquired
+            /// </summary>
+            public readonly char[] Result;
+            private readonly ReusableBufferCreator _owner;
+
+            public LockBuffer(ReusableBufferCreator owner)
+            {
+                Result = owner._buffer;
+                owner._buffer = null;
+                _owner = owner;
+            }
+
+            public void Dispose()
+            {
+                if (Result != null)
+                {
+                    _owner._buffer = Result;
+                }
+            }
         }
     }
 }

--- a/src/NLog/Internal/ReusableBuilderCreator.cs
+++ b/src/NLog/Internal/ReusableBuilderCreator.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,48 +31,53 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.LayoutRenderers.Wrappers
+using System;
+using System.Text;
+
+namespace NLog.Internal
 {
-    using System.Text;
-    using NLog.Config;
-    using NLog.Layouts;
-
     /// <summary>
-    /// Outputs alternative layout when the inner layout produces empty result.
+    /// Controls a single allocated StringBuilder for reuse (only one active user)
     /// </summary>
-    [LayoutRenderer("whenEmpty")]
-    [AmbientProperty("WhenEmpty")]
-    [ThreadAgnostic]
-    public sealed class WhenEmptyLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    internal class ReusableBuilderCreator
     {
-        /// <summary>
-        /// Gets or sets the layout to be rendered when original layout produced empty result.
-        /// </summary>
-        /// <docgen category="Transformation Options" order="10"/>
-        [RequiredParameter]
-        public Layout WhenEmpty { get; set; }
+        private StringBuilder _builder = new StringBuilder();
+
+        /// <summary>Empty handle when <see cref="Targets.Target.OptimizeBufferReuse"/> is disabled</summary>
+        public readonly LockBuilder None = default(LockBuilder);
 
         /// <summary>
-        /// Transforms the output of another layout.
+        /// Creates handle to the reusable StringBuilder for active usage
         /// </summary>
-        /// <param name="target">Output to be transform.</param>
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        /// <returns>Handle to the reusable item, that can release it again</returns>
+        public LockBuilder Allocate()
         {
+            return new LockBuilder(this);
         }
 
-        /// <summary>
-        /// Renders the inner layout contents.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
-        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        public struct LockBuilder : IDisposable
         {
-            base.RenderFormattedMessage(logEvent, target);
-            if (target.Length > 0)
-                return;
+            /// <summary>
+            /// Access the StringBuilder acquired
+            /// </summary>
+            public readonly StringBuilder Result;
+            private readonly ReusableBuilderCreator _owner;
 
-            // render WhenEmpty when the inner layout was empty
-            this.WhenEmpty.RenderAppendBuilder(logEvent, target);
+            public LockBuilder(ReusableBuilderCreator owner)
+            {
+                Result = owner._builder;
+                owner._builder = null;
+                _owner = owner;
+            }
+
+            public void Dispose()
+            {
+                if (Result != null)
+                {
+                    Result.ClearBuilder();
+                    _owner._builder = Result;
+                }
+            }
         }
     }
 }

--- a/src/NLog/LayoutRenderers/EnvironmentLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EnvironmentLayoutRenderer.cs
@@ -59,8 +59,9 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         public string Default { get; set; }
-	
- 
+
+        private System.Collections.Generic.KeyValuePair<string, SimpleLayout> _cachedValue;
+
         /// <summary>
         /// Renders the specified environment variable and appends it to the specified <see cref="StringBuilder" />.
         /// </summary>
@@ -68,21 +69,22 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-	        if (this.Variable != null)
-	        {
-	            var environmentVariable = EnvironmentHelper.GetSafeEnvironmentVariable(this.Variable);
-	            if (!string.IsNullOrEmpty(environmentVariable))
-	            {
-	                var layout = new SimpleLayout(environmentVariable);
-	                builder.Append(layout.Render(logEvent));
-	            }
-	            else {
-	                if (this.Default != null) 
-	                {
-	                    var layout = new SimpleLayout(this.Default);
-	                    builder.Append(layout.Render(logEvent));
-	                }
-	            }
+            if (this.Variable != null)
+            {
+                var environmentVariable = EnvironmentHelper.GetSafeEnvironmentVariable(this.Variable);
+                if (string.IsNullOrEmpty(environmentVariable))
+                    environmentVariable = Default;
+
+                if (!string.IsNullOrEmpty(environmentVariable))
+                {
+                    if (string.CompareOrdinal(_cachedValue.Key, environmentVariable) != 0)
+                    {
+                        _cachedValue = new System.Collections.Generic.KeyValuePair<string, SimpleLayout>(environmentVariable,
+                            new SimpleLayout(environmentVariable));
+                    }
+
+                    _cachedValue.Value.RenderAppendBuilder(logEvent, builder);
+                }
             }
         }
     }

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -96,8 +96,7 @@ namespace NLog.LayoutRenderers
             }
 
             var builder = new StringBuilder(initialLength);
-
-            this.Render(builder, logEvent);
+            this.RenderAppendBuilder(logEvent, builder);
             if (builder.Length > this.maxRenderedLength)
             {
                 this.maxRenderedLength = builder.Length;
@@ -152,7 +151,12 @@ namespace NLog.LayoutRenderers
             }
         }
 
-        internal void Render(StringBuilder builder, LogEventInfo logEvent)
+        /// <summary>
+        /// Renders the the value of layout renderer in the context of the specified log event.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="builder">The layout render output is appended to builder</param>
+        internal void RenderAppendBuilder(LogEventInfo logEvent, StringBuilder builder)
         {
             if (!this.isInitialized)
             {
@@ -172,7 +176,6 @@ namespace NLog.LayoutRenderers
                 {
                     throw;
                 }
-              
             }
         }
 

--- a/src/NLog/LayoutRenderers/Wrappers/FileSystemNormalizeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/FileSystemNormalizeLayoutRendererWrapper.cs
@@ -43,7 +43,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [LayoutRenderer("filesystem-normalize")]
     [AmbientProperty("FSNormalize")]
     [ThreadAgnostic]
-    public sealed class FileSystemNormalizeLayoutRendererWrapper : WrapperLayoutRendererBase
+    public sealed class FileSystemNormalizeLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSystemNormalizeLayoutRendererWrapper" /> class.
@@ -62,15 +62,13 @@ namespace NLog.LayoutRenderers.Wrappers
         public bool FSNormalize { get; set; }
 
         /// <summary>
-        /// Post-processes the rendered message. 
+        /// Replaces all non-safe characters with underscore to make valid filepath
         /// </summary>
-        /// <param name="text">The text to be post-processed.</param>
-        /// <returns>Padded and trimmed string.</returns>
-        protected override string Transform(string text)
+        /// <param name="builder">Output to be transformed.</param>
+        protected override void TransformFormattedMesssage(StringBuilder builder)
         {
             if (this.FSNormalize)
             {
-                var builder = new StringBuilder(text);
                 for (int i = 0; i < builder.Length; i++)
                 {
                     char c = builder[i];
@@ -79,11 +77,7 @@ namespace NLog.LayoutRenderers.Wrappers
                         builder[i] = '_';
                     }
                 }
-
-                return builder.ToString();
             }
-
-            return text;
         }
 
         private static bool IsSafeCharacter(char c)

--- a/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
@@ -43,7 +43,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [LayoutRenderer("lowercase")]
     [AmbientProperty("Lowercase")]
     [ThreadAgnostic]
-    public sealed class LowercaseLayoutRendererWrapper : WrapperLayoutRendererBase
+    public sealed class LowercaseLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LowercaseLayoutRendererWrapper" /> class.
@@ -71,11 +71,15 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <summary>
         /// Post-processes the rendered message. 
         /// </summary>
-        /// <param name="text">The text to be post-processed.</param>
-        /// <returns>Padded and trimmed string.</returns>
-        protected override string Transform(string text)
+        /// <param name="target">Output to be post-processed.</param>
+        protected override void TransformFormattedMesssage(System.Text.StringBuilder target)
         {
-            return this.Lowercase ? text.ToLower(this.Culture) : text;
+            if (this.Lowercase)
+            {
+                CultureInfo culture = this.Culture;
+                for (int i = 0; i < target.Length; ++i)
+                    target[i] = char.ToLower(target[i], culture);
+            }
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -44,7 +44,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [LayoutRenderer("replace-newlines")]
     [AmbientProperty("ReplaceNewLines")]
     [ThreadAgnostic]
-    public sealed class ReplaceNewLinesLayoutRendererWrapper : WrapperLayoutRendererBase
+    public sealed class ReplaceNewLinesLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ReplaceNewLinesLayoutRendererWrapper" /> class.
@@ -64,12 +64,10 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <summary>
         /// Post-processes the rendered message. 
         /// </summary>
-        /// <param name="text">The text to be post-processed.</param>
-        /// <returns>String with newline characters replaced with spaces.</returns>
-        protected override string Transform(string text)
+        /// <param name="target">Output to be post-processed.</param>
+        protected override void TransformFormattedMesssage(System.Text.StringBuilder target)
         {
-            return text.Replace(Environment.NewLine, Replacement);
+            target.Replace(Environment.NewLine, Replacement);
         }
-
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/Rot13LayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/Rot13LayoutRendererWrapper.cs
@@ -45,7 +45,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [LayoutRenderer("rot13")]
     [AppDomainFixedOutput]
     [ThreadAgnostic]
-    public sealed class Rot13LayoutRendererWrapper : WrapperLayoutRendererBase
+    public sealed class Rot13LayoutRendererWrapper : WrapperLayoutRendererBuilderBase
     {
         /// <summary>
         /// Gets or sets the layout to be wrapped.
@@ -66,28 +66,36 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <returns>Encoded/Decoded text.</returns>
         public static string DecodeRot13(string encodedValue)
         {
-            if (encodedValue == null)
-            {
-                return null;
-            }
-
-            char[] chars = encodedValue.ToCharArray();
-            for (int i = 0; i < chars.Length; ++i)
-            {
-                chars[i] = DecodeRot13Char(chars[i]);
-            }
-
-            return new string(chars);
+            System.Text.StringBuilder sb = new System.Text.StringBuilder(encodedValue.Length);
+            sb.Append(encodedValue);
+            DecodeRot13(sb);
+            return sb.ToString();
         }
 
         /// <summary>
-        /// Transforms the output of another layout.
+        /// Encodes/Decodes ROT-13-encoded string.
         /// </summary>
-        /// <param name="text">Output to be transform.</param>
-        /// <returns>Transformed text.</returns>
-        protected override string Transform(string text)
+        /// <param name="encodedValue">The string to be encoded/decoded.</param>
+        internal static void DecodeRot13(System.Text.StringBuilder encodedValue)
         {
-            return DecodeRot13(text);
+            if (encodedValue == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < encodedValue.Length; ++i)
+            {
+                encodedValue[i] = DecodeRot13Char(encodedValue[i]);
+            }
+        }
+
+        /// <summary>
+        /// Post-processes the rendered message. 
+        /// </summary>
+        /// <param name="target">Output to be transform.</param>
+        protected override void TransformFormattedMesssage(System.Text.StringBuilder target)
+        {
+            DecodeRot13(target);
         }
 
         private static char DecodeRot13Char(char c)

--- a/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
@@ -34,7 +34,6 @@
 namespace NLog.LayoutRenderers.Wrappers
 {
     using System.ComponentModel;
-    using System.Globalization;
     using NLog.Config;
 
     /// <summary>
@@ -43,7 +42,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [LayoutRenderer("trim-whitespace")]
     [AmbientProperty("TrimWhiteSpace")]
     [ThreadAgnostic]
-    public sealed class TrimWhiteSpaceLayoutRendererWrapper : WrapperLayoutRendererBase
+    public sealed class TrimWhiteSpaceLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TrimWhiteSpaceLayoutRendererWrapper" /> class.
@@ -62,13 +61,42 @@ namespace NLog.LayoutRenderers.Wrappers
         public bool TrimWhiteSpace { get; set; }
 
         /// <summary>
-        /// Post-processes the rendered message. 
+        /// Removes white-spaces from both sides of the provided target
         /// </summary>
-        /// <param name="text">The text to be post-processed.</param>
-        /// <returns>Trimmed string.</returns>
-        protected override string Transform(string text)
+        /// <param name="target">Output to be transform.</param>
+        protected override void TransformFormattedMesssage(System.Text.StringBuilder target)
         {
-            return this.TrimWhiteSpace ? text.Trim() : text;
+            if (target == null || target.Length == 0)
+                return;
+
+            if (this.TrimWhiteSpace)
+            {
+                TrimRight(target);  // Fast
+                if (target.Length > 0)
+                    TrimLeft(target);   // Slower
+            }
+        }
+
+        private void TrimRight(System.Text.StringBuilder sb)
+        {
+            int i = sb.Length - 1;
+            for (; i >= 0; i--)
+                if (!char.IsWhiteSpace(sb[i]))
+                    break;
+
+            if (i < sb.Length - 1)
+                sb.Length = i + 1;
+        }
+
+        private void TrimLeft(System.Text.StringBuilder sb)
+        {
+            int i = 0;
+            for (; i < sb.Length; i++)
+                if (!char.IsWhiteSpace(sb[i]))
+                    break;
+
+            if (i > 0)
+                sb.Remove(0, i);
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
@@ -48,7 +48,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [LayoutRenderer("uppercase")]
     [AmbientProperty("Uppercase")]
     [ThreadAgnostic]
-    public sealed class UppercaseLayoutRendererWrapper : WrapperLayoutRendererBase
+    public sealed class UppercaseLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UppercaseLayoutRendererWrapper" /> class.
@@ -76,11 +76,15 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <summary>
         /// Post-processes the rendered message. 
         /// </summary>
-        /// <param name="text">The text to be post-processed.</param>
-        /// <returns>Padded and trimmed string.</returns>
-        protected override string Transform(string text)
+        /// <param name="target">Output to be post-processed.</param>
+        protected override void TransformFormattedMesssage(System.Text.StringBuilder target)
         {
-            return this.Uppercase ? text.ToUpper(this.Culture) : text;
+            if (this.Uppercase)
+            {
+                CultureInfo culture = this.Culture;
+                for (int i = 0; i < target.Length; ++i)
+                    target[i] = char.ToUpper(target[i], culture);
+            }
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
@@ -35,6 +35,7 @@ using NLog.Layouts;
 
 namespace NLog.LayoutRenderers.Wrappers
 {
+    using System.Text;
     using NLog.Conditions;
     using NLog.Config;
 
@@ -44,7 +45,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [LayoutRenderer("when")]
     [AmbientProperty("When")]
     [ThreadAgnostic]
-    public sealed class WhenLayoutRendererWrapper : WrapperLayoutRendererBase
+    public sealed class WhenLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
     {
         /// <summary>
         /// Gets or sets the condition that must be met for the <see cref="WrapperLayoutRendererBase.Inner"/> layout to be printed.
@@ -63,31 +64,26 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <summary>
         /// Transforms the output of another layout.
         /// </summary>
-        /// <param name="text">Output to be transform.</param>
-        /// <returns>Transformed text.</returns>
-        protected override string Transform(string text)
+        /// <param name="target">Output to be transform.</param>
+        protected override void TransformFormattedMesssage(StringBuilder target)
         {
-            return text;
         }
 
         /// <summary>
         /// Renders the inner layout contents.
         /// </summary>
         /// <param name="logEvent">The log event.</param>
-        /// <returns>
-        /// Contents of inner layout.
-        /// </returns>
-        protected override string RenderInner(LogEventInfo logEvent)
+        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             if (this.When == null || true.Equals(this.When.Evaluate(logEvent)))
             {
-                return base.RenderInner(logEvent);
-            }else if (Else != null)
-            {
-                return Else.Render(logEvent);
+                base.RenderFormattedMessage(logEvent, target);
             }
-
-            return string.Empty;
+            else if (Else != null)
+            {
+                Else.RenderAppendBuilder(logEvent, target);
+            }
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
@@ -1,0 +1,108 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System.Text;
+
+namespace NLog.LayoutRenderers.Wrappers
+{
+    /// <summary>
+    /// Base class for <see cref="LayoutRenderer"/>s which wrapping other <see cref="LayoutRenderer"/>s. 
+    /// 
+    /// This expects the transformation to work on a <see cref="StringBuilder"/>
+    /// </summary>
+    public abstract class WrapperLayoutRendererBuilderBase : WrapperLayoutRendererBase
+    {
+        private const int MaxInitialRenderBufferLength = 16384;
+        private int maxRenderedLength;
+
+        /// <summary>
+        /// Render to local target using Inner Layout, and then transform before final append
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="logEvent"></param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            int initialLength = this.maxRenderedLength;
+            if (initialLength > MaxInitialRenderBufferLength)
+            {
+                initialLength = MaxInitialRenderBufferLength;
+            }
+
+            using (var localTarget = new Internal.AppendBuilderCreator(builder, initialLength))
+            {
+                RenderFormattedMessage(logEvent, localTarget.Builder);
+                if (localTarget.Builder.Length > this.maxRenderedLength)
+                {
+                    this.maxRenderedLength = localTarget.Builder.Length;
+                }
+                TransformFormattedMesssage(localTarget.Builder);
+            }
+        }
+
+        /// <summary>
+        /// Transforms the output of another layout.
+        /// </summary>
+        /// <param name="target">Output to be transform.</param>
+        protected abstract void TransformFormattedMesssage(StringBuilder target);
+
+        /// <summary>
+        /// Renders the inner layout contents.
+        /// </summary>
+        /// <param name="logEvent">Logging</param>
+        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+        protected virtual void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        {
+            this.Inner.RenderAppendBuilder(logEvent, target);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        protected sealed override string Transform(string text)
+        {
+            throw new System.NotSupportedException("Use TransformFormattedMesssage");
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns></returns>
+        protected sealed override string RenderInner(LogEventInfo logEvent)
+        {
+            throw new System.NotSupportedException("Use RenderFormattedMessage");
+        }
+    }
+}

--- a/src/NLog/Layouts/CompoundLayout.cs
+++ b/src/NLog/Layouts/CompoundLayout.cs
@@ -69,7 +69,7 @@ namespace NLog.Layouts
                 layout.Initialize(this.LoggingConfiguration);
         }
 
-            /// <summary>
+        /// <summary>
         /// Formats the log event relying on inner layouts.
         /// </summary>
         /// <param name="logEvent">The log event to be formatted.</param>
@@ -77,9 +77,24 @@ namespace NLog.Layouts
         protected override string GetFormattedMessage(LogEventInfo logEvent)
         {
             var sb = new StringBuilder();
-            foreach (var layout in Layouts)
-                sb.Append(layout.Render(logEvent));
+            RenderFormattedMessage(logEvent, sb);
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Formats the log event relying on inner layouts.
+        /// </summary>
+        /// <param name="logEvent">The logging event.</param>
+        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        {
+            //Memory profiling pointed out that using a foreach-loop was allocating
+            //an Enumerator. Switching to a for-loop avoids the memory allocation.
+            for (int i = 0; i < this.Layouts.Count; i++)
+            {
+                Layout layout = this.Layouts[i];
+                layout.RenderAppendBuilder(logEvent, target);
+            }
         }
 
         /// <summary>

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -36,6 +36,7 @@ using System;
 namespace NLog.Layouts
 {
     using System.ComponentModel;
+    using System.Text;
     using NLog.Config;
     using NLog.Internal;
 
@@ -69,6 +70,9 @@ namespace NLog.Layouts
 		{
             get { return this.threadAgnostic; }
         }
+
+        private const int MaxInitialRenderBufferLength = 16384;
+        private int maxRenderedLength;
 
         /// <summary>
         /// Gets the logging configuration this target is part of.
@@ -140,6 +144,69 @@ namespace NLog.Layouts
             }
 
             return this.GetFormattedMessage(logEvent);
+        }
+
+        internal void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+        {
+            if (!this.threadAgnostic)
+            {
+                RenderAppendBuilder(logEvent, target, true);
+            }
+        }
+
+        /// <summary>
+        /// Renders the event info in layout to the provided target
+        /// </summary>
+        /// <param name="logEvent">The event info.</param>
+        /// <param name="target">Appends the string representing log event to target</param>
+        /// <param name="cacheLayoutResult">Should rendering result be cached on LogEventInfo</param>
+        internal void RenderAppendBuilder(LogEventInfo logEvent, StringBuilder target, bool cacheLayoutResult = false)
+        {
+            if (!this.isInitialized)
+            {
+                this.isInitialized = true;
+                this.InitializeLayout();
+            }
+
+            if (!this.threadAgnostic)
+            {
+                string cachedValue;
+                if (logEvent.TryGetCachedLayoutValue(this, out cachedValue))
+                {
+                    target.Append(cachedValue);
+                    return;
+                }
+            }
+
+            int initialLength = this.maxRenderedLength;
+            if (initialLength > MaxInitialRenderBufferLength)
+            {
+                initialLength = MaxInitialRenderBufferLength;
+            }
+
+            using (var localTarget = new AppendBuilderCreator(target, initialLength))
+            {
+                RenderFormattedMessage(logEvent, localTarget.Builder);
+                if (localTarget.Builder.Length > this.maxRenderedLength)
+                {
+                    this.maxRenderedLength = localTarget.Builder.Length;
+                }
+                if (cacheLayoutResult && !this.threadAgnostic)
+                {
+                    // when needed as it generates garbage
+                    logEvent.AddCachedLayoutValue(this, localTarget.Builder.ToString());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Renders the layout for the specified logging event by invoking layout renderers.
+        /// </summary>
+        /// <param name="logEvent">The logging event.</param>
+        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+        protected virtual void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        {
+            target.Append(GetFormattedMessage(logEvent));
         }
 
         /// <summary>

--- a/src/NLog/Layouts/LayoutWithHeaderAndFooter.cs
+++ b/src/NLog/Layouts/LayoutWithHeaderAndFooter.cs
@@ -70,5 +70,15 @@ namespace NLog.Layouts
         {
             return this.Layout.Render(logEvent);
         }
+
+        /// <summary>
+        /// Renders the layout for the specified logging event by invoking layout renderers.
+        /// </summary>
+        /// <param name="logEvent">The logging event.</param>
+        /// <param name="target">Initially empty <see cref="System.Text.StringBuilder"/> for the result</param>
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, System.Text.StringBuilder target)
+        {
+            this.Layout.RenderAppendBuilder(logEvent, target);
+        }
     }
 }

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -73,5 +73,15 @@ namespace NLog.Layouts
 
             return logEvent.AddCachedLayoutValue(this, this.Renderer.Render(logEvent));
         }
+
+        /// <summary>
+        /// Renders the layout for the specified logging event by invoking layout renderers.
+        /// </summary>
+        /// <param name="logEvent">The logging event.</param>
+        /// <param name="target">Initially empty <see cref="System.Text.StringBuilder"/> for the result</param>
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, System.Text.StringBuilder target)
+        {
+            this.Renderer.RenderAppendBuilder(logEvent, target);
+        }
     }
 }

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -31,8 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using JetBrains.Annotations;
-
 namespace NLog
 {
     using System;
@@ -46,7 +44,6 @@ namespace NLog
     using NLog.Config;
     using NLog.Filters;
     using NLog.Internal;
-    using NLog.Targets;
 
     /// <summary>
     /// Implementation of logging engine.
@@ -84,15 +81,15 @@ namespace NLog
 
             int originalThreadId = Thread.CurrentThread.ManagedThreadId;
             AsyncContinuation exceptionHandler = ex =>
+            {
+                if (ex != null)
                 {
-                    if (ex != null)
+                    if (factory.ThrowExceptions && Thread.CurrentThread.ManagedThreadId == originalThreadId)
                     {
-                        if (factory.ThrowExceptions && Thread.CurrentThread.ManagedThreadId == originalThreadId)
-                        {
-                            throw new NLogRuntimeException("Exception occurred in NLog", ex);
-                        }
+                        throw new NLogRuntimeException("Exception occurred in NLog", ex);
                     }
-                };
+                }
+            };
 
             for (var t = targets; t != null; t = t.NextInChain)
             {
@@ -160,7 +157,7 @@ namespace NLog
                     {
                         var next = allStackFrames[last.StackFrameIndex + 1];
                         var declaringType = next.StackFrame.GetMethod().DeclaringType;
-                        if (declaringType == typeof(System.Runtime.CompilerServices.AsyncTaskMethodBuilder) || 
+                        if (declaringType == typeof(System.Runtime.CompilerServices.AsyncTaskMethodBuilder) ||
                             declaringType == typeof(System.Runtime.CompilerServices.AsyncTaskMethodBuilder<>))
                         {
                             //async, search futher
@@ -231,9 +228,7 @@ namespace NLog
 
         private static bool WriteToTargetWithFilterChain(TargetWithFilterChain targetListHead, LogEventInfo logEvent, AsyncContinuation onException)
         {
-            Target target = targetListHead.Target;
             FilterResult result = GetFilterResult(targetListHead.FilterChain, logEvent);
-
             if ((result == FilterResult.Ignore) || (result == FilterResult.IgnoreFinal))
             {
                 if (InternalLogger.IsDebugEnabled)
@@ -249,7 +244,7 @@ namespace NLog
                 return true;
             }
 
-            target.WriteAsyncLogEvent(logEvent.WithContinuation(onException));
+            targetListHead.Target.WriteAsyncLogEvent(logEvent.WithContinuation(onException));
             if (result == FilterResult.LogFinal)
             {
                 return false;

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -125,6 +125,7 @@
     <Compile Include="ILoggerBase.cs" />
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
+    <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
@@ -142,6 +143,7 @@
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\NullAppender.cs" />
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
@@ -180,6 +182,10 @@
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />
+    <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
+    <Compile Include="Internal\ReusableBufferCreator.cs" />
+    <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />
     <Compile Include="Internal\SingleCallContinuation.cs" />
@@ -276,6 +282,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBuilderBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
     <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -122,6 +122,7 @@
     <Compile Include="ILoggerBase.cs" />
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
+    <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
@@ -139,6 +140,7 @@
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\NullAppender.cs" />
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
@@ -177,6 +179,10 @@
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />
+    <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
+    <Compile Include="Internal\ReusableBufferCreator.cs" />
+    <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />
     <Compile Include="Internal\SingleCallContinuation.cs" />
@@ -273,6 +279,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBuilderBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
     <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -135,6 +135,7 @@
     <Compile Include="ILoggerBase.cs" />
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
+    <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
@@ -152,6 +153,7 @@
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\NullAppender.cs" />
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
@@ -190,6 +192,10 @@
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />
+    <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
+    <Compile Include="Internal\ReusableBufferCreator.cs" />
+    <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />
     <Compile Include="Internal\SingleCallContinuation.cs" />
@@ -286,6 +292,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBuilderBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
     <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -141,6 +141,7 @@
     <Compile Include="ILoggerBase.cs" />
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
+    <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
@@ -158,6 +159,7 @@
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\NullAppender.cs" />
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
@@ -196,6 +198,10 @@
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />
+    <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
+    <Compile Include="Internal\ReusableBufferCreator.cs" />
+    <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />
     <Compile Include="Internal\SingleCallContinuation.cs" />
@@ -292,6 +298,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBuilderBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
     <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -135,6 +135,7 @@
     <Compile Include="ILoggerBase.cs" />
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
+    <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
@@ -152,6 +153,7 @@
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\NullAppender.cs" />
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
@@ -190,6 +192,10 @@
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />
+    <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
+    <Compile Include="Internal\ReusableBufferCreator.cs" />
+    <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />
     <Compile Include="Internal\SingleCallContinuation.cs" />
@@ -286,6 +292,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBuilderBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
     <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -135,6 +135,7 @@
     <Compile Include="ILoggerBase.cs" />
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
+    <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
@@ -152,6 +153,7 @@
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\NullAppender.cs" />
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
@@ -190,6 +192,10 @@
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />
+    <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
+    <Compile Include="Internal\ReusableBufferCreator.cs" />
+    <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />
     <Compile Include="Internal\SingleCallContinuation.cs" />
@@ -286,6 +292,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBuilderBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
     <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -141,6 +141,7 @@
     <Compile Include="ILoggerBase.cs" />
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
+    <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
@@ -158,6 +159,7 @@
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\NullAppender.cs" />
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
@@ -196,6 +198,10 @@
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />
+    <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
+    <Compile Include="Internal\ReusableBufferCreator.cs" />
+    <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />
     <Compile Include="Internal\SingleCallContinuation.cs" />
@@ -292,6 +298,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBuilderBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
     <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -142,6 +142,7 @@
     <Compile Include="ILoggerBase.cs" />
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
+    <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
@@ -159,6 +160,7 @@
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\NullAppender.cs" />
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
@@ -197,6 +199,10 @@
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />
+    <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
+    <Compile Include="Internal\ReusableBufferCreator.cs" />
+    <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />
     <Compile Include="Internal\SingleCallContinuation.cs" />
@@ -293,6 +299,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBuilderBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
     <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -139,6 +139,7 @@
     <Compile Include="ILoggerBase.cs" />
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
+    <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
@@ -156,6 +157,7 @@
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\NullAppender.cs" />
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
@@ -194,6 +196,10 @@
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />
+    <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
+    <Compile Include="Internal\ReusableBufferCreator.cs" />
+    <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />
     <Compile Include="Internal\SingleCallContinuation.cs" />
@@ -290,6 +296,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBuilderBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
     <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -138,6 +138,7 @@
     <Compile Include="ILoggerBase.cs" />
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
+    <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
@@ -155,6 +156,7 @@
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\NullAppender.cs" />
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
@@ -193,6 +195,10 @@
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />
+    <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
+    <Compile Include="Internal\ReusableBufferCreator.cs" />
+    <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />
     <Compile Include="Internal\SingleCallContinuation.cs" />
@@ -289,6 +295,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBuilderBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
     <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -138,6 +138,7 @@
     <Compile Include="ILoggerBase.cs" />
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
+    <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
@@ -155,6 +156,7 @@
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\NullAppender.cs" />
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
@@ -193,6 +195,10 @@
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />
+    <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
+    <Compile Include="Internal\ReusableBufferCreator.cs" />
+    <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />
     <Compile Include="Internal\SingleCallContinuation.cs" />
@@ -289,6 +295,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBuilderBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
     <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -163,6 +163,7 @@
     <Compile Include="ILoggerBase.cs" />
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
+    <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
@@ -180,6 +181,7 @@
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\NullAppender.cs" />
     <Compile Include="Internal\FileAppenders\RetryingMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\SingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\UnixMultiProcessFileAppender.cs" />
@@ -218,6 +220,10 @@
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />
+    <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
+    <Compile Include="Internal\ReusableBufferCreator.cs" />
+    <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />
     <Compile Include="Internal\SingleCallContinuation.cs" />
@@ -314,6 +320,7 @@
     <Compile Include="LayoutRenderers\Wrappers\WhenLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapLineLayoutRendererWrapper.cs" />
     <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBase.cs" />
+    <Compile Include="LayoutRenderers\Wrappers\WrapperLayoutRendererBuilderBase.cs" />
     <Compile Include="LayoutRenderers\Wrappers\XmlEncodeLayoutRendererWrapper.cs" />
     <Compile Include="Layouts\CompoundLayout.cs" />
     <Compile Include="Layouts\CsvColumn.cs" />

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -432,12 +432,25 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// 
         /// Writes an array of logging events to the log target. By default it iterates on all
         /// events and passes them to "Write" method. Inheriting classes can use this method to
         /// optimize batch writes.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
         protected override void Write(AsyncLogEventInfo[] logEvents)
+        {
+            Write((IList<AsyncLogEventInfo>)logEvents);
+        }
+
+        /// <summary>
+        /// Writes an array of logging events to the log target. By default it iterates on all
+        /// events and passes them to "Write" method. Inheriting classes can use this method to
+        /// optimize batch writes.
+        /// </summary>
+        /// <param name="logEvents">Logging events to be written out.</param>
+        protected override void Write(IList<AsyncLogEventInfo> logEvents)
         {
             var buckets = logEvents.BucketSort(c => this.BuildConnectionString(c.LogEvent));
 

--- a/src/NLog/Targets/DebugTarget.cs
+++ b/src/NLog/Targets/DebugTarget.cs
@@ -100,7 +100,7 @@ namespace NLog.Targets
         protected override void Write(LogEventInfo logEvent)
         {
             this.Counter++;
-            this.LastMessage = this.Layout.Render(logEvent);
+            this.LastMessage = this.RenderLogEvent(this.Layout, logEvent);
         }
     }
 }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -196,6 +196,8 @@ namespace NLog.Targets
             this.CleanupFileName = true;
 
             this.WriteFooterOnArchivingOnly = false;
+
+            this.OptimizeBufferReuse = GetType() == typeof(FileTarget);    // Pure FileTarget has support
         }
 
 #if NET4_5
@@ -444,6 +446,14 @@ namespace NLog.Targets
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
         public Encoding Encoding { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether or not this target should just discard all data that its asked to write.
+        /// Mostly used for when testing NLog Stack except final write
+        /// </summary>
+        [DefaultValue(false)]
+        [Advanced]
+        public bool DiscardAll { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether concurrent writes to the log file by multiple processes on the same host.
@@ -704,7 +714,10 @@ namespace NLog.Targets
         private void RefreshFileArchive()
         {
             var nullEvent = LogEventInfo.CreateNullEvent();
-            string fileNamePattern = GetArchiveFileNamePattern(GetFullFileName(nullEvent), nullEvent);
+            string fullFileName = string.Empty;
+            lock (this.SyncRoot)
+                fullFileName = GetFullFileName(nullEvent);  // Protect layouts
+            string fileNamePattern = GetArchiveFileNamePattern(fullFileName, nullEvent);
             if (fileNamePattern == null)
             {
                 InternalLogger.Debug("no RefreshFileArchive because fileName is NULL");
@@ -746,7 +759,10 @@ namespace NLog.Targets
                 if (mustWatchArchiving)
                 {
                     var nullEvent = LogEventInfo.CreateNullEvent();
-                    string fileNamePattern = GetArchiveFileNamePattern(GetFullFileName(nullEvent), nullEvent);
+                    string fullFileName = string.Empty;
+                    lock (this.SyncRoot)
+                        fullFileName = GetFullFileName(nullEvent);  // Protect layouts
+                    string fileNamePattern = GetArchiveFileNamePattern(fullFileName, nullEvent);
                     if (!string.IsNullOrEmpty(fileNamePattern))
                     {
                         fileNamePattern = Path.Combine(Path.GetDirectoryName(fileNamePattern),
@@ -882,7 +898,11 @@ namespace NLog.Targets
         /// <returns><see cref="IFileAppenderFactory"/> suitable for this instance.</returns>
         private IFileAppenderFactory GetFileAppenderFactory()
         {
-            if (!this.KeepFileOpen)
+            if (this.DiscardAll)
+            {
+                return NullAppender.TheFactory;
+            }
+            else if (!this.KeepFileOpen)
             {
                 return RetryingMultiProcessFileAppender.TheFactory;
             }
@@ -980,15 +1000,44 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Can be used if <see cref="Target.OptimizeBufferReuse"/> has been enabled.
+        /// </summary>
+        private readonly ReusableStreamCreator reusableFileWriteStream = new ReusableStreamCreator();
+        /// <summary>
+        /// Can be used if <see cref="Target.OptimizeBufferReuse"/> has been enabled.
+        /// </summary>
+        private readonly ReusableStreamCreator reusableAsyncFileWriteStream = new ReusableStreamCreator();
+        /// <summary>
+        /// Can be used if <see cref="Target.OptimizeBufferReuse"/> has been enabled.
+        /// </summary>
+        private readonly ReusableBufferCreator reusableEncodingBuffer = new ReusableBufferCreator(4096);
+
+        /// <summary>
         /// Writes the specified logging event to a file specified in the FileName 
         /// parameter.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>
         protected override void Write(LogEventInfo logEvent)
         {
-            var fullFileName = this.GetFullFileName(logEvent);
-            byte[] bytes = this.GetBytesToWrite(logEvent);
-            ProcessLogEvent(logEvent, fullFileName, bytes);
+            var logFileName = this.GetFullFileName(logEvent);
+            if (OptimizeBufferReuse)
+            {
+                using (var targetStream = this.reusableFileWriteStream.Allocate())
+                {
+                    using (var targetBuilder = this.ReusableLayoutBuilder.Allocate())
+                    using (var targetBuffer = this.reusableEncodingBuffer.Allocate())
+                    {
+                        this.RenderFormattedMessageToStream(logEvent, targetBuilder.Result, targetBuffer.Result, targetStream.Result);
+                    }
+
+                    ProcessLogEvent(logEvent, logFileName, new ArraySegment<byte>(targetStream.Result.GetBuffer(), 0, (int)targetStream.Result.Length));
+                }
+            }
+            else
+            {
+                byte[] bytes = this.GetBytesToWrite(logEvent);
+                ProcessLogEvent(logEvent, logFileName, new ArraySegment<byte>(bytes));
+            }
         }
 
         /// <summary>
@@ -1002,8 +1051,34 @@ namespace NLog.Targets
             {
                 return null;
             }
-            return this.fullFileName.Render(logEvent);
+
+            if (OptimizeBufferReuse)
+            {
+                using (var targetBuilder = this.ReusableLayoutBuilder.Allocate())
+                {
+                    return this.fullFileName.RenderWithBuilder(logEvent, targetBuilder.Result);
+                }
+            }
+            else
+            {
+                return this.fullFileName.Render(logEvent);
+            }
         }
+
+        /// <summary>
+        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// 
+        /// Writes an array of logging events to the log target. By default it iterates on all
+        /// events and passes them to "Write" method. Inheriting classes can use this method to
+        /// optimize batch writes.
+        /// </summary>
+        /// <param name="logEvents">Logging events to be written out.</param>
+        protected override void Write(AsyncLogEventInfo[] logEvents)
+        {
+            Write((IList<AsyncLogEventInfo>)logEvents);
+        }
+
+        SortHelpers.KeySelector<AsyncLogEventInfo, string> getFullFileNameDelegate;
 
         /// <summary>
         /// Writes the specified array of logging events to a file specified in the FileName
@@ -1015,12 +1090,17 @@ namespace NLog.Targets
         /// the requests by filename. This optimizes the number of open/close calls
         /// and can help improve performance.
         /// </remarks>
-        protected override void Write(AsyncLogEventInfo[] logEvents)
+        protected override void Write(IList<AsyncLogEventInfo> logEvents)
         {
-            var buckets = logEvents.BucketSort(c => this.GetFullFileName(c.LogEvent));
-            using (var ms = new MemoryStream())
+            if (getFullFileNameDelegate == null)
+                getFullFileNameDelegate = c => this.GetFullFileName(c.LogEvent);
+
+            var buckets = logEvents.BucketSort(getFullFileNameDelegate);
+
+            using (var reusableStream = (OptimizeBufferReuse && logEvents.Count <= 1000) ? reusableAsyncFileWriteStream.Allocate() : reusableAsyncFileWriteStream.None)
+            using (var allocatedStream = reusableStream.Result != null ? null : new MemoryStream())
             {
-                var pendingContinuations = new List<AsyncContinuation>();
+                var ms = allocatedStream != null ? allocatedStream : reusableStream.Result;
 
                 foreach (var bucket in buckets)
                 {
@@ -1031,27 +1111,58 @@ namespace NLog.Targets
 
                     LogEventInfo firstLogEvent = null;
 
-                    for (int i = 0; i < bucket.Value.Count; i++)
-                    {
-                        AsyncLogEventInfo ev = bucket.Value[i];
-                        if (firstLogEvent == null)
-                        {
-                            firstLogEvent = ev.LogEvent;
-                        }
+                    int bucketCount = bucket.Value.Count;
 
-                        byte[] bytes = this.GetBytesToWrite(ev.LogEvent);
-                        ms.Write(bytes, 0, bytes.Length);
-                        pendingContinuations.Add(ev.Continuation);
+                    using (var targetBuilder = OptimizeBufferReuse ? ReusableLayoutBuilder.Allocate() : ReusableLayoutBuilder.None)
+                    using (var targetBuffer = OptimizeBufferReuse ? reusableEncodingBuffer.Allocate() : reusableEncodingBuffer.None)
+                    using (var targetStream = OptimizeBufferReuse ? reusableFileWriteStream.Allocate() : reusableFileWriteStream.None)
+                    {
+                        for (int i = 0; i < bucketCount; i++)
+                        {
+                            AsyncLogEventInfo ev = bucket.Value[i];
+                            if (firstLogEvent == null)
+                            {
+                                firstLogEvent = ev.LogEvent;
+                            }
+
+                            if (targetBuilder.Result != null && targetStream.Result != null)
+                            {
+                                // For some CPU's then it is faster to write to a small MemoryStream, and then copy to the larger one
+                                targetStream.Result.Position = 0;
+                                targetStream.Result.SetLength(0);
+                                targetBuilder.Result.ClearBuilder();
+                                RenderFormattedMessageToStream(ev.LogEvent, targetBuilder.Result, targetBuffer.Result, targetStream.Result);
+                                ms.Write(targetStream.Result.GetBuffer(), 0, (int)targetStream.Result.Length);
+                            }
+                            else
+                            {
+                                byte[] bytes = this.GetBytesToWrite(ev.LogEvent);
+                                if (ms.Capacity == 0)
+                                {
+                                    if (bucketCount > 10)
+                                        ms.Capacity = ((((bucketCount + 1) * bytes.Length) / 1024 + 1) * 1024);
+                                    else if (bucketCount > 1)
+                                        ms.Capacity = ((1 + bucketCount) * bytes.Length);
+                                }
+                                ms.Write(bytes, 0, bytes.Length);
+                            }
+                        }
                     }
 
-                    this.FlushCurrentFileWrites(fileName, firstLogEvent, ms, pendingContinuations);
+                    Exception lastException;
+                    this.FlushCurrentFileWrites(fileName, firstLogEvent, ms, out lastException);
+
+                    for (int i = 0; i < bucketCount; ++i)
+                    {
+                        bucket.Value[i].Continuation(lastException);
+                    }
                 }
             }
         }
 
-        private void ProcessLogEvent(LogEventInfo logEvent, string fileName, byte[] bytesToWrite)
+        private void ProcessLogEvent(LogEventInfo logEvent, string fileName, ArraySegment<byte> bytesToWrite)
         {
-            TryArchiveFile(fileName, logEvent, bytesToWrite.Length);
+            TryArchiveFile(fileName, logEvent, bytesToWrite.Count);
 
             // Clean up old archives if this is the first time a log record is being written to
             // this log file and the archiving system is date/time based.
@@ -1112,6 +1223,66 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Gets the bytes to be written to the file.
+        /// </summary>
+        /// <param name="logEvent">The log event to be formatted.</param>
+        /// <param name="formatBuilder"><see cref="StringBuilder"/> to help format log event.</param>
+        /// <param name="transformBuffer">Optional temporary char-array to help format log event.</param>
+        /// <param name="streamTarget">Destination <see cref="MemoryStream"/> for the encoded result.</param>
+        protected virtual void RenderFormattedMessageToStream(LogEventInfo logEvent, StringBuilder formatBuilder, char[] transformBuffer, MemoryStream streamTarget)
+        {
+            RenderFormattedMessage(logEvent, formatBuilder);
+            formatBuilder.Append(NewLineChars);
+            TransformBuilderToStream(logEvent, formatBuilder, transformBuffer, streamTarget);
+        }
+
+        /// <summary>
+        /// Formats the log event for write.
+        /// </summary>
+        /// <param name="logEvent">The log event to be formatted.</param>
+        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result.</param>
+        protected virtual void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        {
+            this.Layout.RenderAppendBuilder(logEvent, target);
+        }
+
+        private void TransformBuilderToStream(LogEventInfo logEvent, StringBuilder builder, char[] transformBuffer, MemoryStream workStream)
+        {
+#if !SILVERLIGHT
+            if (transformBuffer != null)
+            {
+                for (int i = 0; i < builder.Length; i += transformBuffer.Length)
+                {
+                    int charCount = Math.Min(builder.Length - i, transformBuffer.Length);
+                    builder.CopyTo(i, transformBuffer, 0, charCount);
+                    int byteCount = this.Encoding.GetByteCount(transformBuffer, 0, charCount);
+                    workStream.SetLength(workStream.Length + byteCount);
+                    this.Encoding.GetBytes(transformBuffer, 0, charCount, workStream.GetBuffer(), (int)workStream.Position);
+                    workStream.Position = workStream.Length;
+                }
+                TransformStream(logEvent, workStream);
+            }
+            else
+#endif
+            {
+                // Faster than MemoryStream, but generates garbage
+                var str = builder.ToString();
+                byte[] bytes = this.Encoding.GetBytes(str);
+                workStream.Write(bytes, 0, bytes.Length);
+                TransformStream(logEvent, workStream);
+            }
+        }
+
+        /// <summary>
+        /// Modifies the specified byte array before it gets sent to a file.
+        /// </summary>
+        /// <param name="logEvent">The LogEvent being written</param>
+        /// <param name="stream">The byte array.</param>
+        protected virtual void TransformStream(LogEventInfo logEvent, MemoryStream stream)
+        {
+        }
+
+        /// <summary>
         /// Replaces the numeric pattern i.e. {#} in a file name with the <paramref name="value"/> parameter value.
         /// </summary>
         /// <param name="pattern">File name which contains the numeric pattern.</param>
@@ -1127,15 +1298,17 @@ namespace NLog.Targets
                    pattern.Substring(lastPart);
         }
 
-        private void FlushCurrentFileWrites(string currentFileName, LogEventInfo firstLogEvent, MemoryStream ms,
-            List<AsyncContinuation> pendingContinuations)
+        private void FlushCurrentFileWrites(string currentFileName, LogEventInfo firstLogEvent, MemoryStream ms, out Exception lastException)
         {
-            Exception lastException = null;
+            lastException = null;
 
             try
             {
                 if (currentFileName != null)
-                    ProcessLogEvent(firstLogEvent, currentFileName, ms.ToArray());
+                {
+                    ArraySegment<byte> bytes = new ArraySegment<byte>(ms.GetBuffer(), 0, (int)ms.Length);
+                    ProcessLogEvent(firstLogEvent, currentFileName, bytes);
+                }
             }
             catch (Exception exception)
             {
@@ -1146,13 +1319,6 @@ namespace NLog.Targets
 
                 lastException = exception;
             }
-
-            foreach (AsyncContinuation cont in pendingContinuations)
-            {
-                cont(lastException);
-            }
-
-            pendingContinuations.Clear();
         }
 
         /// <summary>
@@ -2088,24 +2254,6 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// The sequence of <see langword="byte"/> to be written for the file header.
-        /// </summary>
-        /// <returns>Sequence of <see langword="byte"/> to be written.</returns>
-        private byte[] GetHeaderBytes()
-        {
-            return this.GetLayoutBytes(this.Header);
-        }
-
-        /// <summary>
-        /// The sequence of <see langword="byte"/> to be written for the file footer.
-        /// </summary>
-        /// <returns>Sequence of <see langword="byte"/> to be written.</returns>        
-        private byte[] GetFooterBytes()
-        {
-            return this.GetLayoutBytes(this.Footer);
-        }
-
-        /// <summary>
         /// Evaluates which parts of a file should be written (header, content, footer) based on various properties of
         /// <see cref="FileTarget"/> instance and writes them.
         /// </summary>
@@ -2113,7 +2261,7 @@ namespace NLog.Targets
         /// <param name="logEvent">Log event that the <see cref="FileTarget"/> instance is currently processing.</param>
         /// <param name="bytes">Raw sequence of <see langword="byte"/> to be written into the content part of the file.</param>        
         /// <param name="justData">Indicates that only content section should be written in the file.</param>
-        private void WriteToFile(string fileName, LogEventInfo logEvent, byte[] bytes, bool justData)
+        private void WriteToFile(string fileName, LogEventInfo logEvent, ArraySegment<byte> bytes, bool justData)
         {
             if (this.ReplaceFileContentsOnEachWrite)
             {
@@ -2131,7 +2279,7 @@ namespace NLog.Targets
                     this.WriteHeader(appender);
                 }
 
-                appender.Write(bytes);
+                appender.Write(bytes.Array, bytes.Offset, bytes.Count);
 
                 if (this.AutoFlush)
                 {
@@ -2162,7 +2310,8 @@ namespace NLog.Targets
             {
                 //UtcNow is much faster then .now. This was a bottleneck in writing a lot of files after CPU test.
                 var now = DateTime.UtcNow;
-                if (!this.initializedFiles.ContainsKey(fileName))
+                DateTime lastTime;
+                if (!this.initializedFiles.TryGetValue(fileName, out lastTime))
                 {
                     ProcessOnStartup(fileName, logEvent);
 
@@ -2176,8 +2325,8 @@ namespace NLog.Targets
                         this.CleanupInitializedFiles();
                     }
                 }
-
-                this.initializedFiles[fileName] = now;
+                if (lastTime != now)
+                    this.initializedFiles[fileName] = now;
             }
 
             return writeHeader;
@@ -2203,8 +2352,8 @@ namespace NLog.Targets
         /// <param name="fileName">The file path to write to.</param>
         private void WriteFooter(string fileName)
         {
-            byte[] footerBytes = this.GetFooterBytes();
-            if (footerBytes != null)
+            ArraySegment<byte> footerBytes = this.GetLayoutBytes(Footer);
+            if (footerBytes.Count > 0)
             {
                 if (File.Exists(fileName))
                 {
@@ -2253,24 +2402,24 @@ namespace NLog.Targets
         /// <param name="bytes">Sequence of <see langword="byte"/> to be written in the content section of the file.</param>
         /// <param name="firstAttempt">First attempt to write?</param>
         /// <remarks>This method is used when the content of the log file is re-written on every write.</remarks>
-        private void ReplaceFileContent(string fileName, byte[] bytes, bool firstAttempt)
+        private void ReplaceFileContent(string fileName, ArraySegment<byte> bytes, bool firstAttempt)
         {
             try
             {
                 using (FileStream fs = File.Create(fileName))
                 {
-                    byte[] headerBytes = this.GetHeaderBytes();
-                    if (headerBytes != null)
+                    ArraySegment<byte> headerBytes = this.GetLayoutBytes(Header);
+                    if (headerBytes.Count > 0)
                     {
-                        fs.Write(headerBytes, 0, headerBytes.Length);
+                        fs.Write(headerBytes.Array, headerBytes.Offset, headerBytes.Count);
                     }
 
-                    fs.Write(bytes, 0, bytes.Length);
+                    fs.Write(bytes.Array, bytes.Offset, bytes.Count);
 
-                    byte[] footerBytes = this.GetFooterBytes();
-                    if (footerBytes != null)
+                    ArraySegment<byte> footerBytes = this.GetLayoutBytes(Footer);
+                    if (footerBytes.Count > 0)
                     {
-                        fs.Write(footerBytes, 0, footerBytes.Length);
+                        fs.Write(footerBytes.Array, footerBytes.Offset, footerBytes.Count);
                     }
                 }
             }
@@ -2300,10 +2449,10 @@ namespace NLog.Targets
             //  Write header only on empty files or if file info cannot be obtained.
             if (length == null || length == 0)
             {
-                byte[] headerBytes = this.GetHeaderBytes();
-                if (headerBytes != null)
+                ArraySegment<byte> headerBytes = this.GetLayoutBytes(Header);
+                if (headerBytes.Count > 0)
                 {
-                    appender.Write(headerBytes);
+                    appender.Write(headerBytes.Array, headerBytes.Offset, headerBytes.Count);
                 }
             }
         }
@@ -2316,17 +2465,34 @@ namespace NLog.Targets
         /// <param name="layout">The layout used to render output message.</param>
         /// <returns>Sequence of <see langword="byte"/> to be written.</returns>
         /// <remarks>Usually it is used to render the header and hooter of the files.</remarks>
-        private byte[] GetLayoutBytes(Layout layout)
+        private ArraySegment<byte> GetLayoutBytes(Layout layout)
         {
             if (layout == null)
             {
-                return null;
+                return default(ArraySegment<byte>);
             }
-            //todo remove 
-            string renderedText = layout.Render(LogEventInfo.CreateNullEvent()) + this.NewLineChars;
-            return this.TransformBytes(this.Encoding.GetBytes(renderedText));
-        }
 
+            if (OptimizeBufferReuse)
+            {
+                using (var targetBuilder = this.ReusableLayoutBuilder.Allocate())
+                using (var targetBuffer = this.reusableEncodingBuffer.Allocate())
+                {
+                    var nullEvent = LogEventInfo.CreateNullEvent();
+                    layout.RenderAppendBuilder(nullEvent, targetBuilder.Result);
+                    targetBuilder.Result.Append(NewLineChars);
+                    using (MemoryStream ms = new MemoryStream(targetBuilder.Result.Length))
+                    {
+                        TransformBuilderToStream(nullEvent, targetBuilder.Result, targetBuffer.Result, ms);
+                        return new ArraySegment<byte>(ms.ToArray());
+                    }
+                }
+            }
+            else
+            {
+                string renderedText = layout.Render(LogEventInfo.CreateNullEvent()) + this.NewLineChars;
+                return new ArraySegment<byte>(this.TransformBytes(this.Encoding.GetBytes(renderedText)));
+            }
+        }
 
         private class DynamicFileArchive
         {

--- a/src/NLog/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog/Targets/LogReceiverWebServiceTarget.cs
@@ -60,7 +60,7 @@ namespace NLog.Targets
     [Target("LogReceiverService")]
     public class LogReceiverWebServiceTarget : Target
     {
-        private LogEventInfoBuffer buffer = new LogEventInfoBuffer(10000, false, 10000);
+        private readonly LogEventInfoBuffer buffer = new LogEventInfoBuffer(10000, false, 10000);
         private bool inCall;
 
         /// <summary>
@@ -148,7 +148,20 @@ namespace NLog.Targets
         /// <param name="logEvent">Logging event to be written out.</param>
         protected override void Write(AsyncLogEventInfo logEvent)
         {
-            this.Write(new[] { logEvent });
+            this.Write((IList<AsyncLogEventInfo>)new[] { logEvent });
+        }
+
+        /// <summary>
+        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// 
+        /// Writes an array of logging events to the log target. By default it iterates on all
+        /// events and passes them to "Write" method. Inheriting classes can use this method to
+        /// optimize batch writes.
+        /// </summary>
+        /// <param name="logEvents">Logging events to be written out.</param>
+        protected override void Write(AsyncLogEventInfo[] logEvents)
+        {
+            Write((IList<AsyncLogEventInfo>)logEvents);
         }
 
         /// <summary>
@@ -157,22 +170,26 @@ namespace NLog.Targets
         /// optimize batch writes.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
-        protected override void Write(AsyncLogEventInfo[] logEvents)
+        protected override void Write(IList<AsyncLogEventInfo> logEvents)
         {
             // if web service call is being processed, buffer new events and return
             // lock is being held here
             if (this.inCall)
             {
-                foreach (var ev in logEvents)
+                for (int i = 0; i < logEvents.Count; ++i)
                 {
-                    this.buffer.Append(ev);
+                    this.buffer.Append(logEvents[i]);
                 }
 
                 return;
             }
 
-            var networkLogEvents = this.TranslateLogEvents(logEvents);
-            this.Send(networkLogEvents, logEvents);
+            // RestrictedBufferReuse = false, will reuse the input-array on method-exit (so we make clone here)
+            AsyncLogEventInfo[] logEventsArray = new AsyncLogEventInfo[logEvents.Count];
+            logEvents.CopyTo(logEventsArray, 0);
+
+            var networkLogEvents = this.TranslateLogEvents(logEventsArray);
+            this.Send(networkLogEvents, logEventsArray);
         }
 
         /// <summary>
@@ -211,9 +228,9 @@ namespace NLog.Targets
             return stringIndex;
         }
 
-        private NLogEvents TranslateLogEvents(AsyncLogEventInfo[] logEvents)
+        private NLogEvents TranslateLogEvents(IList<AsyncLogEventInfo> logEvents)
         {
-            if (logEvents.Length == 0 && !LogManager.ThrowExceptions)
+            if (logEvents.Count == 0 && !LogManager.ThrowExceptions)
             {
                 InternalLogger.Error("LogEvents array is empty, sending empty event...");
                 return new NLogEvents();
@@ -242,7 +259,7 @@ namespace NLog.Targets
 
             if (this.IncludeEventProperties)
             {
-                for (int i = 0; i < logEvents.Length; ++i)
+                for (int i = 0; i < logEvents.Count; ++i)
                 {
                     var ev = logEvents[i].LogEvent;
 
@@ -264,10 +281,11 @@ namespace NLog.Targets
                 }
             }
 
-            networkLogEvents.Events = new NLogEvent[logEvents.Length];
-            for (int i = 0; i < logEvents.Length; ++i)
+            networkLogEvents.Events = new NLogEvent[logEvents.Count];
+            for (int i = 0; i < logEvents.Count; ++i)
             {
-                networkLogEvents.Events[i] = this.TranslateEvent(logEvents[i].LogEvent, networkLogEvents, stringTable);
+                AsyncLogEventInfo ev = logEvents[i];
+                networkLogEvents.Events[i] = this.TranslateEvent(ev.LogEvent, networkLogEvents, stringTable);
             }
 
             return networkLogEvents;
@@ -285,19 +303,19 @@ namespace NLog.Targets
             var client = CreateLogReceiver();
 
             client.ProcessLogMessagesCompleted += (sender, e) =>
+            {
+                // report error to the callers
+                foreach (var ev in asyncContinuations)
                 {
-                    // report error to the callers
-                    foreach (var ev in asyncContinuations)
-                    {
-                        ev.Continuation(e.Error);
-                    }
+                    ev.Continuation(e.Error);
+                }
 
-                    // send any buffered events
-                    this.SendBufferedEvents();
-                };
+                // send any buffered events
+                this.SendBufferedEvents();
+            };
 
             this.inCall = true;
-#if SILVERLIGHT 
+#if SILVERLIGHT
             if (!Deployment.Current.Dispatcher.CheckAccess())
             {
                 Deployment.Current.Dispatcher.BeginInvoke(() => client.ProcessLogMessagesAsync(events));
@@ -462,7 +480,7 @@ namespace NLog.Targets
                 string value;
                 object propertyValue;
 
-                if (eventInfo.Properties.TryGetValue(context.LayoutNames[i], out propertyValue))
+                if (eventInfo.HasProperties && eventInfo.Properties.TryGetValue(context.LayoutNames[i], out propertyValue))
                 {
                     value = Convert.ToString(propertyValue, CultureInfo.InvariantCulture);
                 }

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -339,14 +339,27 @@ namespace NLog.Targets
         /// <param name="logEvent">The logging event.</param>
         protected override void Write(AsyncLogEventInfo logEvent)
         {
-            this.Write(new[] { logEvent });
+            this.Write((IList<AsyncLogEventInfo>)new[] { logEvent });
+        }
+
+        /// <summary>
+        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// 
+        /// Writes an array of logging events to the log target. By default it iterates on all
+        /// events and passes them to "Write" method. Inheriting classes can use this method to
+        /// optimize batch writes.
+        /// </summary>
+        /// <param name="logEvents">Logging events to be written out.</param>
+        protected override void Write(AsyncLogEventInfo[] logEvents)
+        {
+            Write((IList<AsyncLogEventInfo>)logEvents);
         }
 
         /// <summary>
         /// Renders an array logging events.
         /// </summary>
         /// <param name="logEvents">Array of logging events.</param>
-        protected override void Write(AsyncLogEventInfo[] logEvents)
+        protected override void Write(IList<AsyncLogEventInfo> logEvents)
         {
             var buckets = logEvents.BucketSort(c => this.GetSmtpSettingsKey(c.LogEvent));
             foreach (var bucket in buckets)

--- a/src/NLog/Targets/NullTarget.cs
+++ b/src/NLog/Targets/NullTarget.cs
@@ -95,7 +95,7 @@ namespace NLog.Targets
         {
             if (this.FormatMessage)
             {
-                this.Layout.Render(logEvent);
+                this.RenderLogEvent(this.Layout, logEvent);
             }
         }
     }

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -36,7 +36,6 @@ namespace NLog.Targets
     using System;
     using System.Collections.Generic;
     using System.Threading;
-
     using NLog.Common;
     using NLog.Config;
     using NLog.Internal;
@@ -48,7 +47,7 @@ namespace NLog.Targets
     [NLogConfigurationItem]
     public abstract class Target : ISupportsInitialize, IDisposable
     {
-        private object lockObject = new object();
+        private readonly object lockObject = new object();
         private List<Layout> allLayouts;
         private bool allLayoutsAreThreadAgnostic;
         private bool scannedForLayouts;
@@ -59,6 +58,13 @@ namespace NLog.Targets
         /// </summary>
         /// <docgen category='General Options' order='10' />
         public string Name { get; set; }
+
+        /// <summary>
+        /// Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers
+        /// Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit
+        /// </summary>
+        /// <docgen category='Performance Tuning Options' order='10' />
+        public bool OptimizeBufferReuse { get; set; }
 
         /// <summary>
         /// Gets the object which can be used to synchronize asynchronous operations that must rely on the .
@@ -91,6 +97,11 @@ namespace NLog.Targets
             }
         }
         private volatile bool isInitialized;
+
+        /// <summary>
+        /// Can be used if <see cref="OptimizeBufferReuse"/> has been enabled.
+        /// </summary>
+        internal readonly ReusableBuilderCreator ReusableLayoutBuilder = new ReusableBuilderCreator();
 
         /// <summary>
         /// Get all used layouts in this target.
@@ -192,9 +203,23 @@ namespace NLog.Targets
 
                 if (this.allLayouts != null)
                 {
-                    foreach (Layout layout in this.allLayouts)
+                    if (this.OptimizeBufferReuse)
                     {
-                        layout.Precalculate(logEvent);
+                        using (var targetBuilder = this.ReusableLayoutBuilder.Allocate())
+                        {
+                            foreach (Layout layout in this.allLayouts)
+                            {
+                                targetBuilder.Result.ClearBuilder();
+                                layout.PrecalculateBuilder(logEvent, targetBuilder.Result);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        foreach (Layout layout in this.allLayouts)
+                        {
+                            layout.Precalculate(logEvent);
+                        }
                     }
                 }
             }
@@ -257,13 +282,27 @@ namespace NLog.Targets
                 return;
             }
 
+            WriteAsyncLogEvents((IList<AsyncLogEventInfo>)logEvents);
+        }
+
+        /// <summary>
+        /// Writes the array of log events.
+        /// </summary>
+        /// <param name="logEvents">The log events.</param>
+        internal void WriteAsyncLogEvents(IList<AsyncLogEventInfo> logEvents)
+        {
+            if (logEvents == null || logEvents.Count == 0)
+            {
+                return;
+            }
+
             if (!this.IsInitialized)
             {
                 lock (this.SyncRoot)
                 {
-                    foreach (var ev in logEvents)
+                    for (int i = 0; i < logEvents.Count; ++i)
                     {
-                        ev.Continuation(null);
+                        logEvents[i].Continuation(null);
                     }
                 }
                 return;
@@ -273,18 +312,32 @@ namespace NLog.Targets
             {
                 lock (this.SyncRoot)
                 {
-                    foreach (var ev in logEvents)
+                    for (int i = 0; i < logEvents.Count; ++i)
                     {
-                        ev.Continuation(this.CreateInitException());
+                        logEvents[i].Continuation(this.CreateInitException());
                     }
                 }
                 return;
             }
 
-            var wrappedEvents = new AsyncLogEventInfo[logEvents.Length];
-            for (int i = 0; i < logEvents.Length; ++i)
+            IList<AsyncLogEventInfo> wrappedEvents;
+            if (this.OptimizeBufferReuse)
             {
-                wrappedEvents[i] = logEvents[i].LogEvent.WithContinuation(AsyncHelpers.PreventMultipleCalls(logEvents[i].Continuation));
+                for (int i = 0; i < logEvents.Count; ++i)
+                {
+                    logEvents[i] = logEvents[i].LogEvent.WithContinuation(AsyncHelpers.PreventMultipleCalls(logEvents[i].Continuation));
+                }
+                wrappedEvents = logEvents;
+            }
+            else
+            {
+                var cloneLogEvents = new AsyncLogEventInfo[logEvents.Count];
+                for (int i = 0; i < logEvents.Count; ++i)
+                {
+                    AsyncLogEventInfo ev = logEvents[i];
+                    cloneLogEvents[i] = ev.LogEvent.WithContinuation(AsyncHelpers.PreventMultipleCalls(ev.Continuation));
+                }
+                wrappedEvents = cloneLogEvents;
             }
 
             this.WriteAsyncThreadSafe(wrappedEvents);
@@ -491,6 +544,8 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// 
         /// Writes an array of logging events to the log target. By default it iterates on all
         /// events and passes them to "Write" method. Inheriting classes can use this method to
         /// optimize batch writes.
@@ -498,33 +553,66 @@ namespace NLog.Targets
         /// <param name="logEvents">Logging events to be written out.</param>
         protected virtual void Write(AsyncLogEventInfo[] logEvents)
         {
-            for (int i = 0; i < logEvents.Length; ++i)
+            Write((IList<AsyncLogEventInfo>)logEvents);
+        }
+
+        /// <summary>
+        /// Writes an array of logging events to the log target. By default it iterates on all
+        /// events and passes them to "Write" method. Inheriting classes can use this method to
+        /// optimize batch writes.
+        /// </summary>
+        /// <param name="logEvents">Logging events to be written out.</param>
+        protected virtual void Write(IList<AsyncLogEventInfo> logEvents)
+        {
+            for (int i = 0; i < logEvents.Count; ++i)
             {
                 this.Write(logEvents[i]);
             }
         }
 
         /// <summary>
+        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// 
         /// Writes an array of logging events to the log target, in a thread safe manner.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
         protected virtual void WriteAsyncThreadSafe(AsyncLogEventInfo[] logEvents)
+        {
+            WriteAsyncThreadSafe((IList<AsyncLogEventInfo>)logEvents);
+        }
+
+        /// <summary>
+        /// Writes an array of logging events to the log target, in a thread safe manner.
+        /// </summary>
+        /// <param name="logEvents">Logging events to be written out.</param>
+        protected virtual void WriteAsyncThreadSafe(IList<AsyncLogEventInfo> logEvents)
         {
             lock (this.SyncRoot)
             {
                 if (!this.IsInitialized)
                 {
                     // In case target was Closed
-                    foreach (var ev in logEvents)
+                    for (int i = 0; i < logEvents.Count; ++i)
                     {
-                        ev.Continuation(null);
+                        logEvents[i].Continuation(null);
                     }
                     return;
                 }
 
                 try
                 {
-                    this.Write(logEvents);
+                    AsyncLogEventInfo[] logEventsArray = this.OptimizeBufferReuse ? null : logEvents as AsyncLogEventInfo[];
+                    if (!this.OptimizeBufferReuse && logEventsArray != null)
+                    {
+                        // Backwards compatibility
+#pragma warning disable 612, 618
+                        this.Write(logEventsArray);
+#pragma warning restore 612, 618
+                    }
+                    else
+                    {
+                        this.Write(logEvents);
+                    }
                 }
                 catch (Exception exception)
                 {
@@ -534,9 +622,9 @@ namespace NLog.Targets
                     }
 
                     // in case of synchronous failure, assume that nothing is running asynchronously
-                    foreach (var ev in logEvents)
+                    for (int i = 0; i < logEvents.Count; ++i)
                     {
-                        ev.Continuation(exception);
+                        logEvents[i].Continuation(exception);
                     }
                 }
             }
@@ -572,6 +660,32 @@ namespace NLog.Targets
                     }
                     logEventParameter.Properties.Clear();
                 }
+            }
+        }
+
+        /// <summary>
+        /// Renders the event info in layout.
+        /// </summary>
+        /// <param name="layout">The layout.</param>
+        /// <param name="logEvent">The event info.</param>
+        /// <returns>String representing log event.</returns>
+        protected string RenderLogEvent(Layout layout, LogEventInfo logEvent)
+        {
+            if (OptimizeBufferReuse)
+            {
+                SimpleLayout simpleLayout = layout as SimpleLayout;
+                if (simpleLayout != null && simpleLayout.IsFixedText)
+                    return simpleLayout.Render(logEvent);
+
+                using (var localTarget = ReusableLayoutBuilder.Allocate())
+                {
+                    layout.RenderAppendBuilder(logEvent, localTarget.Result);
+                    return localTarget.Result.ToString();
+                }
+            }
+            else
+            {
+                return layout.Render(logEvent);
             }
         }
 

--- a/src/NLog/Targets/Wrappers/ImpersonatingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/ImpersonatingTargetWrapper.cs
@@ -36,6 +36,7 @@
 namespace NLog.Targets.Wrappers
 {
     using System;
+    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Runtime.InteropServices;
     using System.Security;
@@ -183,11 +184,24 @@ namespace NLog.Targets.Wrappers
         }
 
         /// <summary>
+        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// 
+        /// Writes an array of logging events to the log target. By default it iterates on all
+        /// events and passes them to "Write" method. Inheriting classes can use this method to
+        /// optimize batch writes.
+        /// </summary>
+        /// <param name="logEvents">Logging events to be written out.</param>
+        protected override void Write(AsyncLogEventInfo[] logEvents)
+        {
+            Write((IList<AsyncLogEventInfo>)logEvents);
+        }
+
+        /// <summary>
         /// Changes the security context, forwards the call to the <see cref="WrapperTargetBase.WrappedTarget"/>.Write()
         /// and switches the context back to original.
         /// </summary>
         /// <param name="logEvents">Log events.</param>
-        protected override void Write(AsyncLogEventInfo[] logEvents)
+        protected override void Write(IList<AsyncLogEventInfo> logEvents)
         {
             using (this.DoImpersonate())
             {

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -116,20 +116,33 @@ namespace NLog.Targets.Wrappers
         public IList<FilteringRule> Rules { get; private set; }
 
         /// <summary>
+        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// 
+        /// Writes an array of logging events to the log target. By default it iterates on all
+        /// events and passes them to "Write" method. Inheriting classes can use this method to
+        /// optimize batch writes.
+        /// </summary>
+        /// <param name="logEvents">Logging events to be written out.</param>
+        protected override void Write(AsyncLogEventInfo[] logEvents)
+        {
+            Write((IList<AsyncLogEventInfo>)logEvents);
+        }
+
+        /// <summary>
         /// Evaluates all filtering rules to find the first one that matches.
         /// The matching rule determines the filtering condition to be applied
         /// to all items in a buffer. If no condition matches, default filter
         /// is applied to the array of log events.
         /// </summary>
         /// <param name="logEvents">Array of log events to be post-filtered.</param>
-        protected override void Write(AsyncLogEventInfo[] logEvents)
+        protected override void Write(IList<AsyncLogEventInfo> logEvents)
         {
             ConditionExpression resultFilter = null;
 
-            InternalLogger.Trace("Running {0} on {1} events", this, logEvents.Length);
+            InternalLogger.Trace("Running {0} on {1} events", this, logEvents.Count);
 
             // evaluate all the rules to get the filtering condition
-            for (int i = 0; i < logEvents.Length; ++i)
+            for (int i = 0; i < logEvents.Count; ++i)
             {
                 foreach (FilteringRule rule in this.Rules)
                 {
@@ -166,7 +179,7 @@ namespace NLog.Targets.Wrappers
                 // apply the condition to the buffer
                 var resultBuffer = new List<AsyncLogEventInfo>();
 
-                for (int i = 0; i < logEvents.Length; ++i)
+                for (int i = 0; i < logEvents.Count; ++i)
                 {
                     object v = resultFilter.Evaluate(logEvents[i].LogEvent);
                     if (boxedTrue.Equals(v))

--- a/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
@@ -98,6 +98,8 @@ namespace NLog.Targets.Wrappers
         }
 
         /// <summary>
+        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        ///
         /// Writes an array of logging events to the log target. By default it iterates on all
         /// events and passes them to "Write" method. Inheriting classes can use this method to
         /// optimize batch writes.
@@ -105,17 +107,39 @@ namespace NLog.Targets.Wrappers
         /// <param name="logEvents">Logging events to be written out.</param>
         protected override void Write(AsyncLogEventInfo[] logEvents)
         {
-            InternalLogger.Trace("Writing {0} events", logEvents.Length);
+            Write((IList<AsyncLogEventInfo>)logEvents);
+        }
 
-            for (int i = 0; i < logEvents.Length; ++i)
+        /// <summary>
+        /// Writes an array of logging events to the log target. By default it iterates on all
+        /// events and passes them to "Write" method. Inheriting classes can use this method to
+        /// optimize batch writes.
+        /// </summary>
+        /// <param name="logEvents">Logging events to be written out.</param>
+        protected override void Write(IList<AsyncLogEventInfo> logEvents)
+        {
+            InternalLogger.Trace("Writing {0} events", logEvents.Count);
+
+            for (int i = 0; i < logEvents.Count; ++i)
             {
-                logEvents[i].Continuation = CountedWrap(logEvents[i].Continuation, this.Targets.Count);
+                AsyncLogEventInfo ev = logEvents[i];
+                logEvents[i] = new AsyncLogEventInfo(ev.LogEvent, CountedWrap(ev.Continuation, this.Targets.Count));
             }
 
-            foreach (var t in this.Targets)
+            for (int i = 0; i < this.Targets.Count; ++i)
             {
-                InternalLogger.Trace("Sending {0} events to {1}", logEvents.Length, t);
-                t.WriteAsyncLogEvents(logEvents);
+                InternalLogger.Trace("Sending {0} events to {1}", logEvents.Count, this.Targets[i]);
+
+                var targetLogEvents = logEvents;
+                if (i < this.Targets.Count - 1)
+                {
+                    // RestrictedBufferReuse = false, will change the input-array (so we make clones here)
+                    AsyncLogEventInfo[] cloneLogEvents = new AsyncLogEventInfo[logEvents.Count];
+                    logEvents.CopyTo(cloneLogEvents, 0);
+                    targetLogEvents = cloneLogEvents;
+                }
+
+                this.Targets[i].WriteAsyncLogEvents(targetLogEvents);
             }
         }
 
@@ -130,28 +154,28 @@ namespace NLog.Targets.Wrappers
 
             AsyncContinuation wrapper =
                 ex =>
+                {
+                    if (ex != null)
                     {
-                        if (ex != null)
+                        lock (exceptions)
                         {
-                            lock (exceptions)
-                            {
-                                exceptions.Add(ex);
-                            }
+                            exceptions.Add(ex);
                         }
+                    }
 
-                        int c = Interlocked.Decrement(ref counter);
+                    int c = Interlocked.Decrement(ref counter);
 
-                        if (c == 0)
-                        {
-                            var combinedException = AsyncHelpers.GetCombinedException(exceptions);
-                            InternalLogger.Trace("Combined exception: {0}", combinedException);
-                            originalContinuation(combinedException);
-                        }
-                        else
-                        {
-                            InternalLogger.Trace("{0} remaining.", c);
-                        }
-                    };
+                    if (c == 0)
+                    {
+                        var combinedException = AsyncHelpers.GetCombinedException(exceptions);
+                        InternalLogger.Trace("Combined exception: {0}", combinedException);
+                        originalContinuation(combinedException);
+                    }
+                    else
+                    {
+                        InternalLogger.Trace("{0} remaining.", c);
+                    }
+                };
 
             return wrapper;
         }

--- a/tests/NLog.UnitTests/Layouts/AllEventPropertiesTests.cs
+++ b/tests/NLog.UnitTests/Layouts/AllEventPropertiesTests.cs
@@ -45,51 +45,47 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void AllParametersAreSetToDefault()
         {
-            var sb = new StringBuilder();
             var renderer = new AllEventPropertiesLayoutRenderer();
             var ev = BuildLogEventWithProperties();
             
-            renderer.Render(sb, ev);
+            var result = renderer.Render(ev);
 
-            Assert.Equal("a=1, hello=world, 17=100", sb.ToString());
+            Assert.Equal("a=1, hello=world, 17=100", result);
         }
 
         [Fact]
         public void CustomSeparator()
         {
-            var sb = new StringBuilder();
             var renderer = new AllEventPropertiesLayoutRenderer();
             renderer.Separator = " | ";
             var ev = BuildLogEventWithProperties();
 
-            renderer.Render(sb, ev);
+            var result = renderer.Render(ev);
 
-            Assert.Equal("a=1 | hello=world | 17=100", sb.ToString());
+            Assert.Equal("a=1 | hello=world | 17=100", result);
         }
 
         [Fact]
         public void CustomFormat()
         {
-            var sb = new StringBuilder();
             var renderer = new AllEventPropertiesLayoutRenderer();
             renderer.Format = "[key] is [value]";
             var ev = BuildLogEventWithProperties();
 
-            renderer.Render(sb, ev);
+            var result = renderer.Render(ev);
 
-            Assert.Equal("a is 1, hello is world, 17 is 100", sb.ToString());
+            Assert.Equal("a is 1, hello is world, 17 is 100", result);
         }
 
         [Fact]
         public void NoProperties()
         {
-            var sb = new StringBuilder();
             var renderer = new AllEventPropertiesLayoutRenderer();
             var ev = new LogEventInfo();
 
-            renderer.Render(sb, ev);
+            var result = renderer.Render(ev);
 
-            Assert.Equal("", sb.ToString());
+            Assert.Equal("", result);
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -63,7 +63,6 @@ namespace NLog.UnitTests
             {
                 //flush all events if needed.
                 LogManager.Configuration.Close();
-
             }
 
             if (LogManager.LogFactory != null)
@@ -75,7 +74,10 @@ namespace NLog.UnitTests
             InternalLogger.Reset();
             LogManager.ThrowExceptions = false;
             LogManager.ThrowConfigExceptions = null;
-
+#if !SILVERLIGHT
+            System.Diagnostics.Trace.Listeners.Clear();
+            System.Diagnostics.Debug.Listeners.Clear();
+#endif
         }
 
         protected void AssertDebugCounter(string targetName, int val)
@@ -124,16 +126,14 @@ namespace NLog.UnitTests
                 Assert.True(false, "File '" + fileName + "' doesn't exist.");
 
             byte[] encodedBuf = encoding.GetBytes(contents);
-            Assert.True(encodedBuf.Length <= fi.Length);
-            byte[] buf = new byte[encodedBuf.Length];
-            using (FileStream fs = new FileStream(fileName, FileMode.Open, FileAccess.Read))
-            {
-                fs.Read(buf, 0, buf.Length);
-            }
 
-            for (int i = 0; i < buf.Length; ++i)
+            byte[] buf = File.ReadAllBytes(fileName);
+            Assert.True(encodedBuf.Length <= buf.Length, string.Format("File:{0} encodedBytes:{1} does not match file.content:{2}, file.length = {3}", fileName, encodedBuf.Length, buf.Length, fi.Length));
+
+            for (int i = 0; i < encodedBuf.Length; ++i)
             {
-                Assert.Equal(encodedBuf[i], buf[i]);
+                if (encodedBuf[i] != buf[i])
+                    Assert.True(encodedBuf[i] == buf[i], string.Format("File:{0} content mismatch {1} <> {2} at index {3}", fileName, (int)encodedBuf[i], (int)buf[i], i));
             }
         }
 
@@ -244,16 +244,14 @@ namespace NLog.UnitTests
 
                 }
             }
-            Assert.Equal(encodedBuf.Length, fi.Length);
-            byte[] buf = new byte[(int)fi.Length];
-            using (FileStream fs = new FileStream(fileName, FileMode.Open, FileAccess.Read))
-            {
-                fs.Read(buf, 0, buf.Length);
-            }
+
+            byte[] buf = File.ReadAllBytes(fileName);
+            Assert.True(encodedBuf.Length == buf.Length, string.Format("File:{0} encodedBytes:{1} does not match file.content:{2}, file.length = {3}", fileName, encodedBuf.Length, buf.Length, fi.Length));
 
             for (int i = 0; i < buf.Length; ++i)
             {
-                Assert.Equal(encodedBuf[i], buf[i]);
+                if (encodedBuf[i] != buf[i])
+                    Assert.True(encodedBuf[i] == buf[i], string.Format("File:{0} content mismatch {1} <> {2} at index {3}", fileName, (int)encodedBuf[i], (int)buf[i], i));
             }
         }
 
@@ -322,7 +320,7 @@ namespace NLog.UnitTests
         /// </summary>
         protected int GetPrevLineNumber()
         {
-        //fixed value set with #line 100000
+            //fixed value set with #line 100000
             return 100001;
         }
 
@@ -350,13 +348,58 @@ namespace NLog.UnitTests
 
         protected string RunAndCaptureInternalLog(SyncAction action, LogLevel internalLogLevel)
         {
-            var stringWriter = new StringWriter();
+            var stringWriter = new Logger();
             InternalLogger.LogWriter = stringWriter;
             InternalLogger.LogLevel = LogLevel.Trace;
             InternalLogger.IncludeTimestamp = false;
             action();
 
             return stringWriter.ToString();
+        }
+
+        /// <summary>
+        /// This class has to be used when outputting from the InternalLogger.LogWriter.
+        /// Just creating a string writer will cause issues, since string writer is not thread safe.
+        /// This can cause issues when calling the ToString() on the text writer, since the underlying stringbuilder
+        /// of the textwriter, has char arrays that gets fucked up by the multiple threads.
+        /// this is a simple wrapper that just locks access to the writer so only one thread can access
+        /// it at a time.
+        /// </summary>
+        private class Logger : TextWriter
+        {
+            private readonly StringWriter writer = new StringWriter();
+
+            public override Encoding Encoding
+            {
+                get
+                {
+                    return this.writer.Encoding;
+                }
+            }
+
+            public override void Write(string value)
+            {
+                lock (this.writer)
+                {
+                    this.writer.Write(value);
+                }
+            }
+
+            public override void WriteLine(string value)
+            {
+                lock (this.writer)
+                {
+                    this.writer.WriteLine(value);
+                }
+            }
+
+            public override string ToString()
+            {
+                lock (this.writer)
+                {
+                    return this.writer.ToString();
+                }
+            }
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
@@ -172,12 +172,12 @@ namespace NLog.UnitTests.Targets
         }
 
         [Theory]
-        [InlineData(2, 10000, "none")]
-        [InlineData(5, 4000, "none")]
-        [InlineData(10, 2000, "none")]
-        [InlineData(2, 10000, "none|mutex")]
-        [InlineData(5, 4000, "none|mutex")]
-        [InlineData(10, 2000, "none|mutex")]
+        [InlineData(2, 1000, "none")]
+        [InlineData(5, 1000, "none")]
+        [InlineData(10, 1000, "none")]
+        [InlineData(2, 1000, "none|mutex")]
+        [InlineData(5, 1000, "none|mutex")]
+        [InlineData(10, 1000, "none|mutex")]
         public void SimpleConcurrentTest(int numProcesses, int numLogs, string mode)
         {
             DoConcurrentTest(numProcesses, numLogs, mode);
@@ -194,7 +194,7 @@ namespace NLog.UnitTests.Targets
             // Due to the buffering it makes no big difference in runtime, whether we
             // have 2 process writing 10K events each or couple more processes with even more events.
             // Runtime is mostly defined by Runner.exe compilation and JITing the first.
-            DoConcurrentTest(5, 50000, mode);
+            DoConcurrentTest(5, 1000, mode);
         }
 
         [Theory]
@@ -202,7 +202,7 @@ namespace NLog.UnitTests.Targets
         [InlineData("buffered|mutex")]
         public void BufferedConcurrentTest(string mode)
         {
-            DoConcurrentTest(5, 50000, mode);
+            DoConcurrentTest(5, 1000, mode);
         }
 
         [Theory]
@@ -210,7 +210,7 @@ namespace NLog.UnitTests.Targets
         [InlineData("buffered_timed_flush|mutex")]
         public void BufferedTimedFlushConcurrentTest(string mode)
         {
-            DoConcurrentTest(5, 50000, mode);
+            DoConcurrentTest(5, 1000, mode);
         }
     }
 }

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -468,7 +468,7 @@ namespace NLog.UnitTests.Targets
             {
                 try
                 {
-                    target.BlockingOperation(1000);
+                    target.BlockingOperation(500);
                 }
                 catch (Exception ex)
                 {
@@ -589,7 +589,7 @@ namespace NLog.UnitTests.Targets
                 base.Write(logEvent);
             }
 
-            protected override void Write(AsyncLogEventInfo[] logEvents)
+            protected override void Write(IList<AsyncLogEventInfo> logEvents)
             {
                 Assert.Equal(0, this.inBlockingOperation);
                 this.WriteCount3++;

--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
@@ -51,7 +51,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             Assert.Equal(AsyncTargetWrapperOverflowAction.Grow, targetWrapper.OverflowAction);
             Assert.Equal(300, targetWrapper.QueueLimit);
             Assert.Equal(50, targetWrapper.TimeToSleepBetweenBatches);
-            Assert.Equal(100, targetWrapper.BatchSize);
+            Assert.Equal(200, targetWrapper.BatchSize);
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             Assert.Equal(AsyncTargetWrapperOverflowAction.Discard, targetWrapper.OverflowAction);
             Assert.Equal(10000, targetWrapper.QueueLimit);
             Assert.Equal(50, targetWrapper.TimeToSleepBetweenBatches);
-            Assert.Equal(100, targetWrapper.BatchSize);
+            Assert.Equal(200, targetWrapper.BatchSize);
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 int flushCounter = 0;
                 AsyncContinuation flushHandler = (ex) => { ++flushCounter; };
 
-                List<KeyValuePair<LogEventInfo, AsyncContinuation>> itemPrepareList = new List<KeyValuePair<LogEventInfo, AsyncContinuation>>(2500);
+                List<KeyValuePair<LogEventInfo, AsyncContinuation>> itemPrepareList = new List<KeyValuePair<LogEventInfo, AsyncContinuation>>(500);
                 List<int> itemWrittenList = new List<int>(itemPrepareList.Capacity);
                 for (int i = 0; i< itemPrepareList.Capacity; ++i)
                 {
@@ -125,7 +125,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 }
 
 #if MONO || NET3_5
-                Assert.True(elapsedMilliseconds < 2500);    // Skip timing test when running within OpenCover.Console.exe
+                Assert.True(elapsedMilliseconds < 500);    // Skip timing test when running within OpenCover.Console.exe
 #endif
 
                 targetWrapper.Flush(flushHandler);
@@ -414,7 +414,7 @@ namespace NLog.UnitTests.Targets.Wrappers
         {
             var asyncTarget = new AsyncTargetWrapper
             {
-                TimeToSleepBetweenBatches = 2000,
+                TimeToSleepBetweenBatches = 1000,
                 WrappedTarget = new DebugTarget(),
                 Name = "FlushingMultipleTimesSimultaneous_Wrapper"
             };

--- a/tests/NLog.UnitTests/Targets/Wrappers/BufferingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/BufferingTargetWrapperTests.cs
@@ -36,6 +36,7 @@ using System.Diagnostics;
 namespace NLog.UnitTests.Targets.Wrappers
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using NLog.Common;
     using NLog.Targets;
@@ -210,7 +211,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             {
                 WrappedTarget = myTarget,
                 BufferSize = 10,
-                FlushTimeout = 1000,
+                FlushTimeout = 500,
             };
 
             InitializeTargets(myTarget, targetWrapper);
@@ -242,8 +243,8 @@ namespace NLog.UnitTests.Targets.Wrappers
             Assert.Equal(0, hitCount);
             Assert.Equal(0, myTarget.WriteCount);
 
-            // sleep 2 seconds, this will trigger the timer and flush all events
-            Thread.Sleep(1500);
+            // sleep 1 second, this will trigger the timer and flush all events
+            Thread.Sleep(1000);
             Assert.Equal(9, hitCount);
             Assert.Equal(1, myTarget.BufferedWriteCount);
             Assert.Equal(9, myTarget.BufferedTotalEvents);
@@ -267,7 +268,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             Assert.Equal(19, myTarget.WriteCount);
 
             // sleep 2 seconds and the last remaining one will be flushed
-            Thread.Sleep(1500);
+            Thread.Sleep(1000);
             Assert.Equal(20, hitCount);
             Assert.Equal(3, myTarget.BufferedWriteCount);
             Assert.Equal(20, myTarget.BufferedTotalEvents);
@@ -519,14 +520,14 @@ namespace NLog.UnitTests.Targets.Wrappers
                 throw new NotSupportedException();
             }
 
-            protected override void Write(AsyncLogEventInfo[] logEvents)
+            protected override void Write(IList<AsyncLogEventInfo> logEvents)
             {
                 this.BufferedWriteCount++;
-                this.BufferedTotalEvents += logEvents.Length;
+                this.BufferedTotalEvents += logEvents.Count;
 
-                foreach (var logEvent in logEvents)
+                for (int i = 0; i < logEvents.Count; ++i)
                 {
-                    var @event = logEvent;
+                    var @event = logEvents[i];
                     ThreadPool.QueueUserWorkItem(
                         s =>
                         {
@@ -562,10 +563,10 @@ namespace NLog.UnitTests.Targets.Wrappers
             public bool ThrowException { get; set; }
             public int FailCounter { get; set; }
 
-            protected override void Write(AsyncLogEventInfo[] logEvents)
+            protected override void Write(IList<AsyncLogEventInfo> logEvents)
             {
                 this.BufferedWriteCount++;
-                this.BufferedTotalEvents += logEvents.Length;
+                this.BufferedTotalEvents += logEvents.Count;
                 base.Write(logEvents);
             }
 

--- a/tests/NLog.UnitTests/Targets/Wrappers/ImpersonatingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/ImpersonatingTargetWrapperTests.cs
@@ -284,7 +284,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 this.Events.Add(logEvent);
             }
 
-            protected override void Write(AsyncLogEventInfo[] logEvents)
+            protected override void Write(IList<AsyncLogEventInfo> logEvents)
             {
                 this.AssertExpectedUser();
                 base.Write(logEvents);


### PR DESCRIPTION
FileTarget and AsyncTargetWrapper with optimized memory allocations for layout rendering, encoding and streaming. Optimization is disabled by default for all targets with the setting OptimizeBufferReuse (Default = false). It has been explicit enabled for pure NLog-FileTarget and pure NLog-AsyncTargetWrapper.

Introduced a new property AsyncTargetWrapper.FullBatchSizeWriteLimit (Default = 5). It gives better performance to have many small writes. But have increased AsyncTargetWrapper.BatchSize to 200. 

Refactoring of #1663

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1799)
<!-- Reviewable:end -->
