### PR TITLE
Don't run SonarQube on forks

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,13 +9,7 @@ environment:
 build_script:     
   - msbuild  src/NLog.proj /verbosity:minimal /t:rebuild /t:xsd /t:NuGetPackage /p:BuildVersion=4.4.10  /p:AssemblyFileVersion=4.4.%APPVEYOR_BUILD_NUMBER% /p:BuildLastMajorVersion=4.0.0 /p:configuration=release /p:BuildLabelOverride=NONE 
   - msbuild  src/NLog.proj /verbosity:minimal /t:BuildTests /p:BuildNetFX35=true /p:BuildNetFX40=true /p:BuildNetFX45=true
-  - choco install "msbuild-sonarqube-runner" -y
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER) { MSBuild.SonarQube.Runner.exe begin /k:"nlog" /d:"sonar.host.url=https://sonarqube.com" /d:"sonar.login=$env:sonar_token" /d:"sonar.analysis.mode=preview" /d:"sonar.github.pullRequest=$env:APPVEYOR_PULL_REQUEST_NUMBER" /d:"sonar.github.repository=nlog/nlog" /d:"sonar.github.oauth=$env:github_auth_token" }
-  - ps: if (-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) { MSBuild.SonarQube.Runner.exe begin /k:"nlog" /d:"sonar.host.url=https://sonarqube.com" /d:"sonar.login=$env:sonar_token" }
-  - msbuild "c:\projects\nlog\src\NLog\NLog.netfx45.csproj" /verbosity:minimal
-  - ps: MSBuild.SonarQube.Runner.exe end /d:"sonar.login=$env:sonar_token"
-
-
+  - ps: .\run-sonar.ps1
 
 test_script:
   - tools\CheckSourceCode\NLog.SourceCodeTests.exe no-interactive

--- a/run-sonar.ps1
+++ b/run-sonar.ps1
@@ -1,0 +1,25 @@
+$projectFile = "src\NLog\NLog.netfx45.csproj"
+$sonarQubeId = "nlog"
+$github = "nlog/nlog"
+
+
+if($env:APPVEYOR_REPO_NAME -eq $github){
+
+    if(-not $env:sonar_token){
+        Write-warning "not running SonarQube, no sonar_token"
+        return;
+    }
+
+    choco install "msbuild-sonarqube-runner" -y
+     
+    if ($env:APPVEYOR_PULL_REQUEST_NUMBER) { 
+        MSBuild.SonarQube.Runner.exe begin /k:"$sonarQubeId" /d:"sonar.host.url=https://sonarqube.com" /d:"sonar.login=$env:sonar_token" /d:"sonar.analysis.mode=preview" /d:"sonar.github.pullRequest=$env:APPVEYOR_PULL_REQUEST_NUMBER" /d:"sonar.github.repository=$github" /d:"sonar.github.oauth=$env:github_auth_token" 
+    }
+    else {
+        MSBuild.SonarQube.Runner.exe begin /k:"$sonarQubeId" /d:"sonar.host.url=https://sonarqube.com" /d:"sonar.login=$env:sonar_token" 
+    }
+    msbuild $projectFile /verbosity:minimal
+    MSBuild.SonarQube.Runner.exe end /d:"sonar.login=$env:sonar_token"
+}else {
+    Write-Output "not running SonarQube as we're on '$env:APPVEYOR_REPO_NAME'"
+}


### PR DESCRIPTION
- Don't run SonarQube on forks
- Don't let SonarQube crash build
- build scripts of CodeCov to separate ps1 file.

fixes https://github.com/NLog/NLog/issues/2168