### PR TITLE
Revert "Avoid struct copy on readonly field access"

### DIFF
--- a/src/NLog/Internal/MruCache.cs
+++ b/src/NLog/Internal/MruCache.cs
@@ -199,9 +199,9 @@ namespace NLog.Internal
 
         struct MruItem
         {
-            public TValue Value;
-            public long Version;
-            public bool Virgin;
+            public readonly TValue Value;
+            public readonly long Version;
+            public readonly bool Virgin;
 
             public MruItem(TValue value, long version, bool virgin)
             {

--- a/src/NLog/Internal/PropertiesDictionary.cs
+++ b/src/NLog/Internal/PropertiesDictionary.cs
@@ -52,12 +52,12 @@ namespace NLog.Internal
             /// <summary>
             /// Value of the property 
             /// </summary>
-            public object Value;
+            public readonly object Value;
 
             /// <summary>
             /// Is this a property of the message?
             /// </summary>
-            public bool IsMessageProperty;
+            public readonly bool IsMessageProperty;
 
             /// <summary>
             /// 

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -1286,8 +1286,8 @@ namespace NLog
         /// </summary>
         internal struct LoggerCacheKey : IEquatable<LoggerCacheKey>
         {
-            public string Name { get; }
-            public Type ConcreteType { get; }
+            public readonly string Name;
+            public readonly Type ConcreteType;
 
             public LoggerCacheKey(string name, Type concreteType)
             {

--- a/src/NLog/MessageTemplates/Hole.cs
+++ b/src/NLog/MessageTemplates/Hole.cs
@@ -53,19 +53,19 @@ namespace NLog.MessageTemplates
         /// <summary>Parameter name sent to structured loggers.</summary>
         /// <remarks>This is everything between "{" and the first of ",:}". 
         /// Including surrounding spaces and names that are numbers.</remarks>
-        public string Name { get; }
+        public readonly string Name;
         /// <summary>Format to render the parameter.</summary>
         /// <remarks>This is everything between ":" and the first unescaped "}"</remarks>
-        public string Format { get; }
+        public readonly string Format;
         /// <summary>
         /// Type
         /// </summary>
-        public CaptureType CaptureType { get; }
+        public readonly CaptureType CaptureType;
         /// <summary>When the template is positional, this is the parsed name of this parameter.</summary>
         /// <remarks>For named templates, the value of Index is undefined.</remarks>
-        public short Index { get; }
+        public readonly short Index;
         /// <summary>Alignment to render the parameter, by default 0.</summary>
         /// <remarks>This is the parsed value between "," and the first of ":}"</remarks>
-        public short Alignment { get; }
+        public readonly short Alignment;
     }
 }

--- a/src/NLog/MessageTemplates/LiteralHole.cs
+++ b/src/NLog/MessageTemplates/LiteralHole.cs
@@ -39,10 +39,10 @@ namespace NLog.MessageTemplates
     internal struct LiteralHole
     {
         /// <summary>Literal</summary>
-        public Literal Literal { get; }
+        public readonly Literal Literal;
         /// <summary>Hole</summary>
         /// <remarks>Uninitialized when <see cref="MessageTemplates.Literal.Skip"/> = 0.</remarks>
-        public Hole Hole { get; }
+        public readonly Hole Hole;
 
         internal LiteralHole(Literal literal, Hole hole)
         {


### PR DESCRIPTION
This partially reverts #2399

Misunderstood the issue. The problem is not having readonly fields, but having property-methods on structs (That really hurts when the struct is used as readonly-member-variable).