### PR TITLE
LoggingConfiguration - Modify and clone LoggingRules under lock

### DIFF
--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -37,9 +37,10 @@ namespace NLog.Config
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Globalization;
+    using System.Linq;
     using System.Text;
-    using Filters;
-    using Targets;
+    using NLog.Filters;
+    using NLog.Targets;
 
     /// <summary>
     /// Represents a logging rule. An equivalent of &lt;logger /&gt; configuration element.
@@ -125,6 +126,8 @@ namespace NLog.Config
         /// Gets a collection of child rules to be evaluated when this rule matches.
         /// </summary>
         public IList<LoggingRule> ChildRules { get; private set; }
+
+        internal List<LoggingRule> CloneChildRulesThreadSafe() { lock (ChildRules) return ChildRules.ToList(); }
 
         /// <summary>
         /// Gets a collection of filters to be checked before writing to targets.

--- a/src/NLog/Config/SimpleConfigurator.cs
+++ b/src/NLog/Config/SimpleConfigurator.cs
@@ -33,7 +33,8 @@
 
 namespace NLog.Config
 {
-    using Targets;
+    using System;
+    using NLog.Targets;
 
     /// <summary>
     /// Provides simple programmatic configuration API used for trivial logging cases.
@@ -44,7 +45,7 @@ namespace NLog.Config
     {
         /// <summary>
         /// Configures NLog for console logging so that all messages above and including
-        /// the <see cref="LogLevel.Info"/> level are output to the console.
+        /// the <see cref="NLog.LogLevel.Info"/> level are output to the console.
         /// </summary>
         public static void ConfigureForConsoleLogging()
         {
@@ -62,18 +63,18 @@ namespace NLog.Config
             ConsoleTarget consoleTarget = new ConsoleTarget();
 
             LoggingConfiguration config = new LoggingConfiguration();
-            LoggingRule rule = new LoggingRule("*", minLevel, consoleTarget);
-            config.LoggingRules.Add(rule);
+            config.AddRule(minLevel, LogLevel.MaxLevel, consoleTarget, "*");
             LogManager.Configuration = config;
         }
 
         /// <summary>
         /// Configures NLog for to log to the specified target so that all messages 
-        /// above and including the <see cref="LogLevel.Info"/> level are output.
+        /// above and including the <see cref="NLog.LogLevel.Info"/> level are output.
         /// </summary>
         /// <param name="target">The target to log all messages to.</param>
         public static void ConfigureForTargetLogging(Target target)
         {
+            if (target == null) { throw new ArgumentNullException(nameof(target)); }
             ConfigureForTargetLogging(target, LogLevel.Info);
         }
 
@@ -85,15 +86,15 @@ namespace NLog.Config
         /// <param name="minLevel">The minimal logging level.</param>
         public static void ConfigureForTargetLogging(Target target, LogLevel minLevel)
         {
+            if (target == null) { throw new ArgumentNullException(nameof(target)); }
             LoggingConfiguration config = new LoggingConfiguration();
-            LoggingRule rule = new LoggingRule("*", minLevel, target);
-            config.LoggingRules.Add(rule);
+            config.AddRule(minLevel, LogLevel.MaxLevel, target, "*");
             LogManager.Configuration = config;
         }
 
         /// <summary>
         /// Configures NLog for file logging so that all messages above and including
-        /// the <see cref="LogLevel.Info"/> level are written to the specified file.
+        /// the <see cref="NLog.LogLevel.Info"/> level are written to the specified file.
         /// </summary>
         /// <param name="fileName">Log file name.</param>
         public static void ConfigureForFileLogging(string fileName)


### PR DESCRIPTION
Attempt to resolve #2393 

An extended solution would be to implement a cache of the clone, and mark it dirty whenever LoggingRules are modified. But that is for another day.

The pretty solution would probably be to invent a special thread-safe IList-container, since LoggingRules is also a public property. But that is also for another day.