### PR TITLE
LogFactory.Dispose - Should always close down created targets

### DIFF
--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -66,7 +66,7 @@ namespace NLog
         [Obsolete("Marked obsolete before v4.3.11")]
         public delegate CultureInfo GetCultureInfo();
 
-#if !SILVERLIGHT && !MONO
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
         /// <summary>
         /// Initializes static members of the LogManager class.
         /// </summary>
@@ -151,7 +151,7 @@ namespace NLog
             get { return currentAppDomain ?? (currentAppDomain = AppDomainWrapper.CurrentDomain); }
             set
             {
-#if !SILVERLIGHT && !MONO
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
                 if (currentAppDomain != null)
                 {
                     currentAppDomain.DomainUnload -= LogManager_OnStopLogging;
@@ -393,7 +393,7 @@ namespace NLog
             }
         }
 
-#if !SILVERLIGHT && !MONO
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
         private static void SetupTerminationEvents()
         {
             try
@@ -445,6 +445,7 @@ namespace NLog
             return className;
         }
 
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
         private static void LogManager_OnStopLogging(object sender, EventArgs args)
         {
             try
@@ -461,5 +462,6 @@ namespace NLog
                 InternalLogger.Error(ex, "Logger failed to shut down properly.");
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
MONO now also automatically close down created targets (and their timers) on LogFactory-shutdown, just like it currently closes the reload-config-timer (but without spinning up threads for flushing). See also:

http://nlog-project.org/2011/10/30/using-nlog-with-mono.html

It is still a good idea for MONO applications to clear the NLog-configuration just before leaving main(), as it will allow a more speedy (multi-threaded) flush on shutdown (with longer timeout):

> LogManager.Configuration = null

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1883)
<!-- Reviewable:end -->
