### PR TITLE
JsonConverter - Do not include static properties by default

### DIFF
--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -740,6 +740,6 @@ namespace NLog.Targets
             return props;
         }
 
-        private const BindingFlags PublicProperties = BindingFlags.Instance | BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy;
+        private const BindingFlags PublicProperties = BindingFlags.Instance | BindingFlags.Public;
     }
 }


### PR DESCRIPTION
Only include instance properties by default.