### PR TITLE
Filetarget allocations optimization (up to 15% speed improvement)

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1022,7 +1022,7 @@ namespace NLog.Targets
                 LogEventInfo firstLogEvent = null;
 
                 byte[][] logEventsBytes = new byte[bucket.Value.Count][];
-                int totalBytesSize = 0;
+                int bucketByteCount = 0;
                 for (int i = 0; i < bucket.Value.Count; i++)
                 {
                     AsyncLogEventInfo ev = bucket.Value[i];
@@ -1033,11 +1033,11 @@ namespace NLog.Targets
 
                     var bytes = this.GetBytesToWrite(ev.LogEvent);
                     logEventsBytes[i] = bytes;
-                    totalBytesSize += bytes.Length;
+                    bucketByteCount += bytes.Length;
                     pendingContinuations.Add(ev.Continuation);
                 }
 
-                using (var ms = new MemoryStream(totalBytesSize))
+                using (var ms = new MemoryStream(bucketByteCount))
                 {
                     for (int i = 0; i < logEventsBytes.Length; i++)
                     {


### PR DESCRIPTION
1. Removed new string allocation in GetBytesToWrite method. Now we are get count of bytes for text and newline characters and write directly into byte array.

2. Allocate MemoryStream directly with required buffer size. 

Performance results for this test https://github.com/NLog/NLog-Performance-tests/blob/master/NLogPerformance
with following parameters:

| Messages 	| Size 	| Threads 	| Loggers 	|
|----------	|------	|---------	|---------	|
| 1000000  	| 100  	| 2       	| 1       	|

| version   	| Time (ms) 	| Msgs/sec 	| GC2 	| GC1 	| GC0 	| CPU (ms) 	| Mem (MB) 	|
|-----------	|-----------	|----------	|-----	|-----	|-----	|----------	|----------	|
| master    	| 14,885    	| 67,178   	| 328 	| 409 	| 848 	| 28,671   	| 51.051   	|
| optimized 	| 12,914    	| 77,432   	| 179 	| 324 	| 704 	| 25,000   	| 47,344   	|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1871)
<!-- Reviewable:end -->
