### PR TITLE
Codecov less picky

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,12 @@ coverage:
     patch:
       default:
         target: 50
+    project:                  
+      default:
+        enabled: yes
+        threshold: 1
+
 comment:
   layout: "header, diff, changes, sunburst, uncovered"
   branches: null
+


### PR DESCRIPTION
Something the coverage is not 100% correct due too timings/threadings in the tests.

This will result in errors, even when there are no source changes:

![image](https://user-images.githubusercontent.com/5808377/27762428-3ef8cb5c-5e72-11e7-9c7b-c0850a990a53.png)
