### PR TITLE
Add weekly archival option to FileTarget

### DIFF
--- a/src/NLog/Targets/FileArchivePeriod.cs
+++ b/src/NLog/Targets/FileArchivePeriod.cs
@@ -66,6 +66,43 @@ namespace NLog.Targets
         /// <summary>
         /// AddToArchive every minute.
         /// </summary>
-        Minute
+        Minute,
+
+        #region Weekdays
+        /// <summary>
+        /// AddToArchive every Sunday.
+        /// </summary>
+        Sunday,
+
+        /// <summary>
+        /// AddToArchive every Monday.
+        /// </summary>
+        Monday,
+
+        /// <summary>
+        /// AddToArchive every Tuesday.
+        /// </summary>
+        Tuesday,
+
+        /// <summary>
+        /// AddToArchive every Wednesday.
+        /// </summary>
+        Wednesday,
+
+        /// <summary>
+        /// AddToArchive every Thursday.
+        /// </summary>
+        Thursday,
+
+        /// <summary>
+        /// AddToArchive every Friday.
+        /// </summary>
+        Friday,
+
+        /// <summary>
+        /// AddToArchive every Saturday.
+        /// </summary>
+        Saturday
+        #endregion 
     }
 }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1882,8 +1882,11 @@ namespace NLog.Targets
 
         private bool PreviousLogOverlappedPeriod(LogEventInfo logEvent, DateTime lastWrite)
         {
-            if (!previousLogEventTimestamp.HasValue)
+            DateTime timestamp;
+            if(!previousLogEventTimestamp.HasValue)
                 return false;
+            else
+                timestamp = previousLogEventTimestamp.Value;
 
             string formatString = GetArchiveDateFormatString(string.Empty);
             string lastWriteTimeString = lastWrite.ToString(formatString, CultureInfo.InvariantCulture);
@@ -1895,18 +1898,18 @@ namespace NLog.Targets
             DateTime periodAfterPreviousLogEventTime;
             switch (this.ArchiveEvery)
             {
-                case FileArchivePeriod.Year: periodAfterPreviousLogEventTime = previousLogEventTimestamp.Value.AddYears(1); break;
-                case FileArchivePeriod.Month: periodAfterPreviousLogEventTime = previousLogEventTimestamp.Value.AddMonths(1); break;
-                case FileArchivePeriod.Day: periodAfterPreviousLogEventTime = previousLogEventTimestamp.Value.AddDays(1); break;
-                case FileArchivePeriod.Hour: periodAfterPreviousLogEventTime = previousLogEventTimestamp.Value.AddHours(1); break;
-                case FileArchivePeriod.Minute: periodAfterPreviousLogEventTime = previousLogEventTimestamp.Value.AddMinutes(1); break;
-                case FileArchivePeriod.Sunday: periodAfterPreviousLogEventTime = CalculateNextWeekday(previousLogEventTimestamp, DayOfWeek.Sunday); break;
-                case FileArchivePeriod.Monday: periodAfterPreviousLogEventTime = CalculateNextWeekday(previousLogEventTimestamp, DayOfWeek.Monday); break;
-                case FileArchivePeriod.Tuesday: periodAfterPreviousLogEventTime = CalculateNextWeekday(previousLogEventTimestamp, DayOfWeek.Tuesday); break;
-                case FileArchivePeriod.Wednesday: periodAfterPreviousLogEventTime = CalculateNextWeekday(previousLogEventTimestamp, DayOfWeek.Wednesday); break;
-                case FileArchivePeriod.Thursday: periodAfterPreviousLogEventTime = CalculateNextWeekday(previousLogEventTimestamp, DayOfWeek.Thursday); break;
-                case FileArchivePeriod.Friday: periodAfterPreviousLogEventTime = CalculateNextWeekday(previousLogEventTimestamp, DayOfWeek.Friday); break;
-                case FileArchivePeriod.Saturday: periodAfterPreviousLogEventTime = CalculateNextWeekday(previousLogEventTimestamp, DayOfWeek.Saturday); break;
+                case FileArchivePeriod.Year: periodAfterPreviousLogEventTime = timestamp.AddYears(1); break;
+                case FileArchivePeriod.Month: periodAfterPreviousLogEventTime = timestamp.AddMonths(1); break;
+                case FileArchivePeriod.Day: periodAfterPreviousLogEventTime = timestamp.AddDays(1); break;
+                case FileArchivePeriod.Hour: periodAfterPreviousLogEventTime = timestamp.AddHours(1); break;
+                case FileArchivePeriod.Minute: periodAfterPreviousLogEventTime = timestamp.AddMinutes(1); break;
+                case FileArchivePeriod.Sunday: periodAfterPreviousLogEventTime = CalculateNextWeekday(timestamp, DayOfWeek.Sunday); break;
+                case FileArchivePeriod.Monday: periodAfterPreviousLogEventTime = CalculateNextWeekday(timestamp, DayOfWeek.Monday); break;
+                case FileArchivePeriod.Tuesday: periodAfterPreviousLogEventTime = CalculateNextWeekday(timestamp, DayOfWeek.Tuesday); break;
+                case FileArchivePeriod.Wednesday: periodAfterPreviousLogEventTime = CalculateNextWeekday(timestamp, DayOfWeek.Wednesday); break;
+                case FileArchivePeriod.Thursday: periodAfterPreviousLogEventTime = CalculateNextWeekday(timestamp, DayOfWeek.Thursday); break;
+                case FileArchivePeriod.Friday: periodAfterPreviousLogEventTime = CalculateNextWeekday(timestamp, DayOfWeek.Friday); break;
+                case FileArchivePeriod.Saturday: periodAfterPreviousLogEventTime = CalculateNextWeekday(timestamp, DayOfWeek.Saturday); break;
                 default: return false;
             }
 
@@ -1922,14 +1925,14 @@ namespace NLog.Targets
         /// <returns>The DateTime of the next occuring dayOfWeek.</returns>
         /// <remarks>For example: if previousLogEventTimestamp is Thursday 2017-03-02 and dayOfWeek is Sunday, this will return
         ///  Sunday 2017-03-05. If dayOfWeek is Thursday, this will return *next* Thursday 2017-03-09.</remarks>
-        private DateTime CalculateNextWeekday(DateTime? previousLogEventTimestamp, DayOfWeek dayOfWeek)
+        public static DateTime CalculateNextWeekday(DateTime previousLogEventTimestamp, DayOfWeek dayOfWeek)
         {
             // Shamelessly taken from http://stackoverflow.com/a/7611480/1354930
-            int start = (int)previousLogEventTimestamp.Value.DayOfWeek;
+            int start = (int)previousLogEventTimestamp.DayOfWeek;
             int target = (int)dayOfWeek;
             if(target <= start)
                 target += 7;
-            return previousLogEventTimestamp.Value.AddDays(target - start);
+            return previousLogEventTimestamp.AddDays(target - start);
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -3269,6 +3269,17 @@ namespace NLog.UnitTests.Targets
             Assert.Equal(expectedFileName, path);
         }
 
+        [Theory]
+        [InlineData(DayOfWeek.Sunday, "2017-03-02 15:27:34.651", "2017-03-05 15:27:34.651")]    // On a Thursday, finding next Sunday
+        [InlineData(DayOfWeek.Thursday, "2017-03-02 15:27:34.651", "2017-03-09 15:27:34.651")]  // On a Thursday, finding next Thursday
+        [InlineData(DayOfWeek.Monday, "2017-03-02 00:00:00.000", "2017-03-06 00:00:00.000")]    // On Thursday at Midnight, finding next Monday
+        public void TestCalculateNextWeekday(DayOfWeek day, string todayString, string expectedString)
+        {
+            DateTime today = DateTime.Parse(todayString);
+            DateTime expected = DateTime.Parse(expectedString);
+            DateTime actual = FileTarget.CalculateNextWeekday(today, day);
+            Assert.Equal(expected, actual);
+        }
 
         protected abstract Target WrapFileTarget(FileTarget target);
     }


### PR DESCRIPTION
This PR adds a `Weekly` archiving option to FileTarget.

The reasoning behind this change is that, for some projects, Daily archiving is too often and Monthly archiving is too infrequent.

### Discussion
Typically weekly archival options, such as the [Python TimedRotatingFileHandler](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.TimedRotatingFileHandler), will require the user to specify the day of the week that archiving should occur. To implement this, we have two options:

1. Add a configuration option to the File target. Something like:
    ```xml
    <target xsi:type="File"
            name="file"
            layout="${defaultLayout}"
            fileName="${logFileDir}/my_program.log"
            archiveFileName="${logFileDir}/my_program_{#}.log"
            archiveEvery="Week"
            archiveOn="Sunday"            <-- a new archival option
            archiveNumbering="Date"
            archiveDateFormat="yyyyMMdd"
            maxArchiveFiles="14"
      />
    ```
2. Simply use the day of the week as the `archiveEvery` value:
    ```xml
    <target xsi:type="File"
            name="file"
            layout="${defaultLayout}"
            fileName="${logFileDir}/my_program.log"
            archiveFileName="${logFileDir}/my_program_{#}.log"
            archiveEvery="Tuesday"
            archiveNumbering="Date"
            archiveDateFormat="yyyyMMdd"
            maxArchiveFiles="14"
      />
    ```

Personally I feel that option 2 is easier for the user and also easier to implement, so that's what this PR will be focusing on. If you'd prefer option 1 or have another suggestion, please let me know.