### PR TITLE
Target.Write(AsyncLogEventInfo[]) marked obsolete

### DIFF
--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -432,13 +432,14 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// NOTE! Obsolete, instead override Write(IList{AsyncLogEventInfo} logEvents)
         /// 
         /// Writes an array of logging events to the log target. By default it iterates on all
         /// events and passes them to "Write" method. Inheriting classes can use this method to
         /// optimize batch writes.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
+        [Obsolete("Instead override Write(IList<AsyncLogEventInfo> logEvents. Marked obsolete on NLog 4.5")]
         protected override void Write(AsyncLogEventInfo[] logEvents)
         {
             Write((IList<AsyncLogEventInfo>)logEvents);

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1006,13 +1006,14 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// NOTE! Obsolete, instead override Write(IList{AsyncLogEventInfo} logEvents)
         /// 
         /// Writes an array of logging events to the log target. By default it iterates on all
         /// events and passes them to "Write" method. Inheriting classes can use this method to
         /// optimize batch writes.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
+        [Obsolete("Instead override Write(IList<AsyncLogEventInfo> logEvents. Marked obsolete on NLog 4.5")]
         protected override void Write(AsyncLogEventInfo[] logEvents)
         {
             Write((IList<AsyncLogEventInfo>)logEvents);

--- a/src/NLog/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog/Targets/LogReceiverWebServiceTarget.cs
@@ -152,13 +152,14 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// NOTE! Obsolete, instead override Write(IList{AsyncLogEventInfo} logEvents)
         /// 
         /// Writes an array of logging events to the log target. By default it iterates on all
         /// events and passes them to "Write" method. Inheriting classes can use this method to
         /// optimize batch writes.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
+        [Obsolete("Instead override Write(IList<AsyncLogEventInfo> logEvents. Marked obsolete on NLog 4.5")]
         protected override void Write(AsyncLogEventInfo[] logEvents)
         {
             Write((IList<AsyncLogEventInfo>)logEvents);
@@ -184,7 +185,7 @@ namespace NLog.Targets
                 return;
             }
 
-            // RestrictedBufferReuse = false, will reuse the input-array on method-exit (so we make clone here)
+            // OptimizeBufferReuse = true, will reuse the input-array on method-exit (so we make clone here)
             AsyncLogEventInfo[] logEventsArray = new AsyncLogEventInfo[logEvents.Count];
             logEvents.CopyTo(logEventsArray, 0);
 

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -343,13 +343,14 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// NOTE! Obsolete, instead override Write(IList{AsyncLogEventInfo} logEvents)
         /// 
         /// Writes an array of logging events to the log target. By default it iterates on all
         /// events and passes them to "Write" method. Inheriting classes can use this method to
         /// optimize batch writes.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
+        [Obsolete("Instead override Write(IList<AsyncLogEventInfo> logEvents. Marked obsolete on NLog 4.5")]
         protected override void Write(AsyncLogEventInfo[] logEvents)
         {
             Write((IList<AsyncLogEventInfo>)logEvents);

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -548,13 +548,14 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// NOTE! Obsolete, instead override Write(IList{AsyncLogEventInfo} logEvents)
         /// 
         /// Writes an array of logging events to the log target. By default it iterates on all
         /// events and passes them to "Write" method. Inheriting classes can use this method to
         /// optimize batch writes.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
+        [Obsolete("Instead override Write(IList<AsyncLogEventInfo> logEvents. Marked obsolete on NLog 4.5")]
         protected virtual void Write(AsyncLogEventInfo[] logEvents)
         {
             Write((IList<AsyncLogEventInfo>)logEvents);
@@ -575,11 +576,12 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// NOTE! Obsolete, instead override WriteAsyncThreadSafe(IList{AsyncLogEventInfo} logEvents)
         /// 
         /// Writes an array of logging events to the log target, in a thread safe manner.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
+        [Obsolete("Instead override WriteAsyncThreadSafe(IList<AsyncLogEventInfo> logEvents. Marked obsolete on NLog 4.5")]
         protected virtual void WriteAsyncThreadSafe(AsyncLogEventInfo[] logEvents)
         {
             WriteAsyncThreadSafe((IList<AsyncLogEventInfo>)logEvents);

--- a/src/NLog/Targets/Wrappers/ImpersonatingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/ImpersonatingTargetWrapper.cs
@@ -184,13 +184,14 @@ namespace NLog.Targets.Wrappers
         }
 
         /// <summary>
-        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// NOTE! Obsolete, instead override Write(IList{AsyncLogEventInfo} logEvents)
         /// 
         /// Writes an array of logging events to the log target. By default it iterates on all
         /// events and passes them to "Write" method. Inheriting classes can use this method to
         /// optimize batch writes.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
+        [Obsolete("Instead override Write(IList<AsyncLogEventInfo> logEvents. Marked obsolete on NLog 4.5")]
         protected override void Write(AsyncLogEventInfo[] logEvents)
         {
             Write((IList<AsyncLogEventInfo>)logEvents);

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -116,13 +116,14 @@ namespace NLog.Targets.Wrappers
         public IList<FilteringRule> Rules { get; private set; }
 
         /// <summary>
-        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// NOTE! Obsolete, instead override Write(IList{AsyncLogEventInfo} logEvents)
         /// 
         /// Writes an array of logging events to the log target. By default it iterates on all
         /// events and passes them to "Write" method. Inheriting classes can use this method to
         /// optimize batch writes.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
+        [Obsolete("Instead override Write(IList<AsyncLogEventInfo> logEvents. Marked obsolete on NLog 4.5")]
         protected override void Write(AsyncLogEventInfo[] logEvents)
         {
             Write((IList<AsyncLogEventInfo>)logEvents);
@@ -197,7 +198,7 @@ namespace NLog.Targets.Wrappers
                 if (resultBuffer.Count > 0)
                 {
                     InternalLogger.Trace("Sending to {0}", this.WrappedTarget);
-                    this.WrappedTarget.WriteAsyncLogEvents(resultBuffer.ToArray());
+                    this.WrappedTarget.WriteAsyncLogEvents(resultBuffer);
                 }
             }
         }

--- a/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
@@ -98,13 +98,14 @@ namespace NLog.Targets.Wrappers
         }
 
         /// <summary>
-        /// NOTE! Will soon be marked obsolete. Instead override Write(IList{AsyncLogEventInfo} logEvents)
+        /// NOTE! Obsolete, instead override Write(IList{AsyncLogEventInfo} logEvents)
         ///
         /// Writes an array of logging events to the log target. By default it iterates on all
         /// events and passes them to "Write" method. Inheriting classes can use this method to
         /// optimize batch writes.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
+        [Obsolete("Instead override Write(IList<AsyncLogEventInfo> logEvents. Marked obsolete on NLog 4.5")]
         protected override void Write(AsyncLogEventInfo[] logEvents)
         {
             Write((IList<AsyncLogEventInfo>)logEvents);
@@ -133,7 +134,7 @@ namespace NLog.Targets.Wrappers
                 var targetLogEvents = logEvents;
                 if (i < this.Targets.Count - 1)
                 {
-                    // RestrictedBufferReuse = false, will change the input-array (so we make clones here)
+                    // OptimizeBufferReuse = true, will change the input-array (so we make clones here)
                     AsyncLogEventInfo[] cloneLogEvents = new AsyncLogEventInfo[logEvents.Count];
                     logEvents.CopyTo(cloneLogEvents, 0);
                     targetLogEvents = cloneLogEvents;


### PR DESCRIPTION
Instead one should override:

`Target.Write(IList<AsyncLogEventInfo> logEvents)`

Waiting for NLog ver. 4.5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1922)
<!-- Reviewable:end -->
