### PR TITLE
InternalLogger - Better support for multiple threads when using file

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -250,9 +250,12 @@ namespace NLog.Common
                 var logFile = LogFile;
                 if (!string.IsNullOrEmpty(logFile))
                 {
-                    using (var textWriter = File.AppendText(logFile))
+                    lock (LockObject)
                     {
-                        textWriter.WriteLine(msg);
+                        using (var textWriter = File.AppendText(logFile))
+                        {
+                            textWriter.WriteLine(msg);
+                        }
                     }
                 }
 
@@ -269,14 +272,21 @@ namespace NLog.Common
                 // log to console
                 if (LogToConsole)
                 {
-                    Console.WriteLine(msg);
+                    lock (LockObject)
+                    {
+                        Console.WriteLine(msg);
+                    }
                 }
 
                 // log to console error
                 if (LogToConsoleError)
                 {
-                    Console.Error.WriteLine(msg);
+                    lock (LockObject)
+                    {
+                        Console.Error.WriteLine(msg);
+                    }
                 }
+
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
                 WriteToTrace(msg);
 #endif
@@ -290,7 +300,6 @@ namespace NLog.Common
                 {
                     throw;
                 }
-
             }
         }
 


### PR DESCRIPTION
Extra lock-operation has been added when doing exclusive file-lock, to improve support for 
multi-threaded use of the InternalLogger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1927)
<!-- Reviewable:end -->
