### PR TITLE
Bugfix for logging on a target even after removed #2227

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -31,6 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+
 namespace NLog.Config
 {
     using JetBrains.Annotations;
@@ -340,12 +341,26 @@ namespace NLog.Config
         public void RemoveTarget(string name)
         {
             this.targets.Remove(name);
+            CloseAndRemoveTarget(name);
+            ValidateConfig();
+        }
+
+        /// <summary>
+        /// Removes a target from the logging rules and flush it.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        private void CloseAndRemoveTarget(string name)
+        {
             var loggingRules = LoggingRules.ToList();
             foreach (var rule in loggingRules)
             {
-                ((List<Target>)rule.Targets)?.RemoveAll(t => t.Name == name);
+                var targets = rule.Targets.Where(t => t.Name == name).ToList();
+                foreach (var target in targets)
+                {
+                    target.Close();
+                    rule.Targets.Remove(target);
+                }
             }
-            ValidateConfig();
         }
 
         /// <summary>

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -340,13 +340,12 @@ namespace NLog.Config
         public void RemoveTarget(string name)
         {
             this.targets.Remove(name);
-
-            configItems.RemoveAll(c => c is Target && ((Target) c).Name == name);
             var loggingRules = LoggingRules.ToList();
             foreach (var rule in loggingRules)
             {
                 ((List<Target>)rule.Targets)?.RemoveAll(t => t.Name == name);
             }
+            ValidateConfig();
         }
 
         /// <summary>

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -33,18 +33,16 @@
 
 namespace NLog.Config
 {
+    using JetBrains.Annotations;
+    using NLog.Common;
+    using NLog.Internal;
+    using NLog.Layouts;
+    using NLog.Targets;
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Globalization;
     using System.Linq;
-
-    using JetBrains.Annotations;
-
-    using NLog.Common;
-    using NLog.Internal;
-    using NLog.Layouts;
-    using NLog.Targets;
 
     /// <summary>
     /// Keeps logging configuration and provides simple API
@@ -342,6 +340,10 @@ namespace NLog.Config
         public void RemoveTarget(string name)
         {
             this.targets.Remove(name);
+
+            var target = configItems.OfType<Target>().Single(t => t.Name == name);
+            if (target != null)
+                configItems.Remove(target);
         }
 
         /// <summary>

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -345,7 +345,7 @@ namespace NLog.Config
             var loggingRules = LoggingRules.ToList();
             foreach (var rule in loggingRules)
             {
-                ((List<Target>)rule.Targets).RemoveAll(t => t.Name == name);
+                ((List<Target>)rule.Targets)?.RemoveAll(t => t.Name == name);
             }
         }
 

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -341,7 +341,7 @@ namespace NLog.Config
         {
             this.targets.Remove(name);
 
-            var target = configItems.OfType<Target>().Single(t => t.Name == name);
+            var target = configItems.OfType<Target>().FirstOrDefault(t => t.Name == name);
             if (target != null)
                 configItems.Remove(target);
         }

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -342,7 +342,8 @@ namespace NLog.Config
             this.targets.Remove(name);
 
             configItems.RemoveAll(c => c is Target && ((Target) c).Name == name);
-            foreach (var rule in LoggingRules)
+            var loggingRules = LoggingRules.ToList();
+            foreach (var rule in loggingRules)
             {
                 ((List<Target>)rule.Targets).RemoveAll(t => t.Name == name);
             }

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -341,9 +341,11 @@ namespace NLog.Config
         {
             this.targets.Remove(name);
 
-            var target = configItems.OfType<Target>().FirstOrDefault(t => t.Name == name);
-            if (target != null)
-                configItems.Remove(target);
+            configItems.RemoveAll(c => c is Target && ((Target) c).Name == name);
+            foreach (var rule in LoggingRules)
+            {
+                ((List<Target>)rule.Targets).RemoveAll(t => t.Name == name);
+            }
         }
 
         /// <summary>

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -33,6 +33,12 @@
 
 namespace NLog
 {
+    using JetBrains.Annotations;
+    using NLog.Common;
+    using NLog.Config;
+    using NLog.Internal;
+    using NLog.Internal.Fakeables;
+    using NLog.Targets;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
@@ -43,14 +49,6 @@ namespace NLog
     using System.Security;
     using System.Text;
     using System.Threading;
-
-    using JetBrains.Annotations;
-
-    using NLog.Common;
-    using NLog.Config;
-    using NLog.Internal;
-    using NLog.Targets;
-    using NLog.Internal.Fakeables;
 
 #if SILVERLIGHT && !__IOS__ && !__ANDROID__
     using System.Windows;
@@ -850,9 +848,6 @@ namespace NLog
 
                     foreach (Target target in rule.Targets.ToList())
                     {
-                        if (!Configuration.AllTargets.Any(t => t.Name == target.Name))
-                            break;
-
                         var awf = new TargetWithFilterChain(target, rule.Filters);
                         if (lastTargetsByLevel[i] != null)
                         {

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -850,6 +850,9 @@ namespace NLog
 
                     foreach (Target target in rule.Targets.ToList())
                     {
+                        if (!Configuration.AllTargets.Any(t => t.Name == target.Name))
+                            break;
+
                         var awf = new TargetWithFilterChain(target, rule.Filters);
                         if (lastTargetsByLevel[i] != null)
                         {

--- a/tests/NLog.UnitTests/LogManagerTests.cs
+++ b/tests/NLog.UnitTests/LogManagerTests.cs
@@ -681,10 +681,10 @@ namespace NLog.UnitTests
                 var output = writer.ToString();
 
                 Assert.Contains("B | Hello", output);           // Success
-                Assert.DoesNotContain("A | Hello", output);     // FAILURE
+                Assert.DoesNotContain("A | Hello", output);     // Success
             }
 
-            // FAILURE: contains { "ConsoleA", "ConsoleB" }
+            // Success
             Assert.Equal(
                 new[] { "ConsoleB" },
                 LogManager.Configuration.AllTargets.Select(target => target.Name)

--- a/tests/NLog.UnitTests/LogManagerTests.cs
+++ b/tests/NLog.UnitTests/LogManagerTests.cs
@@ -635,5 +635,60 @@ namespace NLog.UnitTests
             }
         }
 #endif
+
+        [Fact]
+        public void RemovedTargetShouldNotLog()
+        {
+            // Setup a configuration with 2 console targets
+            var config = new LoggingConfiguration();
+
+            config.AddTarget(new ConsoleTarget("ConsoleA") { Layout = "A | ${message}" });
+            config.AddTarget(new ConsoleTarget("ConsoleB") { Layout = "B | ${message}" });
+
+            config.AddRule(LogLevel.Debug, LogLevel.Fatal, "ConsoleA");
+            config.AddRule(LogLevel.Debug, LogLevel.Fatal, "ConsoleB");
+
+            LogManager.ThrowConfigExceptions = true;
+            LogManager.ThrowExceptions = true;
+
+            InternalLogger.LogLevel = LogLevel.Debug;
+            InternalLogger.LogFile = "nlog_internal.log";
+
+            // Apply the configuration
+            LogManager.Configuration = config;
+
+            // Success
+            Assert.Equal(
+                new[] { "ConsoleA", "ConsoleB" },
+                LogManager.Configuration.ConfiguredNamedTargets.Select(target => target.Name)
+            );
+
+            // Remove the first target from the configuration
+            LogManager.Configuration.RemoveTarget("ConsoleA");
+
+            // Success
+            Assert.Equal(
+                new[] { "ConsoleB" },
+                LogManager.Configuration.ConfiguredNamedTargets.Select(target => target.Name)
+            );
+
+            using (var writer = new StringWriter())
+            {
+                Console.SetOut(writer);
+                var logger = LogManager.GetCurrentClassLogger();
+                logger.Debug("Hello");
+
+                var output = writer.ToString();
+
+                Assert.Contains("B | Hello", output);           // Success
+                Assert.DoesNotContain("A | Hello", output);     // FAILURE
+            }
+
+            // FAILURE: contains { "ConsoleA", "ConsoleB" }
+            Assert.Equal(
+                new[] { "ConsoleB" },
+                LogManager.Configuration.AllTargets.Select(target => target.Name)
+            );
+        }
     }
 }


### PR DESCRIPTION
* Fixed the logging configuration to also remove the target from the configItems.
* Fixed the log factory to skip setting targets by level if the target doesn't exists (removed). 
* Added unit test (from the issue) to test the behavior.