### PR TITLE
NLog - MessageTemplates - Renamed config to parseMessageTemplates

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -216,7 +216,12 @@ namespace NLog.Config
         /// <summary>
         /// Perform mesage template parsing and formatting of LogEvent messages (True = Always, False = Never, Null = Auto Detect)
         /// </summary>
-        public bool? EnableMessageTemplateParser
+        /// <remarks>
+        /// - Null (Auto Detect) : NLog-parser checks <see cref="LogEventInfo.Message"/> for positional parameters, and will then fallback to string.Format-rendering.
+        /// - True: Always performs the parsing of <see cref="LogEventInfo.Message"/> and rendering of <see cref="LogEventInfo.FormattedMessage"/> using the NLog-parser (Allows custom formatting with <see cref="ValueSerializer"/>)
+        /// - False: Always performs parsing and rendering using string.Format (Fastest if not using structured logging)
+        /// </remarks>
+        public bool? ParseMessageTemplates
         {
             get
             {

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -597,8 +597,8 @@ namespace NLog.Config
             InternalLogger.LogToConsoleError = nlogElement.GetOptionalBooleanAttribute("internalLogToConsoleError", InternalLogger.LogToConsoleError);
             InternalLogger.LogFile = nlogElement.GetOptionalAttribute("internalLogFile", InternalLogger.LogFile);
 
-            bool? messageTemplateParser = nlogElement.GetOptionalBooleanAttribute("messageTemplateParser", null);
-            ConfigurationItemFactory.EnableMessageTemplateParser = messageTemplateParser;
+            bool? parseMessageTemplates = nlogElement.GetOptionalBooleanAttribute("parseMessageTemplates", null);
+            ConfigurationItemFactory.ParseMessageTemplates = parseMessageTemplates;
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
             InternalLogger.LogToTrace = nlogElement.GetOptionalBooleanAttribute("internalLogToTrace", InternalLogger.LogToTrace);

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -1757,29 +1757,29 @@ namespace NLog.UnitTests
         [InlineData(null, true)]
         [InlineData(null, false)]
         [InlineData(null, null)]
-        public void StructuredEventsConfigTest(bool? messageTemplateParser, bool? overrideMessageTemplateParser)
+        public void StructuredEventsConfigTest(bool? parseMessageTemplates, bool? overrideParseMessageTemplates)
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
-                <nlog messageTemplateParser='" + (messageTemplateParser?.ToString() ?? string.Empty) + @"'>
+                <nlog parseMessageTemplates='" + (parseMessageTemplates?.ToString() ?? string.Empty) + @"'>
                     <targets><target name='debug' type='Debug' layout='${message}${exception}' /></targets>
                     <rules>
                         <logger name='*' writeTo='debug' />
                     </rules>
                 </nlog>");
 
-            if (messageTemplateParser.HasValue)
+            if (parseMessageTemplates.HasValue)
             {
-                Assert.Equal(ConfigurationItemFactory.Default.EnableMessageTemplateParser, messageTemplateParser.Value);
+                Assert.Equal(ConfigurationItemFactory.Default.ParseMessageTemplates, parseMessageTemplates.Value);
             }
 
-            if (overrideMessageTemplateParser.HasValue)
+            if (overrideParseMessageTemplates.HasValue)
             {
-                ConfigurationItemFactory.Default.EnableMessageTemplateParser = overrideMessageTemplateParser.Value;
+                ConfigurationItemFactory.Default.ParseMessageTemplates = overrideParseMessageTemplates.Value;
             }
 
             ILogger logger = LogManager.GetLogger("A");
             logger.Debug("Hello World {0}", new object[] { null });
-            if (messageTemplateParser == true || overrideMessageTemplateParser == true)
+            if (parseMessageTemplates == true || overrideParseMessageTemplates == true)
                 AssertDebugLastMessage("debug", "Hello World NULL");
             else
                 AssertDebugLastMessage("debug", "Hello World ");

--- a/tools/MakeNLogXSD/TemplateXSD.xml
+++ b/tools/MakeNLogXSD/TemplateXSD.xml
@@ -76,7 +76,7 @@
         <xs:documentation>Use InvariantCulture as default culture instead of CurrentCulture.  Default value is: false.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="messageTemplateParser" type="xs:boolean">
+    <xs:attribute name="parseMessageTemplates" type="xs:boolean">
       <xs:annotation>
         <xs:documentation>Perform mesage template parsing and formatting of LogEvent messages (true = Always, false = Never, empty = Auto Detect). Default value is: empty.</xs:documentation>
       </xs:annotation>


### PR DESCRIPTION
Trying to resolve #2347