### PR TITLE
Proper apply default-target-parameters to nested targets in WrappedTargets

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using JetBrains.Annotations;
+
 namespace NLog.Config
 {
     using System;
@@ -835,14 +837,7 @@ namespace NLog.Config
                         }
 
                         Target newTarget = this.ConfigurationItemFactory.Targets.CreateInstance(typeAttributeVal);
-
-                        NLogXmlElement defaults;
-                        if (typeNameToDefaultTargetParameters.TryGetValue(typeAttributeVal, out defaults))
-                        {
-                            this.ParseTargetElement(newTarget, defaults);
-                        }
-
-                        this.ParseTargetElement(newTarget, targetElement);
+                        this.ParseTargetElement(newTarget, targetElement, typeNameToDefaultTargetParameters);
 
                         if (asyncWrap)
                         {
@@ -861,8 +856,15 @@ namespace NLog.Config
             }
         }
 
-        private void ParseTargetElement(Target target, NLogXmlElement targetElement)
+        private void ParseTargetElement(Target target, NLogXmlElement targetElement, Dictionary<string, NLogXmlElement> typeNameToDefaultTargetParameters = null)
         {
+            string targetType = StripOptionalNamespacePrefix(targetElement.GetRequiredAttribute("type"));
+            NLogXmlElement defaults;
+            if (typeNameToDefaultTargetParameters != null && typeNameToDefaultTargetParameters.TryGetValue(targetType, out defaults))
+            {
+                this.ParseTargetElement(target, defaults, null);
+            }
+
             var compound = target as CompoundTargetBase;
             var wrapper = target as WrapperTargetBase;
 
@@ -895,7 +897,7 @@ namespace NLog.Config
                         Target newTarget = this.ConfigurationItemFactory.Targets.CreateInstance(type);
                         if (newTarget != null)
                         {
-                            this.ParseTargetElement(newTarget, childElement);
+                            this.ParseTargetElement(newTarget, childElement, typeNameToDefaultTargetParameters);
                             if (newTarget.Name != null)
                             {
                                 // if the new target has name, register it
@@ -931,7 +933,7 @@ namespace NLog.Config
                         Target newTarget = this.ConfigurationItemFactory.Targets.CreateInstance(type);
                         if (newTarget != null)
                         {
-                            this.ParseTargetElement(newTarget, childElement);
+                            this.ParseTargetElement(newTarget, childElement, typeNameToDefaultTargetParameters);
                             if (newTarget.Name != null)
                             {
                                 // if the new target has name, register it

--- a/tests/NLog.UnitTests/Config/TargetConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/TargetConfigurationTests.cs
@@ -420,6 +420,28 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        public void DefaultTargetParametersOnWrappedTargetTest()
+        {
+            LoggingConfiguration c = CreateConfigurationFromString(@"
+            <nlog>
+                <targets>
+                    <default-target-parameters type='Debug' layout='x${message}x' />
+                    <target type='BufferingWrapper' name='buf1'>
+                        <target type='Debug' name='d1' />
+                    </target>
+                </targets>
+            </nlog>");
+
+            var wrap = c.FindTargetByName("buf1") as BufferingTargetWrapper;
+            Assert.NotNull(wrap);
+            Assert.NotNull(wrap.WrappedTarget);
+
+            var t = wrap.WrappedTarget as DebugTarget;
+            Assert.NotNull(t);
+            Assert.Equal("'x${message}x'", t.Layout.ToString());
+        }
+
+        [Fact]
         public void DefaultWrapperTest()
         {
             LoggingConfiguration c = CreateConfigurationFromString(@"


### PR DESCRIPTION
Now we passing default parameters to parsetargetmethod, to use when child targets are created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/1995)
<!-- Reviewable:end -->
