### PR TITLE
FileTarget - Validate File CreationTimeUtc when non-Windows

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -337,24 +337,19 @@ namespace NLog.Internal.FileAppenders
 
         private void UpdateCreationTime()
         {
-            if (File.Exists(this.FileName))
+            FileInfo fileInfo = new FileInfo(this.FileName);
+            if (fileInfo.Exists)
             {
-#if !SILVERLIGHT
-                this.CreationTimeUtc = File.GetCreationTimeUtc(this.FileName);
-#else
-                this.CreationTimeUtc = File.GetCreationTime(this.FileName);
-#endif
+                this.CreationTimeUtc = FileCharacteristicsHelper.ValidateFileCreationTime(fileInfo, (f) => f.GetCreationTimeUtc(), (f) => f.GetLastWriteTimeUtc()).Value;
             }
             else
             {
                 File.Create(this.FileName).Dispose();
+                this.CreationTimeUtc = DateTime.UtcNow;
 
 #if !SILVERLIGHT
-                this.CreationTimeUtc = DateTime.UtcNow;
                 // Set the file's creation time to avoid being thwarted by Windows' Tunneling capabilities (https://support.microsoft.com/en-us/kb/172190).
                 File.SetCreationTimeUtc(this.FileName, this.CreationTimeUtc);
-#else
-                this.CreationTimeUtc = File.GetCreationTime(this.FileName);
 #endif
             }
         }

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -416,11 +416,12 @@ namespace NLog.Internal.FileAppenders
             {
                 try
                 {
-                    result = appender.GetFileCreationTimeUtc();
+                    result = FileCharacteristicsHelper.ValidateFileCreationTime(appender, (f) => f.GetFileCreationTimeUtc(), (f) => f.CreationTimeUtc, (f) => f.GetFileLastWriteTimeUtc());
                     if (result.HasValue)
                     {
                         // Check if cached value is still valid, and update if not (Will automatically update CreationTimeSource)
-                        if (result.Value != appender.CreationTimeUtc)
+                        DateTime cachedTimeUtc = appender.CreationTimeUtc;
+                        if (result.Value != cachedTimeUtc)
                         {
                             appender.CreationTimeUtc = result.Value;
                         }
@@ -439,7 +440,8 @@ namespace NLog.Internal.FileAppenders
                 var fileInfo = new FileInfo(filePath);
                 if (fileInfo.Exists)
                 {
-                    return Time.TimeSource.Current.FromSystemTime(fileInfo.GetCreationTimeUtc());
+                    result = FileCharacteristicsHelper.ValidateFileCreationTime(fileInfo, (f) => f.GetCreationTimeUtc(), (f) => f.GetLastWriteTimeUtc()).Value;
+                    return Time.TimeSource.Current.FromSystemTime(result.Value);
                 }
             }
 

--- a/src/NLog/Internal/FileCharacteristicsHelper.cs
+++ b/src/NLog/Internal/FileCharacteristicsHelper.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.Internal
 {
+    using System;
     using System.IO;
 
     /// <summary>
@@ -64,5 +65,23 @@ namespace NLog.Internal
         /// <param name="fileStream">The file stream.</param>
         /// <returns>The file characteristics, if the file information was retrieved successfully, otherwise null.</returns>
         public abstract FileCharacteristics GetFileCharacteristics(string fileName, FileStream fileStream);
+
+        public static DateTime? ValidateFileCreationTime<T>(T fileInfo, Func<T, DateTime?> primary, Func<T, DateTime?> fallback, Func<T, DateTime?> finalFallback = null)
+        {
+            DateTime? fileCreationTime = primary(fileInfo);
+            if (fileCreationTime.HasValue && fileCreationTime.Value.Year < 1980)
+            {
+                // Non-Windows-FileSystems doesn't always provide correct CreationTime/BirthTime
+                if (!PlatformDetector.IsDesktopWin32)
+                {
+                    fileCreationTime = fallback(fileInfo);
+                    if (finalFallback != null && (!fileCreationTime.HasValue || fileCreationTime.Value.Year < 1980))
+                    {
+                        fileCreationTime = finalFallback(fileInfo);
+                    }
+                }
+            }
+            return fileCreationTime;
+        }
     }
 }


### PR DESCRIPTION
Simple fallback to FileLastWriteTimeUtc, when FileCreationTimeUtc is very old (when non-windows). Simple fix for #1633 

Also fixes bug in UnixMultiProcessFileAppender, where the fileExists-check was wrongly done after having created the file-descriptor.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1931)
<!-- Reviewable:end -->
