### PR TITLE
Inject basedir - allow one current IAppDomain, open IAppDomain in all platforms

### DIFF
--- a/src/NLog/Config/ConfigSectionHandler.cs
+++ b/src/NLog/Config/ConfigSectionHandler.cs
@@ -73,7 +73,7 @@ namespace NLog.Config
         /// <returns>The created section handler object.</returns>
         object IConfigurationSectionHandler.Create(object parent, object configContext, XmlNode section)
         {
-            return Create(section, AppDomainWrapper.CurrentDomain);
+            return Create(section, LogFactory.CurrentAppDomain);
         }
     }
 }

--- a/src/NLog/Internal/Fakeables/AppDomainWrapper.cs
+++ b/src/NLog/Internal/Fakeables/AppDomainWrapper.cs
@@ -88,7 +88,6 @@ namespace NLog.Internal.Fakeables
         /// </summary>
         public static AppDomainWrapper CurrentDomain { get { return new AppDomainWrapper(AppDomain.CurrentDomain); } }
 
-#if !SILVERLIGHT
         /// <summary>
         /// Gets or sets the base directory that the assembly resolver uses to probe for assemblies.
         /// </summary>
@@ -113,9 +112,7 @@ namespace NLog.Internal.Fakeables
         /// Gets an integer that uniquely identifies the application domain within the process. 
         /// </summary>
         public int Id { get; private set; }
-#endif
 
-#if !SILVERLIGHT
         /// <summary>
         /// Process exit event.
         /// </summary>
@@ -123,15 +120,19 @@ namespace NLog.Internal.Fakeables
         {
             add
             {
-                if (this.processExitEvent == null)
+#if !SILVERLIGHT
+                if (this.processExitEvent == null && this.currentAppDomain != null)
                     this.currentAppDomain.ProcessExit += OnProcessExit;
+#endif
                 this.processExitEvent += value;
             }
             remove
             {
                 this.processExitEvent -= value;
-                if (this.processExitEvent == null)
+#if !SILVERLIGHT
+                if (this.processExitEvent == null && this.currentAppDomain != null)
                     this.currentAppDomain.ProcessExit -= OnProcessExit;
+#endif
             }
         }
         private event EventHandler<EventArgs> processExitEvent;
@@ -143,15 +144,20 @@ namespace NLog.Internal.Fakeables
         {
             add
             {
-                if (this.domainUnloadEvent == null)
+#if !SILVERLIGHT
+                if (this.domainUnloadEvent == null && this.currentAppDomain != null)
                     this.currentAppDomain.DomainUnload += OnDomainUnload;
+#endif
                 this.domainUnloadEvent += value;
+
             }
             remove
             {
                 this.domainUnloadEvent -= value;
-                if (this.domainUnloadEvent == null)
+#if !SILVERLIGHT
+                if (this.domainUnloadEvent == null && this.currentAppDomain != null)
                     this.currentAppDomain.DomainUnload -= OnDomainUnload;
+#endif
             }
         }
         private event EventHandler<EventArgs> domainUnloadEvent;
@@ -159,14 +165,13 @@ namespace NLog.Internal.Fakeables
         private void OnDomainUnload(object sender, EventArgs e)
         {
             var handler = domainUnloadEvent;
-            if (handler != null) handler(sender, e);
+            if (handler != null) handler.Invoke(sender, e);
         }
 
         private void OnProcessExit(object sender, EventArgs eventArgs)
         {
             var handler = processExitEvent;
-            if (handler != null) handler(sender, eventArgs);
+            if (handler != null) handler.Invoke(sender, eventArgs);
         }
-#endif
     }
 }

--- a/src/NLog/Internal/Fakeables/IAppDomain.cs
+++ b/src/NLog/Internal/Fakeables/IAppDomain.cs
@@ -41,7 +41,6 @@ namespace NLog.Internal.Fakeables
     /// </summary>
     public interface IAppDomain
     {
-#if !SILVERLIGHT
         /// <summary>
         /// Gets or sets the base directory that the assembly resolver uses to probe for assemblies.
         /// </summary>
@@ -66,9 +65,7 @@ namespace NLog.Internal.Fakeables
         /// Gets an integer that uniquely identifies the application domain within the process. 
         /// </summary>
         int Id { get; }
-#endif
 
-#if !SILVERLIGHT
         /// <summary>
         /// Process exit event.
         /// </summary>
@@ -78,6 +75,5 @@ namespace NLog.Internal.Fakeables
         /// Domain unloaded event.
         /// </summary>
         event EventHandler<EventArgs> DomainUnload;
-#endif
     }
 }

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -135,7 +135,7 @@ namespace NLog.Internal
 #if !SILVERLIGHT
             if (_filePathKind == FilePathKind.Relative)
             {
-                _baseDir = AppDomainWrapper.CurrentDomain.BaseDirectory;
+                _baseDir = LogFactory.CurrentAppDomain.BaseDirectory;
             }
 #endif
 

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -63,12 +63,10 @@ namespace NLog.Internal
 
         private FilePathKind _filePathKind;
 
-#if !SILVERLIGHT
         /// <summary>
         /// not null when <see cref="_filePathKind"/> == <c>false</c>
         /// </summary>
         private string _baseDir;
-#endif
 
         /// <summary>
         /// non null is fixed,
@@ -132,12 +130,10 @@ namespace NLog.Internal
                 }
             }
 
-#if !SILVERLIGHT
             if (_filePathKind == FilePathKind.Relative)
             {
                 _baseDir = LogFactory.CurrentAppDomain.BaseDirectory;
             }
-#endif
 
         }
 
@@ -213,14 +209,12 @@ namespace NLog.Internal
                 return cleanFileName;
             }
 
-#if !SILVERLIGHT
-            if (_filePathKind == FilePathKind.Relative)
+            if (_filePathKind == FilePathKind.Relative && _baseDir != null)
             {
                 //use basedir, faster than Path.GetFullPath
                 cleanFileName = Path.Combine(_baseDir, cleanFileName);
                 return cleanFileName;
             }
-#endif
             //unknown, use slow method
             cleanFileName = Path.GetFullPath(cleanFileName);
             return cleanFileName;

--- a/src/NLog/LayoutRenderers/AppDomainLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AppDomainLayoutRenderer.cs
@@ -59,7 +59,7 @@ namespace NLog.LayoutRenderers
         /// Create a new renderer
         /// </summary>
         public AppDomainLayoutRenderer()
-            : this(AppDomainWrapper.CurrentDomain)
+            : this(LogFactory.CurrentAppDomain)
         {
         }
 

--- a/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
@@ -31,8 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT
-
 namespace NLog.LayoutRenderers
 {
     using System;
@@ -85,10 +83,12 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            var path = PathHelpers.CombinePaths(baseDir, this.Dir, this.File);
-            builder.Append(path);
+            if (baseDir != null)
+            {
+                var path = PathHelpers.CombinePaths(baseDir, this.Dir, this.File);
+                builder.Append(path);
+            }
         }
     }
 }
 
-#endif

--- a/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
@@ -54,7 +54,7 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseDirLayoutRenderer" /> class.
         /// </summary>
-        public BaseDirLayoutRenderer() : this(AppDomainWrapper.CurrentDomain)
+        public BaseDirLayoutRenderer() : this(LogFactory.CurrentAppDomain)
         {
         }
 

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -63,7 +63,7 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Initializes a new instance of the <see cref="Log4JXmlEventLayoutRenderer" /> class.
         /// </summary>
-        public Log4JXmlEventLayoutRenderer() : this(AppDomainWrapper.CurrentDomain)
+        public Log4JXmlEventLayoutRenderer() : this(LogFactory.CurrentAppDomain)
         {
         }
         

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -97,6 +97,17 @@ namespace NLog
         public event EventHandler<LoggingConfigurationReloadedEventArgs> ConfigurationReloaded;
 #endif
 
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+        /// <summary>
+        /// Initializes static members of the LogManager class.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline", Justification = "Significant logic in .cctor()")]
+        static LogFactory()
+        {
+            RegisterEvents(CurrentAppDomain);
+        }
+#endif
+
         /// <summary>
         /// Initializes a new instance of the <see cref="LogFactory" /> class.
         /// </summary>
@@ -125,7 +136,17 @@ namespace NLog
         public static IAppDomain CurrentAppDomain
         {
             get { return currentAppDomain ?? (currentAppDomain = AppDomainWrapper.CurrentDomain); }
-            set { currentAppDomain = value; }
+            set
+            {
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+                UnregisterEvents(currentAppDomain);
+                //make sure we aren't double registering.
+                UnregisterEvents(value);
+                RegisterEvents(value);
+#endif
+                currentAppDomain = value;
+
+            }
         }
 
         /// <summary>
@@ -323,7 +344,7 @@ namespace NLog
                             catch (Exception exception)
                             {
                                 //ToArray needed for .Net 3.5
-                                InternalLogger.Warn(exception, "Cannot start file watching: {0}", string.Join(",", this.config.FileNamesToWatch.ToArray()));
+                                InternalLogger.Warn(exception, "Cannot start file watching: {0}", String.Join(",", this.config.FileNamesToWatch.ToArray()));
 
                                 if (exception.MustBeRethrown())
                                 {
@@ -386,7 +407,7 @@ namespace NLog
             {
                 InternalLogger.LogAssemblyVersion(typeof(ILogger).Assembly);
             }
-            catch (SecurityException ex) 
+            catch (SecurityException ex)
             {
                 InternalLogger.Debug(ex, "Not running in full trust");
             }
@@ -721,11 +742,7 @@ namespace NLog
         /// <param name="e">Event arguments</param>
         protected virtual void OnConfigurationReloaded(LoggingConfigurationReloadedEventArgs e)
         {
-            var reloaded = ConfigurationReloaded;
-            if (reloaded != null)
-            {
-                reloaded(this, e);
-            }
+            ConfigurationReloaded?.Invoke(this, e);
         }
 #endif
 
@@ -897,7 +914,7 @@ namespace NLog
         /// </summary>
         private bool IsDisposing;
 
-        internal void Close(TimeSpan flushTimeout)
+        private  void Close(TimeSpan flushTimeout)
         {
             if (this.IsDisposing)
             {
@@ -1076,7 +1093,7 @@ namespace NLog
             var nlogAssembly = typeof(LogFactory).Assembly;
             if (!nlogAssembly.GlobalAssemblyCache)
             {
-                if (!string.IsNullOrEmpty(nlogAssembly.Location))
+                if (!String.IsNullOrEmpty(nlogAssembly.Location))
                 {
                     yield return nlogAssembly.Location + ".nlog";
                 }
@@ -1106,7 +1123,7 @@ namespace NLog
                         //creating instance of static class isn't possible, and also not wanted (it cannot inherited from Logger)
                         if (cacheKey.ConcreteType.IsStaticClass())
                         {
-                            var errorMessage = string.Format("GetLogger / GetCurrentClassLogger is '{0}' as loggerType can be a static class and should inherit from Logger",
+                            var errorMessage = String.Format("GetLogger / GetCurrentClassLogger is '{0}' as loggerType can be a static class and should inherit from Logger",
                                 fullName);
                             InternalLogger.Error(errorMessage);
                             if (ThrowExceptions)
@@ -1124,7 +1141,7 @@ namespace NLog
                             {
                                 //well, it's not a Logger, and we should return a Logger.
 
-                                var errorMessage = string.Format("GetLogger / GetCurrentClassLogger got '{0}' as loggerType which doesn't inherit from Logger", fullName);
+                                var errorMessage = String.Format("GetLogger / GetCurrentClassLogger got '{0}' as loggerType which doesn't inherit from Logger", fullName);
                                 InternalLogger.Error(errorMessage);
                                 if (ThrowExceptions)
                                 {
@@ -1370,6 +1387,55 @@ namespace NLog
             void IDisposable.Dispose()
             {
                 this.factory.ResumeLogging();
+            }
+        }
+
+        private static void RegisterEvents(IAppDomain appDomain)
+        {
+            if (appDomain == null) return;
+
+            try
+            {
+                appDomain.ProcessExit += OnStopLogging;
+                appDomain.DomainUnload += OnStopLogging;
+            }
+            catch (Exception exception)
+            {
+                InternalLogger.Warn(exception, "Error setting up termination events.");
+
+                if (exception.MustBeRethrown())
+                {
+                    throw;
+                }
+            }
+        }
+
+        private static void UnregisterEvents(IAppDomain appDomain)
+        {
+            if (appDomain == null) return;
+            appDomain.DomainUnload -= OnStopLogging;
+            appDomain.ProcessExit -= OnStopLogging;
+        }
+
+        private static void OnStopLogging(object sender, EventArgs args)
+        {
+            try
+            {
+                var logFactory = sender as LogFactory;
+                InternalLogger.Info("Shutting down logging...");
+                if (logFactory != null)
+                {
+                    // Finalizer thread has about 2 secs, before being terminated
+                    logFactory.Close(TimeSpan.FromMilliseconds(1500));
+                }
+                currentAppDomain = null;    // No longer part of AppDomains
+                InternalLogger.Info("Logger has been shut down.");
+            }
+            catch (Exception ex)
+            {
+                if (ex.MustBeRethrownImmediately())
+                    throw;
+                InternalLogger.Error(ex, "Logger failed to shut down properly.");
             }
         }
     }

--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -74,7 +74,7 @@ namespace NLog.Targets
         /// Initializes a new instance of the <see cref="EventLogTarget"/> class.
         /// </summary>
         public EventLogTarget()
-            : this(AppDomainWrapper.CurrentDomain)
+            : this(LogFactory.CurrentAppDomain)
         {
         }
 
@@ -93,7 +93,8 @@ namespace NLog.Targets
         /// Initializes a new instance of the <see cref="EventLogTarget"/> class.
         /// </summary>
         /// <param name="name">Name of the target.</param>
-        public EventLogTarget(string name) : this(AppDomainWrapper.CurrentDomain)
+        public EventLogTarget(string name) 
+            : this(LogFactory.CurrentAppDomain)
         {
             this.Name = name;
         }


### PR DESCRIPTION
- having in two classes (LogManager & LogFactory) the (static) currentAppDomain is confusing
  - Moved logic to LogFactory, 
  - removed internal stuff in LogManager
  - same logic will be executed
- cleanup of event-hook so we don't double hook
- don't use AppDomainWrapper everywhere, but the static `IAppDomain` property
- remove old `#if` stuff and handle empty properties of `IAppDomain` 


Goal: inject basedir in another package, by using the `IAppDomain `

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1906)
<!-- Reviewable:end -->


As the interface is altered for SL, this could a breaking change for SL. But i'm pretty sure there aren't custom implementations of IAppDomain for SL in custom code.