### PR TITLE
${exception} -  only include separator when items are available 

### DIFF
--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -197,10 +197,14 @@ namespace NLog.LayoutRenderers
 
                 foreach (ExceptionRenderingFormat renderingFormat in this.Formats)
                 {
-                    sb2.Append(separator);
-
+                    var sbCurrentRender = new StringBuilder();
                     var currentRenderFunction = _renderingfunctions[renderingFormat];
-                    currentRenderFunction(sb2, primaryException);
+                    currentRenderFunction(sbCurrentRender, primaryException);
+                    if (sbCurrentRender.Length > 0)
+                    {
+                        sb2.Append(separator);
+                        sb2.Append(sbCurrentRender);
+                    }
                     separator = this.Separator;
                 }
 

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -802,6 +802,54 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug2", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + "\r\n----DATA----\r\n" + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
             AssertDebugLastMessage("debug3", string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) + "\r\n----DATA----\r\n" + string.Format(ExceptionDataFormat, exceptionDataKey2, exceptionDataValue2));
         }
+
+
+        [Fact]
+        public void ExceptionWithSeparatorForExistingRender()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets>                                        
+                    <target name='debug1' type='Debug' layout='${exception:format=tostring,data:separator=\r\nXXX}' />
+                </targets>
+                <rules>
+                    <logger minlevel='Info' writeTo='debug1' />
+                </rules>
+            </nlog>");
+
+            const string exceptionMessage = "message for exception";
+            const string exceptionDataKey1 = "testkey1";
+            const string exceptionDataValue1 = "testvalue1";
+
+            Exception ex = GetExceptionWithoutStackTrace(exceptionMessage);
+            ex.Data.Add(exceptionDataKey1, exceptionDataValue1);
+
+            logger.Error(ex);
+
+            AssertDebugLastMessage("debug1", string.Format(ExceptionDataFormat, ex.GetType().FullName, exceptionMessage) + "\r\nXXX" + string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1));
+        }
+
+        [Fact]
+        public void ExceptionWithoutSeparatorForNoRender()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets>                                        
+                    <target name='debug1' type='Debug' layout='${exception:format=tostring,data:separator=\r\nXXX}' />
+                </targets>
+                <rules>
+                    <logger minlevel='Info' writeTo='debug1' />
+                </rules>
+            </nlog>");
+
+            const string exceptionMessage = "message for exception";
+
+            Exception ex = GetExceptionWithoutStackTrace(exceptionMessage);
+
+            logger.Error(ex);
+
+            AssertDebugLastMessage("debug1", string.Format(ExceptionDataFormat, ex.GetType().FullName, exceptionMessage));
+        }
     }
 
     [LayoutRenderer("exception-custom")]


### PR DESCRIPTION
The reason why it is adding the separator is because in the loop, we always add them first before we render the current function. Moreover, the separator is added even if the current render is empty.

The fix is to add a temporary string builder to be used by the render. Then after the render, check the string builder. If there is a content, that's the only time to append the separator plus the temporary string builder to the main string builder, if none then it will just proceed with the next render - without appending the string builder and adding unnecessary separators.

fixes #2250