### PR TITLE
LogEventInfo.MessageTemplate - Subset of LogEventInfo.Properties

### DIFF
--- a/src/NLog/IMessageTemplateParameters.cs
+++ b/src/NLog/IMessageTemplateParameters.cs
@@ -1,0 +1,87 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Description of a single parameter extracted from a MessageTemplate
+    /// </summary>
+    public struct MessageTemplateParameter
+    {
+        /// <summary>
+        /// Parameter Name extracted from <see cref="LogEventInfo.Message"/>
+        /// This is everything between "{" and the first of ",:}".
+        /// </summary>
+        public readonly string Name;
+        /// <summary>
+        /// Parameter Value extracted from the <see cref="LogEventInfo.Parameters"/>-array
+        /// </summary>
+        public readonly object Value;
+        /// <summary>
+        /// Format to render the parameter.
+        /// This is everything between ":" and the first unescaped "}"
+        /// </summary>
+        public readonly string Format;
+
+        /// <summary>
+        /// Constructs a single message template parameter
+        /// </summary>
+        /// <param name="name">Parameter Name</param>
+        /// <param name="value">Parameter Value</param>
+        /// <param name="format">Parameter Format</param>
+        public MessageTemplateParameter(string name, object value, string format)
+        {
+            Name = name;
+            Value = value;
+            Format = format;
+        }
+    }
+
+    /// <summary>
+    /// Parameters extracted from parsing <see cref="LogEventInfo.Message"/> as MessageTemplate
+    /// </summary>
+    public interface IMessageTemplateParameters : IEnumerable<MessageTemplateParameter>
+    {
+        /// <summary>
+        /// Number of parameters
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        /// Gets the parameters at the given index
+        /// </summary>
+        MessageTemplateParameter this[int index] { get; }
+    }
+}

--- a/src/NLog/Internal/MessageTemplateParameters.cs
+++ b/src/NLog/Internal/MessageTemplateParameters.cs
@@ -1,0 +1,100 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Internal implementation of the interface for returning MessageTemplate parameters
+    /// </summary>
+    internal class MessageTemplateParameters : IMessageTemplateParameters
+    {
+        readonly IList<MessageTemplateParameter> _parameters;
+
+        /// <inheritDoc/>
+        public MessageTemplateParameter this[int index] { get { return _parameters[index]; } }
+
+        /// <inheritDoc/>
+        public int Count { get { return _parameters.Count; } }
+
+        /// <inheritDoc/>
+        public IEnumerator<MessageTemplateParameter> GetEnumerator() { return _parameters.GetEnumerator(); }
+
+        /// <inheritDoc/>
+        IEnumerator IEnumerable.GetEnumerator() { return _parameters.GetEnumerator(); }
+
+        /// <summary>
+        /// Constructore for positional parameters
+        /// </summary>
+        public MessageTemplateParameters(object[] parameters)
+        {
+            if (parameters != null && parameters.Length > 0)
+            {
+                _parameters = new MessageTemplateParameter[parameters.Length];
+                for (int i = 0; i < parameters.Length; ++i)
+                {
+                    string parameterName;
+                    switch (i)
+                    {
+                        case 0: parameterName = "0"; break;
+                        case 1: parameterName = "1"; break;
+                        case 2: parameterName = "2"; break;
+                        case 3: parameterName = "3"; break;
+                        case 4: parameterName = "4"; break;
+                        case 5: parameterName = "5"; break;
+                        case 6: parameterName = "6"; break;
+                        case 7: parameterName = "7"; break;
+                        case 8: parameterName = "8"; break;
+                        case 9: parameterName = "9"; break;
+                        default: parameterName = i.ToString(); break;
+                    }
+                    _parameters[i] = new MessageTemplateParameter(parameterName, parameters[i], null);
+                }
+            }
+            else
+            {
+                _parameters = Internal.ArrayHelper.Empty<MessageTemplateParameter>();
+            }
+        }
+
+        /// <summary>
+        /// Constructore for named parameters
+        /// </summary>
+        public MessageTemplateParameters(IList<MessageTemplateParameter> parameters)
+        {
+            _parameters = parameters ?? Internal.ArrayHelper.Empty<MessageTemplateParameter>();
+        }
+    }
+}

--- a/src/NLog/Internal/PropertiesDictionary.cs
+++ b/src/NLog/Internal/PropertiesDictionary.cs
@@ -1,0 +1,642 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Dictionary that combines the standard <see cref="LogEventInfo.Properties" /> with the
+    /// MessageTemplate-properties extracted from the <see cref="LogEventInfo.Message" />.
+    /// 
+    /// The <see cref="MessageProperties" /> are returned as the first items
+    /// in the collection, and in positional order.
+    /// </summary>
+    internal sealed class PropertiesDictionary : IDictionary<object, object>
+    {
+        struct PropertyValue
+        {
+            public readonly object Value;
+            public readonly bool MessageProperty;
+
+            public PropertyValue(object value, bool messageProperty)
+            {
+                Value = value;
+                MessageProperty = messageProperty;
+            }
+        }
+
+        private Dictionary<object, PropertyValue> _eventProperties;
+        private IList<MessageTemplateParameter> _messageProperties;
+        private DictionaryCollection _keyCollection;
+        private DictionaryCollection _valueCollection;
+        private IDictionary _eventContextAdapter;
+
+        /// <summary>
+        /// Injects the list of message-template-parameter into the IDictionary-interface
+        /// </summary>
+        /// <param name="parameterList">Message-template-parameters</param>
+        public PropertiesDictionary(IList<MessageTemplateParameter> parameterList = null)
+        {
+            MessageProperties = parameterList;
+        }
+
+        private bool IsEmpty { get { return (_eventProperties == null || _eventProperties.Count == 0) && (_messageProperties == null || _messageProperties.Count == 0); } }
+
+        public IDictionary EventContext { get { return _eventContextAdapter ?? (_eventContextAdapter = new DictionaryAdapter<object, object>(this)); } }
+
+        private Dictionary<object, PropertyValue> EventProperties
+        {
+            get
+            {
+                if (_eventProperties == null)
+                {
+                    if (_messageProperties != null && _messageProperties.Count > 0)
+                    {
+                        _eventProperties = new Dictionary<object, PropertyValue>(_messageProperties.Count);
+                        if (!InsertMessagePropertiesIntoEmptyDictionary(_messageProperties, _eventProperties))
+                        {
+                            _messageProperties = CreateUniqueMessagePropertiesListSlow(_messageProperties, _eventProperties);
+                        }
+                    }
+                    else
+                    {
+                        _eventProperties = new Dictionary<object, PropertyValue>();
+                    }
+                }
+                return _eventProperties;
+            }
+        }
+
+        public IList<MessageTemplateParameter> MessageProperties
+        {
+            get
+            {
+                return _messageProperties ?? ArrayHelper.Empty<MessageTemplateParameter>();
+            }
+            private set
+            {
+                if (value != null && value.Count > 0)
+                {
+                    _messageProperties = _eventProperties == null ? CreateUniqueMessagePropertiesListFast(value) : null;
+                    if (_messageProperties == null)
+                    {
+                        // Dictionary was already allocated, or the message-template-parameters are troublesome
+                        var eventProperties = _eventProperties ?? (_eventProperties = new Dictionary<object, PropertyValue>(value.Count));
+
+                        _messageProperties = new List<MessageTemplateParameter>(value.Count);
+                        for (int i = 0; i < value.Count; ++i)
+                            _messageProperties.Add(value[i]);
+
+                        if (eventProperties.Count != 0 || !InsertMessagePropertiesIntoEmptyDictionary(_messageProperties, eventProperties))
+                        {
+                            _messageProperties = CreateUniqueMessagePropertiesListSlow(_messageProperties, eventProperties);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <inheritDoc/>
+        public object this[object key]
+        {
+            get
+            {
+                if (!IsEmpty)
+                {
+                    PropertyValue valueItem;
+                    if (EventProperties.TryGetValue(key, out valueItem))
+                    {
+                        return valueItem.Value;
+                    }
+                }
+
+                throw new KeyNotFoundException();
+            }
+            set
+            {
+                EventProperties[key] = new PropertyValue(value, false);
+            }
+        }
+
+        /// <inheritDoc/>
+        public ICollection<object> Keys { get { return KeyCollection; } }
+        /// <inheritDoc/>
+        public ICollection<object> Values { get { return ValueCollection; } }
+
+        private DictionaryCollection KeyCollection
+        {
+            get
+            {
+                if (_keyCollection != null)
+                    return _keyCollection;
+                else if (IsEmpty)
+                    return EmptyKeyCollection;
+                else
+                    return _keyCollection ?? (_keyCollection = new DictionaryCollection(this, true));
+            }
+        }
+
+        private DictionaryCollection ValueCollection
+        {
+            get
+            {
+                if (_valueCollection != null)
+                    return _valueCollection;
+                else if (IsEmpty)
+                    return EmptyValueCollection;
+                else
+                    return _valueCollection ?? (_valueCollection = new DictionaryCollection(this, false));
+            }
+        }
+
+        private static readonly DictionaryCollection EmptyKeyCollection = new DictionaryCollection(new PropertiesDictionary(), true);
+        private static readonly DictionaryCollection EmptyValueCollection = new DictionaryCollection(new PropertiesDictionary(), false);
+
+        /// <inheritDoc/>
+        public int Count { get { return (_eventProperties?.Count) ?? (_messageProperties?.Count) ?? 0; } }
+
+        /// <inheritDoc/>
+        public bool IsReadOnly { get { return false; } }
+
+        /// <inheritDoc/>
+        public void Add(object key, object value)
+        {
+            EventProperties.Add(key, new PropertyValue(value, false));
+        }
+
+        /// <inheritDoc/>
+        public void Add(KeyValuePair<object, object> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        /// <inheritDoc/>
+        public void Clear()
+        {
+            if (_eventProperties != null)
+                _eventProperties.Clear();
+            if (_messageProperties != null)
+                _messageProperties = ArrayHelper.Empty<MessageTemplateParameter>();
+        }
+
+        /// <inheritDoc/>
+        public bool Contains(KeyValuePair<object, object> item)
+        {
+            if (!IsEmpty)
+            {
+                if (((IDictionary<object, PropertyValue>)EventProperties).Contains(new KeyValuePair<object, PropertyValue>(item.Key, new PropertyValue(item.Value, false))))
+                    return true;
+
+                if (((IDictionary<object, PropertyValue>)EventProperties).Contains(new KeyValuePair<object, PropertyValue>(item.Key, new PropertyValue(item.Value, true))))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <inheritDoc/>
+        public bool ContainsKey(object key)
+        {
+            if (!IsEmpty)
+            {
+                return EventProperties.ContainsKey(key);
+            }
+            return false;
+        }
+
+        /// <inheritDoc/>
+        public void CopyTo(KeyValuePair<object, object>[] array, int arrayIndex)
+        {
+            if (array == null)
+                throw new ArgumentNullException("array");
+            if (arrayIndex < 0)
+                throw new ArgumentOutOfRangeException("arrayIndex");
+
+            if (!IsEmpty)
+            {
+                foreach (var propertyItem in this)
+                {
+                    array[arrayIndex++] = propertyItem;
+                }
+            }
+        }
+
+        /// <inheritDoc/>
+        public IEnumerator<KeyValuePair<object, object>> GetEnumerator()
+        {
+            if (IsEmpty)
+                return System.Linq.Enumerable.Empty<KeyValuePair<object, object>>().GetEnumerator();
+            else
+                return new DictionaryEnumerator(this);
+        }
+
+        /// <inheritDoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            if (IsEmpty)
+                return ArrayHelper.Empty<KeyValuePair<object, object>>().GetEnumerator();
+            else
+                return new DictionaryEnumerator(this);
+        }
+
+        /// <inheritDoc/>
+        public bool Remove(object key)
+        {
+            if (!IsEmpty)
+            {
+                return EventProperties.Remove(key);
+            }
+            return false;
+        }
+
+        /// <inheritDoc/>
+        public bool Remove(KeyValuePair<object, object> item)
+        {
+            if (!IsEmpty)
+            {
+                if (((IDictionary<object, PropertyValue>)EventProperties).Remove(new KeyValuePair<object, PropertyValue>(item.Key, new PropertyValue(item.Value, false))))
+                    return true;
+
+                if (((IDictionary<object, PropertyValue>)EventProperties).Remove(new KeyValuePair<object, PropertyValue>(item.Key, new PropertyValue(item.Value, true))))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritDoc/>
+        public bool TryGetValue(object key, out object value)
+        {
+            if (!IsEmpty)
+            {
+                PropertyValue valueItem;
+                if (EventProperties.TryGetValue(key, out valueItem))
+                {
+                    value = valueItem.Value;
+                    return true;
+                }
+            }
+
+            value = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Attempt to use the message-template-parameters without allocating a dictionary
+        /// </summary>
+        /// <param name="parameterList">Message-template-parameters</param>
+        /// <returns>List of message-template-parameters if succesful (else null)</returns>
+        static IList<MessageTemplateParameter> CreateUniqueMessagePropertiesListFast(IList<MessageTemplateParameter> parameterList)
+        {
+            if (parameterList.Count <= 10)
+            {
+                bool uniqueMessageProperties = true;
+                for (int i = 0; i < parameterList.Count - 1; ++i)
+                {
+                    for (int j = i + 1; j < parameterList.Count; ++j)
+                    {
+                        if (parameterList[i].Name == parameterList[j].Name)
+                        {
+                            uniqueMessageProperties = false;
+                            break;
+                        }
+                    }
+                }
+                if (uniqueMessageProperties)
+                {
+                    var messageProperties = new MessageTemplateParameter[parameterList.Count];
+                    for (int i = 0; i < parameterList.Count; ++i)
+                        messageProperties[i] = parameterList[i];
+                    return messageProperties;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Attempt to insert the message-template-parameters into an empty dictionary
+        /// </summary>
+        /// <param name="messageProperties">Message-template-parameters</param>
+        /// <param name="eventProperties">The initially empty dictionary</param>
+        /// <returns>Message-template-parameters was inserted into dictionary without trouble (true/false)</returns>
+        private static bool InsertMessagePropertiesIntoEmptyDictionary(IList<MessageTemplateParameter> messageProperties, Dictionary<object, PropertyValue> eventProperties)
+        {
+            try
+            {
+                for (int i = 0; i < messageProperties.Count; ++i)
+                {
+                    eventProperties.Add(messageProperties[i].Name, new PropertyValue(messageProperties[i].Value, true));
+                }
+                return true; // We are done
+            }
+            catch (ArgumentException)
+            {
+                // Duplicate keys found, lets try again
+                for (int i = 0; i < messageProperties.Count; ++i)
+                {
+                    eventProperties.Remove(messageProperties[i].Name);
+                }
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attempt to override the existing dictionary values using the message-template-parameters 
+        /// </summary>
+        /// <param name="messageProperties">Message-template-parameters</param>
+        /// <param name="eventProperties">The already filled dictionary</param>
+        /// <returns>List of unique message-template-parameters</returns>
+        private static IList<MessageTemplateParameter> CreateUniqueMessagePropertiesListSlow(IList<MessageTemplateParameter> messageProperties, Dictionary<object, PropertyValue> eventProperties)
+        {
+            List<MessageTemplateParameter> messagePropertiesUnique = null;
+            PropertyValue valueItem;
+            for (int i = 0; i < messageProperties.Count; ++i)
+            {
+                if (eventProperties.TryGetValue(messageProperties[i].Name, out valueItem))
+                {
+                    if (valueItem.MessageProperty)
+                    {
+                        if (messagePropertiesUnique == null)
+                        {
+                            messagePropertiesUnique = new List<MessageTemplateParameter>(messageProperties.Count);
+                            for (int j = 0; j < i; ++j)
+                            {
+                                messagePropertiesUnique.Add(messageProperties[j]);
+                            }
+                        }
+                        continue;   // Skip already exists
+                    }
+                }
+
+                eventProperties[messageProperties[i].Name] = new PropertyValue(messageProperties[i].Value, true);
+                if (messagePropertiesUnique != null)
+                {
+                    messagePropertiesUnique.Add(messageProperties[i]);
+                }
+            }
+
+            return messagePropertiesUnique ?? messageProperties;
+        }
+
+        class DictionaryEnumeratorBase
+        {
+            readonly PropertiesDictionary _dictionary;
+            int? _messagePropertiesEnumerator;
+            bool _eventEnumeratorCreated;
+            Dictionary<object, PropertyValue>.Enumerator _eventEnumerator;
+
+            protected DictionaryEnumeratorBase(PropertiesDictionary dictionary)
+            {
+                _dictionary = dictionary;
+            }
+
+            public KeyValuePair<object, object> CurrentPair
+            {
+                get
+                {
+                    if (_messagePropertiesEnumerator.HasValue)
+                    {
+                        var property = _dictionary._messageProperties[_messagePropertiesEnumerator.Value];
+                        return new KeyValuePair<object, object>(property.Name, property.Value);
+                    }
+                    else if (_eventEnumeratorCreated)
+                        return new KeyValuePair<object, object>(_eventEnumerator.Current.Key, _eventEnumerator.Current.Value.Value);
+                    else
+                        throw new InvalidOperationException();
+                }
+            }
+
+            public bool MoveNext()
+            {
+                if (_messagePropertiesEnumerator.HasValue)
+                {
+                    if ((_messagePropertiesEnumerator.Value + 1) < _dictionary._messageProperties.Count)
+                    {
+                        // Move forward to a key that is not overriden
+                        _messagePropertiesEnumerator = FindNextValidMessagePropertyIndex(_messagePropertiesEnumerator.Value + 1);
+                        if (_messagePropertiesEnumerator.HasValue)
+                            return true;
+
+                        _messagePropertiesEnumerator = _dictionary._eventProperties.Count - 1;
+                    }
+
+                    if (_dictionary._eventProperties != null && _dictionary._eventProperties.Count > 0)
+                    {
+                        _messagePropertiesEnumerator = null;
+                        _eventEnumerator = _dictionary._eventProperties.GetEnumerator();
+                        _eventEnumeratorCreated = true;
+                        return MoveNextValidEventProperty();
+                    }
+
+                    return false;
+                }
+                else
+                {
+                    if (_eventEnumeratorCreated)
+                    {
+                        return MoveNextValidEventProperty();
+                    }
+                    else
+                    {
+                        if (_dictionary._messageProperties != null && _dictionary._messageProperties.Count > 0)
+                        {
+                            // Move forward to a key that is not overriden
+                            _messagePropertiesEnumerator = FindNextValidMessagePropertyIndex(0);
+                            if (_messagePropertiesEnumerator.HasValue)
+                            {
+                                return true;
+                            }
+                        }
+
+                        if (_dictionary._eventProperties != null && _dictionary._eventProperties.Count > 0)
+                        {
+                            _eventEnumerator = _dictionary._eventProperties.GetEnumerator();
+                            _eventEnumeratorCreated = true;
+                            return MoveNextValidEventProperty();
+                        }
+
+                        return false;
+                    }
+                }
+            }
+
+            private bool MoveNextValidEventProperty()
+            {
+                while (_eventEnumerator.MoveNext())
+                {
+                    if (!_eventEnumerator.Current.Value.MessageProperty)
+                        return true;
+                }
+                return false;
+            }
+
+            private int? FindNextValidMessagePropertyIndex(int startIndex)
+            {
+                if (_dictionary._eventProperties == null)
+                    return startIndex;
+
+                PropertyValue valueItem;
+                for (int i = startIndex; i < _dictionary._messageProperties.Count; ++i)
+                {
+                    if (_dictionary._eventProperties.TryGetValue(_dictionary._messageProperties[i].Name, out valueItem) && valueItem.MessageProperty)
+                    {
+                        return i;
+                    }
+                }
+
+                return null;
+            }
+
+            public void Dispose()
+            {
+                // Nothing to do
+            }
+
+            public void Reset()
+            {
+                _messagePropertiesEnumerator = null;
+                _eventEnumeratorCreated = false;
+                _eventEnumerator = default(Dictionary<object, PropertyValue>.Enumerator);
+            }
+        }
+
+        class DictionaryEnumerator : DictionaryEnumeratorBase, IEnumerator<KeyValuePair<object, object>>
+        {
+            /// <inheritDoc/>
+            public KeyValuePair<object, object> Current { get { return CurrentPair; } }
+
+            /// <inheritDoc/>
+            object IEnumerator.Current { get { return CurrentPair; } }
+
+            public DictionaryEnumerator(PropertiesDictionary dictionary)
+                : base(dictionary)
+            {
+            }
+        }
+
+        class DictionaryCollection : ICollection<object>
+        {
+            readonly PropertiesDictionary _dictionary;
+            readonly bool _keyCollection;
+
+            public DictionaryCollection(PropertiesDictionary dictionary, bool keyCollection)
+            {
+                _dictionary = dictionary;
+                _keyCollection = keyCollection;
+            }
+
+            /// <inheritDoc/>
+            public int Count { get { return _dictionary.Count; } }
+
+            /// <inheritDoc/>
+            public bool IsReadOnly { get { return true; } }
+
+
+            /// <summary>Will always throw, as collection is readonly</summary>
+            public void Add(object item) { throw new NotSupportedException(); }
+
+            /// <summary>Will always throw, as collection is readonly</summary>
+            public void Clear() { throw new NotSupportedException(); }
+
+            /// <summary>Will always throw, as collection is readonly</summary>
+            public bool Remove(object item) { throw new NotSupportedException(); }
+
+            /// <inheritDoc/>
+            public bool Contains(object item)
+            {
+                if (_keyCollection)
+                {
+                    return _dictionary.ContainsKey(item);
+                }
+                else
+                {
+                    if (!_dictionary.IsEmpty)
+                    {
+                        if (_dictionary.EventProperties.ContainsValue(new PropertyValue(item, false)))
+                            return true;
+
+                        if (_dictionary.EventProperties.ContainsValue(new PropertyValue(item, true)))
+                            return true;
+                    }
+                    return false;
+                }
+            }
+
+            /// <inheritDoc/>
+            public void CopyTo(object[] array, int arrayIndex)
+            {
+                if (array == null)
+                    throw new ArgumentNullException("array");
+                if (arrayIndex < 0)
+                    throw new ArgumentOutOfRangeException("arrayIndex");
+
+                if (!_dictionary.IsEmpty)
+                {
+                    foreach (var propertyItem in _dictionary)
+                    {
+                        array[arrayIndex++] = _keyCollection ? propertyItem.Key : propertyItem.Value;
+                    }
+                }
+            }
+
+            /// <inheritDoc/>
+            public IEnumerator<object> GetEnumerator()
+            {
+                return new DictionaryCollectionEnumerator(_dictionary, _keyCollection);
+            }
+
+            /// <inheritDoc/>
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            private class DictionaryCollectionEnumerator : DictionaryEnumeratorBase, IEnumerator<object>
+            {
+                readonly bool _keyCollection;
+
+                public DictionaryCollectionEnumerator(PropertiesDictionary dictionary, bool keyCollection)
+                    : base(dictionary)
+                {
+                    _keyCollection = keyCollection;
+                }
+
+                /// <inheritDoc/>
+                public object Current { get { return _keyCollection ? CurrentPair.Key : CurrentPair.Value; } }
+            }
+        }
+    }
+}

--- a/tests/NLog.UnitTests/Internal/PropertiesDictionaryTests.cs
+++ b/tests/NLog.UnitTests/Internal/PropertiesDictionaryTests.cs
@@ -1,0 +1,466 @@
+﻿// 
+// Copyright (c) 2004-2016 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using NLog.Internal;
+using Xunit;
+
+namespace NLog.UnitTests.Internal
+{
+    public class PropertiesDictionaryTests
+    {
+        [Fact]
+        public void DefaultPropertiesDictionary()
+        {
+            LogEventInfo logEvent = new LogEventInfo();
+            IDictionary<object, object> dictionary = logEvent.Properties;
+            Assert.Empty(dictionary);
+            foreach (var item in dictionary)
+                Assert.False(true, "Should be empty");
+            foreach (var item in dictionary.Keys)
+                Assert.False(true, "Should be empty");
+            foreach (var item in dictionary.Values)
+                Assert.False(true, "Should be empty");
+            Assert.DoesNotContain(new KeyValuePair<object, object>("Hello World", 42), dictionary);
+            Assert.False(dictionary.ContainsKey("Hello World"));
+            Assert.False(dictionary.Keys.Contains("Hello World"));
+            Assert.False(dictionary.Values.Contains(42));
+            object value;
+            Assert.False(dictionary.TryGetValue("Hello World", out value));
+            Assert.Null(value);
+            Assert.False(dictionary.Remove("Hello World"));
+            dictionary.CopyTo(new KeyValuePair<object, object>[0], 0);
+            dictionary.Values.CopyTo(new object[0], 0);
+            dictionary.Keys.CopyTo(new object[0], 0);
+            dictionary.Clear();
+        }
+
+        [Fact]
+        public void EmptyEventPropertiesDictionary()
+        {
+            LogEventInfo logEvent = new LogEventInfo();
+            IDictionary<object, object> dictionary = logEvent.Properties;
+            dictionary.Add("Hello World", 42);
+            Assert.True(dictionary.Remove("Hello World"));
+            Assert.Empty(dictionary);
+            foreach (var item in dictionary)
+                Assert.False(true, "Should be empty");
+            foreach (var item in dictionary.Keys)
+                Assert.False(true, "Should be empty");
+            foreach (var item in dictionary.Values)
+                Assert.False(true, "Should be empty");
+            Assert.DoesNotContain(new KeyValuePair<object, object>("Hello World", 42), dictionary);
+            Assert.False(dictionary.ContainsKey("Hello World"));
+            Assert.False(dictionary.Keys.Contains("Hello World"));
+            Assert.False(dictionary.Values.Contains(42));
+            object value;
+            Assert.False(dictionary.TryGetValue("Hello World", out value));
+            Assert.Null(value);
+            Assert.False(dictionary.Remove("Hello World"));
+            dictionary.CopyTo(new KeyValuePair<object, object>[0], 0);
+            dictionary.Values.CopyTo(new object[0], 0);
+            dictionary.Keys.CopyTo(new object[0], 0);
+            dictionary.Clear();
+        }
+
+        [Fact]
+        public void EmptyMessagePropertiesDictionary()
+        {
+            LogEventInfo logEvent = new LogEventInfo(LogLevel.Info, "MyLogger", string.Empty, (IList<MessageTemplateParameter>)null);
+            IDictionary<object, object> dictionary = logEvent.Properties;
+            Assert.Empty(dictionary);
+            foreach (var item in dictionary)
+                Assert.False(true, "Should be empty");
+            foreach (var item in dictionary.Keys)
+                Assert.False(true, "Should be empty");
+            foreach (var item in dictionary.Values)
+                Assert.False(true, "Should be empty");
+            Assert.False(dictionary.ContainsKey("Hello World"));
+            Assert.False(dictionary.Keys.Contains("Hello World"));
+            Assert.False(dictionary.Values.Contains(42));
+            Assert.DoesNotContain(new KeyValuePair<object, object>("Hello World", 42), dictionary);
+            object value;
+            Assert.False(dictionary.TryGetValue("Hello World", out value));
+            Assert.Null(value);
+            Assert.False(dictionary.Remove("Hello World"));
+            dictionary.CopyTo(new KeyValuePair<object, object>[0], 0);
+            dictionary.Values.CopyTo(new object[0], 0);
+            dictionary.Keys.CopyTo(new object[0], 0);
+            dictionary.Clear();
+        }
+
+        [Fact]
+        public void EmptyPropertiesDictionary()
+        {
+            LogEventInfo logEvent = new LogEventInfo(LogLevel.Info, "MyLogger", string.Empty, (IList<MessageTemplateParameter>)null);
+            IDictionary<object, object> dictionary = logEvent.Properties;
+            dictionary.Add("Hello World", null);
+            Assert.True(dictionary.Remove("Hello World"));
+            Assert.Empty(dictionary);
+            foreach (var item in dictionary)
+                Assert.False(true, "Should be empty");
+            foreach (var item in dictionary.Keys)
+                Assert.False(true, "Should be empty");
+            foreach (var item in dictionary.Values)
+                Assert.False(true, "Should be empty");
+            Assert.False(dictionary.ContainsKey("Hello World"));
+            Assert.False(dictionary.Keys.Contains("Hello World"));
+            Assert.False(dictionary.Values.Contains(42));
+            Assert.DoesNotContain(new KeyValuePair<object, object>("Hello World", 42), dictionary);
+            object value;
+            Assert.False(dictionary.TryGetValue("Hello World", out value));
+            Assert.Null(value);
+            Assert.False(dictionary.Remove("Hello World"));
+            dictionary.CopyTo(new KeyValuePair<object, object>[0], 0);
+            dictionary.Values.CopyTo(new object[0], 0);
+            dictionary.Keys.CopyTo(new object[0], 0);
+            dictionary.Clear();
+        }
+
+        [Fact]
+        public void SingleItemEventPropertiesDictionary()
+        {
+            LogEventInfo logEvent = new LogEventInfo();
+            IDictionary<object, object> dictionary = logEvent.Properties;
+            dictionary.Add("Hello World", 42);
+            Assert.Single(dictionary);
+            foreach (var item in dictionary)
+            {
+                Assert.Equal("Hello World", item.Key);
+                Assert.Equal(42, item.Value);
+            }
+            foreach (var item in dictionary.Keys)
+                Assert.Equal("Hello World", item);
+            foreach (var item in dictionary.Values)
+                Assert.Equal(42, item);
+            Assert.Contains(new KeyValuePair<object, object>("Hello World", 42), dictionary);
+            Assert.True(dictionary.ContainsKey("Hello World"));
+            Assert.True(dictionary.Keys.Contains("Hello World"));
+            Assert.True(dictionary.Values.Contains(42));
+            Assert.False(dictionary.ContainsKey("Goodbye World"));
+            Assert.False(dictionary.Keys.Contains("Goodbye World"));
+            Assert.DoesNotContain(new KeyValuePair<object, object>("Goodbye World", 666), dictionary);
+            object value;
+            Assert.True(dictionary.TryGetValue("Hello World", out value));
+            Assert.Equal(42, value);
+            Assert.False(dictionary.TryGetValue("Goodbye World", out value));
+            Assert.Null(value);
+            var copyToArray = new KeyValuePair<object, object>[1];
+            dictionary.CopyTo(copyToArray, 0);
+            Assert.Equal("Hello World", copyToArray[0].Key);
+            Assert.Equal(42, copyToArray[0].Value);
+            var copyToValuesArray = new object[1];
+            dictionary.Values.CopyTo(copyToValuesArray, 0);
+            Assert.Equal(42, copyToValuesArray[0]);
+            var copyToKeysArray = new object[1];
+            dictionary.Keys.CopyTo(copyToKeysArray, 0);
+            Assert.Equal("Hello World", copyToKeysArray[0]);
+            Assert.True(dictionary.Remove("Hello World"));
+            Assert.Empty(dictionary);
+            dictionary["Hello World"] = 42;
+            Assert.Single(dictionary);
+            dictionary.Clear();
+            Assert.Empty(dictionary);
+        }
+
+        [Fact]
+        public void SingleItemMessagePropertiesDictionaryNoLookup()
+        {
+            LogEventInfo logEvent = new LogEventInfo(LogLevel.Info, "MyLogger", string.Empty, new[] { new MessageTemplateParameter("Hello World", 42, null) });
+            IDictionary<object, object> dictionary = logEvent.Properties;
+            Assert.Single(dictionary);
+            foreach (var item in dictionary)
+            {
+                Assert.Equal("Hello World", item.Key);
+                Assert.Equal(42, item.Value);
+            }
+            foreach (var item in dictionary.Keys)
+                Assert.Equal("Hello World", item);
+            foreach (var item in dictionary.Values)
+                Assert.Equal(42, item);
+
+            var copyToArray = new KeyValuePair<object, object>[1];
+            dictionary.CopyTo(copyToArray, 0);
+            Assert.Equal("Hello World", copyToArray[0].Key);
+            Assert.Equal(42, copyToArray[0].Value);
+            var copyToValuesArray = new object[1];
+            dictionary.Values.CopyTo(copyToValuesArray, 0);
+            Assert.Equal(42, copyToValuesArray[0]);
+            var copyToKeysArray = new object[1];
+            dictionary.Keys.CopyTo(copyToKeysArray, 0);
+            Assert.Equal("Hello World", copyToKeysArray[0]);
+
+            dictionary.Clear();
+            Assert.Empty(dictionary);
+        }
+
+        [Fact]
+        public void SingleItemMessagePropertiesDictionaryWithLookup()
+        {
+            LogEventInfo logEvent = new LogEventInfo(LogLevel.Info, "MyLogger", string.Empty, new[] { new MessageTemplateParameter("Hello World", 42, null) });
+            IDictionary<object, object> dictionary = logEvent.Properties;
+
+            Assert.Single(dictionary);
+
+            Assert.Contains(new KeyValuePair<object, object>("Hello World", 42), dictionary);
+            Assert.True(dictionary.ContainsKey("Hello World"));
+            Assert.True(dictionary.Keys.Contains("Hello World"));
+            Assert.True(dictionary.Values.Contains(42));
+            Assert.False(dictionary.ContainsKey("Goodbye World"));
+            Assert.False(dictionary.Keys.Contains("Goodbye World"));
+            Assert.DoesNotContain(new KeyValuePair<object, object>("Goodbye World", 666), dictionary);
+            object value;
+            Assert.True(dictionary.TryGetValue("Hello World", out value));
+            Assert.Equal(42, value);
+            Assert.False(dictionary.TryGetValue("Goodbye World", out value));
+            Assert.Null(value);
+
+            var copyToArray = new KeyValuePair<object, object>[1];
+            dictionary.CopyTo(copyToArray, 0);
+            Assert.Equal("Hello World", copyToArray[0].Key);
+            Assert.Equal(42, copyToArray[0].Value);
+            var copyToValuesArray = new object[1];
+            dictionary.Values.CopyTo(copyToValuesArray, 0);
+            Assert.Equal(42, copyToValuesArray[0]);
+            var copyToKeysArray = new object[1];
+            dictionary.Keys.CopyTo(copyToKeysArray, 0);
+            Assert.Equal("Hello World", copyToKeysArray[0]);
+
+            dictionary.Clear();
+            Assert.Empty(dictionary);
+        }
+
+        [Fact]
+        public void MultiItemPropertiesDictionary()
+        {
+            LogEventInfo logEvent = new LogEventInfo(LogLevel.Info, "MyLogger", string.Empty, new[] { new MessageTemplateParameter("Hello World", 42, null) });
+            IDictionary<object, object> dictionary = logEvent.Properties;
+
+            dictionary["Goodbye World"] = 666;
+            Assert.Equal(2, dictionary.Count);
+            int i = 0;
+            foreach (var item in dictionary)
+            {
+                switch (i++)
+                {
+                    case 0:
+                        Assert.Equal("Hello World", item.Key);
+                        Assert.Equal(42, item.Value);
+                        break;
+                    case 1:
+                        Assert.Equal("Goodbye World", item.Key);
+                        Assert.Equal(666, item.Value);
+                        break;
+                }
+            }
+            Assert.Equal(2, i);
+
+            i = 0;
+            foreach (var item in dictionary.Keys)
+            {
+                switch (i++)
+                {
+                    case 0:
+                        Assert.Equal("Hello World", item);
+                        break;
+                    case 1:
+                        Assert.Equal("Goodbye World", item);
+                        break;
+                }
+            }
+            Assert.Equal(2, i);
+
+            i = 0;
+            foreach (var item in dictionary.Values)
+            {
+                switch (i++)
+                {
+                    case 0:
+                        Assert.Equal(42, item);
+                        break;
+                    case 1:
+                        Assert.Equal(666, item);
+                        break;
+                }
+            }
+            Assert.True(dictionary.ContainsKey("Hello World"));
+            Assert.Contains(new KeyValuePair<object, object>("Hello World", 42), dictionary);
+            Assert.True(dictionary.Keys.Contains("Hello World"));
+            Assert.True(dictionary.Values.Contains(42));
+            Assert.True(dictionary.ContainsKey("Goodbye World"));
+            Assert.Contains(new KeyValuePair<object, object>("Goodbye World", 666), dictionary);
+            Assert.True(dictionary.Keys.Contains("Goodbye World"));
+            Assert.True(dictionary.Values.Contains(666));
+            Assert.False(dictionary.Keys.Contains("Mad World"));
+            Assert.False(dictionary.ContainsKey("Mad World"));
+            object value;
+            Assert.True(dictionary.TryGetValue("Hello World", out value));
+            Assert.Equal(42, value);
+            Assert.True(dictionary.TryGetValue("Goodbye World", out value));
+            Assert.Equal(666, value);
+            Assert.False(dictionary.TryGetValue("Mad World", out value));
+            Assert.Null(value);
+            var copyToArray = new KeyValuePair<object, object>[2];
+            dictionary.CopyTo(copyToArray, 0);
+            Assert.Contains(new KeyValuePair<object,object>("Hello World", 42), copyToArray);
+            Assert.Contains(new KeyValuePair<object, object>("Goodbye World", 666), copyToArray);
+            var copyToValuesArray = new object[2];
+            dictionary.Values.CopyTo(copyToValuesArray, 0);
+            Assert.Contains(42, copyToValuesArray);
+            Assert.Contains(666, copyToValuesArray);
+            var copyToKeysArray = new object[2];
+            dictionary.Keys.CopyTo(copyToKeysArray, 0);
+            Assert.Contains("Hello World", copyToKeysArray);
+            Assert.Contains("Goodbye World", copyToKeysArray);
+            Assert.True(dictionary.Remove("Goodbye World"));
+            Assert.Single(dictionary);
+            dictionary["Goodbye World"] = 666;
+            Assert.Equal(2, dictionary.Count);
+            dictionary.Clear();
+            Assert.Empty(dictionary);
+        }
+
+        [Fact]
+        public void OverrideMessagePropertiesDictionary()
+        {
+            LogEventInfo logEvent = new LogEventInfo(LogLevel.Info, "MyLogger", string.Empty, new[]
+            {
+                new MessageTemplateParameter("Hello World", 42, null),
+                new MessageTemplateParameter("Goodbye World", 666, null)
+            });
+            IDictionary<object, object> dictionary = logEvent.Properties;
+
+            Assert.Equal(42, dictionary["Hello World"]);
+            dictionary["Hello World"] = 999;
+            Assert.Equal(999, dictionary["Hello World"]);
+            Assert.True(dictionary.Values.Contains(999));
+            Assert.True(dictionary.Values.Contains(666));
+            Assert.False(dictionary.Values.Contains(42));
+
+            int i = 0;
+            foreach (var item in dictionary)
+            {
+                switch (i++)
+                {
+                    case 1:
+                        Assert.Equal("Hello World", item.Key);
+                        Assert.Equal(999, item.Value);
+                        break;
+                    case 0:
+                        Assert.Equal("Goodbye World", item.Key);
+                        Assert.Equal(666, item.Value);
+                        break;
+                }
+            }
+            Assert.Equal(2, i);
+
+            i = 0;
+            foreach (var item in dictionary.Keys)
+            {
+                switch (i++)
+                {
+                    case 1:
+                        Assert.Equal("Hello World", item);
+                        break;
+                    case 0:
+                        Assert.Equal("Goodbye World", item);
+                        break;
+                }
+            }
+            Assert.Equal(2, i);
+
+            i = 0;
+            foreach (var item in dictionary.Values)
+            {
+                switch (i++)
+                {
+                    case 1:
+                        Assert.Equal(999, item);
+                        break;
+                    case 0:
+                        Assert.Equal(666, item);
+                        break;
+                }
+            }
+
+            dictionary["Goodbye World"] = 42;
+            i = 0;
+            foreach (var item in dictionary.Keys)
+            {
+                switch (i++)
+                {
+                    case 0:
+                        Assert.Equal("Hello World", item);
+                        break;
+                    case 1:
+                        Assert.Equal("Goodbye World", item);
+                        break;
+                }
+            }
+            Assert.Equal(2, i);
+
+            dictionary.Remove("Hello World");
+            Assert.Single(dictionary);
+            dictionary.Remove("Goodbye World");
+            Assert.Empty(dictionary);
+        }
+
+        [Fact]
+        public void NonUniqueMessagePropertiesDictionary()
+        {
+            LogEventInfo logEvent = new LogEventInfo(LogLevel.Info, "MyLogger", string.Empty, new[]
+{
+                new MessageTemplateParameter("Hello World", 42, null),
+                new MessageTemplateParameter("Hello World", 666, null)
+            });
+            IDictionary<object, object> dictionary = logEvent.Properties;
+
+            Assert.Single(dictionary);
+            Assert.Equal(42, dictionary["Hello World"]);
+
+            List<MessageTemplateParameter> parameters = new List<MessageTemplateParameter>();
+            parameters.Add(new MessageTemplateParameter("Hello World", 42, null));
+            for (int i = 1; i < 100; ++i)
+                parameters.Add(new MessageTemplateParameter("Hello World", 666, null));
+            logEvent = new LogEventInfo(LogLevel.Info, "MyLogger", string.Empty, new[]
+            {
+                new MessageTemplateParameter("Hello World", 42, null),
+                new MessageTemplateParameter("Hello World", 666, null)
+            });
+            Assert.Single(dictionary);
+            Assert.Equal(42, dictionary["Hello World"]);
+        }
+    }
+}


### PR DESCRIPTION
Ordered by position (instead of hashcode).

It is possible to override these properties using the standard LogEventInfo-Properties-IDictionary-interface.

Allows capture of Microsoft FormattedLogValues without loosing the order given in the MessageTemplate. https://github.com/NLog/NLog.Extensions.Logging/pull/125