### PR TITLE
Move mutex functionality into BaseMutexFileAppender

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -31,28 +31,15 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__ANDROID__ && !__IOS__
-// Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) 
-#define SupportsMutex
-#endif
-
 namespace NLog.Internal.FileAppenders
 {
     using System;
     using System.IO;
     using System.Runtime.InteropServices;
     using System.Security;
-    using System.Threading;
-    using System.Text;
 
     using NLog.Common;
     using NLog.Internal;
-
-#if SupportsMutex
-    using System.Security.AccessControl;
-    using System.Security.Principal;
-    using System.Security.Cryptography;
-#endif
 
     /// <summary>
     /// Base class for optimized file appenders.
@@ -74,10 +61,6 @@ namespace NLog.Internal.FileAppenders
             this.OpenTime = DateTime.UtcNow; // to be consistent with timeToKill in FileTarget.AutoClosingTimerCallback
             this.LastWriteTime = DateTime.MinValue;
             this.CaptureLastWriteTime = createParameters.CaptureLastWriteTime;
-#if SupportsMutex
-           
-            this.ArchiveMutex = CreateArchiveMutex();
-#endif
         }
 
         protected bool CaptureLastWriteTime { get; private set; }
@@ -114,14 +97,6 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         /// <value>The file creation parameters.</value>
         public ICreateFileParameters CreateFileParameters { get; private set; }
-
-#if !SILVERLIGHT
-        /// <summary>
-        /// Gets the mutually-exclusive lock for archiving files.
-        /// </summary>
-        /// <value>The mutex for archiving.</value>
-        public Mutex ArchiveMutex { get; private set; }
-#endif
 
         /// <summary>
         /// Writes the specified bytes.
@@ -199,78 +174,6 @@ namespace NLog.Internal.FileAppenders
         {
             this.LastWriteTime = dateTime;
         }
-
-#if SupportsMutex
-        /// <summary>
-        /// Creates a mutually-exclusive lock for archiving files.
-        /// </summary>
-        /// <returns>A <see cref="Mutex"/> object which can be used for controlling the archiving of files.</returns>
-        protected virtual Mutex CreateArchiveMutex()
-        {
-            return new Mutex();
-        }
-
-        /// <summary>
-        /// Creates a mutex for archiving that is sharable by more than one process.
-        /// </summary>
-        /// <returns>A <see cref="Mutex"/> object which can be used for controlling the archiving of files.</returns>
-        protected Mutex CreateSharableArchiveMutex()
-        {
-            return CreateSharableMutex("FileArchiveLock");
-        }
-
-        /// <summary>
-        /// Creates a mutex that is sharable by more than one process.
-        /// </summary>
-        /// <param name="mutexNamePrefix">The prefix to use for the name of the mutex.</param>
-        /// <returns>A <see cref="Mutex"/> object which is sharable by multiple processes.</returns>
-        protected Mutex CreateSharableMutex(string mutexNamePrefix)
-        {
-            // Creates a mutex sharable by more than one process
-            var mutexSecurity = new MutexSecurity();
-            var everyoneSid = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
-            mutexSecurity.AddAccessRule(new MutexAccessRule(everyoneSid, MutexRights.FullControl, AccessControlType.Allow));
-
-            // The constructor will either create new mutex or open
-            // an existing one, in a thread-safe manner
-            bool createdNew;
-            return new Mutex(false, GetMutexName(mutexNamePrefix), out createdNew, mutexSecurity);
-        }
-
-        private string GetMutexName(string mutexNamePrefix)
-        {
-            const string mutexNameFormatString = @"Global\NLog-File{0}-{1}";
-            const int maxMutexNameLength = 260;
-
-            string canonicalName = Path.GetFullPath(FileName).ToLowerInvariant();
-
-            // Mutex names must not contain a backslash, it's the namespace separator,
-            // but all other are OK
-            canonicalName = canonicalName.Replace('\\', '/');
-            string mutexName = string.Format(mutexNameFormatString, mutexNamePrefix, canonicalName);
-
-            // A mutex name must not exceed MAX_PATH (260) characters
-            if (mutexName.Length <= maxMutexNameLength)
-            {
-                return mutexName;
-            }
-
-            // The unusual case of the path being too long; let's hash the canonical name,
-            // so it can be safely shortened and still remain unique
-            string hash;
-            using (MD5 md5 = MD5.Create())
-            {
-                byte[] bytes = md5.ComputeHash(Encoding.UTF8.GetBytes(canonicalName));
-                hash = Convert.ToBase64String(bytes);
-            }
-
-            // The hash makes the name unique, but also add the end of the path,
-            // so the end of the name tells us which file it is (for debugging)
-            mutexName = string.Format(mutexNameFormatString, mutexNamePrefix, hash);
-            int cutOffIndex = canonicalName.Length - (maxMutexNameLength - mutexName.Length);
-            return mutexName + canonicalName.Substring(cutOffIndex);
-        }
-#endif
 
         /// <summary>
         /// Creates the file stream.

--- a/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
@@ -48,9 +48,13 @@ namespace NLog.Internal.FileAppenders
     using System.Security.AccessControl;
     using System.Security.Principal;
     using System.Security.Cryptography;
+#endif
 
     /// <summary>
-    /// Base class for optimized file appenders which require the usage of a mutex.
+    /// Base class for optimized file appenders which require the usage of a mutex. 
+    /// 
+    /// It is possible to use this class as replacement of BaseFileAppender and the mutex functionality 
+    /// is not enforced to the implementing subclasses.
     /// </summary>
     [SecuritySafeCritical]
     internal abstract class BaseMutexFileAppender : BaseFileAppender
@@ -63,7 +67,9 @@ namespace NLog.Internal.FileAppenders
         public BaseMutexFileAppender(string fileName, ICreateFileParameters createParameters) 
             : base(fileName, createParameters)
         {
+#if SupportsMutex
             ArchiveMutex = CreateArchiveMutex();
+#endif
         }
 
 #if !SILVERLIGHT
@@ -74,6 +80,7 @@ namespace NLog.Internal.FileAppenders
         public Mutex ArchiveMutex { get; private set; }
 #endif
 
+#if SupportsMutex
         /// <summary>
         /// Creates a mutually-exclusive lock for archiving files.
         /// </summary>
@@ -143,6 +150,6 @@ namespace NLog.Internal.FileAppenders
             int cutOffIndex = canonicalName.Length - (maxMutexNameLength - mutexName.Length);
             return mutexName + canonicalName.Substring(cutOffIndex);
         }
-    }
 #endif
+    }
 }

--- a/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
@@ -1,0 +1,148 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if !SILVERLIGHT && !__ANDROID__ && !__IOS__
+// Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) 
+#define SupportsMutex
+#endif
+
+namespace NLog.Internal.FileAppenders
+{
+    using System;
+    using System.IO;
+    using System.Security;
+    using System.Threading;
+    using System.Text;
+
+#if SupportsMutex
+    using System.Security.AccessControl;
+    using System.Security.Principal;
+    using System.Security.Cryptography;
+
+    /// <summary>
+    /// Base class for optimized file appenders which require the usage of a mutex.
+    /// </summary>
+    [SecuritySafeCritical]
+    internal abstract class BaseMutexFileAppender : BaseFileAppender
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseMutexFileAppender" /> class.
+        /// </summary>
+        /// <param name="fileName">Name of the file.</param>
+        /// <param name="createParameters">The create parameters.</param>
+        public BaseMutexFileAppender(string fileName, ICreateFileParameters createParameters) 
+            : base(fileName, createParameters)
+        {
+            ArchiveMutex = CreateArchiveMutex();
+        }
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// Gets the mutually-exclusive lock for archiving files.
+        /// </summary>
+        /// <value>The mutex for archiving.</value>
+        public Mutex ArchiveMutex { get; private set; }
+#endif
+
+        /// <summary>
+        /// Creates a mutually-exclusive lock for archiving files.
+        /// </summary>
+        /// <returns>A <see cref="Mutex"/> object which can be used for controlling the archiving of files.</returns>
+        protected virtual Mutex CreateArchiveMutex()
+        {
+            return new Mutex();
+        }
+
+        /// <summary>
+        /// Creates a mutex for archiving that is sharable by more than one process.
+        /// </summary>
+        /// <returns>A <see cref="Mutex"/> object which can be used for controlling the archiving of files.</returns>
+        protected Mutex CreateSharableArchiveMutex()
+        {
+            return CreateSharableMutex("FileArchiveLock");
+        }
+
+        /// <summary>
+        /// Creates a mutex that is sharable by more than one process.
+        /// </summary>
+        /// <param name="mutexNamePrefix">The prefix to use for the name of the mutex.</param>
+        /// <returns>A <see cref="Mutex"/> object which is sharable by multiple processes.</returns>
+        protected Mutex CreateSharableMutex(string mutexNamePrefix)
+        {
+            // Creates a mutex sharable by more than one process
+            var mutexSecurity = new MutexSecurity();
+            var everyoneSid = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+            mutexSecurity.AddAccessRule(new MutexAccessRule(everyoneSid, MutexRights.FullControl, AccessControlType.Allow));
+
+            // The constructor will either create new mutex or open
+            // an existing one, in a thread-safe manner
+            bool createdNew;
+            return new Mutex(false, GetMutexName(mutexNamePrefix), out createdNew, mutexSecurity);
+        }
+
+        private string GetMutexName(string mutexNamePrefix)
+        {
+            const string mutexNameFormatString = @"Global\NLog-File{0}-{1}";
+            const int maxMutexNameLength = 260;
+
+            string canonicalName = Path.GetFullPath(FileName).ToLowerInvariant();
+
+            // Mutex names must not contain a backslash, it's the namespace separator,
+            // but all other are OK
+            canonicalName = canonicalName.Replace('\\', '/');
+            string mutexName = string.Format(mutexNameFormatString, mutexNamePrefix, canonicalName);
+
+            // A mutex name must not exceed MAX_PATH (260) characters
+            if (mutexName.Length <= maxMutexNameLength)
+            {
+                return mutexName;
+            }
+
+            // The unusual case of the path being too long; let's hash the canonical name,
+            // so it can be safely shortened and still remain unique
+            string hash;
+            using (MD5 md5 = MD5.Create())
+            {
+                byte[] bytes = md5.ComputeHash(Encoding.UTF8.GetBytes(canonicalName));
+                hash = Convert.ToBase64String(bytes);
+            }
+
+            // The hash makes the name unique, but also add the end of the path,
+            // so the end of the name tells us which file it is (for debugging)
+            mutexName = string.Format(mutexNameFormatString, mutexNamePrefix, hash);
+            int cutOffIndex = canonicalName.Length - (maxMutexNameLength - mutexName.Length);
+            return mutexName + canonicalName.Substring(cutOffIndex);
+        }
+    }
+#endif
+}

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -309,7 +309,7 @@ namespace NLog.Internal.FileAppenders
 #if SupportsMutex
         public Mutex GetArchiveMutex(string fileName)
         {
-            var appender = GetAppender(fileName);
+            var appender = GetAppender(fileName) as BaseMutexFileAppender;
             return appender == null ? null : appender.ArchiveMutex;
         }
 #endif

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -58,7 +58,7 @@ namespace NLog.Internal.FileAppenders
     /// (global named mutex is used for this)
     /// </remarks>
     [SecuritySafeCritical]
-    internal class MutexMultiProcessFileAppender : BaseFileAppender
+    internal class MutexMultiProcessFileAppender : BaseMutexFileAppender
     {
         public static readonly IFileAppenderFactory TheFactory = new Factory();
 

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -48,7 +48,7 @@ namespace NLog.Internal.FileAppenders
     /// to get exclusive write access and retries if it's not available.
     /// </summary>
     [SecuritySafeCritical]
-    internal class RetryingMultiProcessFileAppender : BaseFileAppender
+    internal class RetryingMultiProcessFileAppender : BaseMutexFileAppender
     {
         public static readonly IFileAppenderFactory TheFactory = new Factory();
 

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Internal\Fakeables\AppDomainWrapper.cs" />
     <Compile Include="Internal\Fakeables\IAppDomain.cs" />
     <Compile Include="Internal\FileAppenders\BaseFileAppender.cs" />
+    <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />


### PR DESCRIPTION
Most of the subclasses of BaseFileAppender are using only a subset of its functionality. There are only two classes require the mutex functionality. Therefore, the mutex functionality is moved into a new abstract class (BaseMutexFileAppender) to re-enforce the single responsibility principle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1841)
<!-- Reviewable:end -->
