### PR TITLE
License should explicit state BSD 3 Clause

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,18 +1,19 @@
+BSD-3-Clause license
 
 Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
 are met:
 
-* Redistributions of source code must retain the above copyright notice, 
-  this list of conditions and the following disclaimer. 
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
 
 * Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution. 
+  and/or other materials provided with the distribution.
 
 * Neither the name of Jaroslaw Kowalski nor the names of its 
   contributors may be used to endorse or promote products derived from this


### PR DESCRIPTION
Instead of trying to guess from the license text (Help Nuget analyzer to deduce license-type)