### PR TITLE
FileTarget - Rename to tmp file before starting actual compression

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1299,9 +1299,20 @@ namespace NLog.Targets
 
             if (EnableArchiveFileCompression)
             {
+                // Would be nice if the FileCompressor used a temporary-output-filename until completed,
+                // but that would require that the FileAppenderCache also reacted to renames in archive-folder
                 InternalLogger.Info("Archiving {0} to compressed {1}", fileName, archiveFileName);
+                // Would be nice if the FileCompressor supported a temporary-input-filename (ex. archiveFileName + ".tmp")
+                // but that would require that the FileCompressor supported 3 parameters (input-filepath, output-filepath and archive-filename)
+                DateTime orgCreationTime = File.GetCreationTime(fileName);
                 FileCompressor.CompressFile(fileName, archiveFileName);
-                DeleteAndWaitForFileDelete(fileName);
+                if (File.Exists(fileName) && File.GetCreationTime(fileName) == orgCreationTime)
+                {
+                    // Manual cleanup after the FileCompressor
+                    DeleteOldArchiveFile(fileName);
+                    if (File.Exists(fileName) && File.GetCreationTime(fileName) == orgCreationTime)
+                        System.Threading.Thread.Sleep(100);
+                }
             }
             else
             {
@@ -1358,35 +1369,6 @@ namespace NLog.Targets
                 }
 
                 return false;
-            }
-        }
-
-        private static void DeleteAndWaitForFileDelete(string fileName)
-        {
-            try
-            {
-                var originalFileCreationTime = (new FileInfo(fileName)).CreationTime;
-                if (DeleteOldArchiveFile(fileName) && File.Exists(fileName))
-                {
-                    FileInfo currentFileInfo;
-                    for (int i = 0; i < 120; ++i)
-                    { 
-                        Thread.Sleep(100);
-                        currentFileInfo = new FileInfo(fileName);
-                        if (!currentFileInfo.Exists || currentFileInfo.CreationTime != originalFileCreationTime)
-                            return;
-                    }
-
-                    InternalLogger.Warn("Timeout while deleting old archive file: '{0}'.", fileName);
-                }
-            }
-            catch (Exception exception)
-            {
-                InternalLogger.Warn(exception, "Failed to delete old archive file: '{0}'.", fileName);
-                if (exception.MustBeRethrown())
-                {
-                    throw;
-                }
             }
         }
 

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -449,7 +449,7 @@ namespace NLog.UnitTests.Targets
                 Assert.True(File.Exists(archiveTempName));
 
                 var assertFileContents = ft.EnableArchiveFileCompression ?
-                    new Action<string, string, Encoding>(AssertZipFileContents) :
+                    new Action<string, string, Encoding>((fileName,contents,encoding) => AssertZipFileContents(logFile, fileName, contents, encoding)) :
                     AssertFileContents;
 
                 assertFileContents(archiveTempName, "Debug aaa\nInfo bbb\nWarn ccc\nDebug aaa\nInfo bbb\nWarn ccc\n",
@@ -1594,9 +1594,10 @@ namespace NLog.UnitTests.Targets
 
                 var assertFileContents =
 #if NET4_5
- enableCompression ? new Action<string, string, Encoding>(AssertZipFileContents) : AssertFileContents;
+    enableCompression ? new Action<string, string, Encoding>((fileName, contents, encoding) => AssertZipFileContents(logFile, fileName, contents, encoding))
+        : AssertFileContents;
 #else
- new Action<string, string, Encoding>(AssertFileContents);
+    new Action<string, string, Encoding>(AssertFileContents);
 #endif
 
                 var times = 25;
@@ -1955,7 +1956,9 @@ namespace NLog.UnitTests.Targets
 
 
 #if NET4_5
-                var assertFileContents = enableCompression ? new Action<string, string, Encoding>(AssertZipFileContents) : AssertFileContents;
+                var assertFileContents = enableCompression ?
+                    new Action<string, string, Encoding>((fileName, contents, encoding) => AssertZipFileContents(logFileName, fileName, contents, encoding))
+                    : AssertFileContents;
 #else
                 var assertFileContents = new Action<string, string, Encoding>(AssertFileContents);
 #endif


### PR DESCRIPTION
The rename will allow other processes to continue without waiting for compression to complete when ConcurrentWrites=true. Will also fix #1314

This will of couse affect performance if the achive-folder is placed on a remote network-drive, since it will do a file-copy of the uncompressed file before doing the compression.

Could consider to perform the compression in a dedicated thread, but then we need extra logic to join with the dedicated-compression-thread when closing file-target. And also control the thread-priority, and possible queuing of file-compression-tasks.

Would be nice if the IFileCompressor took 3 parameters. Input-FilePath, Output-FilePath and Archive-FileName. Then the rename logic didn't have to be done within IFileCompressor.CompressFile(). This is probably something for NLog 5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1880)
<!-- Reviewable:end -->
