### PR TITLE
Add unit test case for include non-existant file

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -1079,6 +1079,8 @@ namespace NLog.Config
 
             string newFileName = includeElement.GetRequiredAttribute("file");
 
+            var ignoreErrors = includeElement.GetOptionalBooleanAttribute("ignoreErrors", false);
+
             try
             {
                 newFileName = this.ExpandSimpleVariables(newFileName);
@@ -1109,6 +1111,14 @@ namespace NLog.Config
                     }
                     else
                     {
+                        if (ignoreErrors)
+                        {
+                            //quick stop for performances
+                            InternalLogger.Debug("Skipping included file '{0}' as it can't be found", fullNewFileName);
+
+                            return;
+                        }
+
                         throw new FileNotFoundException("Included file not found: " + fullNewFileName);
                     }
 
@@ -1118,15 +1128,18 @@ namespace NLog.Config
             {
                 InternalLogger.Error(exception, "Error when including '{0}'.", newFileName);
 
+              
+                if (ignoreErrors)
+                {
+                    return;
+                }
+
                 if (exception.MustBeRethrown())
                 {
                     throw;
                 }
 
-                if (includeElement.GetOptionalBooleanAttribute("ignoreErrors", false))
-                {
-                    return;
-                }
+               
 
                 throw new NLogConfigurationException("Error when including: " + newFileName, exception);
             }

--- a/tests/NLog.UnitTests/Config/IncludeTests.cs
+++ b/tests/NLog.UnitTests/Config/IncludeTests.cs
@@ -161,6 +161,27 @@ namespace NLog.UnitTests.Config
             }
         }
 
+        [Fact]
+        public void IncludeNotExistingIgnoredTest_DoesNotThrow()
+        {
+            LogManager.ThrowExceptions = true;
+            var tempPath = GetTempDir();
+            Directory.CreateDirectory(tempPath);
+
+            var config = @"<nlog>
+                <include file='included-notpresent.nlog' ignoreErrors='true' />
+                <targets><target name='debug' type='Debug' layout='${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>";
+
+            CreateConfigFile(tempPath, "main.nlog", config);
+            string fileToLoad = Path.Combine(tempPath, "main.nlog");
+
+            Assert.DoesNotThrow(() => new XmlLoggingConfiguration(fileToLoad));
+        }
+
         /// <summary>
         /// Create config file in dir
         /// </summary>


### PR DESCRIPTION
When trying to include a non-existant file with
ignoreErrors set to true and exceptions turned on
verify it does not throw an exception.

NLog/NLog#2094