### PR TITLE
FlushTriggerWrapper is implemented

### DIFF
--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -390,6 +390,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTarget.cs" />
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -387,6 +387,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTarget.cs" />
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -400,6 +400,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTarget.cs" />
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -406,6 +406,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTarget.cs" />
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -400,6 +400,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTarget.cs" />
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -400,6 +400,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTarget.cs" />
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -405,6 +406,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTarget.cs" />
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -407,6 +407,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTarget.cs" />
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -404,6 +404,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTarget.cs" />
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -403,6 +403,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTarget.cs" />
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -403,6 +403,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTarget.cs" />
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -428,6 +428,7 @@
     <Compile Include="Targets\Wrappers\FallbackGroupTarget.cs" />
     <Compile Include="Targets\Wrappers\FilteringRule.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapper.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapper.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapper.cs" />
     <Compile Include="Targets\Wrappers\LogOnProviderType.cs" />

--- a/src/NLog/Targets/Wrappers/FlushTriggerWrapper.cs
+++ b/src/NLog/Targets/Wrappers/FlushTriggerWrapper.cs
@@ -1,0 +1,104 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Targets.Wrappers
+{
+    using Common;
+    using Conditions;
+    using Config;
+
+    /// <summary>
+    /// Causes a flush on a wrapped target if LogEvent statisfies the <see cref="Condition"/>
+    /// </summary>
+    [Target("FlushTriggerWrapper", IsWrapper = true)]
+    public class FlushTriggerWrapper : WrapperTargetBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FlushTriggerWrapper" /> class.
+        /// </summary>
+        public FlushTriggerWrapper()
+            : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FlushTriggerWrapper" /> class.
+        /// </summary>
+        /// <param name="wrappedTarget">The wrapped target.</param>
+        /// <param name="name">Name of the target</param>
+        public FlushTriggerWrapper(string name, Target wrappedTarget)
+            : this(wrappedTarget)
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FlushTriggerWrapper" /> class.
+        /// </summary>
+        /// <param name="wrappedTarget">The wrapped target.</param>
+        public FlushTriggerWrapper(Target wrappedTarget)
+        {
+            this.WrappedTarget = wrappedTarget;
+        }
+
+        /// <summary>
+        /// Gets or sets the condition expression. Log events who meet this condition will cause a flush
+        /// on the wrapped target.
+        /// </summary>
+        /// <docgen category='Filtering Options' order='10' />
+        [RequiredParameter]
+        public ConditionExpression Condition { get; set; }
+
+        /// <summary>
+        /// Forwards the call to the <see cref="WrapperTargetBase.WrappedTarget"/>.Write()
+        /// and calls <see cref="Target.Flush(AsyncContinuation)"/> on it if LogEvent satisfies the flush condition.
+        /// </summary>
+        /// <param name="logEvent">Logging event to be written out.</param>
+        protected override void Write(AsyncLogEventInfo logEvent)
+        {
+            object conditionResult = this.Condition.Evaluate(logEvent.LogEvent);
+            if (conditionResult.Equals(true))
+            {
+                var logEventWithFlush =
+                    logEvent.LogEvent.WithContinuation(
+                        AsyncHelpers.PrecededBy(logEvent.Continuation,this.WrappedTarget.Flush));
+
+                this.WrappedTarget.WriteAsyncLogEvent(logEventWithFlush);
+            }
+            else
+            {
+                this.WrappedTarget.WriteAsyncLogEvent(logEvent);
+            }
+        }
+    }
+}

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -212,6 +212,7 @@
     <Compile Include="Targets\Wrappers\BufferingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\FallbackGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapperTests.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -241,6 +241,7 @@
     <Compile Include="Targets\Wrappers\BufferingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\FallbackGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapperTests.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Targets\Wrappers\BufferingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\FallbackGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapperTests.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapperTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,8 +9,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -261,6 +263,7 @@
     <Compile Include="Targets\Wrappers\BufferingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\FallbackGroupTargetTests.cs" />
     <Compile Include="Targets\Wrappers\FilteringTargetWrapperTests.cs" />
+    <Compile Include="Targets\Wrappers\FlushTriggerWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\ImpersonatingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\LimitingTargetWrapperTests.cs" />
     <Compile Include="Targets\Wrappers\PostFilteringTargetWrapperTests.cs" />

--- a/tests/NLog.UnitTests/Targets/Wrappers/FlushTriggerWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/FlushTriggerWrapperTests.cs
@@ -1,0 +1,149 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.Targets.Wrappers
+{
+    using NLog.Common;
+    using NLog.Targets;
+    using NLog.Targets.Wrappers;
+    using Xunit;
+
+    public class FlushTriggerWrapperTests : NLogTestBase
+    {
+        [Fact]
+        public void FlushTriggerWrapperConfigurationReadTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"<nlog>
+                <targets>
+                    <target type='FlushTriggerWrapper' condition='level >= LogLevel.Debug' name='FlushOnError'>
+                        <target name='d2' type='Debug' />
+                    </target>
+                </targets>
+
+                <rules>
+                    <logger name='*' level='Warn' writeTo='FlushOnError'>
+                    </logger>
+                </rules>
+            </nlog>");
+            var target = LogManager.Configuration.FindTargetByName("FlushOnError") as FlushTriggerWrapper;
+            Assert.NotNull(target);
+            Assert.NotNull(target.Condition);
+            Assert.Equal("(level >= Debug)", target.Condition.ToString());
+            Assert.Equal("d2", target.WrappedTarget.Name);
+        }
+
+        [Fact]
+        public void FlushTriggerWrapperConditionMissingErrorTest()
+        {
+            var exception = Assert.Throws<NLogConfigurationException>(() =>
+            {
+                LogManager.Configuration = CreateConfigurationFromString(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target type='FlushTriggerWrapper' name='FlushOnError'>
+                        <target name='d2' type='Debug' />
+                    </target>
+
+                </targets>
+
+                <rules>
+                    <logger name='*' level='Warn' writeTo='FlushOnError'>
+                    </logger>
+                </rules>
+            </nlog>");
+            });
+
+            Assert.Contains("Required parameter 'Condition'", exception.Message);
+        }
+
+        [Fact]
+        public void FlushTriggerWrapperFlushOnConditionTest()
+        {
+            var testTarget = new TestTarget();
+            var flushTriggerWrapper = new FlushTriggerWrapper(testTarget);
+            flushTriggerWrapper.Condition = "level > LogLevel.Info";
+            testTarget.Initialize(null);
+            flushTriggerWrapper.Initialize(null);
+            AsyncContinuation continuation = ex => { };
+            flushTriggerWrapper.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Info, "*", "test").WithContinuation(continuation));
+            flushTriggerWrapper.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Trace, "*", "test").WithContinuation(continuation));
+            Assert.Equal(2, testTarget.WriteCount);
+            Assert.Equal(0, testTarget.FlushCount);
+            flushTriggerWrapper.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Warn, "*", "test").WithContinuation(continuation));
+            flushTriggerWrapper.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Error, "*", "test").WithContinuation(continuation));
+            Assert.Equal(4, testTarget.WriteCount);
+            Assert.Equal(2, testTarget.FlushCount);
+        }
+
+        [Fact]
+        public void FlushTriggerWrapperMultipleWrappersTest()
+        {
+            var testTarget = new TestTarget();
+            var flushTriggerWrapperLevel = new FlushTriggerWrapper(testTarget);
+            flushTriggerWrapperLevel.Condition = "level > LogLevel.Info";
+            var flushTriggerWrapperMessage = new FlushTriggerWrapper(flushTriggerWrapperLevel);
+            flushTriggerWrapperMessage.Condition = "contains('${message}','FlushThis')";
+            testTarget.Initialize(null);
+            flushTriggerWrapperLevel.Initialize(null);
+            flushTriggerWrapperMessage.Initialize(null);
+
+            AsyncContinuation continuation = ex => { };
+            flushTriggerWrapperMessage.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Trace, "*", "test").WithContinuation(continuation));
+            Assert.Equal(1, testTarget.WriteCount);
+            Assert.Equal(0, testTarget.FlushCount);
+            flushTriggerWrapperMessage.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Fatal, "*", "test").WithContinuation(continuation));
+            Assert.Equal(2, testTarget.WriteCount);
+            Assert.Equal(1, testTarget.FlushCount);
+            flushTriggerWrapperMessage.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Trace, "*", "Please FlushThis").WithContinuation(continuation));
+            Assert.Equal(3, testTarget.WriteCount);
+            Assert.Equal(2, testTarget.FlushCount);
+        }
+
+
+        class TestTarget : Target
+        {
+            public int FlushCount { get; set; }
+            public int WriteCount { get; set; }
+
+            protected override void Write(LogEventInfo logEvent)
+            {
+                this.WriteCount++;
+            }
+
+            protected override void FlushAsync(AsyncContinuation asyncContinuation)
+            {
+                this.FlushCount++;
+                asyncContinuation(null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I needed a way to automatically flushing to a File target(autoflush=false, keepOpen=true, concurrentWrites=false), only for special LogLevels(>=Warn). 
After some research i have found this [idea](https://github.com/NLog/NLog/issues/1712) of FlushTriggerWrapper and implemented this wrapper.

fixes #1712

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1807)
<!-- Reviewable:end -->
