### PR TITLE
LogManager.Shutdown - Verify that active config exists

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -1010,6 +1010,18 @@ namespace NLog
             }
         }
 
+        internal void Shutdown()
+        {
+            InternalLogger.Info("Logger closing down...");
+            if (!IsDisposing && configLoaded)
+            {
+                var loadedConfig = Configuration;
+                if (loadedConfig != null)
+                    loadedConfig.Close();
+            }
+            InternalLogger.Info("Logger has been closed down.");
+        }
+
         /// <summary>
         /// Get file paths (including filename) for the possible NLog config files. 
         /// </summary>

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -357,10 +357,7 @@ namespace NLog
         /// </summary>
         public static void Shutdown()
         {
-            InternalLogger.Info("Logger closing down...");
-            if (Configuration != null)
-                Configuration.Close();
-            InternalLogger.Info("Logger has been closed down.");
+            factory.Shutdown();
         }
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__


### PR DESCRIPTION
Small enhancement to  #1899, so it doesn't attempt to load config if it wasn't loaded already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1937)
<!-- Reviewable:end -->
