### PR TITLE
EventLogTarget: don't crash with invalid Category / EventId

### DIFF
--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -246,19 +246,9 @@ namespace NLog.Targets
 
             EventLogEntryType entryType = GetEntryType(logEvent);
 
-            int eventId = 0;
+            int eventId = this.EventId.RenderInt(logEvent, 0, "EventLogTarget.EventId");
 
-            if (this.EventId != null)
-            {
-                eventId = Convert.ToInt32(this.EventId.Render(logEvent), CultureInfo.InvariantCulture);
-            }
-
-            short category = 0;
-
-            if (this.Category != null)
-            {
-                category = Convert.ToInt16(this.Category.Render(logEvent), CultureInfo.InvariantCulture);
-            }
+            short category = this.EventId.RenderShort(logEvent, 0, "EventLogTarget.Category");
 
             EventLog eventLog = GetEventLog(logEvent);
 


### PR DESCRIPTION
dependent of https://github.com/NLog/NLog/pull/1815

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1816)
<!-- Reviewable:end -->
