### PR TITLE
RetryingWrapper - Allow closing target, even when busy retrying

### DIFF
--- a/tests/NLog.UnitTests/Targets/Wrappers/RetryingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/RetryingTargetWrapperTests.cs
@@ -133,6 +133,54 @@ namespace NLog.UnitTests.Targets.Wrappers
             Assert.Null(exceptions[2]);
         }
 
+#if MONO
+        [Fact(Skip="Not working under MONO - Premature abort seems to fail, and instead it just waits until finished")]
+#else
+        [Fact]
+#endif
+        public void RetryingTargetWrapperBlockingCloseTest()
+        {
+            var target = new MyTarget()
+            {
+                ThrowExceptions = 5,
+            };
+            var wrapper = new RetryingTargetWrapper()
+            {
+                WrappedTarget = target,
+                RetryCount = 10,
+                RetryDelayMilliseconds = 5000,
+            };
+            var asyncWrapper = new AsyncTargetWrapper(wrapper) { TimeToSleepBetweenBatches = 1 };
+
+            asyncWrapper.Initialize(null);
+            wrapper.Initialize(null);
+            target.Initialize(null);
+
+            var exceptions = new List<Exception>();
+
+            var events = new[]
+            {
+                new LogEventInfo(LogLevel.Debug, "Logger1", "Hello").WithContinuation(exceptions.Add),
+                new LogEventInfo(LogLevel.Info, "Logger1", "Hello").WithContinuation(exceptions.Add),
+                new LogEventInfo(LogLevel.Info, "Logger2", "Hello").WithContinuation(exceptions.Add),
+            };
+
+            // Attempt to write LogEvents that will take forever to retry
+            asyncWrapper.WriteAsyncLogEvents(events);
+            // Wait a little for the AsyncWrapper to start writing
+            System.Threading.Thread.Sleep(50);
+            // Close down the AsyncWrapper while busy writing
+            asyncWrapper.Close();
+            // Close down the RetryingWrapper while busy retrying
+            wrapper.Close();
+            // Close down the actual target while busy writing
+            target.Close();
+            // Wait a little for the RetryingWrapper to detect that it has been closed down
+            System.Threading.Thread.Sleep(200);
+            // The premature abort, causes the exception to be logged
+            Assert.NotNull(exceptions[0]);
+        }
+
         public class MyTarget : Target
         {
             public MyTarget()


### PR DESCRIPTION
If wrapped target is working on retrying for ever, then it should not block one from closing target.

This is a breaking change, as the RetryingWrapper is not sealed. Has to wait for NLog 5.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1926)
<!-- Reviewable:end -->
