### PR TITLE
JsonLayout - Support Precalculate for async processing

### DIFF
--- a/src/NLog/Layouts/CompoundLayout.cs
+++ b/src/NLog/Layouts/CompoundLayout.cs
@@ -76,9 +76,7 @@ namespace NLog.Layouts
         /// <returns>A string representation of the log event.</returns>
         protected override string GetFormattedMessage(LogEventInfo logEvent)
         {
-            var sb = new StringBuilder();
-            RenderFormattedMessage(logEvent, sb);
-            return sb.ToString();
+            return RenderAllocateBuilder(logEvent);
         }
 
         /// <summary>

--- a/src/NLog/Layouts/CsvLayout.cs
+++ b/src/NLog/Layouts/CsvLayout.cs
@@ -162,16 +162,7 @@ namespace NLog.Layouts
         /// <returns>A string representation of the log event.</returns>
         protected override string GetFormattedMessage(LogEventInfo logEvent)
         {
-            string cachedValue;
-
-            if (logEvent.TryGetCachedLayoutValue(this, out cachedValue))
-            {
-                return cachedValue;
-            }
-
-            var sb = new StringBuilder();
-            RenderAllColumns(logEvent, sb);
-            return logEvent.AddCachedLayoutValue(this, sb.ToString());
+            return RenderAllocateBuilder(logEvent);
         }
 
         private void RenderAllColumns(LogEventInfo logEvent, StringBuilder sb)
@@ -332,15 +323,7 @@ namespace NLog.Layouts
             /// <returns>The rendered layout.</returns>
             protected override string GetFormattedMessage(LogEventInfo logEvent)
             {
-                string cached;
-                if (logEvent.TryGetCachedLayoutValue(this, out cached))
-                {
-                    return cached;
-                }
-
-                var sb = new StringBuilder();
-                this.parent.RenderHeader(sb);
-                return logEvent.AddCachedLayoutValue(this, sb.ToString());
+                return RenderAllocateBuilder(logEvent);
             }
 
             /// <summary>

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -64,14 +64,7 @@ namespace NLog.Layouts
         /// <returns>The rendered layout.</returns>
         protected override string GetFormattedMessage(LogEventInfo logEvent)
         {
-            string cachedValue;
-
-            if (logEvent.TryGetCachedLayoutValue(this, out cachedValue))
-            {
-                return cachedValue;
-            }
-
-            return logEvent.AddCachedLayoutValue(this, this.Renderer.Render(logEvent));
+            return RenderAllocateBuilder(logEvent);
         }
 
         /// <summary>

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -56,9 +56,6 @@ namespace NLog.Layouts
     [AppDomainFixedOutput]
     public class SimpleLayout : Layout, IUsesStackTrace
     {
-        private const int MaxInitialRenderBufferLength = 16384;
-        private int maxRenderedLength;
-
         private string fixedText;
         private string layoutText;
         private ConfigurationItemFactory configurationItemFactory;
@@ -297,26 +294,7 @@ namespace NLog.Layouts
                 return this.fixedText;
             }
 
-            string cachedValue;
-            if (logEvent.TryGetCachedLayoutValue(this, out cachedValue))
-            {
-                return cachedValue;
-            }
-
-            int initialSize = this.maxRenderedLength;
-            if (initialSize > MaxInitialRenderBufferLength)
-            {
-                initialSize = MaxInitialRenderBufferLength;
-            }
-
-            var builder = new StringBuilder(initialSize);
-            RenderAllRenderers(logEvent, builder);
-            if (builder.Length > this.maxRenderedLength)
-            {
-                this.maxRenderedLength = builder.Length;
-            }
-
-            return logEvent.AddCachedLayoutValue(this, builder.ToString());
+            return RenderAllocateBuilder(logEvent);
         }
 
         private void RenderAllRenderers(LogEventInfo logEvent, StringBuilder target)

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -683,8 +683,7 @@ namespace NLog.Targets
 
                 using (var localTarget = ReusableLayoutBuilder.Allocate())
                 {
-                    layout.RenderAppendBuilder(logEvent, localTarget.Result);
-                    return localTarget.Result.ToString();
+                    return layout.RenderAllocateBuilder(logEvent, localTarget.Result, false);
                 }
             }
             else

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -183,6 +183,30 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void JsonAttributeThreadAgnosticTest()
+        {
+            var jsonLayout = new JsonLayout
+            {
+                Attributes =
+                {
+                    new JsonAttribute("type", "${exception:format=Type}"),
+                    new JsonAttribute("message", "${exception:format=Message}"),
+                    new JsonAttribute("threadid", "${threadid}"),
+                }
+            };
+
+            var logEventInfo = CreateLogEventWithExcluded();
+            var result = jsonLayout.Render(logEventInfo);
+            string cachedLookup;
+            logEventInfo.TryGetCachedLayoutValue(jsonLayout, out cachedLookup);
+            Assert.NotNull(cachedLookup);
+            Assert.Equal(result, cachedLookup);
+
+            string cacheVerification = jsonLayout.Render(logEventInfo);
+            Assert.Equal(true, ReferenceEquals(cachedLookup, cacheVerification));
+        }
+
+        [Fact]
         public void NestedJsonAttrTest()
         {
             var jsonLayout = new JsonLayout
@@ -350,9 +374,7 @@ namespace NLog.UnitTests.Layouts
 
             var logEventInfo = CreateLogEventWithExcluded();
 
-
             Assert.Equal(ExpectedIncludeAllPropertiesWithExcludes, jsonLayout.Render(logEventInfo));
-
         }
 
         /// <summary>


### PR DESCRIPTION
Forgot to check the thread-agnostic attribute, and to cache the layout when needed. 

Made a standard implementation for GetFormattedMessage, that can be reused by all Layout-implementations that overrides RenderFormattedMessage (Optimizes memory allocations).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1925)
<!-- Reviewable:end -->
