### PR TITLE
FallbackGroup loses events with async targets

### DIFF
--- a/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
@@ -111,7 +111,7 @@ namespace NLog.Targets.Wrappers
         {
             AsyncContinuation continuation = null;
             int tryCounter = 0;
-            int targetToInvoke;
+            int targetToInvoke = 0;
 
             continuation = ex =>
                 {
@@ -124,7 +124,7 @@ namespace NLog.Targets.Wrappers
                             {
                                 if (this.ReturnToFirstOnSuccess)
                                 {
-                                    InternalLogger.Debug("Fallback: target '{0}' succeeded. Returning to the first one.", this.Targets[this.currentTarget]);
+                                    InternalLogger.Debug("Fallback: target '{0}' succeeded. Returning to the first one.", this.Targets[targetToInvoke]);
                                     this.currentTarget = 0;
                                 }
                             }
@@ -137,10 +137,10 @@ namespace NLog.Targets.Wrappers
                     // failure
                     lock (this.lockObject)
                     {
-                        InternalLogger.Warn(ex, "Fallback: target '{0}' failed. Proceeding to the next one.", this.Targets[this.currentTarget]);
+                        InternalLogger.Warn(ex, "Fallback: target '{0}' failed. Proceeding to the next one.", this.Targets[targetToInvoke]);
 
                         // error while writing, go to the next one
-                        this.currentTarget = (this.currentTarget + 1) % this.Targets.Count;
+                        this.currentTarget = (targetToInvoke + 1) % this.Targets.Count;
 
                         tryCounter++;
                         targetToInvoke = this.currentTarget;

--- a/tests/NLog.UnitTests/Targets/Wrappers/FallbackGroupTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/FallbackGroupTargetTests.cs
@@ -198,6 +198,60 @@ namespace NLog.UnitTests.Targets.Wrappers
             Assert.Equal(1, myTarget3.FlushCount);
         }
 
+        [Fact]
+        public void FallbackGroupWithBufferingTargets_ReturnToFirstOnSuccess()
+        {
+            FallbackGroupWithBufferingTargets(true);
+        }
+
+        [Fact]
+        public void FallbackGroupWithBufferingTargets_DoNotReturnToFirstOnSuccess()
+        {
+            FallbackGroupWithBufferingTargets(false);
+        }
+
+        private void FallbackGroupWithBufferingTargets(bool returnToFirstOnSuccess)
+        {
+            const int totalEvents = 1000;
+
+            var myTarget1 = new MyTarget { FailCounter = int.MaxValue }; // Always failing.
+            var myTarget2 = new MyTarget();
+            var myTarget3 = new MyTarget();
+
+            var buffer1 = new BufferingTargetWrapper() { WrappedTarget = myTarget1, FlushTimeout = 100, SlidingTimeout = false };
+            var buffer2 = new BufferingTargetWrapper() { WrappedTarget = myTarget2, FlushTimeout = 100, SlidingTimeout = false };
+            var buffer3 = new BufferingTargetWrapper() { WrappedTarget = myTarget3, FlushTimeout = 100, SlidingTimeout = false };
+
+            var wrapper = CreateAndInitializeFallbackGroupTarget(returnToFirstOnSuccess, buffer1, buffer2, buffer3);
+
+            var allEventsDone = new ManualResetEvent(false);
+            var exceptions = new List<Exception>();
+            for (var i = 0; i < totalEvents; ++i)
+            {
+                wrapper.WriteAsyncLogEvent(LogEventInfo.CreateNullEvent().WithContinuation(ex =>
+                {
+                    lock (exceptions)
+                    {
+                        exceptions.Add(ex);
+                        if (exceptions.Count >= totalEvents)
+                            allEventsDone.Set();
+                    }
+                }));
+            }
+            allEventsDone.WaitOne();                            // Wait for all events to be delivered.
+
+            Assert.True(totalEvents >= myTarget1.WriteCount,    // Check events weren't delivered twice to myTarget1,
+                "Target 1 received " + myTarget1.WriteCount + " writes although only " + totalEvents + " events were written");
+            Assert.Equal(totalEvents, myTarget2.WriteCount);    // were all delivered exactly once to myTarget2,
+            Assert.Equal(0, myTarget3.WriteCount);              // with nothing delivered to myTarget3.
+
+            Assert.Equal(totalEvents, exceptions.Count);
+            foreach (var e in exceptions)
+            {
+                Assert.Null(e);                                 // All events should have succeeded on myTarget2.
+            }
+        }
+
         private static FallbackGroupTarget CreateAndInitializeFallbackGroupTarget(bool returnToFirstOnSuccess, params Target[] targets)
         {
             var wrapper = new FallbackGroupTarget(targets)
@@ -207,6 +261,10 @@ namespace NLog.UnitTests.Targets.Wrappers
 
             foreach (var target in targets)
             {
+                WrapperTargetBase wrapperTarget = target as WrapperTargetBase;
+                if (wrapperTarget != null)
+                    wrapperTarget.WrappedTarget.Initialize(null);
+
                 target.Initialize(null);
             }
 


### PR DESCRIPTION
**Type**: Bug

**NLog version**: 4.4.12

**Platform**: .NET 4.5

**Current NLog config**:

```xml
<nlog>
  <targets>
    <target xsi:type="FallbackGroup" name="T" returnToFirstOnSuccess="true">
      <target xsi:type="BufferingWrapper" name="WA">
        <!-- Simulate main target's failure with invalid path. -->
        <target xsi:type="File" name="A" fileName="DOES\NOT\EXIST" createDirs="false" />
      </target>
      <target xsi:type="BufferingWrapper" name="WB">
        <target xsi:type="File" name="B" fileName="repro.log" />
      </target>
    </target>
  </targets>
  <rules>
    <logger name="*" minlevel="Trace" writeTo="T" />
  </rules>
</nlog>
```
```C#
static void Main(string[] args)
{
    var log = LogManager.GetCurrentClassLogger();
    log.Info("entry 1");
    log.Info("entry 2");
    log.Info("entry 3");
}
```

- *What is the current result?* `repro.log` only contains entries 1 and 3 (entry 2 was lost).
- *What is the expected result?* `repro.log` contains all 3 entries, as target [A] always fails.
- *Did you check the [Internal log](https://github.com/NLog/NLog/wiki/Internal-Logging)?* Yes, see below.
- *Are there any workarounds?* No.
- *Is there a version in which it did work?* Unknown.


I traced the issue to `FallbackGroupTarget.Write`, which does not seem to work with async targets such as `BufferingWrapper`.
`targetToInvoke` and `this.currentTarget` are equal when a target is called, but the implementation assumes that they will still be equal during the continuation. With an async target, another log event's continuation can execute in-between, and modify `this.currentTarget`.

In the example above, what happens is usually:
- currentTarget=0, targetToInvoke=0, entry 1 sent to target [WA]
- currentTarget=0, targetToInvoke=0, entry 2 sent to target [WA]
- continuation for entry 1, targetToInvoke=0 => internal log says failure of target [WA]
  - at the end currentTarget=1, entry 1 sent to target [WB]
- continuation for entry 2, targetToInvoke=0 => *internal log says failure of target [WB] instead of [WA], because currentTarget=1*
  - at the end currentTarget=0, so *entry 2 is sent to target [WA] again (and lost, as [A] always fails) instead of [WB]*
