### PR TITLE
FileTarget - Faster archive check by caching the static file-create-time (60-70% improvement)

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -58,8 +58,8 @@ namespace NLog.Internal.FileAppenders
         {
             this.CreateFileParameters = createParameters;
             this.FileName = fileName;
-            this.OpenTime = DateTime.UtcNow; // to be consistent with timeToKill in FileTarget.AutoClosingTimerCallback
-            this.LastWriteTime = DateTime.MinValue;
+            this.OpenTimeUtc = DateTime.UtcNow; // to be consistent with timeToKill in FileTarget.AutoClosingTimerCallback
+            this.LastWriteTimeUtc = DateTime.MinValue;
             this.CaptureLastWriteTime = createParameters.CaptureLastWriteTime;
         }
 
@@ -76,21 +76,24 @@ namespace NLog.Internal.FileAppenders
         /// Universal Time [UTC] standard.
         /// </summary>
         /// <returns>The creation time of the file.</returns>
-        public DateTime CreationTime { get; internal set; }
+        public DateTime CreationTimeUtc { get { return _creationTimeUtc; } internal set { _creationTimeUtc = value; CreationTimeSouce = Time.TimeSource.Current.FromSystemTime(value); } }
+        DateTime _creationTimeUtc;
+
+        public DateTime CreationTimeSouce { get; private set; }
 
         /// <summary>
         /// Gets the last time the file associated with the appeander is opened. The time returned is in Coordinated 
         /// Universal Time [UTC] standard.
         /// </summary>
         /// <returns>The time the file was last opened.</returns>
-        public DateTime OpenTime { get; private set; }
+        public DateTime OpenTimeUtc { get; private set; }
 
         /// <summary>
         /// Gets the last time the file associated with the appeander is written. The time returned is in  
         /// Coordinated Universal Time [UTC] standard.
         /// </summary>
         /// <returns>The time the file was last written to.</returns>
-        public DateTime LastWriteTime { get; private set; }
+        public DateTime LastWriteTimeUtc { get; private set; }
 
         /// <summary>
         /// Gets the file creation parameters.
@@ -172,7 +175,7 @@ namespace NLog.Internal.FileAppenders
         /// <param name="dateTime">Date and time when the last write occurred in UTC.</param>
         protected void FileTouched(DateTime dateTime)
         {
-            this.LastWriteTime = dateTime;
+            this.LastWriteTimeUtc = dateTime;
         }
 
         /// <summary>
@@ -320,9 +323,9 @@ namespace NLog.Internal.FileAppenders
             if (File.Exists(this.FileName))
             {
 #if !SILVERLIGHT
-                this.CreationTime = File.GetCreationTimeUtc(this.FileName);
+                this.CreationTimeUtc = File.GetCreationTimeUtc(this.FileName);
 #else
-                this.CreationTime = File.GetCreationTime(this.FileName);
+                this.CreationTimeUtc = File.GetCreationTime(this.FileName);
 #endif
             }
             else
@@ -330,11 +333,11 @@ namespace NLog.Internal.FileAppenders
                 File.Create(this.FileName).Dispose();
 
 #if !SILVERLIGHT
-                this.CreationTime = DateTime.UtcNow;
+                this.CreationTimeUtc = DateTime.UtcNow;
                 // Set the file's creation time to avoid being thwarted by Windows' Tunneling capabilities (https://support.microsoft.com/en-us/kb/172190).
-                File.SetCreationTimeUtc(this.FileName, this.CreationTime);
+                File.SetCreationTimeUtc(this.FileName, this.CreationTimeUtc);
 #else
-                this.CreationTime = File.GetCreationTime(this.FileName);
+                this.CreationTimeUtc = File.GetCreationTime(this.FileName);
 #endif
             }
         }

--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -76,10 +76,22 @@ namespace NLog.Internal.FileAppenders
         /// Universal Time [UTC] standard.
         /// </summary>
         /// <returns>The creation time of the file.</returns>
-        public DateTime CreationTimeUtc { get { return _creationTimeUtc; } internal set { _creationTimeUtc = value; CreationTimeSouce = Time.TimeSource.Current.FromSystemTime(value); } }
+        public DateTime CreationTimeUtc
+        {
+            get { return _creationTimeUtc; }
+            internal set
+            {
+                _creationTimeUtc = value;
+                CreationTimeSource = Time.TimeSource.Current.FromSystemTime(value); // Performance optimization to skip converting every time
+            }
+        }
         DateTime _creationTimeUtc;
 
-        public DateTime CreationTimeSouce { get; private set; }
+        /// <summary>
+        /// Gets or sets the creation time for a file associated with the appender. Synchronized by <see cref="CreationTimeUtc"/>
+        /// The time format is based on <see cref="NLog.Time.TimeSource" />
+        /// </summary>
+        public DateTime CreationTimeSource { get; private set; }
 
         /// <summary>
         /// Gets the last time the file associated with the appeander is opened. The time returned is in Coordinated 

--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -124,7 +124,7 @@ namespace NLog.Internal.FileAppenders
         /// <returns>The file creation time.</returns>
         public override DateTime? GetFileCreationTimeUtc()
         {
-            return this.CreationTime;
+            return this.CreationTimeUtc;
         }
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace NLog.Internal.FileAppenders
         /// <returns>The time the file was last written to.</returns>
         public override DateTime? GetFileLastWriteTimeUtc()
         {
-            return this.LastWriteTime;
+            return this.LastWriteTimeUtc;
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -174,12 +174,12 @@ namespace NLog.Internal.FileAppenders
                     break;
                 }
 
-                if (string.CompareOrdinal(appenders[i].FileName, fileName) == 0)
+                if (string.Equals(appenders[i].FileName, fileName, StringComparison.Ordinal))
                 {
                     // found it, move it to the first place on the list
                     // (MRU)
                     BaseFileAppender app = appenders[i];
-                    if (i != 0)
+                    if (i > 0)
                     {
                         // file open has a chance of failure
                         // if it fails in the constructor, we won't modify any data structures
@@ -303,7 +303,7 @@ namespace NLog.Internal.FileAppenders
                 if (appender == null)
                     break;
 
-                if (string.CompareOrdinal(appender.FileName, fileName)==0)
+                if (string.Equals(appender.FileName, fileName, StringComparison.Ordinal))
                     return appender;
             }
 
@@ -329,11 +329,12 @@ namespace NLog.Internal.FileAppenders
                     result = appender.GetFileCreationTimeUtc();
                     if (result.HasValue)
                     {
+                        // Check if cached value is still valid, and update if not (Will automatically update CreationTimeSource)
                         if (result.Value != appender.CreationTimeUtc)
                         {
                             appender.CreationTimeUtc = result.Value;
                         }
-                        return appender.CreationTimeSouce;
+                        return appender.CreationTimeSource;
                     }
                 }
                 catch (Exception ex)
@@ -426,7 +427,7 @@ namespace NLog.Internal.FileAppenders
                     break;
                 }
 
-                if (string.CompareOrdinal(appenders[i].FileName, filePath) == 0)
+                if (string.Equals(appenders[i].FileName, filePath, StringComparison.Ordinal))
                 {
                     CloseAppender(appenders[i]);
                     for (int j = i; j < appenders.Length - 1; ++j)

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -193,8 +193,7 @@ namespace NLog.Internal.FileAppenders
         /// <returns>The file creation time.</returns>
         public override DateTime? GetFileCreationTimeUtc()
         {
-            var fileChars = GetFileCharacteristics();
-            return fileChars.CreationTimeUtc;
+            return CreationTimeUtc; // File is kept open, so creation time is static
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -139,7 +139,7 @@ namespace NLog.Internal.FileAppenders
         /// <returns>The file creation time.</returns>
         public override DateTime? GetFileCreationTimeUtc()
         {
-            return this.CreationTime;
+            return this.CreationTimeUtc;
         }
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace NLog.Internal.FileAppenders
         /// <returns>The time the file was last written to.</returns>
         public override DateTime? GetFileLastWriteTimeUtc()
         {
-            return this.LastWriteTime;
+            return this.LastWriteTimeUtc;
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
@@ -117,15 +117,15 @@ namespace NLog.Internal.FileAppenders
                 long filePosition = fileStream.Position;
                 if (fileExists || filePosition > 0)
                 {
-                    this.CreationTime = File.GetCreationTimeUtc(this.FileName);
-                    if (this.CreationTime < DateTime.UtcNow - TimeSpan.FromSeconds(2) && filePosition == 0)
+                    this.CreationTimeUtc = File.GetCreationTimeUtc(this.FileName);
+                    if (this.CreationTimeUtc < DateTime.UtcNow - TimeSpan.FromSeconds(2) && filePosition == 0)
                     {
                         // File wasn't created "almost now". 
                         // This could mean creation time has tunneled through from another file (see comment below).
                         Thread.Sleep(50);
                         // Having waited for a short amount of time usually means the file creation process has continued
                         // code execution just enough to the above point where it has fixed up the creation time.
-                        this.CreationTime = File.GetCreationTimeUtc(this.FileName);
+                        this.CreationTimeUtc = File.GetCreationTimeUtc(this.FileName);
                     }
                 }
                 else
@@ -137,8 +137,8 @@ namespace NLog.Internal.FileAppenders
                     // Unfortunately we can't use the native SetFileTime() to prevent opening the file 2nd time.
                     // This would require another desiredAccess flag which would disable the atomic append feature.
                     // See also UpdateCreationTime()
-                    this.CreationTime = DateTime.UtcNow;
-                    File.SetCreationTimeUtc(this.FileName, this.CreationTime);
+                    this.CreationTimeUtc = DateTime.UtcNow;
+                    File.SetCreationTimeUtc(this.FileName, this.CreationTimeUtc);
                 }
             }
             catch
@@ -200,8 +200,7 @@ namespace NLog.Internal.FileAppenders
 
         public override DateTime? GetFileCreationTimeUtc()
         {
-            var fileChars = GetFileCharacteristics();
-            return fileChars != null ? fileChars.CreationTimeUtc : (DateTime?)null;
+            return CreationTimeUtc; // File is kept open, so creation time is static
         }
 
         public override DateTime? GetFileLastWriteTimeUtc()

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -210,7 +210,7 @@ namespace NLog.Internal
             if ((!_cleanupInvalidChars || cleanedFixedResult != null) && _filePathKind == FilePathKind.Absolute)
                 return rawFileName; // Skip clean filename string-allocation
 
-            if (string.CompareOrdinal(_cachedPrevRawFileName, rawFileName) == 0 && _cachedPrevCleanFileName != null)
+            if (string.Equals(_cachedPrevRawFileName, rawFileName, StringComparison.Ordinal) && _cachedPrevCleanFileName != null)
                 return _cachedPrevCleanFileName;    // Cache Hit, reuse clean filename string-allocation
 
             var cleanFileName = GetCleanFileName(rawFileName);

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -2062,6 +2062,12 @@ namespace NLog.Targets
             return null;
         }
 
+        /// <summary>
+        /// Truncates the input-time, so comparison of low resolution times (like dates) are not affected by ticks
+        /// </summary>
+        /// <param name="input">High resolution Time</param>
+        /// <param name="resolution">Time Resolution Level</param>
+        /// <returns>Truncated Low Resolution Time</returns>
         private static DateTime TruncateArchiveTime(DateTime input, FileArchivePeriod resolution)
         {
             switch (resolution)

--- a/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
+++ b/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
@@ -202,13 +202,13 @@ namespace NLog.UnitTests.Internal.FileAppenders
         {
             // Invoke GetFileCharacteristics() on an Empty FileAppenderCache.
             FileAppenderCache emptyCache = FileAppenderCache.Empty;
-            Assert.Null(emptyCache.GetFileCreationTimeUtc("file.txt", false));
+            Assert.Null(emptyCache.GetFileCreationTimeSource("file.txt", false));
             Assert.Null(emptyCache.GetFileLastWriteTimeUtc("file.txt", false));
             Assert.Null(emptyCache.GetFileLength("file.txt", false));
           
             FileAppenderCache cache = new FileAppenderCache(3, appenderFactory, fileParameters);
             // Invoke GetFileCharacteristics() on non-empty FileAppenderCache - Before allocating any appenders. 
-            Assert.Null(emptyCache.GetFileCreationTimeUtc("file.txt", false));
+            Assert.Null(emptyCache.GetFileCreationTimeSource("file.txt", false));
             Assert.Null(emptyCache.GetFileLastWriteTimeUtc("file.txt", false));
             Assert.Null(emptyCache.GetFileLength("file.txt", false));
 
@@ -228,10 +228,10 @@ namespace NLog.UnitTests.Internal.FileAppenders
             //
 
             // File information should be returned.
-           
-            var fileCreationTimeUtc = cache.GetFileCreationTimeUtc(tempFile, false);
+
+            var fileCreationTimeUtc = cache.GetFileCreationTimeSource(tempFile, false);
             Assert.NotNull(fileCreationTimeUtc);
-            Assert.True(fileCreationTimeUtc > DateTime.UtcNow.AddMinutes(-2),"creationtime is wrong");
+            Assert.True(fileCreationTimeUtc > Time.TimeSource.Current.FromSystemTime(DateTime.UtcNow.AddMinutes(-2)),"creationtime is wrong");
 
             var fileLastWriteTimeUtc = cache.GetFileLastWriteTimeUtc(tempFile, false);
             Assert.NotNull(fileLastWriteTimeUtc);

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -74,8 +74,8 @@ namespace NLog.UnitTests.Targets
         {
             if (!concurrentWrites && !networkWrites && !forceMutexConcurrentWrites)
                 return true;    // Allow keepFileOpen = true / false, Allow forceManaged = true / false
-            if (concurrentWrites && !networkWrites)
-                return true;    // Allow keepFileOpen = true / false, forceManaged = true / false, forceMutexConcurrentWrites = true / false
+            if (concurrentWrites && !networkWrites && keepFileOpen)
+                return true;    // Allow forceManaged = true / false, forceMutexConcurrentWrites = true / false
             if (networkWrites && keepFileOpen && !concurrentWrites && !forceMutexConcurrentWrites)
                 return true;    // Allow forceManaged = true / false
             return false;
@@ -98,7 +98,7 @@ namespace NLog.UnitTests.Targets
                     KeepFileOpen = keepFileOpen,
                     NetworkWrites = networkWrites,
                     ForceManaged = forceManaged,
-                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites
+                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites,
                 });
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
@@ -106,7 +106,9 @@ namespace NLog.UnitTests.Targets
                 logger.Debug("aaa");
                 logger.Info("bbb");
                 logger.Warn("ccc");
-                LogManager.Configuration = null;
+
+                LogManager.Configuration = null;    // Flush
+
                 AssertFileContents(logFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
             }
             finally
@@ -124,7 +126,6 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void SimpleFileTestInRoot()
         {
-
             if (NLog.Internal.PlatformDetector.IsWin32)
             {
                 var logFile = "c:\\nlog-test.log";
@@ -142,7 +143,9 @@ namespace NLog.UnitTests.Targets
                     logger.Debug("aaa");
                     logger.Info("bbb");
                     logger.Warn("ccc");
-                    LogManager.Configuration = null;
+
+                    LogManager.Configuration = null;    // Flush
+
                     AssertFileContents(logFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
                 }
                 finally
@@ -177,7 +180,7 @@ namespace NLog.UnitTests.Targets
                     KeepFileOpen = keepFileOpen,
                     NetworkWrites = networkWrites,
                     ForceManaged = forceManaged,
-                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites
+                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites,
                 });
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
@@ -185,6 +188,8 @@ namespace NLog.UnitTests.Targets
                 {
                     logger.Debug("aaa");
                 }
+
+                LogManager.Configuration = null;    // Flush
             }
             finally
             {
@@ -241,7 +246,8 @@ namespace NLog.UnitTests.Targets
                     SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                     logger.Debug("aaa");
-                    LogManager.Configuration = null;
+
+                    LogManager.Configuration = null;    // Flush
                 }
                 AssertFileContents(logFile, "name;level;message\nNLog.UnitTests.Targets.FileTargetTests;Debug;aaa\nNLog.UnitTests.Targets.FileTargetTests;Debug;aaa\n", Encoding.UTF8);
             }
@@ -312,7 +318,8 @@ namespace NLog.UnitTests.Targets
                 logger.Info("bbb");
                 logger.Warn("ccc");
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
+
                 AssertFileContents(logFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
             }
             finally
@@ -416,7 +423,7 @@ namespace NLog.UnitTests.Targets
                 logger.Info("bbb");
                 logger.Warn("ccc");
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
                 AssertFileContents(logFile, "Debug aaa\nInfo bbb\nWarn ccc\nDebug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
 
 
@@ -444,7 +451,8 @@ namespace NLog.UnitTests.Targets
                 logger.Info("eee");
                 logger.Warn("fff");
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
+
                 AssertFileContents(logFile, "Debug ddd\nInfo eee\nWarn fff\n", Encoding.UTF8);
                 Assert.True(File.Exists(archiveTempName));
 
@@ -507,12 +515,16 @@ namespace NLog.UnitTests.Targets
                 string footerPart = useFooter ? footer + LineEndingMode.LF.NewLineCharacters : string.Empty;
 
                 logger.Debug("aaa");
+                LogManager.Flush();
                 AssertFileContents(logFile, headerPart + "Debug aaa\n" + footerPart, Encoding.UTF8);
-                logger.Info("bbb");
-                AssertFileContents(logFile, headerPart + "Info bbb\n" + footerPart, Encoding.UTF8);
-                logger.Warn("ccc");
-                AssertFileContents(logFile, headerPart + "Warn ccc\n" + footerPart, Encoding.UTF8);
 
+                logger.Info("bbb");
+                LogManager.Flush();
+                AssertFileContents(logFile, headerPart + "Info bbb\n" + footerPart, Encoding.UTF8);
+
+                logger.Warn("ccc");
+                LogManager.Flush();
+                AssertFileContents(logFile, headerPart + "Warn ccc\n" + footerPart, Encoding.UTF8);
             }
             finally
             {
@@ -582,7 +594,8 @@ namespace NLog.UnitTests.Targets
                 logger.Debug("aaa");
                 logger.Info("bbb");
                 logger.Warn("ccc");
-                LogManager.Configuration = null;
+
+                LogManager.Configuration = null;    // Flush
                 AssertFileContents(logFile, "Debug aaa\nInfo bbb\nWarn ccc\n", Encoding.UTF8);
             }
             finally
@@ -624,7 +637,7 @@ namespace NLog.UnitTests.Targets
                 Generate100BytesLog('d');
                 Generate100BytesLog('e');
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 var times = 25;
                 AssertFileContents(logFile,
@@ -687,7 +700,7 @@ namespace NLog.UnitTests.Targets
                 Generate100BytesLog('d');
                 Generate100BytesLog('e');
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 AssertFileContents(logFile,
                     StringRepeat(25, "eee\n"),
@@ -772,8 +785,7 @@ namespace NLog.UnitTests.Targets
                     logger.Debug("eee");
                 }
 
-                LogManager.Configuration = null;
-
+                LogManager.Configuration = null;    // Flush
 
                 //we expect only eee and all other in the archive
                 AssertFileContents(logFile,
@@ -786,7 +798,6 @@ namespace NLog.UnitTests.Targets
                     Path.Combine(archiveFolder, string.Format("{0}.txt", archiveFileName)),
                    StringRepeat(times, "aaa\n") + StringRepeat(times, "bbb\n") + StringRepeat(times, "ccc\n") + StringRepeat(times, "ddd\n"),
                     Encoding.UTF8);
-
             }
             finally
             {
@@ -830,8 +841,9 @@ namespace NLog.UnitTests.Targets
                     if (i % 5 == 0)
                         Thread.Sleep(50);
                 }
+
                 //Setting the Configuration to [null] will result in a 'Dump' of the current log entries
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 var files = Directory.GetFiles(archiveFolder).OrderBy(s => s);
                 //the amount of archived files may not exceed the set 'MaxArchiveFiles'
@@ -842,7 +854,8 @@ namespace NLog.UnitTests.Targets
                 //writing just one line of 11 bytes will trigger the cleanup of old archived files
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest file
                 logger.Debug("1234567890");
-                LogManager.Configuration = null;
+
+                LogManager.Configuration = null;    // Flush
 
                 var files2 = Directory.GetFiles(archiveFolder).OrderBy(s => s);
                 Assert.Equal(maxArchiveFiles, files2.Count());
@@ -893,7 +906,7 @@ namespace NLog.UnitTests.Targets
                     Thread.Sleep(50);
                 }
                 //Setting the Configuration to [null] will result in a 'Dump' of the current log entries
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 var files = Directory.GetFiles(tempPath).OrderBy(s => s);
                 //we expect 3 archive files, plus one current file
@@ -905,7 +918,7 @@ namespace NLog.UnitTests.Targets
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest file
                 Thread.Sleep(50);
                 logger.Debug("123456789");
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 var files2 = Directory.GetFiles(tempPath).OrderBy(s => s);
                 Assert.Equal(maxArchiveFiles + 1, files2.Count());
@@ -1010,6 +1023,7 @@ namespace NLog.UnitTests.Targets
 
                     var eventInfo = new LogEventInfo(LogLevel.Debug, logger.Name, "123456789");
                     logger.Log(eventInfo);
+                    LogManager.Flush();
 
                     var dayIsChanged = eventInfo.TimeStamp.Date != previousWriteTime.Date;
                     // ensure new archive is created only when the day part of time is changed
@@ -1025,19 +1039,19 @@ namespace NLog.UnitTests.Targets
                         timeSource.AddToSystemTime(TimeSpan.FromDays(1));
                 }
                 //Setting the Configuration to [null] will result in a 'Dump' of the current log entries
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 var files = Directory.GetFiles(archiveFolder);
                 //the amount of archived files may not exceed the set 'MaxArchiveFiles'
                 Assert.Equal(maxArchiveFiles, files.Length);
-
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 //writing one line on a new day will trigger the cleanup of old archived files
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest file
                 timeSource.AddToLocalTime(TimeSpan.FromDays(1));
                 logger.Debug("1234567890");
-                LogManager.Configuration = null;
+
+                LogManager.Configuration = null;    // Flush
 
                 var files2 = Directory.GetFiles(archiveFolder);
                 Assert.Equal(maxArchiveFiles, files2.Length);
@@ -1067,7 +1081,6 @@ namespace NLog.UnitTests.Targets
                     from concurrentWrites in booleanValues
                     from keepFileOpen in booleanValues
                     from networkWrites in booleanValues
-                    where AllowsExternalFileModification(concurrentWrites, keepFileOpen, networkWrites)
                     from forceMutexConcurrentWrites in booleanValues
                     where UniqueBaseAppender(concurrentWrites, keepFileOpen, networkWrites, forceMutexConcurrentWrites)
                     from includeDateInLogFilePath in booleanValues
@@ -1077,19 +1090,26 @@ namespace NLog.UnitTests.Targets
             }
         }
 
-        private static bool AllowsExternalFileModification(bool concurrentWrites, bool keepFileOpen, bool networkWrites)
-        {
-            return (concurrentWrites) || (!keepFileOpen) || (networkWrites);
-        }
-
         [Theory]
         [PropertyData("DateArchive_ArchiveOnceOnly_TestParameters")]
         public void DateArchive_ArchiveOnceOnly(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool dateInLogFilePath, bool includeSequenceInArchive, bool forceManaged, bool forceMutexConcurrentWrites)
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var logFile = Path.Combine(tempPath, dateInLogFilePath ? "file_${shortdate}.txt" : "file.txt");
+
+            var defaultTimeSource = TimeSource.Current;
+
             try
             {
+                var timeSource = new TimeSourceTests.ShiftedTimeSource(DateTimeKind.Local);
+                if (timeSource.Time.Minute == 59)
+                {
+                    // Avoid double-archive due to overflow of the hour.
+                    timeSource.AddToLocalTime(TimeSpan.FromMinutes(1));
+                    timeSource.AddToSystemTime(TimeSpan.FromMinutes(1));
+                }
+                TimeSource.Current = timeSource;
+
                 string archiveFolder = Path.Combine(tempPath, "archive");
                 var fileTarget = WrapFileTarget(new FileTarget
                 {
@@ -1104,28 +1124,39 @@ namespace NLog.UnitTests.Targets
                     KeepFileOpen = keepFileOpen,
                     NetworkWrites = networkWrites,
                     ForceManaged = forceManaged,
-                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites
+                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites,
                 });
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
                 logger.Debug("123456789");
-                string currentLogFile = Directory.GetFiles(tempPath)[0];
-                File.SetCreationTime(currentLogFile, File.GetCreationTime(currentLogFile).AddDays(-1));
-                File.SetLastWriteTime(currentLogFile, File.GetLastWriteTime(currentLogFile).AddDays(-1));
+                LogManager.Flush();
+
+                timeSource.AddToLocalTime(TimeSpan.FromDays(1));
+
                 // This should archive the log before logging.
-                logger.Debug("123456789");
+                logger.Debug("123456789");  
+
+                timeSource.AddToSystemTime(TimeSpan.FromDays(1));   // Archive only once
+
                 // This must not archive.
                 logger.Debug("123456789");
 
-                LogManager.Configuration = null;
-                File.Equals(1, Directory.GetFiles(archiveFolder).Length);
+                LogManager.Configuration = null;    // Flush
+
+                Assert.Equal(1, Directory.GetFiles(archiveFolder).Length);
+                var prevLogFile = Directory.GetFiles(archiveFolder)[0];
+                AssertFileContents(prevLogFile, StringRepeat(1, "123456789\n"), Encoding.UTF8);
+
+                var currentLogFile = Directory.GetFiles(tempPath)[0];
                 AssertFileContents(currentLogFile, StringRepeat(2, "123456789\n"), Encoding.UTF8);
             }
             finally
             {
+                TimeSource.Current = defaultTimeSource; // restore default time source
+
                 if (Directory.Exists(tempPath))
-                    Directory.Delete(tempPath, true);
+                Directory.Delete(tempPath, true);
             }
         }
 
@@ -1191,7 +1222,8 @@ namespace NLog.UnitTests.Targets
 
                 timeSource.AddToLocalTime(TimeSpan.FromDays(2));
                 logger.Debug("1234567890");
-                LogManager.Configuration = null;
+
+                LogManager.Configuration = null;    // Flush
 
                 string archivePath = Path.Combine(tempPath, "archive");
                 var archiveFiles = Directory.GetFiles(archivePath);
@@ -1215,7 +1247,6 @@ namespace NLog.UnitTests.Targets
                     from concurrentWrites in booleanValues
                     from keepFileOpen in booleanValues
                     from networkWrites in booleanValues
-                    where AllowsExternalFileModification(concurrentWrites, keepFileOpen, networkWrites)
                     from forceMutexConcurrentWrites in booleanValues
                     where UniqueBaseAppender(concurrentWrites, keepFileOpen, networkWrites, forceMutexConcurrentWrites)
                     from includeDateInLogFilePath in booleanValues
@@ -1230,10 +1261,29 @@ namespace NLog.UnitTests.Targets
         [PropertyData("DateArchive_AllLoggersTransferToCurrentLogFile_TestParameters")]
         public void DateArchive_AllLoggersTransferToCurrentLogFile(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool includeDateInLogFilePath, bool includeSequenceInArchive, bool enableArchiveCompression, bool forceManaged, bool forceMutexConcurrentWrites)
         {
+#if !NET4_5
+            if (enableArchiveCompression)
+                return; // No need to test with compression
+#endif
+
+            if (keepFileOpen && !networkWrites && !concurrentWrites)
+                return; // This combination do not support two local FileTargets to the same file
+
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var logfile = Path.Combine(tempPath, includeDateInLogFilePath ? "file_${shortdate}.txt" : "file.txt");
+            var defaultTimeSource = TimeSource.Current;
+
             try
             {
+                var timeSource = new TimeSourceTests.ShiftedTimeSource(DateTimeKind.Local);
+                if (timeSource.Time.Minute == 59)
+                {
+                    // Avoid double-archive due to overflow of the hour.
+                    timeSource.AddToLocalTime(TimeSpan.FromMinutes(1));
+                    timeSource.AddToSystemTime(TimeSpan.FromMinutes(1));
+                }
+                TimeSource.Current = timeSource;
+
                 var config = new LoggingConfiguration();
 
                 string archiveFolder = Path.Combine(tempPath, "archive");
@@ -1253,7 +1303,7 @@ namespace NLog.UnitTests.Targets
                     KeepFileOpen = keepFileOpen,
                     NetworkWrites = networkWrites,
                     ForceManaged = forceManaged,
-                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites
+                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites,
                 });
                 var logger1Rule = new LoggingRule("logger1", LogLevel.Debug, fileTarget1);
                 config.LoggingRules.Add(logger1Rule);
@@ -1274,7 +1324,7 @@ namespace NLog.UnitTests.Targets
                     KeepFileOpen = keepFileOpen,
                     NetworkWrites = networkWrites,
                     ForceManaged = forceManaged,
-                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites
+                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites,
                 });
                 var logger2Rule = new LoggingRule("logger2", LogLevel.Debug, fileTarget2);
                 config.LoggingRules.Add(logger2Rule);
@@ -1286,20 +1336,33 @@ namespace NLog.UnitTests.Targets
 
                 logger1.Debug("123456789");
                 logger2.Debug("123456789");
-                string currentLogFile = Directory.GetFiles(tempPath)[0];
-                File.SetCreationTime(currentLogFile, File.GetCreationTime(currentLogFile).AddDays(-1));
-                File.SetLastWriteTime(currentLogFile, File.GetLastWriteTime(currentLogFile).AddDays(-1));
+                LogManager.Flush();
+
+                timeSource.AddToLocalTime(TimeSpan.FromDays(1));
+
+                // This should archive the log before logging.
                 logger1.Debug("123456789");
+
+                timeSource.AddToSystemTime(TimeSpan.FromDays(1));   // Archive only once
+
                 Thread.Sleep(10);
                 logger2.Debug("123456789");
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
+
                 var files = Directory.GetFiles(archiveFolder);
                 Assert.Equal(1, files.Length);
+                if (!enableArchiveCompression)
+                {
+                    string prevLogFile = Directory.GetFiles(archiveFolder)[0];
+                    AssertFileContents(prevLogFile, StringRepeat(2, "123456789\n"), Encoding.UTF8);
+                }
+                string currentLogFile = Directory.GetFiles(tempPath)[0];
                 AssertFileContents(currentLogFile, StringRepeat(2, "123456789\n"), Encoding.UTF8);
             }
             finally
             {
+                TimeSource.Current = defaultTimeSource; // restore default time source
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -1339,7 +1402,7 @@ namespace NLog.UnitTests.Targets
                 }
 
                 //Setting the Configuration to [null] will result in a 'Dump' of the current log entries
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 var fileCount = Directory.EnumerateFiles(archiveFolder).Count();
 
@@ -1414,7 +1477,7 @@ namespace NLog.UnitTests.Targets
                 //writing just one line of 11 bytes will trigger the cleanup of old archived files
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest files
                 logger.Debug("1234567890");
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 var files2 = Directory.GetFiles(archiveFolder).OrderBy(s => s);
                 Assert.Equal(innerFileTarget.MaxArchiveFiles, files2.Count());
@@ -1467,7 +1530,7 @@ namespace NLog.UnitTests.Targets
                     logger.Debug("123456789");
                 }
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 AssertFileContentsStartsWith(logFile, header, Encoding.UTF8);
 
@@ -1590,7 +1653,7 @@ namespace NLog.UnitTests.Targets
                 Generate100BytesLog('d');
                 Generate100BytesLog('e');
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 var assertFileContents =
 #if NET4_5
@@ -1664,7 +1727,7 @@ namespace NLog.UnitTests.Targets
                 Generate100BytesLog('d');
                 Generate100BytesLog('e');
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 var times = 25;
                 AssertFileContents(logFile,
@@ -1732,7 +1795,7 @@ namespace NLog.UnitTests.Targets
                     logger.Fatal("eee");
                 }
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 Assert.False(File.Exists(Path.Combine(tempPath, "Trace.txt")));
 
@@ -1784,7 +1847,7 @@ namespace NLog.UnitTests.Targets
                     logger.Fatal("eee");
                 }
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null; // Flush
 
                 Assert.False(File.Exists(Path.Combine(tempPath, "Trace.txt")));
 
@@ -1831,7 +1894,8 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(fileTarget, 10, AsyncTargetWrapperOverflowAction.Grow)
                 {
-                    Name = "AsyncMultiFileWrite_wrapper"
+                    Name = "AsyncMultiFileWrite_wrapper",
+                    TimeToSleepBetweenBatches = 1,
                 }, LogLevel.Debug);
                 LogManager.ThrowExceptions = true;
 
@@ -1845,8 +1909,8 @@ namespace NLog.UnitTests.Targets
                     logger.Error("ddd");
                     logger.Fatal("eee");
                 }
-                LogManager.Flush();
-                LogManager.Configuration = null;
+
+                LogManager.Configuration = null;    // Flush
 
                 Assert.False(File.Exists(Path.Combine(tempPath, "Trace.txt")));
 
@@ -2041,7 +2105,9 @@ namespace NLog.UnitTests.Targets
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Fatal);
 
                 logger.Fatal("aaa");
-                LogManager.Configuration = null;
+
+                LogManager.Configuration = null;    // Flush
+
                 AssertFileContents(expectedCorrectedTempFile, "Fatal aaa\n", Encoding.UTF8);
             }
             finally
@@ -2082,6 +2148,8 @@ namespace NLog.UnitTests.Targets
                     logger.Debug("a");
                 }
 
+                LogManager.Configuration = null;    // Flush
+
                 Assert.True(File.Exists(logFile));
 
                 //Five archive files, plus the log file itself.
@@ -2094,7 +2162,6 @@ namespace NLog.UnitTests.Targets
                     tempDirectory.Delete(true);
                 }
             }
-
         }
 
         [Fact]
@@ -2123,12 +2190,13 @@ namespace NLog.UnitTests.Targets
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-
                 string existingFile = archiveFileLayout.Replace("{#}", "notadate");
                 Directory.CreateDirectory(Path.GetDirectoryName(logFile));
                 File.Create(existingFile).Close();
 
                 logger.Debug("test");
+
+                LogManager.Configuration = null;    // Flush
 
                 AssertFileContents(logFile, "test" + LineEndingMode.Default.NewLineCharacters, Encoding.UTF8);
                 Assert.True(File.Exists(existingFile));
@@ -2174,6 +2242,8 @@ namespace NLog.UnitTests.Targets
                     logger.Debug("bbb");
                 }
 
+                LogManager.Flush();
+
                 AssertFileContents(logFile,
                     StringRepeat(times, "bbb\n"),
                     Encoding.UTF8);
@@ -2187,7 +2257,7 @@ namespace NLog.UnitTests.Targets
                     logger.Debug("ccc");
                 }
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 AssertFileContents(logFile,
                     StringRepeat(times, "ccc\n"),
@@ -2241,6 +2311,8 @@ namespace NLog.UnitTests.Targets
                     logger.Debug("ccc");
                 }
 
+                LogManager.Flush();
+
                 AssertFileContents(logFile,
                     StringRepeat(times, "ccc\n"),
                     Encoding.UTF8);
@@ -2258,7 +2330,7 @@ namespace NLog.UnitTests.Targets
                     logger.Debug("ddd");
                 }
 
-                LogManager.Configuration = null;
+                LogManager.Configuration = null;    // Flush
 
                 AssertFileContents(logFile,
                     StringRepeat(times, "ddd\n"),
@@ -2316,6 +2388,8 @@ namespace NLog.UnitTests.Targets
                 {
                     logger.Debug("bbb");
                 }
+
+                LogManager.Configuration = null;    // Flush
 
                 AssertFileContents(logFile,
                     StringRepeat(times, "bbb\n"),
@@ -2499,6 +2573,8 @@ namespace NLog.UnitTests.Targets
             SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
             for (int currentSequenceNumber = 0; currentSequenceNumber < count; currentSequenceNumber++)
                 logger.Debug("Test {0}", currentSequenceNumber);
+
+            LogManager.Flush();
         }
 
         [Fact]
@@ -2728,7 +2804,7 @@ namespace NLog.UnitTests.Targets
                 var app1DebugNm = "App1_Debug";
                 var app2Nm = "App2";
 
-                #region Create Mock Archive Files
+#region Create Mock Archive Files
                 var now = DateTime.Now;
                 var i = 0;
                 // create mock app1_trace archives (matches app1 config for trace target)
@@ -2769,7 +2845,7 @@ namespace NLog.UnitTests.Targets
                     }
                     i--;
                 }
-                #endregion
+#endregion
 
                 // Create same app1 Debug file as config defines. Will force archiving to happen on startup
                 File.WriteAllLines(logdir + "\\" + app1DebugNm + fileExt, new[] { "Write first app debug target. Startup will archive this file" }, Encoding.ASCII);
@@ -2867,7 +2943,7 @@ namespace NLog.UnitTests.Targets
                 var app1Nm = "App1";
                 var app2Nm = "App2";
 
-                #region Create Mock Archive Files
+#region Create Mock Archive Files
                 var now = DateTime.Now;
                 var i = 0;
                 // create mock app1 archives (matches app1 config for target)
@@ -2895,7 +2971,7 @@ namespace NLog.UnitTests.Targets
                     }
                     i--;
                 }
-                #endregion
+#endregion
 
                 // Create same app1 file as config defines. Will force archiving to happen on startup
                 File.WriteAllLines(logdir + "\\" + app1Nm + fileExt, new[] { "Write first app debug target. Startup will archive this file" }, Encoding.ASCII);
@@ -3160,6 +3236,7 @@ namespace NLog.UnitTests.Targets
             };
 
             fileTarget.WriteAsyncLogEvents(events);
+            LogManager.Flush();
 
             Assert.Equal(4, exceptions.Count);
             Assert.Null(exceptions[0]);

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -220,8 +220,8 @@ namespace NLog.UnitTests.Targets
         [PropertyData("SimpleFileTest_TestParameters")]
         public void NonExistingDriveShouldNotDelayMuch(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool forceManaged, bool forceMutexConcurrentWrites, bool optimizeBufferReuse)
         {
-            if (!optimizeBufferReuse)
-                return; // No need to test with buffer optimization enabled
+            if (optimizeBufferReuse)
+                return; // No need to test with buffer optimization enabled, as it is enabled by default
 
             var nonExistingDrive = GetFirstNonExistingDriveWindows();
 
@@ -1190,7 +1190,7 @@ namespace NLog.UnitTests.Targets
                 timeSource.AddToLocalTime(TimeSpan.FromDays(1));
 
                 // This should archive the log before logging.
-                logger.Debug("123456789");  
+                logger.Debug("123456789");
 
                 timeSource.AddToSystemTime(TimeSpan.FromDays(1));   // Archive only once
 
@@ -1211,7 +1211,7 @@ namespace NLog.UnitTests.Targets
                 TimeSource.Current = defaultTimeSource; // restore default time source
 
                 if (Directory.Exists(tempPath))
-                Directory.Delete(tempPath, true);
+                    Directory.Delete(tempPath, true);
             }
         }
 
@@ -2862,7 +2862,7 @@ namespace NLog.UnitTests.Targets
                 var app1DebugNm = "App1_Debug";
                 var app2Nm = "App2";
 
-#region Create Mock Archive Files
+                #region Create Mock Archive Files
                 var now = DateTime.Now;
                 var i = 0;
                 // create mock app1_trace archives (matches app1 config for trace target)
@@ -2903,7 +2903,7 @@ namespace NLog.UnitTests.Targets
                     }
                     i--;
                 }
-#endregion
+                #endregion
 
                 // Create same app1 Debug file as config defines. Will force archiving to happen on startup
                 File.WriteAllLines(logdir + "\\" + app1DebugNm + fileExt, new[] { "Write first app debug target. Startup will archive this file" }, Encoding.ASCII);
@@ -3001,7 +3001,7 @@ namespace NLog.UnitTests.Targets
                 var app1Nm = "App1";
                 var app2Nm = "App2";
 
-#region Create Mock Archive Files
+                #region Create Mock Archive Files
                 var now = DateTime.Now;
                 var i = 0;
                 // create mock app1 archives (matches app1 config for target)
@@ -3029,7 +3029,7 @@ namespace NLog.UnitTests.Targets
                     }
                     i--;
                 }
-#endregion
+                #endregion
 
                 // Create same app1 file as config defines. Will force archiving to happen on startup
                 File.WriteAllLines(logdir + "\\" + app1Nm + fileExt, new[] { "Write first app debug target. Startup will archive this file" }, Encoding.ASCII);


### PR DESCRIPTION
FileTarget - FileAppenderCache now caches the conversion of File-Time-Utc to File-Time-TimeSource thus avoiding the expensive DateTime.ToLocalTime(). Also the ArchiveEvery-check now performs truncate of DateTime.Ticks instead of performing DateTime.ToString() allocation.

This PR also contains the following changes:
- MutexMultiProcessFileAppender now uses the cached File-Creation-Time, instead of doing lookup using file-handle
- WindowsMultiProcessFileAppender now uses the cached File-Creation-Time, instead of doing lookup using file-handle
- UnixMultiProcessFileAppender now updates the cached File-Creation-Time as expected by the FileTarget / FileAppenderCache.
- Changed some FileTargetTests to use ShiftedTimeSource instead of using File.SetCreationTime. This allows FileAppenders that caches the static File-Creation-Time to be tested (Now also testing SingleProcessFileAppender).

Have done performance tests with the following config:

`<target name="SyncFilePerfArchive" type="File" fileName="C:\Temp\Log\NLogPerformanceArchivePerf.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${message}" ArchiveAboveSize="10000000000" MaxArchiveFiles="1000" ArchiveEvery="Year" ArchiveNumbering="Date" />`

| Logger Name      | Messages   | Size | Threads | Loggers |
|------------------|------------|------|---------|---------|
| PerfArchiveLogger | 10.000.000 |  128 |       1 |       1 |

| This PR | Time (ms) | Msgs/sec  | GC2 | GC1 | GC0 | CPU (ms) | Mem (MB) |
|------------|-----------|-----------|-----|-----|-----|----------|----------|
| concurrentWrites = false   |    18.694 |   534.917 |   0 |   0 | 1243 |   19.000 |   36,551 |
| concurrentWrites = true    |    90.754 |   110.187 |   0 |   0 | 1275 |   90.843 |   36,320 |

| Master | Time (ms) | Msgs/sec  | GC2 | GC1 | GC0 | CPU (ms) | Mem (MB) |
|------------|-----------|-----------|-----|-----|-----|----------|----------|
| concurrentWrites = false   |    32.902 |   303.924 |   0 |   1 | 1459 |   33.046 |   36,746 |
| concurrentWrites = true    |    144.539 |    69.185 |   0 |   1 | 1520 |  143.015 |   36,648 |

Merry Kerstmis :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1876)
<!-- Reviewable:end -->
