### PR TITLE
FileTarget - KeepFileOpen should watch for file deletion

### DIFF
--- a/src/NLog/Internal/MultiFileWatcher.cs
+++ b/src/NLog/Internal/MultiFileWatcher.cs
@@ -176,9 +176,9 @@ namespace NLog.Internal
 
             var exception = e.GetException();
             if (exception != null)
-                InternalLogger.Info(exception, "Error Watching Path {0}", watcherPath);
+                InternalLogger.Warn(exception, "Error Watching Path {0}", watcherPath);
             else
-                InternalLogger.Info("Error Watching Path {0}", watcherPath);
+                InternalLogger.Warn("Error Watching Path {0}", watcherPath);
         }
 
         private void OnFileChanged(object source, FileSystemEventArgs e)

--- a/src/NLog/Internal/MultiFileWatcher.cs
+++ b/src/NLog/Internal/MultiFileWatcher.cs
@@ -154,9 +154,11 @@ namespace NLog.Internal
                     NotifyFilter = NotifyFilters
                 };
 
-                watcher.Created += FileChanged;
-                watcher.Changed += FileChanged;
-                watcher.Deleted += FileChanged;
+                watcher.Created += OnFileChanged;
+                watcher.Changed += OnFileChanged;
+                watcher.Deleted += OnFileChanged;
+                watcher.Renamed += OnFileChanged;
+                watcher.Error += OnWatcherError;
                 watcher.EnableRaisingEvents = true;
 
                 InternalLogger.Info("Watching path '{0}' filter '{1}' for changes.", watcher.Path, watcher.Filter);
@@ -165,12 +167,35 @@ namespace NLog.Internal
             }
         }
 
-        protected virtual void OnFileChanged(FileSystemEventArgs e)
+        private void OnWatcherError(object source, ErrorEventArgs e)
+        {
+            var watcherPath = string.Empty;
+            var watcher = source as FileSystemWatcher;
+            if (watcher != null)
+                watcherPath = watcher.Path;
+
+            var exception = e.GetException();
+            if (exception != null)
+                InternalLogger.Info(exception, "Error Watching Path {0}", watcherPath);
+            else
+                InternalLogger.Info("Error Watching Path {0}", watcherPath);
+        }
+
+        private void OnFileChanged(object source, FileSystemEventArgs e)
         {
             var changed = FileChanged;
             if (changed != null)
             {
-                changed(this, e);
+                try
+                {
+                    changed(source, e);
+                }
+                catch (Exception ex)
+                {
+                    InternalLogger.Error(ex, "Error Handling File Changed");
+                    if (ex.MustBeRethrownImmediately())
+                        throw;
+                }
             }
         }
     }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -732,11 +732,11 @@ namespace NLog.Targets
         /// </summary>
         private void RefreshArchiveFilePatternToWatch()
         {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
             if (this.fileAppenderCache != null)
             {
                 this.fileAppenderCache.CheckCloseAppenders -= AutoClosingTimerCallback;
 
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
                 if (KeepFileOpen || OpenFileCacheTimeout > 0)
                     this.fileAppenderCache.CheckCloseAppenders += AutoClosingTimerCallback;
 
@@ -757,8 +757,11 @@ namespace NLog.Targets
                 {
                     this.fileAppenderCache.ArchiveFilePatternToWatch = null;
                 }
-            }
+#else
+                if (OpenFileCacheTimeout > 0)
+                    this.fileAppenderCache.CheckCloseAppenders += AutoClosingTimerCallback;
 #endif
+            }
         }
 
         /// <summary>

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -100,13 +100,6 @@ namespace NLog.Targets
         /// </summary>
         private FileAppenderCache fileAppenderCache;
 
-        private Timer autoClosingTimer;
-
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-        private Thread appenderInvalidatorThread = null;
-        private EventWaitHandle stopAppenderInvalidatorThreadWaitHandle = new ManualResetEvent(false);
-#endif
-
         /// <summary>
         /// The number of initialised files at any one time.
         /// </summary>
@@ -742,6 +735,11 @@ namespace NLog.Targets
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
             if (this.fileAppenderCache != null)
             {
+                this.fileAppenderCache.CheckCloseAppenders -= AutoClosingTimerCallback;
+
+                if (KeepFileOpen || OpenFileCacheTimeout > 0)
+                    this.fileAppenderCache.CheckCloseAppenders += AutoClosingTimerCallback;
+
                 bool mustWatchArchiving = IsArchivingEnabled() && ConcurrentWrites && KeepFileOpen;
                 if (mustWatchArchiving)
                 {
@@ -753,56 +751,12 @@ namespace NLog.Targets
                             ReplaceFileNamePattern(fileNamePattern, "*"));
                         //fileNamePattern is absolute
                         this.fileAppenderCache.ArchiveFilePatternToWatch = fileNamePattern;
-
-                        if ((EnableArchiveFileCompression) && (this.appenderInvalidatorThread == null))
-                        {
-                            // EnableArchiveFileCompression creates a new file for the archive, instead of just moving the log file.
-                            // The log file is deleted instead of moved. This process may be holding a lock to that file which will
-                            // avoid the file from being deleted. Therefore we must periodically close appenders for files that 
-                            // were archived so that the file can be deleted.
-
-                            this.appenderInvalidatorThread = new Thread(() =>
-                            {
-                                while (true)
-                                {
-                                    try
-                                    {
-                                        if (this.stopAppenderInvalidatorThreadWaitHandle.WaitOne(200))
-                                            break;
-
-                                        lock (SyncRoot)
-                                        {
-                                            this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
-                                        }
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        InternalLogger.Debug(ex, "Exception in FileTarget appender-invalidator thread.");
-                                    }
-                                }
-                            });
-                            this.appenderInvalidatorThread.IsBackground = true;
-                            this.appenderInvalidatorThread.Start();
-                        }
                     }
                 }
                 else
                 {
                     this.fileAppenderCache.ArchiveFilePatternToWatch = null;
-
-                    this.StopAppenderInvalidatorThread();
                 }
-            }
-#endif
-        }
-
-        private void StopAppenderInvalidatorThread()
-        {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-            if (this.appenderInvalidatorThread != null)
-            {
-                this.stopAppenderInvalidatorThreadWaitHandle.Set();
-                this.appenderInvalidatorThread = null;
             }
 #endif
         }
@@ -944,15 +898,6 @@ namespace NLog.Targets
 
             this.fileAppenderCache = new FileAppenderCache(this.OpenFileCacheSize, this.appenderFactory, this);
             RefreshArchiveFilePatternToWatch();
-
-            if ((this.OpenFileCacheSize > 0 || this.EnableFileDelete) && this.OpenFileCacheTimeout > 0)
-            {
-                this.autoClosingTimer = new Timer(
-                    this.AutoClosingTimerCallback,
-                    null,
-                    this.OpenFileCacheTimeout*1000,
-                    this.OpenFileCacheTimeout*1000);
-            }
         }
 
         /// <summary>
@@ -967,16 +912,8 @@ namespace NLog.Targets
                 this.FinalizeFile(fileName);
             }
 
-            if (this.autoClosingTimer != null)
-            {
-                this.autoClosingTimer.Change(Timeout.Infinite, Timeout.Infinite);
-                this.autoClosingTimer.Dispose();
-                this.autoClosingTimer = null;
-            }
-
-            this.StopAppenderInvalidatorThread();
-
-            this.fileAppenderCache.CloseAppenders();
+            this.fileAppenderCache.CloseAppenders("Dispose");
+            this.fileAppenderCache.Dispose();
         }
 
         /// <summary>
@@ -2061,7 +1998,7 @@ namespace NLog.Targets
             return null;
         }
 
-        private void AutoClosingTimerCallback(object state)
+        private void AutoClosingTimerCallback(object sender, EventArgs state)
         {
             try
             {
@@ -2072,7 +2009,7 @@ namespace NLog.Targets
                         return;
                     }
 
-                    DateTime expireTime = DateTime.UtcNow.AddSeconds(-this.OpenFileCacheTimeout);
+                    DateTime expireTime = this.OpenFileCacheTimeout > 0 ? DateTime.UtcNow.AddSeconds(-this.OpenFileCacheTimeout) : DateTime.MinValue;
                     this.fileAppenderCache.CloseAppenders(expireTime);
                 }
             }

--- a/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
+++ b/tests/NLog.UnitTests/Internal/FileAppenders/FileAppenderCacheTests.cs
@@ -138,24 +138,24 @@ namespace NLog.UnitTests.Internal.FileAppenders
         {
             // Invoke CloseAppenders() on an Empty FileAppenderCache.
             FileAppenderCache emptyCache = FileAppenderCache.Empty;
-            emptyCache.CloseAppenders();
+            emptyCache.CloseAppenders(string.Empty);
 
             
             IFileAppenderFactory appenderFactory = SingleProcessFileAppender.TheFactory;
             ICreateFileParameters fileTarget = new FileTarget();
             FileAppenderCache cache = new FileAppenderCache(3, appenderFactory, fileTarget);
             // Invoke CloseAppenders() on non-empty FileAppenderCache - Before allocating any appenders. 
-            cache.CloseAppenders();            
+            cache.CloseAppenders(string.Empty);            
 
             // Invoke CloseAppenders() on non-empty FileAppenderCache - After allocating N appenders. 
             cache.AllocateAppender("file1.txt");
             cache.AllocateAppender("file2.txt");
-            cache.CloseAppenders();
+            cache.CloseAppenders(string.Empty);
 
             // Invoke CloseAppenders() on non-empty FileAppenderCache - After allocating N appenders. 
             cache.AllocateAppender("file1.txt");
             cache.AllocateAppender("file2.txt");
-            cache.CloseAppenders();
+            cache.CloseAppenders(string.Empty);
 
             FileAppenderCache cache2 = new FileAppenderCache(3, appenderFactory, fileTarget);
             // Invoke CloseAppenders() on non-empty FileAppenderCache - Before allocating any appenders. 

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -116,6 +116,57 @@ namespace NLog.UnitTests.Targets
             }
         }
 
+        [Theory]
+        [PropertyData("SimpleFileTest_TestParameters")]
+        public void SimpleFileDeleteTest(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool forceManaged, bool forceMutexConcurrentWrites)
+        {
+            var logFile = Path.GetTempFileName();
+            var logFile2 = Path.Combine(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()), Path.GetFileName(logFile));
+
+            try
+            {
+                var fileTarget = WrapFileTarget(new FileTarget
+                {
+                    FileName = SimpleLayout.Escape(logFile),
+                    LineEnding = LineEndingMode.LF,
+                    Layout = "${level} ${message}",
+                    OpenFileCacheTimeout = 0,
+                    EnableFileDelete = true,
+                    ConcurrentWrites = concurrentWrites,
+                    KeepFileOpen = keepFileOpen,
+                    NetworkWrites = networkWrites,
+                    ForceManaged = forceManaged,
+                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites
+                });
+
+                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+
+                logger.Debug("aaa");
+
+                LogManager.Flush();
+
+                Directory.CreateDirectory(Path.GetDirectoryName(logFile2));
+                File.Move(logFile, logFile2);
+                if (keepFileOpen)
+                    Thread.Sleep(150);  // Allow AutoClose-Timer-Thread to react (Runs every 50 msec)
+                logger.Info("bbb");
+
+                LogManager.Configuration = null;
+
+                AssertFileContents(logFile, "Info bbb\n", Encoding.UTF8);
+            }
+            finally
+            {
+                if (File.Exists(logFile2))
+                {
+                    File.Delete(logFile2);
+                    Directory.Delete(Path.GetDirectoryName(logFile2));
+                }
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
+            }
+        }
+
         /// <summary>
         /// There was a bug when creating the file in the root.
         /// 

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -870,9 +870,9 @@ namespace NLog.UnitTests.Targets
             const int maxArchiveFiles = 3;
             LogManager.ThrowExceptions = true;
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var logFile = Path.Combine(tempPath, "${date:format=yyyyMMddHHmmssfff}.txt");
             try
             {
+                var logFile = Path.Combine(tempPath, "${date:format=yyyyMMddHHmmssfff}.txt");
                 var fileTarget = WrapFileTarget(new FileTarget
                 {
                     FileName = logFile,
@@ -921,8 +921,6 @@ namespace NLog.UnitTests.Targets
             }
             finally
             {
-                if (File.Exists(logFile))
-                    File.Delete(logFile);
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -2046,10 +2044,10 @@ namespace NLog.UnitTests.Targets
             }
             finally
             {
-                if (File.Exists(invalidLogFileName))
-                    File.Delete(invalidLogFileName);
                 if (File.Exists(expectedCorrectedTempFile))
                     File.Delete(expectedCorrectedTempFile);
+                if (File.Exists(invalidLogFileName))
+                    File.Delete(invalidLogFileName);
             }
         }
 
@@ -2081,6 +2079,8 @@ namespace NLog.UnitTests.Targets
                 {
                     logger.Debug("a");
                 }
+
+                LogManager.Configuration = null;    // Flush
 
                 Assert.True(File.Exists(logFile));
 
@@ -2317,6 +2317,8 @@ namespace NLog.UnitTests.Targets
                     logger.Debug("bbb");
                 }
 
+                LogManager.Configuration = null;
+
                 AssertFileContents(logFile,
                     StringRepeat(times, "bbb\n"),
                     Encoding.UTF8);
@@ -2380,6 +2382,7 @@ namespace NLog.UnitTests.Targets
                     Assert.True(!helper.Exists(numberToBeRemoved), string.Format("archive file {0} has not been removed! We are created file {1}", numberToBeRemoved, i));
                 }
 
+                LogManager.Configuration = null;
             }
             finally
             {
@@ -3243,8 +3246,8 @@ namespace NLog.UnitTests.Targets
                 // write, this should append.
                 logger.Info("log to force archiving");
 
+                LogManager.Configuration = null;    // Flush
 
-                LogManager.Flush();
                 AssertFileContents(archiveFileName, "message already in archive" + Environment.NewLine + "some content" + Environment.NewLine, encoding, hasBom);
             }
             finally
@@ -3307,7 +3310,7 @@ namespace NLog.UnitTests.Targets
                 var logger = LogManager.GetLogger("DontCrashWhenDateAndSequenceDoesntMatchFiles");
                 logger.Info("Log message");
 
-                LogManager.Flush();
+                LogManager.Configuration = null;
             }
             finally
             {


### PR DESCRIPTION
KeepFileOpen should watch for file deletes/renames and close active appenders. Deactivate background monitoring when no active appenders.

(Should) fixes #1826, fixes #1856, fixes #1866

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1878)
<!-- Reviewable:end -->
