### PR TITLE
Improve [Obsolete] warnings - include the Nlog version when it became obsolete

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -74,8 +74,8 @@ namespace NLog.Config
         /// <summary>
         /// Use the old exception log handling of NLog 3.0? 
         /// </summary>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("This option will be removed in NLog 5. Marked obsolete before v4.3.11")]
+        /// <remarks>This method was marked as obsolete on NLog 4.1 and it may be removed in a future release.</remarks>
+        [Obsolete("This option will be removed in NLog 5. Marked obsolete on NLog 4.1")]
         public bool ExceptionLoggingOldStyle { get; set; }
 
         /// <summary>

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -74,7 +74,8 @@ namespace NLog.Config
         /// <summary>
         /// Use the old exception log handling of NLog 3.0? 
         /// </summary>
-        [Obsolete("This option will be removed in NLog 5")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("This option will be removed in NLog 5. Marked obsolete before v4.3.11")]
         public bool ExceptionLoggingOldStyle { get; set; }
 
         /// <summary>

--- a/src/NLog/GDC.cs
+++ b/src/NLog/GDC.cs
@@ -39,8 +39,8 @@ namespace NLog
     /// <summary>
     /// Global Diagnostics Context - used for log4net compatibility.
     /// </summary>
-    /// <remarks>This class was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-    [Obsolete("Use GlobalDiagnosticsContext class instead. Marked obsolete before v4.3.11")]
+    /// <remarks>This class was marked as obsolete on NLog 2.0 and it may be removed in a future release.</remarks>
+    [Obsolete("Use GlobalDiagnosticsContext class instead. Marked obsolete on NLog 2.0")]
     public static class GDC
     {
         /// <summary>

--- a/src/NLog/GDC.cs
+++ b/src/NLog/GDC.cs
@@ -39,7 +39,8 @@ namespace NLog
     /// <summary>
     /// Global Diagnostics Context - used for log4net compatibility.
     /// </summary>
-    [Obsolete("Use GlobalDiagnosticsContext instead")]
+    /// <remarks>This class was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+    [Obsolete("Use GlobalDiagnosticsContext class instead. Marked obsolete before v4.3.11")]
     public static class GDC
     {
         /// <summary>

--- a/src/NLog/ILogger.cs
+++ b/src/NLog/ILogger.cs
@@ -131,7 +131,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Trace(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Trace(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         void TraceException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -188,7 +189,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Trace(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Trace(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         void Trace([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -293,7 +295,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         void DebugException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -350,7 +353,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         void Debug([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -455,7 +459,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         void InfoException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -512,7 +517,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         void Info([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -617,7 +623,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         void WarnException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -674,7 +681,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         void Warn([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -779,7 +787,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         void ErrorException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -837,7 +846,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         void Error([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -942,7 +952,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         void FatalException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -999,7 +1010,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         void Fatal([Localizable(false)] string message, Exception exception);
 
         /// <summary>

--- a/src/NLog/ILoggerBase.cs
+++ b/src/NLog/ILoggerBase.cs
@@ -118,7 +118,8 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args)")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args) instead. Marked obsolete before v4.3.11")]
         void LogException(LogLevel level, [Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -174,7 +175,8 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args)")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args) instead. Marked obsolete before v4.3.11")]
         void Log(LogLevel level, [Localizable(false)] string message, Exception exception);
 
         /// <summary>

--- a/src/NLog/Internal/LoggerConfiguration.cs
+++ b/src/NLog/Internal/LoggerConfiguration.cs
@@ -59,7 +59,8 @@ namespace NLog.Internal
         /// <summary>
         /// Use the old exception log handling of NLog 3.0? 
         /// </summary>
-        [Obsolete("This option will be removed in NLog 5")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it  will be removed in NLog 5.</remarks>
+        [Obsolete("This property marked obsolete before v4.3.11 and it will be removed in NLog 5.")]
         public bool ExceptionLoggingOldStyle { get; private set; }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/EventContextLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EventContextLayoutRenderer.cs
@@ -41,9 +41,9 @@ namespace NLog.LayoutRenderers
     /// <summary>
     /// Log event context data.
     /// </summary>
-    /// <remarks>This class was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+    /// <remarks>This class was marked as obsolete on NLog 2.0 and it may be removed in a future release.</remarks>
     [LayoutRenderer("event-context")]
-    [Obsolete("Use EventPropertiesLayoutRenderer class instead. Marked obsolete before v4.3.11")]
+    [Obsolete("Use EventPropertiesLayoutRenderer class instead. Marked obsolete on NLog 2.0")]
     public class EventContextLayoutRenderer : LayoutRenderer
     {
         /// <summary>

--- a/src/NLog/LayoutRenderers/EventContextLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EventContextLayoutRenderer.cs
@@ -41,8 +41,9 @@ namespace NLog.LayoutRenderers
     /// <summary>
     /// Log event context data.
     /// </summary>
+    /// <remarks>This class was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
     [LayoutRenderer("event-context")]
-    [Obsolete("Use EventPropertiesLayoutRenderer instead.")]
+    [Obsolete("Use EventPropertiesLayoutRenderer class instead. Marked obsolete before v4.3.11")]
     public class EventContextLayoutRenderer : LayoutRenderer
     {
         /// <summary>

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -183,8 +183,8 @@ namespace NLog
         /// <summary>
         /// Gets the logger short name.
         /// </summary>
-        /// <remarks>This property was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("This property should not be used. Marked obsolete before v4.3.11")]
+        /// <remarks>This property was marked as obsolete on NLog 2.0 and it may be removed in a future release.</remarks>
+        [Obsolete("This property should not be used. Marked obsolete on NLog 2.0")]
         public string LoggerShortName
         {
             // NOTE: This property is not referenced by NLog code anymore. 
@@ -284,8 +284,8 @@ namespace NLog
         /// <summary>
         /// Gets the dictionary of per-event context properties.
         /// </summary>
-        /// <remarks>This property was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use LogEventInfo.Properties instead.  Marked obsolete before v4.3.11", true)]
+        /// <remarks>This property was marked as obsolete on NLog 2.0 and it may be removed in a future release.</remarks>
+        [Obsolete("Use LogEventInfo.Properties instead.  Marked obsolete on NLog 2.0", true)]
         public IDictionary Context
         {
             // NOTE: This propepery is not referenced in NLog code anymore. 

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -183,9 +183,11 @@ namespace NLog
         /// <summary>
         /// Gets the logger short name.
         /// </summary>
-        [Obsolete("This property should not be used.")]
+        /// <remarks>This property was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("This property should not be used. Marked obsolete before v4.3.11")]
         public string LoggerShortName
         {
+            // NOTE: This property is not referenced by NLog code anymore. 
             get
             {
                 int lastDot = this.LoggerName.LastIndexOf('.');
@@ -282,9 +284,11 @@ namespace NLog
         /// <summary>
         /// Gets the dictionary of per-event context properties.
         /// </summary>
-        [Obsolete("Use LogEventInfo.Properties instead.", true)]
+        /// <remarks>This property was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use LogEventInfo.Properties instead.  Marked obsolete before v4.3.11", true)]
         public IDictionary Context
         {
+            // NOTE: This propepery is not referenced in NLog code anymore. 
             get
             {
                 if (this.eventContextAdapter == null)
@@ -352,7 +356,8 @@ namespace NLog
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
         /// <returns>Instance of <see cref="LogEventInfo"/>.</returns>
-        [Obsolete("use Create(LogLevel logLevel, string loggerName, Exception exception, IFormatProvider formatProvider, string message)")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("use Create(LogLevel logLevel, string loggerName, Exception exception, IFormatProvider formatProvider, string message) instead. Marked obsolete before v4.3.11")]
         public static LogEventInfo Create(LogLevel logLevel, string loggerName, [Localizable(false)] string message, Exception exception)
         {
             return new LogEventInfo(logLevel, loggerName, null, message, null, exception);

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -621,10 +621,12 @@ namespace NLog
         /// <remarks>
         /// Logging is enabled if the number of <see cref="ResumeLogging"/> calls is greater than 
         /// or equal to <see cref="SuspendLogging"/> calls.
+        /// 
+        /// This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.
         /// </remarks>
         /// <returns>An object that implements IDisposable whose Dispose() method re-enables logging. 
         /// To be used with C# <c>using ()</c> statement.</returns>
-        [Obsolete("Use SuspendLogging() instead.")]
+        [Obsolete("Use SuspendLogging() instead. Marked obsolete before v4.3.11")]
         public IDisposable DisableLogging()
         {
             return SuspendLogging();
@@ -635,8 +637,11 @@ namespace NLog
         /// </summary>
         /// <remarks>
         /// Logging is enabled if the number of <see cref="ResumeLogging"/> calls is greater than 
-        /// or equal to <see cref="SuspendLogging"/> calls.</remarks>
-        [Obsolete("Use ResumeLogging() instead.")]
+        /// or equal to <see cref="SuspendLogging"/> calls.
+        /// 
+        /// This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.
+        /// </remarks>
+        [Obsolete("Use ResumeLogging() instead. Marked obsolete before v4.3.11")]
         public void EnableLogging()
         {
             ResumeLogging();

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -622,11 +622,11 @@ namespace NLog
         /// Logging is enabled if the number of <see cref="ResumeLogging"/> calls is greater than 
         /// or equal to <see cref="SuspendLogging"/> calls.
         /// 
-        /// This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.
+        /// This method was marked as obsolete on NLog 4.0 and it may be removed in a future release.
         /// </remarks>
         /// <returns>An object that implements IDisposable whose Dispose() method re-enables logging. 
         /// To be used with C# <c>using ()</c> statement.</returns>
-        [Obsolete("Use SuspendLogging() instead. Marked obsolete before v4.3.11")]
+        [Obsolete("Use SuspendLogging() instead. Marked obsolete on NLog 4.0")]
         public IDisposable DisableLogging()
         {
             return SuspendLogging();
@@ -639,9 +639,9 @@ namespace NLog
         /// Logging is enabled if the number of <see cref="ResumeLogging"/> calls is greater than 
         /// or equal to <see cref="SuspendLogging"/> calls.
         /// 
-        /// This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.
+        /// This method was marked as obsolete on NLog 4.0 and it may be removed in a future release.
         /// </remarks>
-        [Obsolete("Use ResumeLogging() instead. Marked obsolete before v4.3.11")]
+        [Obsolete("Use ResumeLogging() instead. Marked obsolete on NLog 4.0")]
         public void EnableLogging()
         {
             ResumeLogging();

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -62,7 +62,8 @@ namespace NLog
         /// <summary>
         /// Delegate used to set/get the culture in use.
         /// </summary>
-        [Obsolete]
+        /// <remarks>This delegate marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Marked obsolete before v4.3.11")]
         public delegate CultureInfo GetCultureInfo();
 
 #if !SILVERLIGHT && !MONO
@@ -183,7 +184,8 @@ namespace NLog
         /// <summary>
         /// Gets or sets the default culture to use.
         /// </summary>
-        [Obsolete("Use Configuration.DefaultCultureInfo property instead")]
+        /// <remarks>This property was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Configuration.DefaultCultureInfo property instead. Marked obsolete before v4.3.11")]
         public static GetCultureInfo DefaultCultureInfo
         {
             get { return () => factory.DefaultCultureInfo ?? CultureInfo.CurrentCulture; }

--- a/src/NLog/LogReceiverService/ILogReceiverClient.cs
+++ b/src/NLog/LogReceiverService/ILogReceiverClient.cs
@@ -40,10 +40,11 @@ namespace NLog.LogReceiverService
     /// <summary>
     /// Service contract for Log Receiver client.
     /// </summary>
+    /// <remarks>This class marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
 #if WCF_SUPPORTED
     [ServiceContract(Namespace = LogReceiverServiceConfig.WebServiceNamespace, ConfigurationName = "NLog.LogReceiverService.ILogReceiverClient")]
 #endif
-    [Obsolete("This may be removed in a future release.  Use ILogReceiverOneWayClient or ILogReceiverTwoWayClient.")]
+    [Obsolete("Use ILogReceiverOneWayClient or ILogReceiverTwoWayClient instead. Marked obsolete before v4.3.11 and it may be removed in a future release.")]
     public interface ILogReceiverClient
     {
         /// <summary>

--- a/src/NLog/LogReceiverService/WcfILogReceiverClient.cs
+++ b/src/NLog/LogReceiverService/WcfILogReceiverClient.cs
@@ -47,10 +47,13 @@ namespace NLog.LogReceiverService
     /// Log Receiver Client using WCF.
     /// </summary>
     /// <remarks>
-    /// This will be removed when ILogReceiverClient is removed.
-    /// This provides an implementation of the legacy interface.</remarks>
+    /// This class marked as obsolete before NLog 4.3.11 and it will be removed in a future release.  
+    /// 
+    /// It provides an implementation of the legacy interface and it will be completely obsolete when the 
+    /// ILogReceiverClient is removed.
+    /// </remarks>
 #pragma warning disable 612, 618
-    [Obsolete("This may be removed in a future release.  Use WcfLogReceiverOneWayClient.")]
+    [Obsolete("Use WcfLogReceiverOneWayClient class instead. Marked obsolete before v4.3.11 and it may be removed in a future release.")]
     public sealed class WcfILogReceiverClient : WcfLogReceiverClientBase<ILogReceiverClient>, ILogReceiverClient
 #pragma warning restore 612, 618
     {

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -177,7 +177,8 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Log(LogLevel, String, Exception) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Log(LogLevel, String, Exception) method instead. Marked obsolete before v4.3.11")]
         public void LogException(LogLevel level, [Localizable(false)] string message, Exception exception)
         {
             this.Log(level, message, exception);
@@ -232,7 +233,8 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args)")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args) instead. Marked obsolete before v4.3.11")]
         public void Log(LogLevel level, [Localizable(false)] string message, Exception exception)
         {
             if (this.IsEnabled(level))
@@ -572,7 +574,7 @@ namespace NLog
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), logEvent, this.Factory);
         }
 
-        [Obsolete("Use WriteToTargets(Exception ex, LogLevel level, IFormatProvider formatProvider, string message, object[] args) method instead.")]
+        [Obsolete("Use WriteToTargets(Exception ex, LogLevel level, IFormatProvider formatProvider, string message, object[] args) method instead. Marked obsolete before v4.3.11")]
         internal void WriteToTargets(LogLevel level, [Localizable(false)] string message, Exception ex)
         {
             LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, message, ex)), this.Factory);

--- a/src/NLog/Logger1.cs
+++ b/src/NLog/Logger1.cs
@@ -151,7 +151,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Trace(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Trace(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         public void TraceException([Localizable(false)] string message, Exception exception)
         {
             this.Trace(message, exception); 
@@ -203,6 +204,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
         [Obsolete("Use Trace(Exception exception, string message, params object[] args) method instead.")]
         public void Trace([Localizable(false)] string message, Exception exception)
         {
@@ -435,7 +437,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         public void DebugException([Localizable(false)] string message, Exception exception)
         {
             this.Debug(message, exception); 
@@ -487,7 +490,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         public void Debug([Localizable(false)] string message, Exception exception)
         {
             if (this.IsDebugEnabled)
@@ -719,7 +723,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         public void InfoException([Localizable(false)] string message, Exception exception)
         {
             this.Info(message, exception); 
@@ -771,7 +776,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         public void Info([Localizable(false)] string message, Exception exception)
         {
             if (this.IsInfoEnabled)
@@ -1003,7 +1009,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         public void WarnException([Localizable(false)] string message, Exception exception)
         {
             this.Warn(message, exception); 
@@ -1055,7 +1062,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         public void Warn([Localizable(false)] string message, Exception exception)
         {
             if (this.IsWarnEnabled)
@@ -1287,7 +1295,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         public void ErrorException([Localizable(false)] string message, Exception exception)
         {
             this.Error(message, exception); 
@@ -1339,7 +1348,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         public void Error([Localizable(false)] string message, Exception exception)
         {
             if (this.IsErrorEnabled)
@@ -1571,7 +1581,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         public void FatalException([Localizable(false)] string message, Exception exception)
         {
             this.Fatal(message, exception); 
@@ -1623,7 +1634,8 @@ namespace NLog
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead.")]
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
         public void Fatal([Localizable(false)] string message, Exception exception)
         {
             if (this.IsFatalEnabled)

--- a/src/NLog/MDC.cs
+++ b/src/NLog/MDC.cs
@@ -39,8 +39,8 @@ namespace NLog
     /// <summary>
     /// Mapped Diagnostics Context - used for log4net compatibility.
     /// </summary>
-    /// <remarks>This class marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-    [Obsolete("Use MappedDiagnosticsContext class instead. Marked obsolete before v4.3.11")]
+    /// <remarks>This class marked as obsolete before NLog 2.0 and it may be removed in a future release.</remarks>
+    [Obsolete("Use MappedDiagnosticsContext class instead. Marked obsolete on NLog 2.0")]
     public static class MDC
     {
         /// <summary>

--- a/src/NLog/MDC.cs
+++ b/src/NLog/MDC.cs
@@ -39,7 +39,8 @@ namespace NLog
     /// <summary>
     /// Mapped Diagnostics Context - used for log4net compatibility.
     /// </summary>
-    [Obsolete("Use MappedDiagnosticsContext instead")]
+    /// <remarks>This class marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+    [Obsolete("Use MappedDiagnosticsContext class instead. Marked obsolete before v4.3.11")]
     public static class MDC
     {
         /// <summary>

--- a/src/NLog/NDC.cs
+++ b/src/NLog/NDC.cs
@@ -38,7 +38,8 @@ namespace NLog
     /// <summary>
     /// Nested Diagnostics Context - for log4net compatibility.
     /// </summary>
-    [Obsolete("Use NestedDiagnosticsContext")]
+    /// <remarks>This class marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+    [Obsolete("Use NestedDiagnosticsContext class instead. Marked obsolete before v4.3.11")]
     public static class NDC
     {
         /// <summary>

--- a/src/NLog/NDC.cs
+++ b/src/NLog/NDC.cs
@@ -38,8 +38,8 @@ namespace NLog
     /// <summary>
     /// Nested Diagnostics Context - for log4net compatibility.
     /// </summary>
-    /// <remarks>This class marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-    [Obsolete("Use NestedDiagnosticsContext class instead. Marked obsolete before v4.3.11")]
+    /// <remarks>This class marked as obsolete on NLog 2.0 and it may be removed in a future release.</remarks>
+    [Obsolete("Use NestedDiagnosticsContext class instead. Marked obsolete on NLog 2.0")]
     public static class NDC
     {
         /// <summary>

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -185,7 +185,7 @@ namespace NLog.Targets
         /// This option was removed in NLog 4.0 because the logging code always runs outside of transaction. 
         /// This ensures that the log gets written to the database if you rollback the main transaction because of an error and want to log the error.
         /// </remarks>
-        [Obsolete("Obsolete - value will be ignored - logging code always runs outside of transaction. Marked obsolete on NLog 4.0 and it will be removed in NLog 6.")]
+        [Obsolete("Value will be ignored as logging code always executes outside of a transaction. Marked obsolete on NLog 4.0 and it will be removed in NLog 6.")]
         public bool? UseTransactions { get; set; }
 
         /// <summary>

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -185,7 +185,7 @@ namespace NLog.Targets
         /// This option was removed in NLog 4.0 because the logging code always runs outside of transaction. 
         /// This ensures that the log gets written to the database if you rollback the main transaction because of an error and want to log the error.
         /// </remarks>
-        [Obsolete("Obsolete - value will be ignored - logging code always runs outside of transaction. Will be removed in NLog 6.")]
+        [Obsolete("Obsolete - value will be ignored - logging code always runs outside of transaction. Marked obsolete on NLog 4.0 and it will be removed in NLog 6.")]
         public bool? UseTransactions { get; set; }
 
         /// <summary>
@@ -323,7 +323,7 @@ namespace NLog.Targets
             if (UseTransactions.HasValue)
 #pragma warning restore 618
             {
-                InternalLogger.Warn("UseTransactions is obsolete and will not be used - will be removed in NLog 6");
+                InternalLogger.Warn("UseTransactions property is obsolete and will not be used - will be removed in NLog 6");
             }
 
             bool foundProvider = false;

--- a/src/NLog/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog/Targets/LogReceiverWebServiceTarget.cs
@@ -352,8 +352,8 @@ namespace NLog.Targets
         /// Inheritors can override this method and provide their own 
         /// service configuration - binding and endpoint address
         /// </summary>
-        /// <returns></returns>
-        [Obsolete("Ths may be removed in a future release.  Use CreateLogReceiver.")]
+        /// <remarks>This method marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use CreateLogReceiver instead. Marked obsolete before v4.3.11 and it may be removed in a future release.")]
         protected virtual WcfLogReceiverClient CreateWcfLogReceiverClient()
         {
             WcfLogReceiverClient client;


### PR DESCRIPTION
Document on XML comment as well as the [Obsolete] attribute the NLog
version where a class, method or property was marked as obsolete.

This might help in the future releases to evaluate if an element should
be removed completely from the code and it provides the users with more
information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1814)
<!-- Reviewable:end -->
