### PR TITLE
FileAppenderCache implements IDisposable

### DIFF
--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -45,7 +45,7 @@ namespace NLog.Internal.FileAppenders
     /// <summary>
     /// Maintains a collection of file appenders usually associated with file targets.
     /// </summary>
-    internal sealed class FileAppenderCache
+    internal sealed class FileAppenderCache : IDisposable
     {
         private BaseFileAppender[] appenders;
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
@@ -401,6 +401,13 @@ namespace NLog.Internal.FileAppenders
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
             externalFileArchivingWatcher.StopWatching();
+#endif
+        }
+
+        public void Dispose()
+        {
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+            externalFileArchivingWatcher.Dispose();
 #endif
         }
     }


### PR DESCRIPTION
IDisposable is implemented by FileAppenderCache class according to Microsoft recommendations "CA1001: Types that own disposable fields should be disposable".

Non-breaking change as the class is internal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1860)
<!-- Reviewable:end -->
