### PR TITLE
FileTarget - Reopen filehandle when file write fails

### DIFF
--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -92,6 +92,7 @@ namespace NLog.Internal.FileAppenders
                 }
                 catch (Exception ex)
                 {
+                    // Swallow exception as the file-stream now is in final state (broken instead of closed)
                     InternalLogger.Warn(ex, "Failed to close file: '{0}'", FileName);
                 }
                 finally
@@ -111,14 +112,7 @@ namespace NLog.Internal.FileAppenders
                 return;
             }
 
-            try
-            {
-                this.file.Flush();
-            }
-            catch (Exception ex)
-            {
-                throw new System.IO.IOException("FileStream Flush Failed: " + FileName, ex);
-            }
+            this.file.Flush();
             FileTouched();
         }
 
@@ -162,15 +156,8 @@ namespace NLog.Internal.FileAppenders
                 return;
             }
 
-            try
-            {
-                this.currentFileLength += bytes.Length;
-                this.file.Write(bytes, 0, bytes.Length);
-            }
-            catch (Exception ex)
-            {
-                throw new System.IO.IOException("FileStream Write Failed: " + FileName, ex);
-            }
+            this.currentFileLength += bytes.Length;
+            this.file.Write(bytes, 0, bytes.Length);
 
             if (CaptureLastWriteTime)
             {

--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -94,6 +94,7 @@ namespace NLog.Internal.FileAppenders
                 {
                     // Swallow exception as the file-stream now is in final state (broken instead of closed)
                     InternalLogger.Warn(ex, "Failed to close file: '{0}'", FileName);
+                    System.Threading.Thread.Sleep(1);   // Artificial delay to avoid hammering a bad file location
                 }
                 finally
                 {

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -41,6 +41,7 @@ namespace NLog.Internal.FileAppenders
     using System;
     using System.IO;
     using System.Threading;
+    using NLog.Common;
 
     /// <summary>
     /// Maintains a collection of file appenders usually associated with file targets.
@@ -319,7 +320,18 @@ namespace NLog.Internal.FileAppenders
             var appender = GetAppender(filePath);
             DateTime? result = null;
             if (appender != null)
-                result = appender.GetFileCreationTimeUtc();
+            {
+                try
+                {
+                    result = appender.GetFileCreationTimeUtc();
+                }
+                catch (Exception ex)
+                {
+                    InternalLogger.Error(ex, "Failed to get file creation time for file '{0}'.", appender.FileName);
+                    InvalidateAppender(appender.FileName);
+                    throw;
+                }
+            }                
             if (result == null && fallback)
             {
                 var fileInfo = new FileInfo(filePath);
@@ -337,7 +349,18 @@ namespace NLog.Internal.FileAppenders
             var appender = GetAppender(filePath);
             DateTime? result = null;
             if (appender != null)
-                result = appender.GetFileLastWriteTimeUtc();
+            {
+                try
+                {
+                    result = appender.GetFileLastWriteTimeUtc();
+                }
+                catch (Exception ex)
+                {
+                    InternalLogger.Error(ex, "Failed to get last write time for file '{0}'.", appender.FileName);
+                    InvalidateAppender(appender.FileName);
+                    throw;
+                }
+            }
             if (result == null && fallback)
             {
                 var fileInfo = new FileInfo(filePath);
@@ -355,7 +378,18 @@ namespace NLog.Internal.FileAppenders
             var appender = GetAppender(filePath);
             long? result = null;
             if (appender != null)
-                result = appender.GetFileLength();
+            {
+                try
+                {
+                    result = appender.GetFileLength();
+                }
+                catch (Exception ex)
+                {
+                    InternalLogger.Error(ex, "Failed to get length for file '{0}'.", appender.FileName);
+                    InvalidateAppender(appender.FileName);
+                    throw;
+                }
+            }
             if (result == null && fallback)
             {
                 var fileInfo = new FileInfo(filePath);

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -129,6 +129,10 @@ namespace NLog.Internal.FileAppenders
                     FileTouched();
                 }
             }
+            catch (Exception ex)
+            {
+                throw new System.IO.IOException("FileStream Write Failed: " + FileName, ex);
+            }
             finally
             {
                 this.mutex.ReleaseMutex();
@@ -143,16 +147,36 @@ namespace NLog.Internal.FileAppenders
             InternalLogger.Trace("Closing '{0}'", FileName);
             if (this.mutex != null)
             {
-                this.mutex.Close();
+                try
+                {
+                    this.mutex.Close();
+                }
+                catch (Exception ex)
+                {
+                    InternalLogger.Warn(ex, "Failed to close mutex: '{0}'", FileName);
+                }
+                finally
+                {
+                    this.mutex = null;
+                }
             }
 
             if (this.fileStream != null)
             {
-                this.fileStream.Close();
+                try
+                {
+                    this.fileStream.Close();
+                }
+                catch (Exception ex)
+                {
+                    InternalLogger.Warn(ex, "Failed to close file: '{0}'", FileName);
+                }
+                finally
+                {
+                    this.fileStream = null;
+                }
             }
 
-            this.mutex = null;
-            this.fileStream = null;
             FileTouched();
         }
 

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -103,7 +103,7 @@ namespace NLog.Internal.FileAppenders
         /// <param name="bytes">The bytes to be written.</param>
         public override void Write(byte[] bytes)
         {
-            if (this.mutex == null)
+            if (this.mutex == null || this.fileStream == null)
             {
                 return;
             }
@@ -129,10 +129,6 @@ namespace NLog.Internal.FileAppenders
                     FileTouched();
                 }
             }
-            catch (Exception ex)
-            {
-                throw new System.IO.IOException("FileStream Write Failed: " + FileName, ex);
-            }
             finally
             {
                 this.mutex.ReleaseMutex();
@@ -153,6 +149,7 @@ namespace NLog.Internal.FileAppenders
                 }
                 catch (Exception ex)
                 {
+                    // Swallow exception as the mutex now is in final state (abandoned instead of closed)
                     InternalLogger.Warn(ex, "Failed to close mutex: '{0}'", FileName);
                 }
                 finally
@@ -169,6 +166,7 @@ namespace NLog.Internal.FileAppenders
                 }
                 catch (Exception ex)
                 {
+                    // Swallow exception as the file-stream now is in final state (broken instead of closed)
                     InternalLogger.Warn(ex, "Failed to close file: '{0}'", FileName);
                 }
                 finally

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -83,7 +83,15 @@ namespace NLog.Internal.FileAppenders
                 return;
             }
 
-            this.file.Write(bytes, 0, bytes.Length);
+            try
+            {
+                this.file.Write(bytes, 0, bytes.Length);
+            }
+            catch (Exception ex)
+            {
+                throw new System.IO.IOException("FileStream Write Failed: " + FileName, ex);
+            }
+            
             if (CaptureLastWriteTime)
             {
                 FileTouched();
@@ -100,7 +108,14 @@ namespace NLog.Internal.FileAppenders
                 return;
             }
 
-            this.file.Flush();
+            try
+            {
+                this.file.Flush();
+            }
+            catch (Exception ex)
+            {
+                throw new System.IO.IOException("FileStream Flush Failed: " + FileName, ex);
+            }
             FileTouched();
         }
 
@@ -115,8 +130,18 @@ namespace NLog.Internal.FileAppenders
             }
 
             InternalLogger.Trace("Closing '{0}'", FileName);
-            this.file.Close();
-            this.file = null;
+            try
+            {
+                this.file.Close();
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Warn(ex, "Failed to close file '{0}'", FileName);
+            }
+            finally
+            {
+                this.file = null;
+            }
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -124,6 +124,7 @@ namespace NLog.Internal.FileAppenders
             {
                 // Swallow exception as the file-stream now is in final state (broken instead of closed)
                 InternalLogger.Warn(ex, "Failed to close file '{0}'", FileName);
+                System.Threading.Thread.Sleep(1);   // Artificial delay to avoid hammering a bad file location
             }
             finally
             {

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -83,14 +83,7 @@ namespace NLog.Internal.FileAppenders
                 return;
             }
 
-            try
-            {
-                this.file.Write(bytes, 0, bytes.Length);
-            }
-            catch (Exception ex)
-            {
-                throw new System.IO.IOException("FileStream Write Failed: " + FileName, ex);
-            }
+            this.file.Write(bytes, 0, bytes.Length);
             
             if (CaptureLastWriteTime)
             {
@@ -108,14 +101,7 @@ namespace NLog.Internal.FileAppenders
                 return;
             }
 
-            try
-            {
-                this.file.Flush();
-            }
-            catch (Exception ex)
-            {
-                throw new System.IO.IOException("FileStream Flush Failed: " + FileName, ex);
-            }
+            this.file.Flush();
             FileTouched();
         }
 

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -122,6 +122,7 @@ namespace NLog.Internal.FileAppenders
             }
             catch (Exception ex)
             {
+                // Swallow exception as the file-stream now is in final state (broken instead of closed)
                 InternalLogger.Warn(ex, "Failed to close file '{0}'", FileName);
             }
             finally

--- a/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
@@ -124,6 +124,7 @@ namespace NLog.Internal.FileAppenders
             }
             catch (Exception ex)
             {
+                // Swallow exception as the file-stream now is in final state (broken instead of closed)
                 InternalLogger.Warn(ex, "Failed to close file '{0}'", FileName);
             }
             finally

--- a/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
@@ -126,6 +126,7 @@ namespace NLog.Internal.FileAppenders
             {
                 // Swallow exception as the file-stream now is in final state (broken instead of closed)
                 InternalLogger.Warn(ex, "Failed to close file '{0}'", FileName);
+                System.Threading.Thread.Sleep(1);   // Artificial delay to avoid hammering a bad file location
             }
             finally
             {

--- a/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
@@ -106,7 +106,15 @@ namespace NLog.Internal.FileAppenders
         {
             if (this.file == null)
                 return;
-            this.file.Write(bytes, 0, bytes.Length);
+
+            try
+            {
+                this.file.Write(bytes, 0, bytes.Length);
+            }
+            catch (Exception ex)
+            {
+                throw new System.IO.IOException("FileStream Write Failed: " + FileName, ex);
+            }
         }
 
         /// <summary>
@@ -117,8 +125,18 @@ namespace NLog.Internal.FileAppenders
             if (this.file == null)
                 return;
             InternalLogger.Trace("Closing '{0}'", FileName);
-            this.file.Close();
-            this.file = null;
+            try
+            {
+                this.file.Close();
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Warn(ex, "Failed to close file '{0}'", FileName);
+            }
+            finally
+            {
+                this.file = null;
+            }
         }
         
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
@@ -107,14 +107,7 @@ namespace NLog.Internal.FileAppenders
             if (this.file == null)
                 return;
 
-            try
-            {
-                this.file.Write(bytes, 0, bytes.Length);
-            }
-            catch (Exception ex)
-            {
-                throw new System.IO.IOException("FileStream Write Failed: " + FileName, ex);
-            }
+            this.file.Write(bytes, 0, bytes.Length);
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
@@ -158,7 +158,14 @@ namespace NLog.Internal.FileAppenders
         {
             if (fileStream != null)
             {
-                fileStream.Write(bytes, 0, bytes.Length);
+                try
+                {
+                    fileStream.Write(bytes, 0, bytes.Length);
+                }
+                catch (Exception ex)
+                {
+                    throw new System.IO.IOException("FileStream Write Failed: " + FileName, ex);
+                }
 
                 if (CaptureLastWriteTime)
                 {
@@ -173,9 +180,19 @@ namespace NLog.Internal.FileAppenders
         public override void Close()
         {
             InternalLogger.Trace("Closing '{0}'", FileName);
-            if (fileStream != null)
-                fileStream.Dispose();
-            fileStream = null;
+            try
+            {
+                if (fileStream != null)
+                    fileStream.Dispose();
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Warn(ex, "Failed to close file '{0}'", FileName);
+            }
+            finally
+            {
+                fileStream = null;
+            }
             FileTouched();
         }
 

--- a/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
@@ -181,6 +181,7 @@ namespace NLog.Internal.FileAppenders
             catch (Exception ex)
             {
                 InternalLogger.Warn(ex, "Failed to close file '{0}'", FileName);
+                System.Threading.Thread.Sleep(1);   // Artificial delay to avoid hammering a bad file location
             }
             finally
             {

--- a/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
@@ -158,14 +158,7 @@ namespace NLog.Internal.FileAppenders
         {
             if (fileStream != null)
             {
-                try
-                {
-                    fileStream.Write(bytes, 0, bytes.Length);
-                }
-                catch (Exception ex)
-                {
-                    throw new System.IO.IOException("FileStream Write Failed: " + FileName, ex);
-                }
+                fileStream.Write(bytes, 0, bytes.Length);
 
                 if (CaptureLastWriteTime)
                 {

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -2071,13 +2071,13 @@ namespace NLog.Targets
             bool writeHeader = InitializeFile(fileName, logEvent, justData);
             BaseFileAppender appender = this.fileAppenderCache.AllocateAppender(fileName);
 
-            if (writeHeader)
-            {
-                this.WriteHeader(appender);
-            }
-
             try
             {
+                if (writeHeader)
+                {
+                    this.WriteHeader(appender);
+                }
+
                 appender.Write(bytes);
 
                 if (this.AutoFlush)


### PR DESCRIPTION
Making FileTarget more resilient to disconnecting network drives, or forceful close of file handles. See also #1856

It is certainly not a perfect solution, as the FileStream will continue to work until the buffer is full, causing the unwritten buffer to be discarded on failure.

Also there is no throttle on error, but I guess that is for another PR. To have a wrapper that take a pauses every second, while hammering (Before it would not hit the disk/network again, but just keep failing internally. But I guess one should always use the RetryingMultiProcessFileAppender for network drives).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1858)
<!-- Reviewable:end -->
