### PR TITLE
FileTarget - KeepFileOpen should watch for file deletion, but not every second

### DIFF
--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -115,7 +115,7 @@ namespace NLog.Internal.FileAppenders
             if (logFileWasArchived)
             {
                 if (autoClosingTimer != null)
-                    autoClosingTimer.Change(50, 1000);
+                    autoClosingTimer.Change(50, Timeout.Infinite);
             }
         }
 
@@ -297,8 +297,6 @@ namespace NLog.Internal.FileAppenders
                     }
                     externalFileArchivingWatcher.Watch(appenderToWrite.FileName);   // Monitor the active file-appender
 #endif
-                    if (freeSpot == 0)
-                        autoClosingTimer.Change(1000, 1000);    // Check every second
                 }
             }
 


### PR DESCRIPTION
Avoid timer every second. Restore OpenFileCacheTimeout-autoClosingTimer when needed. Small fix to #1878

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1942)
<!-- Reviewable:end -->
