### PR TITLE
Fixed bug to logging by day of week [Исправлена ошибка с логированием…

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -2272,13 +2272,19 @@ namespace NLog.Targets
                 case FileArchivePeriod.Minute:
                     return input.AddTicks(-(input.Ticks % TimeSpan.TicksPerMinute));
                 case FileArchivePeriod.Sunday:
+                    return CalculateNextWeekday(input.Date, DayOfWeek.Sunday);
                 case FileArchivePeriod.Monday:
+                    return CalculateNextWeekday(input.Date, DayOfWeek.Monday);
                 case FileArchivePeriod.Tuesday:
+                    return CalculateNextWeekday(input.Date, DayOfWeek.Tuesday);
                 case FileArchivePeriod.Wednesday:
+                    return CalculateNextWeekday(input.Date, DayOfWeek.Wednesday);
                 case FileArchivePeriod.Thursday:
+                    return CalculateNextWeekday(input.Date, DayOfWeek.Thursday);
                 case FileArchivePeriod.Friday:
+                    return CalculateNextWeekday(input.Date, DayOfWeek.Friday);
                 case FileArchivePeriod.Saturday:
-                    return input.Date;
+                    return CalculateNextWeekday(input.Date, DayOfWeek.Saturday);
                 default:
                     return input;   // Unknown time-resolution-truncate, leave unchanged
             }


### PR DESCRIPTION
Fixed bug to logging by day of week.

Exemple config
```
<target name="testName" xsi:type="File" fileName="C:/log/${logger}.log"
			layout="${message}"
      archiveFileName="C:/log/${logger}_{##}.log" archiveNumbering="Date" archiveEvery="Monday" maxArchiveFiles="10" archiveDateFormat="yyyy-MM-dd-HH-mm"
			concurrentWrites="true" keepFileOpen="false" encoding="UTF-8"/>
<logger name="testLogger" writeTo="testName" levels="Trace,Debug,Info,Warn,Error,Fatal" final="true"/>
```
With this configuration, logs are archived every day, but I expect a new archive file every week.

I fix this bug.