### PR TITLE
test for Callsite.cs--Show_correct_filename_with_async (issue #1805)

### DIFF
--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -666,6 +666,25 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
+        public void Show_correct_filename_with_async()
+        {
+
+            //namespace en name of current method
+            const string currentFileName = "CallSiteTests.cs";
+
+            LogManager.Configuration = CreateConfigurationFromString(@"
+           <nlog>
+               <targets><target name='debug' type='Debug' layout='${callsite:className=False:fileName=True:includeSourcePath=False:methodName=False}|${message}' /></targets>
+               <rules>
+                   <logger name='*' levels='Warn' writeTo='debug' />
+               </rules>
+           </nlog>");
+
+            AsyncMethod().Wait();
+            AssertDebugLastMessage("debug", string.Format("{0}|direct", currentFileName));
+        }
+
+        [Fact]
         public void Show_correct_method_with_async2()
         {
 


### PR DESCRIPTION
Callsite.cs not renders filename with layout
`${callsite:className=False:fileName=True:includeSourcePath=False:methodName=False}`

pulling test for it;

Other same problems in https://github.com/NLog/NLog/issues/1805#issuecomment-264672530

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1812)
<!-- Reviewable:end -->
