### PR TITLE
Fixed the parameter value parser (ParseParameterValue) #2249

### DIFF
--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -802,6 +802,40 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug2", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + "\r\n----DATA----\r\n" + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
             AssertDebugLastMessage("debug3", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + "\r\n----DATA----\r\n" + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
         }
+
+        [Fact]
+        public void ExceptionDataWithLayoutMacroSeparators()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets>                                        
+                    <target name='debug1' type='Debug' layout='${exception:format=data:ExceptionDataSeparator=\r\n}' />
+                    <target name='debug2' type='Debug' layout='${exception:format=data:ExceptionDataSeparator=${newline}}' />
+                    <target name='debug3' type='Debug' layout='${exception:format=data:ExceptionDataSeparator=${newline}${newline}}' />
+                    <target name='debug4' type='Debug' layout='${exception:format=data:ExceptionDataSeparator=${newline}--***--${newline}}' />
+                </targets>
+                <rules>
+                    <logger minlevel='Info' writeTo='debug1, debug2, debug3, debug4' />
+                </rules>
+            </nlog>");
+
+            const string exceptionMessage = "message for exception";
+            const string exceptionDataKey1 = "testkey1";
+            const string exceptionDataValue1 = "testvalue1";
+            const string exceptionDataKey2 = "testkey2";
+            const string exceptionDataValue2 = "testvalue2";
+
+            Exception ex = GetExceptionWithStackTrace(exceptionMessage);
+            ex.Data.Add(exceptionDataKey1, exceptionDataValue1);
+            ex.Data.Add(exceptionDataKey2, exceptionDataValue2);
+
+            logger.Error(ex);
+
+            AssertDebugLastMessage("debug1", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + "\r\n" + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
+            AssertDebugLastMessage("debug2", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + "\r\n" + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
+            AssertDebugLastMessage("debug3", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + "\r\n\r\n" + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
+            AssertDebugLastMessage("debug4", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + "\r\n--***--\r\n" + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
+        }
     }
 
     [LayoutRenderer("exception-custom")]

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -809,13 +809,12 @@ namespace NLog.UnitTests.LayoutRenderers
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog>
                 <targets>                                        
-                    <target name='debug1' type='Debug' layout='${exception:format=data:ExceptionDataSeparator=\r\n}' />
-                    <target name='debug2' type='Debug' layout='${exception:format=data:ExceptionDataSeparator=${newline}}' />
-                    <target name='debug3' type='Debug' layout='${exception:format=data:ExceptionDataSeparator=${newline}${newline}}' />
-                    <target name='debug4' type='Debug' layout='${exception:format=data:ExceptionDataSeparator=${newline}--***--${newline}}' />
+                    <target name='debug1' type='Debug' layout='${exception:format=data:ExceptionDataSeparator=${newline}}' />
+                    <target name='debug2' type='Debug' layout='${exception:format=data:ExceptionDataSeparator=${newline}${newline}}' />
+                    <target name='debug3' type='Debug' layout='${exception:format=data:ExceptionDataSeparator=${newline}--***--${newline}}' />
                 </targets>
                 <rules>
-                    <logger minlevel='Info' writeTo='debug1, debug2, debug3, debug4' />
+                    <logger minlevel='Info' writeTo='debug1, debug2, debug3' />
                 </rules>
             </nlog>");
 
@@ -831,10 +830,9 @@ namespace NLog.UnitTests.LayoutRenderers
 
             logger.Error(ex);
 
-            AssertDebugLastMessage("debug1", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + "\r\n" + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
-            AssertDebugLastMessage("debug2", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + "\r\n" + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
-            AssertDebugLastMessage("debug3", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + "\r\n\r\n" + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
-            AssertDebugLastMessage("debug4", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + "\r\n--***--\r\n" + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
+            AssertDebugLastMessage("debug1", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + EnvironmentHelper.NewLine + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
+            AssertDebugLastMessage("debug2", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + EnvironmentHelper.NewLine + EnvironmentHelper.NewLine + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
+            AssertDebugLastMessage("debug3", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + EnvironmentHelper.NewLine + "--***--" + EnvironmentHelper.NewLine + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
         }
     }
 


### PR DESCRIPTION
The reason why "separator=${newline}" doesn't work is because the parameter value parser isn't able to parse layout macros completely. Even after fixing the parser, it will end up displaying the layout macro tag \ name only without rendering so I've implemented rendering within the parameter value parser as well.