### PR TITLE
Use expression-bodied members

### DIFF
--- a/src/NLog.Extended/LayoutRenderers/AppSettingLayoutRenderer.cs
+++ b/src/NLog.Extended/LayoutRenderers/AppSettingLayoutRenderer.cs
@@ -68,8 +68,8 @@ namespace NLog.LayoutRenderers
 
 		internal IConfigurationManager ConfigurationManager
 		{
-			get { return configurationManager; }
-			set { configurationManager = value; }
+			get => configurationManager;
+		    set => configurationManager = value;
 		}
 
 		/// <summary>

--- a/src/NLog/Common/InternalLogger-generated.cs
+++ b/src/NLog/Common/InternalLogger-generated.cs
@@ -43,50 +43,32 @@ namespace NLog.Common
          /// <summary>
         /// Gets a value indicating whether internal log includes Trace messages.
         /// </summary>
-        public static bool IsTraceEnabled
-        {
-            get { return LogLevel.Trace >= LogLevel; }
-        }
+        public static bool IsTraceEnabled => LogLevel.Trace >= LogLevel;
 
         /// <summary>
         /// Gets a value indicating whether internal log includes Debug messages.
         /// </summary>
-        public static bool IsDebugEnabled
-        {
-            get { return LogLevel.Debug >= LogLevel; }
-        }
+        public static bool IsDebugEnabled => LogLevel.Debug >= LogLevel;
 
         /// <summary>
         /// Gets a value indicating whether internal log includes Info messages.
         /// </summary>
-        public static bool IsInfoEnabled
-        {
-            get { return LogLevel.Info >= LogLevel; }
-        }
+        public static bool IsInfoEnabled => LogLevel.Info >= LogLevel;
 
         /// <summary>
         /// Gets a value indicating whether internal log includes Warn messages.
         /// </summary>
-        public static bool IsWarnEnabled
-        {
-            get { return LogLevel.Warn >= LogLevel; }
-        }
+        public static bool IsWarnEnabled => LogLevel.Warn >= LogLevel;
 
         /// <summary>
         /// Gets a value indicating whether internal log includes Error messages.
         /// </summary>
-        public static bool IsErrorEnabled
-        {
-            get { return LogLevel.Error >= LogLevel; }
-        }
+        public static bool IsErrorEnabled => LogLevel.Error >= LogLevel;
 
         /// <summary>
         /// Gets a value indicating whether internal log includes Fatal messages.
         /// </summary>
-        public static bool IsFatalEnabled
-        {
-            get { return LogLevel.Fatal >= LogLevel; }
-        }
+        public static bool IsFatalEnabled => LogLevel.Fatal >= LogLevel;
 
 
         /// <summary>

--- a/src/NLog/Common/InternalLogger-generated.tt
+++ b/src/NLog/Common/InternalLogger-generated.tt
@@ -49,10 +49,7 @@ namespace NLog.Common
         /// <summary>
         /// Gets a value indicating whether internal log includes <#=level#> messages.
         /// </summary>
-        public static bool Is<#=level#>Enabled
-        {
-            get { return LogLevel.<#=level#> >= LogLevel; }
-        }
+        public static bool Is<#=level#>Enabled => LogLevel.<#=level#> >= LogLevel;
 
 <#
     }

--- a/src/NLog/Common/LogEventInfoBuffer.cs
+++ b/src/NLog/Common/LogEventInfoBuffer.cs
@@ -67,10 +67,7 @@ namespace NLog.Common
         /// <summary>
         /// Gets the number of items in the array.
         /// </summary>
-        public int Size
-        {
-            get { return _buffer.Length; }
-        }
+        public int Size => _buffer.Length;
 
         /// <summary>
         /// Adds the specified log event to the buffer.

--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -119,7 +119,7 @@ namespace NLog.Config
                     defaultInstance = BuildDefaultFactory();
                 return defaultInstance;
             }
-            set { defaultInstance = value; }
+            set => defaultInstance = value;
         }
 
         /// <summary>
@@ -134,19 +134,13 @@ namespace NLog.Config
         /// Gets the <see cref="Target"/> factory.
         /// </summary>
         /// <value>The target factory.</value>
-        public INamedItemFactory<Target, Type> Targets
-        {
-            get { return _targets; }
-        }
+        public INamedItemFactory<Target, Type> Targets => _targets;
 
         /// <summary>
         /// Gets the <see cref="Filter"/> factory.
         /// </summary>
         /// <value>The filter factory.</value>
-        public INamedItemFactory<Filter, Type> Filters
-        {
-            get { return _filters; }
-        }
+        public INamedItemFactory<Filter, Type> Filters => _filters;
 
         /// <summary>
         /// gets the <see cref="LayoutRenderer"/> factory
@@ -162,37 +156,28 @@ namespace NLog.Config
         /// Gets the <see cref="LayoutRenderer"/> factory.
         /// </summary>
         /// <value>The layout renderer factory.</value>
-        public INamedItemFactory<LayoutRenderer, Type> LayoutRenderers
-        {
-            get { return _layoutRenderers; }
-        }
+        public INamedItemFactory<LayoutRenderer, Type> LayoutRenderers => _layoutRenderers;
 
         /// <summary>
         /// Gets the <see cref="LayoutRenderer"/> factory.
         /// </summary>
         /// <value>The layout factory.</value>
-        public INamedItemFactory<Layout, Type> Layouts
-        {
-            get { return _layouts; }
-        }
+        public INamedItemFactory<Layout, Type> Layouts => _layouts;
 
         /// <summary>
         /// Gets the ambient property factory.
         /// </summary>
         /// <value>The ambient property factory.</value>
-        public INamedItemFactory<LayoutRenderer, Type> AmbientProperties
-        {
-            get { return _ambientProperties; }
-        }
-        
+        public INamedItemFactory<LayoutRenderer, Type> AmbientProperties => _ambientProperties;
+
         /// <summary>
         /// Legacy interface, no longer used by the NLog engine
         /// </summary>
         [Obsolete("Use JsonConverter property instead. Marked obsolete on NLog 4.5")]
         public IJsonSerializer JsonSerializer
         {
-            get { return _jsonSerializer as IJsonSerializer; }
-            set { _jsonSerializer = value != null ? (IJsonConverter)new JsonConverterLegacy(value) : DefaultJsonSerializer.Instance; }
+            get => _jsonSerializer as IJsonSerializer;
+            set => _jsonSerializer = value != null ? (IJsonConverter)new JsonConverterLegacy(value) : DefaultJsonSerializer.Instance;
         }
 
         /// <summary>
@@ -200,8 +185,8 @@ namespace NLog.Config
         /// </summary>
         public IJsonConverter JsonConverter
         {
-            get { return _jsonSerializer; }
-            set { _jsonSerializer = value ?? DefaultJsonSerializer.Instance; }
+            get => _jsonSerializer;
+            set => _jsonSerializer = value ?? DefaultJsonSerializer.Instance;
         }
 
         /// <summary>
@@ -209,8 +194,8 @@ namespace NLog.Config
         /// </summary>
         public IValueSerializer ValueSerializer
         {
-            get { return MessageTemplates.ValueSerializer.Instance; }
-            set { MessageTemplates.ValueSerializer.Instance = value; }
+            get => MessageTemplates.ValueSerializer.Instance;
+            set => MessageTemplates.ValueSerializer.Instance = value;
         }
 
         /// <summary>
@@ -238,29 +223,20 @@ namespace NLog.Config
                     return null;
                 }
             }
-            set
-            {
-                LogEventInfo.SetDefaultMessageFormatter(value);
-            }
+            set => LogEventInfo.SetDefaultMessageFormatter(value);
         }
 
         /// <summary>
         /// Gets the time source factory.
         /// </summary>
         /// <value>The time source factory.</value>
-        public INamedItemFactory<TimeSource, Type> TimeSources
-        {
-            get { return _timeSources; }
-        }
+        public INamedItemFactory<TimeSource, Type> TimeSources => _timeSources;
 
         /// <summary>
         /// Gets the condition method factory.
         /// </summary>
         /// <value>The condition method factory.</value>
-        public INamedItemFactory<MethodInfo, MethodInfo> ConditionMethods
-        {
-            get { return _conditionMethods; }
-        }
+        public INamedItemFactory<MethodInfo, MethodInfo> ConditionMethods => _conditionMethods;
 
         /// <summary>
         /// Registers named items from the assembly.

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -81,13 +81,7 @@ namespace NLog.Config
         /// <summary>
         /// Gets the variables defined in the configuration.
         /// </summary>
-        public IDictionary<string, SimpleLayout> Variables
-        {
-            get
-            {
-                return _variables;
-            }
-        }
+        public IDictionary<string, SimpleLayout> Variables => _variables;
 
         /// <summary>
         /// Gets a collection of named targets specified in the configuration.
@@ -98,18 +92,12 @@ namespace NLog.Config
         /// <remarks>
         /// Unnamed targets (such as those wrapped by other targets) are not returned.
         /// </remarks>
-        public ReadOnlyCollection<Target> ConfiguredNamedTargets
-        {
-            get { return new List<Target>(_targets.Values).AsReadOnly(); }
-        }
+        public ReadOnlyCollection<Target> ConfiguredNamedTargets => new List<Target>(_targets.Values).AsReadOnly();
 
         /// <summary>
         /// Gets the collection of file names which should be watched for changes by NLog.
         /// </summary>
-        public virtual IEnumerable<string> FileNamesToWatch
-        {
-            get { return ArrayHelper.Empty<string>(); }
-        }
+        public virtual IEnumerable<string> FileNamesToWatch => ArrayHelper.Empty<string>();
 
         /// <summary>
         /// Gets the collection of logging rules.

--- a/src/NLog/Config/LoggingConfigurationChangedEventArgs.cs
+++ b/src/NLog/Config/LoggingConfigurationChangedEventArgs.cs
@@ -68,13 +68,13 @@ namespace NLog.Config
         /// </summary>
         /// <value>The new configuration.</value>
         [Obsolete("This option will be removed in NLog 5. Marked obsolete on NLog 4.5")]
-        public LoggingConfiguration OldConfiguration { get { return ActivatedConfiguration; } }
+        public LoggingConfiguration OldConfiguration => ActivatedConfiguration;
 
         /// <summary>
         /// Gets the old configuration
         /// </summary>
         /// <value>The old configuration.</value>
         [Obsolete("This option will be removed in NLog 5. Marked obsolete on NLog 4.5")]
-        public LoggingConfiguration NewConfiguration { get { return DeactivatedConfiguration; } }
+        public LoggingConfiguration NewConfiguration => DeactivatedConfiguration;
     }
 }

--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -144,10 +144,7 @@ namespace NLog.Config
         /// </remarks>
         public string LoggerNamePattern
         {
-            get
-            {
-                return _loggerNamePattern;
-            }
+            get => _loggerNamePattern;
 
             set
             {

--- a/src/NLog/Config/MethodFactory.cs
+++ b/src/NLog/Config/MethodFactory.cs
@@ -58,10 +58,7 @@ namespace NLog.Config
         /// of the item and value is the <see cref="MethodInfo"/> of
         /// the item.
         /// </returns>
-        public IDictionary<string, MethodInfo> AllRegisteredItems
-        {
-            get { return _nameToMethodInfo; }
-        }
+        public IDictionary<string, MethodInfo> AllRegisteredItems => _nameToMethodInfo;
 
         /// <summary>
         /// Scans the assembly for classes marked with <typeparamref name="TClassAttributeType"/>

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -86,10 +86,7 @@ namespace NLog.Config
 
         private LogFactory _logFactory = null;
 
-        private ConfigurationItemFactory ConfigurationItemFactory
-        {
-            get { return ConfigurationItemFactory.Default; }
-        }
+        private ConfigurationItemFactory ConfigurationItemFactory => ConfigurationItemFactory.Default;
 
         #endregion
 

--- a/src/NLog/Fluent/LogBuilder.cs
+++ b/src/NLog/Fluent/LogBuilder.cs
@@ -83,10 +83,7 @@ namespace NLog.Fluent
         /// <summary>
         /// Gets the <see cref="LogEventInfo"/> created by the builder.
         /// </summary>
-        public LogEventInfo LogEventInfo
-        {
-            get { return _logEvent; }
-        }
+        public LogEventInfo LogEventInfo => _logEvent;
 
         /// <summary>
         /// Sets the <paramref name="exception"/> information of the logging event.

--- a/src/NLog/Internal/AppendBuilderCreator.cs
+++ b/src/NLog/Internal/AppendBuilderCreator.cs
@@ -47,7 +47,8 @@ namespace NLog.Internal
         /// <summary>
         /// Access the new builder allocated
         /// </summary>
-        public StringBuilder Builder { get { return _builder.Item; } }
+        public StringBuilder Builder => _builder.Item;
+
         private readonly StringBuilderPool.ItemHolder _builder;
 
         public AppendBuilderCreator(StringBuilder appendTarget, bool mustBeEmpty)

--- a/src/NLog/Internal/ConfigurationManager.cs
+++ b/src/NLog/Internal/ConfigurationManager.cs
@@ -47,13 +47,7 @@ namespace NLog.Internal
         /// <summary>
         /// Gets the wrapper around ConfigurationManager.AppSettings.
         /// </summary>
-        public NameValueCollection AppSettings
-        {
-            get
-            {
-                return System.Configuration.ConfigurationManager.AppSettings;
-            }
-        }
+        public NameValueCollection AppSettings => System.Configuration.ConfigurationManager.AppSettings;
     }
 }
 

--- a/src/NLog/Internal/DictionaryAdapter.cs
+++ b/src/NLog/Internal/DictionaryAdapter.cs
@@ -62,10 +62,7 @@ namespace NLog.Internal
         /// <returns>
         /// An <see cref="T:System.Collections.ICollection"/> object containing the values in the <see cref="T:System.Collections.IDictionary"/> object.
         /// </returns>
-        public ICollection Values
-        {
-            get { return new List<TValue>(_implementation.Values); }
-        }
+        public ICollection Values => new List<TValue>(_implementation.Values);
 
         /// <summary>
         /// Gets the number of elements contained in the <see cref="T:System.Collections.ICollection"/>.
@@ -74,10 +71,7 @@ namespace NLog.Internal
         /// <returns>
         /// The number of elements contained in the <see cref="T:System.Collections.ICollection"/>.
         /// </returns>
-        public int Count
-        {
-            get { return _implementation.Count; }
-        }
+        public int Count => _implementation.Count;
 
         /// <summary>
         /// Gets a value indicating whether access to the <see cref="T:System.Collections.ICollection"/> is synchronized (thread safe).
@@ -85,10 +79,7 @@ namespace NLog.Internal
         /// <value></value>
         /// <returns>true if access to the <see cref="T:System.Collections.ICollection"/> is synchronized (thread safe); otherwise, false.
         /// </returns>
-        public bool IsSynchronized
-        {
-            get { return false; }
-        }
+        public bool IsSynchronized => false;
 
         /// <summary>
         /// Gets an object that can be used to synchronize access to the <see cref="T:System.Collections.ICollection"/>.
@@ -97,10 +88,7 @@ namespace NLog.Internal
         /// <returns>
         /// An object that can be used to synchronize access to the <see cref="T:System.Collections.ICollection"/>.
         /// </returns>
-        public object SyncRoot
-        {
-            get { return _implementation; }
-        }
+        public object SyncRoot => _implementation;
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="T:System.Collections.IDictionary"/> object has a fixed size.
@@ -108,10 +96,7 @@ namespace NLog.Internal
         /// <value></value>
         /// <returns>true if the <see cref="T:System.Collections.IDictionary"/> object has a fixed size; otherwise, false.
         /// </returns>
-        public bool IsFixedSize
-        {
-            get { return false; }
-        }
+        public bool IsFixedSize => false;
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="T:System.Collections.IDictionary"/> object is read-only.
@@ -119,10 +104,7 @@ namespace NLog.Internal
         /// <value></value>
         /// <returns>true if the <see cref="T:System.Collections.IDictionary"/> object is read-only; otherwise, false.
         /// </returns>
-        public bool IsReadOnly
-        {
-            get { return _implementation.IsReadOnly; }
-        }
+        public bool IsReadOnly => _implementation.IsReadOnly;
 
         /// <summary>
         /// Gets an <see cref="T:System.Collections.ICollection"/> object containing the keys of the <see cref="T:System.Collections.IDictionary"/> object.
@@ -131,10 +113,7 @@ namespace NLog.Internal
         /// <returns>
         /// An <see cref="T:System.Collections.ICollection"/> object containing the keys of the <see cref="T:System.Collections.IDictionary"/> object.
         /// </returns>
-        public ICollection Keys
-        {
-            get { return new List<TKey>(_implementation.Keys); }
-        }
+        public ICollection Keys => new List<TKey>(_implementation.Keys);
 
         /// <summary>
         /// Gets or sets the <see cref="System.Object"/> with the specified key.
@@ -157,10 +136,7 @@ namespace NLog.Internal
                 }
             }
 
-            set
-            {
-                _implementation[(TKey)key] = (TValue)value;
-            }
+            set => _implementation[(TKey)key] = (TValue)value;
         }
 
         /// <summary>
@@ -257,10 +233,7 @@ namespace NLog.Internal
             /// <returns>
             /// A <see cref="T:System.Collections.DictionaryEntry"/> containing both the key and the value of the current dictionary entry.
             /// </returns>
-            public DictionaryEntry Entry
-            {
-                get { return new DictionaryEntry(_wrapped.Current.Key, _wrapped.Current.Value); }
-            }
+            public DictionaryEntry Entry => new DictionaryEntry(_wrapped.Current.Key, _wrapped.Current.Value);
 
             /// <summary>
             /// Gets the key of the current dictionary entry.
@@ -269,10 +242,7 @@ namespace NLog.Internal
             /// <returns>
             /// The key of the current element of the enumeration.
             /// </returns>
-            public object Key
-            {
-                get { return _wrapped.Current.Key; }
-            }
+            public object Key => _wrapped.Current.Key;
 
             /// <summary>
             /// Gets the value of the current dictionary entry.
@@ -281,10 +251,7 @@ namespace NLog.Internal
             /// <returns>
             /// The value of the current element of the enumeration.
             /// </returns>
-            public object Value
-            {
-                get { return _wrapped.Current.Value; }
-            }
+            public object Value => _wrapped.Current.Value;
 
             /// <summary>
             /// Gets the current element in the collection.
@@ -293,10 +260,7 @@ namespace NLog.Internal
             /// <returns>
             /// The current element in the collection.
             /// </returns>
-            public object Current
-            {
-                get { return Entry; }
-            }
+            public object Current => Entry;
 
             /// <summary>
             /// Advances the enumerator to the next element of the collection.

--- a/src/NLog/Internal/Fakeables/AppDomainWrapper.cs
+++ b/src/NLog/Internal/Fakeables/AppDomainWrapper.cs
@@ -93,7 +93,7 @@ namespace NLog.Internal.Fakeables
         /// <summary>
         /// Creates an AppDomainWrapper for the current <see cref="AppDomain"/>
         /// </summary>
-        public static AppDomainWrapper CurrentDomain { get { return new AppDomainWrapper(AppDomain.CurrentDomain); } }
+        public static AppDomainWrapper CurrentDomain => new AppDomainWrapper(AppDomain.CurrentDomain);
 
         /// <summary>
         /// Gets or sets the base directory that the assembly resolver uses to probe for assemblies.

--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -78,7 +78,7 @@ namespace NLog.Internal.FileAppenders
         /// <returns>The creation time of the file.</returns>
         public DateTime CreationTimeUtc
         {
-            get { return _creationTimeUtc; }
+            get => _creationTimeUtc;
             internal set
             {
                 _creationTimeUtc = value;

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -149,7 +149,7 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         public string ArchiveFilePatternToWatch
         {
-            get { return _archiveFilePatternToWatch; }
+            get => _archiveFilePatternToWatch;
             set
             {
                 if (_archiveFilePatternToWatch != value)

--- a/src/NLog/Internal/NetworkSenders/SocketProxy.cs
+++ b/src/NLog/Internal/NetworkSenders/SocketProxy.cs
@@ -58,13 +58,7 @@ namespace NLog.Internal.NetworkSenders
         /// <summary>
         /// Gets underlying socket instance.
         /// </summary>
-        public Socket UnderlyingSocket
-        {
-            get
-            {
-                return _socket;
-            }
-        }
+        public Socket UnderlyingSocket => _socket;
 
         /// <summary>
         /// Closes the wrapped socket.

--- a/src/NLog/Internal/PlatformDetector.cs
+++ b/src/NLog/Internal/PlatformDetector.cs
@@ -45,42 +45,27 @@ namespace NLog.Internal
         /// <summary>
         /// Gets the current runtime OS.
         /// </summary>
-        public static RuntimeOS CurrentOS
-        {
-            get { return currentOS; }
-        }
-        
+        public static RuntimeOS CurrentOS => currentOS;
+
         /// <summary>
         /// Gets a value indicating whether current OS is a desktop version of Windows.
         /// </summary>
-        public static bool IsDesktopWin32
-        {
-            get { return currentOS == RuntimeOS.Windows || currentOS == RuntimeOS.WindowsNT; }
-        }
-        
+        public static bool IsDesktopWin32 => currentOS == RuntimeOS.Windows || currentOS == RuntimeOS.WindowsNT;
+
         /// <summary>
         /// Gets a value indicating whether current OS is Win32-based (desktop or mobile).
         /// </summary>
-        public static bool IsWin32
-        {
-            get { return currentOS == RuntimeOS.Windows || currentOS == RuntimeOS.WindowsNT || currentOS == RuntimeOS.WindowsCE; }
-        }
-        
+        public static bool IsWin32 => currentOS == RuntimeOS.Windows || currentOS == RuntimeOS.WindowsNT || currentOS == RuntimeOS.WindowsCE;
+
         /// <summary>
         /// Gets a value indicating whether current OS is Unix-based.
         /// </summary>
-        public static bool IsUnix
-        {
-            get { return currentOS == RuntimeOS.Unix; }
-        }
+        public static bool IsUnix => currentOS == RuntimeOS.Unix;
 
         /// <summary>
         /// Gets a value indicating whether current runtime is Mono-based
         /// </summary>
-        public static bool IsMono
-        {
-            get { return Type.GetType("Mono.Runtime") != null; }
-        }
+        public static bool IsMono => Type.GetType("Mono.Runtime") != null;
 
         /// <summary>
         /// Gets a value indicating whether current runtime supports use of mutex

--- a/src/NLog/Internal/PortableThreadIDHelper.cs
+++ b/src/NLog/Internal/PortableThreadIDHelper.cs
@@ -63,10 +63,7 @@ namespace NLog.Internal
         /// Gets current process ID.
         /// </summary>
         /// <value></value>
-        public override int CurrentProcessID
-        {
-            get { return _currentProcessId; }
-        }
+        public override int CurrentProcessID => _currentProcessId;
 
         /// <summary>
         /// Gets current process name.

--- a/src/NLog/Internal/PropertiesDictionary.cs
+++ b/src/NLog/Internal/PropertiesDictionary.cs
@@ -126,10 +126,7 @@ namespace NLog.Internal
 
         public IList<MessageTemplateParameter> MessageProperties
         {
-            get
-            {
-                return _messageProperties ?? ArrayHelper.Empty<MessageTemplateParameter>();
-            }
+            get => _messageProperties ?? ArrayHelper.Empty<MessageTemplateParameter>();
             internal set
             {
                 if (_eventProperties == null && VerifyUniqueMessageTemplateParametersFast(value))

--- a/src/NLog/Internal/SimpleStringReader.cs
+++ b/src/NLog/Internal/SimpleStringReader.cs
@@ -64,10 +64,7 @@ namespace NLog.Internal
         /// <summary>
         /// Full text to be parsed
         /// </summary>
-        internal string Text
-        {
-            get { return _text; }
-        }
+        internal string Text => _text;
 
 #if DEBUG
         string CurrentState

--- a/src/NLog/Internal/SingleItemOptimizedHashSet.cs
+++ b/src/NLog/Internal/SingleItemOptimizedHashSet.cs
@@ -87,9 +87,9 @@ namespace NLog.Internal
             }
         }
 
-        public int Count { get { return _hashset != null ? _hashset.Count : (EqualityComparer<T>.Default.Equals(_singleItem, default(T)) ? 0 : 1); } }
+        public int Count => _hashset != null ? _hashset.Count : (EqualityComparer<T>.Default.Equals(_singleItem, default(T)) ? 0 : 1);
 
-        public bool IsReadOnly { get { return false; } }
+        public bool IsReadOnly => false;
 
         public SingleItemOptimizedHashSet(T singleItem, SingleItemOptimizedHashSet<T> existing)
         {

--- a/src/NLog/Internal/SortHelpers.cs
+++ b/src/NLog/Internal/SortHelpers.cs
@@ -172,7 +172,7 @@ namespace NLog.Internal
             readonly KeyValuePair<TKey, TValue>? _singleBucket;
             readonly Dictionary<TKey, TValue> _multiBucket;
             readonly IEqualityComparer<TKey> _comparer;
-            public IEqualityComparer<TKey> Comparer { get { return _comparer; } }
+            public IEqualityComparer<TKey> Comparer => _comparer;
 
             public ReadOnlySingleBucketDictionary(KeyValuePair<TKey, TValue> singleBucket)
                 : this(singleBucket, EqualityComparer<TKey>.Default)
@@ -230,7 +230,7 @@ namespace NLog.Internal
             }
 
             /// <inheritDoc/>
-            public bool IsReadOnly { get { return true; } }
+            public bool IsReadOnly => true;
 
             /// <summary>
             /// Allows direct lookup of existing keys. If trying to access non-existing key exception is thrown.
@@ -249,10 +249,7 @@ namespace NLog.Internal
                     else
                         throw new KeyNotFoundException();
                 }
-                set
-                {
-                    throw new NotSupportedException("Readonly");
-                }
+                set => throw new NotSupportedException("Readonly");
             }
 
             /// <summary>
@@ -289,7 +286,7 @@ namespace NLog.Internal
                     }
                 }
 
-                object IEnumerator.Current { get { return Current; } }
+                object IEnumerator.Current => Current;
 
                 public void Dispose()
                 {

--- a/src/NLog/Internal/Win32ThreadIDHelper.cs
+++ b/src/NLog/Internal/Win32ThreadIDHelper.cs
@@ -73,28 +73,19 @@ namespace NLog.Internal
         /// Gets current process ID.
         /// </summary>
         /// <value></value>
-        public override int CurrentProcessID
-        {
-            get { return currentProcessID; }
-        }
+        public override int CurrentProcessID => currentProcessID;
 
         /// <summary>
         /// Gets current process name.
         /// </summary>
         /// <value></value>
-        public override string CurrentProcessName
-        {
-            get { return currentProcessName; }
-        }
+        public override string CurrentProcessName => currentProcessName;
 
         /// <summary>
         /// Gets current process name (excluding filename extension, if any).
         /// </summary>
         /// <value></value>
-        public override string CurrentProcessBaseName
-        {
-            get { return currentProcessBaseName; }
-        }
+        public override string CurrentProcessBaseName => currentProcessBaseName;
     }
 }
 

--- a/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
@@ -86,7 +86,7 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Rendering Options' order='10' />
         public string Format
         {
-            get { return _format; }
+            get => _format;
             set
             {
                 if (!value.Contains("[key]"))

--- a/src/NLog/LayoutRenderers/CallSiteLineNumberLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteLineNumberLayoutRenderer.cs
@@ -57,13 +57,7 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage
-        {
-            get
-            {
-                return StackTraceUsage.WithSource;
-            }
-        }
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsage.WithSource;
 
         /// <summary>
         /// Renders the call site and appends it to the specified <see cref="StringBuilder" />.

--- a/src/NLog/LayoutRenderers/DateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/DateLayoutRenderer.cs
@@ -69,7 +69,7 @@ namespace NLog.LayoutRenderers
         [DefaultParameter]
         public string Format
         {
-            get { return _format; }
+            get => _format;
             set
             {
                 _format = value;

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -101,10 +101,7 @@ namespace NLog.LayoutRenderers
         [DefaultParameter]
         public string Format
         {
-            get
-            {
-                return _format;
-            }
+            get => _format;
 
             set
             {
@@ -121,10 +118,7 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Rendering Options' order='10' />
         public string InnerFormat
         {
-            get
-            {
-                return _innerFormat;
-            }
+            get => _innerFormat;
 
             set
             {

--- a/src/NLog/LayoutRenderers/QueryPerformanceCounterLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/QueryPerformanceCounterLayoutRenderer.cs
@@ -87,8 +87,8 @@ namespace NLog.LayoutRenderers
         [DefaultValue(true)]
         public bool Seconds
         {
-            get { return !raw; }
-            set { raw = !value; }
+            get => !raw;
+            set => raw = !value;
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/RegistryLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/RegistryLayoutRenderer.cs
@@ -190,10 +190,7 @@ namespace NLog.LayoutRenderers
             /// <summary>
             /// Has <see cref="SubKey"/>?
             /// </summary>
-            public bool HasSubKey
-            {
-                get { return !string.IsNullOrEmpty(SubKey); }
-            }
+            public bool HasSubKey => !string.IsNullOrEmpty(SubKey);
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/StackTraceLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/StackTraceLayoutRenderer.cs
@@ -88,10 +88,7 @@ namespace NLog.LayoutRenderers
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
         /// <value></value>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage
-        {
-            get { return (Format == StackTraceFormat.Raw) ? StackTraceUsage.Max : StackTraceUsage.WithoutSource; }
-        }
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => (Format == StackTraceFormat.Raw) ? StackTraceUsage.Max : StackTraceUsage.WithoutSource;
 
         /// <summary>
         /// Renders the call site and appends it to the specified <see cref="StringBuilder" />.

--- a/src/NLog/LayoutRenderers/Wrappers/Rot13LayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/Rot13LayoutRendererWrapper.cs
@@ -55,8 +55,8 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <docgen category='Transformation Options' order='10' />
         public Layout Text
         {
-            get { return Inner; }
-            set { Inner = value; }
+            get => Inner;
+            set => Inner = value;
         }
 
         /// <summary>

--- a/src/NLog/Layouts/JsonAttribute.cs
+++ b/src/NLog/Layouts/JsonAttribute.cs
@@ -77,17 +77,23 @@ namespace NLog.Layouts
         /// Gets or sets the layout that will be rendered as the attribute's value.
         /// </summary>
         [RequiredParameter]
-        public Layout Layout { get { return LayoutWrapper.Inner; } set { LayoutWrapper.Inner = value; } }
+        public Layout Layout { get => LayoutWrapper.Inner;
+            set => LayoutWrapper.Inner = value;
+        }
 
         /// <summary>
         /// Determines wether or not this attribute will be Json encoded.
         /// </summary>
-        public bool Encode { get { return LayoutWrapper.JsonEncode; } set { LayoutWrapper.JsonEncode = value; } }
+        public bool Encode { get => LayoutWrapper.JsonEncode;
+            set => LayoutWrapper.JsonEncode = value;
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether to escape non-ascii characters
         /// </summary>
-        public bool EscapeUnicode { get { return LayoutWrapper.EscapeUnicode; } set { LayoutWrapper.EscapeUnicode = value; } }
+        public bool EscapeUnicode { get => LayoutWrapper.EscapeUnicode;
+            set => LayoutWrapper.EscapeUnicode = value;
+        }
 
         internal readonly LayoutRenderers.Wrappers.JsonEncodeLayoutRendererWrapper LayoutWrapper = new LayoutRenderers.Wrappers.JsonEncodeLayoutRendererWrapper();
     }

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -48,8 +48,8 @@ namespace NLog.Layouts
     {
         private IJsonConverter JsonConverter
         {
-            get { return _jsonConverter ?? (_jsonConverter = ConfigurationItemFactory.Default.JsonConverter); }
-            set { _jsonConverter = value; }
+            get => _jsonConverter ?? (_jsonConverter = ConfigurationItemFactory.Default.JsonConverter);
+            set => _jsonConverter = value;
         }
         private IJsonConverter _jsonConverter = null;
 

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -61,19 +61,25 @@ namespace NLog.Layouts
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsContext"/> dictionary.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        public bool IncludeMdc { get { return Renderer.IncludeMdc; } set { Renderer.IncludeMdc = value; } }
+        public bool IncludeMdc { get => Renderer.IncludeMdc;
+            set => Renderer.IncludeMdc = value;
+        }
 
         /// <summary>
         /// Gets or sets the option to include all properties from the log events
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        public bool IncludeAllProperties { get { return Renderer.IncludeAllProperties; } set { Renderer.IncludeAllProperties = value; } }
+        public bool IncludeAllProperties { get => Renderer.IncludeAllProperties;
+            set => Renderer.IncludeAllProperties = value;
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsContext"/> stack.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        public bool IncludeNdc { get { return Renderer.IncludeNdc; } set { Renderer.IncludeNdc = value; } }
+        public bool IncludeNdc { get => Renderer.IncludeNdc;
+            set => Renderer.IncludeNdc = value;
+        }
 
 #if !SILVERLIGHT
 
@@ -81,13 +87,17 @@ namespace NLog.Layouts
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        public bool IncludeMdlc { get { return Renderer.IncludeMdlc; } set { Renderer.IncludeMdlc = value; } }
+        public bool IncludeMdlc { get => Renderer.IncludeMdlc;
+            set => Renderer.IncludeMdlc = value;
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsLogicalContext"/> stack.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        public bool IncludeNdlc { get { return Renderer.IncludeNdlc; } set { Renderer.IncludeNdlc = value; } }
+        public bool IncludeNdlc { get => Renderer.IncludeNdlc;
+            set => Renderer.IncludeNdlc = value;
+        }
 
 #endif
 

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -102,10 +102,7 @@ namespace NLog.Layouts
         /// <docgen category='Layout Options' order='10' />
         public string Text
         {
-            get
-            {
-                return _layoutText;
-            }
+            get => _layoutText;
 
             set
             {
@@ -133,18 +130,12 @@ namespace NLog.Layouts
         /// <summary>
         /// Is the message fixed? (no Layout renderers used)
         /// </summary>
-        public bool IsFixedText
-        {
-            get { return _fixedText != null; }
-        }
+        public bool IsFixedText => _fixedText != null;
 
         /// <summary>
         /// Get the fixed text. Only set when <see cref="IsFixedText"/> is <c>true</c>
         /// </summary>
-        public string FixedText
-        {
-            get { return _fixedText; }
-        }
+        public string FixedText => _fixedText;
 
         /// <summary>
         /// Gets a collection of <see cref="LayoutRenderer"/> objects that make up this layout.
@@ -154,7 +145,7 @@ namespace NLog.Layouts
         /// <summary>
         /// Gets the level of stack trace information required for rendering.
         /// </summary>
-        public new StackTraceUsage StackTraceUsage { get { return base.StackTraceUsage; } }
+        public new StackTraceUsage StackTraceUsage => base.StackTraceUsage;
 
         /// <summary>
         /// Converts a text to a simple layout.

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -174,18 +174,12 @@ namespace NLog
         /// <summary>
         /// Gets a value indicating whether stack trace has been set for this event.
         /// </summary>
-        public bool HasStackTrace
-        {
-            get { return StackTrace != null; }
-        }
+        public bool HasStackTrace => StackTrace != null;
 
         /// <summary>
         /// Gets the stack frame of the method that did the logging.
         /// </summary>
-        public StackFrame UserStackFrame
-        {
-            get { return (StackTrace != null) ? StackTrace.GetFrame(UserStackFrameNumber) : null; }
-        }
+        public StackFrame UserStackFrame => (StackTrace != null) ? StackTrace.GetFrame(UserStackFrameNumber) : null;
 
         /// <summary>
         /// Gets the number index of the stack frame that represents the user
@@ -233,7 +227,7 @@ namespace NLog
         /// </summary>
         public string Message
         {
-            get { return _message; }
+            get => _message;
             set
             {
                 bool rebuildMessageTemplateParameters = ResetMessageTemplateParameters();
@@ -248,7 +242,7 @@ namespace NLog
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "For backwards compatibility.")]
         public object[] Parameters
         {
-            get { return _parameters; }
+            get => _parameters;
             set
             {
                 bool rebuildMessageTemplateParameters = ResetMessageTemplateParameters();
@@ -263,7 +257,7 @@ namespace NLog
         /// </summary>
         public IFormatProvider FormatProvider
         {
-            get { return _formatProvider; }
+            get => _formatProvider;
             set
             {
                 if (_formatProvider != value)
@@ -280,7 +274,7 @@ namespace NLog
         /// </summary>
         public LogMessageFormatter MessageFormatter
         {
-            get { return _messageFormatter; }
+            get => _messageFormatter;
             set
             {
                 _messageFormatter = value ?? StringFormatMessageFormatter;
@@ -322,15 +316,14 @@ namespace NLog
             }
         }
 
-        internal PropertiesDictionary PropertiesDictionary { get { return _properties; } set { _properties = value; } }
+        internal PropertiesDictionary PropertiesDictionary { get => _properties;
+            set => _properties = value;
+        }
 
         /// <summary>
         /// Gets the dictionary of per-event context properties.
         /// </summary>
-        public IDictionary<object, object> Properties 
-        {
-            get { return GetPropertiesInternal(); }
-        }
+        public IDictionary<object, object> Properties => GetPropertiesInternal();
 
         /// <summary>
         /// Gets the dictionary of per-event context properties. 
@@ -383,7 +376,7 @@ namespace NLog
         /// </summary>
         /// <remarks>This property was marked as obsolete on NLog 2.0 and it may be removed in a future release.</remarks>
         [Obsolete("Use LogEventInfo.Properties instead.  Marked obsolete on NLog 2.0", true)]
-        public IDictionary Context { get { return GetPropertiesInternal().EventContext; } }
+        public IDictionary Context => GetPropertiesInternal().EventContext;
 
         /// <summary>
         /// Creates the null event.

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -380,10 +380,7 @@ namespace NLog
         /// </summary>
         public LogLevel GlobalThreshold
         {
-            get
-            {
-                return _globalThreshold;
-            }
+            get => _globalThreshold;
 
             set
             {
@@ -1361,10 +1358,7 @@ namespace NLog
                 return null;
             }
 
-            public IEnumerable<Logger> Loggers
-            {
-                get { return GetLoggers(); }
-            }
+            public IEnumerable<Logger> Loggers => GetLoggers();
 
             private IEnumerable<Logger> GetLoggers()
             {

--- a/src/NLog/LogLevel.cs
+++ b/src/NLog/LogLevel.cs
@@ -95,13 +95,13 @@ namespace NLog
         /// <summary>
         /// Gets all the availiable log levels (Trace, Debug, Info, Warn, Error, Fatal, Off).
         /// </summary>
-        public static IEnumerable<LogLevel> AllLevels { get { return allLevels; } }
+        public static IEnumerable<LogLevel> AllLevels => allLevels;
 
         /// <summary>
         ///  Gets all the log levels that can be used to log events (Trace, Debug, Info, Warn, Error, Fatal) 
         ///  i.e <c>LogLevel.Off</c> is excluded.
         /// </summary>
-        public static IEnumerable<LogLevel> AllLoggingLevels { get { return allLoggingLevels; } }
+        public static IEnumerable<LogLevel> AllLoggingLevels => allLoggingLevels;
 
 
         private readonly int _ordinal;
@@ -121,28 +121,16 @@ namespace NLog
         /// <summary>
         /// Gets the name of the log level.
         /// </summary>
-        public string Name
-        {
-            get { return _name; }
-        }
+        public string Name => _name;
 
-        internal static LogLevel MaxLevel
-        {
-            get { return Fatal; }
-        }
+        internal static LogLevel MaxLevel => Fatal;
 
-        internal static LogLevel MinLevel
-        {
-            get { return Trace; }
-        }
+        internal static LogLevel MinLevel => Trace;
 
         /// <summary>
         /// Gets the ordinal of the log level.
         /// </summary>
-        public int Ordinal
-        {
-            get { return _ordinal; }
-        }
+        public int Ordinal => _ordinal;
 
         /// <summary>
         /// Compares two <see cref="LogLevel"/> objects 

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -72,18 +72,15 @@ namespace NLog
         /// Gets the <see cref="NLog.LogFactory" /> instance used in the <see cref="LogManager"/>.
         /// </summary>
         /// <remarks>Could be used to pass the to other methods</remarks>
-        public static LogFactory LogFactory
-        {
-            get { return factory; }
-        }
+        public static LogFactory LogFactory => factory;
 
         /// <summary>
         /// Occurs when logging <see cref="Configuration" /> changes.
         /// </summary>
         public static event EventHandler<LoggingConfigurationChangedEventArgs> ConfigurationChanged
         {
-            add { factory.ConfigurationChanged += value; }
-            remove { factory.ConfigurationChanged -= value; }
+            add => factory.ConfigurationChanged += value;
+            remove => factory.ConfigurationChanged -= value;
         }
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
@@ -92,8 +89,8 @@ namespace NLog
         /// </summary>
         public static event EventHandler<LoggingConfigurationReloadedEventArgs> ConfigurationReloaded
         {
-            add { factory.ConfigurationReloaded += value; }
-            remove { factory.ConfigurationReloaded -= value; }
+            add => factory.ConfigurationReloaded += value;
+            remove => factory.ConfigurationReloaded -= value;
         }
 #endif
         /// <summary>
@@ -102,8 +99,8 @@ namespace NLog
         /// </summary>
         public static bool ThrowExceptions
         {
-            get { return factory.ThrowExceptions; }
-            set { factory.ThrowExceptions = value; }
+            get => factory.ThrowExceptions;
+            set => factory.ThrowExceptions = value;
         }
 
         /// <summary>
@@ -117,8 +114,8 @@ namespace NLog
         /// </remarks>
         public static bool? ThrowConfigExceptions
         {
-            get { return factory.ThrowConfigExceptions; }
-            set { factory.ThrowConfigExceptions = value; }
+            get => factory.ThrowConfigExceptions;
+            set => factory.ThrowConfigExceptions = value;
         }
 
         /// <summary>
@@ -127,8 +124,8 @@ namespace NLog
         /// </summary>
         public static bool KeepVariablesOnReload
         {
-            get { return factory.KeepVariablesOnReload; }
-            set { factory.KeepVariablesOnReload = value; }
+            get => factory.KeepVariablesOnReload;
+            set => factory.KeepVariablesOnReload = value;
         }
 
 
@@ -138,8 +135,8 @@ namespace NLog
         /// </summary>
         public static LoggingConfiguration Configuration
         {
-            get { return factory.Configuration; }
-            set { factory.Configuration = value; }
+            get => factory.Configuration;
+            set => factory.Configuration = value;
         }
 
         /// <summary>
@@ -147,8 +144,8 @@ namespace NLog
         /// </summary>
         public static LogLevel GlobalThreshold
         {
-            get { return factory.GlobalThreshold; }
-            set { factory.GlobalThreshold = value; }
+            get => factory.GlobalThreshold;
+            set => factory.GlobalThreshold = value;
         }
 
         /// <summary>
@@ -159,7 +156,7 @@ namespace NLog
         public static GetCultureInfo DefaultCultureInfo
         {
             get { return () => factory.DefaultCultureInfo ?? CultureInfo.CurrentCulture; }
-            set { throw new NotSupportedException("Setting the DefaultCultureInfo delegate is no longer supported. Use the Configuration.DefaultCultureInfo property to change the default CultureInfo."); }
+            set => throw new NotSupportedException("Setting the DefaultCultureInfo delegate is no longer supported. Use the Configuration.DefaultCultureInfo property to change the default CultureInfo.");
         }
 
         /// <summary>

--- a/src/NLog/LogReceiverService/WcfLogReceiverClient.cs
+++ b/src/NLog/LogReceiverService/WcfLogReceiverClient.cs
@@ -203,11 +203,7 @@ namespace NLog.LogReceiverService
         /// <summary>
         /// Enables the user to configure client and service credentials as well as service credential authentication settings for use on the client side of communication.
         /// </summary>
-        public ClientCredentials ClientCredentials
-        {
-            get { return ProxiedClient.ClientCredentials; }
-        }
-
+        public ClientCredentials ClientCredentials => ProxiedClient.ClientCredentials;
 
 
         /// <summary>
@@ -250,8 +246,8 @@ namespace NLog.LogReceiverService
         /// </summary>
         public event EventHandler<AsyncCompletedEventArgs> CloseCompleted
         {
-            add { ProxiedClient.CloseCompleted += value; }
-            remove { ProxiedClient.CloseCompleted -= value; }
+            add => ProxiedClient.CloseCompleted += value;
+            remove => ProxiedClient.CloseCompleted -= value;
         }
 
         /// <summary>
@@ -259,8 +255,8 @@ namespace NLog.LogReceiverService
         /// </summary>
         public event EventHandler Closed
         {
-            add { ProxiedClient.Closed += value; }
-            remove { ProxiedClient.Closed -= value; }
+            add => ProxiedClient.Closed += value;
+            remove => ProxiedClient.Closed -= value;
         }
 
         /// <summary>
@@ -268,8 +264,8 @@ namespace NLog.LogReceiverService
         /// </summary>
         public event EventHandler Closing
         {
-            add { ProxiedClient.Closing += value; }
-            remove { ProxiedClient.Closing -= value; }
+            add => ProxiedClient.Closing += value;
+            remove => ProxiedClient.Closing -= value;
         }
 
 #if !SILVERLIGHT && !NETSTANDARD
@@ -290,8 +286,8 @@ namespace NLog.LogReceiverService
         /// <value>The cookie container.</value>
         public CookieContainer CookieContainer
         {
-            get { return ProxiedClient.CookieContainer; }
-            set { ProxiedClient.CookieContainer = value; }
+            get => ProxiedClient.CookieContainer;
+            set => ProxiedClient.CookieContainer = value;
         }
 #endif
 
@@ -316,10 +312,7 @@ namespace NLog.LogReceiverService
         /// <summary>
         /// Gets the target endpoint for the service to which the WCF client can connect.
         /// </summary>
-        public ServiceEndpoint Endpoint
-        {
-            get { return ProxiedClient.Endpoint; }
-        }
+        public ServiceEndpoint Endpoint => ProxiedClient.Endpoint;
 
         /// <summary>
         /// Ends asynchronous processing of log messages.
@@ -335,17 +328,14 @@ namespace NLog.LogReceiverService
         /// </summary>
         public event EventHandler Faulted
         {
-            add { ProxiedClient.Faulted += value; }
-            remove { ProxiedClient.Faulted -= value; }
+            add => ProxiedClient.Faulted += value;
+            remove => ProxiedClient.Faulted -= value;
         }
 
         /// <summary>
         /// Gets the underlying <see cref="IClientChannel"/> implementation.
         /// </summary>
-        public IClientChannel InnerChannel
-        {
-            get { return ProxiedClient.InnerChannel; }
-        }
+        public IClientChannel InnerChannel => ProxiedClient.InnerChannel;
 
         /// <summary>
         /// Causes a communication object to transition from the created state into the opened state.  
@@ -387,8 +377,8 @@ namespace NLog.LogReceiverService
         /// </summary>
         public event EventHandler<AsyncCompletedEventArgs> OpenCompleted
         {
-            add { ProxiedClient.OpenCompleted += value; }
-            remove { ProxiedClient.OpenCompleted -= value; }
+            add => ProxiedClient.OpenCompleted += value;
+            remove => ProxiedClient.OpenCompleted -= value;
         }
 
         /// <summary>
@@ -396,8 +386,8 @@ namespace NLog.LogReceiverService
         /// </summary>
         public event EventHandler Opened
         {
-            add { ProxiedClient.Opened += value; }
-            remove { ProxiedClient.Opened -= value; }
+            add => ProxiedClient.Opened += value;
+            remove => ProxiedClient.Opened -= value;
         }
 
         /// <summary>
@@ -405,8 +395,8 @@ namespace NLog.LogReceiverService
         /// </summary>
         public event EventHandler Opening
         {
-            add { ProxiedClient.Opening += value; }
-            remove { ProxiedClient.Opening -= value; }
+            add => ProxiedClient.Opening += value;
+            remove => ProxiedClient.Opening -= value;
         }
 
         /// <summary>
@@ -433,8 +423,8 @@ namespace NLog.LogReceiverService
         /// </summary>
         public event EventHandler<AsyncCompletedEventArgs> ProcessLogMessagesCompleted
         {
-            add { ProxiedClient.ProcessLogMessagesCompleted += value; }
-            remove { ProxiedClient.ProcessLogMessagesCompleted -= value; }
+            add => ProxiedClient.ProcessLogMessagesCompleted += value;
+            remove => ProxiedClient.ProcessLogMessagesCompleted -= value;
         }
 
         /// <summary>
@@ -443,10 +433,7 @@ namespace NLog.LogReceiverService
         /// <returns>
         /// The value of the <see cref="T:System.ServiceModel.CommunicationState"/> of the object.
         /// </returns>
-        public CommunicationState State
-        {
-            get { return ProxiedClient.State; }
-        }
+        public CommunicationState State => ProxiedClient.State;
 
         #endregion
 

--- a/src/NLog/Logger-generated.cs
+++ b/src/NLog/Logger-generated.cs
@@ -46,55 +46,37 @@ namespace NLog
         /// Gets a value indicating whether logging is enabled for the <c>Trace</c> level.
         /// </summary>
         /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Trace</c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool IsTraceEnabled
-        {
-            get { return _isTraceEnabled; }
-        }
+        public bool IsTraceEnabled => _isTraceEnabled;
 
         /// <summary>
         /// Gets a value indicating whether logging is enabled for the <c>Debug</c> level.
         /// </summary>
         /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Debug</c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool IsDebugEnabled
-        {
-            get { return _isDebugEnabled; }
-        }
+        public bool IsDebugEnabled => _isDebugEnabled;
 
         /// <summary>
         /// Gets a value indicating whether logging is enabled for the <c>Info</c> level.
         /// </summary>
         /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Info</c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool IsInfoEnabled
-        {
-            get { return _isInfoEnabled; }
-        }
+        public bool IsInfoEnabled => _isInfoEnabled;
 
         /// <summary>
         /// Gets a value indicating whether logging is enabled for the <c>Warn</c> level.
         /// </summary>
         /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Warn</c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool IsWarnEnabled
-        {
-            get { return _isWarnEnabled; }
-        }
+        public bool IsWarnEnabled => _isWarnEnabled;
 
         /// <summary>
         /// Gets a value indicating whether logging is enabled for the <c>Error</c> level.
         /// </summary>
         /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Error</c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool IsErrorEnabled
-        {
-            get { return _isErrorEnabled; }
-        }
+        public bool IsErrorEnabled => _isErrorEnabled;
 
         /// <summary>
         /// Gets a value indicating whether logging is enabled for the <c>Fatal</c> level.
         /// </summary>
         /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Fatal</c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool IsFatalEnabled
-        {
-            get { return _isFatalEnabled; }
-        }
+        public bool IsFatalEnabled => _isFatalEnabled;
 
 
         #region Trace() overloads 

--- a/src/NLog/MessageTemplates/ValueSerializer.cs
+++ b/src/NLog/MessageTemplates/ValueSerializer.cs
@@ -45,8 +45,8 @@ namespace NLog.MessageTemplates
     {
         public static IValueSerializer Instance
         {
-            get { return _instance ?? (_instance = new ValueSerializer()); }
-            set { _instance = value ?? new ValueSerializer(); }
+            get => _instance ?? (_instance = new ValueSerializer());
+            set => _instance = value ?? new ValueSerializer();
         }
         private static IValueSerializer _instance = null;
 

--- a/src/NLog/NDC.cs
+++ b/src/NLog/NDC.cs
@@ -46,19 +46,13 @@ namespace NLog
         /// Gets the top NDC message but doesn't remove it.
         /// </summary>
         /// <returns>The top message. .</returns>
-        public static string TopMessage
-        {
-            get { return NestedDiagnosticsContext.TopMessage; }
-        }
+        public static string TopMessage => NestedDiagnosticsContext.TopMessage;
 
         /// <summary>
         /// Gets the top NDC object but doesn't remove it.
         /// </summary>
         /// <returns>The object from the top of the NDC stack, if defined; otherwise <c>null</c>.</returns>
-        public static object TopObject 
-        {
-            get { return NestedDiagnosticsContext.TopObject; }
-        }
+        public static object TopObject => NestedDiagnosticsContext.TopObject;
 
         /// <summary>
         /// Pushes the specified text on current thread NDC.

--- a/src/NLog/NLogTraceListener.cs
+++ b/src/NLog/NLogTraceListener.cs
@@ -140,10 +140,7 @@ namespace NLog
         /// </summary>
         /// <value></value>
         /// <returns>true if the trace listener is thread safe; otherwise, false. The default is false.</returns>
-        public override bool IsThreadSafe
-        {
-            get { return true; }
-        }
+        public override bool IsThreadSafe => true;
 
         /// <summary>
         /// Gets or sets a value indicating whether to use auto logger name detected from the stack trace.

--- a/src/NLog/NestedDiagnosticsContext.cs
+++ b/src/NLog/NestedDiagnosticsContext.cs
@@ -52,13 +52,7 @@ namespace NLog
         /// Gets the top NDC message but doesn't remove it.
         /// </summary>
         /// <returns>The top message. .</returns>
-        public static string TopMessage
-        {
-            get
-            {
-                return FormatHelper.ConvertToString(TopObject, null);
-            }
-        }
+        public static string TopMessage => FormatHelper.ConvertToString(TopObject, null);
 
         /// <summary>
         /// Gets the top NDC object but doesn't remove it.
@@ -73,10 +67,7 @@ namespace NLog
             }
         }
 
-        private static Stack<object> ThreadStack
-        {
-            get { return ThreadLocalStorageHelper.GetDataForSlot<Stack<object>>(dataSlot); }
-        }
+        private static Stack<object> ThreadStack => ThreadLocalStorageHelper.GetDataForSlot<Stack<object>>(dataSlot);
 
         /// <summary>
         /// Pushes the specified text on current thread NDC.

--- a/src/NLog/NestedDiagnosticsLogicalContext.cs
+++ b/src/NLog/NestedDiagnosticsLogicalContext.cs
@@ -150,7 +150,7 @@ namespace NLog
         {
             public INestedContext Parent { get; private set; }
             public T Value { get; private set; }
-            object INestedContext.Value { get { return Value; } }
+            object INestedContext.Value => Value;
             public int FrameLevel { get; private set; }
 
             public NestedContext(INestedContext parent, T value)

--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -64,7 +64,7 @@ namespace NLog.Targets
         /// <summary>
         /// Task Scheduler used for processing async Tasks
         /// </summary>
-        protected virtual TaskScheduler TaskScheduler { get { return TaskScheduler.Default; } }
+        protected virtual TaskScheduler TaskScheduler => TaskScheduler.Default;
 
         /// <summary>
         /// Constructor

--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -167,10 +167,7 @@ namespace NLog.Targets
         /// <remarks>Has side effect</remarks>
         public Encoding Encoding
         {
-            get
-            {
-                return ConsoleTargetHelper.GetConsoleOutputEncoding(_encoding, IsInitialized, _pauseLogging);
-            }
+            get => ConsoleTargetHelper.GetConsoleOutputEncoding(_encoding, IsInitialized, _pauseLogging);
             set
             {
                 if (ConsoleTargetHelper.SetConsoleOutputEncoding(value, IsInitialized, _pauseLogging))
@@ -459,15 +456,9 @@ namespace NLog.Targets
                 _backgroundColor = backgroundColor;
             }
 
-            internal ConsoleColor BackgroundColor
-            {
-                get { return _backgroundColor; }
-            }
+            internal ConsoleColor BackgroundColor => _backgroundColor;
 
-            internal ConsoleColor ForegroundColor
-            {
-                get { return _foregroundColor; }
-            }
+            internal ConsoleColor ForegroundColor => _foregroundColor;
         }
     }
 }

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -93,10 +93,7 @@ namespace NLog.Targets
         /// <remarks>Has side effect</remarks>
         public Encoding Encoding
         {
-            get
-            {
-                return ConsoleTargetHelper.GetConsoleOutputEncoding(_encoding, IsInitialized, _pauseLogging);
-            }
+            get => ConsoleTargetHelper.GetConsoleOutputEncoding(_encoding, IsInitialized, _pauseLogging);
             set
             {
                 if (ConsoleTargetHelper.SetConsoleOutputEncoding(value, IsInitialized, _pauseLogging))

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -61,10 +61,7 @@ namespace NLog.Targets
         /// <summary>
         /// Singleton instance of the serializer.
         /// </summary>
-        public static DefaultJsonSerializer Instance
-        {
-            get { return instance; }
-        }
+        public static DefaultJsonSerializer Instance => instance;
 
         static DefaultJsonSerializer()
         {

--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -150,7 +150,7 @@ namespace NLog.Targets
         [DefaultValue(16384)]
         public int MaxMessageLength
         {
-            get { return maxMessageLength; }
+            get => maxMessageLength;
             set
             {
                 if (value <= 0)
@@ -174,7 +174,7 @@ namespace NLog.Targets
         [DefaultValue(null)]
         public long? MaxKilobytes
         {
-            get { return maxKilobytes; }
+            get => maxKilobytes;
             set
             {   //Event log API restriction
                 if (value != null && (value < 64 || value > 4194240 || (value % 64 != 0)))

--- a/src/NLog/Targets/FileArchiveModes/FileArchiveModeBase.cs
+++ b/src/NLog/Targets/FileArchiveModes/FileArchiveModeBase.cs
@@ -174,7 +174,7 @@ namespace NLog.Targets.FileArchiveModes
             /// </summary>
             public int EndAt { get; private set; }
 
-            private bool FoundPattern { get { return BeginAt != -1 && EndAt != -1; } }
+            private bool FoundPattern => BeginAt != -1 && EndAt != -1;
 
             public FileNameTemplate(string template)
             {

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -257,7 +257,7 @@ namespace NLog.Targets
         [DefaultValue(true)]
         public bool CleanupFileName
         {
-            get { return _cleanupFileName; }
+            get => _cleanupFileName;
             set
             {
                 if (_cleanupFileName != value)
@@ -276,7 +276,7 @@ namespace NLog.Targets
         [DefaultValue(FilePathKind.Unknown)]
         public FilePathKind FileNameKind
         {
-            get { return _fileNameKind; }
+            get => _fileNameKind;
             set
             {
                 if (_fileNameKind != value)
@@ -328,7 +328,7 @@ namespace NLog.Targets
         [DefaultValue(false)]
         public bool KeepFileOpen
         {
-            get { return _keepFileOpen; }
+            get => _keepFileOpen;
             set
             {
                 if (_keepFileOpen != value)
@@ -369,14 +369,8 @@ namespace NLog.Targets
         /// <summary>
         /// Should we capture the last write time of a file?
         /// </summary>
-        bool ICreateFileParameters.CaptureLastWriteTime
-        {
-            get
-            {
-                return ArchiveNumbering == ArchiveNumberingMode.Date ||
-                       ArchiveNumbering == ArchiveNumberingMode.DateAndSequence;
-            }
-        }
+        bool ICreateFileParameters.CaptureLastWriteTime => ArchiveNumbering == ArchiveNumberingMode.Date ||
+                                                           ArchiveNumbering == ArchiveNumberingMode.DateAndSequence;
 
         /// <summary>
         /// Gets or sets the line ending mode.
@@ -385,9 +379,9 @@ namespace NLog.Targets
         [Advanced]
         public LineEndingMode LineEnding
         {
-            get { return _lineEndingMode; }
+            get => _lineEndingMode;
 
-            set { _lineEndingMode = value; }
+            set => _lineEndingMode = value;
         }
 
         /// <summary>
@@ -455,7 +449,7 @@ namespace NLog.Targets
         [DefaultValue(true)]
         public bool ConcurrentWrites
         {
-            get { return _concurrentWrites; }
+            get => _concurrentWrites;
             set
             {
                 if (_concurrentWrites != value)
@@ -528,7 +522,7 @@ namespace NLog.Targets
         [DefaultValue("")]
         public string ArchiveDateFormat
         {
-            get { return _archiveDateFormat; }
+            get => _archiveDateFormat;
             set
             {
                 if (_archiveDateFormat != value)
@@ -555,7 +549,7 @@ namespace NLog.Targets
         /// <docgen category='Archival Options' order='10' />
         public long ArchiveAboveSize
         {
-            get { return _archiveAboveSize; }
+            get => _archiveAboveSize;
             set
             {
                 if ((_archiveAboveSize == ArchiveAboveSizeDisabled) != (value == ArchiveAboveSizeDisabled))
@@ -587,7 +581,7 @@ namespace NLog.Targets
         /// <docgen category='Archival Options' order='10' />
         public FileArchivePeriod ArchiveEvery
         {
-            get { return _archiveEvery; }
+            get => _archiveEvery;
             set
             {
                 if (_archiveEvery != value)
@@ -603,7 +597,7 @@ namespace NLog.Targets
         /// </summary>
         public FilePathKind ArchiveFileKind
         {
-            get { return _archiveFileKind; }
+            get => _archiveFileKind;
             set
             {
                 if (_archiveFileKind != value)
@@ -647,7 +641,7 @@ namespace NLog.Targets
         [DefaultValue(0)]
         public int MaxArchiveFiles
         {
-            get { return _maxArchiveFiles; }
+            get => _maxArchiveFiles;
             set
             {
                 if (_maxArchiveFiles != value)
@@ -664,7 +658,7 @@ namespace NLog.Targets
         /// <docgen category='Archival Options' order='10' />
         public ArchiveNumberingMode ArchiveNumbering
         {
-            get { return _archiveNumbering; }
+            get => _archiveNumbering;
             set
             {
                 if (_archiveNumbering != value)
@@ -691,7 +685,7 @@ namespace NLog.Targets
         [DefaultValue(false)]
         public bool EnableArchiveFileCompression
         {
-            get { return _enableArchiveFileCompression && FileCompressor != null; }
+            get => _enableArchiveFileCompression && FileCompressor != null;
             set
             {
                 if (_enableArchiveFileCompression != value)
@@ -725,10 +719,7 @@ namespace NLog.Targets
         /// <summary>
         /// Gets the characters that are appended after each line.
         /// </summary>
-        protected internal string NewLineChars
-        {
-            get { return _lineEndingMode.NewLineCharacters; }
-        }
+        protected internal string NewLineChars => _lineEndingMode.NewLineCharacters;
 
         /// <summary>
         /// Refresh the ArchiveFilePatternToWatch option of the <see cref="FileAppenderCache" />. 

--- a/src/NLog/Targets/LineEndingMode.cs
+++ b/src/NLog/Targets/LineEndingMode.cs
@@ -82,18 +82,12 @@ namespace NLog.Targets
         /// <summary>
         /// Gets the name of the LineEndingMode instance.
         /// </summary>
-        public string Name 
-        {       
-            get { return _name; }
-        }
+        public string Name => _name;
 
         /// <summary>
         /// Gets the new line characters (value) of the LineEndingMode instance.  
         /// </summary>
-        public string NewLineCharacters 
-        {
-            get { return _newLineCharacters; }
-        }
+        public string NewLineCharacters => _newLineCharacters;
 
         private LineEndingMode() { }
         

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -143,7 +143,7 @@ namespace NLog.Targets
 
                 return _currentailSettings;
             }
-            set { _currentailSettings = value; }
+            set => _currentailSettings = value;
         }
 #endif
 
@@ -230,8 +230,8 @@ namespace NLog.Targets
         [DefaultValue("${message}${newline}")]
         public Layout Body
         {
-            get { return Layout; }
-            set { Layout = value; }
+            get => Layout;
+            set => Layout = value;
         }
 
         /// <summary>

--- a/src/NLog/Targets/MethodCallParameter.cs
+++ b/src/NLog/Targets/MethodCallParameter.cs
@@ -97,7 +97,9 @@ namespace NLog.Targets
         /// </summary>
         /// <docgen category='Parameter Options' order='10' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "Backwards compatibility")]
-        public Type Type { get { return ParameterType; } set { ParameterType = value; } }
+        public Type Type { get => ParameterType;
+            set => ParameterType = value;
+        }
 
         /// <summary>
         /// Gets or sets the type of the parameter.

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -100,8 +100,8 @@ namespace NLog.Targets
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeNLogData
         {
-            get { return Renderer.IncludeNLogData; }
-            set { Renderer.IncludeNLogData = value; }
+            get => Renderer.IncludeNLogData;
+            set => Renderer.IncludeNLogData = value;
         }
 
         /// <summary>
@@ -110,8 +110,8 @@ namespace NLog.Targets
         /// <docgen category='Payload Options' order='10' />
         public string AppInfo
         {
-            get { return Renderer.AppInfo; }
-            set { Renderer.AppInfo = value; }
+            get => Renderer.AppInfo;
+            set => Renderer.AppInfo = value;
         }
 
         /// <summary>
@@ -120,8 +120,8 @@ namespace NLog.Targets
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeCallSite
         {
-            get { return Renderer.IncludeCallSite; }
-            set { Renderer.IncludeCallSite = value; }
+            get => Renderer.IncludeCallSite;
+            set => Renderer.IncludeCallSite = value;
         }
 
 #if !SILVERLIGHT
@@ -131,8 +131,8 @@ namespace NLog.Targets
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeSourceInfo
         {
-            get { return Renderer.IncludeSourceInfo; }
-            set { Renderer.IncludeSourceInfo = value; }
+            get => Renderer.IncludeSourceInfo;
+            set => Renderer.IncludeSourceInfo = value;
         }
 #endif
 
@@ -142,8 +142,8 @@ namespace NLog.Targets
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeMdc
         {
-            get { return Renderer.IncludeMdc; }
-            set { Renderer.IncludeMdc = value; }
+            get => Renderer.IncludeMdc;
+            set => Renderer.IncludeMdc = value;
         }
 
         /// <summary>
@@ -152,8 +152,8 @@ namespace NLog.Targets
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeNdc
         {
-            get { return Renderer.IncludeNdc; }
-            set { Renderer.IncludeNdc = value; }
+            get => Renderer.IncludeNdc;
+            set => Renderer.IncludeNdc = value;
         }
 
 #if !SILVERLIGHT
@@ -164,8 +164,8 @@ namespace NLog.Targets
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeMdlc
         {
-            get { return Renderer.IncludeMdlc; }
-            set { Renderer.IncludeMdlc = value; }
+            get => Renderer.IncludeMdlc;
+            set => Renderer.IncludeMdlc = value;
         }
 
         /// <summary>
@@ -174,8 +174,8 @@ namespace NLog.Targets
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeNdlc
         {
-            get { return Renderer.IncludeNdlc; }
-            set { Renderer.IncludeNdlc = value; }
+            get => Renderer.IncludeNdlc;
+            set => Renderer.IncludeNdlc = value;
         }
 
 #endif
@@ -186,8 +186,8 @@ namespace NLog.Targets
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeAllProperties
         {
-            get { return Renderer.IncludeAllProperties; }
-            set { Renderer.IncludeAllProperties = value; }
+            get => Renderer.IncludeAllProperties;
+            set => Renderer.IncludeAllProperties = value;
         }
 
         /// <summary>
@@ -196,8 +196,8 @@ namespace NLog.Targets
         /// <docgen category='Payload Options' order='10' />
         public string NdcItemSeparator
         {
-            get { return Renderer.NdcItemSeparator; }
-            set { Renderer.NdcItemSeparator = value; }
+            get => Renderer.NdcItemSeparator;
+            set => Renderer.NdcItemSeparator = value;
         }
 
         /// <summary>
@@ -211,10 +211,7 @@ namespace NLog.Targets
         /// <summary>
         /// Gets the layout renderer which produces Log4j-compatible XML events.
         /// </summary>
-        public Log4JXmlEventLayoutRenderer Renderer
-        {
-            get { return _layout.Renderer; }
-        }
+        public Log4JXmlEventLayoutRenderer Renderer => _layout.Renderer;
 
         /// <summary>
         /// Gets or sets the instance of <see cref="Log4JXmlEventLayout"/> that is used to format log messages.

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -77,10 +77,7 @@ namespace NLog.Targets
         /// <summary>
         /// Gets the object which can be used to synchronize asynchronous operations that must rely on the .
         /// </summary>
-        protected object SyncRoot
-        {
-            get { return _lockObject; }
-        }
+        protected object SyncRoot => _lockObject;
 
         /// <summary>
         /// Gets the logging configuration this target is part of.

--- a/src/NLog/Targets/TargetWithLayoutHeaderAndFooter.cs
+++ b/src/NLog/Targets/TargetWithLayoutHeaderAndFooter.cs
@@ -58,10 +58,7 @@ namespace NLog.Targets
         [RequiredParameter]
         public override Layout Layout
         {
-            get
-            {
-                return LHF.Layout;
-            }
+            get => LHF.Layout;
 
             set
             {
@@ -89,8 +86,8 @@ namespace NLog.Targets
         /// <docgen category='Layout Options' order='3' />
         public Layout Footer
         {
-            get { return LHF.Footer; }
-            set { LHF.Footer = value; }
+            get => LHF.Footer;
+            set => LHF.Footer = value;
         }
 
         /// <summary>
@@ -99,8 +96,8 @@ namespace NLog.Targets
         /// <docgen category='Layout Options' order='2' />
         public Layout Header
         {
-            get { return LHF.Header; }
-            set { LHF.Header = value; }
+            get => LHF.Header;
+            set => LHF.Header = value;
         }
 
         /// <summary>
@@ -109,8 +106,8 @@ namespace NLog.Targets
         /// <value>The layout with header and footer.</value>
         private LayoutWithHeaderAndFooter LHF
         {
-            get { return (LayoutWithHeaderAndFooter)base.Layout; }
-            set { base.Layout = value; }
+            get => (LayoutWithHeaderAndFooter)base.Layout;
+            set => base.Layout = value;
         }
    }
 }

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -136,7 +136,9 @@ namespace NLog.Targets
         /// </summary>
         /// <docgen category='Web Service Options' order='10' />
         [DefaultValue("Soap11")]
-        public WebServiceProtocol Protocol { get { return _activeProtocol.Key; } set { _activeProtocol = new KeyValuePair<WebServiceProtocol, HttpPostFormatterBase>(value, null); } }
+        public WebServiceProtocol Protocol { get => _activeProtocol.Key;
+            set => _activeProtocol = new KeyValuePair<WebServiceProtocol, HttpPostFormatterBase>(value, null);
+        }
         private KeyValuePair<WebServiceProtocol, HttpPostFormatterBase> _activeProtocol = new KeyValuePair<WebServiceProtocol, HttpPostFormatterBase>();
 
         /// <summary>
@@ -702,15 +704,9 @@ namespace NLog.Targets
                 _encodingFlags = UrlHelper.GetUriStringEncodingFlags(target.EscapeDataNLogLegacy, true, target.EscapeDataRfc3986);
             }
 
-            protected override string ContentType
-            {
-                get { return "application/x-www-form-urlencoded"; }
-            }
+            protected override string ContentType => "application/x-www-form-urlencoded";
 
-            protected override string Separator
-            {
-                get { return "&"; }
-            }
+            protected override string Separator => "&";
 
             protected override void AppendFormattedParameter(StringBuilder builder, MethodCallParameter parameter, object value)
             {
@@ -727,25 +723,16 @@ namespace NLog.Targets
 
         private class HttpPostJsonFormatter : HttpPostTextFormatterBase
         {
-            private IJsonConverter JsonConverter
-            {
-                get { return _jsonConverter ?? (_jsonConverter = ConfigurationItemFactory.Default.JsonConverter); }
-            }
+            private IJsonConverter JsonConverter => _jsonConverter ?? (_jsonConverter = ConfigurationItemFactory.Default.JsonConverter);
             private IJsonConverter _jsonConverter = null;
 
             public HttpPostJsonFormatter(WebServiceTarget target) : base(target)
             {
             }
 
-            protected override string ContentType
-            {
-                get { return "application/json"; }
-            }
+            protected override string ContentType => "application/json";
 
-            protected override string Separator
-            {
-                get { return ","; }
-            }
+            protected override string Separator => ",";
 
             protected override void BeginFormattedMessage(StringBuilder builder)
             {
@@ -772,15 +759,9 @@ namespace NLog.Targets
             {
             }
 
-            protected override string SoapEnvelopeNamespace
-            {
-                get { return SoapEnvelopeNamespaceUri; }
-            }
+            protected override string SoapEnvelopeNamespace => SoapEnvelopeNamespaceUri;
 
-            protected override string SoapName
-            {
-                get { return "soap"; }
-            }
+            protected override string SoapName => "soap";
 
             protected override void InitRequest(HttpWebRequest request)
             {
@@ -806,15 +787,9 @@ namespace NLog.Targets
             {
             }
 
-            protected override string SoapEnvelopeNamespace
-            {
-                get { return Soap12EnvelopeNamespaceUri; }
-            }
+            protected override string SoapEnvelopeNamespace => Soap12EnvelopeNamespaceUri;
 
-            protected override string SoapName
-            {
-                get { return "soap12"; }
-            }
+            protected override string SoapName => "soap12";
         }
 
         private abstract class HttpPostSoapFormatterBase : HttpPostXmlFormatterBase
@@ -902,10 +877,7 @@ namespace NLog.Targets
         {
             private readonly XmlWriterSettings _xmlWriterSettings;
 
-            protected override string ContentType
-            {
-                get { return "application/xml"; }
-            }
+            protected override string ContentType => "application/xml";
 
             public HttpPostXmlDocumentFormatter(WebServiceTarget target) : base(target)
             {
@@ -934,10 +906,7 @@ namespace NLog.Targets
             {
             }
 
-            protected override string ContentType
-            {
-                get { return "text/xml"; }
-            }
+            protected override string ContentType => "text/xml";
 
             protected void WriteAllParametersToCurrenElement(XmlWriter currentXmlWriter, object[] parameterValues)
             {

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -150,8 +150,8 @@ namespace NLog.Targets.Wrappers
         [DefaultValue("Discard")]
         public AsyncTargetWrapperOverflowAction OverflowAction
         {
-            get { return RequestQueue.OnOverflow; }
-            set { RequestQueue.OnOverflow = value; }
+            get => RequestQueue.OnOverflow;
+            set => RequestQueue.OnOverflow = value;
         }
 
         /// <summary>
@@ -161,8 +161,8 @@ namespace NLog.Targets.Wrappers
         [DefaultValue(10000)]
         public int QueueLimit
         {
-            get { return RequestQueue.RequestLimit; }
-            set { RequestQueue.RequestLimit = value; }
+            get => RequestQueue.RequestLimit;
+            set => RequestQueue.RequestLimit = value;
         }
 
         /// <summary>

--- a/src/NLog/Targets/Wrappers/AutoFlushTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AutoFlushTargetWrapper.cs
@@ -66,7 +66,9 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Delay the flush until the LogEvent has been confirmed as written
         /// </summary>
-        public bool AsyncFlush { get { return _asyncFlush ?? true; } set { _asyncFlush = value; } }
+        public bool AsyncFlush { get => _asyncFlush ?? true;
+            set => _asyncFlush = value;
+        }
         private bool? _asyncFlush;
 
         private readonly AsyncOperationCounter _pendingManualFlushList = new AsyncOperationCounter();

--- a/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
@@ -110,7 +110,7 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Gets the <c>DateTime</c> when the current <see cref="Interval"/> will be reset.
         /// </summary>
-        public DateTime IntervalResetsAt { get { return _firstWriteInInterval + Interval; } }
+        public DateTime IntervalResetsAt => _firstWriteInInterval + Interval;
 
         /// <summary>
         /// Gets the number of <see cref="AsyncLogEventInfo"/> written in the current <see cref="Interval"/>.

--- a/src/NLog/Time/AccurateLocalTimeSource.cs
+++ b/src/NLog/Time/AccurateLocalTimeSource.cs
@@ -44,7 +44,7 @@ namespace NLog.Time
         /// <summary>
         /// Gets current local time directly from DateTime.Now.
         /// </summary>
-        public override DateTime Time { get { return DateTime.Now; } }
+        public override DateTime Time => DateTime.Now;
 
 
         /// <summary>

--- a/src/NLog/Time/AccurateUtcTimeSource.cs
+++ b/src/NLog/Time/AccurateUtcTimeSource.cs
@@ -44,7 +44,7 @@ namespace NLog.Time
         /// <summary>
         /// Gets current UTC time directly from DateTime.UtcNow.
         /// </summary>
-        public override DateTime Time { get { return DateTime.UtcNow; } }
+        public override DateTime Time => DateTime.UtcNow;
 
         /// <summary>
         ///  Converts the specified system time to the same form as the time value originated from this time source.

--- a/src/NLog/Time/FastLocalTimeSource.cs
+++ b/src/NLog/Time/FastLocalTimeSource.cs
@@ -44,7 +44,7 @@ namespace NLog.Time
         /// <summary>
         /// Gets uncached local time directly from DateTime.Now.
         /// </summary>
-        protected override DateTime FreshTime { get { return DateTime.Now; } }
+        protected override DateTime FreshTime => DateTime.Now;
 
         /// <summary>
         ///  Converts the specified system time to the same form as the time value originated from this time source.

--- a/src/NLog/Time/FastUtcTimeSource.cs
+++ b/src/NLog/Time/FastUtcTimeSource.cs
@@ -44,7 +44,7 @@ namespace NLog.Time
         /// <summary>
         /// Gets uncached UTC time directly from DateTime.UtcNow.
         /// </summary>
-        protected override DateTime FreshTime { get { return DateTime.UtcNow; } }
+        protected override DateTime FreshTime => DateTime.UtcNow;
 
         /// <summary>
         ///  Converts the specified system time to the same form as the time value originated from this time source.

--- a/src/NLog/Time/TimeSource.cs
+++ b/src/NLog/Time/TimeSource.cs
@@ -58,8 +58,8 @@ namespace NLog.Time
         /// </remarks>
         public static TimeSource Current
         {
-            get { return currentSource; }
-            set { currentSource = value; }
+            get => currentSource;
+            set => currentSource = value;
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -404,7 +404,7 @@ namespace NLog.UnitTests.Common
                 _time = time;
             }
 
-            public override DateTime Time { get { return _time; } }
+            public override DateTime Time => _time;
 
             public override DateTime FromSystemTime(DateTime systemTime)
             {

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -593,7 +593,7 @@ namespace NLog.UnitTests.Config
                 LogManager.ConfigurationReloaded += SignalCounterEvent(counterEvent);
             }
 
-            public bool DidReload { get { return counterEvent.WaitOne(0); } }
+            public bool DidReload => counterEvent.WaitOne(0);
 
             public void Dispose()
             {

--- a/tests/NLog.UnitTests/Internal/NetworkSenders/TcpNetworkSenderTests.cs
+++ b/tests/NLog.UnitTests/Internal/NetworkSenders/TcpNetworkSenderTests.cs
@@ -387,13 +387,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
                 this.uri = uri;
             }
 
-            public override AddressFamily AddressFamily
-            {
-                get
-                {
-                    return (AddressFamily)10000;
-                }
-            }
+            public override AddressFamily AddressFamily => (AddressFamily)10000;
 
             public override string ToString()
             {

--- a/tests/NLog.UnitTests/LayoutRenderers/BaseDirTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/BaseDirTests.cs
@@ -122,45 +122,33 @@ namespace NLog.UnitTests.LayoutRenderers
             /// <summary>
             /// Gets or sets the name of the configuration file for an application domain.
             /// </summary>
-            public string ConfigurationFile
-            {
-                get { return _appDomain.ConfigurationFile; }
-            }
+            public string ConfigurationFile => _appDomain.ConfigurationFile;
 
             /// <summary>
             /// Gets or sets the list of directories under the application base directory that are probed for private assemblies.
             /// </summary>
-            public IEnumerable<string> PrivateBinPath
-            {
-                get { return _appDomain.PrivateBinPath; }
-            }
+            public IEnumerable<string> PrivateBinPath => _appDomain.PrivateBinPath;
 
             /// <summary>
             /// Gets or set the friendly name.
             /// </summary>
-            public string FriendlyName
-            {
-                get { return _appDomain.FriendlyName; }
-            }
+            public string FriendlyName => _appDomain.FriendlyName;
 
             /// <summary>
             /// Gets an integer that uniquely identifies the application domain within the process. 
             /// </summary>
-            public int Id
-            {
-                get { return _appDomain.Id; }
-            }
+            public int Id => _appDomain.Id;
 
             public event EventHandler<EventArgs> ProcessExit
             {
-                add { _appDomain.ProcessExit += value; }
-                remove { _appDomain.ProcessExit -= value; }
+                add => _appDomain.ProcessExit += value;
+                remove => _appDomain.ProcessExit -= value;
             }
 
             public event EventHandler<EventArgs> DomainUnload
             {
-                add { _appDomain.DomainUnload += value; }
-                remove { _appDomain.DomainUnload -= value; }
+                add => _appDomain.DomainUnload += value;
+                remove => _appDomain.DomainUnload -= value;
             }
 
             /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -595,10 +595,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
         private class ExceptionWithBrokenMessagePropertyException : NLogConfigurationException
         {
-            public override string Message
-            {
-                get { throw new Exception("Exception from Message property"); }
-            }
+            public override string Message => throw new Exception("Exception from Message property");
         }
 
         private void SetConfigurationForExceptionUsingRootMethodTests()

--- a/tests/NLog.UnitTests/LayoutRenderers/IdentityTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/IdentityTests.cs
@@ -205,12 +205,9 @@ namespace NLog.UnitTests.LayoutRenderers
             /// <returns>
             /// true if the user was has been authenticated; otherwise, false.
             /// </returns>
-            public override bool IsAuthenticated
-            {
-                get { return false; }
-            }
+            public override bool IsAuthenticated => false;
 
-        #endregion
+            #endregion
         }
 #endif
     }

--- a/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
@@ -326,12 +326,7 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             private static readonly LogFactory _instance = new LogFactory(_mockConfig);
 
-            public static LogFactory Instance
-            {
-                get { return _instance; }
-            }
-
-
+            public static LogFactory Instance => _instance;
         }
 
 

--- a/tests/NLog.UnitTests/LogManagerTests.cs
+++ b/tests/NLog.UnitTests/LogManagerTests.cs
@@ -394,7 +394,7 @@ namespace NLog.UnitTests
             public Logger Logger { get; private set; }
             public Logger LoggerType { get; private set; }
 
-            public string BaseName { get { return typeof(ImAAbstractClass).FullName; } }
+            public string BaseName => typeof(ImAAbstractClass).FullName;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="T:System.Object"/> class.
@@ -417,7 +417,7 @@ namespace NLog.UnitTests
             public Logger LoggerInherited = LogManager.GetCurrentClassLogger();
             public Logger LoggerTypeInherited = LogManager.GetCurrentClassLogger(typeof(Logger));
 
-            public string InheritedName { get { return GetType().FullName; } }
+            public string InheritedName => GetType().FullName;
 
             public InheritedFromAbstractClass()
                 : base()

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -392,13 +392,7 @@ namespace NLog.UnitTests
         {
             private readonly StringWriter writer = new StringWriter();
 
-            public override Encoding Encoding
-            {
-                get
-                {
-                    return writer.Encoding;
-                }
-            }
+            public override Encoding Encoding => writer.Encoding;
 
 #if NETSTANDARD1_5
             public override void Write(char value)

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -1324,20 +1324,14 @@ Dispose()
 
             public string ConnectionString { get; set; }
 
-            public int ConnectionTimeout
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public int ConnectionTimeout => throw new NotImplementedException();
 
             public IDbCommand CreateCommand()
             {
                 return new MockDbCommand() { Connection = this };
             }
 
-            public string Database
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public string Database => throw new NotImplementedException();
 
             public void Open()
             {
@@ -1349,10 +1343,7 @@ Dispose()
                 }
             }
 
-            public ConnectionState State
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public ConnectionState State => throw new NotImplementedException();
 
             public void Dispose()
             {
@@ -1430,10 +1421,7 @@ Dispose()
                 throw new NotImplementedException();
             }
 
-            public IDataParameterCollection Parameters
-            {
-                get { return parameters; }
-            }
+            public IDataParameterCollection Parameters => parameters;
 
             public void Prepare()
             {
@@ -1444,8 +1432,8 @@ Dispose()
 
             public UpdateRowSource UpdatedRowSource
             {
-                get { throw new NotImplementedException(); }
-                set { throw new NotImplementedException(); }
+                get => throw new NotImplementedException();
+                set => throw new NotImplementedException();
             }
 
             public void Dispose()
@@ -1471,28 +1459,22 @@ Dispose()
 
             public DbType DbType
             {
-                get { return parameterType; }
-                set { parameterType = value; }
+                get => parameterType;
+                set => parameterType = value;
             }
 
             public ParameterDirection Direction
             {
-                get { throw new NotImplementedException(); }
-                set
-                {
-                    ((MockDbConnection)mockDbCommand.Connection).AddToLog("Parameter #{0} Direction={1}", paramId,
-                        value);
-                }
+                get => throw new NotImplementedException();
+                set => ((MockDbConnection)mockDbCommand.Connection).AddToLog("Parameter #{0} Direction={1}", paramId,
+                    value);
             }
 
-            public bool IsNullable
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public bool IsNullable => throw new NotImplementedException();
 
             public string ParameterName
             {
-                get { return parameterName; }
+                get => parameterName;
                 set
                 {
                     ((MockDbConnection)mockDbCommand.Connection).AddToLog("Parameter #{0} Name={1}", paramId, value);
@@ -1502,19 +1484,19 @@ Dispose()
 
             public string SourceColumn
             {
-                get { throw new NotImplementedException(); }
-                set { throw new NotImplementedException(); }
+                get => throw new NotImplementedException();
+                set => throw new NotImplementedException();
             }
 
             public DataRowVersion SourceVersion
             {
-                get { throw new NotImplementedException(); }
-                set { throw new NotImplementedException(); }
+                get => throw new NotImplementedException();
+                set => throw new NotImplementedException();
             }
 
             public object Value
             {
-                get { return parameterValue; }
+                get => parameterValue;
                 set
                 {
                     ((MockDbConnection)mockDbCommand.Connection).AddToLog("Parameter #{0} Value={1}", paramId, value);
@@ -1524,30 +1506,21 @@ Dispose()
 
             public byte Precision
             {
-                get { throw new NotImplementedException(); }
-                set
-                {
-                    ((MockDbConnection)mockDbCommand.Connection).AddToLog("Parameter #{0} Precision={1}", paramId,
-                        value);
-                }
+                get => throw new NotImplementedException();
+                set => ((MockDbConnection)mockDbCommand.Connection).AddToLog("Parameter #{0} Precision={1}", paramId,
+                    value);
             }
 
             public byte Scale
             {
-                get { throw new NotImplementedException(); }
-                set
-                {
-                    ((MockDbConnection)mockDbCommand.Connection).AddToLog("Parameter #{0} Scale={1}", paramId, value);
-                }
+                get => throw new NotImplementedException();
+                set => ((MockDbConnection)mockDbCommand.Connection).AddToLog("Parameter #{0} Scale={1}", paramId, value);
             }
 
             public int Size
             {
-                get { throw new NotImplementedException(); }
-                set
-                {
-                    ((MockDbConnection)mockDbCommand.Connection).AddToLog("Parameter #{0} Size={1}", paramId, value);
-                }
+                get => throw new NotImplementedException();
+                set => ((MockDbConnection)mockDbCommand.Connection).AddToLog("Parameter #{0} Size={1}", paramId, value);
             }
 
             public override string ToString()
@@ -1575,20 +1548,11 @@ Dispose()
                 throw new NotImplementedException();
             }
 
-            public int Count
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public int Count => throw new NotImplementedException();
 
-            public object SyncRoot
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public object SyncRoot => throw new NotImplementedException();
 
-            public bool IsSynchronized
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public bool IsSynchronized => throw new NotImplementedException();
 
             public int Add(object value)
             {
@@ -1628,19 +1592,13 @@ Dispose()
 
             object IList.this[int index]
             {
-                get { throw new NotImplementedException(); }
-                set { throw new NotImplementedException(); }
+                get => throw new NotImplementedException();
+                set => throw new NotImplementedException();
             }
 
-            public bool IsReadOnly
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public bool IsReadOnly => throw new NotImplementedException();
 
-            public bool IsFixedSize
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public bool IsFixedSize => throw new NotImplementedException();
 
             public bool Contains(string parameterName)
             {
@@ -1659,8 +1617,8 @@ Dispose()
 
             object IDataParameterCollection.this[string parameterName]
             {
-                get { throw new NotImplementedException(); }
-                set { throw new NotImplementedException(); }
+                get => throw new NotImplementedException();
+                set => throw new NotImplementedException();
             }
         }
 
@@ -1702,15 +1660,9 @@ Dispose()
                 throw new NotImplementedException();
             }
 
-            public override string DataSource
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public override string DataSource => throw new NotImplementedException();
 
-            public override string Database
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public override string Database => throw new NotImplementedException();
 
             public override void Open()
             {
@@ -1718,15 +1670,9 @@ Dispose()
                 OpenCount++;
             }
 
-            public override string ServerVersion
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public override string ServerVersion => throw new NotImplementedException();
 
-            public override ConnectionState State
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public override ConnectionState State => throw new NotImplementedException();
         }
 
         private class SQLiteTest

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -506,13 +506,7 @@ namespace NLog.UnitTests.Targets
 
             public string SetOnly { private get; set; }
 
-            public object Ex
-            {
-                get
-                {
-                    throw new Exception("oops");
-                }
-            }
+            public object Ex => throw new Exception("oops");
         }
 
 

--- a/tests/NLog.UnitTests/Targets/MailTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MailTargetTests.cs
@@ -925,7 +925,7 @@ namespace NLog.UnitTests.Targets
                 Client.DeliveryMethod = DeliveryMethod;
             }
 
-            public string SmtpClientPickUpDirectory { get { return Client.PickupDirectoryLocation; } }
+            public string SmtpClientPickUpDirectory => Client.PickupDirectoryLocation;
         }
 
 

--- a/tests/NLog.UnitTests/TimeSourceTests.cs
+++ b/tests/NLog.UnitTests/TimeSourceTests.cs
@@ -76,13 +76,7 @@ namespace NLog.UnitTests
 
         class CustomTimeSource : TimeSource
         {
-            public override DateTime Time
-            {
-                get
-                {
-                    return FromSystemTime(DateTime.UtcNow);
-                }
-            }
+            public override DateTime Time => FromSystemTime(DateTime.UtcNow);
 
             public override DateTime FromSystemTime(DateTime systemTime)
             {
@@ -103,9 +97,9 @@ namespace NLog.UnitTests
                 systemTimeDelta = TimeSpan.Zero;
             }
 
-            public override DateTime Time { get { return ConvertToKind(sourceTime); } }
+            public override DateTime Time => ConvertToKind(sourceTime);
 
-            public DateTime SystemTime { get { return ConvertToKind(sourceTime - systemTimeDelta); } }
+            public DateTime SystemTime => ConvertToKind(sourceTime - systemTimeDelta);
 
             public override DateTime FromSystemTime(DateTime systemTime)
             {

--- a/tests/SampleExtensions/FooLayout.cs
+++ b/tests/SampleExtensions/FooLayout.cs
@@ -43,8 +43,8 @@ namespace MyExtensionNamespace
 
         public int X
         {
-            get { return x; }
-            set { x = value; }
+            get => x;
+            set => x = value;
         }
 
         protected override string GetFormattedMessage(LogEventInfo logEvent)

--- a/tests/SampleExtensions/WhenFooFilter.cs
+++ b/tests/SampleExtensions/WhenFooFilter.cs
@@ -43,8 +43,8 @@ namespace MyExtensionNamespace
 
         public int X
         {
-            get { return x; }
-            set { x = value; }
+            get => x;
+            set => x = value;
         }
 
         protected override FilterResult Check(LogEventInfo logEvent)


### PR DESCRIPTION
Replace code braces in properties with expression-bodied members in C# 6.

For example, this:
```
public static bool IsTraceEnabled
{
    get { return LogLevel.Trace >= LogLevel; }
}
```

becomes this:
`public static bool IsTraceEnabled => LogLevel.Trace >= LogLevel;`