### PR TITLE
Layout - Ensure StackTraceUsage works for all types of Layout

### DIFF
--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -164,7 +164,7 @@ namespace NLog.Internal
 
             if (reusableBuilder != null)
             {
-                if (!_layout.IsThreadAgnostic)
+                if (!_layout.ThreadAgnostic)
                 {
                     string cachedResult;
                     if (logEvent.TryGetCachedLayoutValue(_layout, out cachedResult))

--- a/src/NLog/Internal/TargetWithFilterChain.cs
+++ b/src/NLog/Internal/TargetWithFilterChain.cs
@@ -31,8 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.Linq;
-
 namespace NLog.Internal
 {
     using System.Collections.Generic;
@@ -97,10 +95,9 @@ namespace NLog.Internal
 
             // find all objects which may need stack trace
             // and determine maximum
-            // only the target can have IUsesStackTrace
             if (Target != null)
             {
-                stackTraceUsage = Target.GetAllLayouts().OfType<IUsesStackTrace>().DefaultIfEmpty().Max(usage => usage == null ? StackTraceUsage.None : usage.StackTraceUsage);
+                stackTraceUsage = Target.StackTraceUsage;
             }
 
             //recurse into chain if not max

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -31,9 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.Collections.Generic;
-using System.Linq;
-
 namespace NLog.Layouts
 {
     using System;
@@ -87,6 +84,7 @@ namespace NLog.Layouts
             this.configurationItemFactory = configurationItemFactory;
             this.Text = txt;
         }
+
         internal SimpleLayout(LayoutRenderer[] renderers, string text, ConfigurationItemFactory configurationItemFactory)
         {
             this.configurationItemFactory = configurationItemFactory;
@@ -153,12 +151,10 @@ namespace NLog.Layouts
         /// </summary>
         public ReadOnlyCollection<LayoutRenderer> Renderers { get; private set; }
 
-
         /// <summary>
         /// Gets the level of stack trace information required for rendering.
         /// </summary>
-        /// <remarks>Calculated when setting <see cref="Renderers"/>.</remarks>
-        public StackTraceUsage StackTraceUsage { get; private set; }
+        public new StackTraceUsage StackTraceUsage { get { return base.StackTraceUsage; } }
 
         /// <summary>
         /// Converts a text to a simple layout.
@@ -229,24 +225,22 @@ namespace NLog.Layouts
         {
             this.Renderers = new ReadOnlyCollection<LayoutRenderer>(renderers);
 
-            if (this.Renderers.Count == 0)
-            {
-                //todo fixedText = null is also used if the text is fixed, but is a empty renderers not fixed?
-                this.fixedText = null;
-                this.StackTraceUsage = StackTraceUsage.None;
-            }
-            else if (this.Renderers.Count == 1 && this.Renderers[0] is LiteralLayoutRenderer)
+            if (this.Renderers.Count == 1 && this.Renderers[0] is LiteralLayoutRenderer)
             {
                 this.fixedText = ((LiteralLayoutRenderer)this.Renderers[0]).Text;
-                this.StackTraceUsage = StackTraceUsage.None;
             }
             else
             {
+                //todo fixedText = null is also used if the text is fixed, but is a empty renderers not fixed?
                 this.fixedText = null;
-                this.StackTraceUsage = this.Renderers.OfType<IUsesStackTrace>().DefaultIfEmpty().Max(usage => usage == null ? StackTraceUsage.None : usage.StackTraceUsage);
             }
 
             this.layoutText = text;
+
+            if (this.LoggingConfiguration != null)
+            {
+                PerformObjectScanning();
+            }
         }
 
         /// <summary>

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -35,6 +35,7 @@ namespace NLog.Targets
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     using NLog.Common;
     using NLog.Config;
@@ -54,6 +55,11 @@ namespace NLog.Targets
         private bool allLayoutsAreThreadAgnostic;
         private bool scannedForLayouts;
         private Exception initializeException;
+
+        /// <summary>
+        /// The Max StackTraceUsage of all the <see cref="Layout"/> in this Target
+        /// </summary>
+        internal StackTraceUsage StackTraceUsage { get; private set; }
 
         /// <summary>
         /// Gets or sets the name of the target.
@@ -106,28 +112,20 @@ namespace NLog.Targets
         internal readonly ReusableBuilderCreator ReusableLayoutBuilder = new ReusableBuilderCreator();
 
         /// <summary>
-        /// Get all used layouts in this target.
-        /// </summary>
-        /// <returns></returns>
-        internal List<Layout> GetAllLayouts()
-        {
-            if (!scannedForLayouts)
-            {
-                lock (this.SyncRoot)
-                {
-                    FindAllLayouts();
-                }
-            }
-            return allLayouts;
-        }
-
-        /// <summary>
         /// Initializes this instance.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         void ISupportsInitialize.Initialize(LoggingConfiguration configuration)
         {
-            this.Initialize(configuration);
+            lock (this.SyncRoot)
+            { 
+                bool wasInitialized = this.isInitialized;
+                this.Initialize(configuration);
+                if (wasInitialized && configuration != null)
+                {
+                    FindAllLayouts();
+                }
+            }
         }
 
         /// <summary>
@@ -433,10 +431,13 @@ namespace NLog.Targets
         {
             if (disposing)
             {
-                if (this.isInitialized && this.initializeException == null)
+                if (this.isInitialized)
                 {
                     this.isInitialized = false;
-                    this.CloseTarget();
+                    if (this.initializeException == null)
+                    {
+                        this.CloseTarget();
+                    }
                 }
             }
         }
@@ -453,18 +454,10 @@ namespace NLog.Targets
 
         private void FindAllLayouts()
         {
-            this.allLayouts = new List<Layout>(ObjectGraphScanner.FindReachableObjects<Layout>(this));
+            this.allLayouts = ObjectGraphScanner.FindReachableObjects<Layout>(this);
             InternalLogger.Trace("{0} has {1} layouts", this, this.allLayouts.Count);
-            bool foundNotThreadAgnostic = false;
-            foreach (Layout layout in this.allLayouts)
-            {
-                if (!layout.IsThreadAgnostic)
-                {
-                    foundNotThreadAgnostic = true;
-                    break;
-                }
-            }
-            this.allLayoutsAreThreadAgnostic = !foundNotThreadAgnostic;
+            this.allLayoutsAreThreadAgnostic = allLayouts.All(layout => layout.ThreadAgnostic);
+            this.StackTraceUsage = allLayouts.DefaultIfEmpty().Max(layout => layout == null ? StackTraceUsage.None : layout.StackTraceUsage);
             this.scannedForLayouts = true;
         }
 

--- a/tests/NLog.UnitTests/LayoutRenderers/RegistryTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/RegistryTests.cs
@@ -293,16 +293,13 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertLayoutRendererOutput("${registry:value=NOT_EXISTENT:key=garabageHKLM/NOT_EXISTENT:defaultValue=empty}", "");
         }
 
-        [Fact(Skip = "SimpleLayout.GetFormattedMessage catches exception. Will be fixed in the future")]
-
+        [Fact]
         public void RegistryTestWrongKey_ex()
         {
             LogManager.ThrowExceptions = true;
 
             Assert.Throws<ArgumentException>(
                 () => { AssertLayoutRendererOutput("${registry:value=NOT_EXISTENT:key=garabageHKLM/NOT_EXISTENT:defaultValue=empty}", ""); });
-
-
         }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/CsvLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/CsvLayoutTests.cs
@@ -331,6 +331,7 @@ namespace NLog.UnitTests.Layouts
                         new CsvColumn("date", "${longdate}"),
                         new CsvColumn("level", "${level}"),
                         new CsvColumn("message", "${message}"),
+                        new CsvColumn("threadid", "${threadid}"),
                     },
                 QuoteChar = "'",
                 Delimiter = CsvColumnDelimiterMode.Semicolon,
@@ -356,9 +357,7 @@ namespace NLog.UnitTests.Layouts
             var r22 = csvLayout.Render(e2);
 
             var h11 = csvLayout.Header.Render(e1);
-            var h12 = csvLayout.Header.Render(e1);
             var h21 = csvLayout.Header.Render(e2);
-            var h22 = csvLayout.Header.Render(e2);
 
             Assert.Same(r11, r12);
             Assert.Same(r21, r22);
@@ -366,11 +365,8 @@ namespace NLog.UnitTests.Layouts
             Assert.NotSame(r11, r21);
             Assert.NotSame(r12, r22);
 
-            Assert.Same(h11, h12);
-            Assert.Same(h21, h22);
-
             Assert.NotSame(h11, h21);
-            Assert.NotSame(h12, h22);
+            Assert.Equal(h11, h21);
         }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
@@ -69,7 +69,7 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void SimpleLayoutCachingTest()
         {
-            var l = new SimpleLayout("xx${level}yy");
+            var l = new SimpleLayout("xx${threadid}yy");
             var ev = LogEventInfo.CreateNullEvent();
             string output1 = l.Render(ev);
             string output2 = l.Render(ev);

--- a/tests/NLog.UnitTests/Layouts/ThreadAgnosticTests.cs
+++ b/tests/NLog.UnitTests/Layouts/ThreadAgnosticTests.cs
@@ -65,7 +65,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${message}");
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${threadname}");
             l.Initialize(null);
-            Assert.False(l.IsThreadAgnostic);
+            Assert.False(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${message}${threadname}");
             l.Initialize(null);
-            Assert.False(l.IsThreadAgnostic);
+            Assert.False(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${message}${level}${logger}");
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${rot13:${message}}");
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${lowercase:${rot13:${message}}}");
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -113,7 +113,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${uppercase:${lowercase:${rot13:${message}}}}");
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -121,7 +121,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = new SimpleLayout("${uppercase:${lowercase:${rot13:${message}${threadname}}}}");
             l.Initialize(null);
-            Assert.False(l.IsThreadAgnostic);
+            Assert.False(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = @"${message:padding=-10:padCharacter=Y:when='${pad:${logger}:padding=10:padCharacter=X}'=='XXXXlogger'}";
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace NLog.UnitTests.Layouts
         {
             Layout l = @"${message:padding=-10:padCharacter=Y:when='${pad:${threadname}:padding=10:padCharacter=X}'=='XXXXlogger'}";
             l.Initialize(null);
-            Assert.False(l.IsThreadAgnostic);
+            Assert.False(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -154,7 +154,7 @@ namespace NLog.UnitTests.Layouts
             };
 
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -171,7 +171,7 @@ namespace NLog.UnitTests.Layouts
             };
 
             l.Initialize(null);
-            Assert.False(l.IsThreadAgnostic);
+            Assert.False(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -183,7 +183,7 @@ namespace NLog.UnitTests.Layouts
             Layout l = new SimpleLayout("${customNotAgnostic}", cif);
 
             l.Initialize(null);
-            Assert.False(l.IsThreadAgnostic);
+            Assert.False(l.ThreadAgnostic);
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace NLog.UnitTests.Layouts
             Layout l = new SimpleLayout("${customAgnostic}", cif);
 
             l.Initialize(null);
-            Assert.True(l.IsThreadAgnostic);
+            Assert.True(l.ThreadAgnostic);
         }
 
         [LayoutRenderer("customNotAgnostic")]

--- a/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
@@ -213,7 +213,7 @@ namespace NLog.UnitTests.Targets
 
                         if (verifyFileSize)
                         {
-                            if (sr.BaseStream.Length > 70)
+                            if (sr.BaseStream.Length > 100)
                                 throw new InvalidOperationException(string.Format("Error when reading file {0}, size {1} is too large", file, sr.BaseStream.Length));
                             else if (sr.BaseStream.Length < 35 && files[files.Count - 1] != file)
                                 throw new InvalidOperationException(string.Format("Error when reading file {0}, size {1} is too small", file, sr.BaseStream.Length));

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -615,8 +615,6 @@ namespace NLog.UnitTests.Targets
             SimpleConfigurator.ConfigureForTargetLogging(target);
             var logger = LogManager.GetLogger("WrongMyTargetShouldThrowException");
             logger.Info("Testing");
-            var layouts = target.GetAllLayouts();
-            Assert.NotNull(layouts);
         }
 
 


### PR DESCRIPTION
Fixes #2044 

Little curious whether I'm making a regression of the bug #1262 solved with PR #1310. 

But the difference from that old bug is that now the caching of Layout.StackTraceUsage happens at initialization (single-threaded) instead of at Logger-write (multi-threaded).

This fix has become a very big hammer to a small nail  (Could just have fixed Log4JXmlEventLayout to inherit from IUsesStackTrace). The changes included in this PR:

- Faster allocation of new Loggers, as it now caches the lookup of StackTraceLevel on Target.
- Layout initialization will always scan for StackTraceLevel and ThreadAgnostic. Before it would only scan when initialized with LoggingConfiguration.
- Fixes problem with stale caching of Target.allLayoutsAreThreadAgnostic. Now it is refreshed when calling LogManager.ReconfigExistingLoggers()
  - Same fix is used to refresh the new caching of StackTraceLevel on Target (FindAllLayouts)
- LogManager.ReconfigExistingLoggers() has now become slower as it will now also refresh the caching on all registered Targets (FindAllLayouts)
- LogManager.ReconfigExistingLoggers() is now protected against multiple threads performing re-initialization (will still refresh loggers outside lock)
- Fixes the actual problem with detecting IUsesStackTrace-renders for all Layouts (Also those not depending on SimpleLayout).