### PR TITLE
FileTarget - MONO doesn't like using the native Win32 API

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -290,7 +290,7 @@ namespace NLog.Internal.FileAppenders
 #if !SILVERLIGHT && !MONO && !__IOS__ && !__ANDROID__
             try
             {
-                if (!this.CreateFileParameters.ForceManaged && PlatformDetector.IsDesktopWin32)
+                if (!this.CreateFileParameters.ForceManaged && PlatformDetector.IsDesktopWin32 && !PlatformDetector.IsMono)
                 {
                     return this.WindowsCreateFile(this.FileName, allowFileSharedWriting);
                 }

--- a/src/NLog/Internal/FileCharacteristicsHelper.cs
+++ b/src/NLog/Internal/FileCharacteristicsHelper.cs
@@ -46,7 +46,7 @@ namespace NLog.Internal
         public static FileCharacteristicsHelper CreateHelper(bool forcedManaged)
         {
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-            if (PlatformDetector.IsDesktopWin32 && !forcedManaged)
+            if (!forcedManaged && PlatformDetector.IsDesktopWin32 && !PlatformDetector.IsMono)
             {
                 return new Win32FileCharacteristicsHelper();
             }


### PR DESCRIPTION
Together with #1883, then it will also resolve the issue #1349 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1893)
<!-- Reviewable:end -->
