### PR TITLE
LogManager.LogFactory public

### DIFF
--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -66,9 +66,10 @@ namespace NLog
         public delegate CultureInfo GetCultureInfo();
 
         /// <summary>
-        /// Gets the default <see cref="NLog.LogFactory" /> instance.
+        /// Gets the <see cref="NLog.LogFactory" /> instance used in the <see cref="LogManager"/>.
         /// </summary>
-        internal static LogFactory LogFactory
+        /// <remarks>Could be used to pass the to other methods</remarks>
+        public static LogFactory LogFactory
         {
             get { return factory; }
         }


### PR DESCRIPTION
needed for (in NLog.Web.AspNetCore)

    NLogBuilder.LoadConfig("NLog.config").GetCurrentClassLogger()

(see https://github.com/NLog/NLog.Web/pull/191)

@snakefoot your opinion please :)

