### PR TITLE
LogManager.Shutdown - Use the official method for closing down

### DIFF
--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -384,13 +384,10 @@ namespace NLog
         /// </summary>
         public static void Shutdown()
         {
-            if (Configuration != null && Configuration.AllTargets != null)
-            {
-                foreach (var target in Configuration.AllTargets)
-                {
-                    if (target != null) target.Dispose();
-                }
-            }
+            InternalLogger.Info("Logger closing down...");
+            if (Configuration != null)
+                Configuration.Close();
+            InternalLogger.Info("Logger has been closed down.");
         }
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -35,7 +35,6 @@ namespace NLog.Targets
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading;
 
     using NLog.Common;
     using NLog.Config;
@@ -48,7 +47,7 @@ namespace NLog.Targets
     [NLogConfigurationItem]
     public abstract class Target : ISupportsInitialize, IDisposable
     {
-        private object lockObject = new object();
+        private readonly object lockObject = new object();
         private List<Layout> allLayouts;
         private bool allLayoutsAreThreadAgnostic;
         private bool scannedForLayouts;
@@ -375,7 +374,11 @@ namespace NLog.Targets
         {
             if (disposing)
             {
-                this.CloseTarget();
+                if (this.isInitialized && this.initializeException == null)
+                {
+                    this.isInitialized = false;
+                    this.CloseTarget();
+                }
             }
         }
 

--- a/tests/NLog.UnitTests/LogManagerTests.cs
+++ b/tests/NLog.UnitTests/LogManagerTests.cs
@@ -473,6 +473,28 @@ namespace NLog.UnitTests
 #endif
 #if NET4_5
 
+        [Fact]
+        public void ThreadSafe_Shutdown()
+        {
+            LogManager.Configuration = new LoggingConfiguration();
+            LogManager.ThrowExceptions = true;
+            LogManager.Configuration.AddTarget("memory", new NLog.Targets.Wrappers.BufferingTargetWrapper(new MemoryQueueTarget(500), 5, 1));
+            LogManager.Configuration.LoggingRules.Add(new LoggingRule("*", LogLevel.Debug, LogManager.Configuration.FindTargetByName("memory")));
+            LogManager.Configuration.AddTarget("memory2", new NLog.Targets.Wrappers.BufferingTargetWrapper(new MemoryQueueTarget(500), 5, 1));
+            LogManager.Configuration.LoggingRules.Add(new LoggingRule("*", LogLevel.Debug, LogManager.Configuration.FindTargetByName("memory2")));
+            var stopFlag = false;
+            var exceptionThrown = false;
+            Task.Run(() => { try { var logger = LogManager.GetLogger("Hello"); while (!stopFlag) { logger.Debug("Hello World"); System.Threading.Thread.Sleep(1); } } catch { exceptionThrown = true; } });
+            Task.Run(() => { try { var logger = LogManager.GetLogger("Hello"); while (!stopFlag) { logger.Debug("Hello World"); System.Threading.Thread.Sleep(1); } } catch { exceptionThrown = true; } });
+            System.Threading.Thread.Sleep(20);
+            LogManager.Shutdown();  // Shutdown active LoggingConfiguration
+            System.Threading.Thread.Sleep(20);
+            stopFlag = true;
+            System.Threading.Thread.Sleep(20);
+            Assert.Equal(false, exceptionThrown);
+        }
+
+
         /// <summary>
         /// target for <see cref="ThreadSafe_getCurrentClassLogger_test"/>
         /// </summary>
@@ -532,14 +554,28 @@ namespace NLog.UnitTests
 
             public MemoryQueueTarget(int size)
             {
-                this.Logs = new Queue<string>();
                 this.maxSize = size;
+            }
+
+            protected override void InitializeTarget()
+            {
+                base.InitializeTarget();
+                this.Logs = new Queue<string>(maxSize);
+            }
+
+            protected override void CloseTarget()
+            {
+                base.CloseTarget();
+                this.Logs = null;
             }
 
             public Queue<string> Logs { get; private set; }
 
             protected override void Write(LogEventInfo logEvent)
             {
+                if (this.Logs == null)
+                    throw new ObjectDisposedException("MemoryQueueTarget");
+
                 string msg = this.Layout.Render(logEvent);
                 if (msg.Length > 100)
                     msg = msg.Substring(0, 100) + "...";


### PR DESCRIPTION
Close the active configuration, instead of disposing targets directly (using the correct order). Fixed Target.Dispose so it checks Target.IsInitialized. Attempt to fix #1898

Original request for LogManager.Shutdown was a way to close down targets. See #82

There are now the following explicit shutdown options:

- **LogManager.Configuration = null** - Triggers an explicit multithreaded flush (with a timeout of 15 secs) and then closes down targets. Notifies that LoggingConfiguration has been cleared. And still reacts to reload-events with file-watcher.
- **LogManager.Shutdown()** / **LogManager.Configuration.Close()** -  Closes down targets (and flushes if target implements it). But without triggering LoggingConfiguration changed event. And still reacts to reload-events with file-watcher
- **Logger.Factory.Dispose** - Closes down targets (and flushes if target implements it). Clears LoggingConfiguration, and no more reload-events as the file-watcher is stopped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1899)
<!-- Reviewable:end -->
