### PR TITLE
Feature 2049: Added DatabaseTargetWritten event to LogEventInfo w/ Tests

### DIFF
--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -151,6 +151,31 @@ namespace NLog
         }
 
         /// <summary>
+        /// The delegate for the DatabaseTargetWritten event.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        public delegate void DatabaseTargetWrittenHandler(string name, object value);
+
+        /// <summary>
+        /// The event called when a DatabaseTarget with an output parameter has been written to the database.
+        /// </summary>
+        public event DatabaseTargetWrittenHandler DatabaseTargetWritten;
+
+        /// <summary>
+        /// Used internally to call the client's event handler(s)
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        internal void OnDatabaseTargetWritten(string name, object value)
+        {
+            if (DatabaseTargetWritten != null)
+            {
+                DatabaseTargetWritten(name, value);
+            }
+        }
+
+        /// <summary>
         /// Gets the unique identifier of log event which is automatically generated
         /// and monotonously increasing.
         /// </summary>
@@ -437,7 +462,13 @@ namespace NLog
         /// <returns>Instance of <see cref="LogEventInfo"/>.</returns>
         public static LogEventInfo Create(LogLevel logLevel, string loggerName, IFormatProvider formatProvider, object message)
         {
-            return new LogEventInfo(logLevel, loggerName, formatProvider, "{0}", new[] { message });
+            LogEventInfo retVal = new LogEventInfo(logLevel, loggerName, formatProvider, "{0}", new[] { message });
+            if (message is LogEventInfo)
+            {
+                LogEventInfo logEventInfo = message as LogEventInfo;
+                retVal.DatabaseTargetWritten = logEventInfo.DatabaseTargetWritten;
+            }
+            return retVal;
         }
 
         /// <summary>

--- a/src/NLog/Targets/DatabaseParameterInfo.cs
+++ b/src/NLog/Targets/DatabaseParameterInfo.cs
@@ -36,6 +36,7 @@
 namespace NLog.Targets
 {
     using System.ComponentModel;
+    using System.Data;
     using Config;
     using Layouts;
 
@@ -98,6 +99,21 @@ namespace NLog.Targets
         /// <docgen category='Parameter Options' order='10' />
         [DefaultValue(0)]
         public byte Scale { get; set; }
+            
+        /// <summary>
+        /// Gets or sets the database parameter scale.
+        /// </summary>
+        /// <docgen category='Parameter Options' order='10' />
+        [DefaultValue(ParameterDirection.Input)]
+        public ParameterDirection Direction { get; set; }
+
+        /// <summary>
+        /// Gets or sets the database parameter DbType.
+        /// </summary>
+        /// <docgen category='Parameter Options' order='10' />
+        [DefaultValue(DbType.String)]
+        public DbType DbType { get; set; }
+
     }
 }
 


### PR DESCRIPTION
I'm not crazy about putting the call the the event handler(s) within the transaction in DatabaseTarget.WriteEventToDatabase(). 
What do you think?
An alternative would be to create a temporary dictionary of output parameter values and use it to call the event handler(s) outside the TransactionScope and IDBCommand "using" blocks.