### PR TITLE
 Reduce memory allocations (AsyncContinuation exceptionHandler) & refactor

### DIFF
--- a/src/NLog/Internal/ReusableBufferCreator.cs
+++ b/src/NLog/Internal/ReusableBufferCreator.cs
@@ -38,49 +38,11 @@ namespace NLog.Internal
     /// <summary>
     /// Controls a single allocated char[]-buffer for reuse (only one active user)
     /// </summary>
-    internal class ReusableBufferCreator
+    internal class ReusableBufferCreator : ReusableObjectCreator<char[]>
     {
-        private char[] _buffer;
-
-        /// <summary>Empty handle when <see cref="Targets.Target.OptimizeBufferReuse"/> is disabled</summary>
-        public readonly LockBuffer None = default(LockBuffer);
-
         public ReusableBufferCreator(int capacity)
+            :base(new char[capacity], (b) => { })
         {
-            _buffer = new char[capacity];
-        }
-
-        /// <summary>
-        /// Creates handle to the reusable char[]-buffer for active usage
-        /// </summary>
-        /// <returns>Handle to the reusable item, that can release it again</returns>
-        public LockBuffer Allocate()
-        {
-            return new LockBuffer(this);
-        }
-
-        public struct LockBuffer : IDisposable
-        {
-            /// <summary>
-            /// Access the char[]-buffer acquired
-            /// </summary>
-            public readonly char[] Result;
-            private readonly ReusableBufferCreator _owner;
-
-            public LockBuffer(ReusableBufferCreator owner)
-            {
-                Result = owner._buffer;
-                owner._buffer = null;
-                _owner = owner;
-            }
-
-            public void Dispose()
-            {
-                if (Result != null)
-                {
-                    _owner._buffer = Result;
-                }
-            }
         }
     }
 }

--- a/src/NLog/Internal/ReusableBuilderCreator.cs
+++ b/src/NLog/Internal/ReusableBuilderCreator.cs
@@ -31,7 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
 using System.Text;
 
 namespace NLog.Internal
@@ -39,45 +38,11 @@ namespace NLog.Internal
     /// <summary>
     /// Controls a single allocated StringBuilder for reuse (only one active user)
     /// </summary>
-    internal class ReusableBuilderCreator
+    internal class ReusableBuilderCreator : ReusableObjectCreator<StringBuilder>
     {
-        private StringBuilder _builder = new StringBuilder();
-
-        /// <summary>Empty handle when <see cref="Targets.Target.OptimizeBufferReuse"/> is disabled</summary>
-        public readonly LockBuilder None = default(LockBuilder);
-
-        /// <summary>
-        /// Creates handle to the reusable StringBuilder for active usage
-        /// </summary>
-        /// <returns>Handle to the reusable item, that can release it again</returns>
-        public LockBuilder Allocate()
+        public ReusableBuilderCreator()
+            : base(new StringBuilder(), (sb) => { sb.ClearBuilder(); })
         {
-            return new LockBuilder(this);
-        }
-
-        public struct LockBuilder : IDisposable
-        {
-            /// <summary>
-            /// Access the StringBuilder acquired
-            /// </summary>
-            public readonly StringBuilder Result;
-            private readonly ReusableBuilderCreator _owner;
-
-            public LockBuilder(ReusableBuilderCreator owner)
-            {
-                Result = owner._builder;
-                owner._builder = null;
-                _owner = owner;
-            }
-
-            public void Dispose()
-            {
-                if (Result != null)
-                {
-                    Result.ClearBuilder();
-                    _owner._builder = Result;
-                }
-            }
         }
     }
 }

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -79,17 +79,21 @@ namespace NLog
                 logEvent.SetStackTrace(stackTrace, firstUserFrame);
             }
 
-            int originalThreadId = Thread.CurrentThread.ManagedThreadId;
-            AsyncContinuation exceptionHandler = ex =>
+            AsyncContinuation exceptionHandler = (ex) => { };
+            if (factory.ThrowExceptions)
             {
-                if (ex != null)
+                int originalThreadId = Thread.CurrentThread.ManagedThreadId;
+                exceptionHandler = ex =>
                 {
-                    if (factory.ThrowExceptions && Thread.CurrentThread.ManagedThreadId == originalThreadId)
+                    if (ex != null)
                     {
-                        throw new NLogRuntimeException("Exception occurred in NLog", ex);
+                        if (Thread.CurrentThread.ManagedThreadId == originalThreadId)
+                        {
+                            throw new NLogRuntimeException("Exception occurred in NLog", ex);
+                        }
                     }
-                }
-            };
+                };
+            }
 
             for (var t = targets; t != null; t = t.NextInChain)
             {

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -192,6 +192,7 @@
     <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
     <Compile Include="Internal\ReusableBufferCreator.cs" />
     <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableObjectCreator.cs" />
     <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
     <Compile Include="Internal\ReusableBufferCreator.cs" />
     <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableObjectCreator.cs" />
     <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
     <Compile Include="Internal\ReusableBufferCreator.cs" />
     <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableObjectCreator.cs" />
     <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
     <Compile Include="Internal\ReusableBufferCreator.cs" />
     <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableObjectCreator.cs" />
     <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
     <Compile Include="Internal\ReusableBufferCreator.cs" />
     <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableObjectCreator.cs" />
     <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
     <Compile Include="Internal\ReusableBufferCreator.cs" />
     <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableObjectCreator.cs" />
     <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
     <Compile Include="Internal\ReusableBufferCreator.cs" />
     <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableObjectCreator.cs" />
     <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -209,6 +209,7 @@
     <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
     <Compile Include="Internal\ReusableBufferCreator.cs" />
     <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableObjectCreator.cs" />
     <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -206,6 +206,7 @@
     <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
     <Compile Include="Internal\ReusableBufferCreator.cs" />
     <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableObjectCreator.cs" />
     <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -205,6 +205,7 @@
     <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
     <Compile Include="Internal\ReusableBufferCreator.cs" />
     <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableObjectCreator.cs" />
     <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -205,6 +205,7 @@
     <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
     <Compile Include="Internal\ReusableBufferCreator.cs" />
     <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableObjectCreator.cs" />
     <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Internal\ReusableAsyncLogEventList.cs" />
     <Compile Include="Internal\ReusableBufferCreator.cs" />
     <Compile Include="Internal\ReusableBuilderCreator.cs" />
+    <Compile Include="Internal\ReusableObjectCreator.cs" />
     <Compile Include="Internal\ReusableStreamCreator.cs" />
     <Compile Include="Internal\RuntimeOS.cs" />
     <Compile Include="Internal\SimpleStringReader.cs" />

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -957,15 +957,15 @@ namespace NLog.Targets
         /// <summary>
         /// Can be used if <see cref="Target.OptimizeBufferReuse"/> has been enabled.
         /// </summary>
-        private readonly ReusableStreamCreator reusableFileWriteStream = new ReusableStreamCreator();
+        private readonly ReusableStreamCreator reusableFileWriteStream = new ReusableStreamCreator(1024);
         /// <summary>
         /// Can be used if <see cref="Target.OptimizeBufferReuse"/> has been enabled.
         /// </summary>
-        private readonly ReusableStreamCreator reusableAsyncFileWriteStream = new ReusableStreamCreator();
+        private readonly ReusableStreamCreator reusableAsyncFileWriteStream = new ReusableStreamCreator(1024);
         /// <summary>
         /// Can be used if <see cref="Target.OptimizeBufferReuse"/> has been enabled.
         /// </summary>
-        private readonly ReusableBufferCreator reusableEncodingBuffer = new ReusableBufferCreator(4096);
+        private readonly ReusableBufferCreator reusableEncodingBuffer = new ReusableBufferCreator(1024);
 
         /// <summary>
         /// Writes the specified logging event to a file specified in the FileName 


### PR DESCRIPTION
Introduces ReusableObjectCreator as base-class for OptimizeBufferReuse

Code cleanup and found an extra place to reduce memory allocations (AsyncContinuation exceptionHandler).