### PR TITLE
NLog - NETSTANDARD1_5 (Cleanup package references)

### DIFF
--- a/src/NLog/Conditions/ConditionEvaluationException.cs
+++ b/src/NLog/Conditions/ConditionEvaluationException.cs
@@ -38,7 +38,7 @@ namespace NLog.Conditions
     /// <summary>
     /// Exception during evaluation of condition expression.
     /// </summary>
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD1_5
     [Serializable]
 #endif
     public class ConditionEvaluationException : Exception 

--- a/src/NLog/Conditions/ConditionParseException.cs
+++ b/src/NLog/Conditions/ConditionParseException.cs
@@ -38,7 +38,7 @@ namespace NLog.Conditions
     /// <summary>
     /// Exception during parsing of condition expression.
     /// </summary>
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD1_5
     [Serializable]
 #endif
     public class ConditionParseException : Exception 

--- a/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
@@ -45,7 +45,9 @@ namespace NLog.Internal.FileAppenders
     using System.Text;
 
 #if SupportsMutex
+#if !NETSTANDARD1_5
     using System.Security.AccessControl;
+#endif
     using System.Security.Principal;
     using System.Security.Cryptography;
     using Common;

--- a/src/NLog/LayoutRenderers/WindowsIdentityLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/WindowsIdentityLayoutRenderer.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD1_5
 
 namespace NLog.LayoutRenderers
 {

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -57,6 +57,7 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <Title>NLog for NetStandard 1.5</Title>
     <DefineConstants>$(DefineConstants);NET4_5;NETSTANDARD;NETSTANDARD1_5</DefineConstants>
+    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
@@ -206,25 +207,21 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Watcher" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-    <PackageReference Include="System.Security.AccessControl" Version="4.3.0" />
-    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.Primitives" Version="4.1.0 " />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.1.0" />
+    <PackageReference Include="System.Data.Common" Version="4.1.0" />
+    <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
+    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.0.1" />
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
+    <PackageReference Include="System.IO.FileSystem.Watcher" Version="4.0.0" />
+    <PackageReference Include="System.Net.NameResolution" Version="4.0.0" />
+    <PackageReference Include="System.Net.Requests" Version="4.0.11" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
+    <PackageReference Include="System.Security.Principal" Version="4.0.1" />
+    <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
+    <PackageReference Include="System.Threading.ThreadPool" Version="4.0.10" />
+    <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1" />
+    <PackageReference Include="System.Xml.XmlSerializer" Version="4.0.11" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/NLog/NLogConfigurationException.cs
+++ b/src/NLog/NLogConfigurationException.cs
@@ -40,7 +40,7 @@ namespace NLog
     /// <summary>
     /// Exception thrown during NLog configuration.
     /// </summary>
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD1_5
     [Serializable]
 #endif
     public class NLogConfigurationException : Exception

--- a/src/NLog/NLogRuntimeException.cs
+++ b/src/NLog/NLogRuntimeException.cs
@@ -40,7 +40,7 @@ namespace NLog
     /// <summary>
     /// Exception thrown during log event processing.
     /// </summary>
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD1_5
     [Serializable]
 #endif
     public class NLogRuntimeException : Exception

--- a/src/NLog/NestedDiagnosticsLogicalContext.cs
+++ b/src/NLog/NestedDiagnosticsLogicalContext.cs
@@ -143,7 +143,7 @@ namespace NLog
             object Value { get; }
         }
 
-#if !NETSTANDARD && !NET4_6
+#if !NETSTANDARD1_5
         [Serializable]
 #endif
         class NestedContext<T> : INestedContext


### PR DESCRIPTION
Removed the System.Runtime.InteropServices.RuntimeInformation by using the implicit NetStandard.Library 1.6.0

Apparently one should not reference System.Runtime.InteropServices.RuntimeInformation directly