### PR TITLE
Fixes #2045 by moving rule elements of List<NLogXmlElement> children …

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -619,6 +619,13 @@ namespace NLog.Config
                 this.ParseExtensionsElement(extensionsChild, Path.GetDirectoryName(filePath));
             }
 
+            //target elements should be parsed before rule elements, as target elements are referenced by rule elements
+            var targetChilds = children.Where(child => child.LocalName.Equals("TARGETS", StringComparison.InvariantCultureIgnoreCase)).ToList();
+            foreach (var targetChild in targetChilds)
+            {
+                this.ParseTargetsElement(targetChild);
+            }
+
             //parse all other direct elements
             foreach (var child in children)
             {
@@ -634,7 +641,7 @@ namespace NLog.Config
 
                     case "APPENDERS":
                     case "TARGETS":
-                        this.ParseTargetsElement(child);
+                        //already parsed
                         break;
 
                     case "VARIABLE":

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -607,6 +607,11 @@ namespace NLog.Config
 
             var children = nlogElement.Children.ToList();
 
+            //target elements should be parsed before rule elements, so move rule elements to the end of children list
+            var ruleElements = children.Where(t => t.LocalName.ToUpper(CultureInfo.InvariantCulture) == "RULES").ToList();
+            children.RemoveAll(t => t.LocalName.ToUpper(CultureInfo.InvariantCulture) == "RULES");
+            children.AddRange(ruleElements);
+
             //first load the extensions, as the can be used in other elements (targets etc)
             var extensionsChilds = children.Where(child => child.LocalName.Equals("EXTENSIONS", StringComparison.InvariantCultureIgnoreCase)).ToList();
             foreach (var extensionsChild in extensionsChilds)

--- a/tests/NLog.UnitTests/Config/XmlConfigNodesOrderTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigNodesOrderTests.cs
@@ -1,0 +1,69 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.Config
+{
+    using NLog.Config;
+    using Xunit;
+
+    public class XmlConfigNodesOrderTests : NLogTestBase
+    {
+        [Fact]
+        public void RulesBeforeTargetsTest()
+        {
+            LoggingConfiguration c = CreateConfigurationFromString(@"
+            <nlog>
+                <rules>
+                    <logger name='*' minLevel='Info' writeTo='d1' />
+                </rules>
+
+                <targets>
+                    <target name='d1' type='Debug' />
+                </targets>
+            </nlog>");
+
+            Assert.Equal(1, c.LoggingRules.Count);
+            var rule = c.LoggingRules[0];
+            Assert.Equal("*", rule.LoggerNamePattern);
+            Assert.Equal(4, rule.Levels.Count);
+            Assert.True(rule.Levels.Contains(LogLevel.Info));
+            Assert.True(rule.Levels.Contains(LogLevel.Warn));
+            Assert.True(rule.Levels.Contains(LogLevel.Error));
+            Assert.True(rule.Levels.Contains(LogLevel.Fatal));
+            Assert.Equal(1, rule.Targets.Count);
+            Assert.Same(c.FindTargetByName("d1"), rule.Targets[0]);
+            Assert.False(rule.Final);
+            Assert.Equal(0, rule.Filters.Count);
+        }
+    }
+}

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Config\TargetConfigurationTests.cs" />
     <Compile Include="Config\TimeConfigurationTests.cs" />
     <Compile Include="Config\VariableTests.cs" />
+    <Compile Include="Config\XmlConfigNodesOrderTests.cs" />
     <Compile Include="Config\XmlConfigTests.cs" />
     <Compile Include="ConfigFileLocatorTests.cs" />
     <Compile Include="Contexts\GlobalDiagnosticsContextTests.cs" />


### PR DESCRIPTION
in XmlLoggingConfiguration.ParseNLogElement() method
in switch statement, case "RULES"
the method ParseRulesElement() 
calls ParseLoggerElement()
which has a call to FindTargetByName()

That's why rule wouldn't have target if rules are loaded first

To fix that, rearrange the List<NLogXmlElement> so that targets are handled before rules in the switch statement

From my understanding, I think rules should be loaded last