### PR TITLE
Added "regex-matches" condition method for filtering

### DIFF
--- a/src/NLog/Conditions/ConditionMethods.cs
+++ b/src/NLog/Conditions/ConditionMethods.cs
@@ -173,32 +173,33 @@ namespace NLog.Conditions
         /// </summary>
         /// <param name="input">The string to search for a match.</param>
         /// <param name="pattern">The regular expression pattern to match.</param>
-        /// <param name="options">A string consisting of the desired options for the test. Available options are : 'i' for ignore case, 'm' for multi-line, 's' for single line and 'x' for ignore pattern whitespace.</param>
+        /// <param name="options">A string consisting of the desired options for the test. The possible values are those of the <see cref="RegexOptions"/> separated by commas.</param>
         /// <returns>true if the regular expression finds a match; otherwise, false.</returns>
         [ConditionMethod("regex-matches")]
-        public static bool RegexMatches(string input, string pattern, string options)
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Justification = "Not called directly, only ever Invoked.")]
+#if SILVERLIGHT
+        public static bool RegexMatches(string input, string pattern, [Optional] string options)
+#else
+        public static bool RegexMatches(string input, string pattern, [Optional, DefaultParameterValue("")] string options)
+#endif
         {
-            RegexOptions regexOpts = RegexOptions.None;
-
-            if (options.IndexOf('i') != -1)
-            {
-                regexOpts |= RegexOptions.IgnoreCase;
-            }
-            if (options.IndexOf('m') != -1)
-            {
-                regexOpts |= RegexOptions.Multiline;
-            }
-            if (options.IndexOf('s') != -1)
-            {
-                regexOpts |= RegexOptions.Singleline;
-            }
-            if (options.IndexOf('x') != -1)
-            {
-                regexOpts |= RegexOptions.IgnorePatternWhitespace;
-            }
-
+            RegexOptions regexOpts = ParseRegexOptions(options);
             return Regex.IsMatch(input, pattern, regexOpts);
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        private static RegexOptions ParseRegexOptions(string options)
+        {
+            if (string.IsNullOrEmpty(options))
+            {
+                return RegexOptions.None;
+            }
+
+            return (RegexOptions)Enum.Parse(typeof(RegexOptions), options, true);
+        }
     }
 }

--- a/src/NLog/Conditions/ConditionMethods.cs
+++ b/src/NLog/Conditions/ConditionMethods.cs
@@ -178,12 +178,7 @@ namespace NLog.Conditions
         [ConditionMethod("regex-matches")]
         public static bool RegexMatches(string input, string pattern, string options)
         {
-            RegexOptions regexOpts =
-#if SILVERLIGHT
-                RegexOptions.None;
-#else
-                RegexOptions.Compiled;
-#endif
+            RegexOptions regexOpts = RegexOptions.None;
 
             if (options.IndexOf('i') != -1)
             {

--- a/src/NLog/Conditions/ConditionMethods.cs
+++ b/src/NLog/Conditions/ConditionMethods.cs
@@ -36,6 +36,7 @@ namespace NLog.Conditions
     using System;
     using System.Runtime.InteropServices;
     using System.Reflection;
+    using System.Text.RegularExpressions;
 
     /// <summary>
     /// A bunch of utility methods (mostly predicates) which can be used in
@@ -166,5 +167,43 @@ namespace NLog.Conditions
         {
             return text.Length;
         }
+
+        /// <summary>
+        /// Indicates whether the specified regular expression finds a match in the specified input string.
+        /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A string consisting of the desired options for the test. Available options are : 'i' for ignore case, 'm' for multi-line, 's' for single line and 'x' for ignore pattern whitespace.</param>
+        /// <returns>true if the regular expression finds a match; otherwise, false.</returns>
+        [ConditionMethod("regex-matches")]
+        public static bool RegexMatches(string input, string pattern, string options)
+        {
+            RegexOptions regexOpts =
+#if SILVERLIGHT
+                RegexOptions.None;
+#else
+                RegexOptions.Compiled;
+#endif
+
+            if (options.IndexOf('i') != -1)
+            {
+                regexOpts |= RegexOptions.IgnoreCase;
+            }
+            if (options.IndexOf('m') != -1)
+            {
+                regexOpts |= RegexOptions.Multiline;
+            }
+            if (options.IndexOf('s') != -1)
+            {
+                regexOpts |= RegexOptions.Singleline;
+            }
+            if (options.IndexOf('x') != -1)
+            {
+                regexOpts |= RegexOptions.IgnorePatternWhitespace;
+            }
+
+            return Regex.IsMatch(input, pattern, regexOpts);
+        }
+
     }
 }

--- a/tests/NLog.UnitTests/Conditions/ConditionEvaluatorTests.cs
+++ b/tests/NLog.UnitTests/Conditions/ConditionEvaluatorTests.cs
@@ -78,16 +78,19 @@ namespace NLog.UnitTests.Conditions
             AssertEvaluationResult(false, "contains('','foo')");
             AssertEvaluationResult(true, "contains('foo','')");
 
+            AssertEvaluationResult(true, "regex-matches('foo', '^foo$')");
+            AssertEvaluationResult(false, "regex-matches('foo', '^bar$')");
+            
+            //Check that calling with empty strign is equivalent with not passing the parameter
             AssertEvaluationResult(true, "regex-matches('foo', '^foo$', '')");
             AssertEvaluationResult(false, "regex-matches('foo', '^bar$', '')");
-            AssertEvaluationResult(true, "regex-matches('Foo', '^foo$', 'i')");
-            AssertEvaluationResult(false, "regex-matches('Foo', '^foo$', '')");
-            AssertEvaluationResult(true, "regex-matches('foo\nbar', '^foo$', 'm')");
-            AssertEvaluationResult(false, "regex-matches('foo\nbar', '^foo$', '')");
-            AssertEvaluationResult(true, "regex-matches('foo\nbar', '^foo.bar$', 's')");
-            AssertEvaluationResult(false, "regex-matches('foo\nbar', '^foo.bar$', '')");
-            AssertEvaluationResult(false, "regex-matches('foo bar', '^foo bar$', 'x')");
-            AssertEvaluationResult(true, "regex-matches('foo bar', '^foo bar$', '')");
+
+            //Check that options are parsed correctly
+            AssertEvaluationResult(true, "regex-matches('Foo', '^foo$', 'ignorecase')");
+            AssertEvaluationResult(false, "regex-matches('Foo', '^foo$')");
+            AssertEvaluationResult(true, "regex-matches('foo\nbar', '^Foo$', 'ignorecase,multiline')");
+            AssertEvaluationResult(false, "regex-matches('foo\nbar', '^Foo$')");
+            Assert.Throws<ConditionEvaluationException>(() => AssertEvaluationResult(true, "regex-matches('foo\nbar', '^Foo$', 'ignorecase,nonexistent')"));
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Conditions/ConditionEvaluatorTests.cs
+++ b/tests/NLog.UnitTests/Conditions/ConditionEvaluatorTests.cs
@@ -77,6 +77,17 @@ namespace NLog.UnitTests.Conditions
             AssertEvaluationResult(false, "contains('foobar','oobe')");
             AssertEvaluationResult(false, "contains('','foo')");
             AssertEvaluationResult(true, "contains('foo','')");
+
+            AssertEvaluationResult(true, "regex-matches('foo', '^foo$', '')");
+            AssertEvaluationResult(false, "regex-matches('foo', '^bar$', '')");
+            AssertEvaluationResult(true, "regex-matches('Foo', '^foo$', 'i')");
+            AssertEvaluationResult(false, "regex-matches('Foo', '^foo$', '')");
+            AssertEvaluationResult(true, "regex-matches('foo\nbar', '^foo$', 'm')");
+            AssertEvaluationResult(false, "regex-matches('foo\nbar', '^foo$', '')");
+            AssertEvaluationResult(true, "regex-matches('foo\nbar', '^foo.bar$', 's')");
+            AssertEvaluationResult(false, "regex-matches('foo\nbar', '^foo.bar$', '')");
+            AssertEvaluationResult(false, "regex-matches('foo bar', '^foo bar$', 'x')");
+            AssertEvaluationResult(true, "regex-matches('foo bar', '^foo bar$', '')");
         }
 
         [Fact]


### PR DESCRIPTION
Closes #2324 

I went with the `regex-matches` name since it seemed everybody was OK with it in the issue discussion.

With .NET regexes, it is possible to specify options inline as explained [here](https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-options#specifying-the-options) so the `options` parameter shouldn't be necessary. I find it more usable if it exists but it creates some kind of redundancy and adds some code to parse the options string. Should we leave it ? If yes, should we make it optional ?
At the moment, [all the options you can use inline](https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-options) are supported by the `options` parameter.

