### PR TITLE
LogEventInfo.MessageFormatter - External Structured Logging Formatter

### DIFF
--- a/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
@@ -68,13 +68,22 @@ namespace NLog.LayoutRenderers
         public string ExceptionSeparator { get; set; }
 
         /// <summary>
+        /// Gets or sets whether it should render the raw message without formatting parameters
+        /// </summary>
+        /// <docgen category='Layout Options' order='10' />
+        public bool Raw { get; set; }
+
+        /// <summary>
         /// Renders the log message including any positional parameters and appends it to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            builder.Append(logEvent.FormattedMessage);
+            if (this.Raw)
+                builder.Append(logEvent.Message);
+            else
+                builder.Append(logEvent.FormattedMessage);
             if (this.WithException && logEvent.Exception != null)
             {
                 builder.Append(this.ExceptionSeparator);

--- a/src/NLog/LogMessageFormatter.cs
+++ b/src/NLog/LogMessageFormatter.cs
@@ -1,0 +1,42 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog
+{
+    /// <summary>
+    /// Generates a formatted message from the log event
+    /// </summary>
+    /// <param name="logEvent">Log event.</param>
+    /// <returns>Formatted message</returns>
+    public delegate string LogMessageFormatter(LogEventInfo logEvent);
+}

--- a/src/NLog/NLog.Xamarin.Android.csproj
+++ b/src/NLog/NLog.Xamarin.Android.csproj
@@ -328,6 +328,7 @@
     </Compile>
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogMessageFormatter.cs" />
     <Compile Include="LogMessageGenerator.cs" />
     <Compile Include="LogReceiverService\BaseLogReceiverForwardingService.cs" />
     <Compile Include="LogReceiverService\ILogReceiverClient.cs" />

--- a/src/NLog/NLog.Xamarin.iOS.csproj
+++ b/src/NLog/NLog.Xamarin.iOS.csproj
@@ -325,6 +325,7 @@
     </Compile>
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogMessageFormatter.cs" />
     <Compile Include="LogMessageGenerator.cs" />
     <Compile Include="LogReceiverService\BaseLogReceiverForwardingService.cs" />
     <Compile Include="LogReceiverService\ILogReceiverClient.cs" />

--- a/src/NLog/NLog.doc.csproj
+++ b/src/NLog/NLog.doc.csproj
@@ -338,6 +338,7 @@
     </Compile>
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogMessageFormatter.cs" />
     <Compile Include="LogMessageGenerator.cs" />
     <Compile Include="LogReceiverService\BaseLogReceiverForwardingService.cs" />
     <Compile Include="LogReceiverService\ILogReceiverClient.cs" />

--- a/src/NLog/NLog.mono.csproj
+++ b/src/NLog/NLog.mono.csproj
@@ -344,6 +344,7 @@
     </Compile>
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogMessageFormatter.cs" />
     <Compile Include="LogMessageGenerator.cs" />
     <Compile Include="LogReceiverService\BaseLogReceiverForwardingService.cs" />
     <Compile Include="LogReceiverService\ILogReceiverClient.cs" />

--- a/src/NLog/NLog.netfx35.csproj
+++ b/src/NLog/NLog.netfx35.csproj
@@ -337,6 +337,7 @@
     </Compile>
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogMessageFormatter.cs" />
     <Compile Include="LogMessageGenerator.cs" />
     <Compile Include="LogReceiverService\BaseLogReceiverForwardingService.cs" />
     <Compile Include="LogReceiverService\ILogReceiverClient.cs" />

--- a/src/NLog/NLog.netfx40.csproj
+++ b/src/NLog/NLog.netfx40.csproj
@@ -337,6 +337,7 @@
     </Compile>
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogMessageFormatter.cs" />
     <Compile Include="LogMessageGenerator.cs" />
     <Compile Include="LogReceiverService\BaseLogReceiverForwardingService.cs" />
     <Compile Include="LogReceiverService\ILogReceiverClient.cs" />

--- a/src/NLog/NLog.netfx45.csproj
+++ b/src/NLog/NLog.netfx45.csproj
@@ -343,6 +343,7 @@
     </Compile>
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogMessageFormatter.cs" />
     <Compile Include="LogMessageGenerator.cs" />
     <Compile Include="LogReceiverService\BaseLogReceiverForwardingService.cs" />
     <Compile Include="LogReceiverService\ILogReceiverClient.cs" />

--- a/src/NLog/NLog.sl4.csproj
+++ b/src/NLog/NLog.sl4.csproj
@@ -344,6 +344,7 @@
     </Compile>
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogMessageFormatter.cs" />
     <Compile Include="LogMessageGenerator.cs" />
     <Compile Include="LogReceiverService\BaseLogReceiverForwardingService.cs" />
     <Compile Include="LogReceiverService\ILogReceiverClient.cs" />

--- a/src/NLog/NLog.sl5.csproj
+++ b/src/NLog/NLog.sl5.csproj
@@ -341,6 +341,7 @@
     </Compile>
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogMessageFormatter.cs" />
     <Compile Include="LogMessageGenerator.cs" />
     <Compile Include="LogReceiverService\BaseLogReceiverForwardingService.cs" />
     <Compile Include="LogReceiverService\ILogReceiverClient.cs" />

--- a/src/NLog/NLog.wp7.csproj
+++ b/src/NLog/NLog.wp7.csproj
@@ -341,6 +341,7 @@
     </Compile>
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogMessageFormatter.cs" />
     <Compile Include="LogMessageGenerator.cs" />
     <Compile Include="LogReceiverService\BaseLogReceiverForwardingService.cs" />
     <Compile Include="LogReceiverService\ILogReceiverClient.cs" />

--- a/src/NLog/NLog.wp71.csproj
+++ b/src/NLog/NLog.wp71.csproj
@@ -341,6 +341,7 @@
     </Compile>
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogMessageFormatter.cs" />
     <Compile Include="LogMessageGenerator.cs" />
     <Compile Include="LogReceiverService\BaseLogReceiverForwardingService.cs" />
     <Compile Include="LogReceiverService\ILogReceiverClient.cs" />

--- a/src/NLog/NLog.wp8.csproj
+++ b/src/NLog/NLog.wp8.csproj
@@ -366,6 +366,7 @@
     </Compile>
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogManager.cs" />
+    <Compile Include="LogMessageFormatter.cs" />
     <Compile Include="LogMessageGenerator.cs" />
     <Compile Include="LogReceiverService\BaseLogReceiverForwardingService.cs" />
     <Compile Include="LogReceiverService\ILogReceiverClient.cs" />

--- a/tests/NLog.UnitTests/LogMessageFormatterTests.cs
+++ b/tests/NLog.UnitTests/LogMessageFormatterTests.cs
@@ -1,0 +1,79 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests
+{
+    using Xunit;
+
+    public class LogMessageFormatterTests : NLogTestBase
+    {
+        [Fact]
+        public void StructuredLoggingTest()
+        {
+            LogEventInfo logEventInfo = new LogEventInfo(LogLevel.Info, string.Empty, "Login request from {Username} for {Application}");
+            logEventInfo.Properties["Username"] = "John";
+            logEventInfo.Properties["Application"] = "BestApplicationEver";
+            logEventInfo.Parameters = new object[] { "Login request from John for BestApplicationEver" };   // Must have parameter to activate MessageFormatter
+            logEventInfo.MessageFormatter = (logEvent) =>
+            {
+                object formattedMessage;
+                if (logEvent.Parameters != null && logEvent.Parameters.Length == 1)
+                {
+                    return logEvent.Parameters[0] as string ?? logEvent.Message;
+                }
+                return logEvent.Message;
+            };
+
+            LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog throwExceptions='true'>
+                    <targets>
+                        <target name='debug' type='Debug'  >
+                                <layout type='JsonLayout' IncludeAllProperties='true'>
+                                    <attribute name='LogMessage' layout='${message:raw=true}' />
+                                </layout>
+                        </target>
+                    </targets>
+                    <rules>
+                        <logger name='*' levels='Info' writeTo='debug' />
+                    </rules>
+                </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logEventInfo.LoggerName = logger.Name;
+            logger.Log(logEventInfo);
+            AssertDebugLastMessage("debug", "{ \"LogMessage\": \"Login request from {Username} for {Application}\", \"Username\": \"John\", \"Application\": \"BestApplicationEver\" }");
+
+            Assert.Equal("Login request from John for BestApplicationEver", logEventInfo.FormattedMessage);
+        }
+    }
+}

--- a/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.mono.csproj
@@ -7,8 +7,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -199,6 +198,7 @@
     <Compile Include="LoggerTests.cs" />
     <Compile Include="LogLevelTests.cs" />
     <Compile Include="LogManagerTests.cs" />
+    <Compile Include="LogMessageFormatterTests.cs" />
     <Compile Include="LogReceiverService\LogReceiverForwardingServiceTests.cs" />
     <Compile Include="LogReceiverService\LogReceiverServiceTests.cs" />
     <Compile Include="NLogTestBase.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx35.csproj
@@ -9,10 +9,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)'==''">v4.0</TargetFrameworkVersion>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <ApplicationIcon></ApplicationIcon>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -21,10 +19,8 @@
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <SignAssembly>true</SignAssembly>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
+    <FileUpgradeFlags></FileUpgradeFlags>
+    <UpgradeBackupLocation></UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <PublishUrl>publish\</PublishUrl>
@@ -42,8 +38,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\Debug\</OutputPath>
@@ -226,6 +221,7 @@
     <Compile Include="LoggerTests.cs" />
     <Compile Include="LogLevelTests.cs" />
     <Compile Include="LogManagerTests.cs" />
+    <Compile Include="LogMessageFormatterTests.cs" />
     <Compile Include="LogReceiverService\LogReceiverForwardingServiceTests.cs" />
     <Compile Include="LogReceiverService\LogReceiverServiceTests.cs" />
     <Compile Include="NLogTestBase.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx40.csproj
@@ -10,10 +10,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <ApplicationIcon>
-    </ApplicationIcon>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <ApplicationIcon></ApplicationIcon>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>NLog.UnitTests</AssemblyName>
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -25,8 +23,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <BaseAddress>285212672</BaseAddress>
@@ -205,6 +202,7 @@
     <Compile Include="LoggerTests.cs" />
     <Compile Include="LogLevelTests.cs" />
     <Compile Include="LogManagerTests.cs" />
+    <Compile Include="LogMessageFormatterTests.cs" />
     <Compile Include="LogReceiverService\LogReceiverForwardingServiceTests.cs" />
     <Compile Include="LogReceiverService\LogReceiverServiceTests.cs" />
     <Compile Include="NLogTestBase.cs" />

--- a/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.netfx45.csproj
@@ -244,6 +244,7 @@
     <Compile Include="LoggerTests.cs" />
     <Compile Include="LogLevelTests.cs" />
     <Compile Include="LogManagerTests.cs" />
+    <Compile Include="LogMessageFormatterTests.cs" />
     <Compile Include="LogReceiverService\LogReceiverForwardingServiceTests.cs" />
     <Compile Include="LogReceiverService\LogReceiverServiceTests.cs" />
     <Compile Include="NLogTestBase.cs" />


### PR DESCRIPTION
Add support for external Message Formatter. This will allow integration with external logger formatters like Microsoft.Extensions.Logging. See also https://github.com/NLog/NLog.Extensions.Logging/pull/125