### PR TITLE
JSON serializer: support objects, improvements and formatting, add memoryCache

### DIFF
--- a/src/NLog/Internal/Cache.cs
+++ b/src/NLog/Internal/Cache.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if NET3_5 || NET4_0 || SILVERLIGHT || __IOS__ || __ANDROID__ || WINDOWS_PHONE
+#if NET3_5 || NET4_0 || SILVERLIGHT || __IOS__ || __ANDROID__ || WINDOWS_PHONE || MONO
 #define NO_MEMORY_CACHE
 using System.Collections.Generic;
 #else

--- a/src/NLog/Internal/Cache.cs
+++ b/src/NLog/Internal/Cache.cs
@@ -159,7 +159,20 @@ namespace NLog.Internal
         {
             // ReSharper disable InconsistentlySynchronizedField
 #if NO_MEMORY_CACHE
-            return _cache[key] as T;
+            try
+            {
+                T value;
+                if (_cache.TryGetValue(key, out value))
+                {
+                    return value;
+                }
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Debug(ex, "Exception when getting value with key '{0}'", key);
+            }
+            return null;
+
 #else
             return _cache.Get(key) as T;
             // ReSharper restore InconsistentlySynchronizedField

--- a/src/NLog/Internal/Cache.cs
+++ b/src/NLog/Internal/Cache.cs
@@ -1,0 +1,169 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if NET3_5 || SILVERLIGHT || __IOS__ || __ANDROID__ || WINDOWS_PHONE
+#define NO_MEMORY_CACHE
+using System.Collections.Generic;
+#else
+using System.Runtime.Caching;
+#endif
+
+using System;
+using NLog.Common;
+
+namespace NLog.Internal
+{
+    /// <summary>
+    /// Cache values, create the cache and store it static!
+    /// 
+    /// Note: <c>null</c> is not allowed as cache value.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal class Cache<T> where T : class
+    {
+        /// <summary>
+        /// Unique name, for logging and separating cache
+        /// </summary>
+        private readonly string _cacheName;
+
+        /// <summary>
+        /// Lock writing
+        /// </summary>
+        private readonly object _cacheLock = new object();
+
+#if NO_MEMORY_CACHE
+        private Dictionary<string, T> _cache;
+        private int MaxItems = 1000;
+#else
+
+        private MemoryCache _cache;
+        private CacheItemPolicy _cacheItemPolicy;
+#endif
+
+        /// <summary>
+        /// Create a cache with cacheName, store this in a <c>static</c> variable.
+        /// </summary>
+        /// <param name="cacheName">Unique name</param>
+        public Cache(string cacheName)
+        {
+            _cacheName = cacheName;
+#if NO_MEMORY_CACHE
+            InternalLogger.Trace("Cache {0}: Creating cache without MemoryCache", _cacheName);
+            _cache = new Dictionary<string, T>();
+#else
+            InternalLogger.Trace("Cache {0}: Creating cache with MemoryCache", _cacheName);
+            _cacheItemPolicy = new CacheItemPolicy();
+            _cache = new MemoryCache(cacheName);
+#endif
+        }
+
+        /// <summary>
+        /// Get the value, or create and add to the cache
+        /// </summary>
+        /// <param name="key">Key to get the item</param>
+        /// <param name="create">Function to create the value</param>
+        /// <returns></returns>
+        public T GetOrCreate(string key, Func<T> create)
+        {
+            var value = GetValue(key);
+
+            if (value != null)
+            {
+                return value;
+            }
+
+            lock (_cacheLock)
+            {
+                //Check again if someone already wrote to the case.
+                value = GetValue(key);
+
+                if (value != null)
+                {
+                    return value;
+                }
+
+                value = create();
+                if (value == null)
+                {
+                    InternalLogger.Warn("Cache {0}: creation of cache value yields null and won't be added to the cache", _cacheName);
+                }
+                else
+                {
+                    Add(key, value);
+                }
+                return value;
+            }
+        }
+
+
+        /// <summary>
+        /// Add item to the cache
+        /// </summary>
+        /// <param name="key">Key of the cache item</param>
+        /// <param name="value"></param>
+        private void Add(string key, T value)
+        {
+            InternalLogger.Trace("Cache {0}: Add items with key '{1}' to the cache", _cacheName, key);
+
+#if NO_MEMORY_CACHE
+
+            if (_cache.Count > MaxItems)
+            {
+                InternalLogger.Trace("Cache {0}: Clear cache because of max ({1}) entries. ", _cacheName, MaxItems);
+                _cache.Clear();
+            }
+
+            _cache[key] = value;
+#else
+            _cache.Add(key, value, _cacheItemPolicy);
+#endif
+
+        }
+
+        /// <summary>
+        /// Get value, returns null if the items does not exist,
+        /// </summary>
+        /// <param name="key">Key of the cache item</param>
+        /// <returns>null if and only if not exists.</returns>
+        private T GetValue(string key)
+        {
+            // ReSharper disable InconsistentlySynchronizedField
+#if NO_MEMORY_CACHE
+            return _cache[key] as T;
+#else
+            return _cache.Get(key) as T;
+            // ReSharper restore InconsistentlySynchronizedField
+#endif
+        }
+    }
+}

--- a/src/NLog/Internal/Cache.cs
+++ b/src/NLog/Internal/Cache.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if NET3_5 || SILVERLIGHT || __IOS__ || __ANDROID__ || WINDOWS_PHONE
+#if NET3_5 || NET4_0 || SILVERLIGHT || __IOS__ || __ANDROID__ || WINDOWS_PHONE
 #define NO_MEMORY_CACHE
 using System.Collections.Generic;
 #else

--- a/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
@@ -76,7 +76,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <returns>JSON-encoded string.</returns>
         protected override string Transform(string text)
         {
-            return this.JsonEncode ? Targets.DefaultJsonSerializer.JsonStringEscape(text, this.EscapeUnicode) : text;
+            return this.JsonEncode ? Targets.DefaultJsonSerializer.EscapeString(text, this.EscapeUnicode) : text;
         }
     }
 }

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -210,7 +210,7 @@ namespace NLog.Layouts
         {
             TypeCode objTypeCode = Convert.GetTypeCode(propertyValue);
 
-            string propStringValue = Targets.DefaultJsonSerializer.SerializePrimitive(propertyValue, objTypeCode, true);
+            string propStringValue = Targets.DefaultJsonSerializer.SerializePrimitive(propertyValue, objTypeCode, true, true);
             if (!string.IsNullOrEmpty(propStringValue))
             {
                 AppendJsonAttributeValue(propName, false, propStringValue, sb);

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -211,7 +211,7 @@ namespace NLog.Layouts
             TypeCode objTypeCode = Convert.GetTypeCode(propertyValue);
 
             bool propStringEncode;
-            string propStringValue = Targets.DefaultJsonSerializer.JsonStringEncode(propertyValue, objTypeCode, true, out propStringEncode);
+            string propStringValue = Targets.DefaultJsonSerializer.SerializePrimitive(propertyValue, objTypeCode, true, out propStringEncode);
             if (!string.IsNullOrEmpty(propStringValue))
             {
                 AppendJsonAttributeValue(propName, propStringEncode, propStringValue, sb);

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -210,15 +210,14 @@ namespace NLog.Layouts
         {
             TypeCode objTypeCode = Convert.GetTypeCode(propertyValue);
 
-            bool propStringEncode;
-            string propStringValue = Targets.DefaultJsonSerializer.SerializePrimitive(propertyValue, objTypeCode, true, out propStringEncode);
+            string propStringValue = Targets.DefaultJsonSerializer.SerializePrimitive(propertyValue, objTypeCode, true);
             if (!string.IsNullOrEmpty(propStringValue))
             {
-                AppendJsonAttributeValue(propName, propStringEncode, propStringValue, sb);
+                AppendJsonAttributeValue(propName, false, propStringValue, sb);
             }
         }
 
-        private void AppendJsonAttributeValue(string attributeName, bool attributeEncode, string text, StringBuilder sb)
+        private void AppendJsonAttributeValue(string attributeName, bool attributeQuote, string text, StringBuilder sb)
         {
             bool first = sb.Length == 0;
             if (first)
@@ -241,7 +240,7 @@ namespace NLog.Layouts
             if (!this.SuppressSpaces)
                 sb.Append(' ');
 
-            if (attributeEncode)
+            if (attributeQuote)
             {
                 // "\"{0}\":{1}\"{2}\""
                 sb.Append('"');

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -379,6 +379,7 @@
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\IJsonSerializer.cs" />
+    <Compile Include="Targets\JsonSerializeOptions.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\AsyncOperationCounter.cs" />
+    <Compile Include="Internal\Cache.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -376,6 +376,7 @@
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\IJsonSerializer.cs" />
+    <Compile Include="Targets\JsonSerializeOptions.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\AsyncOperationCounter.cs" />
+    <Compile Include="Internal\Cache.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -389,6 +389,7 @@
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\IJsonSerializer.cs" />
+    <Compile Include="Targets\JsonSerializeOptions.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\AsyncOperationCounter.cs" />
+    <Compile Include="Internal\Cache.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -395,6 +395,7 @@
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\IJsonSerializer.cs" />
+    <Compile Include="Targets\JsonSerializeOptions.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\AsyncOperationCounter.cs" />
+    <Compile Include="Internal\Cache.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -389,6 +389,7 @@
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\IJsonSerializer.cs" />
+    <Compile Include="Targets\JsonSerializeOptions.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\AsyncOperationCounter.cs" />
+    <Compile Include="Internal\Cache.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -389,6 +389,7 @@
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\IJsonSerializer.cs" />
+    <Compile Include="Targets\JsonSerializeOptions.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -15,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -51,6 +52,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
@@ -140,6 +142,7 @@
     <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\AsyncOperationCounter.cs" />
+    <Compile Include="Internal\Cache.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />
@@ -457,6 +460,9 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>InternalLogger-generated.cs</LastGenOutput>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(StyleCopTargetsFile)" Condition="Exists('$(StyleCopTargetsFile)')" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -52,7 +52,6 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -15,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <StyleCopTargetsFile>$(MSBuildExtensionsPath)\Microsoft\StyleCop\v4.4\Microsoft.StyleCop.Targets</StyleCopTargetsFile>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -56,6 +57,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
@@ -394,6 +396,7 @@
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\IJsonSerializer.cs" />
+    <Compile Include="Targets\JsonSerializeOptions.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\AsyncOperationCounter.cs" />
+    <Compile Include="Internal\Cache.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -396,6 +396,7 @@
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\IJsonSerializer.cs" />
+    <Compile Include="Targets\JsonSerializeOptions.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\AsyncOperationCounter.cs" />
+    <Compile Include="Internal\Cache.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -393,6 +393,7 @@
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\IJsonSerializer.cs" />
+    <Compile Include="Targets\JsonSerializeOptions.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\AsyncOperationCounter.cs" />
+    <Compile Include="Internal\Cache.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -392,6 +392,7 @@
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\IJsonSerializer.cs" />
+    <Compile Include="Targets\JsonSerializeOptions.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\AsyncOperationCounter.cs" />
+    <Compile Include="Internal\Cache.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -392,6 +392,7 @@
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\IJsonSerializer.cs" />
+    <Compile Include="Targets\JsonSerializeOptions.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\AsyncOperationCounter.cs" />
+    <Compile Include="Internal\Cache.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -417,6 +417,7 @@
     <Compile Include="Targets\FileTarget.cs" />
     <Compile Include="Targets\IFileCompressor.cs" />
     <Compile Include="Targets\IJsonSerializer.cs" />
+    <Compile Include="Targets\JsonSerializeOptions.cs" />
     <Compile Include="Targets\LineEndingMode.cs" />
     <Compile Include="Targets\LogReceiverWebServiceTarget.cs" />
     <Compile Include="Targets\MailTarget.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Internal\AppendBuilderCreator.cs" />
     <Compile Include="Internal\ArrayHelper.cs" />
     <Compile Include="Internal\AsyncOperationCounter.cs" />
+    <Compile Include="Internal\Cache.cs" />
     <Compile Include="Internal\ConfigurationManager.cs" />
     <Compile Include="Internal\DictionaryAdapter.cs" />
     <Compile Include="Internal\EncodingHelpers.cs" />

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -132,7 +132,7 @@ namespace NLog.Targets
             }
             else if ((str = value as string) != null)
             {
-                returnValue = QuoteValue(JsonStringEscape(str, options.EscapeUnicode));
+                returnValue = QuoteValue(EscapeString(str, options.EscapeUnicode));
             }
             else if ((dict = value as IDictionary) != null)
             {
@@ -291,7 +291,7 @@ namespace NLog.Targets
                 return stringValue;
             }
 
-            return QuoteValue(JsonStringEscape(stringValue, escapeUnicode));
+            return QuoteValue(EscapeString(stringValue, escapeUnicode));
         }
 
         /// <summary>
@@ -333,7 +333,7 @@ namespace NLog.Targets
         /// <param name="text">Input string</param>
         /// <param name="escapeUnicode">Should non-ascii characters be encoded</param>
         /// <returns>JSON escaped string</returns>
-        internal static string JsonStringEscape(string text, bool escapeUnicode)
+        internal static string EscapeString(string text, bool escapeUnicode)
         {
             if (text == null)
                 return null;

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -244,7 +244,7 @@ namespace NLog.Targets
                     }
                     else
                     {
-                        returnValue = SerializePrimitive(value, objTypeCode, options.EscapeUnicode);
+                        returnValue = SerializePrimitive(value, objTypeCode, options.EscapeUnicode, options.EnumAsString);
                     }
                 }
             }
@@ -277,9 +277,17 @@ namespace NLog.Targets
         /// <param name="value">Object value</param>
         /// <param name="objTypeCode">Object TypeCode</param>
         /// <param name="escapeUnicode">Should non-ascii characters be encoded</param>
+        /// <param name="enumAsString">Enum as string value?</param>
         /// <returns>Object value converted to JSON escaped string</returns>
-        internal static string SerializePrimitive(object value, TypeCode objTypeCode, bool escapeUnicode)
+        internal static string SerializePrimitive(object value, TypeCode objTypeCode, bool escapeUnicode, bool enumAsString)
         {
+
+            if (enumAsString && IsNumericTypeCode(objTypeCode) && value.GetType().IsEnum)
+            {
+                //enum as string
+                return QuoteValue(Convert.ToString(value, CultureInfo.InvariantCulture));
+            }
+
             string stringValue = Internal.XmlHelper.XmlConvertToString(value, objTypeCode);
 
             if (stringValue == null)

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -37,7 +37,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Text;
-using NLog.Internal;
 
 namespace NLog.Targets
 {
@@ -190,7 +189,7 @@ namespace NLog.Targets
                     TypeCode objTypeCode = Convert.GetTypeCode(value);
                     if (objTypeCode == TypeCode.Object)
                     {
-                        if (value is Guid)
+                        if (value is Guid || value is TimeSpan)
                         {
                             //object without property, to string
                             return QuoteValue(value.ToString());

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -190,10 +190,6 @@ namespace NLog.Targets
 
             else
             {
-
-
-
-
                 IFormattable formattable;
                 var format = options.Format;
                 var hasFormat = !string.IsNullOrWhiteSpace(format);
@@ -210,7 +206,7 @@ namespace NLog.Targets
                             options.FormatProvider = culture;
                         }
                         returnValue = string.Format(options.FormatProvider, "{0:" + format + "}", value);
-                        
+
                     }
                     else
                     {
@@ -236,8 +232,6 @@ namespace NLog.Targets
                         try
                         {
                             var set = AddToSet(objectsInPath, value);
-
-
                             returnValue = SerializeProperties(value, options, set, depth);
 
                         }
@@ -460,34 +454,44 @@ namespace NLog.Targets
             for (var i = 0; i < props.Length; i++)
             {
                 var prop = props[i];
-                var propValue = prop.GetValue(value, null);
-                if (propValue != null)
+
+                try
                 {
-                    var serializedProperty = SerializeObject(propValue, options, objectsInPath, depth + 1);
-
-                    if (serializedProperty != null)
+                    var propValue = prop.GetValue(value, null);
+                    if (propValue != null)
                     {
-                        if (!isFirst)
-                        {
-                            sb.Append(", ");
-                        }
-                        isFirst = false;
-                        if (options.QuoteKeys)
-                        {
-                            sb.Append("\"");
-                            //no escape needed as properties don't have quotes
-                            sb.Append(prop.Name);
-                            sb.Append("\"");
-                        }
-                        else
-                        {
-                            sb.Append(prop.Name);
-                        }
 
-                        sb.Append(":");
-                        sb.Append(serializedProperty);
+                        var serializedProperty = SerializeObject(propValue, options, objectsInPath, depth + 1);
+
+                        if (serializedProperty != null)
+                        {
+                            if (!isFirst)
+                            {
+                                sb.Append(", ");
+                            }
+                            isFirst = false;
+                            if (options.QuoteKeys)
+                            {
+                                sb.Append("\"");
+                                //no escape needed as properties don't have quotes
+                                sb.Append(prop.Name);
+                                sb.Append("\"");
+                            }
+                            else
+                            {
+                                sb.Append(prop.Name);
+                            }
+
+                            sb.Append(":");
+                            sb.Append(serializedProperty);
+                        }
                     }
                 }
+                catch
+                {
+                    //skip this property
+                }
+
             }
             sb.Append('}');
             return sb.ToString();

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -225,16 +225,19 @@ namespace NLog.Targets
                     TypeCode objTypeCode = Convert.GetTypeCode(value);
                     if (objTypeCode == TypeCode.Object)
                     {
-                        if (value is Guid || value is TimeSpan || value is DateTimeOffset)
+                        if (value is Guid || value is TimeSpan)
                         {
                             //object without property, to string
                             return QuoteValue(Convert.ToString(value, CultureInfo.InvariantCulture));
+                        }
+                        if (value is DateTimeOffset)
+                        {
+                            return QuoteValue(string.Format("{0:yyyy-MM-dd HH:mm:ss zzz}", value));
                         }
                         try
                         {
                             var set = AddToSet(objectsInPath, value);
                             returnValue = SerializeProperties(value, options, set, depth);
-
                         }
                         catch
                         {

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -37,6 +37,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Text;
+using NLog.Internal;
 
 namespace NLog.Targets
 {
@@ -192,7 +193,7 @@ namespace NLog.Targets
             {
                 IFormattable formattable;
                 var format = options.Format;
-                var hasFormat = !string.IsNullOrWhiteSpace(format);
+                var hasFormat = !StringHelpers.IsNullOrWhiteSpace(format);
                 if ((options.FormatProvider != null || hasFormat) && (formattable = value as IFormattable) != null)
                 {
                     TypeCode objTypeCode = Convert.GetTypeCode(value);
@@ -224,10 +225,10 @@ namespace NLog.Targets
                     TypeCode objTypeCode = Convert.GetTypeCode(value);
                     if (objTypeCode == TypeCode.Object)
                     {
-                        if (value is Guid || value is TimeSpan)
+                        if (value is Guid || value is TimeSpan || value is DateTimeOffset)
                         {
                             //object without property, to string
-                            return QuoteValue(value.ToString());
+                            return QuoteValue(Convert.ToString(value, CultureInfo.InvariantCulture));
                         }
                         try
                         {
@@ -433,7 +434,7 @@ namespace NLog.Targets
             if (props.Length == 0)
             {
                 //no props
-                return QuoteValue(value.ToString());
+                return QuoteValue(Convert.ToString(value, CultureInfo.InvariantCulture));
             }
             var sb = new StringBuilder();
             sb.Append('{');

--- a/src/NLog/Targets/JsonSerializeOptions.cs
+++ b/src/NLog/Targets/JsonSerializeOptions.cs
@@ -60,13 +60,21 @@ namespace NLog.Targets
         /// <summary>
         /// Should non-ascii characters be encoded
         /// </summary>
+        [DefaultValue(false)]
         public bool EscapeUnicode { get; set; }
+
+        /// <summary>
+        /// Serialize enum as string value
+        /// </summary>
+        [DefaultValue(true)]
+        public bool EnumAsString { get; set; }
 
 
         /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
         public JsonSerializeOptions()
         {
             QuoteKeys = true;
+            EnumAsString = true;
         }
     }
 }

--- a/src/NLog/Targets/JsonSerializeOptions.cs
+++ b/src/NLog/Targets/JsonSerializeOptions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NLog.Targets
+{
+    /// <summary>
+    /// Options for JSON serialisation
+    /// </summary>
+    public class JsonSerializeOptions
+    {
+        /// <summary>
+        /// Add quotes arround object keys?
+        /// </summary>
+        [DefaultValue(true)]
+        public bool QuoteKeys { get; set; }
+
+        /// <summary>
+        /// Formatprovider for value
+        /// </summary>
+        public IFormatProvider FormatProvider { get; set; }
+
+        /// <summary>
+        /// Format string for value
+        /// </summary>
+        public string Format { get; set; }
+
+        /// <summary>
+        /// Should non-ascii characters be encoded
+        /// </summary>
+        public bool EscapeUnicode { get; set; }
+
+
+        /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+        public JsonSerializeOptions()
+        {
+            QuoteKeys = true;
+        }
+    }
+}

--- a/src/NLog/Targets/JsonSerializeOptions.cs
+++ b/src/NLog/Targets/JsonSerializeOptions.cs
@@ -1,9 +1,38 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NLog.Targets
 {

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -179,6 +179,28 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void SerializeTime_Test()
+        {
+            var actual = _serializer.SerializeObject(new TimeSpan(1,2,3,4));
+            Assert.Equal("\"1.02:03:04\"", actual);
+        }
+
+        [Fact]
+        public void SerializeTime2_Test()
+        {
+            var actual = _serializer.SerializeObject(new TimeSpan(0, 2, 3, 4));
+            Assert.Equal("\"02:03:04\"", actual);
+        }
+
+        [Fact]
+        public void SerializeTime3_Test()
+        {
+            var actual = _serializer.SerializeObject(new TimeSpan(0,0, 2, 3, 4));
+            Assert.Equal("\"00:02:03.0040000\"", actual);
+        }
+
+
+        [Fact]
         public void SerializeNull_Test()
         {
             var actual = _serializer.SerializeObject(null);

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -32,6 +32,9 @@
 // 
 
 using System.Globalization;
+using System.Web.Http.Routing;
+using NLog.Config;
+using UrlHelper = NLog.Internal.UrlHelper;
 
 namespace NLog.UnitTests.Targets
 {
@@ -293,6 +296,32 @@ namespace NLog.UnitTests.Targets
             var actual = _serializer.SerializeObject(newGuid);
             Assert.Equal("\"" + newGuid.ToString() + "\"", actual);
         }
+
+
+        [Fact]
+        public void SerializeEnum_Test()
+        {
+            var val = ExceptionRenderingFormat.Method;
+            var actual = _serializer.SerializeObject(val);
+            Assert.Equal("\"Method\"", actual);
+        }
+
+        [Fact]
+        public void SerializeEnumInt_Test()
+        {
+            var val = ExceptionRenderingFormat.Method;
+            var actual = _serializer.SerializeObject(val, new JsonSerializeOptions() {EnumAsString = false});
+            Assert.Equal("4", actual);
+        }
+
+        [Fact]
+        public void SerializeFlagEnum_Test()
+        {
+            var val = UrlHelper.EscapeEncodingFlag.LegacyRfc2396 | UrlHelper.EscapeEncodingFlag.LowerCaseHex;
+            var actual = _serializer.SerializeObject(val);
+            Assert.Equal("\"LegacyRfc2396, LowerCaseHex\"", actual);
+        }
+
         [Fact]
         public void SerializeObject_Test()
         {

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -261,6 +261,23 @@ namespace NLog.UnitTests.Targets
             Assert.Equal("\"00:02:03.0040000\"", actual);
         }
 
+        [Fact]
+        public void SerializeEmptyDict_Test()
+        {
+            var actual = _serializer.SerializeObject(new Dictionary<string, int>());
+            Assert.Equal("{}", actual);
+        }
+
+        [Fact]
+        public void SerializeDict_Test()
+        {
+            var dictionary = new Dictionary<string, object>();
+            dictionary.Add("key1", 13);
+            dictionary.Add("key 2", 1.3m);
+            var actual = _serializer.SerializeObject(dictionary);
+            Assert.Equal("{\"key1\":13,\"key 2\":1.3}", actual);
+        }
+
 
         [Fact]
         public void SerializeNull_Test()
@@ -324,6 +341,21 @@ namespace NLog.UnitTests.Targets
         }
 
 
+        [Fact]
+        public void SerializeNoPropsObject_Test()
+        {
+            var object1 = new NoPropsObject();
+            var actual = _serializer.SerializeObject(object1);
+            Assert.Equal("\"something\"", actual);
+        }
+
+        [Fact]
+        public void SerializeObjectWithExceptionAndPrivateSetter_Test()
+        {
+            var object1 = new ObjectWithExceptionAndPrivateSetter("test name");
+            var actual = _serializer.SerializeObject(object1);
+            Assert.Equal("{\"Name\":\"test name\"}", actual);
+        }
         private class TestObject
         {
             /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
@@ -337,6 +369,43 @@ namespace NLog.UnitTests.Targets
             public TestObject Linked { get; set; }
         }
 
+
+        public class NoPropsObject
+        {
+            private string something = "something";
+
+            #region Overrides of Object
+
+            /// <summary>Returns a string that represents the current object.</summary>
+            /// <returns>A string that represents the current object.</returns>
+            public override string ToString()
+            {
+                return something;
+            }
+
+            #endregion
+        }
+
+        private class ObjectWithExceptionAndPrivateSetter
+        {
+            /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+            public ObjectWithExceptionAndPrivateSetter(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get;  }
+
+            public string SetOnly { private get; set; }
+
+            public object Ex
+            {
+                get
+                {
+                    throw new Exception("oops");
+                }
+            }
+        }
 
 
         private class TestList : IEnumerable<IEnumerable>

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -185,6 +185,57 @@ namespace NLog.UnitTests.Targets
             var actual = _serializer.SerializeObject(newGuid);
             Assert.Equal("\"" + newGuid.ToString() + "\"", actual);
         }
+        [Fact]
+        public void SerializeObject_Test()
+        {
+            var object1 = new TestObject("object1");
+            var object2 = new TestObject("object2");
+
+            object1.Linked = object2;
+            var actual = _serializer.SerializeObject(object1);
+            Assert.Equal("{\"Name\":\"object1\", \"Linked\":{\"Name\":\"object2\"}}", actual);
+        }
+
+
+
+        [Fact]
+        public void SerializeRecusiveObject_Test()
+        {
+            var object1 = new TestObject("object1");
+
+            object1.Linked = object1;
+            var actual = _serializer.SerializeObject(object1);
+            Assert.Equal("{\"Name\":\"object1\"}", actual);
+        }
+
+        [Fact]
+        public void SerializeListObject_Test()
+        {
+            var object1 = new TestObject("object1");
+            var object2 = new TestObject("object2");
+            object1.Linked = object2;
+
+            var list = new[] {object1, object2};
+
+            var actual = _serializer.SerializeObject(list);
+            Assert.Equal("[{\"Name\":\"object1\", \"Linked\":{\"Name\":\"object2\"}},{\"Name\":\"object2\"}]", actual);
+        }
+
+
+        private class TestObject
+        {
+            /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+            public TestObject(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get; set; }
+
+            public TestObject Linked { get; set; }
+        }
+
+
 
         private class TestList : IEnumerable<IEnumerable>
         {

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -97,6 +97,25 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void SerializeUnicode_test()
+        {
+            var actual = _serializer.SerializeObject("©");
+            Assert.Equal("\"©\"", actual);
+        }
+
+        [Fact]
+        public void SerializeUnicodeInAnomObject_test()
+        {
+            var item = new
+            {
+                text = "©"
+            };
+
+            var actual = _serializer.SerializeObject(item);
+            Assert.Equal("{\"text\":\"©\"}", actual);
+        }
+
+        [Fact]
         public void ReferenceLoopInDictionary_Test()
         {
             var d = new Dictionary<string, object>();

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -147,7 +147,7 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void StringWithMixedControlCharacters_Test()
         {
-            var text = "First\\Second\tand" +(char)3+ "for" + (char)0x1f + "with" + (char)0x10 + "but" + (char)0x0d + "and no" + (char)0x20;
+            var text = "First\\Second\tand" + (char)3 + "for" + (char)0x1f + "with" + (char)0x10 + "but" + (char)0x0d + "and no" + (char)0x20;
             var expected = "\"First\\\\Second\\tand\\u0003for\\u001fwith\\u0010but\\rand no \"";
 
             var actual = _serializer.SerializeObject(text);
@@ -172,7 +172,7 @@ namespace NLog.UnitTests.Targets
         [InlineData(2776145.7743, "2776145.77")]
         public void SerializeNumber_format_Test(object o, string expected)
         {
-            var actual = _serializer.SerializeObject(o, new JsonSerializeOptions() {Format = "N2"});
+            var actual = _serializer.SerializeObject(o, new JsonSerializeOptions() { Format = "N2" });
             Assert.Equal(expected, actual);
         }
 
@@ -194,7 +194,7 @@ namespace NLog.UnitTests.Targets
         [InlineData(2776145.7743, "2.776.145,77")]
         public void SerializeNumber_formatNL_Test(object o, string expected)
         {
-            var actual = _serializer.SerializeObject(o, new JsonSerializeOptions() { Format = "N2", FormatProvider = new CultureInfo("nl-nl")});
+            var actual = _serializer.SerializeObject(o, new JsonSerializeOptions() { Format = "N2", FormatProvider = new CultureInfo("nl-nl") });
             Assert.Equal(expected, actual);
         }
 
@@ -217,12 +217,19 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void SerializeDateTime_Test2()
+        {
+            var val = new DateTime(2016, 12, 31);
+            var actual = _serializer.SerializeObject(val);
+            Assert.Equal("\"" + "2016-12-31T00:00:00Z" + "\"", actual);
+        }
+
+        [Fact]
         public void SerializeDateTime_isoformat_Test()
         {
-            DateTime utcNow = DateTime.UtcNow;
-            utcNow = utcNow.AddTicks(-utcNow.Ticks % TimeSpan.TicksPerSecond);
-            var actual = _serializer.SerializeObject(utcNow, new JsonSerializeOptions { Format = "O"});
-            Assert.Equal("\"" + utcNow.ToString("O", System.Globalization.CultureInfo.InvariantCulture) + "\"", actual);
+            var val = new DateTime(2016, 12, 31);
+            var actual = _serializer.SerializeObject(val, new JsonSerializeOptions { Format = "O" });
+            Assert.Equal("\"2016-12-31T00:00:00.0000000\"", actual);
         }
 
         [Fact]
@@ -244,9 +251,17 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void SerializeDateTimeOffset_Test()
+        {
+            var val = new DateTimeOffset(new DateTime(2016, 12, 31, 2, 30, 59), new TimeSpan(4, 30, 0));
+            var actual = _serializer.SerializeObject(val);
+            Assert.Equal("\"" + "2016-12-31 02:30:59 +04:30" + "\"", actual);
+        }
+
+        [Fact]
         public void SerializeTime_Test()
         {
-            var actual = _serializer.SerializeObject(new TimeSpan(1,2,3,4));
+            var actual = _serializer.SerializeObject(new TimeSpan(1, 2, 3, 4));
             Assert.Equal("\"1.02:03:04\"", actual);
         }
 
@@ -260,7 +275,7 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void SerializeTime3_Test()
         {
-            var actual = _serializer.SerializeObject(new TimeSpan(0,0, 2, 3, 4));
+            var actual = _serializer.SerializeObject(new TimeSpan(0, 0, 2, 3, 4));
             Assert.Equal("\"00:02:03.0040000\"", actual);
         }
 
@@ -310,7 +325,7 @@ namespace NLog.UnitTests.Targets
         public void SerializeEnumInt_Test()
         {
             var val = ExceptionRenderingFormat.Method;
-            var actual = _serializer.SerializeObject(val, new JsonSerializeOptions() {EnumAsString = false});
+            var actual = _serializer.SerializeObject(val, new JsonSerializeOptions() { EnumAsString = false });
             Assert.Equal("4", actual);
         }
 
@@ -341,7 +356,7 @@ namespace NLog.UnitTests.Targets
             var object2 = new TestObject("object2");
 
             object1.Linked = object2;
-            var actual = _serializer.SerializeObject(object1, new JsonSerializeOptions {QuoteKeys = false});
+            var actual = _serializer.SerializeObject(object1, new JsonSerializeOptions { QuoteKeys = false });
             Assert.Equal("{Name:\"object1\", Linked:{Name:\"object2\"}}", actual);
         }
 
@@ -363,7 +378,7 @@ namespace NLog.UnitTests.Targets
             var object2 = new TestObject("object2");
             object1.Linked = object2;
 
-            var list = new[] {object1, object2};
+            var list = new[] { object1, object2 };
 
             var actual = _serializer.SerializeObject(list);
             Assert.Equal("[{\"Name\":\"object1\", \"Linked\":{\"Name\":\"object2\"}},{\"Name\":\"object2\"}]", actual);
@@ -423,7 +438,7 @@ namespace NLog.UnitTests.Targets
                 Name = name;
             }
 
-            public string Name { get;  }
+            public string Name { get; }
 
             public string SetOnly { private get; set; }
 

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -32,7 +32,6 @@
 // 
 
 using System.Globalization;
-using System.Web.Http.Routing;
 using NLog.Config;
 using UrlHelper = NLog.Internal.UrlHelper;
 

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -179,6 +179,13 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void SerializeNull_Test()
+        {
+            var actual = _serializer.SerializeObject(null);
+            Assert.Equal("null", actual);
+        }
+
+        [Fact]
         public void SerializeGuid_Test()
         {
             Guid newGuid = Guid.NewGuid();

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Globalization;
+
 namespace NLog.UnitTests.Targets
 {
     using NLog.Targets;
@@ -160,6 +162,39 @@ namespace NLog.UnitTests.Targets
             Assert.Equal(expected, actual);
         }
 
+        [Theory]
+        [InlineData((int)177, "177.00")]
+        [InlineData((long)32711520331, "32711520331.00")]
+        [InlineData(3.14159265, "3.14")]
+        [InlineData(2776145.7743, "2776145.77")]
+        public void SerializeNumber_format_Test(object o, string expected)
+        {
+            var actual = _serializer.SerializeObject(o, new JsonSerializeOptions() {Format = "N2"});
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData((int)177, "177")]
+        [InlineData((long)32711520331, "32711520331")]
+        [InlineData(3.14159265, "3,14159265")]
+        [InlineData(2776145.7743, "2776145,7743")]
+        public void SerializeNumber_nl_Test(object o, string expected)
+        {
+            var actual = _serializer.SerializeObject(o, new JsonSerializeOptions() { FormatProvider = new CultureInfo("nl-nl") });
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData((int)177, "177,00")]
+        [InlineData((long)32711520331, "32.711.520.331,00")]
+        [InlineData(3.14159265, "3,14")]
+        [InlineData(2776145.7743, "2.776.145,77")]
+        public void SerializeNumber_formatNL_Test(object o, string expected)
+        {
+            var actual = _serializer.SerializeObject(o, new JsonSerializeOptions() { Format = "N2", FormatProvider = new CultureInfo("nl-nl")});
+            Assert.Equal(expected, actual);
+        }
+
         [Fact]
         public void SerializeBool_Test()
         {
@@ -176,6 +211,33 @@ namespace NLog.UnitTests.Targets
             utcNow = utcNow.AddTicks(-utcNow.Ticks % TimeSpan.TicksPerSecond);
             var actual = _serializer.SerializeObject(utcNow);
             Assert.Equal("\"" + utcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", System.Globalization.CultureInfo.InvariantCulture) + "\"", actual);
+        }
+
+        [Fact]
+        public void SerializeDateTime_isoformat_Test()
+        {
+            DateTime utcNow = DateTime.UtcNow;
+            utcNow = utcNow.AddTicks(-utcNow.Ticks % TimeSpan.TicksPerSecond);
+            var actual = _serializer.SerializeObject(utcNow, new JsonSerializeOptions { Format = "O"});
+            Assert.Equal("\"" + utcNow.ToString("O", System.Globalization.CultureInfo.InvariantCulture) + "\"", actual);
+        }
+
+        [Fact]
+        public void SerializeDateTime_format_Test()
+        {
+            DateTime utcNow = DateTime.UtcNow;
+            utcNow = utcNow.AddTicks(-utcNow.Ticks % TimeSpan.TicksPerSecond);
+            var actual = _serializer.SerializeObject(utcNow, new JsonSerializeOptions { Format = "dddd d M" });
+            Assert.Equal("\"" + utcNow.ToString("dddd d M", System.Globalization.CultureInfo.InvariantCulture) + "\"", actual);
+        }
+
+        [Fact]
+        public void SerializeDateTime_formatNl_Test()
+        {
+            DateTime utcNow = DateTime.UtcNow;
+            utcNow = utcNow.AddTicks(-utcNow.Ticks % TimeSpan.TicksPerSecond);
+            var actual = _serializer.SerializeObject(utcNow, new JsonSerializeOptions { Format = "dddd d M", FormatProvider = new CultureInfo("nl-nl") });
+            Assert.Equal("\"" + utcNow.ToString("dddd d M", new CultureInfo("nl-nl")) + "\"", actual);
         }
 
         [Fact]
@@ -225,6 +287,17 @@ namespace NLog.UnitTests.Targets
             Assert.Equal("{\"Name\":\"object1\", \"Linked\":{\"Name\":\"object2\"}}", actual);
         }
 
+
+        [Fact]
+        public void SerializeObject_noQuote_Test()
+        {
+            var object1 = new TestObject("object1");
+            var object2 = new TestObject("object2");
+
+            object1.Linked = object2;
+            var actual = _serializer.SerializeObject(object1, new JsonSerializeOptions {QuoteKeys = false});
+            Assert.Equal("{Name:\"object1\", Linked:{Name:\"object2\"}}", actual);
+        }
 
 
         [Fact]


### PR DESCRIPTION
Extends the default Json Serializer

- number formating with formatting string
- support serializing objects (with reflection)
- support timespan and guid
- serializer options object
- some method renames (only internals)
- performance tweaks
- more unit tests

Needed for #1376 and #2127 

todo:
- [x]  make backwardscomp
- [x] remove inner class
- [x] remove json5 support for now
- [x] quote key
- [x] option to disable quote key  -> for structured logging, so don't enable by default
- [x] is formatting really needed? -> for structured logging, so don't enable by default
- [x] props as real caching instead of static?
- [x] escape quotes
- [x] update commit text
- [x] check enum
