### PR TITLE
NLogTraceListener - set DisableFlush true by default

### DIFF
--- a/src/NLog/NLogTraceListener.cs
+++ b/src/NLog/NLogTraceListener.cs
@@ -475,6 +475,14 @@ namespace NLog
             if (!_attributesLoaded)
             {
                 _attributesLoaded = true;
+
+                if (Trace.AutoFlush)
+                {
+                    // Avoid a world of hurt, by not constantly spawning new flush threads
+                    // Also timeout exceptions thrown by Flush() will not break diagnostic Trace-logic
+                    _disableFlush = true;
+                }
+
                 foreach (DictionaryEntry de in Attributes)
                 {
                     var key = (string)de.Key;


### PR DESCRIPTION
NLog will automatically flush on AppDomain-shutdown, so going crazy and eating all threads when autoflush=true is not a good idea. See also #353

This gives a better out-of-box-experience, but also a breaking change, so should be deferred to NLog 4.5 or 5.0

Replaces  #2142