### PR TITLE
Better parsing for Layouts with int/bool type.

### DIFF
--- a/src/NLog/Internal/LayoutHelpers-generated.cs
+++ b/src/NLog/Internal/LayoutHelpers-generated.cs
@@ -1,0 +1,145 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+ 
+
+using System;
+using System.Globalization;
+using NLog.Common;
+using NLog.Layouts;
+
+namespace NLog.Internal
+{
+    internal static class LayoutHelpers
+    {
+        
+        /// <summary>
+        /// Render the event info as parse as <c>short</c>
+        /// </summary>
+        /// <param name="layout">current layout</param>
+        /// <param name="logEvent"></param>
+        /// <param name="defaultValue">default value when the render </param>
+        /// <param name="layoutName">layout name for log message to internal log when logging fails</param>
+        /// <returns></returns>
+        public static short RenderShort(this Layout layout, LogEventInfo logEvent, short defaultValue, string layoutName)
+        {
+            if (layout == null)
+            {
+                InternalLogger.Debug(layoutName + " is null so default value of " + defaultValue);
+                return defaultValue;
+            }
+            if (logEvent == null)
+            {
+                InternalLogger.Debug(layoutName + ": logEvent is null so default value of " + defaultValue);
+                return defaultValue;
+            }
+
+            var rendered = layout.Render(logEvent);
+            short result;
+  
+            // NumberStyles.Integer is default of Convert.ToInt16
+            // CultureInfo.InvariantCulture is backwardscomp.
+            if (!short.TryParse(rendered, NumberStyles.Integer, CultureInfo.InvariantCulture, out result)) 
+            {
+                InternalLogger.Warn(layoutName + ": parse of value '" + rendered + "' failed, return " + defaultValue);
+                return defaultValue;
+            }
+            return result;
+        }
+        
+        /// <summary>
+        /// Render the event info as parse as <c>int</c>
+        /// </summary>
+        /// <param name="layout">current layout</param>
+        /// <param name="logEvent"></param>
+        /// <param name="defaultValue">default value when the render </param>
+        /// <param name="layoutName">layout name for log message to internal log when logging fails</param>
+        /// <returns></returns>
+        public static int RenderInt(this Layout layout, LogEventInfo logEvent, int defaultValue, string layoutName)
+        {
+            if (layout == null)
+            {
+                InternalLogger.Debug(layoutName + " is null so default value of " + defaultValue);
+                return defaultValue;
+            }
+            if (logEvent == null)
+            {
+                InternalLogger.Debug(layoutName + ": logEvent is null so default value of " + defaultValue);
+                return defaultValue;
+            }
+
+            var rendered = layout.Render(logEvent);
+            int result;
+  
+            // NumberStyles.Integer is default of Convert.ToInt16
+            // CultureInfo.InvariantCulture is backwardscomp.
+            if (!int.TryParse(rendered, NumberStyles.Integer, CultureInfo.InvariantCulture, out result)) 
+            {
+                InternalLogger.Warn(layoutName + ": parse of value '" + rendered + "' failed, return " + defaultValue);
+                return defaultValue;
+            }
+            return result;
+        }
+        
+        /// <summary>
+        /// Render the event info as parse as <c>bool</c>
+        /// </summary>
+        /// <param name="layout">current layout</param>
+        /// <param name="logEvent"></param>
+        /// <param name="defaultValue">default value when the render </param>
+        /// <param name="layoutName">layout name for log message to internal log when logging fails</param>
+        /// <returns></returns>
+        public static bool RenderBool(this Layout layout, LogEventInfo logEvent, bool defaultValue, string layoutName)
+        {
+            if (layout == null)
+            {
+                InternalLogger.Debug(layoutName + " is null so default value of " + defaultValue);
+                return defaultValue;
+            }
+            if (logEvent == null)
+            {
+                InternalLogger.Debug(layoutName + ": logEvent is null so default value of " + defaultValue);
+                return defaultValue;
+            }
+
+            var rendered = layout.Render(logEvent);
+            bool result;
+  
+            if (!bool.TryParse(rendered, out result)) 
+            {
+                InternalLogger.Warn(layoutName + ": parse of value '" + rendered + "' failed, return " + defaultValue);
+                return defaultValue;
+            }
+            return result;
+        }
+    }
+}

--- a/src/NLog/Internal/LayoutHelpers.tt
+++ b/src/NLog/Internal/LayoutHelpers.tt
@@ -1,0 +1,99 @@
+﻿<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<# 
+    //Render all Render and parse methods
+    //T4 templates are built in Visual Studio. See https://msdn.microsoft.com/en-us/library/bb126445.aspx
+#>// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+ 
+
+using System;
+using System.Globalization;
+using NLog.Common;
+using NLog.Layouts;
+
+namespace NLog.Internal
+{
+    internal static class LayoutHelpers
+    {
+<#
+    var types = new HashSet<string> { "short", "int", "bool" };
+    var numericTypes = new HashSet<string> { "short", "int"};
+
+    foreach(var type in types)
+    { 
+
+       var typeCapitalize  = char.ToUpper(type[0]) + type.Substring(1);
+#>
+        
+        /// <summary>
+        /// Render the event info as parse as <c><#=type#></c>
+        /// </summary>
+        /// <param name="layout">current layout</param>
+        /// <param name="logEvent"></param>
+        /// <param name="defaultValue">default value when the render </param>
+        /// <param name="layoutName">layout name for log message to internal log when logging fails</param>
+        /// <returns></returns>
+        public static <#=type#> Render<#=typeCapitalize#>(this Layout layout, LogEventInfo logEvent, <#=type#> defaultValue, string layoutName)
+        {
+            if (layout == null)
+            {
+                InternalLogger.Debug(layoutName + " is null so default value of " + defaultValue);
+                return defaultValue;
+            }
+            if (logEvent == null)
+            {
+                InternalLogger.Debug(layoutName + ": logEvent is null so default value of " + defaultValue);
+                return defaultValue;
+            }
+
+            var rendered = layout.Render(logEvent);
+            <#=type#> result;
+<# if (numericTypes.Contains(type)) {  #>  
+            // NumberStyles.Integer is default of Convert.ToInt16
+            // CultureInfo.InvariantCulture is backwardscomp.
+            if (!<#=type#>.TryParse(rendered, NumberStyles.Integer, CultureInfo.InvariantCulture, out result)) 
+<# } else {  #>  
+            if (!<#=type#>.TryParse(rendered, out result)) 
+<# } 
+#>            {
+                InternalLogger.Warn(layoutName + ": parse of value '" + rendered + "' failed, return " + defaultValue);
+                return defaultValue;
+            }
+            return result;
+        }
+<#  } #>
+    }
+}

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -32,6 +32,7 @@
 // 
 
 using System;
+using System.Collections.Generic;
 
 namespace NLog.Layouts
 {
@@ -138,6 +139,7 @@ namespace NLog.Layouts
                 this.isInitialized = true;
                 this.InitializeLayout();
             }
+
 
             return this.GetFormattedMessage(logEvent);
         }

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -154,6 +154,11 @@
     <Compile Include="Internal\ISmtpClient.cs" />
     <Compile Include="Internal\ISupportsInitialize.cs" />
     <Compile Include="Internal\IUsesStackTrace.cs" />
+    <Compile Include="Internal\LayoutHelpers-generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LayoutHelpers.tt</DependentUpon>
+    </Compile>
     <Compile Include="Internal\LocalizableAttribute.cs" />
     <Compile Include="Internal\LoggerConfiguration.cs" />
     <Compile Include="Internal\MultiFileWatcher.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -151,6 +151,11 @@
     <Compile Include="Internal\ISmtpClient.cs" />
     <Compile Include="Internal\ISupportsInitialize.cs" />
     <Compile Include="Internal\IUsesStackTrace.cs" />
+    <Compile Include="Internal\LayoutHelpers-generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LayoutHelpers.tt</DependentUpon>
+    </Compile>
     <Compile Include="Internal\LocalizableAttribute.cs" />
     <Compile Include="Internal\LoggerConfiguration.cs" />
     <Compile Include="Internal\MultiFileWatcher.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -164,6 +164,11 @@
     <Compile Include="Internal\ISmtpClient.cs" />
     <Compile Include="Internal\ISupportsInitialize.cs" />
     <Compile Include="Internal\IUsesStackTrace.cs" />
+    <Compile Include="Internal\LayoutHelpers-generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LayoutHelpers.tt</DependentUpon>
+    </Compile>
     <Compile Include="Internal\LocalizableAttribute.cs" />
     <Compile Include="Internal\LoggerConfiguration.cs" />
     <Compile Include="Internal\MultiFileWatcher.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -170,6 +170,11 @@
     <Compile Include="Internal\ISmtpClient.cs" />
     <Compile Include="Internal\ISupportsInitialize.cs" />
     <Compile Include="Internal\IUsesStackTrace.cs" />
+    <Compile Include="Internal\LayoutHelpers-generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LayoutHelpers.tt</DependentUpon>
+    </Compile>
     <Compile Include="Internal\LocalizableAttribute.cs" />
     <Compile Include="Internal\LoggerConfiguration.cs" />
     <Compile Include="Internal\MultiFileWatcher.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -164,6 +164,11 @@
     <Compile Include="Internal\ISmtpClient.cs" />
     <Compile Include="Internal\ISupportsInitialize.cs" />
     <Compile Include="Internal\IUsesStackTrace.cs" />
+    <Compile Include="Internal\LayoutHelpers-generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LayoutHelpers.tt</DependentUpon>
+    </Compile>
     <Compile Include="Internal\LocalizableAttribute.cs" />
     <Compile Include="Internal\LoggerConfiguration.cs" />
     <Compile Include="Internal\MultiFileWatcher.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -164,6 +164,11 @@
     <Compile Include="Internal\ISmtpClient.cs" />
     <Compile Include="Internal\ISupportsInitialize.cs" />
     <Compile Include="Internal\IUsesStackTrace.cs" />
+    <Compile Include="Internal\LayoutHelpers-generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LayoutHelpers.tt</DependentUpon>
+    </Compile>
     <Compile Include="Internal\LocalizableAttribute.cs" />
     <Compile Include="Internal\LoggerConfiguration.cs" />
     <Compile Include="Internal\MultiFileWatcher.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -169,6 +170,11 @@
     <Compile Include="Internal\ISmtpClient.cs" />
     <Compile Include="Internal\ISupportsInitialize.cs" />
     <Compile Include="Internal\IUsesStackTrace.cs" />
+    <Compile Include="Internal\LayoutHelpers-generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LayoutHelpers.tt</DependentUpon>
+    </Compile>
     <Compile Include="Internal\LocalizableAttribute.cs" />
     <Compile Include="Internal\LoggerConfiguration.cs" />
     <Compile Include="Internal\MultiFileWatcher.cs" />
@@ -442,6 +448,12 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Internal\LayoutHelpers.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>LayoutHelpers-generated.cs</LastGenOutput>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(StyleCopTargetsFile)" Condition="Exists('$(StyleCopTargetsFile)')" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -171,6 +171,11 @@
     <Compile Include="Internal\ISmtpClient.cs" />
     <Compile Include="Internal\ISupportsInitialize.cs" />
     <Compile Include="Internal\IUsesStackTrace.cs" />
+    <Compile Include="Internal\LayoutHelpers-generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LayoutHelpers.tt</DependentUpon>
+    </Compile>
     <Compile Include="Internal\LocalizableAttribute.cs" />
     <Compile Include="Internal\LoggerConfiguration.cs" />
     <Compile Include="Internal\MultiFileWatcher.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -168,6 +168,11 @@
     <Compile Include="Internal\ISmtpClient.cs" />
     <Compile Include="Internal\ISupportsInitialize.cs" />
     <Compile Include="Internal\IUsesStackTrace.cs" />
+    <Compile Include="Internal\LayoutHelpers-generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LayoutHelpers.tt</DependentUpon>
+    </Compile>
     <Compile Include="Internal\LocalizableAttribute.cs" />
     <Compile Include="Internal\LoggerConfiguration.cs" />
     <Compile Include="Internal\MultiFileWatcher.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -167,6 +167,11 @@
     <Compile Include="Internal\ISmtpClient.cs" />
     <Compile Include="Internal\ISupportsInitialize.cs" />
     <Compile Include="Internal\IUsesStackTrace.cs" />
+    <Compile Include="Internal\LayoutHelpers-generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LayoutHelpers.tt</DependentUpon>
+    </Compile>
     <Compile Include="Internal\LocalizableAttribute.cs" />
     <Compile Include="Internal\LoggerConfiguration.cs" />
     <Compile Include="Internal\MultiFileWatcher.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -167,6 +167,11 @@
     <Compile Include="Internal\ISmtpClient.cs" />
     <Compile Include="Internal\ISupportsInitialize.cs" />
     <Compile Include="Internal\IUsesStackTrace.cs" />
+    <Compile Include="Internal\LayoutHelpers-generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LayoutHelpers.tt</DependentUpon>
+    </Compile>
     <Compile Include="Internal\LocalizableAttribute.cs" />
     <Compile Include="Internal\LoggerConfiguration.cs" />
     <Compile Include="Internal\MultiFileWatcher.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -192,6 +192,11 @@
     <Compile Include="Internal\ISmtpClient.cs" />
     <Compile Include="Internal\ISupportsInitialize.cs" />
     <Compile Include="Internal\IUsesStackTrace.cs" />
+    <Compile Include="Internal\LayoutHelpers-generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LayoutHelpers.tt</DependentUpon>
+    </Compile>
     <Compile Include="Internal\LocalizableAttribute.cs" />
     <Compile Include="Internal\LoggerConfiguration.cs" />
     <Compile Include="Internal\MultiFileWatcher.cs" />

--- a/src/NLog/ProjectFileInfo.xml
+++ b/src/NLog/ProjectFileInfo.xml
@@ -68,6 +68,25 @@
     <Generator>TextTemplatingFileGenerator</Generator>
     <LastGenOutput>InternalLogger-generated.cs</LastGenOutput>
   </Customize>
+  
+    
+  <FileSet Name="LayoutHelpers.tt-result">
+    <Include File="Internal\LayoutHelpers-generated.cs" />
+  </FileSet>
+  <Customize FileSet="LayoutHelpers.tt-result" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <AutoGen>True</AutoGen>
+    <DesignTime>True</DesignTime>
+    <DependentUpon>LayoutHelpers.tt</DependentUpon>
+  </Customize>
+  
+  <FileSet Name="LayoutHelpers.tt">
+    <Include File="Internal\LayoutHelpers.tt" />
+  </FileSet>
+  <Customize FileSet="LayoutHelpers.tt" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Generator>TextTemplatingFileGenerator</Generator>
+    <LastGenOutput>LayoutHelpers-generated.cs</LastGenOutput>
+  </Customize>
+
 
   <Project File="NLog.sl4.csproj">
     <ItemGroup Name="Compile">
@@ -86,6 +105,7 @@
     <ItemGroup Name="None" KeepOldFiles="true">
       <FileSet Include="Logger.tt" />
       <FileSet Include="InternalLogger.tt" />
+      <FileSet Include="LayoutHelpers.tt" />
     </ItemGroup>
   </Project>
 
@@ -96,6 +116,7 @@
     <ItemGroup Name="None" KeepOldFiles="true">
       <FileSet Include="Logger.tt" />
       <FileSet Include="InternalLogger.tt" />
+      <FileSet Include="LayoutHelpers.tt" />
     </ItemGroup>
     <ItemGroup Name="EmbeddedResource">
       <FileSet Include="AllResources" />
@@ -109,6 +130,7 @@
     <ItemGroup Name="None" KeepOldFiles="true">
       <FileSet Include="Logger.tt" />
       <FileSet Include="InternalLogger.tt" />
+      <FileSet Include="LayoutHelpers.tt" />
     </ItemGroup>
     <ItemGroup Name="EmbeddedResource">
       <FileSet Include="AllResources" />
@@ -122,6 +144,7 @@
     <ItemGroup Name="None" KeepOldFiles="true">
       <FileSet Include="Logger.tt" />
       <FileSet Include="InternalLogger.tt" />
+      <FileSet Include="LayoutHelpers.tt" />
     </ItemGroup>
     <ItemGroup Name="EmbeddedResource">
       <FileSet Include="AllResources" />
@@ -135,6 +158,7 @@
     <ItemGroup Name="None" KeepOldFiles="true">
       <FileSet Include="Logger.tt" />
       <FileSet Include="InternalLogger.tt" />
+      <FileSet Include="LayoutHelpers.tt" />
     </ItemGroup>
     <ItemGroup Name="EmbeddedResource">
       <FileSet Include="AllResources" />
@@ -148,6 +172,7 @@
     <ItemGroup Name="None" KeepOldFiles="true">
       <FileSet Include="Logger.tt" />
       <FileSet Include="InternalLogger.tt" />
+      <FileSet Include="LayoutHelpers.tt" />
     </ItemGroup>
     <ItemGroup Name="EmbeddedResource">
       <FileSet Include="AllResources" />
@@ -161,6 +186,7 @@
     <ItemGroup Name="None" KeepOldFiles="true">
       <FileSet Include="Logger.tt" />
       <FileSet Include="InternalLogger.tt" />
+      <FileSet Include="LayoutHelpers.tt" />
     </ItemGroup>
     <ItemGroup Name="EmbeddedResource">
       <FileSet Include="AllResources" />
@@ -174,6 +200,7 @@
     <ItemGroup Name="None" KeepOldFiles="true">
       <FileSet Include="Logger.tt" />
       <FileSet Include="InternalLogger.tt" />
+      <FileSet Include="LayoutHelpers.tt" />
     </ItemGroup>
   </Project>
 
@@ -184,6 +211,7 @@
     <ItemGroup Name="None" KeepOldFiles="true">
       <FileSet Include="Logger.tt" />
       <FileSet Include="InternalLogger.tt" />
+      <FileSet Include="LayoutHelpers.tt" />
     </ItemGroup>
   </Project>
 
@@ -194,6 +222,7 @@
     <ItemGroup Name="None" KeepOldFiles="true">
       <FileSet Include="Logger.tt" />
       <FileSet Include="InternalLogger.tt" />
+      <FileSet Include="LayoutHelpers.tt" />
     </ItemGroup>
     <ItemGroup Name="EmbeddedResource">
       <FileSet Include="AllResources" />
@@ -207,6 +236,7 @@
     <ItemGroup Name="None" KeepOldFiles="true">
       <FileSet Include="Logger.tt" />
       <FileSet Include="InternalLogger.tt" />
+      <FileSet Include="LayoutHelpers.tt" />
     </ItemGroup>
     <ItemGroup Name="EmbeddedResource">
       <FileSet Include="AllResources" />

--- a/tests/NLog.UnitTests/Internal/LayoutHelpersTests.cs
+++ b/tests/NLog.UnitTests/Internal/LayoutHelpersTests.cs
@@ -1,0 +1,151 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NLog.Internal;
+using NLog.Layouts;
+using Xunit;
+using Xunit.Extensions;
+
+namespace NLog.UnitTests.Internal
+{
+    public class LayoutHelpersTests
+    {
+        private string _eventPropertiesLayout;
+
+        /// <summary>
+        /// int.MaxValue:    2,147,483,647
+        /// </summary>
+        private const int DefaultInt = int.MinValue;
+
+        /// <summary>
+        /// short.MaxValue:  32767
+        /// </summary>
+        private const short DefaultShort = short.MinValue;
+
+
+        [Theory]
+        [InlineData("4", 4)]
+        [InlineData(" 4", 4)] //spaces
+        [InlineData("4 ", 4)]
+        [InlineData("-4", -4)] //neg
+        [InlineData(" -4", -4)]
+        [InlineData(" -4 ", -4)]
+        [InlineData("4.0 ", DefaultInt)] //no (thousand) separators
+        [InlineData("4,000 ", DefaultInt)] //no (thousand) separators
+        [InlineData("2147483647", int.MaxValue)]
+        [InlineData("2147483648", DefaultInt)] //overflow
+        [InlineData("", DefaultInt)]
+        [InlineData(null, DefaultInt)]
+        public void TestRenderInt(string input, int expected)
+        {
+            _eventPropertiesLayout = "${event-properties:val}";
+            Layout layout = _eventPropertiesLayout;
+            var result = layout.RenderInt(CreateLogEvent(input), DefaultInt, "event-properties");
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("4", (short)4)]
+        [InlineData(" 4", (short)4)] //spaces
+        [InlineData("4 ", (short)4)]
+        [InlineData("4.0", DefaultShort)]  //no (thousand) separators
+        [InlineData("4,0", DefaultShort)]  //no (thousand) separators
+        [InlineData("2147483647", DefaultShort)] //overflow
+        [InlineData("2147483648", DefaultShort)] //overflow
+        [InlineData("32768", DefaultShort)] //overflow
+        [InlineData("32767", short.MaxValue)]
+        [InlineData("", DefaultShort)]
+        [InlineData(null, DefaultShort)]
+
+        public void TestRenderShort(string input, short expected)
+        {
+            _eventPropertiesLayout = "${event-properties:val}";
+            Layout layout = _eventPropertiesLayout;
+            var result = layout.RenderShort(CreateLogEvent(input), DefaultShort, "event-properties");
+            Assert.Equal(expected, result);
+        }
+
+
+        /// <summary>
+        /// test with both default. True or false, case insentive, no numbers
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="expected">null = default</param>
+        [Theory]
+        [InlineData("4", null)]
+        [InlineData("1", null)]
+        [InlineData("0", null)]
+        [InlineData("-1", null)]
+        [InlineData("true", true)]
+        [InlineData("true ", true)]
+        [InlineData(" true ", true)]
+        [InlineData(" True ", true)]
+        [InlineData(" TRUE ", true)]
+        [InlineData("false", false)]
+        [InlineData("false ", false)]
+        [InlineData(" false ", false)]
+        [InlineData(" False ", false)]
+        [InlineData(" FALSE ", false)]
+        [InlineData(" DALSE ", null)]
+        
+        public void TestRenderBool(string input, bool? expected)
+        {
+            _eventPropertiesLayout = "${event-properties:val}";
+            Layout layout = _eventPropertiesLayout;
+            //test with default=false
+            {
+                const bool defaultValue = false;
+                var result1 = layout.RenderBool(CreateLogEvent(input), defaultValue, "event-properties");
+                Assert.Equal(expected ?? defaultValue, result1);
+            }
+            //test with default=true
+            {
+                const bool defaultValue = true;
+                var result2 = layout.RenderBool(CreateLogEvent(input), defaultValue, "event-properties");
+                Assert.Equal(expected ?? defaultValue, result2);
+            }
+        }
+
+        private static LogEventInfo CreateLogEvent(string input)
+        {
+            var logEvent = new LogEventInfo();
+            logEvent.Properties["val"] = input;
+            return logEvent;
+        }
+    }
+}

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
     <Compile Include="Internal\FilePathLayoutTests.cs" />
+    <Compile Include="Internal\LayoutHelpersTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\PlatformDetectorTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
     <Compile Include="Internal\FilePathLayoutTests.cs" />
+    <Compile Include="Internal\LayoutHelpersTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\PlatformDetectorTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
     <Compile Include="Internal\FilePathLayoutTests.cs" />
+    <Compile Include="Internal\LayoutHelpersTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\PlatformDetectorTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Internal\ExceptionHelperTests.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCacheTests.cs" />
     <Compile Include="Internal\FilePathLayoutTests.cs" />
+    <Compile Include="Internal\LayoutHelpersTests.cs" />
     <Compile Include="Internal\NetworkSenders\TcpNetworkSenderTests.cs" />
     <Compile Include="Internal\NetworkSenders\UdpNetworkSenderTests.cs" />
     <Compile Include="Internal\PlatformDetectorTests.cs" />


### PR DESCRIPTION

Added helpers layout.RenderInt, RenderBool and RenderShort

included logging to internal logger

in the future maybe throwing also exception

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1815)
<!-- Reviewable:end -->
