### PR TITLE
LogFactory - Ensure to flush and close on shutdown

### DIFF
--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -360,10 +360,6 @@ namespace NLog
             factory.Shutdown();
         }
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-
-#endif
-
         /// <summary>
         /// Gets the fully qualified name of the class invoking the LogManager, including the 
         /// namespace but not the assembly.    
@@ -395,8 +391,5 @@ namespace NLog
 
             return className;
         }
-
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-#endif
     }
 }

--- a/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
+++ b/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
@@ -108,11 +108,13 @@ namespace NLog.UnitTests.Internal
         {
             var filePath = Path.Combine(fileWritePath, "${level}.txt");
 
-
+            // NOTE Using BufferingWrapper to validate that DomainUnload remembers to perform flush
             var configXml = string.Format(@"
             <nlog throwExceptions='false'>
                 <targets async='true'> 
-                    <target name='file' type='file' layout='${{message}} ${{threadid}}' filename='{0}' LineEnding='lf' />
+                    <target name='file' type='BufferingWrapper' bufferSize='10000' flushTimeout='15000'>
+                        <target name='filewrapped' type='file' layout='${{message}} ${{threadid}}' filename='{0}' LineEnding='lf' />
+                    </target>
                 </targets>
                 <rules>
                     <logger name='*' minlevel='Debug' appendto='file'>
@@ -136,8 +138,6 @@ namespace NLog.UnitTests.Internal
                 logger.Error("ddd");
                 logger.Fatal("eee");
             }
-
-            LogManager.Flush();
         }
     }
 


### PR DESCRIPTION
Fixes bug introduced with #1906 and reported in #1998 (Abused the medium-trust-AppDomain-unit-test to verify flush is done properly on AppDomain-unload)