### PR TITLE
Avoid unnecessary string-allocation, skip unnecessary lock

### DIFF
--- a/src/NLog/Internal/AppendBuilderCreator.cs
+++ b/src/NLog/Internal/AppendBuilderCreator.cs
@@ -68,9 +68,9 @@ namespace NLog.Internal
         {
             if (!ReferenceEquals(_builder.Item, _appendTarget))
             {
-                _appendTarget.Append(_builder.Item.ToString());
+                _builder.Item.CopyTo(_appendTarget);
+                _builder.Dispose();
             }
-            _builder.Dispose();
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -400,7 +400,7 @@ namespace NLog.LayoutRenderers
                 // get rid of 'nlog' and 'log4j' namespace declarations
                 sb.Replace(dummyNamespaceRemover, string.Empty);
                 sb.Replace(dummyNLogNamespaceRemover, string.Empty);
-                builder.Append(sb.ToString());  // StringBuilder.Replace is not good when reusing the StringBuilder
+                sb.CopyTo(builder); // StringBuilder.Replace is not good when reusing the StringBuilder
             }
         }
 


### PR DESCRIPTION
Avoid unnecessary string-allocation when appending two StringBuilders.

Skip use of lock-statement when no message-template properties captured.