### PR TITLE
Layout class refactoring

### DIFF
--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -168,7 +168,7 @@ namespace NLog.Internal
 
             if (reusableBuilder != null)
             {
-                if (!_layout.IsThreadAgnostic)
+                if (!_layout.ThreadAgnostic)
                 {
                     string cachedResult;
                     if (logEvent.TryGetCachedLayoutValue(_layout, out cachedResult))

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -261,19 +261,7 @@ namespace NLog.Layouts
             {
                 this.LoggingConfiguration = configuration;
                 this.isInitialized = true;
-
-                // determine whether the layout is thread-agnostic
-                // layout is thread agnostic if it is thread-agnostic and 
-                // all its nested objects are thread-agnostic.
-                this.ThreadAgnostic = true;
-                foreach (object item in ObjectGraphScanner.FindReachableObjects<object>(this))
-                {
-                    if (!item.GetType().IsDefined< ThreadAgnosticAttribute>(true))
-                    {
-                        this.ThreadAgnostic = false;
-                        break;
-                    }
-                }
+                this.ThreadAgnostic = IsThreadAgnostic();
 
                 this.InitializeLayout();
             }
@@ -343,6 +331,24 @@ namespace NLog.Layouts
             return (maxRenderedLength > MaxInitialRenderBufferLength) 
                     ? MaxInitialRenderBufferLength 
                     : maxRenderedLength;
+        }
+
+        /// <summary>
+        /// Determine whether the layout is thread-agnostic or not. The layout is thread-agnostic when itself  
+        /// and all the nested objects are thread-agnostic.
+        /// </summary>
+        /// <returns>True when thread-agnostic; false otherwise.</returns>
+        private bool IsThreadAgnostic() {
+            var result = true;
+
+            foreach (object item in ObjectGraphScanner.FindReachableObjects<object>(this)) {
+                if (!item.GetType().IsDefined<ThreadAgnosticAttribute>(true)) {
+                    result = false;
+                    break;
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -178,11 +178,7 @@ namespace NLog.Layouts
                 }
             }
 
-            int initialLength = this.maxRenderedLength;
-            if (initialLength > MaxInitialRenderBufferLength)
-            {
-                initialLength = MaxInitialRenderBufferLength;
-            }
+            int initialLength = GetRenderBufferLength();
 
             using (var localTarget = new AppendBuilderCreator(target, initialLength))
             {
@@ -217,11 +213,7 @@ namespace NLog.Layouts
                 }
             }
 
-            int initialLength = this.maxRenderedLength;
-            if (initialLength > MaxInitialRenderBufferLength)
-            {
-                initialLength = MaxInitialRenderBufferLength;
-            }
+            int initialLength = GetRenderBufferLength();
 
             var sb = reusableBuilder ?? new StringBuilder(initialLength);
             RenderFormattedMessage(logEvent, sb);
@@ -352,6 +344,13 @@ namespace NLog.Layouts
         {
             ConfigurationItemFactory.Default.Layouts
                 .RegisterDefinition(name, layoutType);
+        }
+
+        private int GetRenderBufferLength()
+        {
+            return (maxRenderedLength > MaxInitialRenderBufferLength) 
+                    ? MaxInitialRenderBufferLength 
+                    : maxRenderedLength;
         }
     }
 }

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -453,7 +453,7 @@ namespace NLog.Targets
             bool foundNotThreadAgnostic = false;
             foreach (Layout layout in this.allLayouts)
             {
-                if (!layout.IsThreadAgnostic)
+                if (!layout.ThreadAgnostic)
                 {
                     foundNotThreadAgnostic = true;
                     break;

--- a/tests/NLog.UnitTests/Layouts/ThreadAgnosticTests.cs
+++ b/tests/NLog.UnitTests/Layouts/ThreadAgnosticTests.cs
@@ -65,7 +65,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${message}");
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${guid}");
             l.Initialize(null);
-            Assert.False(l.IsThreadAgnostic);
+            Assert.False(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${message}${guid}");
             l.Initialize(null);
-            Assert.False(l.IsThreadAgnostic);
+            Assert.False(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${message}${level}${logger}");
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${rot13:${message}}");
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${lowercase:${rot13:${message}}}");
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -113,7 +113,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${uppercase:${lowercase:${rot13:${message}}}}");
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -121,7 +121,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${uppercase:${lowercase:${rot13:${message}${guid}}}}");
             l.Initialize(null);
-            Assert.False(l.IsThreadAgnostic);
+            Assert.False(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = @"${message:padding=-10:padCharacter=Y:when='${pad:${logger}:padding=10:padCharacter=X}'=='XXXXlogger'}";
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = @"${message:padding=-10:padCharacter=Y:when='${pad:${guid}:padding=10:padCharacter=X}'=='XXXXlogger'}";
             l.Initialize(null);
-            Assert.False(l.IsThreadAgnostic);
+            Assert.False(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace NLog.UnitTests.Layouts
             };
 
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace NLog.UnitTests.Layouts
             };
 
             l.Initialize(null);
-            Assert.False(l.IsThreadAgnostic);
+            Assert.False(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -184,7 +184,7 @@ namespace NLog.UnitTests.Layouts
             Layout l = new SimpleLayout("${customNotAgnostic}", cif);
 
             l.Initialize(null);
-            Assert.False(l.IsThreadAgnostic);
+            Assert.False(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -196,7 +196,7 @@ namespace NLog.UnitTests.Layouts
             Layout l = new SimpleLayout("${customAgnostic}", cif);
 
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [LayoutRenderer("customNotAgnostic")]


### PR DESCRIPTION
The refactorings of Layout class supplied in small commits in order to be easy to review the changes on each one of them.

----
Extract IsThreadAgnostic() method
 Improve the code readability by extracting IsThreadAgnostic() method.

Refactor internal property ThreadAgnostic
* Remove obsolete threadAgnostic private property.
* Rename the IsThreadAgnostic internal property to ThreadAgnostic to align with the expected naming for properties.

Reduce duplicate code in Layout class
* Extract method GetRenderBufferLength() to reduce code replication
