### PR TITLE
${level} add format option (full, single char and ordinal)

### DIFF
--- a/src/NLog/LayoutRenderers/LevelFormat.cs
+++ b/src/NLog/LayoutRenderers/LevelFormat.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -33,45 +33,24 @@
 
 namespace NLog.LayoutRenderers
 {
-    using System.Diagnostics;
-    using System.ComponentModel;
-    using System.Text;
-    using System;
-
-    using NLog.Config;
-
     /// <summary>
-    /// The log level.
+    /// Format of the ${level} layout renderer output.
     /// </summary>
-    [LayoutRenderer("level")]
-    [ThreadAgnostic]
-    public class LevelLayoutRenderer : LayoutRenderer
+    public enum LevelFormat
     {
         /// <summary>
-        /// Gets or sets a value indicating the output format of the level.
+        /// Render the full level name.
         /// </summary>
-        [DefaultValue(LevelFormat.Name)]
-        public LevelFormat Format { get; set; }
+        Name,
 
         /// <summary>
-        /// Renders the current log level and appends it to the specified <see cref="StringBuilder" />.
+        /// Render the first character of the level.
         /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
-        {
-            switch (Format)
-            {
-                case LevelFormat.Name:
-                    builder.Append(logEvent.Level.ToString());
-                    break;
-                case LevelFormat.FirstCharacter:
-                    builder.Append(logEvent.Level.ToString()[0]);
-                    break;
-                case LevelFormat.Ordinal:
-                    builder.Append(logEvent.Level.Ordinal);
-                    break;
-            }
-        }
+        FirstCharacter,
+
+        /// <summary>
+        /// Render the ordinal (aka number) for the level.
+        /// </summary>
+        Ordinal
     }
 }

--- a/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
@@ -34,7 +34,9 @@
 namespace NLog.LayoutRenderers
 {
     using System.Diagnostics;
+    using System.ComponentModel;
     using System.Text;
+    using System;
 
     using NLog.Config;
 
@@ -46,13 +48,44 @@ namespace NLog.LayoutRenderers
     public class LevelLayoutRenderer : LayoutRenderer
     {
         /// <summary>
+        /// A value indicating when the cache is cleared.
+        /// </summary>
+        [Flags]
+        public enum LevelOutputOption
+        {
+            /// <summary>Ouput the name as the level.</summary>
+            Name = 0,
+            /// <summary>Output a single character as the level.</summary>
+            SingleCharacter = 1,
+            /// <summary>Output an ordinal (i.e. number) as the level.</summary>
+            Ordinal = 2
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating how the level is output.
+        /// </summary>
+        [DefaultValue(LevelOutputOption.Name)]
+        public LevelOutputOption LevelOutput { get; set; }
+
+        /// <summary>
         /// Renders the current log level and appends it to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            builder.Append(logEvent.Level.ToString());
+            switch (LevelOutput)
+            {
+                case LevelOutputOption.Name:
+                    builder.Append(logEvent.Level.ToString());
+                    break;
+                case LevelOutputOption.SingleCharacter:
+                    builder.Append(logEvent.Level.ToString()[0]);
+                    break;
+                case LevelOutputOption.Ordinal:
+                    builder.Append(logEvent.Level.Ordinal);
+                    break;
+            }
         }
     }
 }

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -238,6 +238,7 @@
     <Compile Include="LayoutRenderers\InstallContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRendererAttribute.cs" />
+    <Compile Include="LayoutRenderers\LevelFormat.cs" />
     <Compile Include="LayoutRenderers\LevelLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LiteralLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Log4JXmlEventLayoutRenderer.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -235,6 +235,7 @@
     <Compile Include="LayoutRenderers\InstallContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRendererAttribute.cs" />
+    <Compile Include="LayoutRenderers\LevelFormat.cs" />
     <Compile Include="LayoutRenderers\LevelLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LiteralLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Log4JXmlEventLayoutRenderer.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -248,6 +248,7 @@
     <Compile Include="LayoutRenderers\InstallContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRendererAttribute.cs" />
+    <Compile Include="LayoutRenderers\LevelFormat.cs" />
     <Compile Include="LayoutRenderers\LevelLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LiteralLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Log4JXmlEventLayoutRenderer.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -254,6 +254,7 @@
     <Compile Include="LayoutRenderers\InstallContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRendererAttribute.cs" />
+    <Compile Include="LayoutRenderers\LevelFormat.cs" />
     <Compile Include="LayoutRenderers\LevelLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LiteralLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Log4JXmlEventLayoutRenderer.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -248,6 +248,7 @@
     <Compile Include="LayoutRenderers\InstallContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRendererAttribute.cs" />
+    <Compile Include="LayoutRenderers\LevelFormat.cs" />
     <Compile Include="LayoutRenderers\LevelLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LiteralLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Log4JXmlEventLayoutRenderer.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -248,6 +248,7 @@
     <Compile Include="LayoutRenderers\InstallContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRendererAttribute.cs" />
+    <Compile Include="LayoutRenderers\LevelFormat.cs" />
     <Compile Include="LayoutRenderers\LevelLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LiteralLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Log4JXmlEventLayoutRenderer.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -254,6 +254,7 @@
     <Compile Include="LayoutRenderers\InstallContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRendererAttribute.cs" />
+    <Compile Include="LayoutRenderers\LevelFormat.cs" />
     <Compile Include="LayoutRenderers\LevelLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LiteralLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Log4JXmlEventLayoutRenderer.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -255,6 +255,7 @@
     <Compile Include="LayoutRenderers\InstallContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRendererAttribute.cs" />
+    <Compile Include="LayoutRenderers\LevelFormat.cs" />
     <Compile Include="LayoutRenderers\LevelLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LiteralLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Log4JXmlEventLayoutRenderer.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -252,6 +252,7 @@
     <Compile Include="LayoutRenderers\InstallContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRendererAttribute.cs" />
+    <Compile Include="LayoutRenderers\LevelFormat.cs" />
     <Compile Include="LayoutRenderers\LevelLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LiteralLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Log4JXmlEventLayoutRenderer.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -251,6 +251,7 @@
     <Compile Include="LayoutRenderers\InstallContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRendererAttribute.cs" />
+    <Compile Include="LayoutRenderers\LevelFormat.cs" />
     <Compile Include="LayoutRenderers\LevelLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LiteralLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Log4JXmlEventLayoutRenderer.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -251,6 +251,7 @@
     <Compile Include="LayoutRenderers\InstallContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRendererAttribute.cs" />
+    <Compile Include="LayoutRenderers\LevelFormat.cs" />
     <Compile Include="LayoutRenderers\LevelLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LiteralLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Log4JXmlEventLayoutRenderer.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -276,6 +276,7 @@
     <Compile Include="LayoutRenderers\InstallContextLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LayoutRendererAttribute.cs" />
+    <Compile Include="LayoutRenderers\LevelFormat.cs" />
     <Compile Include="LayoutRenderers\LevelLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\LiteralLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\Log4JXmlEventLayoutRenderer.cs" />

--- a/tests/NLog.UnitTests/LayoutRenderers/LogLevelTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/LogLevelTests.cs
@@ -60,5 +60,53 @@ namespace NLog.UnitTests.LayoutRenderers
             logger.Fatal("a");
             AssertDebugLastMessage("debug", "Fatal a");
         }
+
+        [Fact]
+        public void LogLevelSingleCharacterTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${level:levelOutput=SingleCharacter} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("a");
+            AssertDebugLastMessage("debug", "D a");
+            logger.Info("a");
+            AssertDebugLastMessage("debug", "I a");
+            logger.Warn("a");
+            AssertDebugLastMessage("debug", "W a");
+            logger.Error("a");
+            AssertDebugLastMessage("debug", "E a");
+            logger.Fatal("a");
+            AssertDebugLastMessage("debug", "F a");
+        }
+
+        [Fact]
+        public void LogLevelOrdinalTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${level:levelOutput=Ordinal} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("a");
+            AssertDebugLastMessage("debug", "1 a");
+            logger.Info("a");
+            AssertDebugLastMessage("debug", "2 a");
+            logger.Warn("a");
+            AssertDebugLastMessage("debug", "3 a");
+            logger.Error("a");
+            AssertDebugLastMessage("debug", "4 a");
+            logger.Fatal("a");
+            AssertDebugLastMessage("debug", "5 a");
+        }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/LogLevelTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/LogLevelTests.cs
@@ -66,13 +66,15 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${level:levelOutput=SingleCharacter} ${message}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${level:format=FirstCharacter} ${message}' /></targets>
                 <rules>
-                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                    <logger name='*' minlevel='Trace' writeTo='debug' />
                 </rules>
             </nlog>");
 
             ILogger logger = LogManager.GetLogger("A");
+            logger.Trace("a");
+            AssertDebugLastMessage("debug", "T a");
             logger.Debug("a");
             AssertDebugLastMessage("debug", "D a");
             logger.Info("a");
@@ -90,13 +92,15 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
-                <targets><target name='debug' type='Debug' layout='${level:levelOutput=Ordinal} ${message}' /></targets>
+                <targets><target name='debug' type='Debug' layout='${level:format=Ordinal} ${message}' /></targets>
                 <rules>
-                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                    <logger name='*' minlevel='Trace' writeTo='debug' />
                 </rules>
             </nlog>");
 
             ILogger logger = LogManager.GetLogger("A");
+            logger.Trace("a");
+            AssertDebugLastMessage("debug", "0 a");
             logger.Debug("a");
             AssertDebugLastMessage("debug", "1 a");
             logger.Info("a");

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -423,6 +423,75 @@ Dispose()
         }
 
         [Fact]
+        public void LevelParameterTest()
+        {
+            MockDbConnection.ClearLog();
+            DatabaseTarget dt = new DatabaseTarget()
+            {
+                CommandText = "INSERT INTO FooBar VALUES(@lvl, @msg)",
+                DBProvider = typeof(MockDbConnection).AssemblyQualifiedName,
+                KeepConnection = true,
+                Parameters =
+                {
+                    new DatabaseParameterInfo("lvl", "${level:levelOutput=Ordinal}"),
+                    new DatabaseParameterInfo("msg", "${message}")
+                }
+            };
+
+            dt.Initialize(null);
+
+            Assert.Same(typeof(MockDbConnection), dt.ConnectionType);
+
+            List<Exception> exceptions = new List<Exception>();
+            var events = new[]
+            {
+                new LogEventInfo(LogLevel.Info, "MyLogger", "msg1").WithContinuation(exceptions.Add),
+                new LogEventInfo(LogLevel.Debug, "MyLogger2", "msg3").WithContinuation(exceptions.Add),
+            };
+
+            dt.WriteAsyncLogEvents(events);
+            foreach (var ex in exceptions)
+            {
+                Assert.Null(ex);
+            }
+
+            string expectedLog = @"Open('Server=.;Trusted_Connection=SSPI;').
+CreateParameter(0)
+Parameter #0 Direction=Input
+Parameter #0 Name=lvl
+Parameter #0 Value=2
+Add Parameter Parameter #0
+CreateParameter(1)
+Parameter #1 Direction=Input
+Parameter #1 Name=msg
+Parameter #1 Value=msg1
+Add Parameter Parameter #1
+ExecuteNonQuery: INSERT INTO FooBar VALUES(@lvl, @msg)
+CreateParameter(0)
+Parameter #0 Direction=Input
+Parameter #0 Name=lvl
+Parameter #0 Value=1
+Add Parameter Parameter #0
+CreateParameter(1)
+Parameter #1 Direction=Input
+Parameter #1 Name=msg
+Parameter #1 Value=msg3
+Add Parameter Parameter #1
+ExecuteNonQuery: INSERT INTO FooBar VALUES(@lvl, @msg)
+";
+
+            AssertLog(expectedLog);
+
+            MockDbConnection.ClearLog();
+            dt.Close();
+            expectedLog = @"Close()
+Dispose()
+";
+
+            AssertLog(expectedLog);
+        }
+
+        [Fact]
         public void ParameterFacetTest()
         {
             MockDbConnection.ClearLog();

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -433,7 +433,7 @@ Dispose()
                 KeepConnection = true,
                 Parameters =
                 {
-                    new DatabaseParameterInfo("lvl", "${level:levelOutput=Ordinal}"),
+                    new DatabaseParameterInfo("lvl", "${level:format=Ordinal}"),
                     new DatabaseParameterInfo("msg", "${message}")
                 }
             };


### PR DESCRIPTION
Adds single character and ordinal level output options to the LevelLayoutRenderer to address #1949 and #1950