### PR TITLE
FileTarget - RetryingMultiProcessFileAppender should use BufferSize=1024

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -176,7 +176,6 @@ namespace NLog.Targets
 #else
             this.Encoding = Encoding.Default;
 #endif
-            this.BufferSize = 32768;
             this.AutoFlush = true;
 #if !SILVERLIGHT
             this.FileAttributes = Win32FileAttributes.Normal;
@@ -437,7 +436,8 @@ namespace NLog.Targets
         /// </summary>
         /// <docgen category='Performance Tuning Options' order='10' />
         [DefaultValue(32768)]
-        public int BufferSize { get; set; }
+        public int BufferSize { get { return bufferSize ?? (!IsInitialized || (KeepFileOpen && !NetworkWrites) ? 32768 : 1024); } set { bufferSize = value; } }
+        private int? bufferSize;
 
         /// <summary>
         /// Gets or sets the file encoding.


### PR DESCRIPTION
| Logger Name      | Messages   | Size | Threads | Loggers |
|------------------|------------|------|---------|---------|
| PerfSyncLogger   |     10.000 |   16 |       1 |       1 |

| BufferSize  | Time (ms) | Msgs/sec  | GC2 | GC1 | GC0 | CPU (ms) | Mem (MB) |
|------------|-----------|-----------|-----|-----|-----|----------|----------|
| 32768      |    26.918 |       371 |   0 |   1 |  22 |    3.312 |   36,332 |
| 4096    |    26.745 |       373 |   0 |   0 |   3 |    3.203 |   35,680 |
| 1024    |    26.433 |       378 |   0 |   0 |   1 |    3.093 |   35,496 |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1864)
<!-- Reviewable:end -->
