### PR TITLE
JsonLayout - IncludeMdc and IncludeMdlc are not ThreadAgnostic

### DIFF
--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -77,13 +77,17 @@ namespace NLog.Layouts
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsContext"/> dictionary.
         /// </summary>
-        public bool IncludeMdc { get; set; }
+        public bool IncludeMdc { get { return IncludeMdcRenderer != null; } set { IncludeMdcRenderer = value ? new LayoutRenderers.MdcLayoutRenderer() { Item = "NotThreadAgnostic" } : null; } }
+        /// <summary>Magic helper to ensure <see cref="Layout.ThreadAgnostic"/> is updated properly.</summary>
+        public LayoutRenderers.LayoutRenderer IncludeMdcRenderer { get; private set; }
 
 #if NET4_0 || NET4_5
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
-        public bool IncludeMdlc { get; set; }
+        public bool IncludeMdlc { get { return IncludeMdlcRenderer != null; } set { IncludeMdlcRenderer = value ? new LayoutRenderers.MdlcLayoutRenderer() { Item = "NotThreadAgnostic" } : null; } }
+        /// <summary>Magic helper to ensure <see cref="Layout.ThreadAgnostic"/> is updated properly.</summary>
+        public LayoutRenderers.LayoutRenderer IncludeMdlcRenderer { get; private set; }
 #endif
 
         /// <summary>

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -438,10 +438,22 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void IncludeMdcJsonProperties()
         {
-            var jsonLayout = new JsonLayout()
-            {
-                IncludeMdc = true
-            };
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog throwExceptions='true'>
+            <targets>
+                <target name='asyncDebug' type='AsyncWrapper' timeToSleepBetweenBatches='0'>
+                <target name='debug' type='Debug'  >
+                 <layout type=""JsonLayout"" IncludeMdc='true' ExcludeProperties='Excluded1,Excluded2'>
+                 </layout>
+                </target>
+                </target>
+            </targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='asyncDebug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
 
             var logEventInfo = CreateLogEventWithExcluded();
 
@@ -451,17 +463,33 @@ namespace NLog.UnitTests.Layouts
                     MappedDiagnosticsContext.Set(prop.Key.ToString(), prop.Value);
             logEventInfo.Properties.Clear();
 
-            Assert.Equal(ExpectedIncludeAllPropertiesWithExcludes, jsonLayout.Render(logEventInfo));
+            logger.Debug(logEventInfo);
+
+            LogManager.Flush();
+
+            AssertDebugLastMessage("debug", ExpectedIncludeAllPropertiesWithExcludes);
         }
 
 #if NET4_0 || NET4_5
         [Fact]
         public void IncludeMdlcJsonProperties()
         {
-            var jsonLayout = new JsonLayout()
-            {
-                IncludeMdlc = true
-            };
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog throwExceptions='true'>
+            <targets>
+                <target name='asyncDebug' type='AsyncWrapper' timeToSleepBetweenBatches='0'>
+                <target name='debug' type='Debug'  >
+                 <layout type=""JsonLayout"" IncludeMdlc='true' ExcludeProperties='Excluded1,Excluded2'>
+                 </layout>
+                </target>
+                </target>
+            </targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='asyncDebug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
 
             var logEventInfo = CreateLogEventWithExcluded();
 
@@ -471,7 +499,11 @@ namespace NLog.UnitTests.Layouts
                         MappedDiagnosticsLogicalContext.Set(prop.Key.ToString(), prop.Value);
             logEventInfo.Properties.Clear();
 
-            Assert.Equal(ExpectedIncludeAllPropertiesWithExcludes, jsonLayout.Render(logEventInfo));
+            logger.Debug(logEventInfo);
+
+            LogManager.Flush();
+
+            AssertDebugLastMessage("debug", ExpectedIncludeAllPropertiesWithExcludes);
         }
 #endif
 


### PR DESCRIPTION
Kind of a special hack. Maybe it is better to make a virtual-method that gets the object-graph as input parameter. Then JsonLayout can override this an check its IncludeMdc and IncludeMdlc.