### PR TITLE
FileTarget - Perform archive retry when concurrent file access

### DIFF
--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -226,15 +226,6 @@ namespace NLog.Internal.FileAppenders
         }
 
         /// <summary>
-        /// Creates a mutually-exclusive lock for archiving files.
-        /// </summary>
-        /// <returns>A <see cref="Mutex"/> object which can be used for controlling the archiving of files.</returns>
-        protected override Mutex CreateArchiveMutex()
-        {
-            return CreateSharableArchiveMutex();
-        }
-
-        /// <summary>
         /// Factory class.
         /// </summary>
         private class Factory : IFileAppenderFactory

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -31,17 +31,11 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__ANDROID__ && !__IOS__
-// Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) so the BaseFileAppender class now throws an exception in the constructor.
-#define SupportsMutex
-#endif
-
 namespace NLog.Internal.FileAppenders
 {
     using System;
     using System.IO;
     using System.Security;
-    using System.Threading;
 
     /// <summary>
     /// Multi-process and multi-host file appender which attempts
@@ -139,17 +133,6 @@ namespace NLog.Internal.FileAppenders
             }
             return null;
         }
-
-#if SupportsMutex
-        /// <summary>
-        /// Creates a mutually-exclusive lock for archiving files.
-        /// </summary>
-        /// <returns>A <see cref="Mutex"/> object which can be used for controlling the archiving of files.</returns>
-        protected override Mutex CreateArchiveMutex()
-        {
-            return CreateSharableArchiveMutex();
-        }
-#endif
 
         /// <summary>
         /// Factory class.

--- a/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
@@ -155,17 +155,6 @@ namespace NLog.Internal.FileAppenders
             }
         }
 
-#if SupportsMutex
-        /// <summary>
-        /// Creates a mutually-exclusive lock for archiving files.
-        /// </summary>
-        /// <returns>A <see cref="Mutex"/> object which can be used for controlling the archiving of files.</returns>
-        protected override Mutex CreateArchiveMutex()
-        {
-            return CreateSharableArchiveMutex();
-        }
-#endif
-
         /// <summary>
         /// Writes the specified bytes.
         /// </summary>

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1308,7 +1308,36 @@ namespace NLog.Targets
                 }
                 else
                 {
-                    File.Move(fileName, archiveFileName);
+                    try
+                    {
+                        File.Move(fileName, archiveFileName);
+                    }
+                    catch (System.IO.IOException ex)
+                    {
+                        if (KeepFileOpen && !ConcurrentWrites)
+                            throw;  // No need to retry, when only single process access
+
+                        if (!EnableFileDelete && KeepFileOpen)
+                            throw;  // No need to retry when file delete has been disabled
+
+                        if (!PlatformDetector.SupportsSharableMutex)
+                            throw;  // No need to retry when not having a real archive mutex to protect us
+
+                        // It is possible to move a file while other processes has open file-handles.
+                        // Unless the other process is actively writing, then the file move might fail.
+                        // We are already holding the archive-mutex, so lets retry if things are stable
+                        InternalLogger.Warn(ex, "Archiving failed. Checking for retry move of {0} to {1}.", fileName, archiveFileName);
+                        if (!File.Exists(fileName) || File.Exists(archiveFileName))
+                            throw;
+
+                        Thread.Sleep(50);
+
+                        if (!File.Exists(fileName) || File.Exists(archiveFileName))
+                            throw;
+
+                        InternalLogger.Info("Archiving retrying move of {0} to {1}.", fileName, archiveFileName);
+                        File.Move(fileName, archiveFileName);
+                    }
                 }
             }
         }
@@ -1425,7 +1454,7 @@ namespace NLog.Targets
         private bool PreviousLogOverlappedPeriod(LogEventInfo logEvent, DateTime lastWrite)
         {
             DateTime timestamp;
-            if(!previousLogEventTimestamp.HasValue)
+            if (!previousLogEventTimestamp.HasValue)
                 return false;
             else
                 timestamp = previousLogEventTimestamp.Value;
@@ -1472,7 +1501,7 @@ namespace NLog.Targets
             // Shamelessly taken from http://stackoverflow.com/a/7611480/1354930
             int start = (int)previousLogEventTimestamp.DayOfWeek;
             int target = (int)dayOfWeek;
-            if(target <= start)
+            if (target <= start)
                 target += 7;
             return previousLogEventTimestamp.AddDays(target - start);
         }
@@ -1622,10 +1651,11 @@ namespace NLog.Targets
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
                     this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
 #endif
-
                     // Close possible stale file handles, before doing extra check
-                    if (archiveFile != fileName)
+                    if (!string.IsNullOrEmpty(fileName) && fileName != archiveFile)
                         this.fileAppenderCache.InvalidateAppender(fileName);
+                    if (!string.IsNullOrEmpty(previousLogFileName) && previousLogFileName != archiveFile && previousLogFileName != fileName)
+                        this.fileAppenderCache.InvalidateAppender(previousLogFileName);
                     this.fileAppenderCache.InvalidateAppender(archiveFile);
                 }
                 else
@@ -1653,6 +1683,8 @@ namespace NLog.Targets
                     {
                         if (archiveMutex != null)
                             archiveMutex.WaitOne();
+                        else if (!KeepFileOpen || ConcurrentWrites)
+                            InternalLogger.Info("Archive mutex not available: {0}", archiveFile);
                     }
                     catch (AbandonedMutexException)
                     {
@@ -1688,7 +1720,9 @@ namespace NLog.Targets
                 {
 #if SupportsMutex
                     if (archiveMutex != null)
+                    {
                         archiveMutex.ReleaseMutex();
+                    }
 #endif
                 }
             }

--- a/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
@@ -242,12 +242,12 @@ namespace NLog.UnitTests.Targets
         [InlineData(2, 500, "none|archive")]
         [InlineData(2, 500, "none|mutex|archive")]
 #endif
-        [InlineData(2, 1000, "none")]
-        [InlineData(5, 1000, "none")]
-        [InlineData(10, 1000, "none")]
-        [InlineData(2, 1000, "none|mutex")]
-        [InlineData(5, 1000, "none|mutex")]
-        [InlineData(10, 1000, "none|mutex")]
+        [InlineData(2, 10000, "none")]
+        [InlineData(5, 4000, "none")]
+        [InlineData(10, 2000, "none")]
+        [InlineData(2, 10000, "none|mutex")]
+        [InlineData(5, 4000, "none|mutex")]
+        [InlineData(10, 2000, "none|mutex")]
         public void SimpleConcurrentTest(int numProcesses, int numLogs, string mode)
         {
             DoConcurrentTest(numProcesses, numLogs, mode);


### PR DESCRIPTION
Extended Fix for #1887. Perform archive-retry when doing concurrent file-access.

Minor refactoring of BaseMutexFileAppender to make it easier to use. Inheriting from the class activates the archive mutex by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1889)
<!-- Reviewable:end -->
