### PR TITLE
LogFactory - Fix ConfigurationChanged-event has flipped the values

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -338,7 +338,7 @@ namespace NLog
                         }
                     }
 
-                    this.OnConfigurationChanged(new LoggingConfigurationChangedEventArgs(value, oldConfig));
+                    this.OnConfigurationChanged(new LoggingConfigurationChangedEventArgs(oldConfig, value));
                 }
             }
         }
@@ -955,7 +955,7 @@ namespace NLog
                                 // Flush completed within timeout, lets try and close down
                                 oldConfig.Close();
                                 this.config = null;
-                                this.OnConfigurationChanged(new LoggingConfigurationChangedEventArgs(null, oldConfig));
+                                this.OnConfigurationChanged(new LoggingConfigurationChangedEventArgs(oldConfig, null));
                             }
                         }
                         catch (Exception ex)


### PR DESCRIPTION
Fixes bug introduced with #491 (NLog 4)

Also reported by  #1122. Breaking change for .NET 5 ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1891)
<!-- Reviewable:end -->
