### PR TITLE
LogEventInfo.StackTrace moved into CallSiteInformation

### DIFF
--- a/src/NLog/Fluent/LogBuilder.cs
+++ b/src/NLog/Fluent/LogBuilder.cs
@@ -298,12 +298,15 @@ namespace NLog.Fluent
             [CallerFilePath]string callerFilePath = null,
             [CallerLineNumber]int callerLineNumber = 0)
         {
+            // TODO NLog ver. 5 - Remove these properties
             if (callerMemberName != null)
                 Property("CallerMemberName", callerMemberName);
             if (callerFilePath != null)
                 Property("CallerFilePath", callerFilePath);
             if (callerLineNumber != 0)
                 Property("CallerLineNumber", callerLineNumber);
+
+            _logEvent.SetCallerInfo(callerMemberName, callerFilePath, callerLineNumber);
 
             _logger.Log(_logEvent);
         }

--- a/src/NLog/Internal/CallSiteInformation.cs
+++ b/src/NLog/Internal/CallSiteInformation.cs
@@ -1,0 +1,146 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal
+{
+    using System;
+    using System.Diagnostics;
+    using System.Reflection;
+
+    internal class CallSiteInformation
+    {
+        /// <summary>
+        /// Sets the stack trace for the event info.
+        /// </summary>
+        /// <param name="stackTrace">The stack trace.</param>
+        /// <param name="userStackFrame">Index of the first user stack frame within the stack trace.</param>
+        /// <param name="userStackFrameLegacy">Index of the first user stack frame within the stack trace.</param>
+        public void SetStackTrace(StackTrace stackTrace, int userStackFrame, int? userStackFrameLegacy)
+        {
+            StackTrace = stackTrace;
+            UserStackFrameNumber = userStackFrame;
+            UserStackFrameNumberLegacy = userStackFrameLegacy != userStackFrame ? userStackFrameLegacy : null;
+        }
+
+        /// <summary>
+        /// Sets the details retrieved from the Caller Information Attributes
+        /// </summary>
+        /// <param name="callerMemberName"></param>
+        /// <param name="callerFilePath"></param>
+        /// <param name="callerLineNumber"></param>
+        public void SetCallerInfo(string callerMemberName, string callerFilePath, int callerLineNumber)
+        {
+            CallerMemberName = callerMemberName;
+            CallerFilePath = callerFilePath;
+            CallerLineNumber = callerLineNumber;
+        }
+
+        /// <summary>
+        /// Gets the stack frame of the method that did the logging.
+        /// </summary>
+        public StackFrame UserStackFrame => (StackTrace != null) ? StackTrace.GetFrame(UserStackFrameNumberLegacy ?? UserStackFrameNumber) : null;
+
+        /// <summary>
+        /// Gets the number index of the stack frame that represents the user
+        /// code (not the NLog code).
+        /// </summary>
+        public int UserStackFrameNumber { get; private set; }
+
+        /// <summary>
+        /// Legacy attempt to skip async MoveNext, but caused source file line number to be lost
+        /// </summary>
+        public int? UserStackFrameNumberLegacy { get; private set; }
+
+        /// <summary>
+        /// Gets the entire stack trace.
+        /// </summary>
+        public StackTrace StackTrace { get; private set; }
+
+        public MethodBase GetCallerStackFrameMethod(int skipFrames)
+        {
+            StackFrame frame = StackTrace?.GetFrame(UserStackFrameNumber + skipFrames);
+            return frame?.GetMethod();
+        }
+
+        public string GetCallerClassName(MethodBase method, bool includeNameSpace, bool cleanAsyncMoveNext, bool cleanAnonymousDelegates)
+        {
+            method = method ?? GetCallerStackFrameMethod(0);
+            if (method == null)
+                return string.Empty;
+
+            cleanAsyncMoveNext = cleanAsyncMoveNext || UserStackFrameNumberLegacy.HasValue;
+            cleanAnonymousDelegates = cleanAnonymousDelegates || UserStackFrameNumberLegacy.HasValue;
+            return StackTraceUsageUtils.GetStackFrameMethodClassName(method, includeNameSpace, cleanAsyncMoveNext, cleanAnonymousDelegates) ?? string.Empty;
+        }
+
+        public string GetCallerMemberName(MethodBase method, bool includeMethodInfo, bool cleanAsyncMoveNext, bool cleanAnonymousDelegates)
+        {
+            if (!string.IsNullOrEmpty(CallerMemberName))
+                return CallerMemberName;
+
+            method = method ?? GetCallerStackFrameMethod(0);
+            if (method == null)
+                return string.Empty;
+
+            cleanAsyncMoveNext = cleanAsyncMoveNext || UserStackFrameNumberLegacy.HasValue;
+            cleanAnonymousDelegates = cleanAnonymousDelegates || UserStackFrameNumberLegacy.HasValue;
+            return StackTraceUsageUtils.GetStackFrameMethodName(method, includeMethodInfo, cleanAsyncMoveNext, cleanAnonymousDelegates) ?? string.Empty;
+        }
+
+        public string GetCallerFilePath(int skipFrames)
+        {
+            if (!string.IsNullOrEmpty(CallerFilePath))
+                return CallerFilePath;
+
+#if !SILVERLIGHT
+            StackFrame frame = StackTrace?.GetFrame(UserStackFrameNumber + skipFrames);
+            return frame?.GetFileName() ?? string.Empty;
+#else
+            return string.Empty;
+#endif
+        }
+
+        public int GetCallerLineNumber(int skipFrames)
+        {
+            if (CallerLineNumber.HasValue)
+                return CallerLineNumber.Value;
+
+            StackFrame frame = StackTrace?.GetFrame(UserStackFrameNumber + skipFrames);
+            return frame?.GetFileLineNumber() ?? 0;
+        }
+
+        public string CallerMemberName { get; private set; }
+        public string CallerFilePath { get; private set; }
+        public int? CallerLineNumber { get; private set; }
+    }
+}

--- a/src/NLog/LayoutRenderers/CallSiteLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteLayoutRenderer.cs
@@ -148,127 +148,63 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            StackFrame frame = logEvent.StackTrace?.GetFrame(logEvent.UserStackFrameNumber + SkipFrames);
-            if (frame != null)
+            if (logEvent.CallSiteInformation != null)
             {
-                MethodBase method = frame.GetMethod();
-                if (ClassName)
+                if (ClassName || MethodName)
                 {
-                    AppendClassName(builder, method);
-                }
+                    var method = logEvent.CallSiteInformation.GetCallerStackFrameMethod(SkipFrames);
+                    if (ClassName)
+                    {
+                        string className = logEvent.CallSiteInformation.GetCallerClassName(method, IncludeNamespace, CleanNamesOfAsyncContinuations, CleanNamesOfAnonymousDelegates);
+                        if (string.IsNullOrEmpty(className))
+                            className = "<no type>";
+                        builder.Append(className);
+                    }
+                    if (MethodName)
+                    {
+                        string methodName = logEvent.CallSiteInformation.GetCallerMemberName(method, false, CleanNamesOfAsyncContinuations, CleanNamesOfAnonymousDelegates);
+                        if (string.IsNullOrEmpty(methodName))
+                            methodName = "<no method>";
 
-                if (MethodName)
-                {
-                    AppendMethodName(builder, method);
+                        if (ClassName)
+                        {
+                            builder.Append(".");
+                        }
+                        builder.Append(methodName);
+                    }
                 }
 
 #if !SILVERLIGHT
                 if (FileName)
                 {
-                    AppendFileName(builder, frame);
+                    string fileName = logEvent.CallSiteInformation.GetCallerFilePath(SkipFrames);
+                    if (fileName != null)
+                    {
+                        int lineNumber = logEvent.CallSiteInformation.GetCallerLineNumber(SkipFrames);
+                        AppendFileName(builder, fileName, lineNumber);
+                    }
                 }
 #endif
-            }
-        }
-
-        private void AppendClassName(StringBuilder builder, MethodBase method)
-        {
-            var type = method.DeclaringType;
-            if (type != null)
-            {
-
-                if (CleanNamesOfAsyncContinuations && method.Name == "MoveNext" && type.DeclaringType != null && type.Name.StartsWith("<"))
-                {
-                    // NLog.UnitTests.LayoutRenderers.CallSiteTests+<CleanNamesOfAsyncContinuations>d_3'1
-                    int endIndex = type.Name.IndexOf('>', 1);
-                    if (endIndex > 1)
-                    {
-                        type = type.DeclaringType;
-                    }
-                }
-                string className = IncludeNamespace ? type.FullName : type.Name;
-
-                if (CleanNamesOfAnonymousDelegates && className != null)
-                {
-                    // NLog.UnitTests.LayoutRenderers.CallSiteTests+<>c__DisplayClassa
-                    int index = className.IndexOf("+<>", StringComparison.Ordinal);
-                    if (index >= 0)
-                    {
-                        className = className.Substring(0, index);
-                    }
-                }
-
-                builder.Append(className);
-            }
-            else
-            {
-                builder.Append("<no type>");
-            }
-        }
-
-        private void AppendMethodName(StringBuilder builder, MethodBase method)
-        {
-            if (ClassName)
-            {
-                builder.Append(".");
-            }
-
-            if (method != null)
-            {
-                string methodName = method.Name;
-
-                var type = method.DeclaringType;
-                if (CleanNamesOfAsyncContinuations && method.Name == "MoveNext" && type?.DeclaringType != null && type.Name.StartsWith("<"))
-                {
-                    // NLog.UnitTests.LayoutRenderers.CallSiteTests+<CleanNamesOfAsyncContinuations>d_3'1.MoveNext
-                    int endIndex = type.Name.IndexOf('>', 1);
-                    if (endIndex > 1)
-                    {
-                        methodName = type.Name.Substring(1, endIndex - 1);
-                    }
-                }
-
-                // Clean up the function name if it is an anonymous delegate
-                // <.ctor>b__0
-                // <Main>b__2
-                if (CleanNamesOfAnonymousDelegates && (methodName.StartsWith("<") && methodName.Contains("__") && methodName.Contains(">")))
-                {
-                    int startIndex = methodName.IndexOf('<') + 1;
-                    int endIndex = methodName.IndexOf('>');
-
-                    methodName = methodName.Substring(startIndex, endIndex - startIndex);
-                }
-
-                builder.Append(methodName);
-            }
-            else
-            {
-                builder.Append("<no method>");
             }
         }
 
 #if !SILVERLIGHT
-        private void AppendFileName(StringBuilder builder, StackFrame frame)
+        private void AppendFileName(StringBuilder builder, string fileName, int lineNumber)
         {
-            string fileName = frame.GetFileName();
-            if (fileName != null)
+            builder.Append("(");
+            if (IncludeSourcePath)
             {
-                builder.Append("(");
-                if (IncludeSourcePath)
-                {
-                    builder.Append(fileName);
-                }
-                else
-                {
-                    builder.Append(Path.GetFileName(fileName));
-                }
-
-                builder.Append(":");
-                builder.Append(frame.GetFileLineNumber());
-                builder.Append(")");
+                builder.Append(fileName);
             }
+            else
+            {
+                builder.Append(Path.GetFileName(fileName));
+            }
+
+            builder.Append(":");
+            builder.Append(lineNumber);
+            builder.Append(")");
         }
 #endif
-
     }
 }

--- a/src/NLog/LayoutRenderers/CallSiteLineNumberLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteLineNumberLayoutRenderer.cs
@@ -33,11 +33,10 @@
 
 using System;
 using System.ComponentModel;
-using System.Diagnostics;
-using System.Linq;
 using System.Text;
 using NLog.Config;
 using NLog.Internal;
+
 #if !SILVERLIGHT
 namespace NLog.LayoutRenderers
 {
@@ -66,12 +65,10 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            StackFrame frame = logEvent.StackTrace != null ? logEvent.StackTrace.GetFrame(logEvent.UserStackFrameNumber + SkipFrames) : null;
-            if (frame != null)
+            if (logEvent.CallSiteInformation != null)
             {
-                var linenumber = frame.GetFileLineNumber();
+                int linenumber = logEvent.CallSiteInformation.GetCallerLineNumber(SkipFrames);
                 builder.Append(linenumber);
-
             }
         }
     }

--- a/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
+++ b/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
@@ -565,11 +565,11 @@ namespace NLog.UnitTests.Fluent
             Assert.Equal(expected.Message, lastLogEvent.Message);
 
             Assert.NotNull(lastLogEvent.Properties);
-            //remove caller as they are also removed from the alleventrenders.
+
+            // TODO NLog ver. 5 - Remove these properties
             lastLogEvent.Properties.Remove("CallerMemberName");
             lastLogEvent.Properties.Remove("CallerLineNumber");
             lastLogEvent.Properties.Remove("CallerFilePath");
-
 
             Assert.Equal(expected.Properties, lastLogEvent.Properties);
             Assert.Equal(expected.LoggerName, lastLogEvent.LoggerName);

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -815,8 +815,10 @@ namespace NLog.UnitTests.LayoutRenderers
 #if !NETSTANDARD1_5
             Type loggerType = typeof(Logger);
             var stacktrace = StackTraceUsageUtils.GetWriteStackTrace(loggerType);
-            var index = LoggerImpl.FindCallingMethodOnStackTrace(stacktrace, loggerType);
-            logEvent.SetStackTrace(stacktrace, index);
+            var stackFrames = stacktrace.GetFrames();
+            var index = LoggerImpl.FindCallingMethodOnStackTrace(stackFrames, loggerType) ?? 0;
+            int? indexLegacy = LoggerImpl.SkipToUserStackFrameLegacy(stackFrames, index);
+            logEvent.GetCallSiteInformationInternal().SetStackTrace(stacktrace, index, indexLegacy);
 #endif
             await Task.Delay(0);
             Layout l = "${callsite}";
@@ -1065,8 +1067,10 @@ namespace NLog.UnitTests.LayoutRenderers
             var logEvent = new LogEventInfo(LogLevel.Error, "logger1", "message1");
             Type loggerType = typeof(Logger);
             var stacktrace = StackTraceUsageUtils.GetWriteStackTrace(loggerType);
-            var index = LoggerImpl.FindCallingMethodOnStackTrace(stacktrace, loggerType);
-            logEvent.SetStackTrace(stacktrace, index);
+            var stackFrames = stacktrace.GetFrames();
+            var index = LoggerImpl.FindCallingMethodOnStackTrace(stackFrames, loggerType) ?? 0;
+            int? indexLegacy = LoggerImpl.SkipToUserStackFrameLegacy(stackFrames, index);
+            logEvent.GetCallSiteInformationInternal().SetStackTrace(stacktrace, index, indexLegacy);
             Layout l = "${callsite}";
             var callSite = l.Render(logEvent);
             Assert.Equal("NLog.UnitTests.LayoutRenderers.CallSiteTests.CallSiteShouldWorkEvenInlined", callSite);


### PR DESCRIPTION
Attempt to resolve #2382 

- Introduced internal CallsiteInformation-class for handling Callsite-state. Also when using Caller Information Attributes.
- Deprecated the old calculation of UserStackFrameNumber, but still returns the legacy value for external partners. Instead the method and filenumber-detail is extracted from the MoveNext-MethodBase.
- Changed Log4JXmlEventLayoutRenderer to handle async-MoveNext out of the box.
- Added lots of TODOs about removing the use of LogEventInfo.Properties for storing Caller Information Attributes (NLog-fluent)