### PR TITLE
Naming: consistent private fields

### DIFF
--- a/src/NLog/Common/LogEventInfoBuffer.cs
+++ b/src/NLog/Common/LogEventInfoBuffer.cs
@@ -41,13 +41,13 @@ namespace NLog.Common
     /// </summary>
     public class LogEventInfoBuffer
     {
-        private readonly bool growAsNeeded;
-        private readonly int growLimit;
+        private readonly bool _growAsNeeded;
+        private readonly int _growLimit;
 
-        private AsyncLogEventInfo[] buffer;
-        private int getPointer;
-        private int putPointer;
-        private int count;
+        private AsyncLogEventInfo[] _buffer;
+        private int _getPointer;
+        private int _putPointer;
+        private int _count;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LogEventInfoBuffer" /> class.
@@ -57,11 +57,11 @@ namespace NLog.Common
         /// <param name="growLimit">The maximum number of items that the buffer can grow to.</param>
         public LogEventInfoBuffer(int size, bool growAsNeeded, int growLimit)
         {
-            this.growAsNeeded = growAsNeeded;
-            this.buffer = new AsyncLogEventInfo[size];
-            this.growLimit = growLimit;
-            this.getPointer = 0;
-            this.putPointer = 0;
+            this._growAsNeeded = growAsNeeded;
+            this._buffer = new AsyncLogEventInfo[size];
+            this._growLimit = growLimit;
+            this._getPointer = 0;
+            this._putPointer = 0;
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace NLog.Common
         /// </summary>
         public int Size
         {
-            get { return this.buffer.Length; }
+            get { return this._buffer.Length; }
         }
 
         /// <summary>
@@ -82,40 +82,40 @@ namespace NLog.Common
             lock (this)
             {
                 // make room for additional item
-                if (this.count >= this.buffer.Length)
+                if (this._count >= this._buffer.Length)
                 {
-                    if (this.growAsNeeded && this.buffer.Length < this.growLimit)
+                    if (this._growAsNeeded && this._buffer.Length < this._growLimit)
                     {
                         // create a new buffer, copy data from current
-                        int newLength = this.buffer.Length * 2;
-                        if (newLength >= this.growLimit)
+                        int newLength = this._buffer.Length * 2;
+                        if (newLength >= this._growLimit)
                         {
-                            newLength = this.growLimit;
+                            newLength = this._growLimit;
                         }
 
                         // InternalLogger.Trace("Enlarging LogEventInfoBuffer from {0} to {1}", this.buffer.Length, this.buffer.Length * 2);
                         var newBuffer = new AsyncLogEventInfo[newLength];
-                        Array.Copy(this.buffer, 0, newBuffer, 0, this.buffer.Length);
-                        this.buffer = newBuffer;
+                        Array.Copy(this._buffer, 0, newBuffer, 0, this._buffer.Length);
+                        this._buffer = newBuffer;
                     }
                     else
                     {
                         // lose the oldest item
-                        this.getPointer = this.getPointer + 1;
+                        this._getPointer = this._getPointer + 1;
                     }
                 }
 
                 // put the item
-                this.putPointer = this.putPointer % this.buffer.Length;
-                this.buffer[this.putPointer] = eventInfo;
-                this.putPointer = this.putPointer + 1;
-                this.count++;
-                if (this.count >= this.buffer.Length)
+                this._putPointer = this._putPointer % this._buffer.Length;
+                this._buffer[this._putPointer] = eventInfo;
+                this._putPointer = this._putPointer + 1;
+                this._count++;
+                if (this._count >= this._buffer.Length)
                 {
-                    this.count = this.buffer.Length;
+                    this._count = this._buffer.Length;
                 }
 
-                return this.count;
+                return this._count;
             }
         }
 
@@ -127,7 +127,7 @@ namespace NLog.Common
         {
             lock (this)
             {
-                int cnt = this.count;
+                int cnt = this._count;
                 if (cnt == 0)
                     return Internal.ArrayHelper.Empty<AsyncLogEventInfo>();
 
@@ -136,15 +136,15 @@ namespace NLog.Common
                 // InternalLogger.Trace("GetEventsAndClear({0},{1},{2})", this.getPointer, this.putPointer, this.count);
                 for (int i = 0; i < cnt; ++i)
                 {
-                    int p = (this.getPointer + i) % this.buffer.Length;
-                    var e = this.buffer[p];
-                    this.buffer[p] = default(AsyncLogEventInfo); // we don't want memory leaks
+                    int p = (this._getPointer + i) % this._buffer.Length;
+                    var e = this._buffer[p];
+                    this._buffer[p] = default(AsyncLogEventInfo); // we don't want memory leaks
                     returnValue[i] = e;
                 }
 
-                this.count = 0;
-                this.getPointer = 0;
-                this.putPointer = 0;
+                this._count = 0;
+                this._getPointer = 0;
+                this._putPointer = 0;
 
                 return returnValue;
             }

--- a/src/NLog/Conditions/ConditionMethodExpression.cs
+++ b/src/NLog/Conditions/ConditionMethodExpression.cs
@@ -45,8 +45,8 @@ namespace NLog.Conditions
     /// </summary>
 	internal sealed class ConditionMethodExpression : ConditionExpression
     {
-        private readonly bool acceptsLogEvent;
-        private readonly string conditionMethodName;
+        private readonly bool _acceptsLogEvent;
+        private readonly string _conditionMethodName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConditionMethodExpression" /> class.
@@ -57,17 +57,17 @@ namespace NLog.Conditions
         public ConditionMethodExpression(string conditionMethodName, MethodInfo methodInfo, IEnumerable<ConditionExpression> methodParameters)
         {
             this.MethodInfo = methodInfo;
-            this.conditionMethodName = conditionMethodName;
+            this._conditionMethodName = conditionMethodName;
             this.MethodParameters = new List<ConditionExpression>(methodParameters).AsReadOnly();
 
             ParameterInfo[] formalParameters = this.MethodInfo.GetParameters();
             if (formalParameters.Length > 0 && formalParameters[0].ParameterType == typeof(LogEventInfo))
             {
-                this.acceptsLogEvent = true;
+                this._acceptsLogEvent = true;
             }
 
             int actualParameterCount = this.MethodParameters.Count;
-            if (this.acceptsLogEvent)
+            if (this._acceptsLogEvent)
             {
                 actualParameterCount++;
             }
@@ -111,19 +111,19 @@ namespace NLog.Conditions
                 throw new ConditionParseException(message);
             }
 
-            this.lateBoundMethod = Internal.ReflectionHelpers.CreateLateBoundMethod(MethodInfo);
+            this._lateBoundMethod = Internal.ReflectionHelpers.CreateLateBoundMethod(MethodInfo);
             if (formalParameters.Length > MethodParameters.Count)
             {
-                this.lateBoundMethodDefaultParameters = new object[formalParameters.Length - MethodParameters.Count];
+                this._lateBoundMethodDefaultParameters = new object[formalParameters.Length - MethodParameters.Count];
                 for (int i = MethodParameters.Count; i < formalParameters.Length; ++i)
                 {
                     ParameterInfo param = formalParameters[i];
-                    this.lateBoundMethodDefaultParameters[i - MethodParameters.Count] = param.DefaultValue;
+                    this._lateBoundMethodDefaultParameters[i - MethodParameters.Count] = param.DefaultValue;
                 }
             }
             else
             {
-                this.lateBoundMethodDefaultParameters = null;
+                this._lateBoundMethodDefaultParameters = null;
             }
         }
 
@@ -131,8 +131,8 @@ namespace NLog.Conditions
         /// Gets the method info.
         /// </summary>
         public MethodInfo MethodInfo { get; private set; }
-        private readonly Internal.ReflectionHelpers.LateBoundMethod lateBoundMethod;
-        private readonly object[] lateBoundMethodDefaultParameters;
+        private readonly Internal.ReflectionHelpers.LateBoundMethod _lateBoundMethod;
+        private readonly object[] _lateBoundMethodDefaultParameters;
 
         /// <summary>
         /// Gets the method parameters.
@@ -149,7 +149,7 @@ namespace NLog.Conditions
         public override string ToString()
         {
             var sb = new StringBuilder();
-            sb.Append(this.conditionMethodName);
+            sb.Append(this._conditionMethodName);
             sb.Append("(");
 
             string separator = string.Empty;
@@ -175,8 +175,8 @@ namespace NLog.Conditions
         /// <returns>Expression result.</returns>
         protected override object EvaluateNode(LogEventInfo context)
         {
-            int parameterOffset = this.acceptsLogEvent ? 1 : 0;
-            int parameterDefaults = this.lateBoundMethodDefaultParameters != null ? this.lateBoundMethodDefaultParameters.Length : 0;
+            int parameterOffset = this._acceptsLogEvent ? 1 : 0;
+            int parameterDefaults = this._lateBoundMethodDefaultParameters != null ? this._lateBoundMethodDefaultParameters.Length : 0;
 
             var callParameters = new object[this.MethodParameters.Count + parameterOffset + parameterDefaults];
 
@@ -188,20 +188,20 @@ namespace NLog.Conditions
                 callParameters[i + parameterOffset] = ce.Evaluate(context);
             }
 
-            if (this.acceptsLogEvent)
+            if (this._acceptsLogEvent)
             {
                 callParameters[0] = context;
             }
 
-            if (this.lateBoundMethodDefaultParameters != null)
+            if (this._lateBoundMethodDefaultParameters != null)
             {
-                for (int i = this.lateBoundMethodDefaultParameters.Length - 1; i >= 0; --i)
+                for (int i = this._lateBoundMethodDefaultParameters.Length - 1; i >= 0; --i)
                 {
-                    callParameters[callParameters.Length - i - 1] = this.lateBoundMethodDefaultParameters[i];
+                    callParameters[callParameters.Length - i - 1] = this._lateBoundMethodDefaultParameters[i];
                 }
             }
 
-            return this.lateBoundMethod(null, callParameters);  // Static-method so object-instance = null
+            return this._lateBoundMethod(null, callParameters);  // Static-method so object-instance = null
         }
     }
 }

--- a/src/NLog/Conditions/ConditionParser.cs
+++ b/src/NLog/Conditions/ConditionParser.cs
@@ -48,8 +48,8 @@ namespace NLog.Conditions
     /// </summary>
     public class ConditionParser
     {
-        private readonly ConditionTokenizer tokenizer;
-        private readonly ConfigurationItemFactory configurationItemFactory;
+        private readonly ConditionTokenizer _tokenizer;
+        private readonly ConfigurationItemFactory _configurationItemFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConditionParser"/> class.
@@ -58,8 +58,8 @@ namespace NLog.Conditions
         /// <param name="configurationItemFactory">Instance of <see cref="ConfigurationItemFactory"/> used to resolve references to condition methods and layout renderers.</param>
         private ConditionParser(SimpleStringReader stringReader, ConfigurationItemFactory configurationItemFactory)
         {
-            this.configurationItemFactory = configurationItemFactory;
-            this.tokenizer = new ConditionTokenizer(stringReader);
+            this._configurationItemFactory = configurationItemFactory;
+            this._tokenizer = new ConditionTokenizer(stringReader);
         }
 
         /// <summary>
@@ -89,9 +89,9 @@ namespace NLog.Conditions
 
             var parser = new ConditionParser(new SimpleStringReader(expressionText), configurationItemFactories);
             ConditionExpression expression = parser.ParseExpression();
-            if (!parser.tokenizer.IsEOF())
+            if (!parser._tokenizer.IsEOF())
             {
-                throw new ConditionParseException("Unexpected token: " + parser.tokenizer.TokenValue);
+                throw new ConditionParseException("Unexpected token: " + parser._tokenizer.TokenValue);
             }
 
             return expression;
@@ -118,22 +118,22 @@ namespace NLog.Conditions
         {
             var par = new List<ConditionExpression>();
 
-            while (!this.tokenizer.IsEOF() && this.tokenizer.TokenType != ConditionTokenType.RightParen)
+            while (!this._tokenizer.IsEOF() && this._tokenizer.TokenType != ConditionTokenType.RightParen)
             {
                 par.Add(ParseExpression());
-                if (this.tokenizer.TokenType != ConditionTokenType.Comma)
+                if (this._tokenizer.TokenType != ConditionTokenType.Comma)
                 {
                     break;
                 }
 
-                this.tokenizer.GetNextToken();
+                this._tokenizer.GetNextToken();
             }
 
-            this.tokenizer.Expect(ConditionTokenType.RightParen);
+            this._tokenizer.Expect(ConditionTokenType.RightParen);
 
             try
             {
-                var methodInfo = this.configurationItemFactory.ConditionMethods.CreateInstance(functionName);
+                var methodInfo = this._configurationItemFactory.ConditionMethods.CreateInstance(functionName);
                 return new ConditionMethodExpression(functionName, methodInfo, par);
             }
             catch (Exception exception)
@@ -151,24 +151,24 @@ namespace NLog.Conditions
 
         private ConditionExpression ParseLiteralExpression()
         {
-            if (this.tokenizer.IsToken(ConditionTokenType.LeftParen))
+            if (this._tokenizer.IsToken(ConditionTokenType.LeftParen))
             {
-                this.tokenizer.GetNextToken();
+                this._tokenizer.GetNextToken();
                 ConditionExpression e = this.ParseExpression();
-                this.tokenizer.Expect(ConditionTokenType.RightParen);
+                this._tokenizer.Expect(ConditionTokenType.RightParen);
                 return e;
             }
 
-            if (this.tokenizer.IsToken(ConditionTokenType.Minus))
+            if (this._tokenizer.IsToken(ConditionTokenType.Minus))
             {
-                this.tokenizer.GetNextToken();
-                if (!this.tokenizer.IsNumber())
+                this._tokenizer.GetNextToken();
+                if (!this._tokenizer.IsNumber())
                 {
-                    throw new ConditionParseException("Number expected, got " + this.tokenizer.TokenType);
+                    throw new ConditionParseException("Number expected, got " + this._tokenizer.TokenType);
                 }
 
-                string numberString = this.tokenizer.TokenValue;
-                this.tokenizer.GetNextToken();
+                string numberString = this._tokenizer.TokenValue;
+                this._tokenizer.GetNextToken();
                 if (numberString.IndexOf('.') >= 0)
                 {
                     return new ConditionLiteralExpression(-double.Parse(numberString, CultureInfo.InvariantCulture));
@@ -177,10 +177,10 @@ namespace NLog.Conditions
                 return new ConditionLiteralExpression(-int.Parse(numberString, CultureInfo.InvariantCulture));
             }
 
-            if (this.tokenizer.IsNumber())
+            if (this._tokenizer.IsNumber())
             {
-                string numberString = this.tokenizer.TokenValue;
-                this.tokenizer.GetNextToken();
+                string numberString = this._tokenizer.TokenValue;
+                this._tokenizer.GetNextToken();
                 if (numberString.IndexOf('.') >= 0)
                 {
                     return new ConditionLiteralExpression(double.Parse(numberString, CultureInfo.InvariantCulture));
@@ -189,16 +189,16 @@ namespace NLog.Conditions
                 return new ConditionLiteralExpression(int.Parse(numberString, CultureInfo.InvariantCulture));
             }
 
-            if (this.tokenizer.TokenType == ConditionTokenType.String)
+            if (this._tokenizer.TokenType == ConditionTokenType.String)
             {
-                ConditionExpression e = new ConditionLayoutExpression(Layout.FromString(this.tokenizer.StringTokenValue, this.configurationItemFactory));
-                this.tokenizer.GetNextToken();
+                ConditionExpression e = new ConditionLayoutExpression(Layout.FromString(this._tokenizer.StringTokenValue, this._configurationItemFactory));
+                this._tokenizer.GetNextToken();
                 return e;
             }
 
-            if (this.tokenizer.TokenType == ConditionTokenType.Keyword)
+            if (this._tokenizer.TokenType == ConditionTokenType.Keyword)
             {
-                string keyword = this.tokenizer.EatKeyword();
+                string keyword = this._tokenizer.EatKeyword();
 
                 if (0 == string.Compare(keyword, "level", StringComparison.OrdinalIgnoreCase))
                 {
@@ -217,8 +217,8 @@ namespace NLog.Conditions
 
                 if (0 == string.Compare(keyword, "loglevel", StringComparison.OrdinalIgnoreCase))
                 {
-                    this.tokenizer.Expect(ConditionTokenType.Dot);
-                    return new ConditionLiteralExpression(LogLevel.FromString(this.tokenizer.EatKeyword()));
+                    this._tokenizer.Expect(ConditionTokenType.Dot);
+                    return new ConditionLiteralExpression(LogLevel.FromString(this._tokenizer.EatKeyword()));
                 }
 
                 if (0 == string.Compare(keyword, "true", StringComparison.OrdinalIgnoreCase))
@@ -236,55 +236,55 @@ namespace NLog.Conditions
                     return new ConditionLiteralExpression(null);
                 }
 
-                if (this.tokenizer.TokenType == ConditionTokenType.LeftParen)
+                if (this._tokenizer.TokenType == ConditionTokenType.LeftParen)
                 {
-                    this.tokenizer.GetNextToken();
+                    this._tokenizer.GetNextToken();
 
                     ConditionMethodExpression predicateExpression = this.ParsePredicate(keyword);
                     return predicateExpression;
                 }
             }
 
-            throw new ConditionParseException("Unexpected token: " + this.tokenizer.TokenValue);
+            throw new ConditionParseException("Unexpected token: " + this._tokenizer.TokenValue);
         }
 
         private ConditionExpression ParseBooleanRelation()
         {
             ConditionExpression e = this.ParseLiteralExpression();
 
-            if (this.tokenizer.IsToken(ConditionTokenType.EqualTo))
+            if (this._tokenizer.IsToken(ConditionTokenType.EqualTo))
             {
-                this.tokenizer.GetNextToken();
+                this._tokenizer.GetNextToken();
                 return new ConditionRelationalExpression(e, this.ParseLiteralExpression(), ConditionRelationalOperator.Equal);
             }
 
-            if (this.tokenizer.IsToken(ConditionTokenType.NotEqual))
+            if (this._tokenizer.IsToken(ConditionTokenType.NotEqual))
             {
-                this.tokenizer.GetNextToken();
+                this._tokenizer.GetNextToken();
                 return new ConditionRelationalExpression(e, this.ParseLiteralExpression(), ConditionRelationalOperator.NotEqual);
             }
 
-            if (this.tokenizer.IsToken(ConditionTokenType.LessThan))
+            if (this._tokenizer.IsToken(ConditionTokenType.LessThan))
             {
-                this.tokenizer.GetNextToken();
+                this._tokenizer.GetNextToken();
                 return new ConditionRelationalExpression(e, this.ParseLiteralExpression(), ConditionRelationalOperator.Less);
             }
 
-            if (this.tokenizer.IsToken(ConditionTokenType.GreaterThan))
+            if (this._tokenizer.IsToken(ConditionTokenType.GreaterThan))
             {
-                this.tokenizer.GetNextToken();
+                this._tokenizer.GetNextToken();
                 return new ConditionRelationalExpression(e, this.ParseLiteralExpression(), ConditionRelationalOperator.Greater);
             }
 
-            if (this.tokenizer.IsToken(ConditionTokenType.LessThanOrEqualTo))
+            if (this._tokenizer.IsToken(ConditionTokenType.LessThanOrEqualTo))
             {
-                this.tokenizer.GetNextToken();
+                this._tokenizer.GetNextToken();
                 return new ConditionRelationalExpression(e, this.ParseLiteralExpression(), ConditionRelationalOperator.LessOrEqual);
             }
 
-            if (this.tokenizer.IsToken(ConditionTokenType.GreaterThanOrEqualTo))
+            if (this._tokenizer.IsToken(ConditionTokenType.GreaterThanOrEqualTo))
             {
-                this.tokenizer.GetNextToken();
+                this._tokenizer.GetNextToken();
                 return new ConditionRelationalExpression(e, this.ParseLiteralExpression(), ConditionRelationalOperator.GreaterOrEqual);
             }
 
@@ -293,9 +293,9 @@ namespace NLog.Conditions
 
         private ConditionExpression ParseBooleanPredicate()
         {
-            if (this.tokenizer.IsKeyword("not") || this.tokenizer.IsToken(ConditionTokenType.Not))
+            if (this._tokenizer.IsKeyword("not") || this._tokenizer.IsToken(ConditionTokenType.Not))
             {
-                this.tokenizer.GetNextToken();
+                this._tokenizer.GetNextToken();
                 return new ConditionNotExpression(this.ParseBooleanPredicate());
             }
 
@@ -306,9 +306,9 @@ namespace NLog.Conditions
         {
             ConditionExpression expression = this.ParseBooleanPredicate();
 
-            while (this.tokenizer.IsKeyword("and") || this.tokenizer.IsToken(ConditionTokenType.And))
+            while (this._tokenizer.IsKeyword("and") || this._tokenizer.IsToken(ConditionTokenType.And))
             {
-                this.tokenizer.GetNextToken();
+                this._tokenizer.GetNextToken();
                 expression = new ConditionAndExpression(expression, this.ParseBooleanPredicate());
             }
 
@@ -319,9 +319,9 @@ namespace NLog.Conditions
         {
             ConditionExpression expression = this.ParseBooleanAnd();
 
-            while (this.tokenizer.IsKeyword("or") || this.tokenizer.IsToken(ConditionTokenType.Or))
+            while (this._tokenizer.IsKeyword("or") || this._tokenizer.IsToken(ConditionTokenType.Or))
             {
-                this.tokenizer.GetNextToken();
+                this._tokenizer.GetNextToken();
                 expression = new ConditionOrExpression(expression, this.ParseBooleanAnd());
             }
 

--- a/src/NLog/Conditions/ConditionTokenizer.cs
+++ b/src/NLog/Conditions/ConditionTokenizer.cs
@@ -43,7 +43,7 @@ namespace NLog.Conditions
     internal sealed class ConditionTokenizer
     {
         private static readonly ConditionTokenType[] charIndexToTokenType = BuildCharIndexToTokenType();
-        private readonly SimpleStringReader stringReader;
+        private readonly SimpleStringReader _stringReader;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConditionTokenizer"/> class.
@@ -51,7 +51,7 @@ namespace NLog.Conditions
         /// <param name="stringReader">The string reader.</param>
         public ConditionTokenizer(SimpleStringReader stringReader)
         {
-            this.stringReader = stringReader;
+            this._stringReader = stringReader;
             this.TokenType = ConditionTokenType.BeginningOfInput;
             this.GetNextToken();
         }
@@ -517,12 +517,12 @@ namespace NLog.Conditions
 
         private int PeekChar()
         {
-            return this.stringReader.Peek();
+            return this._stringReader.Peek();
         }
 
         private int ReadChar()
         {
-            return this.stringReader.Read();
+            return this._stringReader.Read();
         }
 
         /// <summary>

--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -57,16 +57,16 @@ namespace NLog.Config
     {
         private static ConfigurationItemFactory defaultInstance = null;
 
-        private readonly IList<object> allFactories;
-        private readonly Factory<Target, TargetAttribute> targets;
-        private readonly Factory<Filter, FilterAttribute> filters;
-        private readonly LayoutRendererFactory layoutRenderers;
-        private readonly Factory<Layout, LayoutAttribute> layouts;
-        private readonly MethodFactory<ConditionMethodsAttribute, ConditionMethodAttribute> conditionMethods;
-        private readonly Factory<LayoutRenderer, AmbientPropertyAttribute> ambientProperties;
-        private readonly Factory<TimeSource, TimeSourceAttribute> timeSources;
+        private readonly IList<object> _allFactories;
+        private readonly Factory<Target, TargetAttribute> _targets;
+        private readonly Factory<Filter, FilterAttribute> _filters;
+        private readonly LayoutRendererFactory _layoutRenderers;
+        private readonly Factory<Layout, LayoutAttribute> _layouts;
+        private readonly MethodFactory<ConditionMethodsAttribute, ConditionMethodAttribute> _conditionMethods;
+        private readonly Factory<LayoutRenderer, AmbientPropertyAttribute> _ambientProperties;
+        private readonly Factory<TimeSource, TimeSourceAttribute> _timeSources;
 
-        private IJsonConverter jsonSerializer = DefaultJsonSerializer.Instance;
+        private IJsonConverter _jsonSerializer = DefaultJsonSerializer.Instance;
 
         /// <summary>
         /// Called before the assembly will be loaded.
@@ -80,22 +80,22 @@ namespace NLog.Config
         public ConfigurationItemFactory(params Assembly[] assemblies)
         {
             this.CreateInstance = FactoryHelper.CreateInstance;
-            this.targets = new Factory<Target, TargetAttribute>(this);
-            this.filters = new Factory<Filter, FilterAttribute>(this);
-            this.layoutRenderers = new LayoutRendererFactory(this);
-            this.layouts = new Factory<Layout, LayoutAttribute>(this);
-            this.conditionMethods = new MethodFactory<ConditionMethodsAttribute, ConditionMethodAttribute>();
-            this.ambientProperties = new Factory<LayoutRenderer, AmbientPropertyAttribute>(this);
-            this.timeSources = new Factory<TimeSource, TimeSourceAttribute>(this);
-            this.allFactories = new List<object>
+            this._targets = new Factory<Target, TargetAttribute>(this);
+            this._filters = new Factory<Filter, FilterAttribute>(this);
+            this._layoutRenderers = new LayoutRendererFactory(this);
+            this._layouts = new Factory<Layout, LayoutAttribute>(this);
+            this._conditionMethods = new MethodFactory<ConditionMethodsAttribute, ConditionMethodAttribute>();
+            this._ambientProperties = new Factory<LayoutRenderer, AmbientPropertyAttribute>(this);
+            this._timeSources = new Factory<TimeSource, TimeSourceAttribute>(this);
+            this._allFactories = new List<object>
             {
-                this.targets,
-                this.filters,
-                this.layoutRenderers,
-                this.layouts,
-                this.conditionMethods,
-                this.ambientProperties,
-                this.timeSources,
+                this._targets,
+                this._filters,
+                this._layoutRenderers,
+                this._layouts,
+                this._conditionMethods,
+                this._ambientProperties,
+                this._timeSources,
             };
 
             foreach (var asm in assemblies)
@@ -136,7 +136,7 @@ namespace NLog.Config
         /// <value>The target factory.</value>
         public INamedItemFactory<Target, Type> Targets
         {
-            get { return this.targets; }
+            get { return this._targets; }
         }
 
         /// <summary>
@@ -145,17 +145,17 @@ namespace NLog.Config
         /// <value>The filter factory.</value>
         public INamedItemFactory<Filter, Type> Filters
         {
-            get { return this.filters; }
+            get { return this._filters; }
         }
 
         /// <summary>
         /// gets the <see cref="LayoutRenderer"/> factory
         /// </summary>
-        /// <remarks>not using <see cref="layoutRenderers"/> due to backwardscomp.</remarks>
+        /// <remarks>not using <see cref="_layoutRenderers"/> due to backwardscomp.</remarks>
         /// <returns></returns>
         internal LayoutRendererFactory GetLayoutRenderers()
         {
-            return this.layoutRenderers;
+            return this._layoutRenderers;
         }
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace NLog.Config
         /// <value>The layout renderer factory.</value>
         public INamedItemFactory<LayoutRenderer, Type> LayoutRenderers
         {
-            get { return this.layoutRenderers; }
+            get { return this._layoutRenderers; }
         }
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace NLog.Config
         /// <value>The layout factory.</value>
         public INamedItemFactory<Layout, Type> Layouts
         {
-            get { return this.layouts; }
+            get { return this._layouts; }
         }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace NLog.Config
         /// <value>The ambient property factory.</value>
         public INamedItemFactory<LayoutRenderer, Type> AmbientProperties
         {
-            get { return this.ambientProperties; }
+            get { return this._ambientProperties; }
         }
         
         /// <summary>
@@ -191,8 +191,8 @@ namespace NLog.Config
         [Obsolete("Use JsonConverter property instead. Marked obsolete on NLog 4.5")]
         public NLog.Targets.IJsonSerializer JsonSerializer
         {
-            get { return jsonSerializer as NLog.Targets.IJsonSerializer; }
-            set { jsonSerializer = value != null ? (IJsonConverter)new JsonConverterLegacy(value) : DefaultJsonSerializer.Instance; }
+            get { return _jsonSerializer as NLog.Targets.IJsonSerializer; }
+            set { _jsonSerializer = value != null ? (IJsonConverter)new JsonConverterLegacy(value) : DefaultJsonSerializer.Instance; }
         }
 
         /// <summary>
@@ -200,8 +200,8 @@ namespace NLog.Config
         /// </summary>
         public IJsonConverter JsonConverter
         {
-            get { return jsonSerializer; }
-            set { jsonSerializer = value ?? DefaultJsonSerializer.Instance; }
+            get { return _jsonSerializer; }
+            set { _jsonSerializer = value ?? DefaultJsonSerializer.Instance; }
         }
 
         /// <summary>
@@ -245,7 +245,7 @@ namespace NLog.Config
         /// <value>The time source factory.</value>
         public INamedItemFactory<TimeSource, Type> TimeSources
         {
-            get { return this.timeSources; }
+            get { return this._timeSources; }
         }
 
         /// <summary>
@@ -254,7 +254,7 @@ namespace NLog.Config
         /// <value>The condition method factory.</value>
         public INamedItemFactory<MethodInfo, MethodInfo> ConditionMethods
         {
-            get { return this.conditionMethods; }
+            get { return this._conditionMethods; }
         }
 
         /// <summary>
@@ -287,7 +287,7 @@ namespace NLog.Config
             InternalLogger.Debug("ScanAssembly('{0}')", assembly.FullName);
             var typesToScan = assembly.SafeGetTypes();
             PreloadAssembly(typesToScan);
-            foreach (IFactory f in this.allFactories)
+            foreach (IFactory f in this._allFactories)
             {
                 f.ScanTypes(typesToScan, itemNamePrefix);
             }
@@ -357,7 +357,7 @@ namespace NLog.Config
         /// </summary>
         public void Clear()
         {
-            foreach (IFactory f in this.allFactories)
+            foreach (IFactory f in this._allFactories)
             {
                 f.Clear();
             }
@@ -370,7 +370,7 @@ namespace NLog.Config
         /// <param name="itemNamePrefix">The item name prefix.</param>
         public void RegisterType(Type type, string itemNamePrefix)
         {
-            foreach (IFactory f in this.allFactories)
+            foreach (IFactory f in this._allFactories)
             {
                 f.RegisterType(type, itemNamePrefix);
             }
@@ -481,19 +481,19 @@ namespace NLog.Config
 
                 // register types
                 string targetsNamespace = typeof(DebugTarget).Namespace;
-                this.targets.RegisterNamedType("AspNetTrace", targetsNamespace + ".AspNetTraceTarget" + suffix);
-                this.targets.RegisterNamedType("MSMQ", targetsNamespace + ".MessageQueueTarget" + suffix);
-                this.targets.RegisterNamedType("AspNetBufferingWrapper", targetsNamespace + ".Wrappers.AspNetBufferingTargetWrapper" + suffix);
+                this._targets.RegisterNamedType("AspNetTrace", targetsNamespace + ".AspNetTraceTarget" + suffix);
+                this._targets.RegisterNamedType("MSMQ", targetsNamespace + ".MessageQueueTarget" + suffix);
+                this._targets.RegisterNamedType("AspNetBufferingWrapper", targetsNamespace + ".Wrappers.AspNetBufferingTargetWrapper" + suffix);
 
                 // register layout renderers
                 string layoutRenderersNamespace = typeof(MessageLayoutRenderer).Namespace;
-                this.layoutRenderers.RegisterNamedType("appsetting", layoutRenderersNamespace + ".AppSettingLayoutRenderer" + suffix);
-                this.layoutRenderers.RegisterNamedType("aspnet-application", layoutRenderersNamespace + ".AspNetApplicationValueLayoutRenderer" + suffix);
-                this.layoutRenderers.RegisterNamedType("aspnet-request", layoutRenderersNamespace + ".AspNetRequestValueLayoutRenderer" + suffix);
-                this.layoutRenderers.RegisterNamedType("aspnet-sessionid", layoutRenderersNamespace + ".AspNetSessionIDLayoutRenderer" + suffix);
-                this.layoutRenderers.RegisterNamedType("aspnet-session", layoutRenderersNamespace + ".AspNetSessionValueLayoutRenderer" + suffix);
-                this.layoutRenderers.RegisterNamedType("aspnet-user-authtype", layoutRenderersNamespace + ".AspNetUserAuthTypeLayoutRenderer" + suffix);
-                this.layoutRenderers.RegisterNamedType("aspnet-user-identity", layoutRenderersNamespace + ".AspNetUserIdentityLayoutRenderer" + suffix);
+                this._layoutRenderers.RegisterNamedType("appsetting", layoutRenderersNamespace + ".AppSettingLayoutRenderer" + suffix);
+                this._layoutRenderers.RegisterNamedType("aspnet-application", layoutRenderersNamespace + ".AspNetApplicationValueLayoutRenderer" + suffix);
+                this._layoutRenderers.RegisterNamedType("aspnet-request", layoutRenderersNamespace + ".AspNetRequestValueLayoutRenderer" + suffix);
+                this._layoutRenderers.RegisterNamedType("aspnet-sessionid", layoutRenderersNamespace + ".AspNetSessionIDLayoutRenderer" + suffix);
+                this._layoutRenderers.RegisterNamedType("aspnet-session", layoutRenderersNamespace + ".AspNetSessionValueLayoutRenderer" + suffix);
+                this._layoutRenderers.RegisterNamedType("aspnet-user-authtype", layoutRenderersNamespace + ".AspNetUserAuthTypeLayoutRenderer" + suffix);
+                this._layoutRenderers.RegisterNamedType("aspnet-user-identity", layoutRenderersNamespace + ".AspNetUserIdentityLayoutRenderer" + suffix);
             }
         }
     }

--- a/src/NLog/Config/Factory.cs
+++ b/src/NLog/Config/Factory.cs
@@ -49,12 +49,12 @@ namespace NLog.Config
         where TBaseType : class
         where TAttributeType : NameBaseAttribute
     {
-        private readonly Dictionary<string, GetTypeDelegate> items = new Dictionary<string, GetTypeDelegate>(StringComparer.OrdinalIgnoreCase);
-        private ConfigurationItemFactory parentFactory;
+        private readonly Dictionary<string, GetTypeDelegate> _items = new Dictionary<string, GetTypeDelegate>(StringComparer.OrdinalIgnoreCase);
+        private ConfigurationItemFactory _parentFactory;
 
         internal Factory(ConfigurationItemFactory parentFactory)
         {
-            this.parentFactory = parentFactory;
+            this._parentFactory = parentFactory;
         }
 
         private delegate Type GetTypeDelegate();
@@ -109,7 +109,7 @@ namespace NLog.Config
         /// <param name="typeName">Name of the type.</param>
         public void RegisterNamedType(string itemName, string typeName)
         {
-            this.items[itemName] = () => Type.GetType(typeName, false);
+            this._items[itemName] = () => Type.GetType(typeName, false);
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace NLog.Config
         /// </summary>
         public void Clear()
         {
-            this.items.Clear();
+            this._items.Clear();
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace NLog.Config
         /// <param name="type">The type of the item.</param>
         public void RegisterDefinition(string name, Type type)
         {
-            this.items[name] = () => type;
+            this._items[name] = () => type;
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace NLog.Config
         {
             GetTypeDelegate getTypeDelegate;
 
-            if (!this.items.TryGetValue(itemName, out getTypeDelegate))
+            if (!this._items.TryGetValue(itemName, out getTypeDelegate))
             {
                 result = null;
                 return false;
@@ -180,7 +180,7 @@ namespace NLog.Config
                 return false;
             }
 
-            result = (TBaseType)this.parentFactory.CreateInstance(type);
+            result = (TBaseType)this._parentFactory.CreateInstance(type);
             return true;
         }
 
@@ -219,14 +219,14 @@ namespace NLog.Config
         {
         }
 
-        private Dictionary<string, FuncLayoutRenderer> funcRenderers;
+        private Dictionary<string, FuncLayoutRenderer> _funcRenderers;
 
         /// <summary>
         /// Clear all func layouts
         /// </summary>
         public void ClearFuncLayouts()
         {
-            funcRenderers = null;
+            _funcRenderers = null;
         }
 
         /// <summary>
@@ -236,10 +236,10 @@ namespace NLog.Config
         /// <param name="renderer">the renderer that renders the value.</param>
         public void RegisterFuncLayout(string name, FuncLayoutRenderer renderer)
         {
-            funcRenderers = funcRenderers ?? new Dictionary<string, FuncLayoutRenderer>(StringComparer.OrdinalIgnoreCase);
+            _funcRenderers = _funcRenderers ?? new Dictionary<string, FuncLayoutRenderer>(StringComparer.OrdinalIgnoreCase);
 
             //overwrite current if there is one
-            funcRenderers[name] = renderer;
+            _funcRenderers[name] = renderer;
         }
 
 
@@ -252,10 +252,10 @@ namespace NLog.Config
         public override bool TryCreateInstance(string itemName, out LayoutRenderer result)
         {
             //first try func renderers, as they should have the possiblity to overwrite a current one.
-            if (funcRenderers != null)
+            if (_funcRenderers != null)
             {
                 FuncLayoutRenderer funcResult;
-                var succesAsFunc = funcRenderers.TryGetValue(itemName, out funcResult);
+                var succesAsFunc = _funcRenderers.TryGetValue(itemName, out funcResult);
                 if (succesAsFunc)
                 {
                     result = funcResult;

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -53,15 +53,15 @@ namespace NLog.Config
     ///<remarks>This class is thread-safe.<c>.ToList()</c> is used for that purpose.</remarks>
     public class LoggingConfiguration
     {
-        private readonly IDictionary<string, Target> targets =
+        private readonly IDictionary<string, Target> _targets =
             new Dictionary<string, Target>(StringComparer.OrdinalIgnoreCase);
 
-        private List<object> configItems = new List<object>();
+        private List<object> _configItems = new List<object>();
 
         /// <summary>
         /// Variables defined in xml or in API. name is case case insensitive. 
         /// </summary>
-        private readonly Dictionary<string, SimpleLayout> variables = new Dictionary<string, SimpleLayout>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, SimpleLayout> _variables = new Dictionary<string, SimpleLayout>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggingConfiguration" /> class.
@@ -85,7 +85,7 @@ namespace NLog.Config
         {
             get
             {
-                return variables;
+                return _variables;
             }
         }
 
@@ -100,7 +100,7 @@ namespace NLog.Config
         /// </remarks>
         public ReadOnlyCollection<Target> ConfiguredNamedTargets
         {
-            get { return new List<Target>(this.targets.Values).AsReadOnly(); }
+            get { return new List<Target>(this._targets.Values).AsReadOnly(); }
         }
 
         /// <summary>
@@ -132,8 +132,8 @@ namespace NLog.Config
         {
             get
             {
-                var configTargets = this.configItems.OfType<Target>();
-                return configTargets.Concat(targets.Values).Distinct(TargetNameComparer).ToList().AsReadOnly();
+                var configTargets = this._configItems.OfType<Target>();
+                return configTargets.Concat(_targets.Values).Distinct(TargetNameComparer).ToList().AsReadOnly();
             }
         }
 
@@ -194,7 +194,7 @@ namespace NLog.Config
             if (target == null) { throw new ArgumentNullException("target"); }
 
             InternalLogger.Debug("Registering target {0}: {1}", name, target.GetType().FullName);
-            this.targets[name] = target;
+            this._targets[name] = target;
         }
 
         /// <summary>
@@ -210,7 +210,7 @@ namespace NLog.Config
         {
             Target value;
 
-            if (!this.targets.TryGetValue(name, out value))
+            if (!this._targets.TryGetValue(name, out value))
             {
                 return null;
             }
@@ -341,7 +341,7 @@ namespace NLog.Config
         /// </param>
         public void RemoveTarget(string name)
         {
-            this.targets.Remove(name);
+            this._targets.Remove(name);
         }
 
         /// <summary>
@@ -468,7 +468,7 @@ namespace NLog.Config
 
             InternalLogger.Debug("--- NLog configuration dump ---");
             InternalLogger.Debug("Targets:");
-            var targetList = this.targets.Values.ToList();
+            var targetList = this._targets.Values.ToList();
             foreach (Target target in targetList)
             {
                 InternalLogger.Debug("{0}", target);
@@ -522,19 +522,19 @@ namespace NLog.Config
                 roots.Add(rule);
             }
 
-            var targetList = this.targets.Values.ToList();
+            var targetList = this._targets.Values.ToList();
             foreach (Target target in targetList)
             {
                 roots.Add(target);
             }
 
-            this.configItems = ObjectGraphScanner.FindReachableObjects<object>(roots.ToArray());
+            this._configItems = ObjectGraphScanner.FindReachableObjects<object>(roots.ToArray());
 
             // initialize all config items starting from most nested first
             // so that whenever the container is initialized its children have already been
-            InternalLogger.Info("Found {0} configuration items", this.configItems.Count);
+            InternalLogger.Info("Found {0} configuration items", this._configItems.Count);
 
-            foreach (object o in this.configItems)
+            foreach (object o in this._configItems)
             {
                 PropertyHelper.CheckRequiredParameters(o);
             }
@@ -575,12 +575,12 @@ namespace NLog.Config
 
         private List<IInstallable> GetInstallableItems()
         {
-            return this.configItems.OfType<IInstallable>().ToList();
+            return this._configItems.OfType<IInstallable>().ToList();
         }
 
         private List<ISupportsInitialize> GetSupportsInitializes(bool reverse = false)
         {
-            var items = this.configItems.OfType<ISupportsInitialize>();
+            var items = this._configItems.OfType<ISupportsInitialize>();
             if (reverse)
             {
                 items = items.Reverse();

--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -47,11 +47,11 @@ namespace NLog.Config
     [NLogConfigurationItem]
     public class LoggingRule
     {
-        private readonly bool[] logLevels = new bool[LogLevel.MaxLevel.Ordinal + 1];
+        private readonly bool[] _logLevels = new bool[LogLevel.MaxLevel.Ordinal + 1];
 
-        private string loggerNamePattern;
-        private MatchMode loggerNameMatchMode;
-        private string loggerNameMatchArgument;
+        private string _loggerNamePattern;
+        private MatchMode _loggerNameMatchMode;
+        private string _loggerNameMatchArgument;
 
         /// <summary>
         /// Create an empty <see cref="LoggingRule" />.
@@ -146,19 +146,19 @@ namespace NLog.Config
         {
             get
             {
-                return this.loggerNamePattern;
+                return this._loggerNamePattern;
             }
 
             set
             {
-                this.loggerNamePattern = value;
-                int firstPos = this.loggerNamePattern.IndexOf('*');
-                int lastPos = this.loggerNamePattern.LastIndexOf('*');
+                this._loggerNamePattern = value;
+                int firstPos = this._loggerNamePattern.IndexOf('*');
+                int lastPos = this._loggerNamePattern.LastIndexOf('*');
 
                 if (firstPos < 0)
                 {
-                    this.loggerNameMatchMode = MatchMode.Equals;
-                    this.loggerNameMatchArgument = value;
+                    this._loggerNameMatchMode = MatchMode.Equals;
+                    this._loggerNameMatchArgument = value;
                     return;
                 }
 
@@ -169,15 +169,15 @@ namespace NLog.Config
 
                     if (before.Length > 0)
                     {
-                        this.loggerNameMatchMode = MatchMode.StartsWith;
-                        this.loggerNameMatchArgument = before;
+                        this._loggerNameMatchMode = MatchMode.StartsWith;
+                        this._loggerNameMatchArgument = before;
                         return;
                     }
 
                     if (after.Length > 0)
                     {
-                        this.loggerNameMatchMode = MatchMode.EndsWith;
-                        this.loggerNameMatchArgument = after;
+                        this._loggerNameMatchMode = MatchMode.EndsWith;
+                        this._loggerNameMatchArgument = after;
                         return;
                     }
 
@@ -188,13 +188,13 @@ namespace NLog.Config
                 if (firstPos == 0 && lastPos == this.LoggerNamePattern.Length - 1)
                 {
                     string text = this.LoggerNamePattern.Substring(1, this.LoggerNamePattern.Length - 2);
-                    this.loggerNameMatchMode = MatchMode.Contains;
-                    this.loggerNameMatchArgument = text;
+                    this._loggerNameMatchMode = MatchMode.Contains;
+                    this._loggerNameMatchArgument = text;
                     return;
                 }
 
-                this.loggerNameMatchMode = MatchMode.None;
-                this.loggerNameMatchArgument = string.Empty;
+                this._loggerNameMatchMode = MatchMode.None;
+                this._loggerNameMatchArgument = string.Empty;
             }
         }
 
@@ -209,7 +209,7 @@ namespace NLog.Config
 
                 for (int i = LogLevel.MinLevel.Ordinal; i <= LogLevel.MaxLevel.Ordinal; ++i)
                 {
-                    if (this.logLevels[i])
+                    if (this._logLevels[i])
                     {
                         levels.Add(LogLevel.FromOrdinal(i));
                     }
@@ -230,7 +230,7 @@ namespace NLog.Config
                 return;
             }
 
-            this.logLevels[level.Ordinal] = true;
+            this._logLevels[level.Ordinal] = true;
         }
 
         /// <summary>
@@ -257,7 +257,7 @@ namespace NLog.Config
                 return;
             }
 
-            this.logLevels[level.Ordinal] = false;
+            this._logLevels[level.Ordinal] = false;
         }
 
         /// <summary>
@@ -270,11 +270,11 @@ namespace NLog.Config
         {
             var sb = new StringBuilder();
 
-            sb.AppendFormat(CultureInfo.InvariantCulture, "logNamePattern: ({0}:{1})", this.loggerNameMatchArgument, this.loggerNameMatchMode);
+            sb.AppendFormat(CultureInfo.InvariantCulture, "logNamePattern: ({0}:{1})", this._loggerNameMatchArgument, this._loggerNameMatchMode);
             sb.Append(" levels: [ ");
-            for (int i = 0; i < this.logLevels.Length; ++i)
+            for (int i = 0; i < this._logLevels.Length; ++i)
             {
-                if (this.logLevels[i])
+                if (this._logLevels[i])
                 {
                     sb.AppendFormat(CultureInfo.InvariantCulture, "{0} ", LogLevel.FromOrdinal(i).ToString());
                 }
@@ -302,7 +302,7 @@ namespace NLog.Config
                 return false;
             }
 
-            return this.logLevels[level.Ordinal];
+            return this._logLevels[level.Ordinal];
         }
 
         /// <summary>
@@ -312,7 +312,7 @@ namespace NLog.Config
         /// <returns>A value of <see langword="true"/> when the name matches, <see langword="false" /> otherwise.</returns>
         public bool NameMatches(string loggerName)
         {
-            switch (this.loggerNameMatchMode)
+            switch (this._loggerNameMatchMode)
             {
                 case MatchMode.All:
                     return true;
@@ -322,16 +322,16 @@ namespace NLog.Config
                     return false;
 
                 case MatchMode.Equals:
-                    return loggerName.Equals(this.loggerNameMatchArgument, StringComparison.Ordinal);
+                    return loggerName.Equals(this._loggerNameMatchArgument, StringComparison.Ordinal);
 
                 case MatchMode.StartsWith:
-                    return loggerName.StartsWith(this.loggerNameMatchArgument, StringComparison.Ordinal);
+                    return loggerName.StartsWith(this._loggerNameMatchArgument, StringComparison.Ordinal);
 
                 case MatchMode.EndsWith:
-                    return loggerName.EndsWith(this.loggerNameMatchArgument, StringComparison.Ordinal);
+                    return loggerName.EndsWith(this._loggerNameMatchArgument, StringComparison.Ordinal);
 
                 case MatchMode.Contains:
-                    return loggerName.IndexOf(this.loggerNameMatchArgument, StringComparison.Ordinal) >= 0;
+                    return loggerName.IndexOf(this._loggerNameMatchArgument, StringComparison.Ordinal) >= 0;
             }
         }
 

--- a/src/NLog/Config/MethodFactory.cs
+++ b/src/NLog/Config/MethodFactory.cs
@@ -48,7 +48,7 @@ namespace NLog.Config
         where TClassAttributeType : Attribute
         where TMethodAttributeType : NameBaseAttribute
     {
-        private readonly Dictionary<string, MethodInfo> nameToMethodInfo = new Dictionary<string, MethodInfo>();
+        private readonly Dictionary<string, MethodInfo> _nameToMethodInfo = new Dictionary<string, MethodInfo>();
 
         /// <summary>
         /// Gets a collection of all registered items in the factory.
@@ -60,7 +60,7 @@ namespace NLog.Config
         /// </returns>
         public IDictionary<string, MethodInfo> AllRegisteredItems
         {
-            get { return this.nameToMethodInfo; }
+            get { return this._nameToMethodInfo; }
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace NLog.Config
         /// </summary>
         public void Clear()
         {
-            this.nameToMethodInfo.Clear();
+            this._nameToMethodInfo.Clear();
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace NLog.Config
         /// <param name="methodInfo">The method info.</param>
         public void RegisterDefinition(string name, MethodInfo methodInfo)
         {
-            this.nameToMethodInfo[name] = methodInfo;
+            this._nameToMethodInfo[name] = methodInfo;
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace NLog.Config
         /// <returns>A value of <c>true</c> if the method was found, <c>false</c> otherwise.</returns>
         public bool TryCreateInstance(string name, out MethodInfo result)
         {
-            return this.nameToMethodInfo.TryGetValue(name, out result);
+            return this._nameToMethodInfo.TryGetValue(name, out result);
         }
 
         /// <summary>
@@ -166,7 +166,7 @@ namespace NLog.Config
         /// <returns>A value of <c>true</c> if the method was found, <c>false</c> otherwise.</returns>
         public bool TryGetDefinition(string name, out MethodInfo result)
         {
-            return this.nameToMethodInfo.TryGetValue(name, out result);
+            return this._nameToMethodInfo.TryGetValue(name, out result);
         }
     }
 }

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -80,11 +80,11 @@ namespace NLog.Config
 
         #region private fields
 
-        private readonly Dictionary<string, bool> fileMustAutoReloadLookup = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, bool> _fileMustAutoReloadLookup = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
-        private string originalFileName;
+        private string _originalFileName;
 
-        private LogFactory logFactory = null;
+        private LogFactory _logFactory = null;
 
         private ConfigurationItemFactory ConfigurationItemFactory
         {
@@ -129,7 +129,7 @@ namespace NLog.Config
         /// <param name="logFactory">The <see cref="LogFactory" /> to which to apply any applicable configuration values.</param>
         public XmlLoggingConfiguration(string fileName, bool ignoreErrors, LogFactory logFactory)
         {
-            this.logFactory = logFactory;
+            this._logFactory = logFactory;
 
             using (XmlReader reader = CreateFileReader(fileName))
             {
@@ -200,7 +200,7 @@ namespace NLog.Config
         /// <param name="logFactory">The <see cref="LogFactory" /> to which to apply any applicable configuration values.</param>
         public XmlLoggingConfiguration(XmlReader reader, string fileName, bool ignoreErrors, LogFactory logFactory)
         {
-            this.logFactory = logFactory;
+            this._logFactory = logFactory;
             this.Initialize(reader, fileName, ignoreErrors);
         }
 
@@ -212,7 +212,7 @@ namespace NLog.Config
         /// <param name="fileName">Name of the XML file.</param>
         internal XmlLoggingConfiguration(XmlElement element, string fileName)
         {
-            logFactory = LogManager.LogFactory;
+            _logFactory = LogManager.LogFactory;
 
             using (var stringReader = new StringReader(element.OuterXml))
             {
@@ -230,7 +230,7 @@ namespace NLog.Config
         /// <param name="ignoreErrors">If set to <c>true</c> errors will be ignored during file processing.</param>
         internal XmlLoggingConfiguration(XmlElement element, string fileName, bool ignoreErrors)
         {
-            logFactory = LogManager.LogFactory;
+            _logFactory = LogManager.LogFactory;
 
             using (var stringReader = new StringReader(element.OuterXml))
             {
@@ -272,13 +272,13 @@ namespace NLog.Config
         {
             get
             {
-                return this.fileMustAutoReloadLookup.Values.All(mustAutoReload => mustAutoReload);
+                return this._fileMustAutoReloadLookup.Values.All(mustAutoReload => mustAutoReload);
             }
             set
             {
-                var autoReloadFiles = this.fileMustAutoReloadLookup.Keys.ToList();
+                var autoReloadFiles = this._fileMustAutoReloadLookup.Keys.ToList();
                 foreach (string nextFile in autoReloadFiles)
-                    this.fileMustAutoReloadLookup[nextFile] = value;
+                    this._fileMustAutoReloadLookup[nextFile] = value;
             }
         }
 
@@ -291,7 +291,7 @@ namespace NLog.Config
         {
             get
             {
-                return this.fileMustAutoReloadLookup.Where(entry => entry.Value).Select(entry => entry.Key);
+                return this._fileMustAutoReloadLookup.Where(entry => entry.Value).Select(entry => entry.Key);
             }
         }
 
@@ -305,7 +305,7 @@ namespace NLog.Config
         /// <returns>The new <see cref="XmlLoggingConfiguration" /> object.</returns>
         public override LoggingConfiguration Reload()
         {
-            return new XmlLoggingConfiguration(this.originalFileName);
+            return new XmlLoggingConfiguration(this._originalFileName);
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace NLog.Config
                 var content = new NLogXmlElement(reader);
                 if (fileName != null)
                 {
-                    this.originalFileName = fileName;
+                    this._originalFileName = fileName;
                     this.ParseTopLevel(content, fileName, autoReloadDefault: false);
 
                     InternalLogger.Info("Configured from an XML element in {0}...", fileName);
@@ -517,7 +517,7 @@ namespace NLog.Config
         /// <param name="autoReloadDefault"></param>
         private void ConfigureFromFile(string fileName, bool autoReloadDefault)
         {
-            if (!this.fileMustAutoReloadLookup.ContainsKey(GetFileLookupKey(fileName)))
+            if (!this._fileMustAutoReloadLookup.ContainsKey(GetFileLookupKey(fileName)))
                 this.ParseTopLevel(new NLogXmlElement(fileName), fileName, autoReloadDefault);
         }
 
@@ -588,11 +588,11 @@ namespace NLog.Config
 
             bool autoReload = nlogElement.GetOptionalBooleanAttribute("autoReload", autoReloadDefault);
             if (filePath != null)
-                this.fileMustAutoReloadLookup[GetFileLookupKey(filePath)] = autoReload;
+                this._fileMustAutoReloadLookup[GetFileLookupKey(filePath)] = autoReload;
 
-            logFactory.ThrowExceptions = nlogElement.GetOptionalBooleanAttribute("throwExceptions", logFactory.ThrowExceptions);
-            logFactory.ThrowConfigExceptions = nlogElement.GetOptionalBooleanAttribute("throwConfigExceptions", logFactory.ThrowConfigExceptions);
-            logFactory.KeepVariablesOnReload = nlogElement.GetOptionalBooleanAttribute("keepVariablesOnReload", logFactory.KeepVariablesOnReload);
+            _logFactory.ThrowExceptions = nlogElement.GetOptionalBooleanAttribute("throwExceptions", _logFactory.ThrowExceptions);
+            _logFactory.ThrowConfigExceptions = nlogElement.GetOptionalBooleanAttribute("throwConfigExceptions", _logFactory.ThrowConfigExceptions);
+            _logFactory.KeepVariablesOnReload = nlogElement.GetOptionalBooleanAttribute("keepVariablesOnReload", _logFactory.KeepVariablesOnReload);
             InternalLogger.LogToConsole = nlogElement.GetOptionalBooleanAttribute("internalLogToConsole", InternalLogger.LogToConsole);
             InternalLogger.LogToConsoleError = nlogElement.GetOptionalBooleanAttribute("internalLogToConsoleError", InternalLogger.LogToConsoleError);
             InternalLogger.LogFile = nlogElement.GetOptionalAttribute("internalLogFile", InternalLogger.LogFile);
@@ -604,7 +604,7 @@ namespace NLog.Config
             InternalLogger.LogToTrace = nlogElement.GetOptionalBooleanAttribute("internalLogToTrace", InternalLogger.LogToTrace);
 #endif
             InternalLogger.IncludeTimestamp = nlogElement.GetOptionalBooleanAttribute("internalLogIncludeTimestamp", InternalLogger.IncludeTimestamp);
-            logFactory.GlobalThreshold = LogLevel.FromString(nlogElement.GetOptionalAttribute("globalThreshold", logFactory.GlobalThreshold.Name));
+            _logFactory.GlobalThreshold = LogLevel.FromString(nlogElement.GetOptionalAttribute("globalThreshold", _logFactory.GlobalThreshold.Name));
 
             var children = nlogElement.Children.ToList();
 

--- a/src/NLog/Filters/WhenRepeatedFilter.cs
+++ b/src/NLog/Filters/WhenRepeatedFilter.cs
@@ -363,13 +363,13 @@ namespace NLog.Filters
         /// </summary>
         private struct FilterInfoKey : IEquatable<FilterInfoKey>
         {
-            private readonly StringBuilder StringBuffer;
+            private readonly StringBuilder _stringBuffer;
             public readonly string StringValue;
             public readonly int StringHashCode;
 
             public FilterInfoKey(StringBuilder stringBuffer, string stringValue, int? stringHashCode = null)
             {
-                StringBuffer = stringBuffer;
+                _stringBuffer = stringBuffer;
                 StringValue = stringValue;
                 if (stringHashCode.HasValue)
                 {
@@ -400,17 +400,17 @@ namespace NLog.Filters
                 {
                     return string.Equals(StringValue, other.StringValue, StringComparison.Ordinal);
                 }
-                if (StringBuffer != null && other.StringBuffer != null)
+                if (_stringBuffer != null && other._stringBuffer != null)
                 {
                     // StringBuilder.Equals only works when StringBuilder.Capacity is the same
-                    if (StringBuffer.Capacity != other.StringBuffer.Capacity)
+                    if (_stringBuffer.Capacity != other._stringBuffer.Capacity)
                     {
-                        if (StringBuffer.Length != other.StringBuffer.Length)
+                        if (_stringBuffer.Length != other._stringBuffer.Length)
                             return false;
 
-                        for (int x = 0; x < StringBuffer.Length; ++x)
+                        for (int x = 0; x < _stringBuffer.Length; ++x)
                         {
-                            if (StringBuffer[x] != other.StringBuffer[x])
+                            if (_stringBuffer[x] != other._stringBuffer[x])
                             {
                                 return false;
                             }
@@ -418,9 +418,9 @@ namespace NLog.Filters
 
                         return true;
                     }
-                    return StringBuffer.Equals(other.StringBuffer);
+                    return _stringBuffer.Equals(other._stringBuffer);
                 }
-                return ReferenceEquals(StringBuffer, other.StringBuffer) && ReferenceEquals(StringValue, other.StringValue);
+                return ReferenceEquals(_stringBuffer, other._stringBuffer) && ReferenceEquals(StringValue, other.StringValue);
             }
 
             public override bool Equals(object other)

--- a/src/NLog/Internal/DictionaryAdapter.cs
+++ b/src/NLog/Internal/DictionaryAdapter.cs
@@ -44,7 +44,7 @@ namespace NLog.Internal
     /// <typeparam name="TValue">The type of the value.</typeparam>
     internal class DictionaryAdapter<TKey, TValue> : IDictionary
     {
-        private readonly IDictionary<TKey, TValue> implementation;
+        private readonly IDictionary<TKey, TValue> _implementation;
 
         /// <summary>
         /// Initializes a new instance of the DictionaryAdapter class.
@@ -52,7 +52,7 @@ namespace NLog.Internal
         /// <param name="implementation">The implementation.</param>
         public DictionaryAdapter(IDictionary<TKey, TValue> implementation)
         {
-            this.implementation = implementation;
+            this._implementation = implementation;
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace NLog.Internal
         /// </returns>
         public ICollection Values
         {
-            get { return new List<TValue>(this.implementation.Values); }
+            get { return new List<TValue>(this._implementation.Values); }
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace NLog.Internal
         /// </returns>
         public int Count
         {
-            get { return this.implementation.Count; }
+            get { return this._implementation.Count; }
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace NLog.Internal
         /// </returns>
         public object SyncRoot
         {
-            get { return this.implementation; }
+            get { return this._implementation; }
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace NLog.Internal
         /// </returns>
         public bool IsReadOnly
         {
-            get { return this.implementation.IsReadOnly; }
+            get { return this._implementation.IsReadOnly; }
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace NLog.Internal
         /// </returns>
         public ICollection Keys
         {
-            get { return new List<TKey>(this.implementation.Keys); }
+            get { return new List<TKey>(this._implementation.Keys); }
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace NLog.Internal
             {
                 TValue value;
 
-                if (this.implementation.TryGetValue((TKey)key, out value))
+                if (this._implementation.TryGetValue((TKey)key, out value))
                 {
                     return value;
                 }
@@ -159,7 +159,7 @@ namespace NLog.Internal
 
             set
             {
-                this.implementation[(TKey)key] = (TValue)value;
+                this._implementation[(TKey)key] = (TValue)value;
             }
         }
 
@@ -170,7 +170,7 @@ namespace NLog.Internal
         /// <param name="value">The <see cref="T:System.Object"/> to use as the value of the element to add.</param>
         public void Add(object key, object value)
         {
-            this.implementation.Add((TKey)key, (TValue)value);
+            this._implementation.Add((TKey)key, (TValue)value);
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace NLog.Internal
         /// </summary>
         public void Clear()
         {
-            this.implementation.Clear();
+            this._implementation.Clear();
         }
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace NLog.Internal
         /// </returns>
         public bool Contains(object key)
         {
-            return this.implementation.ContainsKey((TKey)key);
+            return this._implementation.ContainsKey((TKey)key);
         }
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace NLog.Internal
         /// </returns>
         public IDictionaryEnumerator GetEnumerator()
         {
-            return new MyEnumerator(this.implementation.GetEnumerator());
+            return new MyEnumerator(this._implementation.GetEnumerator());
         }
 
         /// <summary>
@@ -210,7 +210,7 @@ namespace NLog.Internal
         /// <param name="key">The key of the element to remove.</param>
         public void Remove(object key)
         {
-            this.implementation.Remove((TKey)key);
+            this._implementation.Remove((TKey)key);
         }
 
         /// <summary>
@@ -239,7 +239,7 @@ namespace NLog.Internal
         /// </summary>
         private class MyEnumerator : IDictionaryEnumerator
         {
-            private IEnumerator<KeyValuePair<TKey, TValue>> wrapped;
+            private IEnumerator<KeyValuePair<TKey, TValue>> _wrapped;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="MyEnumerator" /> class.
@@ -247,7 +247,7 @@ namespace NLog.Internal
             /// <param name="wrapped">The wrapped.</param>
             public MyEnumerator(IEnumerator<KeyValuePair<TKey, TValue>> wrapped)
             {
-                this.wrapped = wrapped;
+                this._wrapped = wrapped;
             }
 
             /// <summary>
@@ -259,7 +259,7 @@ namespace NLog.Internal
             /// </returns>
             public DictionaryEntry Entry
             {
-                get { return new DictionaryEntry(this.wrapped.Current.Key, this.wrapped.Current.Value); }
+                get { return new DictionaryEntry(this._wrapped.Current.Key, this._wrapped.Current.Value); }
             }
 
             /// <summary>
@@ -271,7 +271,7 @@ namespace NLog.Internal
             /// </returns>
             public object Key
             {
-                get { return this.wrapped.Current.Key; }
+                get { return this._wrapped.Current.Key; }
             }
 
             /// <summary>
@@ -283,7 +283,7 @@ namespace NLog.Internal
             /// </returns>
             public object Value
             {
-                get { return this.wrapped.Current.Value; }
+                get { return this._wrapped.Current.Value; }
             }
 
             /// <summary>
@@ -306,7 +306,7 @@ namespace NLog.Internal
             /// </returns>
             public bool MoveNext()
             {
-                return this.wrapped.MoveNext();
+                return this._wrapped.MoveNext();
             }
 
             /// <summary>
@@ -314,7 +314,7 @@ namespace NLog.Internal
             /// </summary>
             public void Reset()
             {
-                this.wrapped.Reset();
+                this._wrapped.Reset();
             }
         }
     }

--- a/src/NLog/Internal/Fakeables/AppDomainWrapper.cs
+++ b/src/NLog/Internal/Fakeables/AppDomainWrapper.cs
@@ -43,7 +43,7 @@ namespace NLog.Internal.Fakeables
     public class AppDomainWrapper : IAppDomain
     {
 #if !SILVERLIGHT
-        private readonly AppDomain currentAppDomain;
+        private readonly AppDomain _currentAppDomain;
 #endif
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace NLog.Internal.Fakeables
         public AppDomainWrapper(AppDomain appDomain)
         {
 #if !SILVERLIGHT
-            currentAppDomain = appDomain;
+            _currentAppDomain = appDomain;
             try
             {
                 BaseDirectory = appDomain.BaseDirectory;
@@ -126,8 +126,8 @@ namespace NLog.Internal.Fakeables
             add
             {
 #if !SILVERLIGHT
-                if (this.processExitEvent == null && this.currentAppDomain != null)
-                    this.currentAppDomain.ProcessExit += OnProcessExit;
+                if (this.processExitEvent == null && this._currentAppDomain != null)
+                    this._currentAppDomain.ProcessExit += OnProcessExit;
 #endif
                 this.processExitEvent += value;
             }
@@ -135,8 +135,8 @@ namespace NLog.Internal.Fakeables
             {
                 this.processExitEvent -= value;
 #if !SILVERLIGHT
-                if (this.processExitEvent == null && this.currentAppDomain != null)
-                    this.currentAppDomain.ProcessExit -= OnProcessExit;
+                if (this.processExitEvent == null && this._currentAppDomain != null)
+                    this._currentAppDomain.ProcessExit -= OnProcessExit;
 #endif
             }
         }
@@ -150,8 +150,8 @@ namespace NLog.Internal.Fakeables
             add
             {
 #if !SILVERLIGHT
-                if (this.domainUnloadEvent == null && this.currentAppDomain != null)
-                    this.currentAppDomain.DomainUnload += OnDomainUnload;
+                if (this.domainUnloadEvent == null && this._currentAppDomain != null)
+                    this._currentAppDomain.DomainUnload += OnDomainUnload;
 #endif
                 this.domainUnloadEvent += value;
 
@@ -160,8 +160,8 @@ namespace NLog.Internal.Fakeables
             {
                 this.domainUnloadEvent -= value;
 #if !SILVERLIGHT
-                if (this.domainUnloadEvent == null && this.currentAppDomain != null)
-                    this.currentAppDomain.DomainUnload -= OnDomainUnload;
+                if (this.domainUnloadEvent == null && this._currentAppDomain != null)
+                    this._currentAppDomain.DomainUnload -= OnDomainUnload;
 #endif
             }
         }

--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -47,7 +47,7 @@ namespace NLog.Internal.FileAppenders
     [SecuritySafeCritical]
     internal abstract class BaseFileAppender : IDisposable
     {
-        private readonly Random random = new Random();
+        private readonly Random _random = new Random();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseFileAppender" /> class.
@@ -241,7 +241,7 @@ namespace NLog.Internal.FileAppenders
                         throw; // rethrow
                     }
 
-                    int actualDelay = this.random.Next(currentDelay);
+                    int actualDelay = this._random.Next(currentDelay);
                     InternalLogger.Warn("Attempt #{0} to open {1} failed. Sleeping for {2}ms", i, this.FileName, actualDelay);
                     currentDelay *= 2;
                     System.Threading.Thread.Sleep(actualDelay);

--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -47,9 +47,9 @@ namespace NLog.Internal.FileAppenders
     {
         public static readonly IFileAppenderFactory TheFactory = new Factory();
 
-        private FileStream file;
+        private FileStream _file;
 
-        private long currentFileLength;
+        private long _currentFileLength;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CountingSingleProcessFileAppender" /> class.
@@ -66,15 +66,15 @@ namespace NLog.Internal.FileAppenders
                 {
                     FileTouched(fileInfo.GetLastWriteTimeUtc());
                 }
-                this.currentFileLength = fileInfo.Length;
+                this._currentFileLength = fileInfo.Length;
             }
             else
             {
                 FileTouched();
-                this.currentFileLength = 0;
+                this._currentFileLength = 0;
             }
 
-            this.file = this.CreateFileStream(false);
+            this._file = this.CreateFileStream(false);
         }
 
         /// <summary>
@@ -82,13 +82,13 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         public override void Close()
         {
-            if (this.file != null)
+            if (this._file != null)
             {
                 InternalLogger.Trace("Closing '{0}'", FileName);
 
                 try
                 {
-                    this.file.Close();
+                    this._file.Close();
                 }
                 catch (Exception ex)
                 {
@@ -98,7 +98,7 @@ namespace NLog.Internal.FileAppenders
                 }
                 finally
                 {
-                    this.file = null;
+                    this._file = null;
                 }
             }
         }
@@ -108,12 +108,12 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         public override void Flush()
         {
-            if (this.file == null)
+            if (this._file == null)
             {
                 return;
             }
 
-            this.file.Flush();
+            this._file.Flush();
             FileTouched();
         }
 
@@ -143,7 +143,7 @@ namespace NLog.Internal.FileAppenders
         /// <returns>A long value representing the length of the file in bytes.</returns>
         public override long? GetFileLength()
         {
-            return this.currentFileLength;
+            return this._currentFileLength;
         }
 
         /// <summary>
@@ -154,13 +154,13 @@ namespace NLog.Internal.FileAppenders
         /// <param name="count">The number of bytes.</param>
         public override void Write(byte[] bytes, int offset, int count)
         {
-            if (this.file == null)
+            if (this._file == null)
             {
                 return;
             }
 
-            this.currentFileLength += count;
-            this.file.Write(bytes, offset, count);
+            this._currentFileLength += count;
+            this._file.Write(bytes, offset, count);
 
             if (CaptureLastWriteTime)
             {

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -48,13 +48,13 @@ namespace NLog.Internal.FileAppenders
     /// </summary>
     internal sealed class FileAppenderCache : IDisposable
     {
-        private readonly BaseFileAppender[] appenders;
-        private Timer autoClosingTimer;
+        private readonly BaseFileAppender[] _appenders;
+        private Timer _autoClosingTimer;
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-        private string archiveFilePatternToWatch = null;
-        private readonly MultiFileWatcher externalFileArchivingWatcher = new MultiFileWatcher(NotifyFilters.DirectoryName | NotifyFilters.FileName);
-        private bool logFileWasArchived = false;
+        private string _archiveFilePatternToWatch = null;
+        private readonly MultiFileWatcher _externalFileArchivingWatcher = new MultiFileWatcher(NotifyFilters.DirectoryName | NotifyFilters.FileName);
+        private bool _logFileWasArchived = false;
 #endif
 
         /// <summary>
@@ -84,19 +84,19 @@ namespace NLog.Internal.FileAppenders
             Factory = appenderFactory;
             CreateFileParameters = createFileParams;
 
-            appenders = new BaseFileAppender[Size];
+            _appenders = new BaseFileAppender[Size];
 
-            autoClosingTimer = new Timer(AutoClosingTimerCallback, null, Timeout.Infinite, Timeout.Infinite);
+            _autoClosingTimer = new Timer(AutoClosingTimerCallback, null, Timeout.Infinite, Timeout.Infinite);
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-            externalFileArchivingWatcher.FileChanged += ExternalFileArchivingWatcher_OnFileChanged;
+            _externalFileArchivingWatcher.FileChanged += ExternalFileArchivingWatcher_OnFileChanged;
 #endif
         }
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
         private void ExternalFileArchivingWatcher_OnFileChanged(object sender, FileSystemEventArgs e)
         {
-            if (logFileWasArchived || CheckCloseAppenders == null || autoClosingTimer == null)
+            if (_logFileWasArchived || CheckCloseAppenders == null || _autoClosingTimer == null)
             {
                 return;
             }
@@ -104,17 +104,17 @@ namespace NLog.Internal.FileAppenders
             if (FileAppenderFolderChanged(e.FullPath))
             {
                 if ((e.ChangeType & (WatcherChangeTypes.Deleted | WatcherChangeTypes.Renamed)) != 0)
-                    logFileWasArchived = true;  // File Appender file deleted/renamed
+                    _logFileWasArchived = true;  // File Appender file deleted/renamed
             }
             else
             {
                 if ((e.ChangeType & WatcherChangeTypes.Created) == WatcherChangeTypes.Created)
-                    logFileWasArchived = true;  // Something was created in the archive folder
+                    _logFileWasArchived = true;  // Something was created in the archive folder
             }
 
-            if (logFileWasArchived && autoClosingTimer != null)
+            if (_logFileWasArchived && _autoClosingTimer != null)
             {
-                autoClosingTimer.Change(50, Timeout.Infinite);
+                _autoClosingTimer.Change(50, Timeout.Infinite);
             }
         }
 
@@ -122,13 +122,13 @@ namespace NLog.Internal.FileAppenders
         {
             if (!string.IsNullOrEmpty(fullPath))
             {
-                if (string.IsNullOrEmpty(archiveFilePatternToWatch))
+                if (string.IsNullOrEmpty(_archiveFilePatternToWatch))
                 {
                     return true;
                 }
                 else
                 {
-                    string archiveFolderPath = Path.GetDirectoryName(archiveFilePatternToWatch);
+                    string archiveFolderPath = Path.GetDirectoryName(_archiveFilePatternToWatch);
                     if (!string.IsNullOrEmpty(archiveFolderPath))
                     {
                         string currentFolderPath = Path.GetDirectoryName(fullPath);
@@ -149,21 +149,21 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         public string ArchiveFilePatternToWatch
         {
-            get { return archiveFilePatternToWatch; }
+            get { return _archiveFilePatternToWatch; }
             set
             {
-                if (archiveFilePatternToWatch != value)
+                if (_archiveFilePatternToWatch != value)
                 {
-                    if (!string.IsNullOrEmpty(archiveFilePatternToWatch))
+                    if (!string.IsNullOrEmpty(_archiveFilePatternToWatch))
                     {
-                        string directoryPath = Path.GetDirectoryName(archiveFilePatternToWatch);
+                        string directoryPath = Path.GetDirectoryName(_archiveFilePatternToWatch);
                         if (string.IsNullOrEmpty(directoryPath))
-                            externalFileArchivingWatcher.StopWatching(directoryPath);
+                            _externalFileArchivingWatcher.StopWatching(directoryPath);
                     }
 
-                    archiveFilePatternToWatch = value;
+                    _archiveFilePatternToWatch = value;
 
-                    logFileWasArchived = false;
+                    _logFileWasArchived = false;
                 }
             }
         }
@@ -173,9 +173,9 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         public void InvalidateAppendersForInvalidFiles()
         {
-            if (logFileWasArchived)
+            if (_logFileWasArchived)
             {
-                logFileWasArchived = false;
+                _logFileWasArchived = false;
                 CloseAppenders("Cleanup Archive");
             }
         }
@@ -231,32 +231,32 @@ namespace NLog.Internal.FileAppenders
             //
 
             BaseFileAppender appenderToWrite = null;
-            int freeSpot = appenders.Length - 1;
+            int freeSpot = _appenders.Length - 1;
 
-            for (int i = 0; i < appenders.Length; ++i)
+            for (int i = 0; i < _appenders.Length; ++i)
             {
                 // Use empty slot in recent appender list, if there is one.
-                if (appenders[i] == null)
+                if (_appenders[i] == null)
                 {
                     freeSpot = i;
                     break;
                 }
 
-                if (string.Equals(appenders[i].FileName, fileName, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(_appenders[i].FileName, fileName, StringComparison.OrdinalIgnoreCase))
                 {
                     // found it, move it to the first place on the list
                     // (MRU)
-                    BaseFileAppender app = appenders[i];
+                    BaseFileAppender app = _appenders[i];
                     if (i > 0)
                     {
                         // file open has a chance of failure
                         // if it fails in the constructor, we won't modify any data structures
                         for (int j = i; j > 0; --j)
                         {
-                            appenders[j] = appenders[j - 1];
+                            _appenders[j] = _appenders[j - 1];
                         }
 
-                        appenders[0] = app;
+                        _appenders[0] = app;
                     }
                     appenderToWrite = app;
                     break;
@@ -270,34 +270,34 @@ namespace NLog.Internal.FileAppenders
                     InternalLogger.Debug("Creating file appender: {0}", fileName);
                     BaseFileAppender newAppender = Factory.Open(fileName, CreateFileParameters);
 
-                    if (appenders[freeSpot] != null)
+                    if (_appenders[freeSpot] != null)
                     {
-                        CloseAppender(appenders[freeSpot], "Stale", false);
-                        appenders[freeSpot] = null;
+                        CloseAppender(_appenders[freeSpot], "Stale", false);
+                        _appenders[freeSpot] = null;
                     }
 
                     for (int j = freeSpot; j > 0; --j)
                     {
-                        appenders[j] = appenders[j - 1];
+                        _appenders[j] = _appenders[j - 1];
                     }
 
-                    appenders[0] = newAppender;
+                    _appenders[0] = newAppender;
                     appenderToWrite = newAppender;
 
                     if (CheckCloseAppenders != null)
                     {
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
                         if (freeSpot == 0)
-                            logFileWasArchived = false;
-                        if (!string.IsNullOrEmpty(archiveFilePatternToWatch))
+                            _logFileWasArchived = false;
+                        if (!string.IsNullOrEmpty(_archiveFilePatternToWatch))
                         {
-                            string directoryPath = Path.GetDirectoryName(archiveFilePatternToWatch);
+                            string directoryPath = Path.GetDirectoryName(_archiveFilePatternToWatch);
                             if (!Directory.Exists(directoryPath))
                                 Directory.CreateDirectory(directoryPath);
 
-                            externalFileArchivingWatcher.Watch(archiveFilePatternToWatch);  // Always monitor the archive-folder
+                            _externalFileArchivingWatcher.Watch(_archiveFilePatternToWatch);  // Always monitor the archive-folder
                         }
-                        externalFileArchivingWatcher.Watch(appenderToWrite.FileName);   // Monitor the active file-appender
+                        _externalFileArchivingWatcher.Watch(appenderToWrite.FileName);   // Monitor the active file-appender
 #endif
                     }
                 }
@@ -316,17 +316,17 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         public void CloseAppenders(string reason)
         {
-            if (appenders != null)
+            if (_appenders != null)
             {
-                for (int i = 0; i < appenders.Length; ++i)
+                for (int i = 0; i < _appenders.Length; ++i)
                 {
-                    if (appenders[i] == null)
+                    if (_appenders[i] == null)
                     {
                         break;
                     }
 
-                    CloseAppender(appenders[i], reason, true);
-                    appenders[i] = null;
+                    CloseAppender(_appenders[i], reason, true);
+                    _appenders[i] = null;
                 }
             }
         }
@@ -338,9 +338,9 @@ namespace NLog.Internal.FileAppenders
         public void CloseAppenders(DateTime expireTime)
         {
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-            if (logFileWasArchived)
+            if (_logFileWasArchived)
             {
-                logFileWasArchived = false;
+                _logFileWasArchived = false;
                 CloseAppenders("Cleanup Timer");
             }
             else
@@ -348,24 +348,24 @@ namespace NLog.Internal.FileAppenders
             {
                 if (expireTime != DateTime.MinValue)
                 {
-                    for (int i = 0; i < this.appenders.Length; ++i)
+                    for (int i = 0; i < this._appenders.Length; ++i)
                     {
-                        if (this.appenders[i] == null)
+                        if (this._appenders[i] == null)
                         {
                             break;
                         }
 
-                        if (this.appenders[i].OpenTimeUtc < expireTime)
+                        if (this._appenders[i].OpenTimeUtc < expireTime)
                         {
-                            for (int j = i; j < this.appenders.Length; ++j)
+                            for (int j = i; j < this._appenders.Length; ++j)
                             {
-                                if (this.appenders[j] == null)
+                                if (this._appenders[j] == null)
                                 {
                                     break;
                                 }
 
-                                CloseAppender(this.appenders[j], "Expired", i == 0);
-                                this.appenders[j] = null;
+                                CloseAppender(this._appenders[j], "Expired", i == 0);
+                                this._appenders[j] = null;
                             }
 
                             break;
@@ -380,7 +380,7 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         public void FlushAppenders()
         {
-            foreach (BaseFileAppender appender in appenders)
+            foreach (BaseFileAppender appender in _appenders)
             {
                 if (appender == null)
                 {
@@ -393,9 +393,9 @@ namespace NLog.Internal.FileAppenders
 
         private BaseFileAppender GetAppender(string fileName)
         {
-            for (int i = 0; i < this.appenders.Length; ++i)
+            for (int i = 0; i < this._appenders.Length; ++i)
             {
-                BaseFileAppender appender = this.appenders[i];
+                BaseFileAppender appender = this._appenders[i];
                 if (appender == null)
                     break;
 
@@ -518,22 +518,22 @@ namespace NLog.Internal.FileAppenders
         /// <param name="filePath">File name of the appender to be closed.</param>
         public void InvalidateAppender(string filePath)
         {
-            for (int i = 0; i < appenders.Length; ++i)
+            for (int i = 0; i < _appenders.Length; ++i)
             {
-                if (appenders[i] == null)
+                if (_appenders[i] == null)
                 {
                     break;
                 }
 
-                if (string.Equals(appenders[i].FileName, filePath, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(_appenders[i].FileName, filePath, StringComparison.OrdinalIgnoreCase))
                 {
-                    var oldAppender = appenders[i];
-                    for (int j = i; j < appenders.Length - 1; ++j)
+                    var oldAppender = _appenders[i];
+                    for (int j = i; j < _appenders.Length - 1; ++j)
                     {
-                        appenders[j] = appenders[j + 1];
+                        _appenders[j] = _appenders[j + 1];
                     }
-                    appenders[appenders.Length - 1] = null;
-                    CloseAppender(oldAppender, "Invalidate", appenders[0] == null);
+                    _appenders[_appenders.Length - 1] = null;
+                    CloseAppender(oldAppender, "Invalidate", _appenders[0] == null);
                     break;
                 }
             }
@@ -546,15 +546,15 @@ namespace NLog.Internal.FileAppenders
             if (lastAppender)
             {
                 // No active appenders, deactivate background tasks
-                autoClosingTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                _autoClosingTimer.Change(Timeout.Infinite, Timeout.Infinite);
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-                externalFileArchivingWatcher.StopWatching();
-                logFileWasArchived = false;
+                _externalFileArchivingWatcher.StopWatching();
+                _logFileWasArchived = false;
             }
             else
             {
-                externalFileArchivingWatcher.StopWatching(appender.FileName);
+                _externalFileArchivingWatcher.StopWatching(appender.FileName);
 #endif
             }
 
@@ -566,14 +566,14 @@ namespace NLog.Internal.FileAppenders
             CheckCloseAppenders = null;
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-            externalFileArchivingWatcher.Dispose();
-            logFileWasArchived = false;
+            _externalFileArchivingWatcher.Dispose();
+            _logFileWasArchived = false;
 #endif
 
-            var currentTimer = autoClosingTimer;
+            var currentTimer = _autoClosingTimer;
             if (currentTimer != null)
             {
-                autoClosingTimer = null;
+                _autoClosingTimer = null;
                 currentTimer.WaitForDispose(TimeSpan.Zero);
             }
         }

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -62,9 +62,9 @@ namespace NLog.Internal.FileAppenders
     {
         public static readonly IFileAppenderFactory TheFactory = new Factory();
 
-        private FileStream fileStream;
-        private FileCharacteristicsHelper fileCharacteristicsHelper;
-        private Mutex mutex;
+        private FileStream _fileStream;
+        private FileCharacteristicsHelper _fileCharacteristicsHelper;
+        private Mutex _mutex;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MutexMultiProcessFileAppender" /> class.
@@ -75,22 +75,22 @@ namespace NLog.Internal.FileAppenders
         {
             try
             {
-                this.mutex = CreateSharableMutex("FileLock");
-                this.fileStream = CreateFileStream(true);
-                this.fileCharacteristicsHelper = FileCharacteristicsHelper.CreateHelper(parameters.ForceManaged);
+                this._mutex = CreateSharableMutex("FileLock");
+                this._fileStream = CreateFileStream(true);
+                this._fileCharacteristicsHelper = FileCharacteristicsHelper.CreateHelper(parameters.ForceManaged);
             }
             catch
             {
-                if (this.mutex != null)
+                if (this._mutex != null)
                 {
-                    this.mutex.Close();
-                    this.mutex = null;
+                    this._mutex.Close();
+                    this._mutex = null;
                 }
 
-                if (this.fileStream != null)
+                if (this._fileStream != null)
                 {
-                    this.fileStream.Close();
-                    this.fileStream = null;
+                    this._fileStream.Close();
+                    this._fileStream = null;
                 }
 
                 throw;
@@ -105,14 +105,14 @@ namespace NLog.Internal.FileAppenders
         /// <param name="count">The number of bytes.</param>
         public override void Write(byte[] bytes, int offset, int count)
         {
-            if (this.mutex == null || this.fileStream == null)
+            if (this._mutex == null || this._fileStream == null)
             {
                 return;
             }
 
             try
             {
-                this.mutex.WaitOne();
+                this._mutex.WaitOne();
             }
             catch (AbandonedMutexException)
             {
@@ -123,9 +123,9 @@ namespace NLog.Internal.FileAppenders
 
             try
             {
-                this.fileStream.Seek(0, SeekOrigin.End);
-                this.fileStream.Write(bytes, offset, count);
-                this.fileStream.Flush();
+                this._fileStream.Seek(0, SeekOrigin.End);
+                this._fileStream.Write(bytes, offset, count);
+                this._fileStream.Flush();
                 if (CaptureLastWriteTime)
                 {
                     FileTouched();
@@ -133,7 +133,7 @@ namespace NLog.Internal.FileAppenders
             }
             finally
             {
-                this.mutex.ReleaseMutex();
+                this._mutex.ReleaseMutex();
             }
         }
 
@@ -143,11 +143,11 @@ namespace NLog.Internal.FileAppenders
         public override void Close()
         {
             InternalLogger.Trace("Closing '{0}'", FileName);
-            if (this.mutex != null)
+            if (this._mutex != null)
             {
                 try
                 {
-                    this.mutex.Close();
+                    this._mutex.Close();
                 }
                 catch (Exception ex)
                 {
@@ -156,15 +156,15 @@ namespace NLog.Internal.FileAppenders
                 }
                 finally
                 {
-                    this.mutex = null;
+                    this._mutex = null;
                 }
             }
 
-            if (this.fileStream != null)
+            if (this._fileStream != null)
             {
                 try
                 {
-                    this.fileStream.Close();
+                    this._fileStream.Close();
                 }
                 catch (Exception ex)
                 {
@@ -173,7 +173,7 @@ namespace NLog.Internal.FileAppenders
                 }
                 finally
                 {
-                    this.fileStream = null;
+                    this._fileStream = null;
                 }
             }
 
@@ -222,7 +222,7 @@ namespace NLog.Internal.FileAppenders
         private FileCharacteristics GetFileCharacteristics()
         {
             // TODO: It is not efficient to read all the whole FileCharacteristics and then using one property.
-            return fileCharacteristicsHelper.GetFileCharacteristics(FileName, this.fileStream);
+            return _fileCharacteristicsHelper.GetFileCharacteristics(FileName, this._fileStream);
         }
 
         /// <summary>

--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -48,7 +48,7 @@ namespace NLog.Internal.FileAppenders
     {
         public static readonly IFileAppenderFactory TheFactory = new Factory();
 
-        private FileStream file;
+        private FileStream _file;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SingleProcessFileAppender" /> class.
@@ -69,7 +69,7 @@ namespace NLog.Internal.FileAppenders
                     FileTouched();
                 }
             }
-            this.file = CreateFileStream(false);
+            this._file = CreateFileStream(false);
         }
 
         /// <summary>
@@ -80,12 +80,12 @@ namespace NLog.Internal.FileAppenders
         /// <param name="count">The number of bytes.</param>
         public override void Write(byte[] bytes, int offset, int count)
         {
-            if (this.file == null)
+            if (this._file == null)
             {
                 return;
             }
 
-            this.file.Write(bytes, offset, count);
+            this._file.Write(bytes, offset, count);
 
             if (CaptureLastWriteTime)
             {
@@ -98,12 +98,12 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         public override void Flush()
         {
-            if (this.file == null)
+            if (this._file == null)
             {
                 return;
             }
 
-            this.file.Flush();
+            this._file.Flush();
             FileTouched();
         }
 
@@ -112,7 +112,7 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         public override void Close()
         {
-            if (this.file == null)
+            if (this._file == null)
             {
                 return;
             }
@@ -120,7 +120,7 @@ namespace NLog.Internal.FileAppenders
             InternalLogger.Trace("Closing '{0}'", FileName);
             try
             {
-                this.file.Close();
+                this._file.Close();
             }
             catch (Exception ex)
             {
@@ -130,7 +130,7 @@ namespace NLog.Internal.FileAppenders
             }
             finally
             {
-                this.file = null;
+                this._file = null;
             }
         }
 
@@ -160,8 +160,8 @@ namespace NLog.Internal.FileAppenders
         /// <returns>A long value representing the length of the file in bytes.</returns>
         public override long? GetFileLength()
         {
-            if (file == null) { return null; }
-            return file.Length;
+            if (_file == null) { return null; }
+            return _file.Length;
         }
 
         /// <summary>

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -71,7 +71,7 @@ namespace NLog.Internal
         /// <summary>
         /// non null is fixed,
         /// </summary>
-        private string cleanedFixedResult;
+        private string _cleanedFixedResult;
 
         private bool _cleanupInvalidChars;
 
@@ -110,11 +110,11 @@ namespace NLog.Internal
                     var isFixedText = pathLayout2.IsFixedText;
                     if (isFixedText)
                     {
-                        cleanedFixedResult = pathLayout2.FixedText;
+                        _cleanedFixedResult = pathLayout2.FixedText;
                         if (cleanupInvalidChars)
                         {
                             //clean first
-                            cleanedFixedResult = CleanupInvalidFilePath(cleanedFixedResult);
+                            _cleanedFixedResult = CleanupInvalidFilePath(_cleanedFixedResult);
                         }
                     }
 
@@ -152,9 +152,9 @@ namespace NLog.Internal
         /// <returns>String representation of a layout.</returns>
         private string GetRenderedFileName(LogEventInfo logEvent, System.Text.StringBuilder reusableBuilder = null)
         {
-            if (cleanedFixedResult != null)
+            if (_cleanedFixedResult != null)
             {
-                return cleanedFixedResult;
+                return _cleanedFixedResult;
             }
 
             if (_layout == null)
@@ -206,7 +206,7 @@ namespace NLog.Internal
         private string GetCleanFileName(string rawFileName)
         {
             var cleanFileName = rawFileName;
-            if (_cleanupInvalidChars && cleanedFixedResult == null)
+            if (_cleanupInvalidChars && _cleanedFixedResult == null)
             {
                 cleanFileName = CleanupInvalidFilePath(rawFileName);
             }
@@ -240,7 +240,7 @@ namespace NLog.Internal
                 return rawFileName;
             }
 
-            if ((!_cleanupInvalidChars || cleanedFixedResult != null) && _filePathKind == FilePathKind.Absolute)
+            if ((!_cleanupInvalidChars || _cleanedFixedResult != null) && _filePathKind == FilePathKind.Absolute)
                 return rawFileName; // Skip clean filename string-allocation
 
             if (string.Equals(_cachedPrevRawFileName, rawFileName, StringComparison.Ordinal) && _cachedPrevCleanFileName != null)

--- a/src/NLog/Internal/LoggerConfiguration.cs
+++ b/src/NLog/Internal/LoggerConfiguration.cs
@@ -40,7 +40,7 @@ namespace NLog.Internal
     /// </summary>
     internal class LoggerConfiguration
     {
-        private readonly TargetWithFilterChain[] targetsByLevel;
+        private readonly TargetWithFilterChain[] _targetsByLevel;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggerConfiguration" /> class.
@@ -50,7 +50,7 @@ namespace NLog.Internal
         /// </param>
         public LoggerConfiguration(TargetWithFilterChain[] targetsByLevel, bool exceptionLoggingOldStyle = false)
         {
-            this.targetsByLevel = targetsByLevel;
+            this._targetsByLevel = targetsByLevel;
 #pragma warning disable 618
             ExceptionLoggingOldStyle = exceptionLoggingOldStyle;
 #pragma warning restore 618
@@ -75,7 +75,7 @@ namespace NLog.Internal
                 return null;
             }
 
-            return this.targetsByLevel[level.Ordinal];
+            return this._targetsByLevel[level.Ordinal];
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace NLog.Internal
             {
                 return false;
             }
-            return this.targetsByLevel[level.Ordinal] != null;
+            return this._targetsByLevel[level.Ordinal] != null;
         }
     }
 }

--- a/src/NLog/Internal/MultiFileWatcher.cs
+++ b/src/NLog/Internal/MultiFileWatcher.cs
@@ -46,7 +46,7 @@ namespace NLog.Internal
     /// </summary>
     internal class MultiFileWatcher : IDisposable
     {
-        private readonly Dictionary<string, FileSystemWatcher> watcherMap = new Dictionary<string, FileSystemWatcher>();
+        private readonly Dictionary<string, FileSystemWatcher> _watcherMap = new Dictionary<string, FileSystemWatcher>();
 
         /// <summary>
         /// The types of changes to watch for.
@@ -83,11 +83,11 @@ namespace NLog.Internal
         {
             lock (this)
             {
-                foreach (FileSystemWatcher watcher in watcherMap.Values)
+                foreach (FileSystemWatcher watcher in _watcherMap.Values)
                 {
                     StopWatching(watcher);
                 }
-                this.watcherMap.Clear();
+                this._watcherMap.Clear();
             }
         }
 
@@ -100,10 +100,10 @@ namespace NLog.Internal
             lock (this)
             {
                 FileSystemWatcher watcher;
-                if (this.watcherMap.TryGetValue(fileName, out watcher))
+                if (this._watcherMap.TryGetValue(fileName, out watcher))
                 {
                     StopWatching(watcher);
-                    this.watcherMap.Remove(fileName);
+                    this._watcherMap.Remove(fileName);
                 }
             }
         }
@@ -144,7 +144,7 @@ namespace NLog.Internal
 
             lock (this)
             {
-                if (this.watcherMap.ContainsKey(fileName))
+                if (this._watcherMap.ContainsKey(fileName))
                     return;
 
                 var watcher = new FileSystemWatcher
@@ -163,7 +163,7 @@ namespace NLog.Internal
 
                 InternalLogger.Debug("Watching path '{0}' filter '{1}' for changes.", watcher.Path, watcher.Filter);
                 
-                this.watcherMap.Add(fileName, watcher);
+                this._watcherMap.Add(fileName, watcher);
             }
         }
 

--- a/src/NLog/Internal/NetworkSenders/SocketProxy.cs
+++ b/src/NLog/Internal/NetworkSenders/SocketProxy.cs
@@ -42,7 +42,7 @@ namespace NLog.Internal.NetworkSenders
     /// </summary>
     internal sealed class SocketProxy : ISocket, IDisposable
     {
-        private readonly Socket socket;
+        private readonly Socket _socket;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SocketProxy"/> class.
@@ -52,7 +52,7 @@ namespace NLog.Internal.NetworkSenders
         /// <param name="protocolType">Type of the protocol.</param>
         internal SocketProxy(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
         {
-            this.socket = new Socket(addressFamily, socketType, protocolType);
+            this._socket = new Socket(addressFamily, socketType, protocolType);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace NLog.Internal.NetworkSenders
         {
             get
             {
-                return this.socket;
+                return this._socket;
             }
         }
 
@@ -71,7 +71,7 @@ namespace NLog.Internal.NetworkSenders
         /// </summary>
         public void Close()
         {
-            this.socket.Close();
+            this._socket.Close();
         }
 
 #if USE_LEGACY_ASYNC_API
@@ -117,7 +117,7 @@ namespace NLog.Internal.NetworkSenders
         /// <returns>Result of original method.</returns>
         public bool ConnectAsync(SocketAsyncEventArgs args)
         {
-            return this.socket.ConnectAsync(args);
+            return this._socket.ConnectAsync(args);
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace NLog.Internal.NetworkSenders
         /// <returns>Result of original method.</returns>
         public bool SendAsync(SocketAsyncEventArgs args)
         {
-            return this.socket.SendAsync(args);
+            return this._socket.SendAsync(args);
         }
 
 #if !SILVERLIGHT
@@ -138,7 +138,7 @@ namespace NLog.Internal.NetworkSenders
         /// <returns>Result of original method.</returns>
         public bool SendToAsync(SocketAsyncEventArgs args)
         {
-            return this.socket.SendToAsync(args);
+            return this._socket.SendToAsync(args);
         }
 #endif
 
@@ -149,7 +149,7 @@ namespace NLog.Internal.NetworkSenders
         /// </summary>
         public void Dispose()
         {
-            ((IDisposable)this.socket).Dispose();
+            ((IDisposable)this._socket).Dispose();
         }
     }
 }

--- a/src/NLog/Internal/NetworkSenders/UdpNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/UdpNetworkSender.cs
@@ -46,8 +46,8 @@ namespace NLog.Internal.NetworkSenders
     /// </summary>
     internal class UdpNetworkSender : NetworkSender
     {
-        private ISocket socket;
-        private EndPoint endpoint;
+        private ISocket _socket;
+        private EndPoint _endpoint;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UdpNetworkSender"/> class.
@@ -89,8 +89,8 @@ namespace NLog.Internal.NetworkSenders
         /// </summary>
         protected override void DoInitialize()
         {
-            this.endpoint = this.ParseEndpointAddress(new Uri(this.Address), this.AddressFamily);
-            this.socket = this.CreateSocket(this.endpoint.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
+            this._endpoint = this.ParseEndpointAddress(new Uri(this.Address), this.AddressFamily);
+            this._socket = this.CreateSocket(this._endpoint.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
         }
 
         /// <summary>
@@ -109,8 +109,8 @@ namespace NLog.Internal.NetworkSenders
         {
             try
             {
-                var sock = this.socket;
-                this.socket = null;
+                var sock = this._socket;
+                this._socket = null;
 
                 if (sock != null)
                 {
@@ -147,11 +147,11 @@ namespace NLog.Internal.NetworkSenders
                 args.SetBuffer(bytes, offset, length);
                 args.UserToken = asyncContinuation;
                 args.Completed += this.SocketOperationCompleted;
-                args.RemoteEndPoint = this.endpoint;
+                args.RemoteEndPoint = this._endpoint;
 
-                if (!this.socket.SendToAsync(args))
+                if (!this._socket.SendToAsync(args))
                 {
-                    this.SocketOperationCompleted(this.socket, args);
+                    this.SocketOperationCompleted(this._socket, args);
                 }
             }
         }
@@ -177,7 +177,7 @@ namespace NLog.Internal.NetworkSenders
 
         public override void CheckSocket()
         {
-            if (socket == null)
+            if (_socket == null)
             {
                 DoInitialize();
             }

--- a/src/NLog/Internal/PortableThreadIDHelper.cs
+++ b/src/NLog/Internal/PortableThreadIDHelper.cs
@@ -46,17 +46,17 @@ namespace NLog.Internal
     {
         private const string UnknownProcessName = "<unknown>";
 
-        private readonly int currentProcessID;
+        private readonly int _currentProcessId;
 
-        private string currentProcessName;
-        private string currentProcessBaseName;
+        private string _currentProcessName;
+        private string _currentProcessBaseName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PortableThreadIDHelper" /> class.
         /// </summary>
         public PortableThreadIDHelper()
         {
-            this.currentProcessID = Process.GetCurrentProcess().Id;
+            this._currentProcessId = Process.GetCurrentProcess().Id;
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace NLog.Internal
         /// <value></value>
         public override int CurrentProcessID
         {
-            get { return this.currentProcessID; }
+            get { return this._currentProcessId; }
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace NLog.Internal
             get
             {
                 this.GetProcessName();
-                return this.currentProcessName;
+                return this._currentProcessName;
             }
         }
 
@@ -90,7 +90,7 @@ namespace NLog.Internal
             get
             {
                 this.GetProcessName();
-                return this.currentProcessBaseName;
+                return this._currentProcessBaseName;
             }
         }
 
@@ -99,11 +99,11 @@ namespace NLog.Internal
         /// </summary>
         private void GetProcessName()
         {
-            if (this.currentProcessName == null)
+            if (this._currentProcessName == null)
             {
                 try
                 {
-                    this.currentProcessName = Process.GetCurrentProcess().MainModule.FileName;
+                    this._currentProcessName = Process.GetCurrentProcess().MainModule.FileName;
                 }
                 catch (Exception exception)
                 {
@@ -112,10 +112,10 @@ namespace NLog.Internal
                         throw;
                     }
 
-                    this.currentProcessName = UnknownProcessName;
+                    this._currentProcessName = UnknownProcessName;
                 }
 
-                this.currentProcessBaseName = Path.GetFileNameWithoutExtension(this.currentProcessName);
+                this._currentProcessBaseName = Path.GetFileNameWithoutExtension(this._currentProcessName);
             }
         }
     }

--- a/src/NLog/Internal/SimpleStringReader.cs
+++ b/src/NLog/Internal/SimpleStringReader.cs
@@ -44,7 +44,7 @@ namespace NLog.Internal
 #endif
 	internal class SimpleStringReader
 	{
-        private readonly string text;
+        private readonly string _text;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleStringReader" /> class.
@@ -52,7 +52,7 @@ namespace NLog.Internal
         /// <param name="text">The text to be tokenized.</param>
         public SimpleStringReader(string text)
         {
-            this.text = text;
+            this._text = text;
             this.Position = 0;
         }
 
@@ -66,7 +66,7 @@ namespace NLog.Internal
         /// </summary>
         internal string Text
         {
-            get { return this.text; }
+            get { return this._text; }
         }
 
 #if DEBUG
@@ -76,7 +76,7 @@ namespace NLog.Internal
             {
                 var current = (char)Peek();
                 var done = Substring(0, Position - 1);
-                var todo = ((Position > text.Length) ? Text.Substring(Position + 1) : "");
+                var todo = ((Position > _text.Length) ? Text.Substring(Position + 1) : "");
                 return string.Format("done: '{0}'.   current: '{1}'.   todo: '{2}'", done, current, todo);
             }
         }
@@ -88,9 +88,9 @@ namespace NLog.Internal
         /// <returns></returns>
         internal int Peek()
         {
-            if (this.Position < this.text.Length)
+            if (this.Position < this._text.Length)
             {
-                return this.text[this.Position];
+                return this._text[this.Position];
             }
 
             return -1;
@@ -102,9 +102,9 @@ namespace NLog.Internal
         /// <returns></returns>
         internal int Read()
         {
-            if (this.Position < this.text.Length)
+            if (this.Position < this._text.Length)
             {
-                return this.text[this.Position++];
+                return this._text[this.Position++];
             }
 
             return -1;
@@ -118,7 +118,7 @@ namespace NLog.Internal
         /// <returns></returns>
         internal string Substring(int startIndex, int endIndex)
         {
-            return this.text.Substring(startIndex, endIndex - startIndex);
+            return this._text.Substring(startIndex, endIndex - startIndex);
         }
     }
 }

--- a/src/NLog/Internal/SingleCallContinuation.cs
+++ b/src/NLog/Internal/SingleCallContinuation.cs
@@ -42,7 +42,7 @@ namespace NLog.Internal
     /// </summary>
     internal class SingleCallContinuation
     {
-        private AsyncContinuation asyncContinuation;
+        private AsyncContinuation _asyncContinuation;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SingleCallContinuation"/> class.
@@ -50,7 +50,7 @@ namespace NLog.Internal
         /// <param name="asyncContinuation">The asynchronous continuation.</param>
         public SingleCallContinuation(AsyncContinuation asyncContinuation)
         {
-            this.asyncContinuation = asyncContinuation;
+            this._asyncContinuation = asyncContinuation;
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace NLog.Internal
         {
             try
             {
-                var cont = Interlocked.Exchange(ref this.asyncContinuation, null);
+                var cont = Interlocked.Exchange(ref this._asyncContinuation, null);
                 if (cont != null)
                 {
                     cont(exception);

--- a/src/NLog/Internal/TimeoutContinuation.cs
+++ b/src/NLog/Internal/TimeoutContinuation.cs
@@ -42,8 +42,8 @@ namespace NLog.Internal
     /// </summary>
     internal class TimeoutContinuation : IDisposable
     {
-        private AsyncContinuation asyncContinuation;
-        private Timer timeoutTimer;
+        private AsyncContinuation _asyncContinuation;
+        private Timer _timeoutTimer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeoutContinuation"/> class.
@@ -52,8 +52,8 @@ namespace NLog.Internal
         /// <param name="timeout">The timeout.</param>
         public TimeoutContinuation(AsyncContinuation asyncContinuation, TimeSpan timeout)
         {
-            this.asyncContinuation = asyncContinuation;
-            this.timeoutTimer = new Timer(this.TimerElapsed, null, timeout, TimeSpan.FromMilliseconds(-1));
+            this._asyncContinuation = asyncContinuation;
+            this._timeoutTimer = new Timer(this.TimerElapsed, null, timeout, TimeSpan.FromMilliseconds(-1));
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace NLog.Internal
             {
                 this.StopTimer();
 
-                var cont = Interlocked.Exchange(ref this.asyncContinuation, null);
+                var cont = Interlocked.Exchange(ref this._asyncContinuation, null);
                 if (cont != null)
                 {
                     cont(exception);
@@ -95,10 +95,10 @@ namespace NLog.Internal
         {
             lock (this)
             {
-                var currentTimer = this.timeoutTimer;
+                var currentTimer = this._timeoutTimer;
                 if (currentTimer != null)
                 {
-                    this.timeoutTimer = null;
+                    this._timeoutTimer = null;
                     currentTimer.WaitForDispose(TimeSpan.Zero);
                 }
             }

--- a/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
@@ -50,7 +50,7 @@ namespace NLog.LayoutRenderers
     [ThreadAgnostic]
     public class AllEventPropertiesLayoutRenderer : LayoutRenderer
     {
-        private string format;
+        private string _format;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AllEventPropertiesLayoutRenderer"/> class.
@@ -86,7 +86,7 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Rendering Options' order='10' />
         public string Format
         {
-            get { return format; }
+            get { return _format; }
             set
             {
                 if (!value.Contains("[key]"))
@@ -95,7 +95,7 @@ namespace NLog.LayoutRenderers
                 if (!value.Contains("[value]"))
                     throw new ArgumentException("Invalid format: [value] placeholder is missing.");
 
-                format = value;
+                _format = value;
             }
         }
 

--- a/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
@@ -48,14 +48,14 @@ namespace NLog.LayoutRenderers
     [ThreadAgnostic]
     public class BaseDirLayoutRenderer : LayoutRenderer
     {
-        private string baseDir;
+        private string _baseDir;
 
 #if !SILVERLIGHT
 
         /// <summary>
         /// cached
         /// </summary>
-        private string processDir;
+        private string _processDir;
 
         /// <summary>
         /// Use base dir of current process.
@@ -76,7 +76,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         public BaseDirLayoutRenderer(IAppDomain appDomain)
         {
-            this.baseDir = appDomain.BaseDirectory;
+            this._baseDir = appDomain.BaseDirectory;
         }
 
         /// <summary>
@@ -99,11 +99,11 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
 
-            var dir = baseDir;
+            var dir = _baseDir;
 #if !SILVERLIGHT
             if (ProcessDir)
             {
-                dir = processDir ?? (processDir = Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName));
+                dir = _processDir ?? (_processDir = Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName));
             }
 #endif
 

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -51,8 +51,8 @@ namespace NLog.LayoutRenderers
     [ThreadAgnostic]
     public class ExceptionLayoutRenderer : LayoutRenderer
     {
-        private string format;
-        private string innerFormat = string.Empty;
+        private string _format;
+        private string _innerFormat = string.Empty;
         private readonly Dictionary<ExceptionRenderingFormat, Action<StringBuilder, Exception>> _renderingfunctions;
 
         private static readonly Dictionary<String, ExceptionRenderingFormat> _formatsMapping = new Dictionary<string, ExceptionRenderingFormat>(StringComparer.OrdinalIgnoreCase)
@@ -102,12 +102,12 @@ namespace NLog.LayoutRenderers
         {
             get
             {
-                return this.format;
+                return this._format;
             }
 
             set
             {
-                this.format = value;
+                this._format = value;
                 Formats = CompileFormat(value);
             }
         }
@@ -122,12 +122,12 @@ namespace NLog.LayoutRenderers
         {
             get
             {
-                return this.innerFormat;
+                return this._innerFormat;
             }
 
             set
             {
-                this.innerFormat = value;
+                this._innerFormat = value;
                 InnerFormats = CompileFormat(value);
             }
         }

--- a/src/NLog/LayoutRenderers/FileContentsLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/FileContentsLayoutRenderer.cs
@@ -47,8 +47,8 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("file-contents")]
     public class FileContentsLayoutRenderer : LayoutRenderer
     {
-        private string lastFileName;
-        private string currentFileContents;
+        private string _lastFileName;
+        private string _currentFileContents;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FileContentsLayoutRenderer" /> class.
@@ -60,7 +60,7 @@ namespace NLog.LayoutRenderers
 #else
             this.Encoding = Encoding.Default;
 #endif
-            this.lastFileName = string.Empty;
+            this._lastFileName = string.Empty;
         }
 
         /// <summary>
@@ -88,14 +88,14 @@ namespace NLog.LayoutRenderers
             {
                 string fileName = this.FileName.Render(logEvent);
 
-                if (fileName != this.lastFileName)
+                if (fileName != this._lastFileName)
                 {
-                    this.currentFileContents = this.ReadFileContents(fileName);
-                    this.lastFileName = fileName;
+                    this._currentFileContents = this.ReadFileContents(fileName);
+                    this._lastFileName = fileName;
                 }
             }
 
-            builder.Append(this.currentFileContents);
+            builder.Append(this._currentFileContents);
         }
 
         private string ReadFileContents(string fileName)

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -48,8 +48,8 @@ namespace NLog.LayoutRenderers
     public abstract class LayoutRenderer : ISupportsInitialize, IRenderable, IDisposable
     {
         private const int MaxInitialRenderBufferLength = 16384;
-        private int maxRenderedLength;
-        private bool isInitialized;
+        private int _maxRenderedLength;
+        private bool _isInitialized;
 
         /// <summary>
         /// Gets the logging configuration this target is part of.
@@ -89,7 +89,7 @@ namespace NLog.LayoutRenderers
         /// <returns>String representation of a layout renderer.</returns>
         public string Render(LogEventInfo logEvent)
         {
-            int initialLength = this.maxRenderedLength;
+            int initialLength = this._maxRenderedLength;
             if (initialLength > MaxInitialRenderBufferLength)
             {
                 initialLength = MaxInitialRenderBufferLength;
@@ -97,9 +97,9 @@ namespace NLog.LayoutRenderers
 
             var builder = new StringBuilder(initialLength);
             this.RenderAppendBuilder(logEvent, builder);
-            if (builder.Length > this.maxRenderedLength)
+            if (builder.Length > this._maxRenderedLength)
             {
-                this.maxRenderedLength = builder.Length;
+                this._maxRenderedLength = builder.Length;
             }
 
             return builder.ToString();
@@ -131,9 +131,9 @@ namespace NLog.LayoutRenderers
             if (this.LoggingConfiguration == null)
                 this.LoggingConfiguration = configuration;
 
-            if (!this.isInitialized)
+            if (!this._isInitialized)
             {
-                this.isInitialized = true;
+                this._isInitialized = true;
                 this.InitializeLayoutRenderer();
             }
         }
@@ -143,10 +143,10 @@ namespace NLog.LayoutRenderers
         /// </summary>
         internal void Close()
         {
-            if (this.isInitialized)
+            if (this._isInitialized)
             {
                 this.LoggingConfiguration = null;
-                this.isInitialized = false;
+                this._isInitialized = false;
                 this.CloseLayoutRenderer();
             }
         }
@@ -158,9 +158,9 @@ namespace NLog.LayoutRenderers
         /// <param name="builder">The layout render output is appended to builder</param>
         internal void RenderAppendBuilder(LogEventInfo logEvent, StringBuilder builder)
         {
-            if (!this.isInitialized)
+            if (!this._isInitialized)
             {
-                this.isInitialized = true;
+                this._isInitialized = true;
                 this.InitializeLayoutRenderer();
             }
 

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -95,7 +95,7 @@ namespace NLog.LayoutRenderers
             try
             {
 #if SILVERLIGHT
-                this.machineName = "silverlight";
+                this._machineName = "silverlight";
 #else
                 this._machineName = Environment.MachineName;
 #endif

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -66,7 +66,7 @@ namespace NLog.LayoutRenderers
         public Log4JXmlEventLayoutRenderer() : this(LogFactory.CurrentAppDomain)
         {
         }
-
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="Log4JXmlEventLayoutRenderer" /> class.
         /// </summary>
@@ -85,8 +85,8 @@ namespace NLog.LayoutRenderers
 #else
             this.AppInfo = string.Format(
                 CultureInfo.InvariantCulture,
-                "{0}({1})",
-                appDomain.FriendlyName,
+                "{0}({1})", 
+                appDomain.FriendlyName, 
                 ThreadIDHelper.Instance.CurrentProcessID);
 #endif
 
@@ -97,15 +97,15 @@ namespace NLog.LayoutRenderers
 #if SILVERLIGHT
                 this.machineName = "silverlight";
 #else
-                this.machineName = Environment.MachineName;
+                this._machineName = Environment.MachineName;
 #endif
             }
             catch (System.Security.SecurityException)
             {
-                this.machineName = string.Empty;
+                this._machineName = string.Empty;
             }
 
-            this.xmlWriterSettings = new XmlWriterSettings
+            this._xmlWriterSettings = new XmlWriterSettings
             {
                 Indent = this.IndentXml,
                 ConformanceLevel = ConformanceLevel.Fragment,
@@ -190,12 +190,9 @@ namespace NLog.LayoutRenderers
         [DefaultValue(" ")]
         public string NdcItemSeparator { get; set; }
 
+        private readonly string _machineName;
 
-
-
-        private readonly string machineName;
-
-        private readonly XmlWriterSettings xmlWriterSettings;
+        private readonly XmlWriterSettings _xmlWriterSettings;
 
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
@@ -233,7 +230,7 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             StringBuilder sb = new StringBuilder();
-            using (XmlWriter xtw = XmlWriter.Create(sb, this.xmlWriterSettings))
+            using (XmlWriter xtw = XmlWriter.Create(sb, this._xmlWriterSettings))
             {
                 xtw.WriteStartElement("log4j", "event", dummyNamespace);
                 xtw.WriteAttributeSafeString("xmlns", "nlog", null, dummyNLogNamespace);
@@ -375,7 +372,7 @@ namespace NLog.LayoutRenderers
 
                 xtw.WriteStartElement("log4j", "data", dummyNamespace);
                 xtw.WriteAttributeSafeString("name", "log4jmachinename");
-                xtw.WriteAttributeSafeString("value", this.machineName);
+                xtw.WriteAttributeSafeString("value", this._machineName);
                 xtw.WriteEndElement();
 
                 xtw.WriteEndElement();

--- a/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
@@ -49,10 +49,10 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("processinfo")]
     public class ProcessInfoLayoutRenderer : LayoutRenderer
     {
-        private Process process;
+        private Process _process;
 
-        private PropertyInfo propertyInfo;
-        private ReflectionHelpers.LateBoundMethod lateBoundPropertyGet;
+        private PropertyInfo _propertyInfo;
+        private ReflectionHelpers.LateBoundMethod _lateBoundPropertyGet;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProcessInfoLayoutRenderer" /> class.
@@ -82,15 +82,15 @@ namespace NLog.LayoutRenderers
         protected override void InitializeLayoutRenderer()
         {
             base.InitializeLayoutRenderer();
-            this.propertyInfo = typeof(Process).GetProperty(this.Property.ToString());
-            if (this.propertyInfo == null)
+            this._propertyInfo = typeof(Process).GetProperty(this.Property.ToString());
+            if (this._propertyInfo == null)
             {
-                throw new ArgumentException("Property '" + this.propertyInfo + "' not found in System.Diagnostics.Process");
+                throw new ArgumentException("Property '" + this._propertyInfo + "' not found in System.Diagnostics.Process");
             }
 
-            lateBoundPropertyGet = ReflectionHelpers.CreateLateBoundMethod(this.propertyInfo.GetGetMethod());
+            _lateBoundPropertyGet = ReflectionHelpers.CreateLateBoundMethod(this._propertyInfo.GetGetMethod());
 
-            this.process = Process.GetCurrentProcess();
+            this._process = Process.GetCurrentProcess();
         }
 
         /// <summary>
@@ -98,10 +98,10 @@ namespace NLog.LayoutRenderers
         /// </summary>
         protected override void CloseLayoutRenderer()
         {
-            if (this.process != null)
+            if (this._process != null)
             {
-                this.process.Close();
-                this.process = null;
+                this._process.Close();
+                this._process = null;
             }
 
             base.CloseLayoutRenderer();
@@ -114,10 +114,10 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            if (this.lateBoundPropertyGet != null)
+            if (this._lateBoundPropertyGet != null)
             {
                 var formatProvider = GetFormatProvider(logEvent);
-                var value = this.lateBoundPropertyGet(this.process, null);
+                var value = this._lateBoundPropertyGet(this._process, null);
                 builder.AppendFormattedValue(value, this.Format, formatProvider);
             }
         }

--- a/src/NLog/LayoutRenderers/ShortDateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ShortDateLayoutRenderer.cs
@@ -80,8 +80,8 @@ namespace NLog.LayoutRenderers
 
         private class DateData
         {
-            private DateTime date;
-            private string formattedDate;
+            private DateTime _date;
+            private string _formattedDate;
 
             /// <summary>
             /// Appends a date in format yyyy-MM-dd to the StringBuilder.
@@ -94,12 +94,12 @@ namespace NLog.LayoutRenderers
             /// <param name="timestamp">The date to append</param>
             public void AppendDate(StringBuilder builder, DateTime timestamp)
             {
-                if (formattedDate == null || date != timestamp.Date)
+                if (_formattedDate == null || _date != timestamp.Date)
                 {
-                    date = timestamp.Date;
-                    formattedDate = timestamp.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                    _date = timestamp.Date;
+                    _formattedDate = timestamp.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
                 }
-                builder.Append(formattedDate);
+                builder.Append(_formattedDate);
             }
         }
     }

--- a/src/NLog/LayoutRenderers/Wrappers/CachedLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/CachedLayoutRendererWrapper.cs
@@ -65,8 +65,8 @@ namespace NLog.LayoutRenderers.Wrappers
             OnClose = 2
         }
 
-        private string cachedValue = null;
-        private string renderedCacheKey = null;
+        private string _cachedValue = null;
+        private string _renderedCacheKey = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CachedLayoutRendererWrapper"/> class.
@@ -101,7 +101,7 @@ namespace NLog.LayoutRenderers.Wrappers
         {
             base.InitializeLayoutRenderer();
             if ((ClearCache & ClearCacheOption.OnInit) == ClearCacheOption.OnInit)
-                this.cachedValue = null;
+                this._cachedValue = null;
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace NLog.LayoutRenderers.Wrappers
         {
             base.CloseLayoutRenderer();
             if ((ClearCache & ClearCacheOption.OnClose) == ClearCacheOption.OnClose)
-                this.cachedValue = null;
+                this._cachedValue = null;
         }
 
         /// <summary>
@@ -134,13 +134,13 @@ namespace NLog.LayoutRenderers.Wrappers
             if (this.Cached)
             {
                 var newCacheKey = CacheKey == null ? null: CacheKey.Render(logEvent);
-                if (this.cachedValue == null || this.renderedCacheKey != newCacheKey)
+                if (this._cachedValue == null || this._renderedCacheKey != newCacheKey)
                 {
-                    this.cachedValue = base.RenderInner(logEvent);
-                    this.renderedCacheKey = newCacheKey;
+                    this._cachedValue = base.RenderInner(logEvent);
+                    this._renderedCacheKey = newCacheKey;
                 }
 
-                return this.cachedValue;
+                return this._cachedValue;
             }
             else
             {

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceLayoutRendererWrapper.cs
@@ -48,7 +48,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [ThreadAgnostic]
     public sealed class ReplaceLayoutRendererWrapper : WrapperLayoutRendererBase
     {
-        private Regex regex;
+        private Regex _regex;
 
         /// <summary>
         /// Gets or sets the text to search for.
@@ -121,7 +121,7 @@ namespace NLog.LayoutRenderers.Wrappers
                 regexString = "\\b" + regexString + "\\b";
             }
 
-            this.regex = new Regex(regexString, regexOptions);
+            this._regex = new Regex(regexString, regexOptions);
         }
 
         /// <summary>
@@ -134,8 +134,8 @@ namespace NLog.LayoutRenderers.Wrappers
             var replacer = new Replacer(text, this.ReplaceGroupName, this.ReplaceWith);
 
             return string.IsNullOrEmpty(this.ReplaceGroupName) ?
-                this.regex.Replace(text, this.ReplaceWith)
-                : this.regex.Replace(text, replacer.EvaluateMatch);
+                this._regex.Replace(text, this.ReplaceWith)
+                : this._regex.Replace(text, replacer.EvaluateMatch);
         }
 
         /// <summary>
@@ -144,20 +144,20 @@ namespace NLog.LayoutRenderers.Wrappers
         [ThreadAgnostic]
         public class Replacer
         {
-            private readonly string text;
-            private readonly string replaceGroupName;
-            private readonly string replaceWith;
+            private readonly string _text;
+            private readonly string _replaceGroupName;
+            private readonly string _replaceWith;
 
             internal Replacer(string text, string replaceGroupName, string replaceWith)
             {
-                this.text = text;
-                this.replaceGroupName = replaceGroupName;
-                this.replaceWith = replaceWith;
+                this._text = text;
+                this._replaceGroupName = replaceGroupName;
+                this._replaceWith = replaceWith;
             }
 
             internal string EvaluateMatch(Match match)
             {
-                return ReplaceNamedGroup(text, replaceGroupName, replaceWith, match);
+                return ReplaceNamedGroup(_text, _replaceGroupName, _replaceWith, match);
             }
         }
 

--- a/src/NLog/Layouts/CsvLayout.cs
+++ b/src/NLog/Layouts/CsvLayout.cs
@@ -49,9 +49,9 @@ namespace NLog.Layouts
     [AppDomainFixedOutput]
     public class CsvLayout : LayoutWithHeaderAndFooter
     {
-        private string actualColumnDelimiter;
-        private string doubleQuoteChar;
-        private char[] quotableCharacters;
+        private string _actualColumnDelimiter;
+        private string _doubleQuoteChar;
+        private char[] _quotableCharacters;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CsvLayout"/> class.
@@ -123,36 +123,36 @@ namespace NLog.Layouts
             switch (this.Delimiter)
             {
                 case CsvColumnDelimiterMode.Auto:
-                    this.actualColumnDelimiter = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
+                    this._actualColumnDelimiter = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
                     break;
 
                 case CsvColumnDelimiterMode.Comma:
-                    this.actualColumnDelimiter = ",";
+                    this._actualColumnDelimiter = ",";
                     break;
 
                 case CsvColumnDelimiterMode.Semicolon:
-                    this.actualColumnDelimiter = ";";
+                    this._actualColumnDelimiter = ";";
                     break;
 
                 case CsvColumnDelimiterMode.Pipe:
-                    this.actualColumnDelimiter = "|";
+                    this._actualColumnDelimiter = "|";
                     break;
 
                 case CsvColumnDelimiterMode.Tab:
-                    this.actualColumnDelimiter = "\t";
+                    this._actualColumnDelimiter = "\t";
                     break;
 
                 case CsvColumnDelimiterMode.Space:
-                    this.actualColumnDelimiter = " ";
+                    this._actualColumnDelimiter = " ";
                     break;
 
                 case CsvColumnDelimiterMode.Custom:
-                    this.actualColumnDelimiter = this.CustomColumnDelimiter;
+                    this._actualColumnDelimiter = this.CustomColumnDelimiter;
                     break;
             }
 
-            this.quotableCharacters = (this.QuoteChar + "\r\n" + this.actualColumnDelimiter).ToCharArray();
-            this.doubleQuoteChar = this.QuoteChar + this.QuoteChar;
+            this._quotableCharacters = (this.QuoteChar + "\r\n" + this._actualColumnDelimiter).ToCharArray();
+            this._doubleQuoteChar = this.QuoteChar + this.QuoteChar;
         }
 
         /// <summary>
@@ -215,7 +215,7 @@ namespace NLog.Layouts
         {
             if (columnIndex != 0)
             {
-                sb.Append(this.actualColumnDelimiter);
+                sb.Append(this._actualColumnDelimiter);
             }
 
             bool useQuoting;
@@ -232,7 +232,7 @@ namespace NLog.Layouts
 
                 default:
                 case CsvQuotingMode.Auto:
-                    if (columnValue.IndexOfAny(this.quotableCharacters) >= 0)
+                    if (columnValue.IndexOfAny(this._quotableCharacters) >= 0)
                     {
                         useQuoting = true;
                     }
@@ -251,7 +251,7 @@ namespace NLog.Layouts
 
             if (useQuoting)
             {
-                sb.Append(columnValue.Replace(this.QuoteChar, this.doubleQuoteChar));
+                sb.Append(columnValue.Replace(this.QuoteChar, this._doubleQuoteChar));
             }
             else
             {
@@ -270,7 +270,7 @@ namespace NLog.Layouts
         [ThreadAgnostic]
         private class CsvHeaderLayout : Layout
         {
-            private CsvLayout parent;
+            private CsvLayout _parent;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="CsvHeaderLayout"/> class.
@@ -278,7 +278,7 @@ namespace NLog.Layouts
             /// <param name="parent">The parent.</param>
             public CsvHeaderLayout(CsvLayout parent)
             {
-                this.parent = parent;
+                this._parent = parent;
             }
 
             /// <summary>
@@ -298,7 +298,7 @@ namespace NLog.Layouts
             /// <param name="target"><see cref="StringBuilder"/> for the result</param>
             protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
             {
-                this.parent.RenderHeader(target);
+                this._parent.RenderHeader(target);
             }
         }
     }

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -51,8 +51,8 @@ namespace NLog.Layouts
         /// <summary>
         /// Is this layout initialized? See <see cref="Initialize(NLog.Config.LoggingConfiguration)"/>
         /// </summary>
-        private bool isInitialized;
-        private bool scannedForObjects;
+        private bool _isInitialized;
+        private bool _scannedForObjects;
 
         /// <summary>
         /// Gets a value indicating whether this layout is thread-agnostic (can be rendered on any thread).
@@ -71,7 +71,7 @@ namespace NLog.Layouts
         internal StackTraceUsage StackTraceUsage { get; private set; }
 
         private const int MaxInitialRenderBufferLength = 16384;
-        private int maxRenderedLength;
+        private int _maxRenderedLength;
 
         /// <summary>
         /// Gets the logging configuration this target is part of.
@@ -136,7 +136,7 @@ namespace NLog.Layouts
         /// <returns>String representing log event.</returns>
         public string Render(LogEventInfo logEvent)
         {
-            if (!this.isInitialized)
+            if (!this._isInitialized)
             {
                 this.Initialize(this.LoggingConfiguration);
             }
@@ -160,7 +160,7 @@ namespace NLog.Layouts
         /// <param name="cacheLayoutResult">Should rendering result be cached on LogEventInfo</param>
         internal void RenderAppendBuilder(LogEventInfo logEvent, StringBuilder target, bool cacheLayoutResult = false)
         {
-            if (!this.isInitialized)
+            if (!this._isInitialized)
             {
                 this.Initialize(this.LoggingConfiguration);
             }
@@ -205,7 +205,7 @@ namespace NLog.Layouts
                 }
             }
 
-            int initialLength = this.maxRenderedLength;
+            int initialLength = this._maxRenderedLength;
             if (initialLength > MaxInitialRenderBufferLength)
             {
                 initialLength = MaxInitialRenderBufferLength;
@@ -213,9 +213,9 @@ namespace NLog.Layouts
 
             var sb = reusableBuilder ?? new StringBuilder(initialLength);
             RenderFormattedMessage(logEvent, sb);
-            if (sb.Length > this.maxRenderedLength)
+            if (sb.Length > this._maxRenderedLength)
             {
-                this.maxRenderedLength = sb.Length;
+                this._maxRenderedLength = sb.Length;
             }
 
             if (cacheLayoutResult && !this.ThreadAgnostic)
@@ -261,15 +261,15 @@ namespace NLog.Layouts
         /// <param name="configuration">The configuration.</param>
         internal void Initialize(LoggingConfiguration configuration)
         {
-            if (!this.isInitialized)
+            if (!this._isInitialized)
             {
                 this.LoggingConfiguration = configuration;
-                this.isInitialized = true;
-                this.scannedForObjects = false;
+                this._isInitialized = true;
+                this._scannedForObjects = false;
 
                 this.InitializeLayout();
 
-                if (!this.scannedForObjects)
+                if (!this._scannedForObjects)
                 {
                     InternalLogger.Debug("Initialized Layout done but not scanned for objects");
                     PerformObjectScanning();
@@ -290,7 +290,7 @@ namespace NLog.Layouts
             this.StackTraceUsage = StackTraceUsage.None;    // Incase this Layout should implement IStackTraceUsage
             this.StackTraceUsage = objectGraphScannerList.OfType<IUsesStackTrace>().DefaultIfEmpty().Max(item => item == null ? StackTraceUsage.None : item.StackTraceUsage);
 
-            this.scannedForObjects = true;
+            this._scannedForObjects = true;
         }
 
         /// <summary>
@@ -298,10 +298,10 @@ namespace NLog.Layouts
         /// </summary>
         internal void Close()
         {
-            if (this.isInitialized)
+            if (this._isInitialized)
             {
                 this.LoggingConfiguration = null;
-                this.isInitialized = false;
+                this._isInitialized = false;
                 this.CloseLayout();
             }
         }

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -53,9 +53,9 @@ namespace NLog.Layouts
     [AppDomainFixedOutput]
     public class SimpleLayout : Layout, IUsesStackTrace
     {
-        private string fixedText;
-        private string layoutText;
-        private ConfigurationItemFactory configurationItemFactory;
+        private string _fixedText;
+        private string _layoutText;
+        private ConfigurationItemFactory _configurationItemFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleLayout" /> class.
@@ -81,13 +81,13 @@ namespace NLog.Layouts
         /// <param name="configurationItemFactory">The NLog factories to use when creating references to layout renderers.</param>
         public SimpleLayout(string txt, ConfigurationItemFactory configurationItemFactory)
         {
-            this.configurationItemFactory = configurationItemFactory;
+            this._configurationItemFactory = configurationItemFactory;
             this.Text = txt;
         }
 
         internal SimpleLayout(LayoutRenderer[] renderers, string text, ConfigurationItemFactory configurationItemFactory)
         {
-            this.configurationItemFactory = configurationItemFactory;
+            this._configurationItemFactory = configurationItemFactory;
             this.SetRenderers(renderers, text);
         }
 
@@ -104,7 +104,7 @@ namespace NLog.Layouts
         {
             get
             {
-                return this.layoutText;
+                return this._layoutText;
             }
 
             set
@@ -121,7 +121,7 @@ namespace NLog.Layouts
                 else
                 {
                     renderers = LayoutParser.CompileLayout(
-                       this.configurationItemFactory,
+                       this._configurationItemFactory,
                        new SimpleStringReader(value),
                        false,
                        out txt);
@@ -135,7 +135,7 @@ namespace NLog.Layouts
         /// </summary>
         public bool IsFixedText
         {
-            get { return this.fixedText != null; }
+            get { return this._fixedText != null; }
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace NLog.Layouts
         /// </summary>
         public string FixedText
         {
-            get { return fixedText; }
+            get { return _fixedText; }
         }
 
         /// <summary>
@@ -227,15 +227,15 @@ namespace NLog.Layouts
 
             if (this.Renderers.Count == 1 && this.Renderers[0] is LiteralLayoutRenderer)
             {
-                this.fixedText = ((LiteralLayoutRenderer)this.Renderers[0]).Text;
+                this._fixedText = ((LiteralLayoutRenderer)this.Renderers[0]).Text;
             }
             else
             {
                 //todo fixedText = null is also used if the text is fixed, but is a empty renderers not fixed?
-                this.fixedText = null;
+                this._fixedText = null;
             }
 
-            this.layoutText = text;
+            this._layoutText = text;
 
             if (this.LoggingConfiguration != null)
             {
@@ -285,7 +285,7 @@ namespace NLog.Layouts
         {
             if (IsFixedText)
             {
-                return this.fixedText;
+                return this._fixedText;
             }
 
             return RenderAllocateBuilder(logEvent);
@@ -330,7 +330,7 @@ namespace NLog.Layouts
         {
             if (IsFixedText)
             {
-                target.Append(this.fixedText);
+                target.Append(this._fixedText);
                 return;
             }
 

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -62,13 +62,13 @@ namespace NLog
 
         private static int globalSequenceId;
 
-        private string formattedMessage;
-        private string message;
-        private object[] parameters;
-        private IFormatProvider formatProvider;
-        private LogMessageFormatter messageFormatter = DefaultMessageFormatter;
-        private IDictionary<Layout, string> layoutCache;
-        private PropertiesDictionary properties;
+        private string _formattedMessage;
+        private string _message;
+        private object[] _parameters;
+        private IFormatProvider _formatProvider;
+        private LogMessageFormatter _messageFormatter = DefaultMessageFormatter;
+        private IDictionary<Layout, string> _layoutCache;
+        private PropertiesDictionary _properties;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LogEventInfo" /> class.
@@ -102,7 +102,7 @@ namespace NLog
         {
             if (messageTemplateParameters != null && messageTemplateParameters.Count > 0)
             {
-                this.properties = new PropertiesDictionary(messageTemplateParameters);
+                this._properties = new PropertiesDictionary(messageTemplateParameters);
             }
         }
 
@@ -224,11 +224,11 @@ namespace NLog
         /// </summary>
         public string Message
         {
-            get { return this.message; }
+            get { return this._message; }
             set
             {
                 bool rebuildMessageTemplateParameters = ResetMessageTemplateParameters();
-                this.message = value;
+                this._message = value;
                 ResetFormattedMessage(rebuildMessageTemplateParameters);
             }
         }
@@ -239,11 +239,11 @@ namespace NLog
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "For backwards compatibility.")]
         public object[] Parameters
         {
-            get { return this.parameters; }
+            get { return this._parameters; }
             set
             {
                 bool rebuildMessageTemplateParameters = ResetMessageTemplateParameters();
-                this.parameters = value;
+                this._parameters = value;
                 ResetFormattedMessage(rebuildMessageTemplateParameters);
             }
         }
@@ -254,12 +254,12 @@ namespace NLog
         /// </summary>
         public IFormatProvider FormatProvider
         {
-            get { return this.formatProvider; }
+            get { return this._formatProvider; }
             set
             {
-                if (this.formatProvider != value)
+                if (this._formatProvider != value)
                 {
-                    this.formatProvider = value;
+                    this._formatProvider = value;
                     ResetFormattedMessage(false);
                 }
             }
@@ -271,10 +271,10 @@ namespace NLog
         /// </summary>
         public LogMessageFormatter MessageFormatter
         {
-            get { return this.messageFormatter; }
+            get { return this._messageFormatter; }
             set
             {
-                this.messageFormatter = value ?? StringFormatMessageFormatter;
+                this._messageFormatter = value ?? StringFormatMessageFormatter;
                 ResetFormattedMessage(false);
             }
         }
@@ -286,12 +286,12 @@ namespace NLog
         {
             get 
             {
-                if (this.formattedMessage == null)
+                if (this._formattedMessage == null)
                 {
                     this.CalcFormattedMessage();
                 }
 
-                return this.formattedMessage;
+                return this._formattedMessage;
             }
         }
 
@@ -302,9 +302,9 @@ namespace NLog
         {
             get
             {
-                if (this.properties != null)
+                if (this._properties != null)
                 {
-                    return this.properties.Count > 0;
+                    return this._properties.Count > 0;
                 }
                 else
                 {
@@ -313,7 +313,7 @@ namespace NLog
             }
         }
 
-        internal PropertiesDictionary PropertiesDictionary { get { return this.properties; } set { this.properties = value; } }
+        internal PropertiesDictionary PropertiesDictionary { get { return this._properties; } set { this._properties = value; } }
 
         /// <summary>
         /// Gets the dictionary of per-event context properties.
@@ -330,23 +330,23 @@ namespace NLog
         /// <returns></returns>
         private PropertiesDictionary GetPropertiesInternal()
         {
-            if (this.properties == null)
+            if (this._properties == null)
             {
-                Interlocked.CompareExchange(ref this.properties, new PropertiesDictionary(), null);
+                Interlocked.CompareExchange(ref this._properties, new PropertiesDictionary(), null);
                 if (HasMessageTemplateParameters)
                 {
                     this.CalcFormattedMessage();
                     // MessageTemplateParameters have probably been created
                 }
             }
-            return this.properties;
+            return this._properties;
         }
 
         internal bool HasMessageTemplateParameters
         {
             get
             {
-                var logMessageFormatter = this.messageFormatter?.Target as ILogMessageFormatter;
+                var logMessageFormatter = this._messageFormatter?.Target as ILogMessageFormatter;
                 return logMessageFormatter?.HasProperties(this) ?? false;
             }
         }
@@ -358,13 +358,13 @@ namespace NLog
         {
             get
             {
-                if (this.properties != null && this.properties.MessageProperties.Count > 0)
+                if (this._properties != null && this._properties.MessageProperties.Count > 0)
                 {
-                    return new MessageTemplateParameters(this.properties.MessageProperties);
+                    return new MessageTemplateParameters(this._properties.MessageProperties);
                 }
                 else
                 {
-                    return new MessageTemplateParameters(this.parameters);
+                    return new MessageTemplateParameters(this._parameters);
                 }
             }
         }
@@ -500,13 +500,13 @@ namespace NLog
 
         internal string AddCachedLayoutValue(Layout layout, string value)
         {
-            if (this.layoutCache == null)
+            if (this._layoutCache == null)
             {
-                Interlocked.CompareExchange(ref this.layoutCache, new Dictionary<Layout, string>(), null);
+                Interlocked.CompareExchange(ref this._layoutCache, new Dictionary<Layout, string>(), null);
             }
-            lock (this.layoutCache)
+            lock (this._layoutCache)
             {
-                this.layoutCache[layout] = value;
+                this._layoutCache[layout] = value;
             }
 
             return value;
@@ -514,22 +514,22 @@ namespace NLog
 
         internal bool TryGetCachedLayoutValue(Layout layout, out string value)
         {
-            if (this.layoutCache == null)
+            if (this._layoutCache == null)
             {
                 // We don't need lock to see if dictionary has been created
                 value = null;
                 return false;
             }
 
-            lock (this.layoutCache)
+            lock (this._layoutCache)
             {
-                if (this.layoutCache.Count == 0)
+                if (this._layoutCache.Count == 0)
                 {
                     value = null;
                     return false;
                 }
 
-                return this.layoutCache.TryGetValue(layout, out value);
+                return this._layoutCache.TryGetValue(layout, out value);
             }
         }
 
@@ -592,11 +592,11 @@ namespace NLog
         {
             try
             {
-                this.formattedMessage = this.messageFormatter(this);
+                this._formattedMessage = this._messageFormatter(this);
             }
             catch (Exception exception)
             {
-                this.formattedMessage = this.Message;
+                this._formattedMessage = this.Message;
                 InternalLogger.Warn(exception, "Error when formatting a message.");
 
                 if (exception.MustBeRethrown())
@@ -608,7 +608,7 @@ namespace NLog
 
         private void ResetFormattedMessage(bool rebuildMessageTemplateParameters)
         {
-            this.formattedMessage = null;
+            this._formattedMessage = null;
             if (rebuildMessageTemplateParameters && HasMessageTemplateParameters)
             {
                 this.CalcFormattedMessage();
@@ -617,9 +617,9 @@ namespace NLog
 
         private bool ResetMessageTemplateParameters()
         {
-            if (this.properties != null && HasMessageTemplateParameters)
+            if (this._properties != null && HasMessageTemplateParameters)
             {
-                this.properties.MessageProperties = null;
+                this._properties.MessageProperties = null;
                 return true;
             }
             return false;

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -64,26 +64,26 @@ namespace NLog
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
         private const int ReconfigAfterFileChangedTimeout = 1000;
         internal Timer reloadTimer;
-        private readonly MultiFileWatcher watcher;
+        private readonly MultiFileWatcher _watcher;
 #endif
 
         private readonly static TimeSpan DefaultFlushTimeout = TimeSpan.FromSeconds(15);
 
         private static IAppDomain currentAppDomain;
-        private readonly object syncRoot = new object();
+        private readonly object _syncRoot = new object();
 
-        private LoggingConfiguration config;
-        private LogLevel globalThreshold = LogLevel.MinLevel;
-        private bool configLoaded;
+        private LoggingConfiguration _config;
+        private LogLevel _globalThreshold = LogLevel.MinLevel;
+        private bool _configLoaded;
         // TODO: logsEnabled property might be possible to be encapsulated into LogFactory.LogsEnabler class. 
-        private int logsEnabled;
-        private readonly LoggerCache loggerCache = new LoggerCache();
+        private int _logsEnabled;
+        private readonly LoggerCache _loggerCache = new LoggerCache();
 
         /// <summary>
         /// Overwrite possible file paths (including filename) for possible NLog config files. 
         /// When this property is <c>null</c>, the default file paths (<see cref="GetCandidateConfigFilePaths"/> are used.
         /// </summary>
-        private List<string> candidateConfigFilePaths;
+        private List<string> _candidateConfigFilePaths;
 
         /// <summary>
         /// Occurs when logging <see cref="Configuration" /> changes.
@@ -116,8 +116,8 @@ namespace NLog
         public LogFactory()
         {
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-            this.watcher = new MultiFileWatcher();
-            this.watcher.FileChanged += this.ConfigFileChanged;
+            this._watcher = new MultiFileWatcher();
+            this._watcher.FileChanged += this.ConfigFileChanged;
             LoggerShutdown += OnStopLogging;
 #endif
         }
@@ -183,23 +183,23 @@ namespace NLog
         {
             get
             {
-                if (this.configLoaded)
-                    return this.config;
+                if (this._configLoaded)
+                    return this._config;
 
-                lock (this.syncRoot)
+                lock (this._syncRoot)
                 {
-                    if (this.configLoaded)
-                        return this.config;
+                    if (this._configLoaded)
+                        return this._config;
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD
                     //load
 
-                    if (this.config == null)
+                    if (this._config == null)
                     {
                         try
                         {
                             // Try to load default configuration.
-                            this.config = XmlLoggingConfiguration.AppConfig;
+                            this._config = XmlLoggingConfiguration.AppConfig;
                         }
                         catch (Exception ex)
                         {
@@ -213,7 +213,7 @@ namespace NLog
                     }
 #endif
                     // Retest the condition as we might have loaded a config.
-                    if (this.config == null)
+                    if (this._config == null)
                     {
                         var configFileNames = GetCandidateConfigFilePaths();
                         foreach (string configFile in configFileNames)
@@ -258,15 +258,15 @@ namespace NLog
                     }
 #endif
 
-                    if (this.config != null)
+                    if (this._config != null)
                     {
                         try
                         {
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-                            config.Dump();
+                            _config.Dump();
                             try
                             {
-                                this.watcher.Watch(this.config.FileNamesToWatch);
+                                this._watcher.Watch(this._config.FileNamesToWatch);
                             }
                             catch (Exception exception)
                             {
@@ -279,17 +279,17 @@ namespace NLog
                                 //TODO NLog 5: check "MustBeRethrown" 
                             }
 #endif
-                            this.config.InitializeAll();
+                            this._config.InitializeAll();
 
                             LogConfigurationInitialized();
                         }
                         finally
                         {
-                            this.configLoaded = true;
+                            this._configLoaded = true;
                         }
                     }
 
-                    return this.config;
+                    return this._config;
                 }
             }
 
@@ -298,7 +298,7 @@ namespace NLog
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
                 try
                 {
-                    this.watcher.StopWatching();
+                    this._watcher.StopWatching();
                 }
                 catch (Exception exception)
                 {
@@ -311,9 +311,9 @@ namespace NLog
                 }
 #endif
 
-                lock (this.syncRoot)
+                lock (this._syncRoot)
                 {
-                    LoggingConfiguration oldConfig = this.config;
+                    LoggingConfiguration oldConfig = this._config;
                     if (oldConfig != null)
                     {
                         InternalLogger.Info("Closing old configuration.");
@@ -323,27 +323,27 @@ namespace NLog
                         oldConfig.Close();
                     }
 
-                    this.config = value;
+                    this._config = value;
 
-                    if (this.config == null)
-                        this.configLoaded = false;
+                    if (this._config == null)
+                        this._configLoaded = false;
                     else
                     {
                         try
                         {
-                            config.Dump();
+                            _config.Dump();
 
-                            this.config.InitializeAll();
+                            this._config.InitializeAll();
                             this.ReconfigExistingLoggers();
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
                             try
                             {
-                                this.watcher.Watch(this.config.FileNamesToWatch);
+                                this._watcher.Watch(this._config.FileNamesToWatch);
                             }
                             catch (Exception exception)
                             {
                                 //ToArray needed for .Net 3.5
-                                InternalLogger.Warn(exception, "Cannot start file watching: {0}", String.Join(",", this.config.FileNamesToWatch.ToArray()));
+                                InternalLogger.Warn(exception, "Cannot start file watching: {0}", String.Join(",", this._config.FileNamesToWatch.ToArray()));
 
                                 if (exception.MustBeRethrown())
                                 {
@@ -354,7 +354,7 @@ namespace NLog
                         }
                         finally
                         {
-                            this.configLoaded = true;
+                            this._configLoaded = true;
                         }
                     }
 
@@ -370,14 +370,14 @@ namespace NLog
         {
             get
             {
-                return this.globalThreshold;
+                return this._globalThreshold;
             }
 
             set
             {
-                lock (this.syncRoot)
+                lock (this._syncRoot)
                 {
-                    this.globalThreshold = value;
+                    this._globalThreshold = value;
                     this.ReconfigExistingLoggers();
                 }
             }
@@ -532,19 +532,19 @@ namespace NLog
         {
             IEnumerable<Logger> loggers;
 
-            lock (this.syncRoot)
+            lock (this._syncRoot)
             {
-                if (this.config != null)
+                if (this._config != null)
                 {
-                    this.config.InitializeAll();
+                    this._config.InitializeAll();
                 }
 
-                loggers = loggerCache.Loggers;
+                loggers = _loggerCache.Loggers;
             }
 
             foreach (var logger in loggers)
             {
-                logger.SetConfiguration(this.GetConfigurationForLogger(logger.Name, this.config));
+                logger.SetConfiguration(this.GetConfigurationForLogger(logger.Name, this._config));
             }
         }
 
@@ -685,10 +685,10 @@ namespace NLog
         /// To be used with C# <c>using ()</c> statement.</returns>
         public IDisposable SuspendLogging()
         {
-            lock (this.syncRoot)
+            lock (this._syncRoot)
             {
-                this.logsEnabled--;
-                if (this.logsEnabled == -1)
+                this._logsEnabled--;
+                if (this._logsEnabled == -1)
                 {
                     this.ReconfigExistingLoggers();
                 }
@@ -704,10 +704,10 @@ namespace NLog
         /// than or equal to <see cref="SuspendLogging"/> calls.</remarks>
         public void ResumeLogging()
         {
-            lock (this.syncRoot)
+            lock (this._syncRoot)
             {
-                this.logsEnabled++;
-                if (this.logsEnabled == 0)
+                this._logsEnabled++;
+                if (this._logsEnabled == 0)
                 {
                     this.ReconfigExistingLoggers();
                 }
@@ -723,7 +723,7 @@ namespace NLog
         /// than or equal to <see cref="SuspendLogging"/> calls.</remarks>
         public bool IsLoggingEnabled()
         {
-            return this.logsEnabled >= 0;
+            return this._logsEnabled >= 0;
         }
 
         /// <summary>
@@ -753,7 +753,7 @@ namespace NLog
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
         internal void ReloadConfigOnTimer(object state)
         {
-            if (this.reloadTimer == null && this.IsDisposing)
+            if (this.reloadTimer == null && this._isDisposing)
             {
                 return; //timer was disposed already. 
             }
@@ -761,11 +761,11 @@ namespace NLog
             LoggingConfiguration configurationToReload = (LoggingConfiguration)state;
 
             InternalLogger.Info("Reloading configuration...");
-            lock (this.syncRoot)
+            lock (this._syncRoot)
             {
                 try
                 {
-                    if (this.IsDisposing)
+                    if (this._isDisposing)
                     {
                         return; //timer was disposed already. 
                     }
@@ -777,7 +777,7 @@ namespace NLog
                         currentTimer.WaitForDispose(TimeSpan.Zero);
                     }
 
-                    this.watcher.StopWatching();
+                    this._watcher.StopWatching();
 
                     if (this.Configuration != configurationToReload)
                     {
@@ -800,9 +800,9 @@ namespace NLog
 
                     if (newConfig != null)
                     {
-                        if (this.KeepVariablesOnReload && this.config != null)
+                        if (this.KeepVariablesOnReload && this._config != null)
                         {
-                            newConfig.CopyVariables(this.config.Variables);
+                            newConfig.CopyVariables(this._config.Variables);
                         }
                         this.Configuration = newConfig;
                         OnConfigurationReloaded(new LoggingConfigurationReloadedEventArgs(true));
@@ -821,7 +821,7 @@ namespace NLog
                         throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                     }
 
-                    this.watcher.Watch(configurationToReload.FileNamesToWatch);
+                    this._watcher.Watch(configurationToReload.FileNamesToWatch);
                     OnConfigurationReloaded(new LoggingConfigurationReloadedEventArgs(false, exception));
                 }
             }
@@ -918,29 +918,29 @@ namespace NLog
         /// <summary>
         /// Currently this logfactory is disposing?
         /// </summary>
-        private bool IsDisposing;
+        private bool _isDisposing;
 
         private  void Close(TimeSpan flushTimeout)
         {
-            if (this.IsDisposing)
+            if (this._isDisposing)
             {
                 return;
             }
 
-            this.IsDisposing = true;
+            this._isDisposing = true;
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
             LoggerShutdown -= OnStopLogging;
             this.ConfigurationReloaded = null;   // Release event listeners
 
-            if (this.watcher != null)
+            if (this._watcher != null)
             {
                 // Disable startup of new reload-timers
-                this.watcher.FileChanged -= this.ConfigFileChanged;
+                this._watcher.FileChanged -= this.ConfigFileChanged;
             }
 #endif
 
-            if (Monitor.TryEnter(this.syncRoot, 500))
+            if (Monitor.TryEnter(this._syncRoot, 500))
             {
                 try
                 {
@@ -952,15 +952,15 @@ namespace NLog
                         currentTimer.WaitForDispose(TimeSpan.Zero);
                     }
 
-                    if (this.watcher != null)
+                    if (this._watcher != null)
                     {
                         // Dispose file-watcher after having dispose timer to avoid race
-                        this.watcher.Dispose();
+                        this._watcher.Dispose();
                     }
 #endif
 
-                    var oldConfig = this.config;
-                    if (this.configLoaded && oldConfig != null)
+                    var oldConfig = this._config;
+                    if (this._configLoaded && oldConfig != null)
                     {
                         try
                         {
@@ -982,7 +982,7 @@ namespace NLog
                             {
                                 // Flush completed within timeout, lets try and close down
                                 oldConfig.Close();
-                                this.config = null;
+                                this._config = null;
                                 this.OnConfigurationChanged(new LoggingConfigurationChangedEventArgs(null, oldConfig));
                             }
                         }
@@ -994,7 +994,7 @@ namespace NLog
                 }
                 finally
                 {
-                    Monitor.Exit(this.syncRoot);
+                    Monitor.Exit(this._syncRoot);
                 }
             }
 
@@ -1017,7 +1017,7 @@ namespace NLog
         internal void Shutdown()
         {
             InternalLogger.Info("Logger closing down...");
-            if (!IsDisposing && configLoaded)
+            if (!_isDisposing && _configLoaded)
             {
                 var loadedConfig = Configuration;
                 if (loadedConfig != null)
@@ -1037,9 +1037,9 @@ namespace NLog
         /// <returns>The filepaths to the possible config file</returns>
         public IEnumerable<string> GetCandidateConfigFilePaths()
         {
-            if (candidateConfigFilePaths != null)
+            if (_candidateConfigFilePaths != null)
             {
-                return candidateConfigFilePaths.AsReadOnly();
+                return _candidateConfigFilePaths.AsReadOnly();
             }
 
             return GetDefaultCandidateConfigFilePaths();
@@ -1051,11 +1051,11 @@ namespace NLog
         /// <param name="filePaths">The filepaths to the possible config file</param>
         public void SetCandidateConfigFilePaths(IEnumerable<string> filePaths)
         {
-            candidateConfigFilePaths = new List<string>();
+            _candidateConfigFilePaths = new List<string>();
 
             if (filePaths != null)
             {
-                candidateConfigFilePaths.AddRange(filePaths);
+                _candidateConfigFilePaths.AddRange(filePaths);
             }
         }
         /// <summary>
@@ -1063,7 +1063,7 @@ namespace NLog
         /// </summary>
         public void ResetCandidateConfigFilePath()
         {
-            candidateConfigFilePaths = null;
+            _candidateConfigFilePaths = null;
         }
 
         /// <summary>
@@ -1122,9 +1122,9 @@ namespace NLog
 
         private Logger GetLogger(LoggerCacheKey cacheKey)
         {
-            lock (this.syncRoot)
+            lock (this._syncRoot)
             {
-                Logger existingLogger = loggerCache.Retrieve(cacheKey);
+                Logger existingLogger = _loggerCache.Retrieve(cacheKey);
                 if (existingLogger != null)
                 {
                     // Logger is still in cache and referenced.
@@ -1201,7 +1201,7 @@ namespace NLog
                 //      will remain null and inserted into the cache. 
                 //      Should we set cacheKey.ConcreteType = typeof(Logger) for default loggers?
 
-                loggerCache.InsertOrUpdate(cacheKey, newLogger);
+                _loggerCache.InsertOrUpdate(cacheKey, newLogger);
                 return newLogger;
             }
         }
@@ -1217,7 +1217,7 @@ namespace NLog
         private void LoadLoggingConfiguration(string configFile)
         {
             InternalLogger.Debug("Loading config from {0}", configFile);
-            this.config = new XmlLoggingConfiguration(configFile, this);
+            this._config = new XmlLoggingConfiguration(configFile, this);
         }
 
 
@@ -1231,9 +1231,9 @@ namespace NLog
             //
             // The trick is to schedule the reload in one second after
             // the last change notification comes in.
-            lock (this.syncRoot)
+            lock (this._syncRoot)
             {
-                if (this.IsDisposing)
+                if (this._isDisposing)
                 {
                     return;
                 }
@@ -1311,7 +1311,7 @@ namespace NLog
         private class LoggerCache
         {
             // The values of WeakReferences are of type Logger i.e. Directory<LoggerCacheKey, Logger>.
-            private readonly Dictionary<LoggerCacheKey, WeakReference> loggerCache =
+            private readonly Dictionary<LoggerCacheKey, WeakReference> _loggerCache =
                     new Dictionary<LoggerCacheKey, WeakReference>();
 
             /// <summary>
@@ -1321,13 +1321,13 @@ namespace NLog
             /// <param name="logger"></param>
             public void InsertOrUpdate(LoggerCacheKey cacheKey, Logger logger)
             {
-                loggerCache[cacheKey] = new WeakReference(logger);
+                _loggerCache[cacheKey] = new WeakReference(logger);
             }
 
             public Logger Retrieve(LoggerCacheKey cacheKey)
             {
                 WeakReference loggerReference;
-                if (loggerCache.TryGetValue(cacheKey, out loggerReference))
+                if (_loggerCache.TryGetValue(cacheKey, out loggerReference))
                 {
                     // logger in the cache and still referenced
                     return loggerReference.Target as Logger;
@@ -1344,9 +1344,9 @@ namespace NLog
             private IEnumerable<Logger> GetLoggers()
             {
                 // TODO: Test if loggerCache.Values.ToList<Logger>() can be used for the conversion instead.
-                List<Logger> values = new List<Logger>(loggerCache.Count);
+                List<Logger> values = new List<Logger>(_loggerCache.Count);
 
-                foreach (WeakReference loggerReference in loggerCache.Values)
+                foreach (WeakReference loggerReference in _loggerCache.Values)
                 {
                     Logger logger = loggerReference.Target as Logger;
                     if (logger != null)
@@ -1364,7 +1364,7 @@ namespace NLog
         /// </summary>
         private class LogEnabler : IDisposable
         {
-            private LogFactory factory;
+            private LogFactory _factory;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="LogEnabler" /> class.
@@ -1372,7 +1372,7 @@ namespace NLog
             /// <param name="factory">The factory.</param>
             public LogEnabler(LogFactory factory)
             {
-                this.factory = factory;
+                this._factory = factory;
             }
 
             /// <summary>
@@ -1380,7 +1380,7 @@ namespace NLog
             /// </summary>
             void IDisposable.Dispose()
             {
-                this.factory.ResumeLogging();
+                this._factory.ResumeLogging();
             }
         }
 

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -70,7 +70,11 @@ namespace NLog
         private readonly static TimeSpan DefaultFlushTimeout = TimeSpan.FromSeconds(15);
 
         private static IAppDomain currentAppDomain;
-        private readonly object _syncRoot = new object();
+
+        /// <remarks>
+        /// Internal for unit tests
+        /// </remarks>
+        internal readonly object _syncRoot = new object();
 
         private LoggingConfiguration _config;
         private LogLevel _globalThreshold = LogLevel.MinLevel;
@@ -236,7 +240,7 @@ namespace NLog
                     }
 
 #if __ANDROID__
-                    if (this.config == null)
+                    if (this._config == null)
                     {
                         //try nlog.config in assets folder
                         const string nlogConfigFilename = "NLog.config";

--- a/src/NLog/LogLevel.cs
+++ b/src/NLog/LogLevel.cs
@@ -104,8 +104,8 @@ namespace NLog
         public static IEnumerable<LogLevel> AllLoggingLevels { get { return allLoggingLevels; } }
 
 
-        private readonly int ordinal;
-        private readonly string name;
+        private readonly int _ordinal;
+        private readonly string _name;
 
         /// <summary>
         /// Initializes a new instance of <see cref="LogLevel"/>.
@@ -114,8 +114,8 @@ namespace NLog
         /// <param name="ordinal">The log level ordinal number.</param>
         private LogLevel(string name, int ordinal)
         {
-            this.name = name;
-            this.ordinal = ordinal;
+            this._name = name;
+            this._ordinal = ordinal;
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace NLog
         /// </summary>
         public string Name
         {
-            get { return this.name; }
+            get { return this._name; }
         }
 
         internal static LogLevel MaxLevel
@@ -141,7 +141,7 @@ namespace NLog
         /// </summary>
         public int Ordinal
         {
-            get { return this.ordinal; }
+            get { return this._ordinal; }
         }
 
         /// <summary>

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -52,7 +52,10 @@ namespace NLog
     /// </summary>
     public static class LogManager
     {
-        private static readonly LogFactory factory = new LogFactory();
+        /// <remarks>
+        /// Internal for unit tests
+        /// </remarks>
+        internal static readonly LogFactory factory = new LogFactory();
         private static ICollection<Assembly> _hiddenAssemblies;
 
         private static readonly object lockObject = new object();

--- a/src/NLog/LogReceiverService/BaseLogReceiverForwardingService.cs
+++ b/src/NLog/LogReceiverService/BaseLogReceiverForwardingService.cs
@@ -43,7 +43,7 @@ namespace NLog.LogReceiverService
     /// </summary>
     public abstract class BaseLogReceiverForwardingService
     {
-        private readonly LogFactory logFactory;
+        private readonly LogFactory _logFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseLogReceiverForwardingService"/> class.
@@ -59,7 +59,7 @@ namespace NLog.LogReceiverService
         /// <param name="logFactory">The log factory.</param>
         protected BaseLogReceiverForwardingService(LogFactory logFactory)
         {
-            this.logFactory = logFactory;
+            this._logFactory = logFactory;
         }
 
         /// <summary>
@@ -108,9 +108,9 @@ namespace NLog.LogReceiverService
             {
                 if (ev.LoggerName != lastLoggerName)
                 {
-                    if (this.logFactory != null)
+                    if (this._logFactory != null)
                     {
-                        logger = this.logFactory.GetLogger(ev.LoggerName);
+                        logger = this._logFactory.GetLogger(ev.LoggerName);
                     }
                     else
                     {

--- a/src/NLog/Logger-generated.cs
+++ b/src/NLog/Logger-generated.cs
@@ -48,7 +48,7 @@ namespace NLog
         /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Trace</c> level, otherwise it returns <see langword="false" />.</returns>
         public bool IsTraceEnabled
         {
-            get { return this.isTraceEnabled; }
+            get { return this._isTraceEnabled; }
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace NLog
         /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Debug</c> level, otherwise it returns <see langword="false" />.</returns>
         public bool IsDebugEnabled
         {
-            get { return this.isDebugEnabled; }
+            get { return this._isDebugEnabled; }
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace NLog
         /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Info</c> level, otherwise it returns <see langword="false" />.</returns>
         public bool IsInfoEnabled
         {
-            get { return this.isInfoEnabled; }
+            get { return this._isInfoEnabled; }
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace NLog
         /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Warn</c> level, otherwise it returns <see langword="false" />.</returns>
         public bool IsWarnEnabled
         {
-            get { return this.isWarnEnabled; }
+            get { return this._isWarnEnabled; }
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace NLog
         /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Error</c> level, otherwise it returns <see langword="false" />.</returns>
         public bool IsErrorEnabled
         {
-            get { return this.isErrorEnabled; }
+            get { return this._isErrorEnabled; }
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace NLog
         /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Fatal</c> level, otherwise it returns <see langword="false" />.</returns>
         public bool IsFatalEnabled
         {
-            get { return this.isFatalEnabled; }
+            get { return this._isFatalEnabled; }
         }
 
 
@@ -287,7 +287,7 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (this.configuration.ExceptionLoggingOldStyle)
+                if (this._configuration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
                     var exceptionCandidate = argument as Exception;		
@@ -573,7 +573,7 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (this.configuration.ExceptionLoggingOldStyle)
+                if (this._configuration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
                     var exceptionCandidate = argument as Exception;		
@@ -859,7 +859,7 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (this.configuration.ExceptionLoggingOldStyle)
+                if (this._configuration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
                     var exceptionCandidate = argument as Exception;		
@@ -1145,7 +1145,7 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (this.configuration.ExceptionLoggingOldStyle)
+                if (this._configuration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
                     var exceptionCandidate = argument as Exception;		
@@ -1431,7 +1431,7 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (this.configuration.ExceptionLoggingOldStyle)
+                if (this._configuration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
                     var exceptionCandidate = argument as Exception;		
@@ -1717,7 +1717,7 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (this.configuration.ExceptionLoggingOldStyle)
+                if (this._configuration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
                     var exceptionCandidate = argument as Exception;		

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -50,15 +50,15 @@ namespace NLog
     [CLSCompliant(true)]
     public partial class Logger : ILogger
     {
-        private readonly Type loggerType = typeof(Logger);
+        private readonly Type _loggerType = typeof(Logger);
 
-        private volatile LoggerConfiguration configuration;
-        private volatile bool isTraceEnabled;
-        private volatile bool isDebugEnabled;
-        private volatile bool isInfoEnabled;
-        private volatile bool isWarnEnabled;
-        private volatile bool isErrorEnabled;
-        private volatile bool isFatalEnabled;
+        private volatile LoggerConfiguration _configuration;
+        private volatile bool _isTraceEnabled;
+        private volatile bool _isDebugEnabled;
+        private volatile bool _isInfoEnabled;
+        private volatile bool _isWarnEnabled;
+        private volatile bool _isErrorEnabled;
+        private volatile bool _isFatalEnabled;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Logger"/> class.
@@ -388,12 +388,12 @@ namespace NLog
 
         internal void WriteToTargets(LogLevel level, Exception ex, [Localizable(false)] string message, object[] args)
         {
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, ex, this.Factory.DefaultCultureInfo, message, args)), this.Factory);
+            LoggerImpl.Write(this._loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, ex, this.Factory.DefaultCultureInfo, message, args)), this.Factory);
         }
 
         internal void WriteToTargets(LogLevel level, Exception ex, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)
         {
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, ex, formatProvider, message, args)), this.Factory);
+            LoggerImpl.Write(this._loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, ex, formatProvider, message, args)), this.Factory);
         }
 
 
@@ -553,7 +553,7 @@ namespace NLog
 
         internal void WriteToTargets(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, object[] args)
         {
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, formatProvider, message, args)), this.Factory);
+            LoggerImpl.Write(this._loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, formatProvider, message, args)), this.Factory);
         }
 
         internal void WriteToTargets(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message)
@@ -561,7 +561,7 @@ namespace NLog
             // please note that this overload calls the overload of LogEventInfo.Create with object[] parameter on purpose -
             // to avoid unnecessary string.Format (in case of calling Create(LogLevel, string, IFormatProvider, object))
             var logEvent = LogEventInfo.Create(level, this.Name, formatProvider, message, (object[])null);
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(logEvent), this.Factory);
+            LoggerImpl.Write(this._loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(logEvent), this.Factory);
         }
 
         internal void WriteToTargets<T>(LogLevel level, IFormatProvider formatProvider, T value)
@@ -574,13 +574,13 @@ namespace NLog
                 logEvent.Exception = ex;
              
             }
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), logEvent, this.Factory);
+            LoggerImpl.Write(this._loggerType, this.GetTargetsForLevel(level), logEvent, this.Factory);
         }
 
         [Obsolete("Use WriteToTargets(Exception ex, LogLevel level, IFormatProvider formatProvider, string message, object[] args) method instead. Marked obsolete before v4.3.11")]
         internal void WriteToTargets(LogLevel level, [Localizable(false)] string message, Exception ex)
         {
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, message, ex)), this.Factory);
+            LoggerImpl.Write(this._loggerType, this.GetTargetsForLevel(level), PrepareLogEventInfo(LogEventInfo.Create(level, this.Name, message, ex)), this.Factory);
         }
 
         internal void WriteToTargets(LogLevel level, [Localizable(false)] string message, object[] args)
@@ -590,32 +590,32 @@ namespace NLog
 
         internal void WriteToTargets(LogEventInfo logEvent)
         {
-            LoggerImpl.Write(this.loggerType, this.GetTargetsForLevel(logEvent.Level), PrepareLogEventInfo(logEvent), this.Factory);
+            LoggerImpl.Write(this._loggerType, this.GetTargetsForLevel(logEvent.Level), PrepareLogEventInfo(logEvent), this.Factory);
         }
 
         internal void WriteToTargets(Type wrapperType, LogEventInfo logEvent)
         {
-            LoggerImpl.Write(wrapperType ?? this.loggerType, this.GetTargetsForLevel(logEvent.Level), PrepareLogEventInfo(logEvent), this.Factory);
+            LoggerImpl.Write(wrapperType ?? this._loggerType, this.GetTargetsForLevel(logEvent.Level), PrepareLogEventInfo(logEvent), this.Factory);
         }
 
         internal void SetConfiguration(LoggerConfiguration newConfiguration)
         {
-            this.configuration = newConfiguration;
+            this._configuration = newConfiguration;
 
             // pre-calculate 'enabled' flags
-            this.isTraceEnabled = newConfiguration.IsEnabled(LogLevel.Trace);
-            this.isDebugEnabled = newConfiguration.IsEnabled(LogLevel.Debug);
-            this.isInfoEnabled = newConfiguration.IsEnabled(LogLevel.Info);
-            this.isWarnEnabled = newConfiguration.IsEnabled(LogLevel.Warn);
-            this.isErrorEnabled = newConfiguration.IsEnabled(LogLevel.Error);
-            this.isFatalEnabled = newConfiguration.IsEnabled(LogLevel.Fatal);
+            this._isTraceEnabled = newConfiguration.IsEnabled(LogLevel.Trace);
+            this._isDebugEnabled = newConfiguration.IsEnabled(LogLevel.Debug);
+            this._isInfoEnabled = newConfiguration.IsEnabled(LogLevel.Info);
+            this._isWarnEnabled = newConfiguration.IsEnabled(LogLevel.Warn);
+            this._isErrorEnabled = newConfiguration.IsEnabled(LogLevel.Error);
+            this._isFatalEnabled = newConfiguration.IsEnabled(LogLevel.Fatal);
 
             OnLoggerReconfigured(EventArgs.Empty);
         }
 
         private TargetWithFilterChain GetTargetsForLevel(LogLevel level)
         {
-            return this.configuration.GetTargetsForLevel(level);
+            return this._configuration.GetTargetsForLevel(level);
         }
 
         /// <summary>

--- a/src/NLog/NLogTraceListener.cs
+++ b/src/NLog/NLogTraceListener.cs
@@ -49,12 +49,12 @@ namespace NLog
     public class NLogTraceListener : TraceListener
     {
         private static readonly Assembly systemAssembly = typeof(Trace).Assembly;
-        private LogFactory logFactory;
-        private LogLevel defaultLogLevel = LogLevel.Debug;
-        private bool attributesLoaded;
-        private bool autoLoggerName;
-        private LogLevel forceLogLevel;
-        private bool disableFlush;
+        private LogFactory _logFactory;
+        private LogLevel _defaultLogLevel = LogLevel.Debug;
+        private bool _attributesLoaded;
+        private bool _autoLoggerName;
+        private LogLevel _forceLogLevel;
+        private bool _disableFlush;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NLogTraceListener"/> class.
@@ -71,13 +71,13 @@ namespace NLog
             get
             {
                 this.InitAttributes();
-                return this.logFactory;
+                return this._logFactory;
             }
 
             set
             {
-                this.attributesLoaded = true;
-                this.logFactory = value;
+                this._attributesLoaded = true;
+                this._logFactory = value;
             }
         }
 
@@ -89,13 +89,13 @@ namespace NLog
             get
             {
                 this.InitAttributes();
-                return this.defaultLogLevel;
+                return this._defaultLogLevel;
             }
 
             set
             {
-                this.attributesLoaded = true;
-                this.defaultLogLevel = value;
+                this._attributesLoaded = true;
+                this._defaultLogLevel = value;
             }
         }
 
@@ -107,13 +107,13 @@ namespace NLog
             get
             {
                 this.InitAttributes();
-                return this.forceLogLevel;
+                return this._forceLogLevel;
             }
 
             set
             {
-                this.attributesLoaded = true;
-                this.forceLogLevel = value;
+                this._attributesLoaded = true;
+                this._forceLogLevel = value;
             }
         }
 
@@ -125,13 +125,13 @@ namespace NLog
             get
             {
                 this.InitAttributes();
-                return this.disableFlush;
+                return this._disableFlush;
             }
 
             set
             {
-                this.attributesLoaded = true;
-                this.disableFlush = value;
+                this._attributesLoaded = true;
+                this._disableFlush = value;
             }
         }
 
@@ -153,13 +153,13 @@ namespace NLog
             get
             {
                 this.InitAttributes();
-                return this.autoLoggerName;
+                return this._autoLoggerName;
             }
 
             set
             {
-                this.attributesLoaded = true;
-                this.autoLoggerName = value;
+                this._attributesLoaded = true;
+                this._autoLoggerName = value;
             }
         }
 
@@ -437,7 +437,7 @@ namespace NLog
                 logger = LogManager.GetLogger(loggerName);
             }
 
-            logLevel = this.forceLogLevel ?? logLevel;
+            logLevel = this._forceLogLevel ?? logLevel;
             if (!logger.IsEnabled(logLevel))
             {
                 return; // We are done
@@ -458,7 +458,7 @@ namespace NLog
 
             ev.Message = message;
             ev.Parameters = arguments;
-            ev.Level = this.forceLogLevel ?? logLevel;
+            ev.Level = this._forceLogLevel ?? logLevel;
 
             if (eventId.HasValue)
             {
@@ -475,9 +475,9 @@ namespace NLog
 
         private void InitAttributes()
         {
-            if (!this.attributesLoaded)
+            if (!this._attributesLoaded)
             {
-                this.attributesLoaded = true;
+                this._attributesLoaded = true;
                 foreach (DictionaryEntry de in this.Attributes)
                 {
                     var key = (string)de.Key;
@@ -486,11 +486,11 @@ namespace NLog
                     switch (key.ToUpperInvariant())
                     {
                         case "DEFAULTLOGLEVEL":
-                            this.defaultLogLevel = LogLevel.FromString(value);
+                            this._defaultLogLevel = LogLevel.FromString(value);
                             break;
 
                         case "FORCELOGLEVEL":
-                            this.forceLogLevel = LogLevel.FromString(value);
+                            this._forceLogLevel = LogLevel.FromString(value);
                             break;
 
                         case "AUTOLOGGERNAME":
@@ -498,7 +498,7 @@ namespace NLog
                             break;
 
                         case "DISABLEFLUSH":
-                            this.disableFlush = Boolean.Parse(value);
+                            this._disableFlush = Boolean.Parse(value);
                             break;
                     }
                 }

--- a/src/NLog/NestedDiagnosticsContext.cs
+++ b/src/NLog/NestedDiagnosticsContext.cs
@@ -171,8 +171,8 @@ namespace NLog
         /// </summary>
         private class StackPopper : IDisposable
         {
-            private Stack<object> stack;
-            private int previousCount;
+            private Stack<object> _stack;
+            private int _previousCount;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="StackPopper" /> class.
@@ -181,8 +181,8 @@ namespace NLog
             /// <param name="previousCount">The previous count.</param>
             public StackPopper(Stack<object> stack, int previousCount)
             {
-                this.stack = stack;
-                this.previousCount = previousCount;
+                this._stack = stack;
+                this._previousCount = previousCount;
             }
 
             /// <summary>
@@ -190,9 +190,9 @@ namespace NLog
             /// </summary>
             void IDisposable.Dispose()
             {
-                while (this.stack.Count > this.previousCount)
+                while (this._stack.Count > this._previousCount)
                 {
-                    this.stack.Pop();
+                    this._stack.Pop();
                 }
             }
         }

--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -66,7 +66,7 @@ namespace NLog.Targets
         ///   TextWriter's Synchronized methods.This also applies to classes like StreamWriter and StreamReader.
         /// 
         /// </remarks>
-        private bool pauseLogging;
+        private bool _pauseLogging;
 
         private static readonly IList<ConsoleRowHighlightingRule> DefaultConsoleRowHighlightingRules = new List<ConsoleRowHighlightingRule>()
         {
@@ -89,7 +89,7 @@ namespace NLog.Targets
             this.WordHighlightingRules = new List<ConsoleWordHighlightingRule>();
             this.RowHighlightingRules = new List<ConsoleRowHighlightingRule>();
             this.UseDefaultRowHighlightingRules = true;
-            this.pauseLogging = false;
+            this._pauseLogging = false;
             this.DetectConsoleAvailable = false;
             this.OptimizeBufferReuse = true;
         }
@@ -169,15 +169,15 @@ namespace NLog.Targets
         {
             get
             {
-                return ConsoleTargetHelper.GetConsoleOutputEncoding(this.encoding, this.IsInitialized, this.pauseLogging);
+                return ConsoleTargetHelper.GetConsoleOutputEncoding(this._encoding, this.IsInitialized, this._pauseLogging);
             }
             set
             {
-                if (ConsoleTargetHelper.SetConsoleOutputEncoding(value, this.IsInitialized, this.pauseLogging))
-                    encoding = value;
+                if (ConsoleTargetHelper.SetConsoleOutputEncoding(value, this.IsInitialized, this._pauseLogging))
+                    _encoding = value;
             }
         }
-        private Encoding encoding;
+        private Encoding _encoding;
 #endif
 
         /// <summary>
@@ -207,19 +207,19 @@ namespace NLog.Targets
         /// </summary>
         protected override void InitializeTarget()
         {
-            this.pauseLogging = false;
+            this._pauseLogging = false;
             if (DetectConsoleAvailable)
             {
                 string reason;
-                pauseLogging = !ConsoleTargetHelper.IsConsoleAvailable(out reason);
-                if (pauseLogging)
+                _pauseLogging = !ConsoleTargetHelper.IsConsoleAvailable(out reason);
+                if (_pauseLogging)
                 {
                     InternalLogger.Info("Console has been detected as turned off. Disable DetectConsoleAvailable to skip detection. Reason: {0}", reason);
                 }
             }
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-            if (this.encoding != null && !this.pauseLogging)
-                Console.OutputEncoding = this.encoding;
+            if (this._encoding != null && !this._pauseLogging)
+                Console.OutputEncoding = this._encoding;
 #endif
             base.InitializeTarget();
             if (this.Header != null)
@@ -250,7 +250,7 @@ namespace NLog.Targets
         /// <param name="logEvent">Log event.</param>
         protected override void Write(LogEventInfo logEvent)
         {
-            if (pauseLogging)
+            if (_pauseLogging)
             {
                 //check early for performance
                 return;
@@ -301,14 +301,14 @@ namespace NLog.Targets
                 catch (IndexOutOfRangeException ex)
                 {
                     //this is a bug and therefor stopping logging. For docs, see PauseLogging property
-                    pauseLogging = true;
+                    _pauseLogging = true;
                     InternalLogger.Warn(ex, "An IndexOutOfRangeException has been thrown and this is probably due to a race condition." +
                                             "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets");
                 }
                 catch (ArgumentOutOfRangeException ex)
                 {
                     //this is a bug and therefor stopping logging. For docs, see PauseLogging property
-                    pauseLogging = true;
+                    _pauseLogging = true;
                     InternalLogger.Warn(ex, "An ArgumentOutOfRangeException has been thrown and this is probably due to a race condition." +
                                             "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets");
                 }
@@ -450,23 +450,23 @@ namespace NLog.Targets
         /// </summary>
         internal struct ColorPair
         {
-            private readonly ConsoleColor foregroundColor;
-            private readonly ConsoleColor backgroundColor;
+            private readonly ConsoleColor _foregroundColor;
+            private readonly ConsoleColor _backgroundColor;
 
             internal ColorPair(ConsoleColor foregroundColor, ConsoleColor backgroundColor)
             {
-                this.foregroundColor = foregroundColor;
-                this.backgroundColor = backgroundColor;
+                this._foregroundColor = foregroundColor;
+                this._backgroundColor = backgroundColor;
             }
 
             internal ConsoleColor BackgroundColor
             {
-                get { return this.backgroundColor; }
+                get { return this._backgroundColor; }
             }
 
             internal ConsoleColor ForegroundColor
             {
-                get { return this.foregroundColor; }
+                get { return this._foregroundColor; }
             }
         }
     }

--- a/src/NLog/Targets/ConsoleWordHighlightingRule.cs
+++ b/src/NLog/Targets/ConsoleWordHighlightingRule.cs
@@ -47,7 +47,7 @@ namespace NLog.Targets
     [NLogConfigurationItem]
     public class ConsoleWordHighlightingRule
     {
-        private Regex compiledRegex;
+        private Regex _compiledRegex;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConsoleWordHighlightingRule" /> class.
@@ -126,7 +126,7 @@ namespace NLog.Targets
             get
             {
                 //compile regex on first usage.
-                if (this.compiledRegex == null)
+                if (this._compiledRegex == null)
                 {
                     var regexpression = GetRegexExpression();
                     if (regexpression == null)
@@ -136,10 +136,10 @@ namespace NLog.Targets
                     }
 
                     var regexOptions = GetRegexOptions(RegexOptions.Compiled);
-                    this.compiledRegex = new Regex(regexpression, regexOptions);
+                    this._compiledRegex = new Regex(regexpression, regexOptions);
                 }
 
-                return this.compiledRegex;
+                return this._compiledRegex;
             }
         }
 

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -83,8 +83,8 @@ namespace NLog.Targets
     {
         private static Assembly systemDataAssembly = typeof(IDbConnection).Assembly;
 
-        private IDbConnection activeConnection = null;
-        private string activeConnectionString;
+        private IDbConnection _activeConnection = null;
+        private string _activeConnectionString;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DatabaseTarget" /> class.
@@ -543,7 +543,7 @@ namespace NLog.Targets
             {
                 this.EnsureConnectionOpen(this.BuildConnectionString(logEvent));
 
-                using (IDbCommand command = this.activeConnection.CreateCommand())
+                using (IDbCommand command = this._activeConnection.CreateCommand())
                 {
                     command.CommandText = base.RenderLogEvent(this.CommandText, logEvent);
                     command.CommandType = this.CommandType;
@@ -635,33 +635,33 @@ namespace NLog.Targets
 
         private void EnsureConnectionOpen(string connectionString)
         {
-            if (this.activeConnection != null)
+            if (this._activeConnection != null)
             {
-                if (this.activeConnectionString != connectionString)
+                if (this._activeConnectionString != connectionString)
                 {
                     InternalLogger.Trace("DatabaseTarget: close connection because of opening new.");
                     this.CloseConnection();
                 }
             }
 
-            if (this.activeConnection != null)
+            if (this._activeConnection != null)
             {
                 return;
             }
 
             InternalLogger.Trace("DatabaseTarget: open connection.");
-            this.activeConnection = this.OpenConnection(connectionString);
-            this.activeConnectionString = connectionString;
+            this._activeConnection = this.OpenConnection(connectionString);
+            this._activeConnectionString = connectionString;
         }
 
         private void CloseConnection()
         {
-            if (this.activeConnection != null)
+            if (this._activeConnection != null)
             {
-                this.activeConnection.Close();
-                this.activeConnection.Dispose();
-                this.activeConnection = null;
-                this.activeConnectionString = null;
+                this._activeConnection.Close();
+                this._activeConnection.Dispose();
+                this._activeConnection = null;
+                this._activeConnectionString = null;
             }
         }
 
@@ -701,7 +701,7 @@ namespace NLog.Targets
 
                     this.EnsureConnectionOpen(cs);
 
-                    using (var command = this.activeConnection.CreateCommand())
+                    using (var command = this._activeConnection.CreateCommand())
                     {
                         command.CommandType = commandInfo.CommandType;
                         command.CommandText = base.RenderLogEvent(commandInfo.Text, logEvent);

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -86,69 +86,69 @@ namespace NLog.Targets
         /// Holds the initialised files each given time by the <see cref="FileTarget"/> instance. Against each file, the last write time is stored. 
         /// </summary>
         /// <remarks>Last write time is store in local time (no UTC).</remarks>
-        private readonly Dictionary<string, DateTime> initializedFiles = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, DateTime> _initializedFiles = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
 
-        private LineEndingMode lineEndingMode = LineEndingMode.Default;
+        private LineEndingMode _lineEndingMode = LineEndingMode.Default;
 
         /// <summary>
         /// Factory used to create the file appenders in the <see cref="FileTarget"/> instance. 
         /// </summary>
         /// <remarks>File appenders are stored in an instance of <see cref="FileAppenderCache"/>.</remarks>
-        private IFileAppenderFactory appenderFactory;
+        private IFileAppenderFactory _appenderFactory;
 
         /// <summary>
         /// List of the associated file appenders with the <see cref="FileTarget"/> instance.
         /// </summary>
-        private FileAppenderCache fileAppenderCache;
+        private FileAppenderCache _fileAppenderCache;
 
         IFileArchiveMode GetFileArchiveHelper(string archiveFilePattern)
         {
-            return fileArchiveHelper ?? (fileArchiveHelper = FileArchiveModeFactory.CreateArchiveStyle(archiveFilePattern, this.ArchiveNumbering, this.GetArchiveDateFormatString(this.ArchiveDateFormat), this.ArchiveFileName != null, this.MaxArchiveFiles));
+            return _fileArchiveHelper ?? (_fileArchiveHelper = FileArchiveModeFactory.CreateArchiveStyle(archiveFilePattern, this.ArchiveNumbering, this.GetArchiveDateFormatString(this.ArchiveDateFormat), this.ArchiveFileName != null, this.MaxArchiveFiles));
         }
-        private IFileArchiveMode fileArchiveHelper;
+        private IFileArchiveMode _fileArchiveHelper;
 
-        private Timer autoClosingTimer;
+        private Timer _autoClosingTimer;
 
         /// <summary>
         /// The number of initialised files at any one time.
         /// </summary>
-        private int initializedFilesCounter;
+        private int _initializedFilesCounter;
 
         /// <summary>
         /// The maximum number of archive files that should be kept.
         /// </summary>
-        private int maxArchiveFiles;
+        private int _maxArchiveFiles;
 
         /// <summary>
         /// The filename as target
         /// </summary>
-        private FilePathLayout fullFileName;
+        private FilePathLayout _fullFileName;
 
         /// <summary>
         /// The archive file name as target
         /// </summary>
-        private FilePathLayout fullArchiveFileName;
+        private FilePathLayout _fullArchiveFileName;
 
-        private FileArchivePeriod archiveEvery;
-        private long archiveAboveSize;
+        private FileArchivePeriod _archiveEvery;
+        private long _archiveAboveSize;
 
-        private bool enableArchiveFileCompression;
+        private bool _enableArchiveFileCompression;
 
         /// <summary>
         /// The date of the previous log event.
         /// </summary>
-        private DateTime? previousLogEventTimestamp;
+        private DateTime? _previousLogEventTimestamp;
 
         /// <summary>
         /// The file name of the previous log event.
         /// </summary>
-        private string previousLogFileName;
+        private string _previousLogFileName;
 
-        private bool concurrentWrites;
-        private bool keepFileOpen;
-        private bool cleanupFileName;
-        private FilePathKind fileNameKind;
-        private FilePathKind archiveFileKind;
+        private bool _concurrentWrites;
+        private bool _keepFileOpen;
+        private bool _cleanupFileName;
+        private FilePathKind _fileNameKind;
+        private FilePathKind _archiveFileKind;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FileTarget" /> class.
@@ -159,7 +159,7 @@ namespace NLog.Targets
         public FileTarget()
         {
             this.ArchiveNumbering = ArchiveNumberingMode.Sequence;
-            this.maxArchiveFiles = 0;
+            this._maxArchiveFiles = 0;
             this.ConcurrentWriteAttemptDelay = 1;
             this.ArchiveEvery = FileArchivePeriod.None;
             this.ArchiveAboveSize = FileTarget.ArchiveAboveSizeDisabled;
@@ -183,7 +183,7 @@ namespace NLog.Targets
             this.ForceManaged = false;
             this.ArchiveDateFormat = string.Empty;
 
-            this.fileAppenderCache = FileAppenderCache.Empty;
+            this._fileAppenderCache = FileAppenderCache.Empty;
             this.CleanupFileName = true;
 
             this.WriteFooterOnArchivingOnly = false;
@@ -230,13 +230,13 @@ namespace NLog.Targets
         {
             get
             {
-                if (fullFileName == null) return null;
+                if (_fullFileName == null) return null;
 
-                return fullFileName.GetLayout();
+                return _fullFileName.GetLayout();
             }
             set
             {
-                fullFileName = CreateFileNameLayout(value);
+                _fullFileName = CreateFileNameLayout(value);
                 ResetFileAppenders("FileName Changed");
             }
         }
@@ -257,14 +257,14 @@ namespace NLog.Targets
         [DefaultValue(true)]
         public bool CleanupFileName
         {
-            get { return cleanupFileName; }
+            get { return _cleanupFileName; }
             set
             {
-                if (cleanupFileName != value)
+                if (_cleanupFileName != value)
                 {
-                    cleanupFileName = value;
-                    fullFileName = CreateFileNameLayout(FileName);
-                    fullArchiveFileName = CreateFileNameLayout(ArchiveFileName);
+                    _cleanupFileName = value;
+                    _fullFileName = CreateFileNameLayout(FileName);
+                    _fullArchiveFileName = CreateFileNameLayout(ArchiveFileName);
                     ResetFileAppenders("CleanupFileName Changed");
                 }
             }
@@ -276,13 +276,13 @@ namespace NLog.Targets
         [DefaultValue(FilePathKind.Unknown)]
         public FilePathKind FileNameKind
         {
-            get { return fileNameKind; }
+            get { return _fileNameKind; }
             set
             {
-                if (fileNameKind != value)
+                if (_fileNameKind != value)
                 {
-                    fileNameKind = value;
-                    fullFileName = CreateFileNameLayout(FileName);
+                    _fileNameKind = value;
+                    _fullFileName = CreateFileNameLayout(FileName);
                     ResetFileAppenders("FileNameKind Changed");
                 }
             }
@@ -328,12 +328,12 @@ namespace NLog.Targets
         [DefaultValue(false)]
         public bool KeepFileOpen
         {
-            get { return keepFileOpen; }
+            get { return _keepFileOpen; }
             set
             {
-                if (keepFileOpen != value)
+                if (_keepFileOpen != value)
                 {
-                    keepFileOpen = value;
+                    _keepFileOpen = value;
                     ResetFileAppenders("KeepFileOpen Changed");
                 }
             }
@@ -385,9 +385,9 @@ namespace NLog.Targets
         [Advanced]
         public LineEndingMode LineEnding
         {
-            get { return this.lineEndingMode; }
+            get { return this._lineEndingMode; }
 
-            set { this.lineEndingMode = value; }
+            set { this._lineEndingMode = value; }
         }
 
         /// <summary>
@@ -455,12 +455,12 @@ namespace NLog.Targets
         [DefaultValue(true)]
         public bool ConcurrentWrites
         {
-            get { return concurrentWrites; }
+            get { return _concurrentWrites; }
             set
             {
-                if (concurrentWrites != value)
+                if (_concurrentWrites != value)
                 {
-                    concurrentWrites = value;
+                    _concurrentWrites = value;
                     ResetFileAppenders("ConcurrentWrites Changed");
                 }
             }
@@ -528,17 +528,17 @@ namespace NLog.Targets
         [DefaultValue("")]
         public string ArchiveDateFormat
         {
-            get { return archiveDateFormat; }
+            get { return _archiveDateFormat; }
             set
             {
-                if (archiveDateFormat != value)
+                if (_archiveDateFormat != value)
                 {
-                    archiveDateFormat = value;
+                    _archiveDateFormat = value;
                     ResetFileAppenders("ArchiveDateFormat Changed"); // Reset archive file-monitoring
                 }
             }
         }
-        private string archiveDateFormat;
+        private string _archiveDateFormat;
 
         /// <summary>
         /// Gets or sets the size in bytes above which log files will be automatically archived.
@@ -555,17 +555,17 @@ namespace NLog.Targets
         /// <docgen category='Archival Options' order='10' />
         public long ArchiveAboveSize
         {
-            get { return archiveAboveSize; }
+            get { return _archiveAboveSize; }
             set
             {
-                if ((archiveAboveSize == FileTarget.ArchiveAboveSizeDisabled) != (value == FileTarget.ArchiveAboveSizeDisabled))
+                if ((_archiveAboveSize == FileTarget.ArchiveAboveSizeDisabled) != (value == FileTarget.ArchiveAboveSizeDisabled))
                 {
-                    archiveAboveSize = value;
+                    _archiveAboveSize = value;
                     ResetFileAppenders("ArchiveAboveSize Changed"); // Reset archive file-monitoring
                 }
                 else
                 {
-                    archiveAboveSize = value;
+                    _archiveAboveSize = value;
                 }
             }
         }
@@ -587,12 +587,12 @@ namespace NLog.Targets
         /// <docgen category='Archival Options' order='10' />
         public FileArchivePeriod ArchiveEvery
         {
-            get { return archiveEvery; }
+            get { return _archiveEvery; }
             set
             {
-                if (archiveEvery != value)
+                if (_archiveEvery != value)
                 {
-                    archiveEvery = value;
+                    _archiveEvery = value;
                     ResetFileAppenders("ArchiveEvery Changed"); // Reset archive file-monitoring
                 }
             }
@@ -603,13 +603,13 @@ namespace NLog.Targets
         /// </summary>
         public FilePathKind ArchiveFileKind
         {
-            get { return archiveFileKind; }
+            get { return _archiveFileKind; }
             set
             {
-                if (archiveFileKind != value)
+                if (_archiveFileKind != value)
                 {
-                    archiveFileKind = value;
-                    fullArchiveFileName = CreateFileNameLayout(ArchiveFileName);
+                    _archiveFileKind = value;
+                    _fullArchiveFileName = CreateFileNameLayout(ArchiveFileName);
                     ResetFileAppenders("ArchiveFileKind Changed");  // Reset archive file-monitoring
                 }
             }
@@ -629,13 +629,13 @@ namespace NLog.Targets
         {
             get
             {
-                if (fullArchiveFileName == null) return null;
+                if (_fullArchiveFileName == null) return null;
 
-                return fullArchiveFileName.GetLayout();
+                return _fullArchiveFileName.GetLayout();
             }
             set
             {
-                fullArchiveFileName = CreateFileNameLayout(value);
+                _fullArchiveFileName = CreateFileNameLayout(value);
                 ResetFileAppenders("ArchiveFileName Changed");  // Reset archive file-monitoring
             }
         }
@@ -647,12 +647,12 @@ namespace NLog.Targets
         [DefaultValue(0)]
         public int MaxArchiveFiles
         {
-            get { return maxArchiveFiles; }
+            get { return _maxArchiveFiles; }
             set
             {
-                if (maxArchiveFiles != value)
+                if (_maxArchiveFiles != value)
                 {
-                    maxArchiveFiles = value;
+                    _maxArchiveFiles = value;
                     ResetFileAppenders("MaxArchiveFiles Changed");  // Enforce archive cleanup
                 }
             }
@@ -664,17 +664,17 @@ namespace NLog.Targets
         /// <docgen category='Archival Options' order='10' />
         public ArchiveNumberingMode ArchiveNumbering
         {
-            get { return archiveNumbering; }
+            get { return _archiveNumbering; }
             set
             {
-                if (archiveNumbering != value)
+                if (_archiveNumbering != value)
                 {
-                    archiveNumbering = value;
+                    _archiveNumbering = value;
                     ResetFileAppenders("ArchiveNumbering Changed"); // Reset archive file-monitoring
                 }
             }
         }
-        private ArchiveNumberingMode archiveNumbering;
+        private ArchiveNumberingMode _archiveNumbering;
 
         /// <summary>
         /// Used to compress log files during archiving.
@@ -691,12 +691,12 @@ namespace NLog.Targets
         [DefaultValue(false)]
         public bool EnableArchiveFileCompression
         {
-            get { return enableArchiveFileCompression && FileCompressor != null; }
+            get { return _enableArchiveFileCompression && FileCompressor != null; }
             set
             {
-                if (enableArchiveFileCompression != value)
+                if (_enableArchiveFileCompression != value)
                 {
-                    enableArchiveFileCompression = value;
+                    _enableArchiveFileCompression = value;
                     ResetFileAppenders("EnableArchiveFileCompression Changed"); // Reset archive file-monitoring
                 }
             }
@@ -727,7 +727,7 @@ namespace NLog.Targets
         /// </summary>
         protected internal string NewLineChars
         {
-            get { return lineEndingMode.NewLineCharacters; }
+            get { return _lineEndingMode.NewLineCharacters; }
         }
 
         /// <summary>
@@ -737,26 +737,26 @@ namespace NLog.Targets
         /// </summary>
         private void RefreshArchiveFilePatternToWatch(string fileName, LogEventInfo logEvent)
         {
-            if (this.fileAppenderCache != null)
+            if (this._fileAppenderCache != null)
             {
-                this.fileAppenderCache.CheckCloseAppenders -= AutoClosingTimerCallback;
+                this._fileAppenderCache.CheckCloseAppenders -= AutoClosingTimerCallback;
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
                 if (KeepFileOpen)
-                    this.fileAppenderCache.CheckCloseAppenders += AutoClosingTimerCallback;
+                    this._fileAppenderCache.CheckCloseAppenders += AutoClosingTimerCallback;
 
                 bool mustWatchArchiving = IsArchivingEnabled() && ConcurrentWrites && KeepFileOpen;
                 if (mustWatchArchiving)
                 {
                     string fileNamePattern = GetArchiveFileNamePattern(fileName, logEvent);
                     var fileArchiveStyle = !string.IsNullOrEmpty(fileNamePattern) ? GetFileArchiveHelper(fileNamePattern) : null;
-                    string fileNameMask = fileArchiveStyle != null ? fileArchiveHelper.GenerateFileNameMask(fileNamePattern) : string.Empty;
+                    string fileNameMask = fileArchiveStyle != null ? _fileArchiveHelper.GenerateFileNameMask(fileNamePattern) : string.Empty;
                     string directoryMask = !string.IsNullOrEmpty(fileNameMask) ? Path.Combine(Path.GetDirectoryName(fileNamePattern), fileNameMask) : string.Empty;
-                    this.fileAppenderCache.ArchiveFilePatternToWatch = directoryMask;
+                    this._fileAppenderCache.ArchiveFilePatternToWatch = directoryMask;
                 }
                 else
                 {
-                    this.fileAppenderCache.ArchiveFilePatternToWatch = null;
+                    this._fileAppenderCache.ArchiveFilePatternToWatch = null;
                 }
 #endif
             }
@@ -793,7 +793,7 @@ namespace NLog.Targets
             List<string> filesToFinalize = null;
 
             // Select the files require to be finalized.
-            foreach (var file in this.initializedFiles)
+            foreach (var file in this._initializedFiles)
             {
                 if (file.Value < cleanupThreshold)
                 {
@@ -830,7 +830,7 @@ namespace NLog.Targets
             try
             {
                 InternalLogger.Trace("FileTarget: FlushAsync");
-                fileAppenderCache.FlushAppenders();
+                _fileAppenderCache.FlushAppenders();
                 asyncContinuation(null);
                 InternalLogger.Trace("FileTarget: FlushAsync Done");
             }
@@ -913,18 +913,18 @@ namespace NLog.Targets
         {
             base.InitializeTarget();
 
-            this.appenderFactory = GetFileAppenderFactory();
+            this._appenderFactory = GetFileAppenderFactory();
             if (InternalLogger.IsTraceEnabled)
             {
-                InternalLogger.Trace("Using appenderFactory: {0}", appenderFactory.GetType());
+                InternalLogger.Trace("Using appenderFactory: {0}", _appenderFactory.GetType());
             }
 
-            this.fileAppenderCache = new FileAppenderCache(this.OpenFileCacheSize, this.appenderFactory, this);
+            this._fileAppenderCache = new FileAppenderCache(this.OpenFileCacheSize, this._appenderFactory, this);
 
             if ((this.OpenFileCacheSize > 0 || this.EnableFileDelete) && this.OpenFileCacheTimeout > 0)
             {
                 InternalLogger.Trace("FileTarget: Start autoClosingTimer");
-                this.autoClosingTimer = new Timer(
+                this._autoClosingTimer = new Timer(
                     (state) => this.AutoClosingTimerCallback(this, EventArgs.Empty),
                     null,
                     this.OpenFileCacheTimeout * 1000,
@@ -939,47 +939,47 @@ namespace NLog.Targets
         {
             base.CloseTarget();
 
-            foreach (string fileName in new List<string>(this.initializedFiles.Keys))
+            foreach (string fileName in new List<string>(this._initializedFiles.Keys))
             {
                 this.FinalizeFile(fileName);
             }
 
-            this.fileArchiveHelper = null;
+            this._fileArchiveHelper = null;
 
-            var currentTimer = this.autoClosingTimer;
+            var currentTimer = this._autoClosingTimer;
             if (currentTimer != null)
             {
                 InternalLogger.Trace("FileTarget: Stop autoClosingTimer");
-                this.autoClosingTimer = null;
+                this._autoClosingTimer = null;
                 currentTimer.WaitForDispose(TimeSpan.Zero);
             }
 
-            this.fileAppenderCache.CloseAppenders("Dispose");
-            this.fileAppenderCache.Dispose();
+            this._fileAppenderCache.CloseAppenders("Dispose");
+            this._fileAppenderCache.Dispose();
         }
 
         private void ResetFileAppenders(string reason)
         {
-            this.fileArchiveHelper = null;
+            this._fileArchiveHelper = null;
             if (IsInitialized)
             {
-                this.fileAppenderCache.CloseAppenders(reason);
-                this.initializedFiles.Clear();
+                this._fileAppenderCache.CloseAppenders(reason);
+                this._initializedFiles.Clear();
             }
         }
 
         /// <summary>
         /// Can be used if <see cref="Target.OptimizeBufferReuse"/> has been enabled.
         /// </summary>
-        private readonly ReusableStreamCreator reusableFileWriteStream = new ReusableStreamCreator(4096);
+        private readonly ReusableStreamCreator _reusableFileWriteStream = new ReusableStreamCreator(4096);
         /// <summary>
         /// Can be used if <see cref="Target.OptimizeBufferReuse"/> has been enabled.
         /// </summary>
-        private readonly ReusableStreamCreator reusableAsyncFileWriteStream = new ReusableStreamCreator(4096);
+        private readonly ReusableStreamCreator _reusableAsyncFileWriteStream = new ReusableStreamCreator(4096);
         /// <summary>
         /// Can be used if <see cref="Target.OptimizeBufferReuse"/> has been enabled.
         /// </summary>
-        private readonly ReusableBufferCreator reusableEncodingBuffer = new ReusableBufferCreator(1024);
+        private readonly ReusableBufferCreator _reusableEncodingBuffer = new ReusableBufferCreator(1024);
 
         /// <summary>
         /// Writes the specified logging event to a file specified in the FileName 
@@ -991,10 +991,10 @@ namespace NLog.Targets
             var logFileName = this.GetFullFileName(logEvent);
             if (OptimizeBufferReuse)
             {
-                using (var targetStream = this.reusableFileWriteStream.Allocate())
+                using (var targetStream = this._reusableFileWriteStream.Allocate())
                 {
                     using (var targetBuilder = this.ReusableLayoutBuilder.Allocate())
-                    using (var targetBuffer = this.reusableEncodingBuffer.Allocate())
+                    using (var targetBuffer = this._reusableEncodingBuffer.Allocate())
                     {
                         this.RenderFormattedMessageToStream(logEvent, targetBuilder.Result, targetBuffer.Result, targetStream.Result);
                     }
@@ -1016,7 +1016,7 @@ namespace NLog.Targets
         /// <returns></returns>
         internal string GetFullFileName(LogEventInfo logEvent)
         {
-            if (this.fullFileName == null)
+            if (this._fullFileName == null)
             {
                 return null;
             }
@@ -1025,12 +1025,12 @@ namespace NLog.Targets
             {
                 using (var targetBuilder = this.ReusableLayoutBuilder.Allocate())
                 {
-                    return this.fullFileName.RenderWithBuilder(logEvent, targetBuilder.Result);
+                    return this._fullFileName.RenderWithBuilder(logEvent, targetBuilder.Result);
                 }
             }
             else
             {
-                return this.fullFileName.Render(logEvent);
+                return this._fullFileName.Render(logEvent);
             }
         }
 
@@ -1048,7 +1048,7 @@ namespace NLog.Targets
             Write((IList<AsyncLogEventInfo>)logEvents);
         }
 
-        SortHelpers.KeySelector<AsyncLogEventInfo, string> getFullFileNameDelegate;
+        SortHelpers.KeySelector<AsyncLogEventInfo, string> _getFullFileNameDelegate;
 
         /// <summary>
         /// Writes the specified array of logging events to a file specified in the FileName
@@ -1062,12 +1062,12 @@ namespace NLog.Targets
         /// </remarks>
         protected override void Write(IList<AsyncLogEventInfo> logEvents)
         {
-            if (getFullFileNameDelegate == null)
-                getFullFileNameDelegate = c => this.GetFullFileName(c.LogEvent);
+            if (_getFullFileNameDelegate == null)
+                _getFullFileNameDelegate = c => this.GetFullFileName(c.LogEvent);
 
-            var buckets = logEvents.BucketSort(getFullFileNameDelegate);
+            var buckets = logEvents.BucketSort(_getFullFileNameDelegate);
 
-            using (var reusableStream = (OptimizeBufferReuse && logEvents.Count <= 1000) ? reusableAsyncFileWriteStream.Allocate() : reusableAsyncFileWriteStream.None)
+            using (var reusableStream = (OptimizeBufferReuse && logEvents.Count <= 1000) ? _reusableAsyncFileWriteStream.Allocate() : _reusableAsyncFileWriteStream.None)
             using (var allocatedStream = reusableStream.Result != null ? null : new MemoryStream())
             {
                 var ms = allocatedStream != null ? allocatedStream : reusableStream.Result;
@@ -1084,8 +1084,8 @@ namespace NLog.Targets
                     int bucketCount = bucket.Value.Count;
 
                     using (var targetBuilder = OptimizeBufferReuse ? ReusableLayoutBuilder.Allocate() : ReusableLayoutBuilder.None)
-                    using (var targetBuffer = OptimizeBufferReuse ? reusableEncodingBuffer.Allocate() : reusableEncodingBuffer.None)
-                    using (var targetStream = OptimizeBufferReuse ? reusableFileWriteStream.Allocate() : reusableFileWriteStream.None)
+                    using (var targetBuffer = OptimizeBufferReuse ? _reusableEncodingBuffer.Allocate() : _reusableEncodingBuffer.None)
+                    using (var targetStream = OptimizeBufferReuse ? _reusableFileWriteStream.Allocate() : _reusableFileWriteStream.None)
                     {
                         for (int i = 0; i < bucketCount; i++)
                         {
@@ -1153,8 +1153,8 @@ namespace NLog.Targets
 
             this.WriteToFile(fileName, bytesToWrite, initializedNewFile);
 
-            previousLogFileName = fileName;
-            previousLogEventTimestamp = logEvent.TimeStamp;
+            _previousLogFileName = fileName;
+            _previousLogEventTimestamp = logEvent.TimeStamp;
         }
 
         /// <summary>
@@ -1424,24 +1424,24 @@ namespace NLog.Targets
 
         private DateTime GetArchiveDate(string fileName, LogEventInfo logEvent)
         {
-            var lastWriteTimeUtc = this.fileAppenderCache.GetFileLastWriteTimeUtc(fileName, true);
+            var lastWriteTimeUtc = this._fileAppenderCache.GetFileLastWriteTimeUtc(fileName, true);
 
             //todo null check
             var lastWriteTime = TimeSource.Current.FromSystemTime(lastWriteTimeUtc.Value);
 
-            InternalLogger.Trace("Calculating archive date. Last write time: {0}; Previous log event time: {1}", lastWriteTime, previousLogEventTimestamp);
+            InternalLogger.Trace("Calculating archive date. Last write time: {0}; Previous log event time: {1}", lastWriteTime, _previousLogEventTimestamp);
 
-            bool previousLogIsMoreRecent = previousLogEventTimestamp.HasValue && (previousLogEventTimestamp.Value > lastWriteTime);
+            bool previousLogIsMoreRecent = _previousLogEventTimestamp.HasValue && (_previousLogEventTimestamp.Value > lastWriteTime);
             if (previousLogIsMoreRecent)
             {
                 InternalLogger.Trace("Using previous log event time (is more recent)");
-                return previousLogEventTimestamp.Value;
+                return _previousLogEventTimestamp.Value;
             }
 
-            if (previousLogEventTimestamp.HasValue && PreviousLogOverlappedPeriod(logEvent, lastWriteTime))
+            if (_previousLogEventTimestamp.HasValue && PreviousLogOverlappedPeriod(logEvent, lastWriteTime))
             {
                 InternalLogger.Trace("Using previous log event time (previous log overlapped period)");
-                return previousLogEventTimestamp.Value;
+                return _previousLogEventTimestamp.Value;
             }
 
             InternalLogger.Trace("Using last write time");
@@ -1451,10 +1451,10 @@ namespace NLog.Targets
         private bool PreviousLogOverlappedPeriod(LogEventInfo logEvent, DateTime lastWrite)
         {
             DateTime timestamp;
-            if (!previousLogEventTimestamp.HasValue)
+            if (!_previousLogEventTimestamp.HasValue)
                 return false;
             else
-                timestamp = previousLogEventTimestamp.Value;
+                timestamp = _previousLogEventTimestamp.Value;
 
             string formatString = GetArchiveDateFormatString(string.Empty);
             string lastWriteTimeString = lastWrite.ToString(formatString, CultureInfo.InvariantCulture);
@@ -1516,8 +1516,8 @@ namespace NLog.Targets
             if (!fileInfo.Exists)
             {
                 // Close possible stale file handles
-                this.fileAppenderCache.InvalidateAppender(fileName);
-                this.initializedFiles.Remove(fileName);
+                this._fileAppenderCache.InvalidateAppender(fileName);
+                this._initializedFiles.Remove(fileName);
                 return;
             }
 
@@ -1552,7 +1552,7 @@ namespace NLog.Targets
                 {
                     if (string.Equals(Path.GetDirectoryName(archiveFilePattern), fileInfo.DirectoryName, StringComparison.OrdinalIgnoreCase))
                     {
-                        this.initializedFiles.Remove(fileName);
+                        this._initializedFiles.Remove(fileName);
                         DeleteOldArchiveFile(fileName);
                         return;
                     }
@@ -1565,7 +1565,7 @@ namespace NLog.Targets
             {
                 if (initializedNewFile)
                 {
-                    this.initializedFiles.Remove(fileName);
+                    this._initializedFiles.Remove(fileName);
                 }
                 else
                 {
@@ -1605,7 +1605,7 @@ namespace NLog.Targets
         /// <returns>A string with a pattern that will match the archive filenames</returns>
         private string GetArchiveFileNamePattern(string fileName, LogEventInfo eventInfo)
         {
-            if (this.fullArchiveFileName == null)
+            if (this._fullArchiveFileName == null)
             {
                 if (EnableArchiveFileCompression)
                     return Path.ChangeExtension(fileName, ".zip");
@@ -1617,7 +1617,7 @@ namespace NLog.Targets
                 //The archive file name is given. There are two possibilities
                 //(1) User supplied the Filename with pattern
                 //(2) User supplied the normal filename
-                string archiveFileName = this.fullArchiveFileName.Render(eventInfo);
+                string archiveFileName = this._fullArchiveFileName.Render(eventInfo);
                 return archiveFileName;
             }
         }
@@ -1647,26 +1647,26 @@ namespace NLog.Targets
                     InternalLogger.Trace("FileTarget: invalidate for file '{0}'", archiveFile);
 #if SupportsMutex
                     // Acquire the mutex from the file-appender, before closing the file-apppender (remember not to close the Mutex)
-                    archiveMutex = this.fileAppenderCache.GetArchiveMutex(fileName);
+                    archiveMutex = this._fileAppenderCache.GetArchiveMutex(fileName);
                     if (archiveMutex == null && fileName != archiveFile)
-                        archiveMutex = this.fileAppenderCache.GetArchiveMutex(archiveFile);
+                        archiveMutex = this._fileAppenderCache.GetArchiveMutex(archiveFile);
 #endif
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
-                    this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
+                    this._fileAppenderCache.InvalidateAppendersForInvalidFiles();
 #endif
                     // Close possible stale file handles, before doing extra check
                     if (!string.IsNullOrEmpty(fileName) && fileName != archiveFile)
-                        this.fileAppenderCache.InvalidateAppender(fileName);
-                    if (!string.IsNullOrEmpty(previousLogFileName) && previousLogFileName != archiveFile && previousLogFileName != fileName)
-                        this.fileAppenderCache.InvalidateAppender(previousLogFileName);
-                    this.fileAppenderCache.InvalidateAppender(archiveFile);
+                        this._fileAppenderCache.InvalidateAppender(fileName);
+                    if (!string.IsNullOrEmpty(_previousLogFileName) && _previousLogFileName != archiveFile && _previousLogFileName != fileName)
+                        this._fileAppenderCache.InvalidateAppender(_previousLogFileName);
+                    this._fileAppenderCache.InvalidateAppender(archiveFile);
                 }
                 else
                 {
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
                     InternalLogger.Trace("FileTarget: invalidate invalid files");
-                    this.fileAppenderCache.InvalidateAppendersForInvalidFiles();
+                    this._fileAppenderCache.InvalidateAppendersForInvalidFiles();
 #endif
                 }
             }
@@ -1704,8 +1704,8 @@ namespace NLog.Targets
                     if (string.IsNullOrEmpty(validatedArchiveFile))
                     {
                         if (archiveFile != fileName)
-                            this.initializedFiles.Remove(fileName);
-                        this.initializedFiles.Remove(archiveFile);
+                            this._initializedFiles.Remove(fileName);
+                        this._initializedFiles.Remove(archiveFile);
                         return true;
                     }
 
@@ -1741,7 +1741,7 @@ namespace NLog.Targets
         /// <returns>Filename to archive. If <c>null</c>, then nothing to archive.</returns>
         private string GetArchiveFileName(string fileName, LogEventInfo ev, int upcomingWriteSize)
         {
-            var hasFileName = !(fileName == null && previousLogFileName == null);
+            var hasFileName = !(fileName == null && _previousLogFileName == null);
             if (hasFileName)
             {
                 return GetArchiveFileNameBasedOnFileSize(fileName, upcomingWriteSize) ??
@@ -1757,25 +1757,25 @@ namespace NLog.Targets
         /// <returns></returns>
         private string GetPotentialFileForArchiving(string fileName)
         {
-            if (string.Equals(fileName, previousLogFileName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(fileName, _previousLogFileName, StringComparison.OrdinalIgnoreCase))
             {
                 //both the same, so don't care
                 return fileName;
             }
 
-            if (string.IsNullOrEmpty(previousLogFileName))
+            if (string.IsNullOrEmpty(_previousLogFileName))
             {
                 return fileName;
             }
 
             if (string.IsNullOrEmpty(fileName))
             {
-                return previousLogFileName;
+                return _previousLogFileName;
             }
 
             //this is an expensive call
-            var fileLength = this.fileAppenderCache.GetFileLength(fileName, true);
-            string fileToArchive = fileLength != null ? fileName : previousLogFileName;
+            var fileLength = this._fileAppenderCache.GetFileLength(fileName, true);
+            string fileToArchive = fileLength != null ? fileName : _previousLogFileName;
             return fileToArchive;
         }
 
@@ -1799,7 +1799,7 @@ namespace NLog.Targets
                 return null;
             }
 
-            var length = this.fileAppenderCache.GetFileLength(fileName, true);
+            var length = this._fileAppenderCache.GetFileLength(fileName, true);
             if (length == null)
             {
                 return null;
@@ -1834,7 +1834,7 @@ namespace NLog.Targets
                 return null;
             }
 
-            var creationTimeSource = this.fileAppenderCache.GetFileCreationTimeSource(fileName, true);
+            var creationTimeSource = this._fileAppenderCache.GetFileCreationTimeSource(fileName, true);
             if (creationTimeSource == null)
             {
                 return null;
@@ -1909,7 +1909,7 @@ namespace NLog.Targets
 
                     DateTime expireTime = this.OpenFileCacheTimeout > 0 ? DateTime.UtcNow.AddSeconds(-this.OpenFileCacheTimeout) : DateTime.MinValue;
                     InternalLogger.Trace("FileTarget: Stop CloseAppenders");
-                    this.fileAppenderCache.CloseAppenders(expireTime);
+                    this._fileAppenderCache.CloseAppenders(expireTime);
                 }
             }
             catch (Exception exception)
@@ -1938,7 +1938,7 @@ namespace NLog.Targets
                 return;
             }
 
-            BaseFileAppender appender = this.fileAppenderCache.AllocateAppender(fileName);
+            BaseFileAppender appender = this._fileAppenderCache.AllocateAppender(fileName);
             try
             {
                 if (initializedNewFile)
@@ -1956,7 +1956,7 @@ namespace NLog.Targets
             catch (Exception ex)
             {
                 InternalLogger.Error(ex, "Failed write to file '{0}'.", fileName);
-                this.fileAppenderCache.InvalidateAppender(fileName);
+                this._fileAppenderCache.InvalidateAppender(fileName);
                 throw;
             }
         }
@@ -1977,22 +1977,22 @@ namespace NLog.Targets
             {
                 var now = logEvent.TimeStamp;
                 DateTime lastTime;
-                if (!this.initializedFiles.TryGetValue(fileName, out lastTime))
+                if (!this._initializedFiles.TryGetValue(fileName, out lastTime))
                 {
                     ProcessOnStartup(fileName, logEvent);
 
-                    this.initializedFiles[fileName] = now;
-                    this.initializedFilesCounter++;
+                    this._initializedFiles[fileName] = now;
+                    this._initializedFilesCounter++;
                     initializedNewFile = true;
 
-                    if (this.initializedFilesCounter >= FileTarget.InitializedFilesCounterMax)
+                    if (this._initializedFilesCounter >= FileTarget.InitializedFilesCounterMax)
                     {
-                        this.initializedFilesCounter = 0;
+                        this._initializedFilesCounter = 0;
                         this.CleanupInitializedFiles();
                     }
                 }
                 if (lastTime != now)
-                    this.initializedFiles[fileName] = now;
+                    this._initializedFiles[fileName] = now;
             }
 
             return initializedNewFile;
@@ -2009,8 +2009,8 @@ namespace NLog.Targets
             if ((isArchiving) || (!this.WriteFooterOnArchivingOnly))
                 WriteFooter(fileName);
 
-            this.fileAppenderCache.InvalidateAppender(fileName);
-            this.initializedFiles.Remove(fileName);
+            this._fileAppenderCache.InvalidateAppender(fileName);
+            this._initializedFiles.Remove(fileName);
         }
 
         /// <summary>
@@ -2163,7 +2163,7 @@ namespace NLog.Targets
             if (OptimizeBufferReuse)
             {
                 using (var targetBuilder = this.ReusableLayoutBuilder.Allocate())
-                using (var targetBuffer = this.reusableEncodingBuffer.Allocate())
+                using (var targetBuffer = this._reusableEncodingBuffer.Allocate())
                 {
                     var nullEvent = LogEventInfo.CreateNullEvent();
                     layout.RenderAppendBuilder(nullEvent, targetBuilder.Result);

--- a/src/NLog/Targets/LineEndingMode.cs
+++ b/src/NLog/Targets/LineEndingMode.cs
@@ -76,15 +76,15 @@ namespace NLog.Targets
         public static readonly LineEndingMode None = new LineEndingMode("None", String.Empty);
 
 
-        private readonly string name;
-        private readonly string newLineCharacters;
+        private readonly string _name;
+        private readonly string _newLineCharacters;
 
         /// <summary>
         /// Gets the name of the LineEndingMode instance.
         /// </summary>
         public string Name 
         {       
-            get { return this.name; }
+            get { return this._name; }
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace NLog.Targets
         /// </summary>
         public string NewLineCharacters 
         {
-            get { return this.newLineCharacters; }
+            get { return this._newLineCharacters; }
         }
 
         private LineEndingMode() { }
@@ -104,8 +104,8 @@ namespace NLog.Targets
         /// <param name="newLineCharacters">The new line characters to be used.</param>
         private LineEndingMode(string name, string newLineCharacters)
         {
-            this.name = name;
-            this.newLineCharacters = newLineCharacters;
+            this._name = name;
+            this._newLineCharacters = newLineCharacters;
         }
 
 
@@ -197,7 +197,7 @@ namespace NLog.Targets
         /// </returns>
         public override int GetHashCode()
         {
-            return (newLineCharacters != null ? newLineCharacters.GetHashCode() : 0);
+            return (_newLineCharacters != null ? _newLineCharacters.GetHashCode() : 0);
         }
 
         /// <summary>
@@ -227,7 +227,7 @@ namespace NLog.Targets
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return string.Equals(newLineCharacters, other.newLineCharacters);
+            return string.Equals(_newLineCharacters, other._newLineCharacters);
         }
 
 

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -67,7 +67,7 @@ namespace NLog.Targets
     [Target("NLogViewer")]
     public class NLogViewerTarget : NetworkTarget, IIncludeContext
     {
-        private readonly Log4JXmlEventLayout layout = new Log4JXmlEventLayout();
+        private readonly Log4JXmlEventLayout _layout = new Log4JXmlEventLayout();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NLogViewerTarget" /> class.
@@ -213,7 +213,7 @@ namespace NLog.Targets
         /// </summary>
         public Log4JXmlEventLayoutRenderer Renderer
         {
-            get { return this.layout.Renderer; }
+            get { return this._layout.Renderer; }
         }
 
         /// <summary>
@@ -224,7 +224,7 @@ namespace NLog.Targets
         {
             get
             {
-                return this.layout;
+                return this._layout;
             }
 
             set

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -48,13 +48,13 @@ namespace NLog.Targets
     [NLogConfigurationItem]
     public abstract class Target : ISupportsInitialize, IDisposable
     {
-        private readonly object lockObject = new object();
-        private List<Layout> allLayouts;
+        private readonly object _lockObject = new object();
+        private List<Layout> _allLayouts;
         
         /// <summary> Are all layouts in this target thread-agnostic, if so we don't precalculate the layouts </summary>
-        private bool allLayoutsAreThreadAgnostic;
-        private bool scannedForLayouts;
-        private Exception initializeException;
+        private bool _allLayoutsAreThreadAgnostic;
+        private bool _scannedForLayouts;
+        private Exception _initializeException;
 
         /// <summary>
         /// The Max StackTraceUsage of all the <see cref="Layout"/> in this Target
@@ -79,7 +79,7 @@ namespace NLog.Targets
         /// </summary>
         protected object SyncRoot
         {
-            get { return this.lockObject; }
+            get { return this._lockObject; }
         }
 
         /// <summary>
@@ -94,17 +94,17 @@ namespace NLog.Targets
         {
             get
             {
-                if (this.isInitialized)
+                if (this._isInitialized)
                     return true;    // Initialization has completed
 
                 // Lets wait for initialization to complete, and then check again
                 lock (this.SyncRoot)
                 {
-                    return this.isInitialized;
+                    return this._isInitialized;
                 }
             }
         }
-        private volatile bool isInitialized;
+        private volatile bool _isInitialized;
 
         /// <summary>
         /// Can be used if <see cref="OptimizeBufferReuse"/> has been enabled.
@@ -119,7 +119,7 @@ namespace NLog.Targets
         {
             lock (this.SyncRoot)
             { 
-                bool wasInitialized = this.isInitialized;
+                bool wasInitialized = this._isInitialized;
                 this.Initialize(configuration);
                 if (wasInitialized && configuration != null)
                 {
@@ -193,22 +193,22 @@ namespace NLog.Targets
         /// </param>
         public void PrecalculateVolatileLayouts(LogEventInfo logEvent)
         {
-            if (this.allLayoutsAreThreadAgnostic)
+            if (this._allLayoutsAreThreadAgnostic)
                 return;
 
             // Not all Layouts support concurrent threads, so we have to protect them
             lock (this.SyncRoot)
             {
-                if (!this.isInitialized)
+                if (!this._isInitialized)
                     return;
 
-                if (this.allLayouts != null)
+                if (this._allLayouts != null)
                 {
                     if (this.OptimizeBufferReuse)
                     {
                         using (var targetBuilder = this.ReusableLayoutBuilder.Allocate())
                         {
-                            foreach (Layout layout in this.allLayouts)
+                            foreach (Layout layout in this._allLayouts)
                             {
                                 targetBuilder.Result.ClearBuilder();
                                 layout.PrecalculateBuilder(logEvent, targetBuilder.Result);
@@ -217,7 +217,7 @@ namespace NLog.Targets
                     }
                     else
                     {
-                        foreach (Layout layout in this.allLayouts)
+                        foreach (Layout layout in this._allLayouts)
                         {
                             layout.Precalculate(logEvent);
                         }
@@ -258,7 +258,7 @@ namespace NLog.Targets
                 return;
             }
 
-            if (this.initializeException != null)
+            if (this._initializeException != null)
             {
                 lock (this.SyncRoot)
                 {
@@ -309,7 +309,7 @@ namespace NLog.Targets
                 return;
             }
 
-            if (this.initializeException != null)
+            if (this._initializeException != null)
             {
                 lock (this.SyncRoot)
                 {
@@ -360,8 +360,8 @@ namespace NLog.Targets
                     try
                     {
                         this.InitializeTarget();
-                        this.initializeException = null;
-                        if (!scannedForLayouts)
+                        this._initializeException = null;
+                        if (!_scannedForLayouts)
                         {
                             InternalLogger.Debug("InitializeTarget is done but not scanned For Layouts");
                             //this is critical, as we need the layouts. So if base.InitializeTarget() isn't called, we fix the layouts here.
@@ -372,7 +372,7 @@ namespace NLog.Targets
                     {
                         InternalLogger.Error(exception, "Error initializing target '{0}'.", this);
 
-                        this.initializeException = exception;
+                        this._initializeException = exception;
 
                         if (exception.MustBeRethrown())
                         {
@@ -381,7 +381,7 @@ namespace NLog.Targets
                     }
                     finally
                     {
-                        this.isInitialized = true;
+                        this._isInitialized = true;
                     }
                 }
             }
@@ -398,11 +398,11 @@ namespace NLog.Targets
 
                 if (this.IsInitialized)
                 {
-                    this.isInitialized = false;
+                    this._isInitialized = false;
 
                     try
                     {
-                        if (this.initializeException == null)
+                        if (this._initializeException == null)
                         {
                             // if Init succeeded, call Close()
                             InternalLogger.Debug("Closing target '{0}'.", this);
@@ -431,10 +431,10 @@ namespace NLog.Targets
         {
             if (disposing)
             {
-                if (this.isInitialized)
+                if (this._isInitialized)
                 {
-                    this.isInitialized = false;
-                    if (this.initializeException == null)
+                    this._isInitialized = false;
+                    if (this._initializeException == null)
                     {
                         this.CloseTarget();
                     }
@@ -454,11 +454,11 @@ namespace NLog.Targets
 
         private void FindAllLayouts()
         {
-            this.allLayouts = ObjectGraphScanner.FindReachableObjects<Layout>(this);
-            InternalLogger.Trace("{0} has {1} layouts", this, this.allLayouts.Count);
-            this.allLayoutsAreThreadAgnostic = allLayouts.All(layout => layout.ThreadAgnostic);
-            this.StackTraceUsage = allLayouts.DefaultIfEmpty().Max(layout => layout == null ? StackTraceUsage.None : layout.StackTraceUsage);
-            this.scannedForLayouts = true;
+            this._allLayouts = ObjectGraphScanner.FindReachableObjects<Layout>(this);
+            InternalLogger.Trace("{0} has {1} layouts", this, this._allLayouts.Count);
+            this._allLayoutsAreThreadAgnostic = _allLayouts.All(layout => layout.ThreadAgnostic);
+            this.StackTraceUsage = _allLayouts.DefaultIfEmpty().Max(layout => layout == null ? StackTraceUsage.None : layout.StackTraceUsage);
+            this._scannedForLayouts = true;
         }
 
         /// <summary>
@@ -633,7 +633,7 @@ namespace NLog.Targets
 
         private Exception CreateInitException()
         {
-            return new NLogRuntimeException("Target " + this + " failed to initialize.", this.initializeException);
+            return new NLogRuntimeException("Target " + this + " failed to initialize.", this._initializeException);
         }
 
         /// <summary>

--- a/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
+++ b/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
@@ -42,7 +42,7 @@ namespace NLog.Targets.Wrappers
     /// </summary>
 	internal class AsyncRequestQueue
     {
-        private readonly Queue<AsyncLogEventInfo> logEventInfoQueue = new Queue<AsyncLogEventInfo>();
+        private readonly Queue<AsyncLogEventInfo> _logEventInfoQueue = new Queue<AsyncLogEventInfo>();
 
         /// <summary>
         /// Initializes a new instance of the AsyncRequestQueue class.
@@ -75,7 +75,7 @@ namespace NLog.Targets.Wrappers
             {
                 lock (this)
                 {
-                    return this.logEventInfoQueue.Count;
+                    return this._logEventInfoQueue.Count;
                 }
             }
         }
@@ -90,14 +90,14 @@ namespace NLog.Targets.Wrappers
         {
             lock (this)
             {
-                if (this.logEventInfoQueue.Count >= this.RequestLimit)
+                if (this._logEventInfoQueue.Count >= this.RequestLimit)
                 {
                     InternalLogger.Debug("Async queue is full");
                     switch (this.OnOverflow)
                     {
                         case AsyncTargetWrapperOverflowAction.Discard:
                             InternalLogger.Debug("Discarding one element from queue");
-                            this.logEventInfoQueue.Dequeue();
+                            this._logEventInfoQueue.Dequeue();
                             break;
 
                         case AsyncTargetWrapperOverflowAction.Grow:
@@ -105,7 +105,7 @@ namespace NLog.Targets.Wrappers
                             break;
 
                         case AsyncTargetWrapperOverflowAction.Block:
-                            while (this.logEventInfoQueue.Count >= this.RequestLimit)
+                            while (this._logEventInfoQueue.Count >= this.RequestLimit)
                             {
                                 InternalLogger.Debug("Blocking because the overflow action is Block...");
                                 System.Threading.Monitor.Wait(this);
@@ -117,8 +117,8 @@ namespace NLog.Targets.Wrappers
                     }
                 }
 
-                this.logEventInfoQueue.Enqueue(logEventInfo);
-                return this.logEventInfoQueue.Count == 1;
+                this._logEventInfoQueue.Enqueue(logEventInfo);
+                return this._logEventInfoQueue.Count == 1;
             }
         }
 
@@ -134,8 +134,8 @@ namespace NLog.Targets.Wrappers
 
             lock (this)
             {
-                if (this.logEventInfoQueue.Count < count)
-                    count = this.logEventInfoQueue.Count;
+                if (this._logEventInfoQueue.Count < count)
+                    count = this._logEventInfoQueue.Count;
 
                 if (count == 0)
                     return Internal.ArrayHelper.Empty<AsyncLogEventInfo>();
@@ -143,7 +143,7 @@ namespace NLog.Targets.Wrappers
                 resultEvents = new AsyncLogEventInfo[count];
                 for (int i = 0; i < count; ++i)
                 {
-                    resultEvents[i] = this.logEventInfoQueue.Dequeue();
+                    resultEvents[i] = this._logEventInfoQueue.Dequeue();
                 }
 
                 if (this.OnOverflow == AsyncTargetWrapperOverflowAction.Block)
@@ -164,10 +164,10 @@ namespace NLog.Targets.Wrappers
         {
             lock (this)
             {
-                if (this.logEventInfoQueue.Count < count)
-                    count = this.logEventInfoQueue.Count;
+                if (this._logEventInfoQueue.Count < count)
+                    count = this._logEventInfoQueue.Count;
                 for (int i = 0; i < count; ++i)
-                    result.Add(this.logEventInfoQueue.Dequeue());
+                    result.Add(this._logEventInfoQueue.Dequeue());
                 if (this.OnOverflow == AsyncTargetWrapperOverflowAction.Block)
                 {
                     System.Threading.Monitor.PulseAll(this);
@@ -182,7 +182,7 @@ namespace NLog.Targets.Wrappers
         {
             lock (this)
             {
-                this.logEventInfoQueue.Clear();
+                this._logEventInfoQueue.Clear();
             }
         }
     }

--- a/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
@@ -58,8 +58,8 @@ namespace NLog.Targets.Wrappers
     [Target("FallbackGroup", IsCompound = true)]
     public class FallbackGroupTarget : CompoundTargetBase
     {
-        private int currentTarget;
-        private object lockObject = new object();
+        private int _currentTarget;
+        private object _lockObject = new object();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FallbackGroupTarget"/> class.
@@ -118,14 +118,14 @@ namespace NLog.Targets.Wrappers
                     if (ex == null)
                     {
                         // success
-                        lock (this.lockObject)
+                        lock (this._lockObject)
                         {
-                            if (this.currentTarget != 0)
+                            if (this._currentTarget != 0)
                             {
                                 if (this.ReturnToFirstOnSuccess)
                                 {
                                     InternalLogger.Debug("Fallback: target '{0}' succeeded. Returning to the first one.", this.Targets[targetToInvoke]);
-                                    this.currentTarget = 0;
+                                    this._currentTarget = 0;
                                 }
                             }
                         }
@@ -135,15 +135,15 @@ namespace NLog.Targets.Wrappers
                     }
 
                     // failure
-                    lock (this.lockObject)
+                    lock (this._lockObject)
                     {
                         InternalLogger.Warn(ex, "Fallback: target '{0}' failed. Proceeding to the next one.", this.Targets[targetToInvoke]);
 
                         // error while writing, go to the next one
-                        this.currentTarget = (targetToInvoke + 1) % this.Targets.Count;
+                        this._currentTarget = (targetToInvoke + 1) % this.Targets.Count;
 
                         tryCounter++;
-                        targetToInvoke = this.currentTarget;
+                        targetToInvoke = this._currentTarget;
                         if (tryCounter >= this.Targets.Count)
                         {
                             targetToInvoke = -1;
@@ -160,9 +160,9 @@ namespace NLog.Targets.Wrappers
                     }
                 };
 
-            lock (this.lockObject)
+            lock (this._lockObject)
             {
-                targetToInvoke = this.currentTarget;
+                targetToInvoke = this._currentTarget;
             }
 
             this.Targets[targetToInvoke].WriteAsyncLogEvent(logEvent.LogEvent.WithContinuation(continuation));

--- a/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
@@ -45,7 +45,7 @@ namespace NLog.Targets.Wrappers
     [Target("LimitingWrapper", IsWrapper = true)]
     public class LimitingTargetWrapper : WrapperTargetBase
     {
-        private DateTime firstWriteInInterval;
+        private DateTime _firstWriteInInterval;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LimitingTargetWrapper" /> class.
@@ -110,7 +110,7 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Gets the <c>DateTime</c> when the current <see cref="Interval"/> will be reset.
         /// </summary>
-        public DateTime IntervalResetsAt { get { return firstWriteInInterval + Interval; } }
+        public DateTime IntervalResetsAt { get { return _firstWriteInInterval + Interval; } }
 
         /// <summary>
         /// Gets the number of <see cref="AsyncLogEventInfo"/> written in the current <see cref="Interval"/>.
@@ -161,13 +161,13 @@ namespace NLog.Targets.Wrappers
 
         private void ResetInterval()
         {
-            firstWriteInInterval = TimeSource.Current.Time;
+            _firstWriteInInterval = TimeSource.Current.Time;
             MessagesWrittenCount = 0;
         }
 
         private bool IsIntervalExpired()
         {
-            return TimeSource.Current.Time - firstWriteInInterval > Interval;
+            return TimeSource.Current.Time - _firstWriteInInterval > Interval;
         }
 
     }

--- a/src/NLog/Targets/Wrappers/RandomizeGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/RandomizeGroupTarget.cs
@@ -59,7 +59,7 @@ namespace NLog.Targets.Wrappers
     [Target("RandomizeGroup", IsCompound = true)]
     public class RandomizeGroupTarget : CompoundTargetBase
     {
-        private readonly Random random = new Random();
+        private readonly Random _random = new Random();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RandomizeGroupTarget" /> class.
@@ -105,9 +105,9 @@ namespace NLog.Targets.Wrappers
 
             int selectedTarget;
 
-            lock (this.random)
+            lock (this._random)
             {
-                selectedTarget = this.random.Next(this.Targets.Count);
+                selectedTarget = this._random.Next(this.Targets.Count);
             }
 
             this.Targets[selectedTarget].WriteAsyncLogEvent(logEvent);

--- a/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
@@ -113,7 +113,7 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Special SyncObject to allow closing down Target while busy retrying
         /// </summary>
-        private readonly object RetrySyncObject = new object();
+        private readonly object _retrySyncObject = new object();
 
         /// <summary>
         /// Writes the specified log event to the wrapped target, retrying and pausing in case of an error.
@@ -121,7 +121,7 @@ namespace NLog.Targets.Wrappers
         /// <param name="logEvents">The log event.</param>
         protected override void WriteAsyncThreadSafe(IList<AsyncLogEventInfo> logEvents)
         {
-            lock (this.RetrySyncObject)
+            lock (this._retrySyncObject)
             {
                 for (int i = 0; i < logEvents.Count; ++i)
                 {
@@ -139,7 +139,7 @@ namespace NLog.Targets.Wrappers
         /// <param name="logEvent">The log event.</param>
         protected override void WriteAsyncThreadSafe(AsyncLogEventInfo logEvent)
         {
-            lock (this.RetrySyncObject)
+            lock (this._retrySyncObject)
             {
                 // Uses RetrySyncObject instead of Target.SyncRoot to allow closing target while doing sleep and retry.
                 Write(logEvent);

--- a/src/NLog/Targets/Wrappers/RoundRobinGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/RoundRobinGroupTarget.cs
@@ -60,8 +60,8 @@ namespace NLog.Targets.Wrappers
     [Target("RoundRobinGroup", IsCompound = true)]
     public class RoundRobinGroupTarget : CompoundTargetBase
     {
-        private int currentTarget = 0;
-        private object lockObject = new object();
+        private int _currentTarget = 0;
+        private object _lockObject = new object();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RoundRobinGroupTarget" /> class.
@@ -114,10 +114,10 @@ namespace NLog.Targets.Wrappers
 
             int selectedTarget;
 
-            lock (this.lockObject)
+            lock (this._lockObject)
             {
-                selectedTarget = this.currentTarget;
-                this.currentTarget = (this.currentTarget + 1) % this.Targets.Count;
+                selectedTarget = this._currentTarget;
+                this._currentTarget = (this._currentTarget + 1) % this.Targets.Count;
             }
 
             this.Targets[selectedTarget].WriteAsyncLogEvent(logEvent);

--- a/src/NLog/Time/CachedTimeSource.cs
+++ b/src/NLog/Time/CachedTimeSource.cs
@@ -40,8 +40,8 @@ namespace NLog.Time
     /// </summary>
     public abstract class CachedTimeSource : TimeSource
     {
-        private int lastTicks = -1;
-        private DateTime lastTime = DateTime.MinValue;
+        private int _lastTicks = -1;
+        private DateTime _lastTime = DateTime.MinValue;
 
         /// <summary>
         /// Gets raw uncached time from derived time source.
@@ -56,13 +56,13 @@ namespace NLog.Time
             get
             {
                 int tickCount = Environment.TickCount;
-                if (tickCount == lastTicks)
-                    return lastTime;
+                if (tickCount == _lastTicks)
+                    return _lastTime;
                 else
                 {
                     DateTime time = FreshTime;
-                    lastTicks = tickCount;
-                    lastTime = time;
+                    _lastTicks = tickCount;
+                    _lastTime = time;
                     return time;
                 }
             }

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -104,8 +104,8 @@ namespace NLog.UnitTests
             {
                 bool threadTerminated;
 
-                var primaryLogFactory = typeof(LogManager).GetField("factory", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
-                var primaryLogFactoryLock = typeof(LogFactory).GetField("syncRoot", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(primaryLogFactory);
+                var primaryLogFactory = LogManager.factory;
+                var primaryLogFactoryLock = primaryLogFactory._syncRoot;
                 // Simulate a potential deadlock. 
                 // If the creation of the new LogFactory takes the lock of the global LogFactory, the thread will deadlock.
                 lock (primaryLogFactoryLock)


### PR DESCRIPTION
prefixed with `_`

only **private** fields changed

- consistent
- easier to review in GitHub
- no forgot-this-bugs


Currently only the main project, so to be sure not of the tests has been changed.

unneeded `this.` will be removed in another PR 