### PR TITLE
FileTarget - FileLockMultiProcessFileAppender Experimental

### DIFF
--- a/src/NLog/Internal/FileAppenders/FileLockMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/FileLockMultiProcessFileAppender.cs
@@ -1,0 +1,279 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if !SILVERLIGHT
+
+namespace NLog.Internal.FileAppenders
+{
+    using NLog.Common;
+    using System;
+    using System.IO;
+
+    /// <summary>
+    /// Provides a multiprocess-safe atomic file appends while
+    /// keeping the files open.
+    /// </summary>
+    /// <remarks>
+    /// Useful for non-Linux systems where named Mutex is not available.
+    /// Uses file-locking for controlling the atomic write logic.
+    /// </remarks>
+    internal class FileLockMultiProcessFileAppender : BaseMutexFileAppender
+    {
+        public static readonly IFileAppenderFactory TheFactory = new Factory();
+
+        private FileStream fileStream;
+        private readonly FileCharacteristicsHelper fileCharacteristicsHelper;
+        private readonly Random random = new Random();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileLockMultiProcessFileAppender" /> class.
+        /// </summary>
+        /// <param name="fileName">Name of the file.</param>
+        /// <param name="parameters">The parameters.</param>
+        public FileLockMultiProcessFileAppender(string fileName, ICreateFileParameters parameters) : base(fileName, parameters)
+        {
+            try
+            {
+                this.fileStream = CreateFileStream(true);
+                if (this.fileStream.Length == 0)
+                {
+                    // Need a file-length to lock, lets wait for the first write
+                    this.fileStream.Close();
+                    this.fileStream = null;
+                }
+                this.fileCharacteristicsHelper = FileCharacteristicsHelper.CreateHelper(parameters.ForceManaged);
+            }
+            catch
+            {
+                if (this.fileStream != null)
+                {
+                    this.fileStream.Close();
+                    this.fileStream = null;
+                }
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Writes the specified bytes.
+        /// </summary>
+        /// <param name="bytes">The bytes to be written.</param>
+        public override void Write(byte[] bytes)
+        {
+            FileStream mutualExclusive = null;
+            FileStream activeStream = this.fileStream;
+            if (activeStream == null)
+            {
+                int currentDelay = this.CreateFileParameters.ConcurrentWriteAttemptDelay;
+                for (int i = 1; i <= this.CreateFileParameters.ConcurrentWriteAttempts; ++i)
+                {
+                    try
+                    {
+                        mutualExclusive = new FileStream(this.FileName, FileMode.Append, FileAccess.Write, FileShare.Read, this.CreateFileParameters.BufferSize);
+                        activeStream = mutualExclusive;
+                        break;  // We have mutual exclusive access
+                    }
+                    catch (IOException ex)
+                    {
+                        if (i == this.CreateFileParameters.ConcurrentWriteAttempts)
+                            throw;
+
+                        InternalLogger.Warn(ex, "Initial attempt failed to open file {0}", this.FileName);
+                    }
+
+                    activeStream = CreateFileStream(true);
+                    if (activeStream != null)
+                    {
+                        if (activeStream.Length > 0)
+                            break;  // We have a file-length that we can lock
+
+                        activeStream.Close();
+                        activeStream = null;
+                    }
+                }
+            }
+            if (activeStream != null && mutualExclusive == null)
+            {
+                int currentDelay = this.CreateFileParameters.ConcurrentWriteAttemptDelay;
+                for (int i = 1; i <= this.CreateFileParameters.ConcurrentWriteAttempts * 10; ++i)
+                {
+                    try
+                    {
+                        activeStream.Lock(0, 1);
+                        break;
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        throw;
+                    }
+                    catch (IOException)
+                    {
+                        if (i == this.CreateFileParameters.ConcurrentWriteAttempts * 10)
+                            throw;
+
+                        int actualDelay = this.random.Next(currentDelay);
+                        if (currentDelay < 16)
+                            currentDelay *= 2;
+                        System.Threading.Thread.Sleep(actualDelay);
+                        continue;
+                    }
+                }
+            }
+
+            try
+            {
+                activeStream.Seek(0, SeekOrigin.End);
+                activeStream.Write(bytes, 0, bytes.Length);
+                activeStream.Flush();
+                if (CaptureLastWriteTime)
+                {
+                    FileTouched();
+                }
+            }
+            finally
+            {
+                if (mutualExclusive != null)
+                {
+                    bool fileLockAvailable = mutualExclusive.Length > 0;
+                    mutualExclusive.Close();
+                    if (fileLockAvailable)
+                    {
+                        this.fileStream = CreateFileStream(true);
+                        if (this.fileStream.Length == 0)
+                        {
+                            this.fileStream.Close();
+                            this.fileStream = null;
+                        }
+                    }
+                }
+                else if (activeStream != null)
+                {
+                    activeStream.Unlock(0, 1);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Closes this instance.
+        /// </summary>
+        public override void Close()
+        {
+            InternalLogger.Trace("Closing '{0}'", FileName);
+            if (this.fileStream != null)
+            {
+                try
+                {
+                    this.fileStream.Close();
+                }
+                catch (Exception ex)
+                {
+                    // Swallow exception as the file-stream now is in final state (broken instead of closed)
+                    InternalLogger.Warn(ex, "Failed to close file: '{0}'", FileName);
+                }
+                finally
+                {
+                    this.fileStream = null;
+                }
+            }
+
+            FileTouched();
+        }
+
+        /// <summary>
+        /// Flushes this instance.
+        /// </summary>
+        public override void Flush()
+        {
+            // do nothing, the stream is always flushed
+        }
+
+        /// <summary>
+        /// Gets the creation time for a file associated with the appender. The time returned is in Coordinated Universal 
+        /// Time [UTC] standard.
+        /// </summary>
+        /// <returns>The file creation time.</returns>
+        public override DateTime? GetFileCreationTimeUtc()
+        {
+            var fileChars = GetFileCharacteristics();
+            return fileChars != null ? fileChars.CreationTimeUtc : (DateTime?)null;
+        }
+
+        /// <summary>
+        /// Gets the last time the file associated with the appeander is written. The time returned is in Coordinated 
+        /// Universal Time [UTC] standard.
+        /// </summary>
+        /// <returns>The time the file was last written to.</returns>
+        public override DateTime? GetFileLastWriteTimeUtc()
+        {
+            var fileChars = GetFileCharacteristics();
+            return fileChars != null ? fileChars.LastWriteTimeUtc : (DateTime?)null;
+        }
+
+        /// <summary>
+        /// Gets the length in bytes of the file associated with the appeander.
+        /// </summary>
+        /// <returns>A long value representing the length of the file in bytes.</returns>
+        public override long? GetFileLength()
+        {
+            var fileChars = GetFileCharacteristics();
+            return fileChars != null ? fileChars.FileLength : (long?)null;
+        }
+
+        private FileCharacteristics GetFileCharacteristics()
+        {
+            // TODO: It is not efficient to read all the whole FileCharacteristics and then using one property.
+            return fileCharacteristicsHelper.GetFileCharacteristics(FileName, this.fileStream);
+        }
+
+        /// <summary>
+        /// Factory class.
+        /// </summary>
+        private class Factory : IFileAppenderFactory
+        {
+            /// <summary>
+            /// Opens the appender for given file name and parameters.
+            /// </summary>
+            /// <param name="fileName">Name of the file.</param>
+            /// <param name="parameters">Creation parameters.</param>
+            /// <returns>
+            /// Instance of <see cref="BaseFileAppender"/> which can be used to write to the file.
+            /// </returns>
+            BaseFileAppender IFileAppenderFactory.Open(string fileName, ICreateFileParameters parameters)
+            {
+                return new FileLockMultiProcessFileAppender(fileName, parameters);
+            }
+        }
+    }
+}
+
+#endif

--- a/src/NLog/Internal/FileAppenders/ICreateFileParameters.cs
+++ b/src/NLog/Internal/FileAppenders/ICreateFileParameters.cs
@@ -95,5 +95,10 @@ namespace NLog.Internal.FileAppenders
         /// Should we capture the last write time of a file?
         /// </summary>
         bool CaptureLastWriteTime { get; }
+
+        /// <summary>
+        /// Path for storing temporary file-lock-objects when archiving is enabled
+        /// </summary>
+        string CurrentMutexFilePath { get; }
     }
 }

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -31,17 +31,11 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__ANDROID__ && !__IOS__
-// Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) so the BaseFileAppender class now throws an exception in the constructor.
-#define SupportsMutex
-#endif
-
 namespace NLog.Internal.FileAppenders
 {
     using System;
     using System.IO;
     using System.Security;
-    using System.Threading;
 
     /// <summary>
     /// Multi-process and multi-host file appender which attempts
@@ -137,17 +131,6 @@ namespace NLog.Internal.FileAppenders
             }
             return null;
         }
-
-#if SupportsMutex
-        /// <summary>
-        /// Creates a mutually-exclusive lock for archiving files.
-        /// </summary>
-        /// <returns>A <see cref="Mutex"/> object which can be used for controlling the archiving of files.</returns>
-        protected override Mutex CreateArchiveMutex()
-        {
-            return CreateSharableArchiveMutex();
-        }
-#endif
 
         /// <summary>
         /// Factory class.

--- a/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
@@ -60,7 +60,7 @@ namespace NLog.Internal.FileAppenders
     /// processes are trying to write to the same file, because setting the file
     /// pointer to the end of the file and appending can be made one operation.
     /// </remarks>
-    internal class UnixMultiProcessFileAppender : BaseFileAppender
+    internal class UnixMultiProcessFileAppender : BaseMutexFileAppender
     {
         private UnixStream file;
 
@@ -133,7 +133,7 @@ namespace NLog.Internal.FileAppenders
                 this.file = null;
             }
         }
-        
+       
         /// <summary>
         /// Gets the creation time for a file associated with the appender. The time returned is in Coordinated Universal 
         /// Time [UTC] standard.

--- a/src/NLog/Internal/PortableNamedMutex.cs
+++ b/src/NLog/Internal/PortableNamedMutex.cs
@@ -1,0 +1,272 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if !SILVERLIGHT && !__ANDROID__ && !__IOS__
+// Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) 
+#define SupportsMutex
+#endif
+
+namespace NLog.Internal
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Collections.Generic;
+    using NLog.Common;
+
+#if SupportsMutex
+    using System.Security.AccessControl;
+    using System.Security.Principal;
+#endif
+
+    /// <summary>
+    /// Curious if Unix Semaphores are working better
+    /// </summary>
+    internal class PortableNamedMutex : IDisposable
+    {
+#if SupportsMutex
+        readonly Mutex _mutex;
+#endif
+#if !SILVERLIGHT
+        readonly FileStream _fileMutex;
+#endif
+        readonly LockCounter _lockObject;
+
+        private class LockCounter
+        {
+            public LockCounter()
+            {
+                UseCount = 1;
+            }
+            public int UseCount;
+        };
+
+        readonly static object _lockProcess = new object();
+        readonly static Dictionary<string, LockCounter> _lockObjects = new Dictionary<string, LockCounter>(StringComparer.Ordinal);
+
+        public PortableNamedMutex(string name, string mutexPath)
+        {
+#if SupportsMutex
+            try
+            {
+                if (PlatformDetector.SupportsSharableMutex)
+                {
+                    _mutex = CreateSharableMutex(name);
+                    return;
+                }
+            }
+            catch (System.Security.SecurityException ex)
+            {
+                InternalLogger.Warn(ex, "Failed to create global mutex: {0}", name);
+            }
+#endif
+
+#if !SILVERLIGHT
+            if (!string.IsNullOrEmpty(mutexPath))
+            {
+                string fileName = name;
+                foreach (char invalidChar in Path.GetInvalidFileNameChars())
+                    fileName = fileName.Replace(invalidChar, '_');
+
+                string filePath = Path.Combine(mutexPath, fileName);
+                if (filePath.Length > 255)
+                {
+                    fileName = Path.Combine(mutexPath, fileName.Substring(filePath.Length - 255));
+                }
+
+                try
+                {
+                    if (!Directory.Exists(mutexPath))
+                        Directory.CreateDirectory(mutexPath);
+
+                    Random random = null;
+                    for (int i = 1; i <= 10; ++i)
+                    {
+                        try
+                        {
+                            _fileMutex = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete, 1);
+                            if (_fileMutex.Length == 0)
+                            {
+                                var bytes = System.Text.Encoding.Default.GetBytes("NLog File Archive Mutex");
+                                _fileMutex.Write(bytes, 0, bytes.Length);
+                            }
+                            break;
+                        }
+                        catch (System.IO.IOException)
+                        {
+                            if (i == 10)
+                                throw;
+                            if (random == null)
+                                random = new Random();
+                            Thread.Sleep(random.Next(10, 20));
+                        }
+                    }
+                    return;
+                }
+                catch (System.IO.IOException ex)
+                {
+                    InternalLogger.Warn(ex, "Failed to create global file mutex: {0}", filePath);
+                }
+            }
+#endif
+
+            lock (_lockProcess)
+            {
+                if (!_lockObjects.TryGetValue(name, out _lockObject))
+                {
+                    _lockObject = new LockCounter();
+                    _lockObjects[name] = _lockObject;
+                    if (_lockObjects.Count > 5000)
+                    {
+                        List<string> cleanupKeys = new List<string>();
+                        foreach (var lockObject in _lockObjects)
+                            if (lockObject.Value.UseCount <= 0)
+                                cleanupKeys.Add(lockObject.Key);
+                        foreach (var key in cleanupKeys)
+                            _lockObjects.Remove(key);
+                    }
+                }
+                else
+                {
+                    Interlocked.Increment(ref _lockObject.UseCount);
+                }
+            }
+        }
+
+#if SupportsMutex
+        /// <summary>
+        /// Creates a mutex that is sharable by more than one process.
+        /// </summary>
+        /// <param name="name">The prefix to use for the name of the mutex.</param>
+        /// <returns>A <see cref="Mutex"/> object which is sharable by multiple processes.</returns>
+        private Mutex CreateSharableMutex(string name)
+        {
+            // Creates a mutex sharable by more than one process
+            var mutexSecurity = new MutexSecurity();
+            var everyoneSid = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+            mutexSecurity.AddAccessRule(new MutexAccessRule(everyoneSid, MutexRights.FullControl, AccessControlType.Allow));
+
+            // The constructor will either create new mutex or open
+            // an existing one, in a thread-safe manner
+            bool createdNew;
+            return new Mutex(false, name, out createdNew, mutexSecurity);
+        }
+#endif
+
+        public void WaitOne()
+        {
+#if SupportsMutex
+            if (_mutex != null)
+            {
+                try
+                {
+                    _mutex.WaitOne();
+                }
+                catch (AbandonedMutexException)
+                {
+                    // ignore the exception, another process was killed without properly releasing the mutex
+                    // the mutex has been acquired, so proceed to writing
+                    // See: http://msdn.microsoft.com/en-us/library/system.threading.abandonedmutexexception.aspx
+                }
+            }
+            else
+#endif
+#if !SILVERLIGHT
+            if (_fileMutex != null)
+            {
+                Random random = null;
+                for (int i = 1; i <= 1000; ++i)
+                {
+                    try
+                    {
+                        _fileMutex.Lock(0, 1);
+                        break;
+                    }
+                    catch (System.IO.IOException)
+                    {
+                        if (i == 1000)
+                            throw;
+
+                        if (random == null)
+                            random = new Random();
+                        Thread.Sleep(random.Next(10, 20));
+                    }
+                }
+            }
+            else
+#endif
+                Monitor.Enter(_lockObject);
+        }
+
+        public void ReleaseMutex()
+        {
+#if SupportsMutex
+            if (_mutex != null)
+                _mutex.ReleaseMutex();
+            else
+#endif
+#if !SILVERLIGHT
+            if (_fileMutex != null)
+                _fileMutex.Unlock(0, 1);
+            else
+#endif
+                Monitor.Exit(_lockObject);
+        }
+
+        public void Close()
+        {
+            Dispose();
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+
+#if SupportsMutex
+            if (_mutex != null)
+                _mutex.Close();
+            else
+#endif
+#if !SILVERLIGHT
+            if (_fileMutex != null)
+                _fileMutex.Close(); // TODO File Cleanup
+            else
+#endif
+                Interlocked.Decrement(ref _lockObject.UseCount);
+        }
+        private bool _disposed;
+    }
+}

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Internal\PathHelpers.cs" />
     <Compile Include="Internal\PlatformDetector.cs" />
     <Compile Include="Internal\PortableFileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\PortableNamedMutex.cs" />
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
+    <Compile Include="Internal\FileAppenders\FileLockMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -175,6 +175,7 @@
     <Compile Include="Internal\PathHelpers.cs" />
     <Compile Include="Internal\PlatformDetector.cs" />
     <Compile Include="Internal\PortableFileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\PortableNamedMutex.cs" />
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
+    <Compile Include="Internal\FileAppenders\FileLockMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
+    <Compile Include="Internal\FileAppenders\FileLockMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Internal\PathHelpers.cs" />
     <Compile Include="Internal\PlatformDetector.cs" />
     <Compile Include="Internal\PortableFileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\PortableNamedMutex.cs" />
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
+    <Compile Include="Internal\FileAppenders\FileLockMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Internal\PathHelpers.cs" />
     <Compile Include="Internal\PlatformDetector.cs" />
     <Compile Include="Internal\PortableFileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\PortableNamedMutex.cs" />
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
+    <Compile Include="Internal\FileAppenders\FileLockMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Internal\PathHelpers.cs" />
     <Compile Include="Internal\PlatformDetector.cs" />
     <Compile Include="Internal\PortableFileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\PortableNamedMutex.cs" />
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
+    <Compile Include="Internal\FileAppenders\FileLockMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Internal\PathHelpers.cs" />
     <Compile Include="Internal\PlatformDetector.cs" />
     <Compile Include="Internal\PortableFileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\PortableNamedMutex.cs" />
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Internal\PathHelpers.cs" />
     <Compile Include="Internal\PlatformDetector.cs" />
     <Compile Include="Internal\PortableFileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\PortableNamedMutex.cs" />
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,8 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <TargetFrameworkProfile></TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -155,6 +154,7 @@
     <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
+    <Compile Include="Internal\FileAppenders\FileLockMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
+    <Compile Include="Internal\FileAppenders\FileLockMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Internal\PathHelpers.cs" />
     <Compile Include="Internal\PlatformDetector.cs" />
     <Compile Include="Internal\PortableFileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\PortableNamedMutex.cs" />
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -192,6 +192,7 @@
     <Compile Include="Internal\PathHelpers.cs" />
     <Compile Include="Internal\PlatformDetector.cs" />
     <Compile Include="Internal\PortableFileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\PortableNamedMutex.cs" />
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
+    <Compile Include="Internal\FileAppenders\FileLockMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
+    <Compile Include="Internal\FileAppenders\FileLockMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -191,6 +191,7 @@
     <Compile Include="Internal\PathHelpers.cs" />
     <Compile Include="Internal\PlatformDetector.cs" />
     <Compile Include="Internal\PortableFileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\PortableNamedMutex.cs" />
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
+    <Compile Include="Internal\FileAppenders\FileLockMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -191,6 +191,7 @@
     <Compile Include="Internal\PathHelpers.cs" />
     <Compile Include="Internal\PlatformDetector.cs" />
     <Compile Include="Internal\PortableFileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\PortableNamedMutex.cs" />
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Internal\FileAppenders\BaseMutexFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\CountingSingleProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\FileAppenderCache.cs" />
+    <Compile Include="Internal\FileAppenders\FileLockMultiProcessFileAppender.cs" />
     <Compile Include="Internal\FileAppenders\ICreateFileParameters.cs" />
     <Compile Include="Internal\FileAppenders\IFileAppenderFactory.cs" />
     <Compile Include="Internal\FileAppenders\MutexMultiProcessFileAppender.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -216,6 +216,7 @@
     <Compile Include="Internal\PathHelpers.cs" />
     <Compile Include="Internal\PlatformDetector.cs" />
     <Compile Include="Internal\PortableFileCharacteristicsHelper.cs" />
+    <Compile Include="Internal\PortableNamedMutex.cs" />
     <Compile Include="Internal\PortableThreadIDHelper.cs" />
     <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\ReflectionHelpers.cs" />

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -627,6 +627,31 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Path to store temporary mutex archive file handles
+        /// </summary>
+        public Layout ArchiveMutexPath { get; set; }
+
+        /// <summary>
+        /// Hello World
+        /// </summary>
+        string ICreateFileParameters.CurrentMutexFilePath
+        {
+            get
+            {
+
+                if (!IsArchivingEnabled())
+                    return null;    // Not needed
+                if (PlatformDetector.SupportsSharableMutex)
+                    return null;    // Not needed
+
+                if (ArchiveMutexPath == null)
+                    return string.Empty;    // Generate NLogLock-subfolder within filepath
+                else
+                    return ArchiveMutexPath.Render(LogEventInfo.CreateNullEvent());
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the maximum number of archive files that should be kept.
         /// </summary>
         /// <docgen category='Archival Options' order='10' />
@@ -672,7 +697,7 @@ namespace NLog.Targets
                 }
             }
         }
-        
+
         /// <summary>
         /// Gets or set a value indicating whether a managed file stream is forced, instead of using the native implementation.
         /// </summary>
@@ -952,8 +977,8 @@ namespace NLog.Targets
                 this.autoClosingTimer = new Timer(
                     this.AutoClosingTimerCallback,
                     null,
-                    this.OpenFileCacheTimeout*1000,
-                    this.OpenFileCacheTimeout*1000);
+                    this.OpenFileCacheTimeout * 1000,
+                    this.OpenFileCacheTimeout * 1000);
             }
         }
 
@@ -1312,12 +1337,12 @@ namespace NLog.Targets
                 {
                     //todo handle double footer
                     InternalLogger.Info("Already exists, append to {0}", archiveFileName);
-                    
+
                     //todo maybe needs a better filelock behaviour
 
                     //copy to archive file.
                     using (FileStream fileStream = File.Open(fileName, FileMode.Open))
-                    using (FileStream archiveFileStream = File.Open(archiveFileName, FileMode.Append ))
+                    using (FileStream archiveFileStream = File.Open(archiveFileName, FileMode.Append))
                     {
                         fileStream.CopyAndSkipBom(archiveFileStream, Encoding);
                         //clear old content
@@ -1372,7 +1397,7 @@ namespace NLog.Targets
                 {
                     FileInfo currentFileInfo;
                     for (int i = 0; i < 120; ++i)
-                    { 
+                    {
                         Thread.Sleep(100);
                         currentFileInfo = new FileInfo(fileName);
                         if (!currentFileInfo.Exists || currentFileInfo.CreationTime != originalFileCreationTime)
@@ -1867,18 +1892,30 @@ namespace NLog.Targets
         {
             string archiveFile = string.Empty;
 
+            PortableNamedMutex archiveMutex = null;
+
             try
             {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-                this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
-#endif
                 archiveFile = this.GetArchiveFileName(fileName, ev, upcomingWriteSize);
                 if (!string.IsNullOrEmpty(archiveFile))
                 {
+                    // Acquire the mutex from the file-appender, before closing the file-apppender (remember not to close the Mutex)
+                    archiveMutex = this.fileAppenderCache.GetArchiveMutex(fileName);
+
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+                    this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
+#endif
+
                     // Close possible stale file handles, before doing extra check
                     if (archiveFile != fileName)
                         this.fileAppenderCache.InvalidateAppender(fileName);
                     this.fileAppenderCache.InvalidateAppender(archiveFile);
+                }
+                else
+                {
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+                    this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
+#endif
                 }
             }
             catch (Exception exception)
@@ -1892,22 +1929,11 @@ namespace NLog.Targets
 
             if (!string.IsNullOrEmpty(archiveFile))
             {
-#if SupportsMutex
-                Mutex archiveMutex = this.fileAppenderCache.GetArchiveMutex(fileName);
                 try
                 {
                     if (archiveMutex != null)
                         archiveMutex.WaitOne();
-                }
-                catch (AbandonedMutexException)
-                {
-                    // ignore the exception, another process was killed without properly releasing the mutex
-                    // the mutex has been acquired, so proceed to writing
-                    // See: http://msdn.microsoft.com/en-us/library/system.threading.abandonedmutexexception.aspx
-                }
-#endif
-                try
-                {
+
                     // Check again if archive is needed. We could have been raced by another process
                     var validatedArchiveFile = this.GetArchiveFileName(fileName, ev, upcomingWriteSize);
                     if (string.IsNullOrEmpty(validatedArchiveFile))
@@ -1931,10 +1957,8 @@ namespace NLog.Targets
                 }
                 finally
                 {
-#if SupportsMutex
                     if (archiveMutex != null)
                         archiveMutex.ReleaseMutex();
-#endif
                 }
             }
         }

--- a/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
@@ -52,20 +52,28 @@ namespace NLog.UnitTests.Targets
             var modes = mode.Split('|');
 
             FileTarget ft = new FileTarget();
-            ft.FileName = "${basedir}/" + fileName;
+            ft.FileName = fileName;
             ft.Layout = "${message}";
             ft.KeepFileOpen = true;
             ft.OpenFileCacheTimeout = 10;
             ft.OpenFileCacheSize = 1;
             ft.LineEnding = LineEndingMode.LF;
-            ft.ForceMutexConcurrentWrites = modes.Length == 2 && modes[1] == "mutex" ? true : false;
+            ft.KeepFileOpen = Array.IndexOf(modes, "retry") >= 0 ? false : true;
+            ft.ForceMutexConcurrentWrites = Array.IndexOf(modes, "mutex") >= 0 ? true : false;
+            ft.ArchiveAboveSize = Array.IndexOf(modes, "archive") >= 0 ? 50 : -1;
+            if (ft.ArchiveAboveSize > 0)
+            {
+                string archivePath = Path.Combine(Path.GetDirectoryName(fileName), "Archive");
+                ft.ArchiveFileName = Path.Combine(archivePath, "{####}_" + Path.GetFileName(fileName));
+                ft.MaxArchiveFiles = 10000;
+            }
 
             var name = "ConfigureSharedFile_" + mode.Replace('|', '_') + "-wrapper";
 
             switch (modes[0])
             {
                 case "async":
-                    SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(ft, 100, AsyncTargetWrapperOverflowAction.Grow) { Name = name }, LogLevel.Debug);
+                    SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(ft, 100, AsyncTargetWrapperOverflowAction.Grow) { Name = name, TimeToSleepBetweenBatches = 10 }, LogLevel.Debug);
                     break;
 
                 case "buffered":
@@ -82,29 +90,50 @@ namespace NLog.UnitTests.Targets
             }
         }
 
-        public void Process(string processIndex, string numProcessesString, string numLogsString, string mode)
+        public void Process(string processIndex, string fileName, string numLogsString, string mode)
         {
             Thread.CurrentThread.Name = processIndex;
 
-            int numProcesses = Convert.ToInt32(numProcessesString);
             int numLogs = Convert.ToInt32(numLogsString);
-            string fileName = MakeFileName(numProcesses, numLogs, mode);
+            int idxProcess = Convert.ToInt32(processIndex);
 
             ConfigureSharedFile(mode, fileName);
 
             // Having the internal logger enabled would just slow things down, reducing the 
             // likelyhood for uncovering racing conditions.
-            //InternalLogger.LogLevel = LogLevel.Trace;
-            //InternalLogger.LogToConsole = true;
+            //var logWriter = new StringWriter { NewLine = Environment.NewLine };
+            //NLog.Common.InternalLogger.LogLevel = LogLevel.Trace;
+            //NLog.Common.InternalLogger.LogFile = Path.Combine(Path.GetDirectoryName(fileName), string.Format("Internal_{0}.txt", processIndex));
+            //NLog.Common.InternalLogger.LogWriter = logWriter;
+            //NLog.Common.InternalLogger.LogToConsole = true;
 
             string format = processIndex + " {0}";
 
-            for (int i = 0; i < numLogs; ++i)
+            try
             {
-                logger.Debug(format, i);
+                Thread.Sleep(Math.Max((10 - idxProcess), 1) * 5);  // Delay to wait for the other processes
+
+                for (int i = 0; i < numLogs; ++i)
+                {
+                    logger.Debug(format, i);
+                }
+
+                LogManager.Configuration = null;     // Flush + Close
+            }
+            catch (Exception ex)
+            {
+                using (var textWriter = File.AppendText(Path.Combine(Path.GetDirectoryName(fileName), string.Format("Internal_{0}.txt", processIndex))))
+                {
+                    textWriter.WriteLine(ex.ToString());
+                    //textWriter.WriteLine(logWriter.GetStringBuilder().ToString());
+                }
+                throw;
             }
 
-            LogManager.Configuration = null;
+            //using (var textWriter = File.AppendText(Path.Combine(Path.GetDirectoryName(fileName), string.Format("Internal_{0}.txt", processIndex))))
+            //{
+            //    textWriter.WriteLine(logWriter.GetStringBuilder().ToString());
+            //}
         }
 
         private string MakeFileName(int numProcesses, int numLogs, string mode)
@@ -115,63 +144,101 @@ namespace NLog.UnitTests.Targets
 
         private void DoConcurrentTest(int numProcesses, int numLogs, string mode)
         {
-            string logFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, MakeFileName(numProcesses, numLogs, mode));
+            string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string archivePath = Path.Combine(tempPath, "Archive");
 
-            if (File.Exists(logFile))
-                File.Delete(logFile);
-
-            Process[] processes = new Process[numProcesses];
-
-            for (int i = 0; i < numProcesses; ++i)
+            try
             {
-                processes[i] = ProcessRunner.SpawnMethod(
-                    this.GetType(),
-                    "Process",
-                    i.ToString(),
-                    numProcesses.ToString(),
-                    numLogs.ToString(),
-                    mode);
-            }
+                Directory.CreateDirectory(tempPath);
+                Directory.CreateDirectory(archivePath);
 
-            // In case we'd like to capture stdout, we would need to drain it continuously.
-            // StandardOutput.ReadToEnd() wont work, since the other processes console only has limited buffer.
-            for (int i = 0; i < numProcesses; ++i)
-            {
-                processes[i].WaitForExit();
-                Assert.Equal(0, processes[i].ExitCode);
-                processes[i].Dispose();
-                processes[i] = null;
-            }
+                string logFile = Path.Combine(tempPath, MakeFileName(numProcesses, numLogs, mode));
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
 
-            int[] maxNumber = new int[numProcesses];
+                Process[] processes = new Process[numProcesses];
 
-            Console.WriteLine("Verifying output file {0}", logFile);
-            using (StreamReader sr = File.OpenText(logFile))
-            {
-                string line;
-
-                while ((line = sr.ReadLine()) != null)
+                for (int i = 0; i < numProcesses; ++i)
                 {
-                    string[] tokens = line.Split(' ');
-                    Assert.Equal(2, tokens.Length);
-                    try
+                    processes[i] = ProcessRunner.SpawnMethod(
+                        this.GetType(),
+                        "Process",
+                        i.ToString(),
+                        logFile,
+                        numLogs.ToString(),
+                        mode);
+                }
+
+                // In case we'd like to capture stdout, we would need to drain it continuously.
+                // StandardOutput.ReadToEnd() wont work, since the other processes console only has limited buffer.
+                for (int i = 0; i < numProcesses; ++i)
+                {
+                    processes[i].WaitForExit();
+                    Assert.Equal(0, processes[i].ExitCode);
+                    processes[i].Dispose();
+                    processes[i] = null;
+                }
+
+                var files = new System.Collections.Generic.List<string>(Directory.GetFiles(archivePath));
+                files.Add(logFile);
+
+                bool verifyFileSize = files.Count > 1;
+
+                int[] maxNumber = new int[numProcesses];
+                Console.WriteLine("Verifying output file {0}", logFile);
+                foreach (var file in files)
+                {
+                    using (StreamReader sr = File.OpenText(file))
                     {
-                        int thread = Convert.ToInt32(tokens[0]);
-                        int number = Convert.ToInt32(tokens[1]);
-                        Assert.True(thread >= 0);
-                        Assert.True(thread < numProcesses);
-                        Assert.Equal(maxNumber[thread], number);
-                        maxNumber[thread]++;
+                        string line;
+
+                        while ((line = sr.ReadLine()) != null)
+                        {
+                            string[] tokens = line.Split(' ');
+                            Assert.Equal(2, tokens.Length);
+                            try
+                            {
+                                int thread = Convert.ToInt32(tokens[0]);
+                                int number = Convert.ToInt32(tokens[1]);
+                                Assert.True(thread >= 0);
+                                Assert.True(thread < numProcesses);
+                                Assert.Equal(maxNumber[thread], number);
+                                maxNumber[thread]++;
+                            }
+                            catch (Exception ex)
+                            {
+                                throw new InvalidOperationException(string.Format("Error when parsing line '{0}' in file {1}", line, file), ex);
+                            }
+                        }
+
+                        if (verifyFileSize)
+                        {
+                            if (sr.BaseStream.Length > 70)
+                                throw new InvalidOperationException(string.Format("Error when reading file {0}, size {1} is too large", file, sr.BaseStream.Length));
+                            else if (sr.BaseStream.Length < 35 && files[files.Count - 1] != file)
+                                throw new InvalidOperationException(string.Format("Error when reading file {0}, size {1} is too small", file, sr.BaseStream.Length));
+                        }
                     }
-                    catch (Exception ex)
-                    {
-                        throw new InvalidOperationException("Error when parsing line '" + line + "'", ex);
-                    }
+                }
+            }
+            finally
+            {
+                try
+                {
+                    if (Directory.Exists(archivePath))
+                        Directory.Delete(archivePath, true);
+                    if (Directory.Exists(tempPath))
+                        Directory.Delete(tempPath, true);
+                }
+                catch
+                {
                 }
             }
         }
 
         [Theory]
+        [InlineData(2, 500, "none|archive")]
+        [InlineData(2, 500, "none|retry|archive")]
         [InlineData(2, 10000, "none")]
         [InlineData(5, 4000, "none")]
         [InlineData(10, 2000, "none")]


### PR DESCRIPTION
Trying out FileStream.Lock / Unlock for doing multi-process file-write without mutex (MONO non-Linux or NET Core v2 non-Windows). See also https://github.com/dotnet/coreclr/pull/8233

Right now using the log-file for the locking, but could also use an empty file in a NLogLock-subfolder (Ex. also for archive mutex)

Because the FileStream.Lock operation is not blocking, then it becomes a polled interface. So when having many processes actively writing to the same file, then it will be faster with named-mutex if available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1892)
<!-- Reviewable:end -->
