### PR TITLE
Fix TimeZoneTest for negative offset

### DIFF
--- a/tests/NLog.UnitTests/LayoutRenderers/DateTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/DateTests.cs
@@ -79,7 +79,7 @@ namespace NLog.UnitTests.LayoutRenderers
             else
             {
                 //-01:00, etc
-                Assert.Contains(string.Format("-{0:D2}:{1:D2}", offset2.Hours, offset2.Minutes), result);
+                Assert.Contains(string.Format("{0:D2}:{1:D2}", offset2.Hours, offset2.Minutes), result);
             }
 
         }


### PR DESCRIPTION
Remove '-' sign from the expected string, as in case of negative
offset '-' sign will already be present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1964)
<!-- Reviewable:end -->
