### PR TITLE
LogFactory.Shutdown - Add warning on target flush timeout

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -972,7 +972,11 @@ namespace NLog
                                 oldConfig.FlushAllTargets((ex) => flushCompleted.Set());
                                 attemptClose = flushCompleted.WaitOne(flushTimeout);
                             }
-                            if (attemptClose)
+                            if (!attemptClose)
+                            {
+                                InternalLogger.Warn("Target flush timeout. One or more targets did not complete flush operation, skipping target close.");
+                            }
+                            else
 #endif
                             {
                                 // Flush completed within timeout, lets try and close down


### PR DESCRIPTION
Added InternalLogger-Warning when LogFactory.Shutdown does not flush succesfully. See also #2065