### PR TITLE
FileTarget - Archive should not fail when ArchiveFileName matches FileName

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1297,7 +1297,11 @@ namespace NLog.Targets
             if (!Directory.Exists(archiveFolderPath))
                 Directory.CreateDirectory(archiveFolderPath);
 
-            if (EnableArchiveFileCompression)
+            if (string.Equals(fileName, archiveFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                InternalLogger.Info("Archiving {0} skipped as ArchiveFileName equals FileName", fileName);
+            }
+            else if (EnableArchiveFileCompression)
             {
                 InternalLogger.Info("Archiving {0} to compressed {1}", fileName, archiveFileName);
                 FileCompressor.CompressFile(fileName, archiveFileName);

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -877,7 +877,7 @@ namespace NLog.UnitTests.Targets
                 {
                     FileName = logFile,
                     ArchiveFileName = Path.Combine(tempPath, "{#}.txt"),
-                    ArchiveEvery = FileArchivePeriod.Minute,
+                    ArchiveEvery = FileArchivePeriod.Year,
                     LineEnding = LineEndingMode.LF,
                     ArchiveNumbering = ArchiveNumberingMode.Date,
                     ArchiveDateFormat = "yyyyMMddHHmmssfff", //make sure the milliseconds are set in the filename
@@ -1986,9 +1986,10 @@ namespace NLog.UnitTests.Targets
         }
 
         [Theory]
-        [InlineData("/")]
-        [InlineData("\\")]
-        public void FileTarget_WithArchiveFileNameEndingInNumberPlaceholder_ShouldArchiveFile(string slash)
+        [InlineData("archive/test.log.{####}", "archive/test.log.0000")]
+        [InlineData("archive\\test.log.{####}", "archive\\test.log.0000")]
+        [InlineData("file.txt", "file.txt")]
+        public void FileTargetArchiveFileNameTest(string archiveFileName, string expectedArchiveFileName)
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var logFile = Path.Combine(tempPath, "file.txt");
@@ -1997,20 +1998,21 @@ namespace NLog.UnitTests.Targets
                 var fileTarget = WrapFileTarget(new FileTarget
                 {
                     FileName = logFile,
-                    ArchiveFileName = Path.Combine(tempPath, "archive" + slash + "test.log.{####}"),
-                    ArchiveAboveSize = 1000
+                    ArchiveFileName = Path.Combine(tempPath, archiveFileName),
+                    ArchiveAboveSize = 1000,
+                    MaxArchiveFiles = 1000,
                 });
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
 
-                for (var i = 0; i < 100; ++i)
+                for (var i = 0; i < 25; ++i)
                 {
                     logger.Debug("a");
                 }
 
                 LogManager.Configuration = null;
                 Assert.True(File.Exists(logFile));
-                Assert.True(File.Exists(Path.Combine(tempPath, "archive" + slash + "test.log.0000")));
+                Assert.True(File.Exists(Path.Combine(tempPath, expectedArchiveFileName)));
             }
             finally
             {


### PR DESCRIPTION
Attempt to fix the following build error, and also resolve this issue #1707

https://ci.appveyor.com/project/nlog/nlog/build/4.4.4171

Was able to reproduce the bug locally, and it seems the following happens:

The test uses ArchiveEvery = FileArchivePeriod.Minute and FileName = ${date:format=yyyyMMddHHmmssfff}.txt. It sleeps 50 ms between each LogEvent to ensure that each LogEvent get their own file.

If the test is executed at exact 12:59:59.999 then it will trigger an extra unexpected archive operation. As one of LogEvent timestamps will then be one-minute older than the creation-time of the previous log-file.

The archive operation fails because the log-filename (based on current-time) and the generated archive-filename (based on file-write-time) becomes the same. Because the archive-filename already exists then it attempts to append the contents of the log-filename to the archive-filename and it of course fails.

We could change the ArchiveEvery to Year for the test DeleteArchiveFilesByDateWithDateName, and then it would only fail at new years eve.

We could also consider to change FileTarget.ArchiveFile() to check if fileName and archiveFileName is the same, and if so then just do nothing but doing a InternalLogger.Info()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1886)
<!-- Reviewable:end -->
