### PR TITLE
New Substring, Left & Right Wrappers

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
@@ -31,49 +31,42 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Text;
+using NLog.Config;
+
 namespace NLog.LayoutRenderers.Wrappers
 {
-    using System;
-    using System.ComponentModel;
-    using NLog.Config;
-    using System.Text;
-
     /// <summary>
-    /// Substring the result
+    /// Left part of a text
     /// </summary>
-    /// <example>
-    /// ${substring:${level}:start=2:length=2} 
-    /// ${substring:${level}:start=-2:length=2} 
-    /// ${substring:Inner=${level}:start=2:length=2} 
-    /// </example>
-    [LayoutRenderer("substring")]
+    [LayoutRenderer("left")]
     [ThreadAgnostic]
-    public class SubstringLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    public class LeftLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
     {
+        private SubstringLayoutRendererWrapper substringWrapper;
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="UppercaseLayoutRendererWrapper" /> class.
+        /// New wrapper
         /// </summary>
-        public SubstringLayoutRendererWrapper()
+        public LeftLayoutRendererWrapper()
         {
-            Start = 0;
+            substringWrapper = new SubstringLayoutRendererWrapper();
         }
 
         /// <summary>
-        /// Gets or sets the start index. 
+        /// Gets or sets the length in characters. 
         /// </summary>
         /// <value>Index</value>
         /// <docgen category='Transformation Options' order='10' />
-        [DefaultValue(0)]
-        public int Start { get; set; }
-
-        /// <summary>
-        /// Gets or sets the length in characters. If <c>null</c>, then the whole string
-        /// </summary>
-        /// <value>Index</value>
-        /// <docgen category='Transformation Options' order='10' />
-        [DefaultValue(null)]
         [RequiredParameter]
-        public int? Length { get; set; }
+        public int Length
+        {
+            get { return substringWrapper.Length ?? 0; }
+            set { substringWrapper.Length = value; }
+        }
+
+
+        #region Overrides of WrapperLayoutRendererBuilderBase
 
         /// <summary>
         /// Transforms the output of another layout.
@@ -81,37 +74,9 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <param name="target">Output to be transform.</param>
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
-            TransformMessage(target);
+            substringWrapper.TransformMessage(target);
         }
 
-        /// <summary>
-        /// Change the <paramref name="target"/> for the formatting
-        /// </summary>
-        /// <param name="target">change this one</param>
-        internal void TransformMessage(StringBuilder target)
-        {
-            if (Length <= 0 || Start >= target.Length)
-            {
-                //clear everything - no .Clear on .NET 3.5
-                target.Length = 0;
-                return;
-            }
-
-            //start <0, then from end
-            if (Start < 0)
-            {
-                Start = (target.Length + Start);
-            }
-
-            if (Start > 0)
-            {
-                target.Remove(0, Start);
-            }
-
-            if (Length.HasValue && target.Length > Length.Value)
-            {
-                target.Remove(Length.Value, target.Length - Length.Value);
-            }
-        }
+        #endregion
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
@@ -1,5 +1,5 @@
 // 
-// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
 // 

--- a/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
@@ -69,7 +69,7 @@ namespace NLog.LayoutRenderers.Wrappers
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
             _substringWrapper.Inner = Inner;
-            _substringWrapper.DoSubstring(logEvent, builder);
+            _substringWrapper.DoSubstring(logEvent, builder, orgLength);
         }
 
         /// <inheritdoc />

--- a/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
@@ -41,16 +41,16 @@ namespace NLog.LayoutRenderers.Wrappers
     /// </summary>
     [LayoutRenderer("left")]
     [ThreadAgnostic]
-    public class LeftLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    public class LeftLayoutRendererWrapper : WrapperLayoutRendererBase
     {
-        private SubstringLayoutRendererWrapper substringWrapper;
+        private readonly SubstringLayoutRendererWrapper _substringWrapper;
 
         /// <summary>
         /// New wrapper
         /// </summary>
         public LeftLayoutRendererWrapper()
         {
-            substringWrapper = new SubstringLayoutRendererWrapper();
+            _substringWrapper = new SubstringLayoutRendererWrapper();
         }
 
         /// <summary>
@@ -61,22 +61,22 @@ namespace NLog.LayoutRenderers.Wrappers
         [RequiredParameter]
         public int Length
         {
-            get { return substringWrapper.Length ?? 0; }
-            set { substringWrapper.Length = value; }
+            get { return _substringWrapper.Length ?? 0; }
+            set { _substringWrapper.Length = value; }
         }
 
-
-        #region Overrides of WrapperLayoutRendererBuilderBase
-
-        /// <summary>
-        /// Transforms the output of another layout.
-        /// </summary>
-        /// <param name="target">Output to be transform.</param>
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        /// <inheritdoc />
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            substringWrapper.TransformMessage(target);
+            _substringWrapper.Inner = Inner;
+            _substringWrapper.DoSubstring(logEvent, builder);
         }
 
-        #endregion
+        /// <inheritdoc />
+        protected override string Transform(string text)
+        {
+            _substringWrapper.Inner = Inner;
+            return _substringWrapper.DoTransform(text);
+        }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
@@ -31,49 +31,46 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Text;
+using NLog.Config;
+
 namespace NLog.LayoutRenderers.Wrappers
 {
-    using System;
-    using System.ComponentModel;
-    using NLog.Config;
-    using System.Text;
-
     /// <summary>
-    /// Substring the result
+    /// Right part of a text
     /// </summary>
-    /// <example>
-    /// ${substring:${level}:start=2:length=2} 
-    /// ${substring:${level}:start=-2:length=2} 
-    /// ${substring:Inner=${level}:start=2:length=2} 
-    /// </example>
-    [LayoutRenderer("substring")]
+    [LayoutRenderer("right")]
     [ThreadAgnostic]
-    public class SubstringLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    public class RightLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
     {
+        private SubstringLayoutRendererWrapper substringWrapper;
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="UppercaseLayoutRendererWrapper" /> class.
+        /// New wrapper
         /// </summary>
-        public SubstringLayoutRendererWrapper()
+        public RightLayoutRendererWrapper()
         {
-            Start = 0;
+            substringWrapper = new SubstringLayoutRendererWrapper();
         }
 
         /// <summary>
-        /// Gets or sets the start index. 
+        /// Gets or sets the length in characters. 
         /// </summary>
         /// <value>Index</value>
         /// <docgen category='Transformation Options' order='10' />
-        [DefaultValue(0)]
-        public int Start { get; set; }
-
-        /// <summary>
-        /// Gets or sets the length in characters. If <c>null</c>, then the whole string
-        /// </summary>
-        /// <value>Index</value>
-        /// <docgen category='Transformation Options' order='10' />
-        [DefaultValue(null)]
         [RequiredParameter]
-        public int? Length { get; set; }
+        public int Length
+        {
+            get { return substringWrapper.Length ?? 0; }
+            set
+            {
+                substringWrapper.Length = value;
+                substringWrapper.Start = -value;
+            }
+        }
+
+
+        #region Overrides of WrapperLayoutRendererBuilderBase
 
         /// <summary>
         /// Transforms the output of another layout.
@@ -81,37 +78,9 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <param name="target">Output to be transform.</param>
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
-            TransformMessage(target);
+            substringWrapper.TransformMessage(target);
         }
 
-        /// <summary>
-        /// Change the <paramref name="target"/> for the formatting
-        /// </summary>
-        /// <param name="target">change this one</param>
-        internal void TransformMessage(StringBuilder target)
-        {
-            if (Length <= 0 || Start >= target.Length)
-            {
-                //clear everything - no .Clear on .NET 3.5
-                target.Length = 0;
-                return;
-            }
-
-            //start <0, then from end
-            if (Start < 0)
-            {
-                Start = (target.Length + Start);
-            }
-
-            if (Start > 0)
-            {
-                target.Remove(0, Start);
-            }
-
-            if (Length.HasValue && target.Length > Length.Value)
-            {
-                target.Remove(Length.Value, target.Length - Length.Value);
-            }
-        }
+        #endregion
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
@@ -1,5 +1,5 @@
 // 
-// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
 // 

--- a/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
@@ -41,16 +41,16 @@ namespace NLog.LayoutRenderers.Wrappers
     /// </summary>
     [LayoutRenderer("right")]
     [ThreadAgnostic]
-    public class RightLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    public class RightLayoutRendererWrapper : WrapperLayoutRendererBase
     {
-        private SubstringLayoutRendererWrapper substringWrapper;
+        private readonly SubstringLayoutRendererWrapper _substringWrapper;
 
         /// <summary>
         /// New wrapper
         /// </summary>
         public RightLayoutRendererWrapper()
         {
-            substringWrapper = new SubstringLayoutRendererWrapper();
+            _substringWrapper = new SubstringLayoutRendererWrapper();
         }
 
         /// <summary>
@@ -61,26 +61,27 @@ namespace NLog.LayoutRenderers.Wrappers
         [RequiredParameter]
         public int Length
         {
-            get { return substringWrapper.Length ?? 0; }
+            get { return _substringWrapper.Length ?? 0; }
             set
             {
-                substringWrapper.Length = value;
-                substringWrapper.Start = -value;
+                _substringWrapper.Length = value;
+                _substringWrapper.Start = -value;
             }
         }
 
 
-        #region Overrides of WrapperLayoutRendererBuilderBase
-
-        /// <summary>
-        /// Transforms the output of another layout.
-        /// </summary>
-        /// <param name="target">Output to be transform.</param>
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        /// <inheritdoc />
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            substringWrapper.TransformMessage(target);
+            _substringWrapper.Inner = Inner;
+            _substringWrapper.DoSubstring(logEvent, builder);
         }
 
-        #endregion
+        /// <inheritdoc />
+        protected override string Transform(string text)
+        {
+            _substringWrapper.Inner = Inner;
+            return _substringWrapper.DoTransform(text);
+        }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
@@ -74,7 +74,7 @@ namespace NLog.LayoutRenderers.Wrappers
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
             _substringWrapper.Inner = Inner;
-            _substringWrapper.DoSubstring(logEvent, builder);
+            _substringWrapper.DoSubstring(logEvent, builder, orgLength);
         }
 
         /// <inheritdoc />

--- a/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
@@ -78,17 +78,17 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc />
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            DoSubstring(logEvent, builder);
+            DoSubstring(logEvent, builder, orgLength);
         }
 
         /// <summary>
         /// Apply substring transformation
         /// </summary>
-        internal void DoSubstring(LogEventInfo logEvent, StringBuilder builder)
+        internal void DoSubstring(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
             if (Length <= 0)
             {
-                Clear(builder);
+                Clear(builder, orgLength);
                 return;
             }
             var text = RenderInner(logEvent);
@@ -99,7 +99,7 @@ namespace NLog.LayoutRenderers.Wrappers
             }
 
             var substring = Transform(text);
-            Clear(builder);
+            Clear(builder, orgLength);
             if (substring != null)
             {
                 builder.Append(substring);
@@ -131,10 +131,10 @@ namespace NLog.LayoutRenderers.Wrappers
             return substring;
         }
 
-        private static void Clear(StringBuilder builder)
+        private static void Clear(StringBuilder builder, int orgLength)
         {
             // No clear on .NET 3.5, also .Clear is just doing Length = 0
-            builder.Length = 0;
+            builder.Length = orgLength;
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
@@ -1,5 +1,5 @@
 // 
-// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
 // 

--- a/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
@@ -88,22 +88,14 @@ namespace NLog.LayoutRenderers.Wrappers
         {
             if (Length <= 0)
             {
-                Clear(builder, orgLength);
                 return;
             }
             var text = RenderInner(logEvent);
-
             if (text.Length == 0)
             {
                 return;
             }
-
-            var substring = Transform(text);
-            Clear(builder, orgLength);
-            if (substring != null)
-            {
-                builder.Append(substring);
-            }
+            SubstringAndAppend(text, builder);
         }
 
         /// <inheritdoc />
@@ -114,27 +106,27 @@ namespace NLog.LayoutRenderers.Wrappers
 
         internal string DoTransform(string text)
         {
+            var sb = new StringBuilder();
+            SubstringAndAppend(text, sb);
+            return sb.ToString();
+        }
+
+        private void SubstringAndAppend(string text, StringBuilder sb)
+        {
             var textLength = text.Length;
 
             var start = CalcStart(textLength);
 
             if (start >= textLength)
             {
-                return null;
+                return;
             }
 
             // init full length
             var length = CalcLength(textLength, start);
 
             //more efficient than target.Remove
-            var substring = text.Substring(start, length);
-            return substring;
-        }
-
-        private static void Clear(StringBuilder builder, int orgLength)
-        {
-            // No clear on .NET 3.5, also .Clear is just doing Length = 0
-            builder.Length = orgLength;
+            sb.Append(text, start, length);
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
@@ -1,0 +1,107 @@
+// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.LayoutRenderers.Wrappers
+{
+    using System;
+    using System.ComponentModel;
+    using NLog.Config;
+    using System.Text;
+
+    /// <summary>
+    /// Substring the result
+    /// </summary>
+    /// <remarks>
+    /// Same behavior as <see cref="string.Substring(int)"/> / <see cref="string.Substring(int, int)"/></remarks>
+    /// <example>
+    /// ${substring:${level}:start=2:length=2} //[DefaultParameter]
+    /// ${substring:Inner=${level}:start=2:length=2} 
+    /// </example>
+    [LayoutRenderer("substring")]
+    [AmbientProperty("Substring")]
+    [ThreadAgnostic]
+    public sealed class SubstringLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UppercaseLayoutRendererWrapper" /> class.
+        /// </summary>
+        public SubstringLayoutRendererWrapper()
+        {
+            Start = 0;
+        }
+
+        /// <summary>
+        /// Gets or sets the start index. 
+        /// </summary>
+        /// <value>Index</value>
+        /// <docgen category='Transformation Options' order='10' />
+        [DefaultValue(0)]
+        public int Start { get; set; }
+
+        /// <summary>
+        /// Gets or sets the length in characters. If <c>null</c>, then the whole string
+        /// </summary>
+        /// <value>Index</value>
+        /// <docgen category='Transformation Options' order='10' />
+        [DefaultValue(null)]
+        public int? Length { get; set; }
+
+        /// <summary>
+        /// Transforms the output of another layout.
+        /// </summary>
+        /// <param name="target">Output to be transform.</param>
+        protected override void TransformFormattedMesssage(StringBuilder target)
+        {
+
+            if (Length <= 0 || Start > target.Length)
+            {
+                //no .Clear on .NET 3.5
+                target.Length = 0;
+                return;
+            }
+
+            if (Start > 0)
+            {
+                target.Remove(0, Start);
+            }
+
+            if (Length.HasValue && target.Length > Length.Value)
+            {
+                target.Remove(Length.Value, target.Length - Length.Value);
+            }
+
+        }
+
+       
+    }
+}

--- a/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
@@ -93,6 +93,11 @@ namespace NLog.LayoutRenderers.Wrappers
             }
             var text = RenderInner(logEvent);
 
+            if (text.Length == 0)
+            {
+                return;
+            }
+
             var substring = Transform(text);
             Clear(builder);
             if (substring != null)

--- a/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
@@ -45,7 +45,7 @@ namespace NLog.LayoutRenderers.Wrappers
     /// <example>
     /// ${uppercase:${level}} //[DefaultParameter]
     /// ${uppercase:Inner=${level}} 
-    /// ${level:uppercase} // [AmbientProperty]
+    /// ${level:uppercase=true} // [AmbientProperty]
     /// </example>
     [LayoutRenderer("uppercase")]
     [AmbientProperty("Uppercase")]

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBase.cs
@@ -81,7 +81,8 @@ namespace NLog.LayoutRenderers.Wrappers
         /// </summary>
         /// <param name="logEvent">Logging event.</param>
         /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="orgLength">Start position for any necessary transformation of <see cref="StringBuilder"/>.</param>
+        /// <param name="orgLength">Start position for any necessary transformation of <see cref="StringBuilder"/>.
+        /// Don't change in the <paramref name="builder"/> before this position! That will has effect on others renderers.</param>
         protected virtual void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
             string msg = RenderInner(logEvent);

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/LeftLayoutRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/LeftLayoutRendererWrapperTests.cs
@@ -37,23 +37,17 @@ using Xunit.Extensions;
 
 namespace NLog.UnitTests.LayoutRenderers.Wrappers
 {
-    public class SubstringLayoutRendererWrapperTests
+    public class LeftLayoutRendererWrapperTests
     {
 
         [Theory]
         [InlineData(":length=2", "12")]
-        [InlineData(":length=2:start=1", "23")]
-        [InlineData(":length=2:start=100", "")]
-        [InlineData(":length=100", "1234567890")]
-        [InlineData("", "1234567890")]
-        [InlineData(":start=0", "1234567890")]
-        [InlineData(":start=-2:length=2", "90")]
-        [InlineData(":start=-2", "90")]
-        [InlineData(":start=-1:length=2", "0")] //won't take chars from start after starting at end.
+        [InlineData(":length=1000", "1234567890")]
         [InlineData(":length=-1", "")]
-        public void SubstringWrapperTest(string options, string expected)
+        [InlineData(":length=0", "")]
+        public void LeftWrapperTest(string options, string expected)
         {
-            SimpleLayout l = $"${{substring:${{message}}{options}}}";
+            SimpleLayout l = $"${{left:${{message}}{options}}}";
             var result = l.Render(LogEventInfo.Create(LogLevel.Debug, "substringTest", "1234567890"));
             Assert.Equal(expected, result);
         }

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/LeftLayoutRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/LeftLayoutRendererWrapperTests.cs
@@ -1,5 +1,5 @@
 // 
-// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
 // 

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/RightLayoutRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/RightLayoutRendererWrapperTests.cs
@@ -37,23 +37,17 @@ using Xunit.Extensions;
 
 namespace NLog.UnitTests.LayoutRenderers.Wrappers
 {
-    public class SubstringLayoutRendererWrapperTests
+    public class RightLayoutRendererWrapperTests
     {
 
         [Theory]
-        [InlineData(":length=2", "12")]
-        [InlineData(":length=2:start=1", "23")]
-        [InlineData(":length=2:start=100", "")]
-        [InlineData(":length=100", "1234567890")]
-        [InlineData("", "1234567890")]
-        [InlineData(":start=0", "1234567890")]
-        [InlineData(":start=-2:length=2", "90")]
-        [InlineData(":start=-2", "90")]
-        [InlineData(":start=-1:length=2", "0")] //won't take chars from start after starting at end.
+        [InlineData(":length=2", "90")]
         [InlineData(":length=-1", "")]
-        public void SubstringWrapperTest(string options, string expected)
+        [InlineData(":length=1000", "1234567890")]
+        [InlineData(":length=0", "")]
+        public void RightWrapperTest(string options, string expected)
         {
-            SimpleLayout l = $"${{substring:${{message}}{options}}}";
+            SimpleLayout l = $"${{right:${{message}}{options}}}";
             var result = l.Render(LogEventInfo.Create(LogLevel.Debug, "substringTest", "1234567890"));
             Assert.Equal(expected, result);
         }

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/RightLayoutRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/RightLayoutRendererWrapperTests.cs
@@ -1,5 +1,5 @@
 // 
-// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
 // 

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapperTests.cs
@@ -1,0 +1,60 @@
+// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using NLog.Layouts;
+using Xunit;
+using Xunit.Extensions;
+
+namespace NLog.UnitTests.LayoutRenderers.Wrappers
+{
+    public class SubstringLayoutRendererWrapperTests
+    {
+
+        [Theory]
+        [InlineData(":length=2","12")]
+        [InlineData(":length=2:start=1","23")]
+        [InlineData(":length=2:start=100","")]
+        [InlineData(":length=100", "1234567890")]
+        [InlineData("", "1234567890")]
+        [InlineData(":start=0", "1234567890")]
+        [InlineData(":start=-1", "1234567890")]
+        [InlineData(":length=-1", "")]
+        public void SubstringWrapperTest(string options, string expected)
+        {
+            SimpleLayout l = $"${{substring:${{message}}{options}}}";
+            var result = l.Render(LogEventInfo.Create(LogLevel.Debug, "substringTest", "1234567890"));
+            Assert.Equal(expected, result);
+        }
+
+    }
+}

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapperTests.cs
@@ -1,5 +1,5 @@
 // 
-// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
 // 

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapperTests.cs
@@ -42,6 +42,8 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
 
         [Theory]
         [InlineData(":length=2", "12")]
+        [InlineData(":length=3", "before123", "before")]
+        [InlineData(":length=3", "before123end", "before", "end")]
         [InlineData(":length=2:start=1", "23")]
         [InlineData(":length=2:start=100", "")]
         [InlineData(":length=100", "1234567890")]
@@ -51,12 +53,11 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
         [InlineData(":start=-2", "90")]
         [InlineData(":start=-1:length=2", "0")] //won't take chars from start after starting at end.
         [InlineData(":length=-1", "")]
-        public void SubstringWrapperTest(string options, string expected)
+        public void SubstringWrapperTest(string options, string expected, string prefixText = null, string afterText = null)
         {
-            SimpleLayout l = $"${{substring:${{message}}{options}}}";
+            SimpleLayout l = $"{prefixText}${{substring:${{message}}{options}}}{afterText}";
             var result = l.Render(LogEventInfo.Create(LogLevel.Debug, "substringTest", "1234567890"));
             Assert.Equal(expected, result);
         }
-
     }
 }


### PR DESCRIPTION
Examples:
```c#
${substring:${level}:start=2:length=2}    // from index 2, length 2
${substring:${level}:start=-2:length=2}   // from end -2, length 2
${left:${level}:length=2}    // from start, length 2
${right:${level}:length=2}   // from end, length 2
```


- [x] negative start -> measure for end
- [x] negative length? -> empty result
- [x] use WrapperLayoutRendererBase
- [x] review notes