### PR TITLE
FileTarget - Close stale file handles outside archive mutex lock

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1819,6 +1819,11 @@ namespace NLog.Targets
             var archiveFile = this.GetArchiveFileName(fileName, ev, upcomingWriteSize);
             if (!string.IsNullOrEmpty(archiveFile))
             {
+                // Close possible stale file handles, before doing extra check
+                if (archiveFile != fileName)
+                    this.fileAppenderCache.InvalidateAppender(fileName);
+                this.fileAppenderCache.InvalidateAppender(archiveFile);
+
 #if SupportsMutex
                 Mutex archiveMutex = this.fileAppenderCache.GetArchiveMutex(fileName);
                 try
@@ -1836,10 +1841,6 @@ namespace NLog.Targets
                 try
                 {
                     // Check again if archive is needed. We could have been raced by another process
-                    //  - Close possible stale file handles, before doing extra check
-                    if (archiveFile != fileName)
-                        this.fileAppenderCache.InvalidateAppender(fileName);
-                    this.fileAppenderCache.InvalidateAppender(archiveFile);
                     var validatedArchiveFile = this.GetArchiveFileName(fileName, ev, upcomingWriteSize);
                     if (string.IsNullOrEmpty(validatedArchiveFile))
                     {


### PR DESCRIPTION
Will increase chance that all processes has released their handles before doing archive operation (Have verified that #1513 is still working)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1809)
<!-- Reviewable:end -->
