### PR TITLE
NestedDiagnosticsLogicalContext - Support remote AppDomain (NLog 5)

### DIFF
--- a/src/NLog/NestedDiagnosticsLogicalContext.cs
+++ b/src/NLog/NestedDiagnosticsLogicalContext.cs
@@ -103,6 +103,9 @@ namespace NLog
             object Value { get; }
         }
 
+#if !NETSTANDARD && !NET4_6
+        [Serializable]
+#endif
         class NestedContext<T> : INestedContext
         {
             public INestedContext Parent { get; private set; }

--- a/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
+++ b/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
@@ -63,7 +63,12 @@ namespace NLog.UnitTests.Internal
                     // ClassUnderTest must extend MarshalByRefObject
                     AppDomain partialTrusted;
                     var classUnderTest = MediumTrustContext.Create<ClassUnderTest>(fileWritePath, out partialTrusted);
-                    classUnderTest.PartialTrustSuccess(times, fileWritePath);
+#if NET4_0 || NET4_5
+                    using (NLog.NestedDiagnosticsLogicalContext.Push("PartialTrust"))
+#endif
+                    {
+                        classUnderTest.PartialTrustSuccess(times, fileWritePath);
+                    }
                     AppDomain.Unload(partialTrusted);
                 }
 


### PR DESCRIPTION
#2221 for the 5.0.0-Hotfix (Before start using it by default in NLog.Extensions.Logging)