### PR TITLE
WebServiceTarget - FlushAsync - Avoid premature flush

### DIFF
--- a/src/NLog/Internal/AsyncOperationCounter.cs
+++ b/src/NLog/Internal/AsyncOperationCounter.cs
@@ -86,7 +86,7 @@ namespace NLog.Internal
         /// <returns>AsyncContinuation operation</returns>
         public AsyncContinuation RegisterCompletionNotification(AsyncContinuation asyncContinuation)
         {
-            if (this._pendingOperationCounter == 0)
+            if (_pendingOperationCounter == 0)
             {
                 return asyncContinuation;
             }
@@ -101,7 +101,7 @@ namespace NLog.Internal
                     int remainingCompletionCounter = System.Threading.Interlocked.Increment(ref _pendingOperationCounter);
                     if (remainingCompletionCounter <= 0)
                     {
-                        System.Threading.Interlocked.Exchange(ref this._pendingOperationCounter, 0);
+                        System.Threading.Interlocked.Exchange(ref _pendingOperationCounter, 0);
                         _pendingCompletionList.Remove(pendingCompletion);
                         return asyncContinuation;
                     }

--- a/src/NLog/Internal/AsyncOperationCounter.cs
+++ b/src/NLog/Internal/AsyncOperationCounter.cs
@@ -1,0 +1,142 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal
+{
+    using System;
+    using System.Collections.Generic;
+    using NLog.Common;
+
+    /// <summary>
+    /// Keeps track of pending operation count, and can notify when pending operation count reaches zero
+    /// </summary>
+    internal class AsyncOperationCounter
+    {
+        private int _pendingOperationCounter;
+        private readonly LinkedList<AsyncContinuation> _pendingCompletionList = new LinkedList<AsyncContinuation>();
+
+        /// <summary>
+        /// Mark operation has started
+        /// </summary>
+        public void BeginOperation()
+        {
+            System.Threading.Interlocked.Increment(ref _pendingOperationCounter);
+        }
+
+        /// <summary>
+        /// Mark operation has completed
+        /// </summary>
+        /// <param name="exception">Exception coming from the completed operation [optional]</param>
+        public void CompleteOperation(Exception exception)
+        { 
+            if (_pendingCompletionList.Count > 0)
+            {
+                lock (_pendingCompletionList)
+                {
+                    System.Threading.Interlocked.Decrement(ref _pendingOperationCounter);
+                    var nodeNext = _pendingCompletionList.First;
+                    while (nodeNext != null)
+                    {
+                        var nodeValue = nodeNext.Value;
+                        nodeNext = nodeNext.Next;
+                        nodeValue(exception);  // Will modify _pendingCompletionList
+                    }
+                }
+            }
+            else
+            {
+                System.Threading.Interlocked.Decrement(ref _pendingOperationCounter);
+            }
+        }
+
+        /// <summary>
+        /// Registers an AsyncContinuation to be called when all pending operations have completed
+        /// </summary>
+        /// <param name="asyncContinuation">Invoked on completion</param>
+        /// <returns>AsyncContinuation operation</returns>
+        public AsyncContinuation RegisterCompletionNotification(AsyncContinuation asyncContinuation)
+        {
+            if (this._pendingOperationCounter == 0)
+            {
+                return asyncContinuation;
+            }
+            else
+            {
+                lock (_pendingCompletionList)
+                {
+                    var pendingCompletion = new LinkedListNode<AsyncContinuation>(null);
+                    _pendingCompletionList.AddLast(pendingCompletion);
+
+                    // We only want to wait for the operations currently in progress (not the future operations)
+                    int remainingCompletionCounter = System.Threading.Interlocked.Increment(ref _pendingOperationCounter);
+                    if (remainingCompletionCounter <= 0)
+                    {
+                        System.Threading.Interlocked.Exchange(ref this._pendingOperationCounter, 0);
+                        _pendingCompletionList.Remove(pendingCompletion);
+                        return asyncContinuation;
+                    }
+
+                    pendingCompletion.Value = (ex) =>
+                    {
+                        if (System.Threading.Interlocked.Decrement(ref remainingCompletionCounter) == 0)
+                        {
+                            lock (_pendingCompletionList)
+                            {
+                                System.Threading.Interlocked.Decrement(ref _pendingOperationCounter);
+                                _pendingCompletionList.Remove(pendingCompletion);
+                                var nodeNext = _pendingCompletionList.First;
+                                while (nodeNext != null)
+                                {
+                                    var nodeValue = nodeNext.Value;
+                                    nodeNext = nodeNext.Next;
+                                    nodeValue(ex);  // Will modify _pendingCompletionList
+                                }
+                            }
+                            asyncContinuation(ex);
+                        }
+                    };
+
+                    return pendingCompletion.Value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clear o
+        /// </summary>
+        public void Clear()
+        {
+            _pendingCompletionList.Clear();
+        }
+    }
+}

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -126,6 +126,7 @@
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
+    <Compile Include="Internal\AsyncOperationCounter.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -123,6 +123,7 @@
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
+    <Compile Include="Internal\AsyncOperationCounter.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -136,6 +136,7 @@
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
+    <Compile Include="Internal\AsyncOperationCounter.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -142,6 +142,7 @@
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
+    <Compile Include="Internal\AsyncOperationCounter.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -136,6 +136,7 @@
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
+    <Compile Include="Internal\AsyncOperationCounter.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -136,6 +136,7 @@
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
+    <Compile Include="Internal\AsyncOperationCounter.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -142,6 +142,7 @@
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
+    <Compile Include="Internal\AsyncOperationCounter.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -143,6 +143,7 @@
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
+    <Compile Include="Internal\AsyncOperationCounter.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -140,6 +140,7 @@
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
+    <Compile Include="Internal\AsyncOperationCounter.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -139,6 +139,7 @@
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
+    <Compile Include="Internal\AsyncOperationCounter.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -139,6 +139,7 @@
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
+    <Compile Include="Internal\AsyncOperationCounter.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -164,6 +164,7 @@
     <Compile Include="ILoggerBase-V1.cs" />
     <Compile Include="ILogger-V1.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
+    <Compile Include="Internal\AsyncOperationCounter.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -454,6 +454,15 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                     logger.Info(createdMessage);
                 }
 
+                // Make triple-flush to fully exercise the async flushing logic
+                try
+                {
+                    LogManager.Flush(0);
+                }
+                catch (NLog.NLogRuntimeException)
+                { }
+                LogManager.Flush(); // Waits for flush (Scheduled on top of the previous flush)
+                LogManager.Flush(); // Nothing to flush
             });
 
 

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -335,6 +335,36 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             CheckQueueMessage(message2, LogMeController.RecievedLogsGetParam1);
         }
 
+        /// <summary>
+        /// Test the Webservice with REST api -  <see cref="WebServiceProtocol.HttpGet"/>  (only checking for no exception)
+        /// </summary>
+        [Fact]
+        public void WebserviceTest_restapi_httpget_flush()
+        {
+            var logger = SetUpHttpGetWebservice("api/logme");
+
+            LogMeController.ResetState(0);
+
+            var message1 = "message with a post";
+            StartOwinTest(() =>
+            {
+                for (int i = 0; i < 100; ++i)
+                    logger.Info(message1);
+
+                // Make triple-flush to fully exercise the async flushing logic
+                try
+                {
+                    LogManager.Flush(0);
+                }
+                catch (NLog.NLogRuntimeException)
+                { }
+                LogManager.Flush(); // Waits for flush (Scheduled on top of the previous flush)
+                LogManager.Flush(); // Nothing to flush
+            });
+
+            Assert.Equal(100, LogMeController.RecievedLogsGetParam1.Count);
+        }
+
         [Fact]
         public void WebServiceTest_restapi_httpget_querystring()
         {
@@ -453,24 +483,11 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                 {
                     logger.Info(createdMessage);
                 }
-
-                // Make triple-flush to fully exercise the async flushing logic
-                try
-                {
-                    LogManager.Flush(0);
-                }
-                catch (NLog.NLogRuntimeException)
-                { }
-                LogManager.Flush(); // Waits for flush (Scheduled on top of the previous flush)
-                LogManager.Flush(); // Nothing to flush
             });
-
-
 
             Assert.Equal(LogMeController.CountdownEvent.CurrentCount, 0);
             Assert.Equal(createdMessages.Count, LogMeController.RecievedLogsPostParam1.Count);
             //Assert.Equal(createdMessages, ValuesController.RecievedLogsPostParam1);
-
         }
 
 
@@ -603,7 +620,10 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             {
                 RecievedLogsPostParam1 = new ConcurrentBag<string>();
                 RecievedLogsGetParam1 = new ConcurrentBag<string>();
-                CountdownEvent = new CountdownEvent(expectedMessages);
+                if (expectedMessages > 0)
+                    CountdownEvent = new CountdownEvent(expectedMessages);
+                else
+                    CountdownEvent = null;
             }
 
             /// <summary>
@@ -706,7 +726,6 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                 //wait for all recieved message, or timeout. There is no exception on timeout, so we have to check carefully in the unit test.
                 if (LogMeController.CountdownEvent != null)
                 {
-
                     LogMeController.CountdownEvent.Wait(webserviceCheckTimeoutMs);
                     //we need some extra time for completion
                     Thread.Sleep(1000);
@@ -722,7 +741,8 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             {
                 testsFunc();
 
-                testContext.CountdownEvent.Wait(webserviceCheckTimeoutMs);
+                if (LogMeController.CountdownEvent != null)
+                    testContext.CountdownEvent.Wait(webserviceCheckTimeoutMs);
                 Thread.Sleep(1000);
             }
         }

--- a/tests/NLog.UnitTests/Targets/Wrappers/AutoFlushTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AutoFlushTargetWrapperTests.cs
@@ -110,6 +110,35 @@ namespace NLog.UnitTests.Targets.Wrappers
             Assert.Equal(2, myTarget.FlushCount);
         }
 
+        [Fact]
+        public void AutoFlushTargetWrapperAsyncTest2()
+        {
+            var myTarget = new MyAsyncTarget();
+            var wrapper = new AutoFlushTargetWrapper(myTarget);
+            myTarget.Initialize(null);
+            wrapper.Initialize(null);
+            var logEvent = new LogEventInfo();
+            Exception lastException = null;
+
+            for (int i = 0; i < 100; ++i)
+            {
+                wrapper.WriteAsyncLogEvent(logEvent.WithContinuation(ex => lastException = ex));
+            }
+
+            var continuationHit = new ManualResetEvent(false);
+            AsyncContinuation continuation =
+                ex =>
+                {
+                    continuationHit.Set();
+                };
+
+            wrapper.Flush(ex => { });
+            wrapper.Flush(continuation);
+            continuationHit.WaitOne();
+            wrapper.Flush(ex => { });   // Executed right away
+            Assert.Equal(100, myTarget.WriteCount);
+            Assert.Equal(103, myTarget.FlushCount);
+        }
 
         [Fact]
         public void AutoFlushTargetWrapperAsyncWithExceptionTest1()

--- a/tests/NLog.UnitTests/Targets/Wrappers/AutoFlushTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AutoFlushTargetWrapperTests.cs
@@ -133,9 +133,13 @@ namespace NLog.UnitTests.Targets.Wrappers
                 };
 
             wrapper.Flush(ex => { });
+            Assert.Null(lastException);
             wrapper.Flush(continuation);
+            Assert.Null(lastException);
             continuationHit.WaitOne();
+            Assert.Null(lastException);
             wrapper.Flush(ex => { });   // Executed right away
+            Assert.Null(lastException);
             Assert.Equal(100, myTarget.WriteCount);
             Assert.Equal(103, myTarget.FlushCount);
         }


### PR DESCRIPTION
Keeps track of pendingRequests. Tries to fix #259. Instead of expecting async-target to almost handle it #1853

First idea was to keep track of each individual LogEvent (in a dictionary), but the logic (and the allocations) became a little heavy. Now it just keeps track of a pending request count, so it is not completely correct when races occurs, but I think it is good enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1868)
<!-- Reviewable:end -->
