### PR TITLE
Include MDLC in log4j renderer

### DIFF
--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -302,6 +302,17 @@ namespace NLog.LayoutRenderers
                         xtw.WriteAttributeSafeString("value", propertyValue);
                         xtw.WriteEndElement();
                     }
+                    foreach (string key in MappedDiagnosticsLogicalContext.GetNames())
+                    {
+                        string propertyValue = XmlHelper.XmlConvertToString(MappedDiagnosticsLogicalContext.GetObject(key));
+                        if (propertyValue == null)
+                            continue;
+
+                        xtw.WriteStartElement("log4j", "data", dummyNamespace);
+                        xtw.WriteAttributeSafeString("name", key);
+                        xtw.WriteAttributeSafeString("value", propertyValue);
+                        xtw.WriteEndElement();
+                    }
                 }
 
                 if (this.Parameters.Count > 0)

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -302,6 +302,7 @@ namespace NLog.LayoutRenderers
                         xtw.WriteAttributeSafeString("value", propertyValue);
                         xtw.WriteEndElement();
                     }
+#if NET4_0 || NET4_5
                     foreach (string key in MappedDiagnosticsLogicalContext.GetNames())
                     {
                         string propertyValue = XmlHelper.XmlConvertToString(MappedDiagnosticsLogicalContext.GetObject(key));
@@ -313,6 +314,7 @@ namespace NLog.LayoutRenderers
                         xtw.WriteAttributeSafeString("value", propertyValue);
                         xtw.WriteEndElement();
                     }
+#endif
                 }
 
                 if (this.Parameters.Count > 0)

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -148,6 +148,12 @@ namespace NLog.LayoutRenderers
         public bool IncludeMdc { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeMdlc { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsContext"/> stack.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
@@ -302,7 +308,11 @@ namespace NLog.LayoutRenderers
                         xtw.WriteAttributeSafeString("value", propertyValue);
                         xtw.WriteEndElement();
                     }
+                }
+
 #if NET4_0 || NET4_5
+                if (this.IncludeMdlc)
+                {
                     foreach (string key in MappedDiagnosticsLogicalContext.GetNames())
                     {
                         string propertyValue = XmlHelper.XmlConvertToString(MappedDiagnosticsLogicalContext.GetObject(key));
@@ -314,8 +324,8 @@ namespace NLog.LayoutRenderers
                         xtw.WriteAttributeSafeString("value", propertyValue);
                         xtw.WriteEndElement();
                     }
-#endif
                 }
+#endif
 
                 if (this.Parameters.Count > 0)
                 {

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -147,11 +147,13 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeMdc { get; set; }
 
+#if NET4_0 || NET4_5
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeMdlc { get; set; }
+#endif
 
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsContext"/> stack.

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -147,6 +147,16 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to include <see cref="MappedDiagnosticsLogicalContext"/> dictionary contents.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeMdlc
+        {
+            get { return this.Renderer.IncludeMdlc; }
+            set { this.Renderer.IncludeMdlc = value; }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to include <see cref="NestedDiagnosticsContext"/> stack contents.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -146,6 +146,7 @@ namespace NLog.Targets
             set { this.Renderer.IncludeMdc = value; }
         }
 
+#if NET4_0 || NET4_5
         /// <summary>
         /// Gets or sets a value indicating whether to include <see cref="MappedDiagnosticsLogicalContext"/> dictionary contents.
         /// </summary>
@@ -155,6 +156,7 @@ namespace NLog.Targets
             get { return this.Renderer.IncludeMdlc; }
             set { this.Renderer.IncludeMdlc = value; }
         }
+#endif
 
         /// <summary>
         /// Gets or sets a value indicating whether to include <see cref="NestedDiagnosticsContext"/> stack contents.

--- a/tests/NLog.UnitTests/LayoutRenderers/Log4JXmlTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Log4JXmlTests.cs
@@ -50,7 +50,7 @@ namespace NLog.UnitTests.LayoutRenderers
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog throwExceptions='true'>
                 <targets>
-        <target name='debug' type='Debug' layout='${log4jxmlevent:includeCallSite=true:includeSourceInfo=true:includeMdc=true:includendc=true:ndcItemSeparator=\:\::includenlogdata=true}' />
+        <target name='debug' type='Debug' layout='${log4jxmlevent:includeCallSite=true:includeSourceInfo=true:includeMdc=true:includeMdlc=true:includendc=true:ndcItemSeparator=\:\::includenlogdata=true}' />
        </targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />

--- a/tests/NLog.UnitTests/LayoutRenderers/Log4JXmlTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Log4JXmlTests.cs
@@ -59,12 +59,14 @@ namespace NLog.UnitTests.LayoutRenderers
 
             MappedDiagnosticsContext.Clear();
             NestedDiagnosticsContext.Clear();
-            MappedDiagnosticsLogicalContext.Clear();
 
             MappedDiagnosticsContext.Set("foo1", "bar1");
             MappedDiagnosticsContext.Set("foo2", "bar2");
-            MappedDiagnosticsLogicalContext.Set("foo3", "bar3");
 
+#if NET4_0 || NET4_5
+            MappedDiagnosticsLogicalContext.Clear();
+            MappedDiagnosticsLogicalContext.Set("foo3", "bar3");
+#endif
             NestedDiagnosticsContext.Push("baz1");
             NestedDiagnosticsContext.Push("baz2");
             NestedDiagnosticsContext.Push("baz3");
@@ -148,9 +150,11 @@ namespace NLog.UnitTests.LayoutRenderers
                                         Assert.Equal("bar2", value);
                                         break;
 
+#if NET4_0 || NET4_5
                                     case "foo3":
                                         Assert.Equal("bar3", value);
                                         break;
+#endif
 
                                     default:
                                         Assert.True(false, "Unknown <log4j:data>: " + name);

--- a/tests/NLog.UnitTests/LayoutRenderers/Log4JXmlTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Log4JXmlTests.cs
@@ -59,9 +59,11 @@ namespace NLog.UnitTests.LayoutRenderers
 
             MappedDiagnosticsContext.Clear();
             NestedDiagnosticsContext.Clear();
+            MappedDiagnosticsLogicalContext.Clear();
 
             MappedDiagnosticsContext.Set("foo1", "bar1");
             MappedDiagnosticsContext.Set("foo2", "bar2");
+            MappedDiagnosticsLogicalContext.Set("foo3", "bar3");
 
             NestedDiagnosticsContext.Push("baz1");
             NestedDiagnosticsContext.Push("baz2");
@@ -144,6 +146,10 @@ namespace NLog.UnitTests.LayoutRenderers
 
                                     case "foo2":
                                         Assert.Equal("bar2", value);
+                                        break;
+
+                                    case "foo3":
+                                        Assert.Equal("bar3", value);
                                         break;
 
                                     default:


### PR DESCRIPTION
Current the Log4JXMLEvent Layout Renderer includes the content of `MappedDiagnosticsContext` dictionary, but not `MappedDiagnosticsLogicalContext`.

This PR adds the content of `MappedDiagnosticsLogicalContext` too. Unit test is included. 

My code uses the same flag `includeMdc` as `MappedDiagnosticsContext`, I'm not sure if a separate flag `includeMdlc` is required.