### PR TITLE
Allow configuring type of parameters for the database target (including fix for Oracle)

### DIFF
--- a/src/NLog/Targets/DatabaseParameterInfo.cs
+++ b/src/NLog/Targets/DatabaseParameterInfo.cs
@@ -98,6 +98,15 @@ namespace NLog.Targets
         /// <docgen category='Parameter Options' order='10' />
         [DefaultValue(0)]
         public byte Scale { get; set; }
+
+        /// <summary>
+        /// Gets or sets the column type of the database.
+        /// if <c>null</c> then string/varchar type is used
+        /// </summary>
+        /// <docgen category='Parameter Options' order='10' />
+        [DefaultValue(null)]
+        public string DbType { get; set; }
+
     }
 }
 

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -31,6 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
 
 namespace NLog.Targets
@@ -295,6 +296,15 @@ namespace NLog.Targets
 
         internal IDbConnection OpenConnection(string connectionString)
         {
+            var connection = CreateConnection();
+
+            connection.ConnectionString = connectionString;
+            connection.Open();
+            return connection;
+        }
+
+        internal IDbConnection CreateConnection()
+        {
             IDbConnection connection;
 
             if (this.ProviderFactory != null)
@@ -305,9 +315,6 @@ namespace NLog.Targets
             {
                 connection = (IDbConnection)Activator.CreateInstance(this.ConnectionType);
             }
-
-            connection.ConnectionString = connectionString;
-            connection.Open();
             return connection;
         }
 
@@ -344,7 +351,7 @@ namespace NLog.Targets
                     this.ProviderFactory = DbProviderFactories.GetFactory(cs.ProviderName);
                     foundProvider = true;
                 }
-            
+
             }
 
             if (!foundProvider)
@@ -516,53 +523,236 @@ namespace NLog.Targets
             {
                 this.EnsureConnectionOpen(this.BuildConnectionString(logEvent));
 
-                using (IDbCommand command = this.activeConnection.CreateCommand())
+                using (var command = CreateCommand(logEvent, this.activeConnection))
                 {
-                    command.CommandText = base.RenderLogEvent(this.CommandText, logEvent);
-                    command.CommandType = this.CommandType;
-
-                    InternalLogger.Trace("Executing {0}: {1}", command.CommandType, command.CommandText);
-
-                    foreach (DatabaseParameterInfo par in this.Parameters)
-                    {
-                        IDbDataParameter p = command.CreateParameter();
-                        p.Direction = ParameterDirection.Input;
-                        if (par.Name != null)
-                        {
-                            p.ParameterName = par.Name;
-                        }
-
-                        if (par.Size != 0)
-                        {
-                            p.Size = par.Size;
-                        }
-
-                        if (par.Precision != 0)
-                        {
-                            p.Precision = par.Precision;
-                        }
-
-                        if (par.Scale != 0)
-                        {
-                            p.Scale = par.Scale;
-                        }
-
-                        string stringValue = base.RenderLogEvent(par.Layout, logEvent);
-
-                        p.Value = stringValue;
-                        command.Parameters.Add(p);
-
-                        InternalLogger.Trace("  Parameter: '{0}' = '{1}' ({2})", p.ParameterName, p.Value, p.DbType);
-                    }
-
                     int result = command.ExecuteNonQuery();
                     InternalLogger.Trace("Finished execution, result = {0}", result);
-                }
 
-                //not really needed as there is no transaction at all.
-                transactionScope.Complete();
+                    //not really needed as there is no transaction at all.
+                    transactionScope.Complete();
+                }
             }
         }
+
+        internal IDbCommand CreateCommand(LogEventInfo logEvent, IDbConnection dbConnection)
+        {
+            IDbCommand command = dbConnection.CreateCommand();
+            command.CommandText = this.CommandText.Render(logEvent);
+            command.CommandType = this.CommandType;
+
+            InternalLogger.Trace("Executing {0}: {1}", command.CommandType, command.CommandText);
+
+            foreach (DatabaseParameterInfo par in this.Parameters)
+            {
+                IDbDataParameter p = command.CreateParameter();
+                p.Direction = ParameterDirection.Input;
+                if (par.Name != null)
+                {
+                    p.ParameterName = par.Name;
+                }
+
+                if (par.Size != 0)
+                {
+                    p.Size = par.Size;
+                }
+
+                if (par.Precision != 0)
+                {
+                    p.Precision = par.Precision;
+                }
+
+                if (par.Scale != 0)
+                {
+                    p.Scale = par.Scale;
+                }
+
+                string stringValue = base.RenderLogEvent(par.Layout, logEvent);
+
+                p.Value = stringValue;
+                SetParamType(p, par.DbType);
+                command.Parameters.Add(p);
+
+                InternalLogger.Trace("  Parameter: '{0}' = '{1}' ({2})", p.ParameterName, p.Value, p.DbType);
+            }
+            return command;
+        }
+
+        /// <summary>
+        /// Set database type <paramref name="dbType"/> on <paramref name="dbDataParameter"/>
+        /// </summary>
+        /// <param name="dbDataParameter">The parameter.</param>
+        /// <param name="dbType"></param>
+        internal void SetParamType(IDbDataParameter dbDataParameter, string dbType)
+        {
+            if (string.IsNullOrEmpty(dbType))
+                return;
+
+            var parsedDbTyped = EnumNameParseResult.Parse(dbType, dbDataParameter.GetType());
+
+            if (parsedDbTyped != null)
+            {
+                // Get just the fully qualified name of the enum but not the value
+
+                try
+                {
+                    // check first to see if this is DbType otherwise use reflection to get it from the database parameter's assembly
+                    string enumName = parsedDbTyped.EnumName;
+                    var databaseType = parsedDbTyped.GetDatabaseType(enumName);
+                    var enumValueObject = parsedDbTyped.GetEnumValueObject(databaseType);
+
+
+                    //if its a DbType then we can just set it
+                    if (databaseType == typeof(DbType))
+                    {
+                        dbDataParameter.DbType = (DbType)enumValueObject;
+                    }
+                    else
+                    {
+                        // Each custom database type that we want to support will need added here on as needed basis
+                        string propertyName = TryDbType(dbType, "OracleDbType") ?? TryDbType(dbType, "SqlDbType");
+
+                        if (propertyName == null)
+                        {
+                            // we only support additional database types by custom implementation
+                            var exception = new NLogConfigurationException("Custom setting of the database type is not supported for: " +
+                                                                           dbType);
+                            InternalLogger.Error(exception, "Custom setting of the database type is not supported for: {0}", dbType);
+                            if (exception.MustBeRethrown())
+                            {
+                                throw exception;
+                            }
+                            return;
+                        }
+
+                        // find the property on the database specific parameter
+                        var property = dbDataParameter.GetType().GetProperty(propertyName);
+
+                        // if something went wrong with the reflection a bad value was probably set and we can't fix that
+                        if (enumValueObject == null || property == null)
+                        {
+                            var exception = new NLogConfigurationException("Unable set the database type from the database parameter for DbType: "
+                                                                           + dbType);
+                            InternalLogger.Error(exception, "Unable set the database type from the database parameter for DbType: {0}", dbType);
+                            if (exception.MustBeRethrown())
+                            {
+                                throw exception;
+                            }
+                            return;
+                        }
+
+                        // we find the enum and the property ok so now we just set it using reflection
+                        property.SetValue(dbDataParameter, enumValueObject, null);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    InternalLogger.Warn(exception, "DatabaseTarget: unable to use {0} to set database column type.", parsedDbTyped.EnumName);
+                    if (exception.MustBeRethrown())
+                    {
+                        throw;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Test DB type. If OK, returns <paramref name="dbTypeName"/> otherwise <c>null</c>.
+        /// </summary>
+        /// <param name="fullType"></param>
+        /// <param name="dbTypeName">dbtype/propertyname</param>
+        /// <returns></returns>
+        private static string TryDbType(string fullType, string dbTypeName)
+        {
+            var result = fullType.StartsWith(string.Format("{0}.", dbTypeName)) || fullType.Contains(string.Format(".{0}.", dbTypeName));
+            return !result ? null : dbTypeName;
+        }
+
+        private class EnumNameParseResult
+        {
+            /// <summary>
+            /// Name of the enum without value
+            /// </summary>
+            public string EnumName { get; private set; }
+            public string EnumValue { get; private set; }
+
+            /// <summary>
+            /// Full name
+            /// </summary>
+            public string FullName { get; private set; }
+
+            /// <summary>
+            /// Name of assembly. Could be <c>null</c>.
+            /// </summary>
+            public AssemblyName AssemblyName { get; private set; }
+
+
+            public static EnumNameParseResult Parse(string name, Type parameterType)
+            {
+                EnumNameParseResult result = new EnumNameParseResult();
+                result.FullName = name;
+                var indexOfAssmemblySeparator = name.IndexOf(',');
+                if (indexOfAssmemblySeparator > 0)
+                {
+                    var assemblyName = name.Substring(indexOfAssmemblySeparator + 1).Trim();
+                    result.AssemblyName = new AssemblyName(assemblyName);
+                }
+                else
+                {
+                    result.AssemblyName = parameterType.Assembly.GetName();
+                }
+                int lastIndexOfDot;
+                if (indexOfAssmemblySeparator < 0)
+                {
+                    indexOfAssmemblySeparator = name.Length;
+                    lastIndexOfDot = name.LastIndexOf('.');
+                }
+                else
+                {
+                    lastIndexOfDot = name.LastIndexOf('.', indexOfAssmemblySeparator);
+                }
+                if (lastIndexOfDot > 0) result.EnumName = name.Substring(0, lastIndexOfDot);
+                else
+                {
+                    return null;
+                }
+                //todo
+                result.EnumValue = name.Substring(lastIndexOfDot + 1, indexOfAssmemblySeparator - lastIndexOfDot - 1);
+                return result;
+            }
+
+            public object GetEnumValueObject(Type getDatabaseType)
+            {
+
+                var enumDatabaseType = getDatabaseType;
+
+                // get the enum value for the database type
+                var enumValueString = EnumValue;
+                var typeField = enumDatabaseType != null ? enumDatabaseType.GetField(enumValueString) : null;
+                var enumValueObject = typeField != null ? typeField.GetRawConstantValue() : null;
+                return enumValueObject;
+            }
+
+            public Type GetDatabaseType(string enumName)
+            {
+                Type enumDatabaseType;
+                if (IsDbType(enumName))
+                {
+                    enumDatabaseType = typeof(DbType);
+                }
+                else
+                {
+                    var assembly = this.AssemblyName == null ? Assembly.GetCallingAssembly() : Assembly.Load(this.AssemblyName);
+                    enumDatabaseType = assembly.GetType(enumName);
+                }
+                return enumDatabaseType;
+            }
+
+            private static bool IsDbType(string enumName)
+            {
+                return enumName == typeof(DbType).FullName;
+            }
+        }
+
         /// <summary>
         /// Build the connectionstring from the properties. 
         /// </summary>


### PR DESCRIPTION
supersedes https://github.com/NLog/NLog/pull/1435
TODO:
- [ ] use the DB type configured in the config instead of typescanning
- [ ] scan for type at init, not at write
- [ ] implement for all DB types: 
  - [ ]  System.Data.EntityClient.EntityParameter
  - [ ] System.Data.Odbc.OdbcParameter
  - [ ] System.Data.OleDb.OleDbParameter
  - [ ] System.Data.OracleClient.OracleParameter
  - [ ] System.Data.SqlClient.SqlParameter
- [ ] parse DB type when parsing config (not on logging)
- [ ] check if parse type is needed
- [ ] create testcase for at least int, bit and oracletype
- [ ] create testcase with .mdf file.
- [ ] add integration tests .

Discuss:
- Maybe 2nd parameter to distinguish DBType vs **x**DbType (e.g. SqlDbType, OracleDbType)?

supersedes https://github.com/NLog/NLog/pull/1194

thanks to @sorvis