### PR TITLE
AsyncTargetWrapper - Flush should start immediately without waiting

### DIFF
--- a/src/NLog/Common/AsyncHelpers.cs
+++ b/src/NLog/Common/AsyncHelpers.cs
@@ -92,21 +92,21 @@ namespace NLog.Common
             int remaining = repeatCount;
 
             invokeNext = ex =>
+            {
+                if (ex != null)
                 {
-                    if (ex != null)
-                    {
-                        asyncContinuation(ex);
-                        return;
-                    }
+                    asyncContinuation(ex);
+                    return;
+                }
 
-                    if (remaining-- <= 0)
-                    {
-                        asyncContinuation(null);
-                        return;
-                    }
+                if (remaining-- <= 0)
+                {
+                    asyncContinuation(null);
+                    return;
+                }
 
-                    action(PreventMultipleCalls(invokeNext));
-                };
+                action(PreventMultipleCalls(invokeNext));
+            };
 
             invokeNext(null);
         }
@@ -178,31 +178,45 @@ namespace NLog.Common
 
             AsyncContinuation continuation =
                 ex =>
+                {
+                    InternalLogger.Trace("Continuation invoked: {0}", ex);
+                    int r;
+
+                    if (ex != null)
                     {
-                        InternalLogger.Trace("Continuation invoked: {0}", ex);
-                        int r;
-
-                        if (ex != null)
+                        lock (exceptions)
                         {
-                            lock (exceptions)
-                            {
-                                exceptions.Add(ex);
-                            }
+                            exceptions.Add(ex);
                         }
+                    }
 
-                        r = Interlocked.Decrement(ref remaining);
-                        InternalLogger.Trace("Parallel task completed. {0} items remaining", r);
-                        if (r == 0)
-                        {
-                            asyncContinuation(GetCombinedException(exceptions));
-                        }
-                    };
+                    r = Interlocked.Decrement(ref remaining);
+                    InternalLogger.Trace("Parallel task completed. {0} items remaining", r);
+                    if (r == 0)
+                    {
+                        asyncContinuation(GetCombinedException(exceptions));
+                    }
+                };
 
             foreach (T item in items)
             {
                 T itemCopy = item;
 
-                ThreadPool.QueueUserWorkItem(s => action(itemCopy, PreventMultipleCalls(continuation)));
+                ThreadPool.QueueUserWorkItem(s =>
+                {
+                    try
+                    {
+                        action(itemCopy, PreventMultipleCalls(continuation));
+                    }
+                    catch (Exception ex)
+                    {
+                        InternalLogger.Error(ex, "ForEachItemInParallel - Unhandled Exception");
+                        if (ex.MustBeRethrownImmediately())
+                        {
+                            throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
+                        }
+                    }
+                });
             }
         }
 

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -367,35 +367,6 @@ namespace NLog.Targets
             }
         }
 
-        internal void WriteAsyncLogEvents(AsyncLogEventInfo[] logEventInfos, AsyncContinuation continuation)
-        {
-            if (logEventInfos.Length == 0)
-            {
-                continuation(null);
-            }
-            else
-            {
-                var wrappedLogEventInfos = new AsyncLogEventInfo[logEventInfos.Length];
-                int remaining = logEventInfos.Length;
-                for (int i = 0; i < logEventInfos.Length; ++i)
-                {
-                    AsyncContinuation originalContinuation = logEventInfos[i].Continuation;
-                    AsyncContinuation wrappedContinuation = ex =>
-                                                                {
-                                                                    originalContinuation(ex);
-                                                                    if (0 == Interlocked.Decrement(ref remaining))
-                                                                    {
-                                                                        continuation(null);
-                                                                    }
-                                                                };
-
-                    wrappedLogEventInfos[i] = logEventInfos[i].LogEvent.WithContinuation(wrappedContinuation);
-                }
-
-                this.WriteAsyncLogEvents(wrappedLogEventInfos);
-            }
-        }
-
         /// <summary>
         /// Releases unmanaged and - optionally - managed resources.
         /// </summary>

--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
@@ -497,7 +497,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                     s =>
                     {
                         while (0 != this.PendingWriteCount)
-                            Thread.Sleep(1);
+                            Thread.Sleep(10);
                         asyncContinuation(null);
                     });
             }


### PR DESCRIPTION
AsyncTargetWrapper has the following changes:

- FlushAsync now schedules an "instant" QueueUserWorkItem, instead of waiting for the time-thread-event. Instead of waiting for all LogEvents to be written, then explicit Flush is called on WrappedTarget right after having written all pending logevents.  (minor breaking change)
   - This means that putting a BufferingTargetWrapper inside "targets async=true" will no longer cause the AsyncTargetWrapper to wait for the BufferingTargetWrapper-flush-delay.
    - This also means that Targets with broken Flush-method (not keeping track of pending logevents) will not get help from the AsyncTargetWrapper during flush.
- CloseTarget now flushes all pending messages (instead of just the first BatchSize). CloseTarget-caller was also blocking before, so not much change here.

BufferingTargetWrapper has the following changes:

- FlushAsync now lets the WrappedTarget decide when it has flushed. Instead of waiting for all LogEvents to be written and then call explicit Flush on WrappedTarget. Flush-caller was also blocked before, so not much change here.
    - This also means that Targets with broken Flush-method (not keeping track of pending logevents) will not get help from the BufferingTargetWrapper during flush.
- CloseTarget now flushes any pending messages (minor breaking change, if not bugfix)
- Do not hold Target.SyncRoot while writing messages on Timer-thread (Performance)

Reasons for these changes:
- Closer alignment of AsyncTargetWrapper and BufferingTargetWrapper
- Refactoring to increase the chance of making an instant flush on shutdown, without blocking the finalizer thread too much so it is terminated without anything written (See also #1846)
- Could consider to change AsyncTargetWrapper.FlushAsync to perform synchrone flush instead of ThreadPool.QueueUserWorkItem, but then it would be a major breaking change, as the Flush-caller would be blocked while executing all the writes. (Would avoid spinning up new threads during shutdown, though this is already done by LogFactory.Flush)

Related issues in this area: #134 and #214

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1853)
<!-- Reviewable:end -->
