### PR TITLE
EventLogTarget: Properly parse and set EventLog category

### DIFF
--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -249,7 +249,7 @@ namespace NLog.Targets
 
             int eventId = this.EventId.RenderInt(logEvent, 0, "EventLogTarget.EventId");
 
-            short category = this.EventId.RenderShort(logEvent, 0, "EventLogTarget.Category");
+            short category = this.Category.RenderShort(logEvent, 0, "EventLogTarget.Category");
 
             EventLog eventLog = GetEventLog(logEvent);
 


### PR DESCRIPTION
Fix regression issue from 3bd3eb9c06b729e66f28f11a0aaf1c80863c7872.
Category was read from the EventId configuration property instead
of its own property and **was always set incorrectly**.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1960)
<!-- Reviewable:end -->
