### PR TITLE
Target - Precalculate Layout should ignore sub-layouts for complex layouts

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -41,10 +41,10 @@ namespace NLog.Config
 
     using JetBrains.Annotations;
 
-    using Common;
-    using Internal;
-    using Layouts;
-    using Targets;
+    using NLog.Common;
+    using NLog.Internal;
+    using NLog.Layouts;
+    using NLog.Targets;
 
     /// <summary>
     /// Keeps logging configuration and provides simple API
@@ -516,7 +516,7 @@ namespace NLog.Config
                 roots.Add(target);
             }
 
-            _configItems = ObjectGraphScanner.FindReachableObjects<object>(roots.ToArray());
+            _configItems = ObjectGraphScanner.FindReachableObjects<object>(true, roots.ToArray());
 
             // initialize all config items starting from most nested first
             // so that whenever the container is initialized its children have already been

--- a/src/NLog/Internal/ObjectGraphScanner.cs
+++ b/src/NLog/Internal/ObjectGraphScanner.cs
@@ -98,6 +98,11 @@ namespace NLog.Internal
 
             visitedObjects.Add(o);
 
+            if (InternalLogger.IsTraceEnabled)
+            {
+                InternalLogger.Trace("{0}Scanning {1} '{2}'", new string(' ', level), type.Name, o);
+            }
+
             var t = o as T;
             if (t != null)
             {
@@ -106,11 +111,6 @@ namespace NLog.Internal
                 {
                     return;
                 }
-            }
-
-            if (InternalLogger.IsTraceEnabled)
-            {
-                InternalLogger.Trace("{0}Scanning {1} '{2}'", new string(' ', level), type.Name, o);
             }
 
             foreach (PropertyInfo prop in PropertyHelper.GetAllReadableProperties(type))

--- a/src/NLog/Layouts/CompoundLayout.cs
+++ b/src/NLog/Layouts/CompoundLayout.cs
@@ -34,9 +34,10 @@
 
 namespace NLog.Layouts
 {
-    using Config;
+    using System.Linq;
     using System.Collections.Generic;
     using System.Text;
+    using NLog.Config;
 
     /// <summary>
     /// A layout containing one or more nested layouts.
@@ -103,6 +104,15 @@ namespace NLog.Layouts
             foreach (var layout in Layouts)
                 layout.Close();
             base.CloseLayout();
+        }
+
+        /// <summary>
+        /// Generate description of Compound Layout
+        /// </summary>
+        /// <returns>Compound Layout String Description</returns>
+        public override string ToString()
+        {
+            return ToStringWithNestedItems(Layouts, l => l.ToString());
         }
     }
 }

--- a/src/NLog/Layouts/CsvLayout.cs
+++ b/src/NLog/Layouts/CsvLayout.cs
@@ -35,10 +35,11 @@ namespace NLog.Layouts
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.ComponentModel;
     using System.Globalization;
     using System.Text;
-    using Config;
+    using NLog.Config;
 
     /// <summary>
     /// A specialized layout that renders CSV-formatted events.
@@ -300,6 +301,15 @@ namespace NLog.Layouts
             {
                 _parent.RenderHeader(target);
             }
+        }
+
+        /// <summary>
+        /// Generate description of CSV Layout
+        /// </summary>
+        /// <returns>CSV Layout String Description</returns>
+        public override string ToString()
+        {
+            return ToStringWithNestedItems(Columns, c => c.Name);
         }
     }
 }

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -34,6 +34,7 @@
 namespace NLog.Layouts
 {
     using System;
+    using System.Linq;
     using System.Collections.Generic;
     using System.Text;
     using Config;
@@ -271,6 +272,15 @@ namespace NLog.Layouts
                 sb.Append('"');
             }
             return true;
+        }
+
+        /// <summary>
+        /// Generate description of JSON Layout
+        /// </summary>
+        /// <returns>JSON Layout String Description</returns>
+        public override string ToString()
+        {
+            return ToStringWithNestedItems(Attributes, a => string.Concat(a.Name, "-", a.Layout?.ToString()));
         }
     }
 }

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -40,6 +40,7 @@ namespace NLog.Layouts
     using NLog.Config;
     using NLog.Internal;
     using NLog.Common;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Abstract interface that layouts must implement.
@@ -351,6 +352,16 @@ namespace NLog.Layouts
         {
             ConfigurationItemFactory.Default.Layouts
                 .RegisterDefinition(name, layoutType);
+        }
+
+        internal string ToStringWithNestedItems<T>(IList<T> nestedItems, Func<T, string> nextItemToString)
+        {
+            if (nestedItems?.Count > 0)
+            {
+                var nestedNames = nestedItems.Select(c => nextItemToString(c)).ToArray();
+                return string.Concat(GetType().Name, "=", string.Join("|", nestedNames));
+            }
+            return base.ToString();
         }
     }
 }

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -37,9 +37,9 @@ namespace NLog.Layouts
     using System.Linq;
     using System.ComponentModel;
     using System.Text;
-    using Config;
-    using Internal;
-    using Common;
+    using NLog.Config;
+    using NLog.Internal;
+    using NLog.Common;
 
     /// <summary>
     /// Abstract interface that layouts must implement.
@@ -279,7 +279,7 @@ namespace NLog.Layouts
 
         internal void PerformObjectScanning()
         {
-            var objectGraphScannerList = ObjectGraphScanner.FindReachableObjects<object>(this);
+            var objectGraphScannerList = ObjectGraphScanner.FindReachableObjects<object>(true, this);
 
             // determine whether the layout is thread-agnostic
             // layout is thread agnostic if it is thread-agnostic and 

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -38,12 +38,12 @@ namespace NLog.Layouts
     using System.Diagnostics;
     using System.Reflection;
     using System.Text;
-    using Common;
-    using Conditions;
-    using Config;
-    using Internal;
-    using LayoutRenderers;
-    using LayoutRenderers.Wrappers;
+    using NLog.Common;
+    using NLog.Conditions;
+    using NLog.Config;
+    using NLog.Internal;
+    using NLog.LayoutRenderers;
+    using NLog.LayoutRenderers.Wrappers;
 
     /// <summary>
     /// Parses layout strings.
@@ -482,7 +482,7 @@ namespace NLog.Layouts
 
         private static bool CanBeConvertedToLiteral(LayoutRenderer lr)
         {
-            foreach (IRenderable renderable in ObjectGraphScanner.FindReachableObjects<IRenderable>(lr))
+            foreach (IRenderable renderable in ObjectGraphScanner.FindReachableObjects<IRenderable>(true, lr))
             {
                 if (renderable.GetType() == typeof(SimpleLayout))
                 {

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -35,11 +35,12 @@ namespace NLog.Layouts
 {
     using System;
     using System.Collections.ObjectModel;
+    using System.Linq;
     using System.Text;
-    using Common;
-    using Config;
-    using Internal;
-    using LayoutRenderers;
+    using NLog.Common;
+    using NLog.Config;
+    using NLog.Internal;
+    using NLog.LayoutRenderers;
 
     /// <summary>
     /// Represents a string with embedded placeholders that can render contextual information.
@@ -209,7 +210,12 @@ namespace NLog.Layouts
         /// </returns>
         public override string ToString()
         {
-            return "'" + Text + "'";
+            if (string.IsNullOrEmpty(Text) && Renderers?.Count > 0)
+            {
+                return ToStringWithNestedItems(Renderers, r => r.ToString());
+            }
+
+            return string.Concat("'", Text, "'");
         }
 
         internal void SetRenderers(LayoutRenderer[] renderers, string text)

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -37,10 +37,10 @@ namespace NLog.Targets
     using System.Collections.Generic;
     using System.Linq;
 
-    using Common;
-    using Config;
-    using Internal;
-    using Layouts;
+    using NLog.Common;
+    using NLog.Config;
+    using NLog.Internal;
+    using NLog.Layouts;
 
     /// <summary>
     /// Represents logging target.
@@ -451,7 +451,7 @@ namespace NLog.Targets
 
         private void FindAllLayouts()
         {
-            _allLayouts = ObjectGraphScanner.FindReachableObjects<Layout>(this);
+            _allLayouts = ObjectGraphScanner.FindReachableObjects<Layout>(false, this);
             InternalLogger.Trace("{0} has {1} layouts", this, _allLayouts.Count);
             _allLayoutsAreThreadAgnostic = _allLayouts.All(layout => layout.ThreadAgnostic);
             StackTraceUsage = _allLayouts.DefaultIfEmpty().Max(layout => layout == null ? StackTraceUsage.None : layout.StackTraceUsage);


### PR DESCRIPTION
Performance optimization for async-target, so it will not render and string-allocate for each individual sub-layout.

This will improve performance for complex layouts like the JsonLayout (Has a sub-layout for each json-attribute, but they don't need to be rendered individually, only the top JsonLayout).