### PR TITLE
LogFactory - Fixed EventArgs for ConfigurationChanged

### DIFF
--- a/src/NLog/Config/LoggingConfigurationChangedEventArgs.cs
+++ b/src/NLog/Config/LoggingConfigurationChangedEventArgs.cs
@@ -43,24 +43,38 @@ namespace NLog.Config
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggingConfigurationChangedEventArgs" /> class.
         /// </summary>
-        /// <param name="oldConfiguration">The old configuration.</param>
-        /// <param name="newConfiguration">The new configuration.</param>
-        public LoggingConfigurationChangedEventArgs(LoggingConfiguration oldConfiguration, LoggingConfiguration newConfiguration)
+        /// <param name="activatedConfiguration">The new configuration.</param>
+        /// <param name="deactivatedConfiguration">The old configuration.</param>
+        public LoggingConfigurationChangedEventArgs(LoggingConfiguration activatedConfiguration, LoggingConfiguration deactivatedConfiguration)
         {
-            this.OldConfiguration = oldConfiguration;
-            this.NewConfiguration = newConfiguration;
+            this.ActivatedConfiguration = activatedConfiguration;
+            this.DeactivatedConfiguration = deactivatedConfiguration;
         }
 
         /// <summary>
         /// Gets the old configuration.
         /// </summary>
         /// <value>The old configuration.</value>
-        public LoggingConfiguration OldConfiguration { get; private set; }
+        public LoggingConfiguration DeactivatedConfiguration { get; private set; }
 
         /// <summary>
         /// Gets the new configuration.
         /// </summary>
         /// <value>The new configuration.</value>
-        public LoggingConfiguration NewConfiguration { get; private set; }
+        public LoggingConfiguration ActivatedConfiguration { get; private set; }
+
+        /// <summary>
+        /// Gets the new configuration
+        /// </summary>
+        /// <value>The new configuration.</value>
+        [Obsolete("This option will be removed in NLog 5. Marked obsolete on NLog 4.5")]
+        public LoggingConfiguration OldConfiguration { get { return ActivatedConfiguration; } }
+
+        /// <summary>
+        /// Gets the old configuration
+        /// </summary>
+        /// <value>The old configuration.</value>
+        [Obsolete("This option will be removed in NLog 5. Marked obsolete on NLog 4.5")]
+        public LoggingConfiguration NewConfiguration { get { return DeactivatedConfiguration; } }
     }
 }


### PR DESCRIPTION
Fixes the issue #1122 with the breaking change introduced with NLog ver. 4 for LoggingConfigurationChangedEventArgs. See also #491

This marks the broken OldConfiguration and NewConfiguration as obsolete, and instead introduces two new properties:

- ActivatedConfiguration
- DeactivatedConfiguration

No source breaking change, and no binary breaking change. Just obsolete warnings and new properties.