### PR TITLE
GetCurrentClassLogger - Fix NetCore 2.0

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -456,7 +456,7 @@ namespace NLog
 #else
             var frame = new StackFrame(1, false);
 #endif
-            return this.GetLogger(frame.GetMethod().DeclaringType.FullName);
+            return this.GetLogger(frame.GetMethod().DeclaringType.FullName.Replace("+", "."));
 #else
             return this.GetLogger(StackFrameExt.GetClassFullName());
 #endif
@@ -478,7 +478,7 @@ namespace NLog
 #else
             var frame = new StackFrame(1, false);
 #endif
-            return (T)this.GetLogger(frame.GetMethod().DeclaringType.FullName, typeof(T));
+            return (T)this.GetLogger(frame.GetMethod().DeclaringType.FullName.Replace("+", "."), typeof(T));
 #else
             return (T)this.GetLogger(StackFrameExt.GetClassFullName(), typeof(T));
 #endif
@@ -501,7 +501,7 @@ namespace NLog
 #else
             var frame = new StackFrame(1);
 #endif
-            return this.GetLogger(frame.GetMethod().DeclaringType.FullName, loggerType);
+            return this.GetLogger(frame.GetMethod().DeclaringType.FullName.Replace("+", "."), loggerType);
 #else
             return this.GetLogger(StackFrameExt.GetClassFullName(), loggerType);
 #endif

--- a/tests/NLog.UnitTests/GetLoggerTests.cs
+++ b/tests/NLog.UnitTests/GetLoggerTests.cs
@@ -91,6 +91,32 @@ namespace NLog.UnitTests
             Assert.Equal("NLog.UnitTests.GetLoggerTests", l3.Name);
         }
 
+        private class ImANormalClass
+        {
+            public Logger Logger { get; private set; }
+            public Logger LoggerType { get; private set; }
+            public Logger LoggerGeneric { get; private set; }
+
+            public string FullName { get { return GetType().FullName.Replace("+", "."); } }
+
+            public ImANormalClass()
+            {
+                LogFactory lf = new LogFactory();
+                Logger = lf.GetCurrentClassLogger();
+                LoggerType = lf.GetCurrentClassLogger(typeof(Logger));
+                LoggerGeneric = lf.GetCurrentClassLogger<Logger>();
+            }
+        }
+
+        [Fact]
+        public void GetCurrentClassLoggerInnerClassTest()
+        {
+            var instance = new ImANormalClass();
+            Assert.Equal(instance.FullName, instance.Logger.Name);
+            Assert.Equal(instance.FullName, instance.LoggerType.Name);
+            Assert.Equal(instance.FullName, instance.LoggerGeneric.Name);
+        }
+
         [Fact]
         public void GenericGetLoggerTest()
         {
@@ -126,7 +152,6 @@ namespace NLog.UnitTests
             {
             }
         }
-
 
         [Fact]
         public void InvalidLoggerConfiguration_ThrowsConfigurationException_isFalse()


### PR DESCRIPTION
(and remove ´+´ for inner class, so NET4.5 behaves like NetCore 2.0). See #2181