### PR TITLE
Added Structured events / Message Templates

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -205,6 +205,41 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Gets or sets the string serializer to use with <see cref="LogEventInfo.MessageTemplateParameters"/>
+        /// </summary>
+        public IValueSerializer ValueSerializer
+        {
+            get { return MessageTemplates.ValueSerializer.Instance; }
+            set { MessageTemplates.ValueSerializer.Instance = value; }
+        }
+
+        /// <summary>
+        /// Perform mesage template parsing and formatting of LogEvent messages (True = Always, False = Never, Null = Auto Detect)
+        /// </summary>
+        public bool? EnableMessageTemplateParser
+        {
+            get
+            {
+                if (ReferenceEquals(LogEventInfo.DefaultMessageFormatter, LogEventInfo.StringFormatMessageFormatter))
+                {
+                    return false;
+                }
+                else if (ReferenceEquals(LogEventInfo.DefaultMessageFormatter, LogMessageTemplateFormatter.Default.MessageFormatter))
+                {
+                    return true;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            set
+            {
+                LogEventInfo.SetDefaultMessageFormatter(value);
+            }
+        }
+
+        /// <summary>
         /// Gets the time source factory.
         /// </summary>
         /// <value>The time source factory.</value>
@@ -221,8 +256,6 @@ namespace NLog.Config
         {
             get { return this.conditionMethods; }
         }
-
-
 
         /// <summary>
         /// Registers named items from the assembly.

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -595,6 +595,9 @@ namespace NLog.Config
             InternalLogger.LogToConsoleError = nlogElement.GetOptionalBooleanAttribute("internalLogToConsoleError", InternalLogger.LogToConsoleError);
             InternalLogger.LogFile = nlogElement.GetOptionalAttribute("internalLogFile", InternalLogger.LogFile);
 
+            bool? messageTemplateParser = nlogElement.GetOptionalBooleanAttribute("messageTemplateParser", null);
+            this.ConfigurationItemFactory.EnableMessageTemplateParser = messageTemplateParser;
+
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
             InternalLogger.LogToTrace = nlogElement.GetOptionalBooleanAttribute("internalLogToTrace", InternalLogger.LogToTrace);
 #endif

--- a/src/NLog/IValueSerializer.cs
+++ b/src/NLog/IValueSerializer.cs
@@ -1,0 +1,54 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Text;
+
+namespace NLog
+{
+    /// <summary>
+    /// Interface for serialization of object values into string format
+    /// </summary>
+    public interface IValueSerializer
+    {
+        /// <summary>
+        /// Serialization of an object into JSON format.
+        /// </summary>
+        /// <param name="value">The object to serialize to string.</param>
+        /// <param name="format">A standard or custom object format string</param>
+        /// <param name="formatProvider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="builder">Output destination.</param>
+        /// <returns>Serialize succeeded (true/false)</returns>
+        bool SerializeObject(object value, string format, IFormatProvider formatProvider, StringBuilder builder);
+    }
+}

--- a/src/NLog/Internal/ILogMessageFormatter.cs
+++ b/src/NLog/Internal/ILogMessageFormatter.cs
@@ -1,0 +1,57 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal
+{
+    using System;
+
+    /// <summary>
+    /// Format a log message
+    /// </summary>
+    internal interface ILogMessageFormatter
+    {
+        /// <summary>
+        /// Format the message and return
+        /// </summary>
+        /// <param name="logEvent">LogEvent with message to be formatted</param>
+        /// <returns>formatted message</returns>
+        string FormatMessage(LogEventInfo logEvent);
+
+        /// <summary>
+        /// Has the logevent properties?
+        /// </summary>
+        /// <param name="logEvent">LogEvent with message to be formatted</param>
+        /// <returns>formatted message</returns>
+        bool HasProperties(LogEventInfo logEvent);
+    }
+}

--- a/src/NLog/Internal/LogMessageTemplateFormatter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatter.cs
@@ -1,0 +1,101 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal
+{
+    using System;
+    using System.Globalization;
+    using NLog.MessageTemplates;
+
+    internal sealed class LogMessageTemplateFormatter : ILogMessageFormatter
+    {
+        public static readonly LogMessageTemplateFormatter DefaultAuto = new LogMessageTemplateFormatter(false);
+        public static readonly LogMessageTemplateFormatter Default = new LogMessageTemplateFormatter(true);
+        private static readonly StringBuilderPool _builderPool = new StringBuilderPool(Environment.ProcessorCount * 2);
+
+        /// <summary>
+        /// When true: Do not fallback to StringBuilder.Format for positional templates
+        /// </summary>
+        private readonly bool _forceTemplateRenderer;
+
+        /// <summary>
+        /// New formatter
+        /// </summary>
+        /// <param name="forceTemplateRenderer">When true: Do not fallback to StringBuilder.Format for positional templates</param>
+        private LogMessageTemplateFormatter(bool forceTemplateRenderer)
+        {
+            _forceTemplateRenderer = forceTemplateRenderer;
+            MessageFormatter = FormatMessage;
+        }
+
+        /// <summary>
+        /// The MessageFormatter delegate
+        /// </summary>
+        public LogMessageFormatter MessageFormatter { get; }
+
+        public bool HasProperties(LogEventInfo logEvent)
+        {
+            //if message is empty, there no parameters
+            //null check cheapest, so in-front
+            return logEvent.Parameters != null && !string.IsNullOrEmpty(logEvent.Message) && logEvent.Parameters.Length > 0;
+        }
+
+        public string FormatMessage(LogEventInfo logEvent)
+        {
+            if (!HasProperties(logEvent))
+            {
+                return logEvent.Message;
+            }
+            // Prevent multiple layouts on different targets to render the same properties
+            lock (logEvent)
+            {
+                using (var builder = _builderPool.Acquire())
+                {
+                    logEvent.Message.Render(logEvent.FormatProvider ?? CultureInfo.CurrentCulture, logEvent.Parameters, _forceTemplateRenderer, builder.Item, out var messageTemplateParameterList);
+                    if (logEvent.PropertiesDictionary == null)
+                    {
+                        if (messageTemplateParameterList != null && messageTemplateParameterList.Count > 0)
+                        {
+                            logEvent.PropertiesDictionary = new PropertiesDictionary(messageTemplateParameterList);
+                        }
+                    }
+                    else
+                    {
+                        logEvent.PropertiesDictionary.MessageProperties = messageTemplateParameterList;
+                    }
+                    return builder.Item.ToString();
+                }
+            }
+        }
+    }
+}

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -52,31 +52,15 @@ namespace NLog.Internal
         /// <param name="formatProvider">provider, for example culture</param>
         public static void AppendFormattedValue(this StringBuilder builder, object value, string format, IFormatProvider formatProvider)
         {
-            if (format == "@")
+            string stringValue = value as string;
+            if (stringValue != null && string.IsNullOrEmpty(format))
             {
-                Config.ConfigurationItemFactory.Default.JsonConverter.SerializeObject(value, builder);
-                return;
+                builder.Append(value);  // Avoid automatic quotes
             }
-
-            if (value == null)
+            else if (value != null || !string.IsNullOrEmpty(format))
             {
-                return;
+                MessageTemplates.ValueSerializer.Instance.SerializeObject(value, format, formatProvider, builder);
             }
-
-            if (format == null)
-            {
-                builder.Append(Convert.ToString(value, formatProvider));
-                return;
-            }
-
-            var formattable = value as IFormattable;
-            if (formattable != null)
-            {
-                builder.Append(formattable.ToString(format, formatProvider));
-                return;
-            }
-
-            builder.Append(Convert.ToString(value, formatProvider));
         }
 
         /// <summary>

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -169,14 +169,19 @@ namespace NLog.Internal
 #if !SILVERLIGHT
             if (transformBuffer != null)
             {
+                int charCount = 0;
+                int byteCount = 0;
                 for (int i = 0; i < builder.Length; i += transformBuffer.Length)
                 {
-                    int charCount = Math.Min(builder.Length - i, transformBuffer.Length);
+                    charCount = Math.Min(builder.Length - i, transformBuffer.Length);
                     builder.CopyTo(i, transformBuffer, 0, charCount);
-                    int byteCount = encoding.GetByteCount(transformBuffer, 0, charCount);
-                    ms.SetLength(ms.Length + byteCount);
-                    encoding.GetBytes(transformBuffer, 0, charCount, ms.GetBuffer(), (int)ms.Position);
-                    ms.Position = ms.Length;
+                    byteCount = encoding.GetMaxByteCount(charCount);
+                    ms.SetLength(ms.Position + byteCount);
+                    byteCount = encoding.GetBytes(transformBuffer, 0, charCount, ms.GetBuffer(), (int)ms.Position);
+                    if ((ms.Position += byteCount) != ms.Length)
+                    {
+                        ms.SetLength(ms.Position);
+                    }
                 }
             }
             else

--- a/src/NLog/Internal/StringBuilderPool.cs
+++ b/src/NLog/Internal/StringBuilderPool.cs
@@ -1,0 +1,141 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal
+{
+    using System;
+    using System.Text;
+    using System.Threading;
+
+    internal class StringBuilderPool
+    {
+        private StringBuilder _fastPool;
+        private readonly StringBuilder[] _slowPool;
+        private readonly int _maxBuilderCapacity;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="poolCapacity">Max number of items</param>
+        /// <param name="initialBuilderCapacity">Initial StringBuilder Size</param>
+        /// <param name="maxBuilderCapacity">Max StringBuilder Size</param>
+        public StringBuilderPool(int poolCapacity, int initialBuilderCapacity = 16 * 1024, int maxBuilderCapacity = 512 * 1024)
+        {
+            _fastPool = new StringBuilder(initialBuilderCapacity);
+            _slowPool = new StringBuilder[poolCapacity];
+            for (int i = 0; i < _slowPool.Length; ++i)
+            {
+                _slowPool[i] = new StringBuilder(initialBuilderCapacity);
+            }
+            _maxBuilderCapacity = maxBuilderCapacity;
+        }
+
+        /// <summary>
+        /// Takes StringBuilder from pool
+        /// </summary>
+        /// <returns>Allow return to pool</returns>
+        public ItemHolder Acquire()
+        {
+            StringBuilder item = _fastPool;
+            if (item == null || item != Interlocked.CompareExchange(ref _fastPool, null, item))
+            {
+                for (int i = 0; i < _slowPool.Length; i++)
+                {
+                    item = _slowPool[i];
+                    if (item != null && item == Interlocked.CompareExchange(ref _slowPool[i], null, item))
+                    {
+                        return new ItemHolder(item, this, i);
+                    }
+                }
+
+                return new ItemHolder(new StringBuilder(), null, 0);
+            }
+            else
+            {
+                return new ItemHolder(item, this, -1);
+            }
+        }
+
+        /// <summary>
+        /// Releases StringBuilder back to pool at its right place
+        /// </summary>
+        private void Release(StringBuilder stringBuilder, int poolIndex)
+        {
+            if (stringBuilder.Length > _maxBuilderCapacity)
+            {
+                stringBuilder = new StringBuilder(_maxBuilderCapacity / 2);
+            } 
+            else
+            {
+                stringBuilder.Length = 0;
+            }
+
+            if (poolIndex == -1)
+            {
+                _fastPool = stringBuilder;
+            }
+            else
+            {
+                _slowPool[poolIndex] = stringBuilder;
+            }
+        }
+
+        /// <summary>
+        /// Keeps track of acquired pool item
+        /// </summary>
+        public struct ItemHolder : IDisposable
+        {
+            public readonly StringBuilder Item;
+            readonly StringBuilderPool _owner;
+            readonly int _poolIndex;
+
+            public ItemHolder(StringBuilder stringBuilder, StringBuilderPool owner, int poolIndex)
+            {
+                Item = stringBuilder;
+                _owner = owner;
+                _poolIndex = poolIndex;
+            }
+
+            /// <summary>
+            /// Releases pool item back into pool
+            /// </summary>
+            public void Dispose()
+            {
+                if (_owner != null)
+                {
+                    _owner.Release(Item, _poolIndex);
+                }
+            }
+        }
+    }
+}

--- a/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
@@ -64,11 +64,12 @@ namespace NLog.LayoutRenderers.Wrappers
         /// Renders the inner layout contents.
         /// </summary>
         /// <param name="logEvent">The log event.</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
+            int orgLength = target.Length;
             base.RenderFormattedMessage(logEvent, target);
-            if (target.Length > 0)
+            if (target.Length > orgLength)
                 return;
 
             // render WhenEmpty when the inner layout was empty

--- a/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
@@ -73,7 +73,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// Renders the inner layout contents.
         /// </summary>
         /// <param name="logEvent">The log event.</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             if (this.When == null || true.Equals(this.When.Evaluate(logEvent)))

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
@@ -42,9 +42,6 @@ namespace NLog.LayoutRenderers.Wrappers
     /// </summary>
     public abstract class WrapperLayoutRendererBuilderBase : WrapperLayoutRendererBase
     {
-        private const int MaxInitialRenderBufferLength = 16384;
-        private int maxRenderedLength;
-
         /// <summary>
         /// Render to local target using Inner Layout, and then transform before final append
         /// </summary>
@@ -52,19 +49,9 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <param name="logEvent"></param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            int initialLength = this.maxRenderedLength;
-            if (initialLength > MaxInitialRenderBufferLength)
-            {
-                initialLength = MaxInitialRenderBufferLength;
-            }
-
-            using (var localTarget = new Internal.AppendBuilderCreator(builder, initialLength))
+            using (var localTarget = new Internal.AppendBuilderCreator(builder, true))
             {
                 RenderFormattedMessage(logEvent, localTarget.Builder);
-                if (localTarget.Builder.Length > this.maxRenderedLength)
-                {
-                    this.maxRenderedLength = localTarget.Builder.Length;
-                }
                 TransformFormattedMesssage(localTarget.Builder);
             }
         }
@@ -79,7 +66,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// Renders the inner layout contents.
         /// </summary>
         /// <param name="logEvent">Logging</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
         protected virtual void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             this.Inner.RenderAppendBuilder(logEvent, target);

--- a/src/NLog/Layouts/CompoundLayout.cs
+++ b/src/NLog/Layouts/CompoundLayout.cs
@@ -83,7 +83,7 @@ namespace NLog.Layouts
         /// Formats the log event relying on inner layouts.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             //Memory profiling pointed out that using a foreach-loop was allocating

--- a/src/NLog/Layouts/CsvLayout.cs
+++ b/src/NLog/Layouts/CsvLayout.cs
@@ -182,7 +182,7 @@ namespace NLog.Layouts
         /// Formats the log event for write.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             RenderAllColumns(logEvent, target);
@@ -295,7 +295,7 @@ namespace NLog.Layouts
             /// Renders the layout for the specified logging event by invoking layout renderers.
             /// </summary>
             /// <param name="logEvent">The logging event.</param>
-            /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+            /// <param name="target"><see cref="StringBuilder"/> for the result</param>
             protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
             {
                 this.parent.RenderHeader(target);

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -138,11 +138,12 @@ namespace NLog.Layouts
         /// Formats the log event as a JSON document for writing.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
+            int orgLength = target.Length;
             RenderJsonFormattedMessage(logEvent, target);
-            if (target.Length == 0 && RenderEmptyObject)
+            if (target.Length == orgLength && RenderEmptyObject)
             {
                 target.Append(SuppressSpaces ? "{}" : "{  }");
             }
@@ -160,15 +161,17 @@ namespace NLog.Layouts
 
         private void RenderJsonFormattedMessage(LogEventInfo logEvent, StringBuilder sb)
         {
+            int orgLength = sb.Length;
+
             //Memory profiling pointed out that using a foreach-loop was allocating
             //an Enumerator. Switching to a for-loop avoids the memory allocation.
             for (int i = 0; i < this.Attributes.Count; i++)
             {
                 var attrib = this.Attributes[i];
-                string text = attrib.LayoutWrapper.Render(logEvent);
-                if (!string.IsNullOrEmpty(text))
+                int beforeAttribLength = sb.Length;
+                if (!RenderAppendJsonPropertyValue(attrib, logEvent, false, sb, sb.Length == orgLength))
                 {
-                    AppendJsonAttributeValue(attrib.Name, attrib.Encode, text, sb);
+                    sb.Length = beforeAttribLength;
                 }
             }
 
@@ -179,7 +182,7 @@ namespace NLog.Layouts
                     if (string.IsNullOrEmpty(key))
                         continue;
                     object propertyValue = MappedDiagnosticsContext.GetObject(key);
-                    AppendJsonPropertyValue(key, propertyValue, sb);
+                    AppendJsonPropertyValue(key, propertyValue, sb, sb.Length == orgLength);
                 }
             }
 
@@ -191,7 +194,7 @@ namespace NLog.Layouts
                     if (string.IsNullOrEmpty(key))
                         continue;
                     object propertyValue = MappedDiagnosticsLogicalContext.GetObject(key);
-                    AppendJsonPropertyValue(key, propertyValue, sb);
+                    AppendJsonPropertyValue(key, propertyValue, sb, sb.Length == orgLength);
                 }
             }
 #endif
@@ -209,17 +212,17 @@ namespace NLog.Layouts
                     if (this.ExcludeProperties.Contains(propName))
                         continue;
 
-                    AppendJsonPropertyValue(propName, prop.Value, sb);
+                    AppendJsonPropertyValue(propName, prop.Value, sb, sb.Length == orgLength);
                 }
             }
 
-            CompleteJsonMessage(sb);
+            if (sb.Length > orgLength)
+                CompleteJsonMessage(sb);
         }
 
-        private void BeginJsonProperty(StringBuilder sb, string propName)
+        private void BeginJsonProperty(StringBuilder sb, string propName, bool beginJsonMessage)
         {
-            bool first = sb.Length == 0;
-            if (first)
+            if (beginJsonMessage)
             {
                 sb.Append(SuppressSpaces ? "{" : "{ ");
             }
@@ -240,34 +243,34 @@ namespace NLog.Layouts
 
         private void CompleteJsonMessage(StringBuilder sb)
         {
-            if (sb.Length > 0)
-                sb.Append(SuppressSpaces ? "}" : " }");
+            sb.Append(SuppressSpaces ? "}" : " }");
         }
 
-        private void AppendJsonPropertyValue(string propName, object propertyValue, StringBuilder sb)
+        private void AppendJsonPropertyValue(string propName, object propertyValue, StringBuilder sb, bool beginJsonMessage)
         {
-            BeginJsonProperty(sb, propName);
+            BeginJsonProperty(sb, propName, beginJsonMessage);
             JsonConverter.SerializeObject(propertyValue, sb);
         }
 
-        private void AppendJsonAttributeValue(string attributeName, bool attributeQuote, string text, StringBuilder sb)
+        private bool RenderAppendJsonPropertyValue(JsonAttribute attrib, LogEventInfo logEvent, bool renderEmptyValue, StringBuilder sb, bool beginJsonMessage)
         {
-            BeginJsonProperty(sb, attributeName);
-
-            if (attributeQuote)
+            BeginJsonProperty(sb, attrib.Name, beginJsonMessage);
+            if (attrib.Encode)
             {
                 // "\"{0}\":{1}\"{2}\""
                 sb.Append('"');
-                sb.Append(text);
+            }
+            int beforeValueLength = sb.Length;
+            attrib.LayoutWrapper.RenderAppendBuilder(logEvent, sb);
+            if (!renderEmptyValue && beforeValueLength == sb.Length)
+            {
+                return false;
+            }
+            if (attrib.Encode)
+            {
                 sb.Append('"');
             }
-            else
-            {
-                //If encoding is disabled for current attribute, do not escape the value of the attribute.
-                //This enables user to write arbitrary string value (including JSON).
-                // "\"{0}\":{1}{2}"
-                sb.Append(text);
-            }
+            return true;
         }
     }
 }

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -175,20 +175,11 @@ namespace NLog.Layouts
                 }
             }
 
-            int initialLength = this.maxRenderedLength;
-            if (initialLength > MaxInitialRenderBufferLength)
-            {
-                initialLength = MaxInitialRenderBufferLength;
-            }
-
-            using (var localTarget = new AppendBuilderCreator(target, initialLength))
+            cacheLayoutResult = cacheLayoutResult && !this.ThreadAgnostic;
+            using (var localTarget = new AppendBuilderCreator(target, cacheLayoutResult))
             {
                 RenderFormattedMessage(logEvent, localTarget.Builder);
-                if (localTarget.Builder.Length > this.maxRenderedLength)
-                {
-                    this.maxRenderedLength = localTarget.Builder.Length;
-                }
-                if (cacheLayoutResult && !this.ThreadAgnostic)
+                if (cacheLayoutResult)
                 {
                     // when needed as it generates garbage
                     logEvent.AddCachedLayoutValue(this, localTarget.Builder.ToString());
@@ -241,7 +232,7 @@ namespace NLog.Layouts
         /// Renders the layout for the specified logging event by invoking layout renderers.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
         protected virtual void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             target.Append(GetFormattedMessage(logEvent) ?? string.Empty);

--- a/src/NLog/Layouts/LayoutWithHeaderAndFooter.cs
+++ b/src/NLog/Layouts/LayoutWithHeaderAndFooter.cs
@@ -75,7 +75,7 @@ namespace NLog.Layouts
         /// Renders the layout for the specified logging event by invoking layout renderers.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>
-        /// <param name="target">Initially empty <see cref="System.Text.StringBuilder"/> for the result</param>
+        /// <param name="target"><see cref="System.Text.StringBuilder"/> for the result.</param>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, System.Text.StringBuilder target)
         {
             this.Layout.RenderAppendBuilder(logEvent, target);

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -91,7 +91,7 @@ namespace NLog.Layouts
         /// Renders the layout for the specified logging event by invoking layout renderers.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>
-        /// <param name="target">Initially empty <see cref="System.Text.StringBuilder"/> for the result</param>
+        /// <param name="target"><see cref="System.Text.StringBuilder"/> for the result</param>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, System.Text.StringBuilder target)
         {
             this.Renderer.RenderAppendBuilder(logEvent, target);

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -325,7 +325,7 @@ namespace NLog.Layouts
         /// that make up the event.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result</param>
+        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             if (IsFixedText)

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -31,6 +31,9 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Diagnostics.CodeAnalysis;
+using NLog.MessageTemplates;
+
 namespace NLog
 {
     using System;
@@ -54,7 +57,8 @@ namespace NLog
         /// Gets the date of the first log event created.
         /// </summary>
         public static readonly DateTime ZeroDate = DateTime.UtcNow;
-        private static readonly LogMessageFormatter defaultMessageFormatter = DefaultMessageFormatter;
+        internal static readonly LogMessageFormatter StringFormatMessageFormatter = GetStringFormatMessageFormatter;
+        internal static LogMessageFormatter DefaultMessageFormatter { get; set; } = LogMessageTemplateFormatter.DefaultAuto.MessageFormatter;
 
         private static int globalSequenceId;
 
@@ -62,7 +66,7 @@ namespace NLog
         private string message;
         private object[] parameters;
         private IFormatProvider formatProvider;
-        private LogMessageFormatter messageFormatter = defaultMessageFormatter;
+        private LogMessageFormatter messageFormatter = DefaultMessageFormatter;
         private IDictionary<Layout, string> layoutCache;
         private PropertiesDictionary properties;
 
@@ -143,13 +147,14 @@ namespace NLog
         /// Gets the unique identifier of log event which is automatically generated
         /// and monotonously increasing.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "ID", Justification = "Backwards compatibility")]
+        [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "ID", Justification = "Backwards compatibility")]
+        // ReSharper disable once InconsistentNaming
         public int SequenceID { get; private set; }
 
         /// <summary>
         /// Gets or sets the timestamp of the logging event.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "TimeStamp", Justification = "Backwards compatibility.")]
+        [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "TimeStamp", Justification = "Backwards compatibility.")]
         public DateTime TimeStamp { get; set; }
 
         /// <summary>
@@ -222,22 +227,24 @@ namespace NLog
             get { return this.message; }
             set
             {
-                this.message = value; 
-                ResetFormattedMessage();
+                bool rebuildMessageTemplateParameters = ResetMessageTemplateParameters();
+                this.message = value;
+                ResetFormattedMessage(rebuildMessageTemplateParameters);
             }
         }
 
         /// <summary>
         /// Gets or sets the parameter values or null if no parameters have been specified.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "For backwards compatibility.")]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "For backwards compatibility.")]
         public object[] Parameters
         {
             get { return this.parameters; }
             set
             {
+                bool rebuildMessageTemplateParameters = ResetMessageTemplateParameters();
                 this.parameters = value;
-                ResetFormattedMessage();
+                ResetFormattedMessage(rebuildMessageTemplateParameters);
             }
         }
 
@@ -247,13 +254,13 @@ namespace NLog
         /// </summary>
         public IFormatProvider FormatProvider
         {
-            get { return formatProvider; }
+            get { return this.formatProvider; }
             set
             {
-                if (formatProvider != value)
+                if (this.formatProvider != value)
                 {
-                    formatProvider = value;
-                    ResetFormattedMessage();
+                    this.formatProvider = value;
+                    ResetFormattedMessage(false);
                 }
             }
         }
@@ -267,8 +274,8 @@ namespace NLog
             get { return this.messageFormatter; }
             set
             {
-                this.messageFormatter = value ?? defaultMessageFormatter;
-                ResetFormattedMessage();
+                this.messageFormatter = value ?? StringFormatMessageFormatter;
+                ResetFormattedMessage(false);
             }
         }
 
@@ -291,12 +298,57 @@ namespace NLog
         /// <summary>
         /// Checks if any per-event context properties (Without allocation)
         /// </summary>
-        public bool HasProperties { get { return this.properties != null && this.properties.Count > 0; } }
+        public bool HasProperties
+        {
+            get
+            {
+                if (this.properties != null)
+                {
+                    return this.properties.Count > 0;
+                }
+                else
+                {
+                    return HasMessageTemplateParameters;
+                }
+            }
+        }
+
+        internal PropertiesDictionary PropertiesDictionary { get { return this.properties; } set { this.properties = value; } }
 
         /// <summary>
         /// Gets the dictionary of per-event context properties.
         /// </summary>
-        public IDictionary<object,object> Properties { get { return this.properties ?? (this.properties = new PropertiesDictionary()); } }
+        public IDictionary<object, object> Properties 
+        {
+            get { return GetPropertiesInternal(); }
+        }
+
+        /// <summary>
+        /// Gets the dictionary of per-event context properties. 
+        /// Internal helper for the PropertiesDictionary type.
+        /// </summary>
+        /// <returns></returns>
+        private PropertiesDictionary GetPropertiesInternal()
+        {
+            if (this.properties == null)
+            {
+                Interlocked.CompareExchange(ref this.properties, new PropertiesDictionary(), null);
+                if (HasMessageTemplateParameters && !ReferenceEquals(this.Message, this.FormattedMessage))
+                {
+                    // MessageTemplateParameters have probably been created
+                }
+            }
+            return this.properties;
+        }
+
+        internal bool HasMessageTemplateParameters
+        {
+            get
+            {
+                var logMessageFormatter = this.messageFormatter?.Target as ILogMessageFormatter;
+                return logMessageFormatter?.HasProperties(this) ?? false;
+            }
+        }
 
         /// <summary>
         /// Gets the named parameters extracted from parsing <see cref="Message"/> as MessageTemplate
@@ -321,7 +373,7 @@ namespace NLog
         /// </summary>
         /// <remarks>This property was marked as obsolete on NLog 2.0 and it may be removed in a future release.</remarks>
         [Obsolete("Use LogEventInfo.Properties instead.  Marked obsolete on NLog 2.0", true)]
-        public IDictionary Context { get { return (this.properties ?? (this.properties = new PropertiesDictionary())).EventContext; } }
+        public IDictionary Context { get { return GetPropertiesInternal().EventContext; } }
 
         /// <summary>
         /// Creates the null event.
@@ -329,7 +381,7 @@ namespace NLog
         /// <returns>Null log event.</returns>
         public static LogEventInfo CreateNullEvent()
         {
-            return new LogEventInfo(LogLevel.Off, string.Empty, string.Empty);
+            return new LogEventInfo(LogLevel.Off, String.Empty, String.Empty);
         }
 
         /// <summary>
@@ -523,7 +575,7 @@ namespace NLog
             return value.GetType().IsPrimitive || (value is string);
         }
 
-        private static string DefaultMessageFormatter(LogEventInfo logEvent)
+        private static string GetStringFormatMessageFormatter(LogEventInfo logEvent)
         {
             if (logEvent.Parameters == null || logEvent.Parameters.Length == 0)
             {
@@ -531,7 +583,7 @@ namespace NLog
             }
             else
             {
-                return string.Format(logEvent.FormatProvider ?? CultureInfo.CurrentCulture, logEvent.Message, logEvent.Parameters);
+                return String.Format(logEvent.FormatProvider ?? CultureInfo.CurrentCulture, logEvent.Message, logEvent.Parameters);
             }
         }
 
@@ -553,9 +605,47 @@ namespace NLog
             }
         }
 
-        private void ResetFormattedMessage()
+        private void ResetFormattedMessage(bool rebuildMessageTemplateParameters)
         {
             this.formattedMessage = null;
+            if (rebuildMessageTemplateParameters && HasMessageTemplateParameters && !ReferenceEquals(this.Message, this.FormattedMessage))
+            {
+                // Have re-captured MessageTemplateParameters
+            }
+        }
+
+        private bool ResetMessageTemplateParameters()
+        {
+            if (this.properties != null && HasMessageTemplateParameters)
+            {
+                this.properties.MessageProperties = null;
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Set the <see cref="DefaultMessageFormatter"/>
+        /// </summary>
+        /// <param name="mode">true = Always, false = Never, null = Auto Detect</param>
+        internal static void SetDefaultMessageFormatter(bool? mode)
+        {
+            if (mode == true)
+            {
+                InternalLogger.Info("Message Template Format always enabled");
+                DefaultMessageFormatter = LogMessageTemplateFormatter.Default.MessageFormatter;
+            }
+            else if (mode == false)
+            {
+                InternalLogger.Info("Message Template String Format always enabled");
+                DefaultMessageFormatter = LogEventInfo.StringFormatMessageFormatter;
+            }
+            else
+            {
+                //null = auto
+                InternalLogger.Info("Message Template Auto Format enabled");
+                DefaultMessageFormatter = LogMessageTemplateFormatter.DefaultAuto.MessageFormatter;
+            }
         }
     }
 }

--- a/src/NLog/MessageTemplates/CaptureType.cs
+++ b/src/NLog/MessageTemplates/CaptureType.cs
@@ -1,0 +1,54 @@
+// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.MessageTemplates
+{
+    /// <summary>
+    /// The type of the captured hole
+    /// </summary>
+    internal enum CaptureType : byte
+    {
+        /// <summary>
+        /// normal {x}
+        /// </summary>
+        Normal,
+        /// <summary>
+        ///  Serialize operator {@x} (aka destructure)
+        /// </summary>
+        Serialize,
+        /// <summary>
+        /// stringification operator {$x} 
+        /// </summary>
+        Stringify,
+    }
+}

--- a/src/NLog/MessageTemplates/Hole.cs
+++ b/src/NLog/MessageTemplates/Hole.cs
@@ -1,0 +1,71 @@
+// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.MessageTemplates
+{
+    /// <summary>
+    /// A hole that will be replaced with a value
+    /// </summary>
+    internal struct Hole
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public Hole(string name, string format, CaptureType captureType, short position, short alignment)
+        {
+            Name = name;
+            Format = format;
+            CaptureType = captureType;
+            Index = position;
+            Alignment = alignment;
+        }
+
+        /// <summary>Parameter name sent to structured loggers.</summary>
+        /// <remarks>This is everything between "{" and the first of ",:}". 
+        /// Including surrounding spaces and names that are numbers.</remarks>
+        public readonly string Name;
+        /// <summary>Format to render the parameter.</summary>
+        /// <remarks>This is everything between ":" and the first unescaped "}"</remarks>
+        public readonly string Format;
+        /// <summary>
+        /// Type
+        /// </summary>
+        public readonly CaptureType CaptureType;
+        /// <summary>When the template is positional, this is the parsed name of this parameter.</summary>
+        /// <remarks>For named templates, the value of Index is undefined.</remarks>
+        public readonly short Index;
+        /// <summary>Alignment to render the parameter, by default 0.</summary>
+        /// <remarks>This is the parsed value between "," and the first of ":}"</remarks>
+        public readonly short Alignment;
+    }
+}

--- a/src/NLog/MessageTemplates/IMessageTemplateParameters.cs
+++ b/src/NLog/MessageTemplates/IMessageTemplateParameters.cs
@@ -1,0 +1,57 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System.Collections.Generic;
+
+namespace NLog.MessageTemplates
+{
+    /// <summary>
+    /// Parameters extracted from parsing <see cref="LogEventInfo.Message"/> as MessageTemplate
+    /// </summary>
+    public interface IMessageTemplateParameters : IEnumerable<MessageTemplateParameter>
+    {
+        /// <summary>
+        /// Number of parameters
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        /// Gets the parameters at the given index
+        /// </summary>
+        MessageTemplateParameter this[int index] { get; }
+
+        /// <summary>Indicates whether the template should be interpreted as positional 
+        /// (all holes are numbers) or named.</summary>
+        bool IsPositional { get; }
+    }
+}

--- a/src/NLog/MessageTemplates/Literal.cs
+++ b/src/NLog/MessageTemplates/Literal.cs
@@ -1,0 +1,48 @@
+// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.MessageTemplates
+{
+    /// <summary>
+    /// A fixed value
+    /// </summary>
+    internal struct Literal
+    {
+        /// <summary>Number of characters from the original template to copy at the current position.</summary>
+        /// <remarks>This can be 0 when the template starts with a hole or when there are multiple consecutive holes.</remarks>
+        public int Print;
+        /// <summary>Number of characters to skip in the original template at the current position.</summary>
+        /// <remarks>0 is a special value that mean: 1 escaped char, no hole. It can also happen last when the template ends with a literal.</remarks>
+        public short Skip;
+    }
+}

--- a/src/NLog/MessageTemplates/LiteralHole.cs
+++ b/src/NLog/MessageTemplates/LiteralHole.cs
@@ -1,0 +1,53 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.MessageTemplates
+{
+    /// <summary>
+    /// Combines Literal and Hole
+    /// </summary>
+    internal struct LiteralHole
+    {
+        /// <summary>Literal</summary>
+        public readonly Literal Literal;
+        /// <summary>Hole</summary>
+        /// <remarks>Uninitialized when <see cref="MessageTemplates.Literal.Skip"/> = 0.</remarks>
+        public readonly Hole Hole;
+
+        internal LiteralHole(Literal literal, Hole hole)
+        {
+            Literal = literal;
+            Hole = hole;
+        }
+    }
+}

--- a/src/NLog/MessageTemplates/MessageTemplateParameter.cs
+++ b/src/NLog/MessageTemplates/MessageTemplateParameter.cs
@@ -1,0 +1,77 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using JetBrains.Annotations;
+
+namespace NLog.MessageTemplates
+{
+    /// <summary>
+    /// Description of a single parameter extracted from a MessageTemplate
+    /// </summary>
+    public struct MessageTemplateParameter
+    {
+        /// <summary>
+        /// Parameter Name extracted from <see cref="LogEventInfo.Message"/>
+        /// This is everything between "{" and the first of ",:}".
+        /// </summary>
+        [NotNull]
+        public readonly string Name;
+
+        /// <summary>
+        /// Parameter Value extracted from the <see cref="LogEventInfo.Parameters"/>-array
+        /// </summary>
+        [CanBeNull]
+        public readonly object Value;
+
+        /// <summary>
+        /// Format to render the parameter.
+        /// This is everything between ":" and the first unescaped "}"
+        /// </summary>
+        [CanBeNull]
+        public readonly string Format;
+
+        /// <summary>
+        /// Constructs a single message template parameter
+        /// </summary>
+        /// <param name="name">Parameter Name</param>
+        /// <param name="value">Parameter Value</param>
+        /// <param name="format">Parameter Format</param>
+        public MessageTemplateParameter([NotNull] string name, object value, string format)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Value = value;
+            Format = format;
+        }
+    }
+}

--- a/src/NLog/MessageTemplates/MessageTemplateParameters.cs
+++ b/src/NLog/MessageTemplates/MessageTemplateParameters.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.Internal
+namespace NLog.MessageTemplates
 {
     using System.Collections;
     using System.Collections.Generic;
@@ -55,47 +55,88 @@ namespace NLog.Internal
         /// <inheritDoc/>
         IEnumerator IEnumerable.GetEnumerator() { return _parameters.GetEnumerator(); }
 
+        /// <inheritDoc/>
+        public bool IsPositional { get; }
+
         /// <summary>
         /// Constructore for positional parameters
         /// </summary>
         public MessageTemplateParameters(object[] parameters)
         {
-            if (parameters != null && parameters.Length > 0)
+            var hasParameters = parameters != null && parameters.Length > 0;
+            if (hasParameters)
             {
-                _parameters = new MessageTemplateParameter[parameters.Length];
+                IsPositional = true;
+            }
+
+            _parameters = CreateParameters(parameters, hasParameters);
+        }
+
+        /// <summary>
+        /// Constructor for named parameters
+        /// </summary>
+        public MessageTemplateParameters(IList<MessageTemplateParameter> parameters)
+        {
+            _parameters = parameters ?? Internal.ArrayHelper.Empty<MessageTemplateParameter>();
+        }
+
+        /// <summary>
+        /// Create MessageTemplateParameter from <paramref name="parameters"/>
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <param name="hasParameters">is <paramref name="parameters"/> filled? (parameter for performance)</param>
+        /// <returns></returns>
+        private MessageTemplateParameter[] CreateParameters(object[] parameters, bool hasParameters)
+        {
+            if (hasParameters)
+            {
+                var templateParameters = new MessageTemplateParameter[parameters.Length];
                 for (int i = 0; i < parameters.Length; ++i)
                 {
                     string parameterName;
                     switch (i)
                     {
                         //prevent creating a string (int.ToString())
-                        case 0: parameterName = "0"; break;
-                        case 1: parameterName = "1"; break;
-                        case 2: parameterName = "2"; break;
-                        case 3: parameterName = "3"; break;
-                        case 4: parameterName = "4"; break;
-                        case 5: parameterName = "5"; break;
-                        case 6: parameterName = "6"; break;
-                        case 7: parameterName = "7"; break;
-                        case 8: parameterName = "8"; break;
-                        case 9: parameterName = "9"; break;
-                        default: parameterName = i.ToString(); break;
+                        case 0:
+                            parameterName = "0";
+                            break;
+                        case 1:
+                            parameterName = "1";
+                            break;
+                        case 2:
+                            parameterName = "2";
+                            break;
+                        case 3:
+                            parameterName = "3";
+                            break;
+                        case 4:
+                            parameterName = "4";
+                            break;
+                        case 5:
+                            parameterName = "5";
+                            break;
+                        case 6:
+                            parameterName = "6";
+                            break;
+                        case 7:
+                            parameterName = "7";
+                            break;
+                        case 8:
+                            parameterName = "8";
+                            break;
+                        case 9:
+                            parameterName = "9";
+                            break;
+                        default:
+                            parameterName = i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                            break;
                     }
-                    _parameters[i] = new MessageTemplateParameter(parameterName, parameters[i], null);
+                    templateParameters[i] = new MessageTemplateParameter(parameterName, parameters[i], null);
                 }
+                return templateParameters;
             }
-            else
-            {
-                _parameters = Internal.ArrayHelper.Empty<MessageTemplateParameter>();
-            }
-        }
 
-        /// <summary>
-        /// Constructore for named parameters
-        /// </summary>
-        public MessageTemplateParameters(IList<MessageTemplateParameter> parameters)
-        {
-            _parameters = parameters ?? Internal.ArrayHelper.Empty<MessageTemplateParameter>();
+            return Internal.ArrayHelper.Empty<MessageTemplateParameter>();
         }
     }
 }

--- a/src/NLog/MessageTemplates/Template.cs
+++ b/src/NLog/MessageTemplates/Template.cs
@@ -1,0 +1,166 @@
+// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NLog.MessageTemplates
+{
+    /// <summary>
+    /// A mesage template
+    /// </summary>
+    internal class Template
+    {
+        /// <summary>The original template string.</summary>
+        /// <remarks>This is the key passed to structured targets.</remarks>     
+        public string Value { get; }
+
+        /// <summary>The list of literal parts, useful for string rendering.
+        /// It indicates the number of characters from the original string to print,
+        /// then there's a hole with how many chars to skip.</summary>
+        /// <example>
+        /// "Hello {firstName} {lastName}!"
+        /// -------------------------------------
+        /// ║P     |S          ║P|S         ║P|S║
+        /// ║6     |11         ║1|10        ║1|0║
+        /// ║Hello |{firstName}║ |{lastName}║!║
+        /// 
+        /// "{x} * 2 = {2x}"
+        /// --------------------
+        /// ║P|S  ║P      |S   ║
+        /// ║0|3  ║7      |4   ║
+        ///   ║{x}║ * 2 = |{2x}║
+        /// 
+        /// The tricky part is escaped braces. They are represented by a skip = 0,
+        /// which is interpreted as "move one char forward, no hole".
+        /// 
+        /// "Escaped }} is fun."
+        /// ----------------------
+        /// ║P        |S║P       |S║
+        /// ║9        |0║8       |0║
+        /// ║Escaped }|}║ is fun.|║
+        /// </example>
+        public Literal[] Literals { get; }
+
+        /// <summary> This list of holes. It's used both to fill the string rendering
+        /// and to send values along the template to structured targets.</summary>
+        public Hole[] Holes { get; }
+
+        /// <summary>Indicates whether the template should be interpreted as positional 
+        /// (all holes are numbers) or named.</summary>
+        public bool IsPositional { get; }
+
+        /// <summary>
+        /// Create a template, which is already parsed
+        /// </summary>
+        /// <param name="template"></param>
+        /// <param name="isPositional"></param>
+        /// <param name="literals"></param>
+        /// <param name="holes"></param>
+        public Template(string template, bool isPositional, List<Literal> literals, List<Hole> holes)
+        {
+            Value = template;
+            IsPositional = isPositional;
+            // Using arrays is important! It's the only CLR type that will give us a no-copy access to 
+            // the structs contained in the array.
+            Literals = literals.ToArray();
+            Holes = holes.ToArray();
+        }
+
+        /// <summary>
+        /// Create a template, which is already parsed
+        /// </summary>
+        /// <param name="template"></param>
+        /// <param name="isPositional"></param>
+        /// <param name="literals"></param>
+        /// <param name="holes"></param>
+        public Template(string template, bool isPositional, Literal[] literals, Hole[] holes)
+        {
+            Value = template;
+            IsPositional = isPositional;
+            Literals = literals;
+            Holes = holes;
+        }
+
+        /// <summary>This is for testing only: recreates <see cref="Value"/> from the parsed data.</summary>
+        public string Rebuild()
+        {
+            var sb = new StringBuilder(Value.Length);
+            int pos = 0;
+            int h = 0;
+            foreach (var literal in Literals)
+            {
+                sb.Append(Value, pos, literal.Print);
+                pos += literal.Print;
+                if (literal.Skip == 0)
+                {
+                    // 0 means escaping or end of string without hole.
+                    if (pos < Value.Length)
+                        sb.Append(Value[pos++]);
+                }
+                else
+                {
+                    pos += literal.Skip;
+                    RebuildHole(sb, ref Holes[h++]);
+                }
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// This is for testing only: rebuilds the hole
+        /// </summary>
+        /// <param name="sb">Add to this string builder</param>
+        /// <param name="hole">ref for performance</param>
+        private static void RebuildHole(StringBuilder sb, ref Hole hole)
+        {
+            if (hole.CaptureType == CaptureType.Normal)
+                sb.Append('{');
+            else if (hole.CaptureType == CaptureType.Serialize)
+                sb.Append("{@");
+            else  // hole.CaptureType == CaptureType.Stringification
+                sb.Append("{$");
+
+            sb.Append(hole.Name);
+
+            if (hole.Alignment != 0)
+                sb.Append(',').Append(hole.Alignment);
+
+            if (hole.Format != null)
+                sb.Append(':').Append(hole.Format.Replace("{", "{{").Replace("}", "}}")); // rebuild of the escaped brackets in format
+
+            sb.Append('}');
+        }
+    }
+}

--- a/src/NLog/MessageTemplates/TemplateEnumerator.cs
+++ b/src/NLog/MessageTemplates/TemplateEnumerator.cs
@@ -1,0 +1,378 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace NLog.MessageTemplates
+{
+    /// <summary>
+    /// Parse templates.
+    /// </summary>
+    internal struct TemplateEnumerator : IEnumerator<LiteralHole>
+    {
+        private static readonly char[] HoleDelimiters = { '}', ':', ',' };
+        private static readonly char[] TextDelimiters = { '{', '}' };
+
+        private string _template;
+        private int _length;
+        private int _position;
+        private int _literalLength;
+        private LiteralHole _current;
+        private const short Zero = 0;
+
+        /// <summary>
+        /// Parse a template.
+        /// </summary>
+        /// <param name="template">Template to be parsed.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="template"/> is null.</exception>
+        /// <returns>Template, never null</returns>
+        public TemplateEnumerator(string template)
+        {
+            _template = template ?? throw new ArgumentNullException(nameof(template));
+            _length = _template.Length;
+            _position = 0;
+            _literalLength = 0;
+            _current = default(LiteralHole);
+        }
+
+        /// <summary>
+        /// Gets the current literal/hole in the template
+        /// </summary>
+        public LiteralHole Current => _current;
+
+        object System.Collections.IEnumerator.Current => _current;
+
+        /// <summary>
+        /// Clears the enumerator
+        /// </summary>
+        public void Dispose()
+        {
+            _template = string.Empty;
+            _length = 0;
+            Reset();
+        }
+
+        /// <summary>
+        /// Restarts the enumerator of the template
+        /// </summary>
+        public void Reset()
+        {
+            _position = 0;
+            _literalLength = 0;
+            _current = default(LiteralHole);
+        }
+
+        /// <summary>
+        /// Moves to the next literal/hole in the template
+        /// </summary>
+        /// <returns>Found new element [true/false]</returns>
+        public bool MoveNext()
+        {
+            try
+            {
+                while (_position < _length)
+                {
+                    char c = Peek();
+                    if (c == '{')
+                    {
+                        ParseOpenBracketPart();
+                        return true;
+                    }
+                    else if (c == '}')
+                    {
+                        ParseCloseBracketPart();
+                        return true;
+                    }
+                    else
+                        ParseTextPart();
+                }
+                if (_literalLength != 0)
+                {
+                    AddLiteral();
+                    return true;
+                }
+                return false;
+            }
+            catch (IndexOutOfRangeException)
+            {
+                throw new TemplateParserException("Unexpected end of template.", _position, _template);
+            }
+        }
+
+        private void AddLiteral()
+        {
+            _current = new LiteralHole(new Literal { Print = _literalLength, Skip = Zero }, default(Hole));
+            _literalLength = 0;
+        }
+
+        private void ParseTextPart()
+        {
+            _literalLength = (short)SkipUntil(TextDelimiters, required: false);
+        }
+
+        private void ParseOpenBracketPart()
+        {
+            Skip('{');
+            char c = Peek();
+            switch (c)
+            {
+                case '{':
+                    Skip('{');
+                    _literalLength++;
+                    AddLiteral();
+                    return;
+                case '@':
+                    Skip('@');
+                    ParseHole(CaptureType.Serialize);
+                    return;
+                case '$':
+                    Skip('$');
+                    ParseHole(CaptureType.Stringify);
+                    return;
+                default:
+                    ParseHole(CaptureType.Normal);
+                    return;
+            }
+        }
+
+        private void ParseCloseBracketPart()
+        {
+            Skip('}');
+            if (Read() != '}')
+                throw new TemplateParserException("Unexpected '}}' ", _position - 2, _template);
+            _literalLength++;
+            AddLiteral();
+        }
+
+        private void ParseHole(CaptureType type)
+        {
+            int start = _position;
+            string name = ParseName(out var position);
+            int alignment = Peek() == ',' ? ParseAlignment() : 0;
+            string format = Peek() == ':' ? ParseFormat() : null;
+            Skip('}');
+
+            int literalSkip = _position - start + (type == CaptureType.Normal ? 1 : 2);     // Account for skipped '{', '{$' or '{@'
+            _current = new LiteralHole(new Literal { Print = _literalLength, Skip = (short)literalSkip }, new Hole(
+                name,
+                format,
+                type,
+                (short)position,
+                (short)alignment
+            ));
+            _literalLength = 0;
+        }
+
+        private string ParseName(out int parameterIndex)
+        {
+            parameterIndex = -1;
+            char c = Peek();
+            // If the name matches /^\d+ *$/ we consider it positional
+            if (c >= '0' && c <= '9')
+            {
+                int start = _position;
+                int parsed = ReadInt();
+                c = Peek();
+                if (parsed >= 0)
+                {
+                    if (c == '}' || c == ':' || c == ',')
+                    {
+                        // Non-allocating positional hole-name-parsing
+                        parameterIndex = parsed;
+                        switch (parameterIndex)
+                        {
+                            case 0: return "0";
+                            case 1: return "1";
+                            case 2: return "2";
+                            case 3: return "3";
+                            case 4: return "4";
+                            case 5: return "5";
+                            case 6: return "6";
+                            case 7: return "7";
+                            case 8: return "8";
+                            case 9: return "9";
+                        }
+                        return parameterIndex.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                    }
+                    else if (c == ' ')
+                    {
+                        SkipSpaces();
+                        c = Peek();
+                        if (c == '}' || c == ':' || c == ',')
+                            parameterIndex = parsed;
+                    }
+                }
+
+                _position = start;
+            }
+
+            return ReadUntil(HoleDelimiters);
+        }
+
+        /// <summary>
+        /// Parse format after hole name/index. Handle the escaped { and } in the format. Don't read the last }
+        /// </summary>
+        /// <returns></returns>
+        private string ParseFormat()
+        {
+
+            Skip(':');
+            string format = ReadUntil(TextDelimiters);
+            while (true)
+            {
+                var c = Read();
+
+                switch (c)
+                {
+                    case '}':
+                        {
+                            if (_position < _length && Peek() == '}')
+                            {
+                                //this is an escaped } and need to be added to the format.
+                                Skip('}');
+                                format += "}";
+                            }
+                            else
+                            {
+                                //done. unread the }
+                                _position--;
+                                //done
+                                return format;
+                            }
+                            break;
+                        }
+                    case '{':
+                        {
+                            //we need a second {, otherwise this format is wrong.
+                            var next = Peek();
+                            if (next == '{')
+                            {
+                                //this is an escaped } and need to be added to the format.
+                                Skip('{');
+                                format += "{";
+                            }
+                            else
+                            {
+                                throw new TemplateParserException($"Expected '{{' but found '{next}' instead in format.",
+                                    _position, _template);
+                            }
+
+                            break;
+                        }
+                }
+
+                format += ReadUntil(TextDelimiters);
+            }
+        }
+
+        private int ParseAlignment()
+        {
+            Skip(',');
+            int i = ReadInt();
+            SkipSpaces();
+            char next = Peek();
+            if (next != ':' && next != '}')
+                throw new TemplateParserException($"Expected ':' or '}}' but found '{next}' instead.", _position, _template);
+            return i;
+        }
+
+        private char Peek() => _template[_position];
+
+        private char Read() => _template[_position++];
+
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
+        private void Skip(char c)
+        {
+            // Can be out of bounds, but never in correct use (expects a required char).
+            Debug.Assert(_template[_position] == c);
+            _position++;
+        }
+
+        private void SkipSpaces()
+        {
+            // Can be out of bounds, but never in correct use (inside a hole).
+            while (_template[_position] == ' ') _position++;
+        }
+
+        private int SkipUntil(char[] search, bool required = true)
+        {
+            int start = _position;
+            int i = _template.IndexOfAny(search, _position);
+            if (i == -1 && required)
+            {
+                var formattedChars = string.Join(", ", search.Select(c => "'" + c + "'").ToArray());
+                throw new TemplateParserException($"Reached end of template while expecting one of {formattedChars}.", _position, _template);
+            }
+            _position = i == -1 ? _length : i;
+            return _position - start;
+        }
+
+        private int ReadInt()
+        {
+            SkipSpaces();
+
+            bool negative = false;
+            if (Peek() == '-')
+            {
+                negative = true;
+                _position++;
+            }
+
+            int i = 0;
+            bool hasDigits = false;
+            while (true)
+            {
+                // Can be out of bounds, but never in correct use (inside a hole).
+                char c = Peek();
+                int digit = c - '0';
+                if (digit < 0 || digit > 9) break;
+                hasDigits = true;
+                _position++;
+                i = i * 10 + digit;
+            }
+            if (!hasDigits)
+                throw new TemplateParserException("An integer is expected", _position, _template);
+
+            return negative ? -i : i;
+        }
+
+        private string ReadUntil(char[] search, bool required = true)
+        {
+            int start = _position;
+            return _template.Substring(start, SkipUntil(search, required));
+        }
+    }
+}

--- a/src/NLog/MessageTemplates/TemplateParserException.cs
+++ b/src/NLog/MessageTemplates/TemplateParserException.cs
@@ -1,0 +1,65 @@
+// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+
+namespace NLog.MessageTemplates
+{
+    /// <summary>
+    /// Error when parsing a template.
+    /// </summary>
+    public class TemplateParserException : Exception
+    {
+        /// <summary>
+        /// Current index when the error occurred.
+        /// </summary>
+        public int Index { get; }
+
+        /// <summary>
+        /// The template we were parsing
+        /// </summary>
+        public string Template { get; }
+
+        /// <summary>
+        /// New exception
+        /// </summary>
+        /// <param name="message">The message to be shown.</param>
+        /// <param name="index">Current index when the error occurred.</param>
+        /// <param name="template"></param>
+        public TemplateParserException(string message, int index, string template) : base(message)
+        {
+            Index = index;
+            Template = template;
+        }
+    }
+}

--- a/src/NLog/MessageTemplates/TemplateRenderer.cs
+++ b/src/NLog/MessageTemplates/TemplateRenderer.cs
@@ -1,0 +1,177 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NLog.MessageTemplates
+{
+    /// <summary>
+    /// Render templates
+    /// </summary>
+    internal static class TemplateRenderer
+    {
+        /// <summary>
+        /// Render a template to a string.
+        /// </summary>
+        /// <param name="template">The template.</param>
+        /// <param name="formatProvider">Culture.</param>
+        /// <param name="parameters">Parameters for the holes.</param>
+        /// <param name="forceTemplateRenderer">Do not fallback to StringBuilder.Format for positional templates.</param>
+        /// <param name="sb">The String Builder destination.</param>
+        /// <param name="messageTemplateParameters">Parameters for the holes.</param>
+        public static void Render(this string template, IFormatProvider formatProvider, object[] parameters, bool forceTemplateRenderer, StringBuilder sb, out IList<MessageTemplateParameter> messageTemplateParameters)
+        {
+            int pos = 0;
+            int holeIndex = 0;
+            messageTemplateParameters = null;
+
+            TemplateEnumerator holeEnumerator = new TemplateEnumerator(template);
+            while (holeEnumerator.MoveNext())
+            {
+                var literal = holeEnumerator.Current.Literal;
+                if (holeIndex == 0 && !forceTemplateRenderer && sb.Length == 0 && literal.Skip != 0 && holeEnumerator.Current.Hole.Index != -1)
+                {
+                    // Not a template
+                    sb.AppendFormat(formatProvider, template, parameters);
+                    return;
+                }
+
+                sb.Append(template, pos, literal.Print);
+                pos += literal.Print;
+                if (literal.Skip == 0)
+                {
+                    pos++;
+                }
+                else
+                {
+                    pos += literal.Skip;
+                    var hole = holeEnumerator.Current.Hole;
+                    if (hole.Index != -1)
+                    {
+                        RenderHole(sb, hole, formatProvider, parameters[hole.Index], true);
+                    }
+                    else
+                    {
+                        var holeParameter = parameters[holeIndex];
+                        if (messageTemplateParameters == null)
+                        {
+                            messageTemplateParameters = new MessageTemplateParameter[parameters.Length];
+                        }
+                        messageTemplateParameters[holeIndex++] = new MessageTemplateParameter(hole.Name, holeParameter, hole.Format);
+                        RenderHole(sb, hole, formatProvider, holeParameter);
+                    }
+                }
+            }
+
+            if (messageTemplateParameters != null && holeIndex != messageTemplateParameters.Count)
+            {
+                var truncateParameters = new MessageTemplateParameter[holeIndex];
+                for (int i = 0; i < truncateParameters.Length; ++i)
+                    truncateParameters[i] = messageTemplateParameters[i];
+                messageTemplateParameters = truncateParameters;
+            }
+        }
+
+        /// <summary>
+        /// Render a template to a string.
+        /// </summary>
+        /// <param name="template">The template.</param>
+        /// <param name="sb">The String Builder destination.</param>
+        /// <param name="formatProvider">Culture.</param>
+        /// <param name="parameters">Parameters for the holes.</param>
+        /// <returns>Rendered template, never null.</returns>
+        public static void Render(this Template template, StringBuilder sb, IFormatProvider formatProvider, object[] parameters)
+        {
+            int pos = 0;
+            int holeIndex = 0;
+            foreach (var literal in template.Literals)
+            {
+                sb.Append(template.Value, pos, literal.Print);
+                pos += literal.Print;
+                if (literal.Skip == 0)
+                {
+                    pos++;
+                }
+                else
+                {
+                    pos += literal.Skip;
+                    if (template.IsPositional)
+                    {
+                        Hole hole = template.Holes[holeIndex++];
+                        RenderHole(sb, hole, formatProvider, parameters[hole.Index], true);
+                    }
+                    else
+                    {
+                        RenderHole(sb, template.Holes[holeIndex], formatProvider, parameters[holeIndex++]);
+                    }
+                }
+            }
+        }
+
+        private static void RenderHole(StringBuilder sb, Hole hole, IFormatProvider formatProvider, object value, bool legacy = false)
+        {
+            RenderHole(sb, hole.CaptureType, hole.Format, formatProvider, value, legacy);
+        }
+
+        public static void RenderHole(StringBuilder sb, CaptureType captureType, string holeFormat, IFormatProvider formatProvider, object value, bool legacy = false)
+        {
+            if (value == null)
+            {
+                sb.Append("NULL");
+                return;
+            }
+
+            switch (captureType)
+            {
+                case CaptureType.Stringify:
+                    ValueSerializer.Instance.SerializeObject(value, "$", formatProvider, sb);
+                    break;
+                case CaptureType.Serialize:
+                    ValueSerializer.Instance.SerializeObject(value, "@", formatProvider, sb);
+                    break;
+                default:
+                    if (legacy)
+                    {
+                        ValueSerializer.SerializeToString(value, holeFormat, formatProvider, sb);
+                    }
+                    else
+                    {
+                        ValueSerializer.Instance.SerializeObject(value, holeFormat, formatProvider, sb);
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/src/NLog/MessageTemplates/ValueSerializer.cs
+++ b/src/NLog/MessageTemplates/ValueSerializer.cs
@@ -1,0 +1,232 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Collections;
+using System.Text;
+using NLog.Internal;
+
+namespace NLog.MessageTemplates
+{
+    /// <summary>
+    /// Convert Render or serialize a value, with optionnally backwardscompatible with <see cref="string.Format(System.IFormatProvider,string,object[])"/>
+    /// </summary>
+    internal class ValueSerializer : IValueSerializer
+    {
+        public static IValueSerializer Instance
+        {
+            get { return _instance ?? (_instance = new ValueSerializer()); }
+            set { _instance = value ?? new ValueSerializer(); }
+        }
+        private static IValueSerializer _instance = null;
+
+        /// <summary>Singleton</summary>
+        private ValueSerializer()
+        {
+        }
+
+        private const int MaxRecursionDepth = 10;
+        private const int MaxValueLength = 512 * 1024;
+        private const string LiteralFormatSymbol = "l";
+
+        /// <inheritDoc/>
+        public bool SerializeObject(object value, string format, IFormatProvider formatProvider, StringBuilder builder)
+        {
+            bool withoutFormat = string.IsNullOrEmpty(format);
+            if (!withoutFormat && format == "@")
+            {
+                return Config.ConfigurationItemFactory.Default.JsonConverter.SerializeObject(value, builder);
+            }
+            else if (!withoutFormat && format == "$")
+            {
+                builder.Append('"');
+                SerializeToString(value, null, formatProvider, builder);
+                builder.Append('"');
+                return true;
+            }
+            else
+            {
+                if (SerializeSimpleObject(value, format, formatProvider, builder, withoutFormat))
+                {
+                    return true;
+                }
+
+                IEnumerable collection = value as IEnumerable;
+                if (collection != null)
+                {
+                    return SerializeWithoutCyclicLoop(collection, format, formatProvider, builder, withoutFormat, default(SingleItemOptimizedHashSet<object>), 0);
+                }
+
+                builder.Append(Convert.ToString(value, formatProvider));
+                return true;
+            }
+        }
+
+        private bool SerializeSimpleObject(object value, string format, IFormatProvider formatProvider, StringBuilder builder, bool withoutFormat)
+        {
+            // todo support all scalar types: 
+
+            // todo boolean
+            // todo numerics complete? (formatable)
+            // todo byte[] - hex?
+            // todo datetime, timespan, datetimeoffset
+            // todo nullables correct?
+
+            var stringValue = value as string;
+            if (stringValue != null)
+            {
+                bool includeQuotes = withoutFormat || format != LiteralFormatSymbol;
+                if (includeQuotes) builder.Append('"');
+                builder.Append(stringValue);
+                if (includeQuotes) builder.Append('"');
+                return true;
+            }
+
+            if (value is char)
+            {
+                bool includeQuotes = withoutFormat || format != LiteralFormatSymbol;
+                if (includeQuotes) builder.Append('"');
+                builder.Append((char)value);
+                if (includeQuotes) builder.Append('"');
+                return true;
+            }
+
+            if (value == null)
+            {
+                builder.Append("NULL");
+                return true;
+            }
+
+            var formattable = value as IFormattable;
+            if (formattable != null)
+            {
+                builder.Append(formattable.ToString(format, formatProvider));
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool SerializeWithoutCyclicLoop(IEnumerable collection, string format, IFormatProvider formatProvider, StringBuilder builder, bool withoutFormat,
+                SingleItemOptimizedHashSet<object> objectsInPath, int depth)
+        {
+            if (objectsInPath.Contains(collection))
+            {
+                return false; // detected reference loop, skip serialization
+            }
+            if (depth > MaxRecursionDepth)
+            {
+                return false; // reached maximum recursion level, no further serialization
+            }
+
+            IDictionary dictionary = collection as IDictionary;
+            if (dictionary != null)
+            {
+                using (new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(dictionary, ref objectsInPath, true))
+                {
+                    return SerializeDictionaryObject(dictionary, format, formatProvider, builder, withoutFormat, objectsInPath, depth);
+                }
+            }
+
+            using (new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(collection, ref objectsInPath, true))
+            {
+                return SerializeCollectionObject(collection, format, formatProvider, builder, withoutFormat, objectsInPath, depth);
+            }
+        }
+
+        private bool SerializeDictionaryObject(IDictionary dictionary, string format, IFormatProvider formatProvider, StringBuilder builder, bool withoutFormat, SingleItemOptimizedHashSet<object> objectsInPath, int depth)
+        {
+            bool separator = false;
+            foreach (DictionaryEntry item in dictionary)
+            {
+                if (builder.Length > MaxValueLength)
+                    return false;
+
+                if (separator) builder.Append(", ");
+
+                if (item.Key is string || !(item.Key is IEnumerable))
+                    SerializeObject(item.Key, format, formatProvider, builder);
+                else
+                    SerializeWithoutCyclicLoop((IEnumerable)item.Key, format, formatProvider, builder, withoutFormat, objectsInPath, depth + 1);
+                builder.Append("=");
+                if (item.Value is string || !(item.Value is IEnumerable))
+                    SerializeObject(item.Value, format, formatProvider, builder);
+                else
+                    SerializeWithoutCyclicLoop((IEnumerable)item.Value, format, formatProvider, builder, withoutFormat, objectsInPath, depth + 1);
+                separator = true;
+            }
+            return true;
+        }
+
+        private bool SerializeCollectionObject(IEnumerable collection, string format, IFormatProvider formatProvider, StringBuilder builder, bool withoutFormat, SingleItemOptimizedHashSet<object> objectsInPath, int depth)
+        {
+            bool separator = false;
+            foreach (var item in collection)
+            {
+                if (builder.Length > MaxValueLength)
+                    return false;
+
+                if (separator) builder.Append(", ");
+
+                if (item is string || !(item is IEnumerable))
+                    SerializeObject(item, format, formatProvider, builder);
+                else
+                    SerializeWithoutCyclicLoop((IEnumerable)item, format, formatProvider, builder, withoutFormat, objectsInPath, depth + 1);
+                    
+                separator = true;
+            }
+            return true;
+        }
+
+        public static void SerializeToString(object value, string format, IFormatProvider formatProvider, StringBuilder builder)
+        {
+            var stringValue = value as string;
+            if (stringValue != null)
+            {
+                builder.Append(stringValue);
+            }
+            else
+            {
+                var formattable = value as IFormattable;
+                if (formattable != null)
+                {
+                    builder.Append(formattable.ToString(format, formatProvider));
+                }
+                else
+                {
+                    builder.Append(Convert.ToString(value, formatProvider));
+                }
+            }
+        }
+    }
+}

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -5,7 +5,7 @@
 
     <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net45;net40-client;net35;netstandard2.0</TargetFrameworks>
 
-    <Title>NLog</Title>
+    <Title>NLog for .NET Framework and .NET Standard</Title>
     <Company>NLog</Company>
     <Description>NLog is a logging platform for .NET with rich log routing and management capabilities.</Description>
     <Product>NLog v$(ProductVersion)</Product>

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -954,11 +954,11 @@ namespace NLog.Targets
         /// <summary>
         /// Can be used if <see cref="Target.OptimizeBufferReuse"/> has been enabled.
         /// </summary>
-        private readonly ReusableStreamCreator reusableFileWriteStream = new ReusableStreamCreator(1024);
+        private readonly ReusableStreamCreator reusableFileWriteStream = new ReusableStreamCreator(4096);
         /// <summary>
         /// Can be used if <see cref="Target.OptimizeBufferReuse"/> has been enabled.
         /// </summary>
-        private readonly ReusableStreamCreator reusableAsyncFileWriteStream = new ReusableStreamCreator(1024);
+        private readonly ReusableStreamCreator reusableAsyncFileWriteStream = new ReusableStreamCreator(4096);
         /// <summary>
         /// Can be used if <see cref="Target.OptimizeBufferReuse"/> has been enabled.
         /// </summary>
@@ -1194,7 +1194,7 @@ namespace NLog.Targets
         /// Formats the log event for write.
         /// </summary>
         /// <param name="logEvent">The log event to be formatted.</param>
-        /// <param name="target">Initially empty <see cref="StringBuilder"/> for the result.</param>
+        /// <param name="target"><see cref="StringBuilder"/> for the result.</param>
         protected virtual void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             this.Layout.RenderAppendBuilder(logEvent, target);

--- a/src/NLog/Targets/MethodCallTargetBase.cs
+++ b/src/NLog/Targets/MethodCallTargetBase.cs
@@ -119,13 +119,14 @@ namespace NLog.Targets
 
                     if (param.Layout != null)
                     {
+                        // If payload becomes too big, then use local StringBuilder to avoid json-maxlength-validation
                         if (sb.Length < MaxGroupRenderSingleBufferLength)
                         {
                             param.Layout.RenderAppendBuilder(logEvents[x].LogEvent, sb);
                         }
                         else
                         {
-                            using (var localTarget = new AppendBuilderCreator(sb, 16))
+                            using (var localTarget = new AppendBuilderCreator(sb, true))
                             {
                                 param.Layout.RenderAppendBuilder(logEvents[x].LogEvent, localTarget.Builder);
                             }

--- a/tests/NLog.UnitTests/Internal/MruCacheTests.cs
+++ b/tests/NLog.UnitTests/Internal/MruCacheTests.cs
@@ -63,14 +63,79 @@ namespace NLog.UnitTests.Internal
                 mruCache.TryAddValue(i, i.ToString());
 
             string value;
-            Assert.False(mruCache.TryGetValue(0, out value));
-            Assert.False(mruCache.TryGetValue(90, out value));
+            for (int i = 0; i < 100; ++i)
+            {
+                Assert.False(mruCache.TryGetValue(i, out value));
+            }
 
-            for (int i = 120; i < 200; ++i)
+            for (int i = 140; i < 200; ++i)
             {
                 Assert.True(mruCache.TryGetValue(i, out value));
                 Assert.Equal(i.ToString(), value);
             }
+        }
+
+        [Fact]
+        public void OverflowVersionCacheAndLookupTest()
+        {
+            string value;
+            MruCache<int, string> mruCache = new MruCache<int, string>(100);
+            for (int i = 0; i < 200; ++i)
+            {
+                mruCache.TryAddValue(i, i.ToString());
+                Assert.True(mruCache.TryGetValue(i, out value));    // No longer a virgin
+                Assert.Equal(i.ToString(), value);
+            }
+
+            for (int i = 0; i < 90; ++i)
+            {
+                Assert.False(mruCache.TryGetValue(i, out value));
+            }
+
+            for (int i = 140; i < 200; ++i)
+            {
+                Assert.True(mruCache.TryGetValue(i, out value));
+                Assert.Equal(i.ToString(), value);
+            }
+        }
+
+        [Fact]
+        public void OverflowFreshCacheAndLookupTest()
+        {
+            string value;
+            MruCache<int, string> mruCache = new MruCache<int, string>(100);
+            for (int i = 0; i < 200; ++i)
+            {
+                mruCache.TryAddValue(i, i.ToString());
+                Assert.True(mruCache.TryGetValue(i, out value));    // No longer a virgin
+                Assert.Equal(i.ToString(), value);
+            }
+
+            for (int j = 0; j < 2; ++j)
+            {
+                for (int i = 110; i < 200; ++i)
+                {
+                    if (!mruCache.TryGetValue(i, out value))
+                    {
+                        mruCache.TryAddValue(i, i.ToString());
+                        Assert.True(mruCache.TryGetValue(i, out value));
+                    }
+                }
+            }
+
+            for (int i = 300; i < 310; ++i)
+            {
+                mruCache.TryAddValue(i, i.ToString());
+            }
+
+            int cacheCount = 0;
+            for (int i = 110; i < 200; ++i)
+            {
+                if (mruCache.TryGetValue(i, out value))
+                    ++cacheCount;
+            }
+
+            Assert.True(cacheCount > 60);   // See that old cache was not killed
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Internal/PropertiesDictionaryTests.cs
+++ b/tests/NLog.UnitTests/Internal/PropertiesDictionaryTests.cs
@@ -35,6 +35,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using NLog.Internal;
+using NLog.MessageTemplates;
 using Xunit;
 
 namespace NLog.UnitTests.Internal

--- a/tests/NLog.UnitTests/LogMessageFormatterTests.cs
+++ b/tests/NLog.UnitTests/LogMessageFormatterTests.cs
@@ -34,6 +34,7 @@
 namespace NLog.UnitTests
 {
     using System.Collections.Generic;
+    using NLog.MessageTemplates;
     using Xunit;
 
     public class LogMessageFormatterTests : NLogTestBase

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -33,14 +33,15 @@
 
 namespace NLog.UnitTests
 {
-    using System.Reflection;
-    using NLog.Targets;
     using System;
     using System.Globalization;
-    using NLog.Config;
-    using System.Threading.Tasks;
-    using Xunit;
+    using System.Reflection;
+    using System.Collections.Generic;
     using System.Threading;
+    using System.Threading.Tasks;
+    using NLog.Targets;
+    using NLog.Config;
+    using Xunit;
 
     public class LoggerTests : NLogTestBase
     {
@@ -85,8 +86,8 @@ namespace NLog.UnitTests
 
                 logger.Trace(CultureInfo.InvariantCulture, "message{0}", (object)2);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message2");
-                
-                logger.Trace("message{0}{1}", 1,2);
+
+                logger.Trace("message{0}{1}", 1, 2);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message12");
 
                 logger.Trace("message{0}{1}{2}", 1, 2, 3);
@@ -107,7 +108,7 @@ namespace NLog.UnitTests
                 logger.Trace("message{0}", (object)2.3);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message2.3");
 
-                logger.Trace(NLCulture,  "message{0}", (object)2.3);
+                logger.Trace(NLCulture, "message{0}", (object)2.3);
                 if (enabled == 1) AssertDebugLastMessage("debug", "message2,3");
 
                 logger.Trace("message{0}", (ulong)1);
@@ -1515,7 +1516,7 @@ namespace NLog.UnitTests
 
                 logger.ConditionalDebug(argException, NLCulture, "we've got error {0}, {1}, {2}, {3} ...", 500, 501, 502, 503.5);
                 if (enabled == 1) AssertDebugLastMessage("debug", "we\'ve got error 500, 501, 502, 503,5 ...arg1 is obvious wrong\r\nParameter name: arg1");
-                
+
                 logger.ConditionalDebug(argException, "we've got error {0}, {1}, {2}, {3} ...", 500, 501, 502, 503.5);
                 if (enabled == 1) AssertDebugLastMessage("debug", "we\'ve got error 500, 501, 502, 503.5 ...arg1 is obvious wrong\r\nParameter name: arg1");
 
@@ -1750,6 +1751,322 @@ namespace NLog.UnitTests
             Assert.Throws<InvalidOperationException>(() => logger.Log(new LogEventInfo()));
         }
 
+        [Theory]
+        [InlineData(true, null)]
+        [InlineData(false, null)]
+        [InlineData(null, true)]
+        [InlineData(null, false)]
+        [InlineData(null, null)]
+        public void StructuredEventsConfigTest(bool? messageTemplateParser, bool? overrideMessageTemplateParser)
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog messageTemplateParser='" + (messageTemplateParser?.ToString() ?? string.Empty) + @"'>
+                    <targets><target name='debug' type='Debug' layout='${message}${exception}' /></targets>
+                    <rules>
+                        <logger name='*' writeTo='debug' />
+                    </rules>
+                </nlog>");
+
+            if (messageTemplateParser.HasValue)
+            {
+                Assert.Equal(ConfigurationItemFactory.Default.EnableMessageTemplateParser, messageTemplateParser.Value);
+            }
+
+            if (overrideMessageTemplateParser.HasValue)
+            {
+                ConfigurationItemFactory.Default.EnableMessageTemplateParser = overrideMessageTemplateParser.Value;
+            }
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("Hello World {0}", new object[] { null });
+            if (messageTemplateParser == true || overrideMessageTemplateParser == true)
+                AssertDebugLastMessage("debug", "Hello World NULL");
+            else
+                AssertDebugLastMessage("debug", "Hello World ");
+        }
+
+        [Fact]
+        public void StructuredEventsTest1()
+        {
+            // test all possible overloads of the Error() method
+            var James = new Person("James");
+            var Mike = new Person("Mike");
+            var Jane = new Person("Jane") { Childs = new List<Person> { James, Mike } };
+
+
+            for (int enabled = 0; enabled < 2; ++enabled)
+            {
+                if (enabled == 0)
+                {
+                    LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog>
+                    <targets><target name='debug' type='Debug' layout='${message}${exception}' /></targets>
+                    <rules>
+                        <logger name='*' levels='' writeTo='debug' />
+                    </rules>
+                </nlog>");
+                }
+                else
+                {
+                    LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog>
+                    <targets><target name='debug' type='Debug' layout='${message}${exception}' /></targets>
+                    <rules>
+                        <logger name='*' levels='Error' writeTo='debug' />
+                    </rules>
+                </nlog>");
+                }
+
+                ILogger logger = LogManager.GetLogger("A");
+                LogManager.Configuration.DefaultCultureInfo = CultureInfo.InvariantCulture;
+
+                logger.Error("hello from {@Person}", Jane);
+                if (enabled == 1) AssertDebugLastMessage("debug", "hello from {\"Name\":\"Jane\", \"Childs\":[{\"Name\":\"James\"},{\"Name\":\"Mike\"}]}");
+
+                logger.Error("Test structured logging in {NLogVersion} for .NET {NETVersion}", "4.5-alpha01", new[] { 3.5, 4, 4.5 });
+                if (enabled == 1) AssertDebugLastMessage("debug", "Test structured logging in \"4.5-alpha01\" for .NET 3.5, 4, 4.5");
+
+                logger.Error("hello from {FamilyNames}", new Dictionary<int, string>() { { 1, "James" }, { 2, "Mike" }, { 3, "Jane" } });
+                if (enabled == 1) AssertDebugLastMessage("debug", "hello from 1=\"James\", 2=\"Mike\", 3=\"Jane\"");
+
+                logger.Error("message {a} {b}", 1, 2);
+                if (enabled == 1)
+                {
+                    AssertDebugLastMessage("debug", "message 1 2");
+
+                }
+
+                logger.Error("message{a}{b}{c}", 1, 2, 3);
+                if (enabled == 1)
+                {
+                    AssertDebugLastMessage("debug", "message123");
+                }
+
+
+                logger.Error("message {a} {b} {c}", "1", "2", "3");
+                if (enabled == 1)
+                {
+                    //todo single quotes
+                    AssertDebugLastMessage("debug", "message \"1\" \"2\" \"3\"");
+                }
+
+
+                logger.Error("message{a}{b}{c}", 1, 2, 3);
+                if (enabled == 1) AssertDebugLastMessage("debug", "message123");
+
+
+                //todo other tests
+
+                //                logger.Error(NLCulture, "message{0}{1}{2}", 1.4, 2.5, 3.6);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message1,42,53,6");
+
+                //                logger.Error("message{0}", (float)2.3);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2.3");
+
+                //                logger.Error("message{0}", (double)2.3);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2.3");
+
+                //                logger.Error("message{0}", (decimal)2.3);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2.3");
+
+                //                logger.Error("message{0}", (object)2.3);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2.3");
+
+                //                logger.Error(NLCulture, "message{0}", (object)2.3);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2,3");
+
+                //                logger.Error("message{0}", (ulong)1);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message1");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", (ulong)2);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2");
+
+                //                logger.Error("message{0}", (long)1);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message1");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", (long)2);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2");
+
+                //                logger.Error("message{0}", (uint)1);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message1");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", (uint)2);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2");
+
+                //                logger.Error("message{0}", 1);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message1");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", 2);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2");
+
+                //                logger.Error("message{0}", (ushort)1);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message1");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", (ushort)2);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2");
+
+                //                logger.Error("message{0}", (sbyte)1);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message1");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", (sbyte)2);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2");
+
+                //                logger.Error("message{0}", this);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messageobject-to-string");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", this);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messageobject-to-string");
+
+                //                logger.Error("message{0}", (short)1);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message1");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", (short)2);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2");
+
+                //                logger.Error("message{0}", (byte)1);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message1");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", (byte)2);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2");
+
+                //                logger.Error("message{0}", 'c');
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messagec");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", 'd');
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messaged");
+
+                //                logger.Error("message{0}", "ddd");
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messageddd");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", "eee");
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messageeee");
+
+                //                logger.Error("message{0}{1}", "ddd", 1);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messageddd1");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}{1}", "eee", 2);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messageeee2");
+
+                //                logger.Error("message{0}{1}{2}", "ddd", 1, "eee");
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messageddd1eee");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}{1}{2}", "eee", 2, "fff");
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messageeee2fff");
+
+                //                logger.Error("message{0}{1}{2}{3}", "eee", 2, "fff", "ggg");
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messageeee2fffggg");
+
+                //                logger.Error("message{0}", true);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messageTrue");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", false);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messageFalse");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", (float)2.5);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2.5");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", 2.5);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2.5");
+
+                //                logger.Error(CultureInfo.InvariantCulture, "message{0}", (decimal)2.5);
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message2.5");
+
+                //#pragma warning disable 0618
+                //                // Obsolete method requires testing until removed.
+                //                logger.ErrorException("message", new Exception("test"));
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "messagetest");
+                //#pragma warning restore 0618
+
+                logger.Error(new Exception("test"), "message");
+                if (enabled == 1) AssertDebugLastMessage("debug", "messagetest");
+
+                logger.Error(new Exception("test"), "message {Exception}", "from parameter");
+                if (enabled == 1) AssertDebugLastMessage("debug", "message \"from parameter\"test");
+
+
+
+
+                //                logger.Error(delegate { return "message from lambda"; });
+                //                if (enabled == 1) AssertDebugLastMessage("debug", "message from lambda");
+
+                if (enabled == 0)
+                    AssertDebugCounter("debug", 0);
+            }
+        }
+
+        /// <summary>
+        /// Only properties
+        /// </summary>
+        [Fact]
+        public void TestStructuredProperties_json()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog throwExceptions='true'>
+                    <targets>
+                        <target name='debug' type='Debug'  >
+                                <layout type='JsonLayout' IncludeAllProperties='true'>
+                                    <attribute name='LogMessage' layout='${message:raw=true}' />
+                                </layout>
+                        </target>
+                    </targets>
+                    <rules>
+                        <logger name='*' levels='Error' writeTo='debug' />
+                    </rules>
+                </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+
+            logger.Error("Login request from {Username} for {Application}", "John", "BestApplicationEver");
+
+            AssertDebugLastMessage("debug", "{ \"LogMessage\": \"Login request from {Username} for {Application}\", \"Username\": \"John\", \"Application\": \"BestApplicationEver\" }");
+        }
+
+        /// <summary>
+        /// Properties and message
+        /// </summary>
+        [Fact]
+        public void TestStructuredProperties_json_compound()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog throwExceptions='true'>
+                    <targets>
+                        <target name='debug' type='Debug'  >
+                              <layout type='CompoundLayout'>
+                                <layout type='SimpleLayout' text='${message}' />
+                                <layout type='JsonLayout' IncludeAllProperties='true' />
+                              </layout>
+                        </target>
+                    </targets>
+                    <rules>
+                        <logger name='*' levels='Error' writeTo='debug' />
+                    </rules>
+                </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+
+            logger.Error("Login request from {Username} for {Application}", "John", "BestApplicationEver");
+
+            AssertDebugLastMessage("debug", "Login request from \"John\" for \"BestApplicationEver\"{ \"Username\": \"John\", \"Application\": \"BestApplicationEver\" }");
+        }
+
+
+        private class Person
+        {
+            public Person()
+            {
+            }
+
+            public Person(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get; set; }
+
+            public List<Person> Childs { get; set; }
+
+        }
+
         public abstract class BaseWrapper
         {
             public void Log(string what)
@@ -1807,5 +2124,26 @@ namespace NLog.UnitTests
             return "object-to-string";
         }
 
+
+        [Fact]
+        public void LogEventTemplateShouldHaveProperties()
+        {
+            var logEventInfo = new LogEventInfo(LogLevel.Debug, "logger1", null, "{A}", new object[] { "b" });
+            var props = logEventInfo.Properties;
+            Assert.Contains("A", props.Keys);
+            Assert.Equal("b", props["A"]);
+            Assert.Equal(1, props.Count);
+        }
+
+        [Fact]
+        public void LogEventTemplateShouldHaveProperties_even_when_changed()
+        {
+            var logEventInfo = new LogEventInfo(LogLevel.Debug, "logger1", null, "{A}", new object[] { "b" });
+            var props = logEventInfo.Properties;
+            logEventInfo.Message = "{A}";
+            Assert.Contains("A", props.Keys);
+            Assert.Equal("b", props["A"]);
+            Assert.Equal(1, props.Count);
+        }
     }
 }

--- a/tests/NLog.UnitTests/StructuredEvents/ParserTests.cs
+++ b/tests/NLog.UnitTests/StructuredEvents/ParserTests.cs
@@ -1,0 +1,231 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.StructuredEvents
+{
+    using System;
+    using NLog.MessageTemplates;
+    using Xunit;
+    using Xunit.Extensions;
+
+    public class ParserTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("Hello {0}")]
+        [InlineData("I like my {car}")]
+        [InlineData("But when Im drunk I need a {cool} bike")]
+        [InlineData("I have {0} {1} {2} parameters")]
+        [InlineData("{0} on front")]
+        [InlineData(" {0} on front")]
+        [InlineData("end {1}")]
+        [InlineData("end {1} ")]
+        [InlineData("{name} is my name")]
+        [InlineData(" {name} is my name")]
+        [InlineData("{multiple}{parameters}")]
+        [InlineData("I have {{text}} and {{0}}")]
+        [InlineData("{{text}}{{0}}")]
+        [InlineData(" {{text}}{{0}} ")]
+        [InlineData(" {0} ")]
+        [InlineData(" {1} ")]
+        [InlineData(" {2} ")]
+        [InlineData(" {3} {4} {9} {8} {5} {6} {7}")]
+        [InlineData(" {{ ")]
+        [InlineData("{{ ")]
+        [InlineData(" {{")]
+        [InlineData(" }} ")]
+        [InlineData("}} ")]
+        [InlineData(" }}")]
+        [InlineData("{0:000}")]
+        [InlineData("{aaa:000}")]
+        [InlineData(" {@serialize} ")]
+        [InlineData(" {$stringify} ")]
+        [InlineData(" {alignment,-10} ")]
+        [InlineData(" {alignment,10} ")]
+        [InlineData(" {0,10} ")]
+        [InlineData(" {0,-10} ")]
+        [InlineData(" {0,-10:test} ")]
+        [InlineData("{{{0:d}}}")]
+        [InlineData("{{{0:0{{}")]
+        public void ParseAndPrint(string input)
+        {
+            var template = TemplateParser.Parse(input);
+
+            Assert.Equal(input, template.Rebuild());
+        }
+
+        [Theory]
+        [InlineData("{0}", 0, null)]
+        [InlineData("{001}", 1, null)]
+        [InlineData("{9}", 9, null)]
+        [InlineData("{1 }", 1, null)]
+        [InlineData("{1} {2}", 1, null)]
+        [InlineData("{@3} {$4}", 3, null)]
+        [InlineData("{3,6}", 3, null)]
+        [InlineData("{5:R}", 5, "R")]        
+        [InlineData("{0:0}", 0, "0")]        
+        public void ParsePositional(string input, int index, string format)
+        {
+            var template = TemplateParser.Parse(input);
+
+            Assert.True(template.IsPositional);
+            Assert.Equal(format, template.Holes[0].Format);
+            Assert.Equal(index, template.Holes[0].Index);
+        }
+
+        [Theory]
+        [InlineData("{ 0}")]
+        [InlineData("{-1}")]
+        [InlineData("{1.2}")]
+        [InlineData("{42r}")]
+        [InlineData("{6} {x}")]
+        [InlineData("{a} {x}")]
+        public void ParseNominal(string input)
+        {
+            var template = TemplateParser.Parse(input);
+
+            Assert.False(template.IsPositional);
+        }
+
+        [Theory]
+        [InlineData("{hello}", "hello")]
+        [InlineData("{@hello}", "hello")]
+        [InlineData("{$hello}", "hello")]
+        [InlineData("{#hello}", "#hello")]
+        [InlineData("{  spaces  ,-3}", "  spaces  ")]
+        [InlineData("{special!:G})", "special!")]
+        [InlineData("{noescape_in_name}}}", "noescape_in_name")]
+        [InlineData("{noescape_in_name{{}", "noescape_in_name{{")]
+        [InlineData("{0}", "0")]
+        [InlineData("{18 }", "18 ")]
+        public void ParseName(string input, string name)
+        {
+            var template = TemplateParser.Parse(input);
+
+            Assert.Equal(name, template.Holes[0].Name);
+        }
+
+        [Theory]
+        [InlineData("{aaa}", "")]
+        [InlineData("{@a}", "@")]
+        [InlineData("{@A}", "@")]
+        [InlineData("{@8}", "@")]
+        [InlineData("{@aaa}", "@")]
+        [InlineData("{$a}", "$")]
+        [InlineData("{$A}", "$")]
+        [InlineData("{$9}", "$")]
+        [InlineData("{$aaa}", "$")]
+        public void ParseHoleType(string input, string holeType)
+        {
+            var template = TemplateParser.Parse(input);
+
+            Assert.Single(template.Holes);
+            CaptureType captureType = CaptureType.Normal;
+            if (holeType == "@")
+                captureType = CaptureType.Serialize;
+            else if (holeType == "$")
+                captureType = CaptureType.Stringify;
+            Assert.Equal(captureType, template.Holes[0].CaptureType);
+        }
+
+        [Theory]
+        [InlineData(" {0,-10:nl-nl} ", -10, "nl-nl")]
+        [InlineData(" {0,-10} ", -10, null)]
+        [InlineData("{0,  36  }", 36, null)]
+        [InlineData("{0,-36  :x}", -36, "x")]
+        [InlineData(" {0:nl-nl} ", 0, "nl-nl")]
+        [InlineData(" {0} ", 0, null)]
+        public void ParseFormatAndAlignment_numeric(string input, int aligment, string format)
+        {
+            var templates = TemplateParser.Parse(input);
+            var hole = templates.Holes[0];
+
+            Assert.Equal("0", hole.Name);
+            Assert.Equal(0, hole.Index);
+            Assert.Equal(aligment, hole.Alignment);
+            Assert.Equal(format, hole.Format);
+        }
+
+        [Theory]
+        [InlineData(" {car,-10:nl-nl} ", -10, "nl-nl")]
+        [InlineData(" {car,-10} ", -10, null)]
+        [InlineData(" {car:nl-nl} ", 0, "nl-nl")]
+        [InlineData(" {car} ", 0, null)]
+        public void ParseFormatAndAlignment_text(string input, int aligment, string format)
+        {
+            var template = TemplateParser.Parse(input);
+            var hole = template.Holes[0];
+
+            Assert.False(template.IsPositional);
+            Assert.Equal("car", hole.Name);
+            Assert.Equal(aligment, hole.Alignment);
+            Assert.Equal(format, hole.Format);
+        }
+
+        [Theory]
+        [InlineData("Hello {0")]
+        [InlineData("Hello 0}")]
+        [InlineData("Hello {a:")]
+        [InlineData("Hello {a")]
+        [InlineData("Hello {a,")]
+        [InlineData("Hello {a,1")]
+        [InlineData("{")]
+        [InlineData("}")]
+        [InlineData("}}}")]
+        [InlineData("}}}{")]
+        [InlineData("{}}{")]
+        [InlineData("{a,-3.5}")]
+        [InlineData("{a,2x}")]
+        [InlineData("{a,--2}")]
+        [InlineData("{a,-2")]
+        [InlineData("{a,-2 :N0")]
+        [InlineData("{a,-2.0")]
+        [InlineData("{a,:N0}")]
+        [InlineData("{a,}")]        
+        [InlineData("{a,{}")]        
+        [InlineData("{a:{}")]        
+        [InlineData("{a,d{e}")]        
+        [InlineData("{a:d{e}")]        
+        public void ThrowsTemplateParserException(string input)
+        {
+            Assert.Throws<TemplateParserException>(() => TemplateParser.Parse(input));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        public void ThrowsArgumentNullException(string input)
+        {
+            Assert.Throws<ArgumentNullException>(() => TemplateParser.Parse(input));
+        }
+    }
+}

--- a/tests/NLog.UnitTests/StructuredEvents/RendererTests.cs
+++ b/tests/NLog.UnitTests/StructuredEvents/RendererTests.cs
@@ -1,0 +1,105 @@
+// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.StructuredEvents
+{
+    using System;
+    using System.Globalization;
+    using NLog.MessageTemplates;
+    using Xunit;
+    using Xunit.Extensions;
+
+    public class RendererTests
+    {
+        [Theory]
+        [InlineData("{0}", new object[] { "a" }, "a")]
+        [InlineData(" {0}", new object[] { "a" }, " a")]
+        [InlineData(" {0} ", new object[] { "a" }, " a ")]
+        [InlineData(" {0} {1} ", new object[] { "a", "b" }, " a b ")]
+        [InlineData(" {1} {0} ", new object[] { "a", "b" }, " b a ")]
+        [InlineData(" {1} {0} {0}", new object[] { "a", "b" }, " b a a")]
+        [InlineData(" message {1} {0} {0}", new object[] { "a", "b" }, " message b a a")]
+        [InlineData(" message {1} {0} {0}", new object[] { 'a', 'b' }, " message b a a")]
+        [InlineData("char {one}", new object[] { 'X' }, "char \"X\"")]
+        [InlineData("char {one:l}", new object[] { 'X' }, "char X")]
+        [InlineData(" message {{{1}}} {0} {0}", new object[] { "a", "b" }, " message {b} a a")]
+        [InlineData(" message {{{one}}} {two} {three}", new object[] { "a", "b", "c" }, " message {\"a\"} \"b\" \"c\"")]
+        [InlineData(" message {{{1} {0} {0}}}", new object[] { "a", "b" }, " message {b a a}")]
+        [InlineData(" completed in {time} sec", new object[] { 10 }, " completed in 10 sec")]
+        [InlineData(" completed task {name} in {time} sec", new object[] { "test", 10 }, " completed task \"test\" in 10 sec")]
+        [InlineData(" completed task {name:l} in {time} sec", new object[] { "test", 10 }, " completed task test in 10 sec")]
+        [InlineData(" completed task {0} in {1} sec", new object[] { "test", 10 }, " completed task test in 10 sec")]
+        [InlineData(" completed task {0} in {1:000} sec", new object[] { "test", 10 }, " completed task test in 010 sec")]
+        [InlineData(" completed task {name} in {time:000} sec", new object[] { "test", 10 }, " completed task \"test\" in 010 sec")]
+        [InlineData(" completed tasks {tasks} in {time:000} sec", new object[] { new [] { "parsing", "testing", "fixing"}, 10 }, " completed tasks \"parsing\", \"testing\", \"fixing\" in 010 sec")]
+        [InlineData(" completed tasks {tasks:l} in {time:000} sec", new object[] { new [] { "parsing", "testing", "fixing"}, 10 }, " completed tasks parsing, testing, fixing in 010 sec")]
+#if !MONO
+        [InlineData(" completed tasks {$tasks} in {time:000} sec", new object[] { new [] { "parsing", "testing", "fixing"}, 10 }, " completed tasks \"System.String[]\" in 010 sec")]
+        [InlineData(" completed tasks {0} in {1:000} sec", new object[] { new [] { "parsing", "testing", "fixing"}, 10 }, " completed tasks System.String[] in 010 sec")]
+#endif
+        [InlineData("{{{0:d}}}", new object[] { 3 }, "{d}")] //format is here "d}" ... because escape from left-to-right 
+        [InlineData("{{{0:d} }}", new object[] { 3 }, "{3 }")]
+        [InlineData("{{{0:dd}}}", new object[] { 3 }, "{dd}")]
+        [InlineData("{{{0:0{{}", new object[] { 3 }, "{3{")] //format is here "0{"
+        [InlineData("hello {0}", new object[] { null }, "hello NULL")]
+        public void RenderTest(string input, object[] args, string expected)
+        {
+            var culture = CultureInfo.InvariantCulture;
+
+            RenderAndTest(input, culture, args, expected);
+        }
+
+        [Theory]
+        [InlineData("test {0}", "nl", new object[] { 12.3 }, "test 12,3")]
+        [InlineData("test {0}", "en-gb", new object[] { 12.3 }, "test 12.3")]
+        public void RenderCulture(string input, string language, object[] args, string expected)
+        {
+            var culture = new CultureInfo(language);
+
+            RenderAndTest(input, culture, args, expected);
+        }
+
+        private static void RenderAndTest(string input, CultureInfo culture, object[] args, string expected)
+        {
+            var template = TemplateParser.Parse(input);
+
+            var sb = new System.Text.StringBuilder();
+            template.Render(sb, culture, args);
+            Assert.Equal(expected, sb.ToString());
+
+            sb.Length = 0;
+            TemplateRenderer.Render(input, culture, args, true, sb, out var messageTemplateParameters);
+            Assert.Equal(expected, sb.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Have merged https://github.com/NLog/NLog.StructuredEvents together with https://github.com/NLog/NLog

And then introduced a TemplateEnumerator, that only allocates the hole-name-strings (when non-positional), and not any MessageTemplate-object (with friends).

Stolen the unit tests from #2126

Have added some extra performance optimizations:

- New StringBuilderPool so MessageTemplate-renderering only allocates the formatted-string (just like string.Format)
- Using new StringBuilderPool other places in the NLog-core-engine to minimize allocations (AppendBuilderCreator)
- Better reuse of already allocated StringBuilder when possible (AppendBuilderCreator)
- Faster encoding of StringBuilder to byte-array. Instead of doing the encoding twice, to find the exact byte-count, then pre-allocate max-byte-count, and truncate afterwards (if needed).