### PR TITLE
NdlcLayoutRenderer - Nested Diagnostics Logical Context

### DIFF
--- a/src/NLog/LayoutRenderers/NdlcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/NdlcLayoutRenderer.cs
@@ -1,0 +1,85 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.LayoutRenderers
+{
+#if NET4_0 || NET4_5
+    using System;
+    using System.Text;
+
+    /// <summary>
+    /// <see cref="NestedDiagnosticsLogicalContext"/> Renderer (Async scope)
+    /// </summary>
+    [LayoutRenderer("ndlc")]
+    public class NdlcLayoutRenderer : LayoutRenderer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NdlcLayoutRenderer" /> class.
+        /// </summary>
+        public NdlcLayoutRenderer()
+        {
+            this.Separator = " ";
+            this.BottomFrames = -1;
+            this.TopFrames = -1;
+        }
+
+        /// <summary>
+        /// Gets or sets the number of top stack frames to be rendered.
+        /// </summary>
+        /// <docgen category='Rendering Options' order='10' />
+        public int TopFrames { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of bottom stack frames to be rendered.
+        /// </summary>
+        /// <docgen category='Rendering Options' order='10' />
+        public int BottomFrames { get; set; }
+
+        /// <summary>
+        /// Gets or sets the separator to be used for concatenating nested logical context output.
+        /// </summary>
+        /// <docgen category='Rendering Options' order='10' />
+        public string Separator { get; set; }
+
+        /// <summary>
+        /// Renders the specified Nested Logical Context item and appends it to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="logEvent">Logging event.</param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            NestedDiagnosticsLogicalContext.AppendContext(logEvent.FormatProvider, this.TopFrames, this.BottomFrames, this.Separator, builder);
+        }
+    }
+#endif
+}

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -251,6 +251,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\NdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NLogDirLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\PerformanceCounterLayoutRenderer.cs" />
@@ -348,6 +349,7 @@
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />
+    <Compile Include="NestedDiagnosticsLogicalContext.cs" />
     <Compile Include="NLogConfigurationException.cs" />
     <Compile Include="NLogRuntimeException.cs" />
     <Compile Include="NLogTraceListener.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -248,6 +248,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\NdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NLogDirLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\PerformanceCounterLayoutRenderer.cs" />
@@ -345,6 +346,7 @@
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />
+    <Compile Include="NestedDiagnosticsLogicalContext.cs" />
     <Compile Include="NLogConfigurationException.cs" />
     <Compile Include="NLogRuntimeException.cs" />
     <Compile Include="NLogTraceListener.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -261,6 +261,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\NdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NLogDirLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\PerformanceCounterLayoutRenderer.cs" />
@@ -358,6 +359,7 @@
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />
+    <Compile Include="NestedDiagnosticsLogicalContext.cs" />
     <Compile Include="NLogConfigurationException.cs" />
     <Compile Include="NLogRuntimeException.cs" />
     <Compile Include="NLogTraceListener.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -267,6 +267,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\NdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NLogDirLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\PerformanceCounterLayoutRenderer.cs" />
@@ -364,6 +365,7 @@
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />
+    <Compile Include="NestedDiagnosticsLogicalContext.cs" />
     <Compile Include="NLogConfigurationException.cs" />
     <Compile Include="NLogRuntimeException.cs" />
     <Compile Include="NLogTraceListener.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -261,6 +261,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\NdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NLogDirLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\PerformanceCounterLayoutRenderer.cs" />
@@ -358,6 +359,7 @@
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />
+    <Compile Include="NestedDiagnosticsLogicalContext.cs" />
     <Compile Include="NLogConfigurationException.cs" />
     <Compile Include="NLogRuntimeException.cs" />
     <Compile Include="NLogTraceListener.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -261,6 +261,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\NdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NLogDirLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\PerformanceCounterLayoutRenderer.cs" />
@@ -358,6 +359,7 @@
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />
+    <Compile Include="NestedDiagnosticsLogicalContext.cs" />
     <Compile Include="NLogConfigurationException.cs" />
     <Compile Include="NLogRuntimeException.cs" />
     <Compile Include="NLogTraceListener.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -266,6 +266,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\NdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NLogDirLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\PerformanceCounterLayoutRenderer.cs" />
@@ -363,6 +364,7 @@
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />
+    <Compile Include="NestedDiagnosticsLogicalContext.cs" />
     <Compile Include="NLogConfigurationException.cs" />
     <Compile Include="NLogRuntimeException.cs" />
     <Compile Include="NLogTraceListener.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -268,6 +268,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\NdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NLogDirLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\PerformanceCounterLayoutRenderer.cs" />
@@ -365,6 +366,7 @@
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />
+    <Compile Include="NestedDiagnosticsLogicalContext.cs" />
     <Compile Include="NLogConfigurationException.cs" />
     <Compile Include="NLogRuntimeException.cs" />
     <Compile Include="NLogTraceListener.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -265,6 +265,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\NdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NLogDirLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\PerformanceCounterLayoutRenderer.cs" />
@@ -362,6 +363,7 @@
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />
+    <Compile Include="NestedDiagnosticsLogicalContext.cs" />
     <Compile Include="NLogConfigurationException.cs" />
     <Compile Include="NLogRuntimeException.cs" />
     <Compile Include="NLogTraceListener.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -264,6 +264,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\NdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NLogDirLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\PerformanceCounterLayoutRenderer.cs" />
@@ -361,6 +362,7 @@
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />
+    <Compile Include="NestedDiagnosticsLogicalContext.cs" />
     <Compile Include="NLogConfigurationException.cs" />
     <Compile Include="NLogRuntimeException.cs" />
     <Compile Include="NLogTraceListener.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -264,6 +264,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\NdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NLogDirLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\PerformanceCounterLayoutRenderer.cs" />
@@ -361,6 +362,7 @@
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />
+    <Compile Include="NestedDiagnosticsLogicalContext.cs" />
     <Compile Include="NLogConfigurationException.cs" />
     <Compile Include="NLogRuntimeException.cs" />
     <Compile Include="NLogTraceListener.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -289,6 +289,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\MessageLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NdcLayoutRenderer.cs" />
+    <Compile Include="LayoutRenderers\NdlcLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NewLineLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\NLogDirLayoutRenderer.cs" />
     <Compile Include="LayoutRenderers\PerformanceCounterLayoutRenderer.cs" />
@@ -386,6 +387,7 @@
     <Compile Include="MDC.cs" />
     <Compile Include="NDC.cs" />
     <Compile Include="NestedDiagnosticsContext.cs" />
+    <Compile Include="NestedDiagnosticsLogicalContext.cs" />
     <Compile Include="NLogConfigurationException.cs" />
     <Compile Include="NLogRuntimeException.cs" />
     <Compile Include="NLogTraceListener.cs" />

--- a/src/NLog/NestedDiagnosticsLogicalContext.cs
+++ b/src/NLog/NestedDiagnosticsLogicalContext.cs
@@ -1,0 +1,223 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog
+{
+#if NET4_0 || NET4_5
+    using System;
+    using System.Text;
+    using NLog.Internal;
+
+    /// <summary>
+    /// Async version of <see cref="NestedDiagnosticsContext" /> - a logical context structure that keeps a stack
+    /// Allows for maintaining scope across asynchronous tasks and call contexts.
+    /// </summary>
+    public static class NestedDiagnosticsLogicalContext
+    {
+        /// <summary>
+        /// Pushes the specified value on current stack
+        /// </summary>
+        /// <param name="value">The value to be pushed.</param>
+        /// <returns>An instance of the object that implements IDisposable that returns the stack to the previous level when IDisposable.Dispose() is called. To be used with C# using() statement.</returns>
+        public static IDisposable Push<T>(T value)
+        {
+            var parent = GetThreadLocal();
+            var current = new NestedContext<T>(parent, value);
+            SetThreadLocal(current);
+            return current;
+        }
+
+        /// <summary>
+        /// Pops the top message off the current stack
+        /// </summary>
+        /// <returns>The top message which is no longer on the stack.</returns>
+        public static object Pop()
+        {
+            var current = GetThreadLocal();
+            if (current != null)
+                SetThreadLocal(current.Parent);
+            return current != null ? current.Value : string.Empty;
+        }
+
+        /// <summary>
+        /// Clears current stack.
+        /// </summary>
+        public static void Clear()
+        {
+            SetThreadLocal(null);
+        }
+
+        /// <summary>
+        /// Gets all objects on the stack. The objects are not removed from the stack.
+        /// </summary>
+        /// <returns>Array of objects on the stack.</returns>
+        public static object[] GetAllObjects()
+        {
+            var currentContext = GetThreadLocal();
+            if (currentContext == null)
+                return ArrayHelper.Empty<object>();
+
+            int index = 0;
+            object[] messages = new object[currentContext.FrameLevel];
+            while (currentContext != null)
+            {
+                messages[index++] = currentContext.Value;
+                currentContext = currentContext.Parent;
+            }
+            return messages;
+        }
+
+        /// <summary>
+        /// Writes the current stack to the provided StringBuilder
+        /// </summary>
+        internal static void AppendContext(IFormatProvider formatProvider, int topFrames, int bottomFrames, string seperator, StringBuilder builder)
+        {
+            var currentContext = GetThreadLocal();
+            if (currentContext == null)
+                return;
+
+            int startPos = 0;
+            int endPos = currentContext.FrameLevel;
+
+            if (topFrames != -1)
+            {
+                endPos = Math.Min(topFrames, currentContext.FrameLevel);
+            }
+            else if (bottomFrames != -1)
+            {
+                startPos = currentContext.FrameLevel - Math.Min(bottomFrames, currentContext.FrameLevel);
+            }
+
+            if (currentContext.FrameLevel <= 10)
+            {
+                // Use the stack to avoid allocations
+                AppendFrames(currentContext, 0, formatProvider, startPos, endPos, seperator, builder);
+            }
+            else
+            {
+                var messages = GetAllObjects();
+                string currentSeparator = string.Empty;
+                for (int i = endPos - 1; i >= startPos; --i)
+                {
+                    var stringValue = FormatHelper.ConvertToString(messages[i], formatProvider);
+                    builder.Append(currentSeparator);
+                    builder.Append(stringValue);
+                    currentSeparator = seperator;
+                }
+            }
+        }
+
+        private static bool AppendFrames(INestedContext currentContext, int currentPos, IFormatProvider formatProvider, int startPos, int endPos, string seperator, StringBuilder builder)
+        {
+            if (currentContext == null)
+                return false;
+
+            if (currentPos >= endPos)
+                return false;
+
+            bool startedAppend = false;
+            startedAppend = AppendFrames(currentContext.Parent, currentPos + 1, formatProvider, startPos, endPos, seperator, builder);
+            if (currentPos >= startPos)
+            {
+                var stringValue = FormatHelper.ConvertToString(currentContext.Value, formatProvider);
+                if (startedAppend)
+                    builder.Append(seperator);
+                else
+                    startedAppend = true;
+                builder.Append(stringValue);
+            }
+            return startedAppend;
+        }
+
+        interface INestedContext : IDisposable
+        {
+            INestedContext Parent { get; }
+            int FrameLevel { get; }
+            object Value { get; }
+        }
+
+        class NestedContext<T> : INestedContext
+        {
+            public INestedContext Parent { get; private set; }
+            public T Value { get; private set; }
+            object INestedContext.Value { get { return Value; } }
+            public int FrameLevel { get; private set; }
+
+            public NestedContext(INestedContext parent, T value)
+            {
+                Parent = parent;
+                Value = value;
+                FrameLevel = parent != null ? parent.FrameLevel + 1 : 1; 
+            }
+
+            void IDisposable.Dispose()
+            {
+                Pop();
+            }
+
+            public override string ToString()
+            {
+                object value = Value;
+                return value != null ? value.ToString() : "null";
+            }
+        }
+
+        private static void SetThreadLocal(INestedContext newValue)
+        {
+#if NET4_6 || NETSTANDARD1_3
+            AsyncNestedDiagnosticsContext.Value = newValue;
+#else
+            if (newValue == null)
+                System.Runtime.Remoting.Messaging.CallContext.FreeNamedDataSlot(NestedDiagnosticsContextKey);
+            else
+                System.Runtime.Remoting.Messaging.CallContext.LogicalSetData(NestedDiagnosticsContextKey, newValue);
+#endif
+        }
+
+        private static INestedContext GetThreadLocal()
+        {
+#if NET4_6 || NETSTANDARD1_3
+            return AsyncNestedDiagnosticsContext.Value;
+#else
+            return System.Runtime.Remoting.Messaging.CallContext.LogicalGetData(NestedDiagnosticsContextKey) as INestedContext;
+#endif
+        }
+
+#if NET4_6 || NETSTANDARD1_3
+        private static readonly System.Threading.AsyncLocal<INestedScope> AsyncNestedDiagnosticsContext = new System.Threading.AsyncLocal<INestedScope>();
+#else
+        private const string NestedDiagnosticsContextKey = "NLog.AsyncableNestedDiagnosticsContext";
+#endif
+    }
+#endif
+}

--- a/tests/NLog.UnitTests/LayoutRenderers/NDLCTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/NDLCTests.cs
@@ -1,0 +1,296 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.LayoutRenderers
+{
+#if NET4_0 || NET4_5
+    using Xunit;
+
+    public class NDLCTests : NLogTestBase
+    {
+        [Fact]
+        public void NDLCTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${ndlc} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            NestedDiagnosticsLogicalContext.Clear();
+            LogManager.GetLogger("A").Debug("0");
+            AssertDebugLastMessage("debug", " 0");
+            using (NestedDiagnosticsLogicalContext.Push("ala"))
+            {
+                LogManager.GetLogger("A").Debug("a");
+                AssertDebugLastMessage("debug", "ala a");
+                using (NestedDiagnosticsLogicalContext.Push("ma"))
+                {
+                    LogManager.GetLogger("A").Debug("b");
+                    AssertDebugLastMessage("debug", "ala ma b");
+                    using (NestedDiagnosticsLogicalContext.Push("kota"))
+                    {
+                        LogManager.GetLogger("A").Debug("c");
+                        AssertDebugLastMessage("debug", "ala ma kota c");
+                        using (NestedDiagnosticsLogicalContext.Push("kopytko"))
+                        {
+                            LogManager.GetLogger("A").Debug("d");
+                            AssertDebugLastMessage("debug", "ala ma kota kopytko d");
+                        }
+                        LogManager.GetLogger("A").Debug("c");
+                        AssertDebugLastMessage("debug", "ala ma kota c");
+                    }
+                    LogManager.GetLogger("A").Debug("b");
+                    AssertDebugLastMessage("debug", "ala ma b");
+                }
+                LogManager.GetLogger("A").Debug("a");
+                AssertDebugLastMessage("debug", "ala a");
+            }
+            LogManager.GetLogger("A").Debug("0");
+            AssertDebugLastMessage("debug", " 0");
+        }
+
+        [Fact]
+        public void NDLCTopTestTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${ndlc:topframes=2} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            NestedDiagnosticsLogicalContext.Clear();
+            LogManager.GetLogger("A").Debug("0");
+            AssertDebugLastMessage("debug", " 0");
+            using (NestedDiagnosticsLogicalContext.Push("ala"))
+            {
+                LogManager.GetLogger("A").Debug("a");
+                AssertDebugLastMessage("debug", "ala a");
+                using (NestedDiagnosticsLogicalContext.Push("ma"))
+                {
+                    LogManager.GetLogger("A").Debug("b");
+                    AssertDebugLastMessage("debug", "ala ma b");
+                    using (NestedDiagnosticsLogicalContext.Push("kota"))
+                    {
+                        LogManager.GetLogger("A").Debug("c");
+                        AssertDebugLastMessage("debug", "ma kota c");
+                        using (NestedDiagnosticsLogicalContext.Push("kopytko"))
+                        {
+                            LogManager.GetLogger("A").Debug("d");
+                            AssertDebugLastMessage("debug", "kota kopytko d");
+                        }
+                        LogManager.GetLogger("A").Debug("c");
+                        AssertDebugLastMessage("debug", "ma kota c");
+                    }
+                    LogManager.GetLogger("A").Debug("b");
+                    AssertDebugLastMessage("debug", "ala ma b");
+                }
+                LogManager.GetLogger("A").Debug("a");
+                AssertDebugLastMessage("debug", "ala a");
+            }
+            LogManager.GetLogger("A").Debug("0");
+            AssertDebugLastMessage("debug", " 0");
+        }
+
+
+        [Fact]
+        public void NDLCTop1TestTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${ndlc:topframes=1} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            NestedDiagnosticsLogicalContext.Clear();
+            LogManager.GetLogger("A").Debug("0");
+            AssertDebugLastMessage("debug", " 0");
+            using (NestedDiagnosticsLogicalContext.Push("ala"))
+            {
+                LogManager.GetLogger("A").Debug("a");
+                AssertDebugLastMessage("debug", "ala a");
+                using (NestedDiagnosticsLogicalContext.Push("ma"))
+                {
+                    LogManager.GetLogger("A").Debug("b");
+                    AssertDebugLastMessage("debug", "ma b");
+                    using (NestedDiagnosticsLogicalContext.Push("kota"))
+                    {
+                        LogManager.GetLogger("A").Debug("c");
+                        AssertDebugLastMessage("debug", "kota c");
+                        NestedDiagnosticsLogicalContext.Push("kopytko");
+                        LogManager.GetLogger("A").Debug("d");
+                        AssertDebugLastMessage("debug", "kopytko d");
+                        Assert.Equal("kopytko", NestedDiagnosticsLogicalContext.Pop()); // manual pop
+                        LogManager.GetLogger("A").Debug("c");
+                        AssertDebugLastMessage("debug", "kota c");
+                    }
+                    LogManager.GetLogger("A").Debug("b");
+                    AssertDebugLastMessage("debug", "ma b");
+                }
+                LogManager.GetLogger("A").Debug("a");
+                AssertDebugLastMessage("debug", "ala a");
+            }
+            LogManager.GetLogger("A").Debug("0");
+            AssertDebugLastMessage("debug", " 0");
+            Assert.Equal(string.Empty, NestedDiagnosticsLogicalContext.Pop());
+            NestedDiagnosticsLogicalContext.Push("zzz");
+            NestedDiagnosticsLogicalContext.Push("yyy");
+            Assert.Equal("yyy", NestedDiagnosticsLogicalContext.Pop());
+            NestedDiagnosticsLogicalContext.Clear();
+            Assert.Equal(string.Empty, NestedDiagnosticsLogicalContext.Pop());
+        }
+
+        [Fact]
+        public void NDLCBottomTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${ndlc:bottomframes=2} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            NestedDiagnosticsLogicalContext.Clear();
+            LogManager.GetLogger("A").Debug("0");
+            AssertDebugLastMessage("debug", " 0");
+            using (NestedDiagnosticsLogicalContext.Push("ala"))
+            {
+                LogManager.GetLogger("A").Debug("a");
+                AssertDebugLastMessage("debug", "ala a");
+                using (NestedDiagnosticsLogicalContext.Push("ma"))
+                {
+                    LogManager.GetLogger("A").Debug("b");
+                    AssertDebugLastMessage("debug", "ala ma b");
+                    using (NestedDiagnosticsLogicalContext.Push("kota"))
+                    {
+                        LogManager.GetLogger("A").Debug("c");
+                        AssertDebugLastMessage("debug", "ala ma c");
+                        using (NestedDiagnosticsLogicalContext.Push("kopytko"))
+                        {
+                            LogManager.GetLogger("A").Debug("d");
+                            AssertDebugLastMessage("debug", "ala ma d");
+                        }
+                        LogManager.GetLogger("A").Debug("c");
+                        AssertDebugLastMessage("debug", "ala ma c");
+                    }
+                    LogManager.GetLogger("A").Debug("b");
+                    AssertDebugLastMessage("debug", "ala ma b");
+                }
+                LogManager.GetLogger("A").Debug("a");
+                AssertDebugLastMessage("debug", "ala a");
+            }
+            LogManager.GetLogger("A").Debug("0");
+            AssertDebugLastMessage("debug", " 0");
+        }
+
+        [Fact]
+        public void NDLCSeparatorTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${ndlc:separator=\:} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            NestedDiagnosticsLogicalContext.Clear();
+            LogManager.GetLogger("A").Debug("0");
+            AssertDebugLastMessage("debug", " 0");
+            using (NestedDiagnosticsLogicalContext.Push("ala"))
+            {
+                LogManager.GetLogger("A").Debug("a");
+                AssertDebugLastMessage("debug", "ala a");
+                using (NestedDiagnosticsLogicalContext.Push("ma"))
+                {
+                    LogManager.GetLogger("A").Debug("b");
+                    AssertDebugLastMessage("debug", "ala:ma b");
+                    using (NestedDiagnosticsLogicalContext.Push("kota"))
+                    {
+                        LogManager.GetLogger("A").Debug("c");
+                        AssertDebugLastMessage("debug", "ala:ma:kota c");
+                        using (NestedDiagnosticsLogicalContext.Push("kopytko"))
+                        {
+                            LogManager.GetLogger("A").Debug("d");
+                            AssertDebugLastMessage("debug", "ala:ma:kota:kopytko d");
+                        }
+                        LogManager.GetLogger("A").Debug("c");
+                        AssertDebugLastMessage("debug", "ala:ma:kota c");
+                    }
+                    LogManager.GetLogger("A").Debug("b");
+                    AssertDebugLastMessage("debug", "ala:ma b");
+                }
+                LogManager.GetLogger("A").Debug("a");
+                AssertDebugLastMessage("debug", "ala a");
+            }
+            LogManager.GetLogger("A").Debug("0");
+            AssertDebugLastMessage("debug", " 0");
+        }
+
+        [Fact]
+        public void NDLCDeepTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${ndlc:topframes=1} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            NestedDiagnosticsLogicalContext.Clear();
+
+            for (int i = 1; i <= 100; ++i)
+                NestedDiagnosticsLogicalContext.Push(i);
+
+            LogManager.GetLogger("A").Debug("0");
+            AssertDebugLastMessage("debug", "100 0");
+
+            NestedDiagnosticsLogicalContext.Pop();
+            LogManager.GetLogger("A").Debug("1");
+            AssertDebugLastMessage("debug", "99 1");
+
+            NestedDiagnosticsLogicalContext.Clear();
+            LogManager.GetLogger("A").Debug("2");
+            AssertDebugLastMessage("debug", " 2");
+        }
+    }
+#endif
+}

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -145,6 +145,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
+    <Compile Include="LayoutRenderers\NDLCTests.cs" />
     <Compile Include="LayoutRenderers\NLogDirRendererTests.cs" />
     <Compile Include="LayoutRenderers\ProcessIdLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\ProcessNameLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -174,6 +174,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
+    <Compile Include="LayoutRenderers\NDLCTests.cs" />
     <Compile Include="LayoutRenderers\NLogDirRendererTests.cs" />
     <Compile Include="LayoutRenderers\ProcessIdLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\ProcessNameLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -10,8 +10,10 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <ApplicationIcon></ApplicationIcon>
-    <AssemblyKeyContainerName></AssemblyKeyContainerName>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -154,6 +156,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
+    <Compile Include="LayoutRenderers\NDLCTests.cs" />
     <Compile Include="LayoutRenderers\NLogDirRendererTests.cs" />
     <Compile Include="LayoutRenderers\ProcessIdLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\ProcessNameLayoutRendererTests.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -9,10 +9,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <ApplicationIcon></ApplicationIcon>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -196,6 +194,7 @@
     <Compile Include="LayoutRenderers\MdlcLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\MessageTests.cs" />
     <Compile Include="LayoutRenderers\NDCTests.cs" />
+    <Compile Include="LayoutRenderers\NDLCTests.cs" />
     <Compile Include="LayoutRenderers\NLogDirRendererTests.cs" />
     <Compile Include="LayoutRenderers\ProcessIdLayoutRendererTests.cs" />
     <Compile Include="LayoutRenderers\ProcessNameLayoutRendererTests.cs" />


### PR DESCRIPTION
Make it easier to support Microsoft ILogger BeginScope (And maybe resolve #1615)

Maybe rename to Nested Diagnostics Logical Context (NDLC) ?