### PR TITLE
Fix : LogManager.ReconfigureExistingLoggers() could throw InvalidOperationException 

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -1356,6 +1356,7 @@ namespace NLog
                 // TODO: Test if loggerCache.Values.ToList<Logger>() can be used for the conversion instead.
                 List<Logger> values = new List<Logger>(loggerCache.Count);
 
+                //new list for prevent InvalidOperationException on Travis/Mono.
                 List<WeakReference> loggerReferences = new List<WeakReference>(loggerCache.Values.ToList());
 
                 foreach (WeakReference loggerReference in loggerReferences)

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -1356,7 +1356,9 @@ namespace NLog
                 // TODO: Test if loggerCache.Values.ToList<Logger>() can be used for the conversion instead.
                 List<Logger> values = new List<Logger>(loggerCache.Count);
 
-                foreach (WeakReference loggerReference in loggerCache.Values)
+                List<WeakReference> loggerReferences = new List<WeakReference>(loggerCache.Values.ToList());
+
+                foreach (WeakReference loggerReference in loggerReferences)
                 {
                     Logger logger = loggerReference.Target as Logger;
                     if (logger != null)


### PR DESCRIPTION
…tently throws InvalidOperationException on Travis/Mono.

fixes #2130 