### PR TITLE
Added AsyncTaskTarget - Base class for using async methods

### DIFF
--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -351,6 +351,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Targets\ArchiveNumberingMode.cs" />
+    <Compile Include="Targets\AsyncTaskTarget.cs" />
     <Compile Include="Targets\ChainsawTarget.cs" />
     <Compile Include="Targets\ColoredConsoleTarget.cs" />
     <Compile Include="Targets\ConsoleOutputColor.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -348,6 +348,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Targets\ArchiveNumberingMode.cs" />
+    <Compile Include="Targets\AsyncTaskTarget.cs" />
     <Compile Include="Targets\ChainsawTarget.cs" />
     <Compile Include="Targets\ColoredConsoleTarget.cs" />
     <Compile Include="Targets\ConsoleOutputColor.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -361,6 +361,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Targets\ArchiveNumberingMode.cs" />
+    <Compile Include="Targets\AsyncTaskTarget.cs" />
     <Compile Include="Targets\ChainsawTarget.cs" />
     <Compile Include="Targets\ColoredConsoleTarget.cs" />
     <Compile Include="Targets\ConsoleOutputColor.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -367,6 +367,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Targets\ArchiveNumberingMode.cs" />
+    <Compile Include="Targets\AsyncTaskTarget.cs" />
     <Compile Include="Targets\ChainsawTarget.cs" />
     <Compile Include="Targets\ColoredConsoleTarget.cs" />
     <Compile Include="Targets\ConsoleOutputColor.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -361,6 +361,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Targets\ArchiveNumberingMode.cs" />
+    <Compile Include="Targets\AsyncTaskTarget.cs" />
     <Compile Include="Targets\ChainsawTarget.cs" />
     <Compile Include="Targets\ColoredConsoleTarget.cs" />
     <Compile Include="Targets\ConsoleOutputColor.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -361,6 +361,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Targets\ArchiveNumberingMode.cs" />
+    <Compile Include="Targets\AsyncTaskTarget.cs" />
     <Compile Include="Targets\ChainsawTarget.cs" />
     <Compile Include="Targets\ColoredConsoleTarget.cs" />
     <Compile Include="Targets\ConsoleOutputColor.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -367,6 +367,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Targets\ArchiveNumberingMode.cs" />
+    <Compile Include="Targets\AsyncTaskTarget.cs" />
     <Compile Include="Targets\ChainsawTarget.cs" />
     <Compile Include="Targets\ColoredConsoleTarget.cs" />
     <Compile Include="Targets\ConsoleOutputColor.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -368,6 +368,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Targets\ArchiveNumberingMode.cs" />
+    <Compile Include="Targets\AsyncTaskTarget.cs" />
     <Compile Include="Targets\ChainsawTarget.cs" />
     <Compile Include="Targets\ColoredConsoleTarget.cs" />
     <Compile Include="Targets\ConsoleOutputColor.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -365,6 +365,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Targets\ArchiveNumberingMode.cs" />
+    <Compile Include="Targets\AsyncTaskTarget.cs" />
     <Compile Include="Targets\ChainsawTarget.cs" />
     <Compile Include="Targets\ColoredConsoleTarget.cs" />
     <Compile Include="Targets\ConsoleOutputColor.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -364,6 +364,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Targets\ArchiveNumberingMode.cs" />
+    <Compile Include="Targets\AsyncTaskTarget.cs" />
     <Compile Include="Targets\ChainsawTarget.cs" />
     <Compile Include="Targets\ColoredConsoleTarget.cs" />
     <Compile Include="Targets\ConsoleOutputColor.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -364,6 +364,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Targets\ArchiveNumberingMode.cs" />
+    <Compile Include="Targets\AsyncTaskTarget.cs" />
     <Compile Include="Targets\ChainsawTarget.cs" />
     <Compile Include="Targets\ColoredConsoleTarget.cs" />
     <Compile Include="Targets\ConsoleOutputColor.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -389,6 +389,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Targets\ArchiveNumberingMode.cs" />
+    <Compile Include="Targets\AsyncTaskTarget.cs" />
     <Compile Include="Targets\ChainsawTarget.cs" />
     <Compile Include="Targets\ColoredConsoleTarget.cs" />
     <Compile Include="Targets\ConsoleOutputColor.cs" />

--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -191,7 +191,12 @@ namespace NLog.Targets
                     lock (this.SyncRoot)
                     {
                         _previousTask = newTask;
+#if (SILVERLIGHT && !WINDOWS_PHONE) || NET4_0
+                        var continuation = logEvent.Continuation;
+                        _previousTask.ContinueWith(completedTask => TaskCompletion(completedTask, continuation), _cancelTokenSource.Token);
+#else
                         _previousTask.ContinueWith(_taskCompletion, logEvent.Continuation, _cancelTokenSource.Token);
+#endif
                         if (_previousTask.Status == TaskStatus.Created)
                             _previousTask.Start(TaskScheduler.Default);
                     }
@@ -237,4 +242,4 @@ namespace NLog.Targets
         }
     }
 #endif
-}
+                    }

--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -1,0 +1,240 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Targets
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+
+#if !NET3_5 && !SILVERLIGHT4
+    using System.Threading.Tasks;
+    using NLog.Common;
+
+    /// <summary>
+    /// Abstract Target with async Task support
+    /// </summary>
+    public abstract class AsyncTaskTarget : Target
+    {
+        private readonly CancellationTokenSource _cancelTokenSource;
+        private readonly Queue<AsyncLogEventInfo> _requestQueue;
+        private readonly Action _taskStartNext;
+        private readonly Action<Task, object> _taskCompletion;
+        private Task _previousTask;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        protected AsyncTaskTarget()
+        {
+            _taskStartNext = TaskStartNext;
+            _taskCompletion = TaskCompletion;
+            _cancelTokenSource = new CancellationTokenSource();
+            _requestQueue = new Queue<AsyncLogEventInfo>(10000);
+        }
+
+        /// <summary>
+        /// Override this to create the actual logging task
+        /// <example>
+        /// Example of how to override this method, and call custom async method
+        /// <code>
+        /// protected override Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken token)
+        /// {
+        ///    return CustomWriteAsync(logEvent, token);
+        /// }
+        /// 
+        /// private async Task CustomWriteAsync(LogEventInfo logEvent, CancellationToken token)
+        /// {
+        ///     await MyLogMethodAsync(logEvent, token);
+        /// }
+        /// </code></example>
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns></returns>
+        protected abstract Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Schedules the LogEventInfo for async writing
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        protected override void Write(AsyncLogEventInfo logEvent)
+        {
+            if (_cancelTokenSource.IsCancellationRequested)
+            {
+                logEvent.Continuation(null);
+                return;
+            }
+
+            this.MergeEventProperties(logEvent.LogEvent);
+            this.PrecalculateVolatileLayouts(logEvent.LogEvent);
+
+            _requestQueue.Enqueue(logEvent);
+            if (_previousTask == null)
+            {
+                _previousTask = Task.Factory.StartNew(_taskStartNext, _cancelTokenSource.Token, TaskCreationOptions.None, TaskScheduler.Default);
+            }
+        }
+
+        /// <summary>
+        /// Schedules notification of when all messages has been written
+        /// </summary>
+        /// <param name="asyncContinuation"></param>
+        protected override void FlushAsync(AsyncContinuation asyncContinuation)
+        {
+            if (_previousTask == null)
+            {
+                InternalLogger.Debug("{0} Flushing Nothing", this.Name);
+                asyncContinuation(null);
+            }
+            else
+            {
+                InternalLogger.Debug("{0} Flushing {1} items", this.Name, _requestQueue.Count + 1);
+                _requestQueue.Enqueue(new AsyncLogEventInfo(null, asyncContinuation));
+            }
+        }
+
+        /// <summary>
+        /// Closes Target by updating CancellationToken 
+        /// </summary>
+        protected override void CloseTarget()
+        {
+            _cancelTokenSource.Cancel();
+            _requestQueue.Clear();
+            _previousTask = null;
+            base.CloseTarget();
+        }
+
+        /// <summary>
+        /// Releases any managed resources
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+                _cancelTokenSource.Dispose();
+        }
+
+        private void TaskStartNext()
+        {
+            AsyncLogEventInfo logEvent;
+            do
+            {
+                lock (this.SyncRoot)
+                {
+                    if (_requestQueue.Count == 0)
+                    {
+                        _previousTask = null;
+                        break;
+                    }
+
+                    logEvent = _requestQueue.Dequeue();
+                }
+            } while (!TaskCreation(logEvent));
+        }
+
+        private bool TaskCreation(AsyncLogEventInfo logEvent)
+        {
+            try
+            {
+                if (_cancelTokenSource.IsCancellationRequested)
+                {
+                    logEvent.Continuation(null);
+                    return false;
+                }
+
+                if (logEvent.LogEvent == null)
+                {
+                    InternalLogger.Debug("{0} Flush Completed", this.Name);
+                    logEvent.Continuation(null);
+                    return false;
+                }
+
+                var newTask = WriteAsyncTask(logEvent.LogEvent, _cancelTokenSource.Token);
+                if (newTask == null)
+                {
+                    InternalLogger.Debug("{0} WriteAsync returned null", this.Name);
+                }
+                else
+                {
+                    lock (this.SyncRoot)
+                    {
+                        _previousTask = newTask;
+                        _previousTask.ContinueWith(_taskCompletion, logEvent.Continuation, _cancelTokenSource.Token);
+                        if (_previousTask.Status == TaskStatus.Created)
+                            _previousTask.Start(TaskScheduler.Default);
+                    }
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    InternalLogger.Error(ex, "{0} WriteAsync failed on creation", this.Name);
+                    logEvent.Continuation(ex);
+                }
+                catch
+                {
+                    // Don't wanna die
+                }
+            }
+            return false;
+        }
+
+        private void TaskCompletion(Task completedTask, object continuation)
+        {
+            try
+            {
+                if (completedTask.IsCanceled)
+                {
+                    if (completedTask.Exception != null)
+                        InternalLogger.Warn(completedTask.Exception, "{0} WriteAsync was cancelled", this.Name);
+                    else
+                        InternalLogger.Info("{0} WriteAsync was cancelled", this.Name);
+                }
+                else if (completedTask.Exception != null)
+                {
+                    InternalLogger.Warn(completedTask.Exception, "{0} WriteAsync failed on completion", this.Name);
+                }
+                ((AsyncContinuation)continuation)(completedTask.Exception);
+            }
+            finally
+            {
+                TaskStartNext();
+            }
+        }
+    }
+#endif
+}

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -191,6 +191,7 @@
     <Compile Include="ProcessRunner.cs" />
     <Compile Include="RegressionTests.cs" />
     <Compile Include="RoutingTests.cs" />
+    <Compile Include="Targets\AsyncTaskTargetTest.cs" />
     <Compile Include="Targets\ColoredConsoleTargetTests.cs" />
     <Compile Include="Targets\ConcurrentFileTargetTests.cs" />
     <Compile Include="Targets\ConsoleTargetTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -220,6 +220,7 @@
     <Compile Include="ProcessRunner.cs" />
     <Compile Include="RegressionTests.cs" />
     <Compile Include="RoutingTests.cs" />
+    <Compile Include="Targets\AsyncTaskTargetTest.cs" />
     <Compile Include="Targets\ColoredConsoleTargetTests.cs" />
     <Compile Include="Targets\ConcurrentFileTargetTests.cs" />
     <Compile Include="Targets\ConsoleTargetTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -200,6 +200,7 @@
     <Compile Include="ProcessRunner.cs" />
     <Compile Include="RegressionTests.cs" />
     <Compile Include="RoutingTests.cs" />
+    <Compile Include="Targets\AsyncTaskTargetTest.cs" />
     <Compile Include="Targets\ColoredConsoleTargetTests.cs" />
     <Compile Include="Targets\ConcurrentFileTargetTests.cs" />
     <Compile Include="Targets\ConsoleTargetTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -242,6 +242,7 @@
     <Compile Include="ProcessRunner.cs" />
     <Compile Include="RegressionTests.cs" />
     <Compile Include="RoutingTests.cs" />
+    <Compile Include="Targets\AsyncTaskTargetTest.cs" />
     <Compile Include="Targets\ColoredConsoleTargetTests.cs" />
     <Compile Include="Targets\ConcurrentFileTargetTests.cs" />
     <Compile Include="Targets\ConsoleTargetTests.cs" />

--- a/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
+++ b/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
@@ -1,0 +1,90 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System.Collections.Generic;
+using Xunit;
+using NLog.Config;
+using NLog.Layouts;
+using NLog.Targets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NLog.UnitTests.Targets
+{
+    public class AsyncTaskTargetTest : NLogTestBase
+    {
+        class AsyncTaskTestTarget : AsyncTaskTarget
+        {
+            public Layout Layout { get; set; }
+
+            internal Queue<string> Logs = new Queue<string>();
+
+            protected override Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken token)
+            {
+                return WriteLogQueue(logEvent, token);
+            }
+
+            private async Task WriteLogQueue(LogEventInfo logEvent, CancellationToken token)
+            {
+                await Task.Delay(10, token).ContinueWith((t) => Logs.Enqueue(RenderLogEvent(Layout, logEvent)), token).ContinueWith(async (t) => await Task.Delay(10));
+            }
+        }
+
+        [Fact]
+        public void AsyncTaskTarget_TestLogging()
+        {
+            ILogger logger = LogManager.GetCurrentClassLogger();
+
+            var asyncTarget = new AsyncTaskTestTarget();
+            asyncTarget.Layout = "${threadid}|${level}|${message}";
+
+            SimpleConfigurator.ConfigureForTargetLogging(asyncTarget, LogLevel.Trace);
+            Assert.True(asyncTarget.Logs.Count == 0);
+            logger.Trace("TTT");
+            logger.Debug("DDD");
+            logger.Info("III");
+            logger.Warn("WWW");
+            logger.Error("EEE");
+            logger.Fatal("FFF");
+            System.Threading.Thread.Sleep(50);
+            Assert.True(asyncTarget.Logs.Count != 0);
+            LogManager.Flush();
+            Assert.True(asyncTarget.Logs.Count == 6);
+            while (asyncTarget.Logs.Count > 0)
+                Assert.Equal(0, asyncTarget.Logs.Dequeue().IndexOf(System.Threading.Thread.CurrentThread.ManagedThreadId.ToString() + "|"));
+
+            LogManager.Configuration = null;
+        }
+    }
+}
+


### PR DESCRIPTION
AsyncTaskTarget tries to resolve #2004. It has the following properties:

   - Only uses a single Task to protect against out-of-order writing of LogEvents (And avoids using the entire thread pool).
   - WriteAsyncTask is called without holding Target-Lock-object to improve concurrency (loggers can schedule more LogEvents while the initial LogEvent call is being started).
   - Having a requestQueue to make it easier to monitor pending requests (instead of navigating in a ContinueWith-chain).
   - Support flush where it correctly notifies when pending write of LogEvents have completed.
   - Support timeout handling, cancels active task if it fails to complete (and continues with the next)

Following features could probably be added:

   - Support batching of multiple LogEvents in a single write operation.
   - Support parallel writing of LogEvents using a limited number of concurrent Tasks.

Example of how to make custom target:
```
        public class AsyncTaskTestTarget : AsyncTaskTarget
        {
            public Layout Layout { get; set; }

            protected override Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken token)
            {
                return CustomWriteAsync(logEvent, token);
            }

            private async Task CustomWriteAsync(LogEventInfo logEvent, CancellationToken token)
            {
                await Task.Delay(10, token).ConfigureAwait(false);   // TODO Do something with logEvent
            }
        }
```