### PR TITLE
VS2017 - NetCore2 (Fixed package dependency)

### DIFF
--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -198,7 +198,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />


### PR DESCRIPTION
Removed System.Private.ServiceModel (It should not be referenced directly)