### PR TITLE
CallSiteInformation - Prepare for fast classname lookup from filename and linenumber

### DIFF
--- a/src/NLog/Fluent/LogBuilder.cs
+++ b/src/NLog/Fluent/LogBuilder.cs
@@ -306,7 +306,7 @@ namespace NLog.Fluent
             if (callerLineNumber != 0)
                 Property("CallerLineNumber", callerLineNumber);
 
-            _logEvent.SetCallerInfo(callerMemberName, callerFilePath, callerLineNumber);
+            _logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
 
             _logger.Log(_logEvent);
         }

--- a/src/NLog/Internal/CallSiteInformation.cs
+++ b/src/NLog/Internal/CallSiteInformation.cs
@@ -55,11 +55,13 @@ namespace NLog.Internal
         /// <summary>
         /// Sets the details retrieved from the Caller Information Attributes
         /// </summary>
+        /// <param name="callerClassName"></param>
         /// <param name="callerMemberName"></param>
         /// <param name="callerFilePath"></param>
         /// <param name="callerLineNumber"></param>
-        public void SetCallerInfo(string callerMemberName, string callerFilePath, int callerLineNumber)
+        public void SetCallerInfo(string callerClassName, string callerMemberName, string callerFilePath, int callerLineNumber)
         {
+            CallerClassName = callerClassName;
             CallerMemberName = callerMemberName;
             CallerFilePath = callerFilePath;
             CallerLineNumber = callerLineNumber;
@@ -94,6 +96,22 @@ namespace NLog.Internal
 
         public string GetCallerClassName(MethodBase method, bool includeNameSpace, bool cleanAsyncMoveNext, bool cleanAnonymousDelegates)
         {
+            if (!string.IsNullOrEmpty(CallerClassName))
+            {
+                if (includeNameSpace)
+                {
+                    return CallerClassName;
+                }
+                else
+                {
+                    int lastDot = CallerClassName.LastIndexOf('.');
+                    if (lastDot < 0 || lastDot >= CallerClassName.Length - 1)
+                        return CallerClassName;
+                    else
+                        return CallerClassName.Substring(lastDot + 1);
+                }
+            }
+
             method = method ?? GetCallerStackFrameMethod(0);
             if (method == null)
                 return string.Empty;
@@ -139,6 +157,7 @@ namespace NLog.Internal
             return frame?.GetFileLineNumber() ?? 0;
         }
 
+        public string CallerClassName { get; private set; }
         public string CallerMemberName { get; private set; }
         public string CallerFilePath { get; private set; }
         public int? CallerLineNumber { get; private set; }

--- a/src/NLog/LayoutRenderers/CallSiteLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteLayoutRenderer.cs
@@ -31,17 +31,14 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-
 namespace NLog.LayoutRenderers
 {
+    using System;
     using System.ComponentModel;
-    using System.Diagnostics;
     using System.IO;
-    using System.Reflection;
     using System.Text;
-    using Config;
-    using Internal;
+    using NLog.Config;
+    using NLog.Internal;
 
     /// <summary>
     /// The call site (class name, method name and source information).
@@ -178,7 +175,7 @@ namespace NLog.LayoutRenderers
                 if (FileName)
                 {
                     string fileName = logEvent.CallSiteInformation.GetCallerFilePath(SkipFrames);
-                    if (fileName != null)
+                    if (!string.IsNullOrEmpty(fileName))
                     {
                         int lineNumber = logEvent.CallSiteInformation.GetCallerLineNumber(SkipFrames);
                         AppendFileName(builder, fileName, lineNumber);

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -194,6 +194,11 @@ namespace NLog
         public StackTrace StackTrace => CallSiteInformation?.StackTrace;
 
         /// <summary>
+        /// Gets the callsite class name
+        /// </summary>
+        public string CallerClassName => CallSiteInformation?.CallerClassName;
+
+        /// <summary>
         /// Gets the callsite member function name
         /// </summary>
         public string CallerMemberName => CallSiteInformation?.GetCallerMemberName(null, false, true, true);
@@ -516,12 +521,13 @@ namespace NLog
         /// <summary>
         /// Sets the details retrieved from the Caller Information Attributes
         /// </summary>
+        /// <param name="callerClassName"></param>
         /// <param name="callerMemberName"></param>
         /// <param name="callerFilePath"></param>
         /// <param name="callerLineNumber"></param>
-        public void SetCallerInfo(string callerMemberName, string callerFilePath, int callerLineNumber)
+        public void SetCallerInfo(string callerClassName, string callerMemberName, string callerFilePath, int callerLineNumber)
         {
-            GetCallSiteInformationInternal().SetCallerInfo(callerMemberName, callerFilePath, callerLineNumber);
+            GetCallSiteInformationInternal().SetCallerInfo(callerClassName, callerMemberName, callerFilePath, callerLineNumber);
         }
 
         internal string AddCachedLayoutValue(Layout layout, string value)

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -218,6 +218,24 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
+        public void ClassNameTestWithOverride()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${callsite:classname=true:methodname=false:includeNamespace=false} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            var logEvent = LogEventInfo.Create(LogLevel.Debug, logger.Name, "msg");
+            logEvent.SetCallerInfo("NLog.UnitTests.LayoutRenderers.OverrideClassName", nameof(ClassNameTestWithOverride), null, 0);
+            logger.Log(logEvent);
+            AssertDebugLastMessage("debug", "OverrideClassName msg");
+        }
+
+        [Fact]
         public void ClassNameWithPaddingTestPadLeftAlignLeftTest()
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
@@ -542,7 +560,6 @@ namespace NLog.UnitTests.LayoutRenderers
         [Fact]
         public void When_Wrapped_Ignore_Wrapper_Methods_In_Callstack()
         {
-
             //namespace en name of current method
             const string currentMethodFullName = "NLog.UnitTests.LayoutRenderers.CallSiteTests.When_Wrapped_Ignore_Wrapper_Methods_In_Callstack";
 
@@ -633,7 +650,6 @@ namespace NLog.UnitTests.LayoutRenderers
         [Fact]
         public void When_WrappedInCompsition_Ignore_Wrapper_Methods_In_Callstack()
         {
-
             //namespace en name of current method
             const string currentMethodFullName = "NLog.UnitTests.LayoutRenderers.CallSiteTests.When_WrappedInCompsition_Ignore_Wrapper_Methods_In_Callstack";
 
@@ -652,7 +668,6 @@ namespace NLog.UnitTests.LayoutRenderers
             CompositeWrapper wrappedLogger = new CompositeWrapper();
             wrappedLogger.Log("wrapped");
             AssertDebugLastMessage("debug", $"{currentMethodFullName}|wrapped");
-
         }
 
 #if NET3_5 || NET4_0
@@ -662,7 +677,6 @@ namespace NLog.UnitTests.LayoutRenderers
 #endif
         public void Show_correct_method_with_async()
         {
-
             //namespace en name of current method
             const string currentMethodFullName = "NLog.UnitTests.LayoutRenderers.CallSiteTests.AsyncMethod";
 
@@ -676,7 +690,6 @@ namespace NLog.UnitTests.LayoutRenderers
 
             AsyncMethod().Wait();
             AssertDebugLastMessage("debug", $"{currentMethodFullName}|direct");
-
         }
 
         private async Task AsyncMethod()
@@ -716,7 +729,6 @@ namespace NLog.UnitTests.LayoutRenderers
 #endif
         public void Show_correct_method_with_async2()
         {
-
             //namespace en name of current method
             const string currentMethodFullName = "NLog.UnitTests.LayoutRenderers.CallSiteTests.AsyncMethod2b";
 
@@ -801,7 +813,6 @@ namespace NLog.UnitTests.LayoutRenderers
 #endif
         public void Show_correct_method_with_async4()
         {
-
             //namespace en name of current method
             const string currentMethodFullName = "NLog.UnitTests.LayoutRenderers.CallSiteTests.AsyncMethod4";
 
@@ -815,7 +826,6 @@ namespace NLog.UnitTests.LayoutRenderers
 
             AsyncMethod4().Wait();
             AssertDebugLastMessage("debug", $"{currentMethodFullName}|Direct, async method");
-
         }
 
 #if NET3_5 || NET4_0 || NETSTANDARD1_5
@@ -855,7 +865,6 @@ namespace NLog.UnitTests.LayoutRenderers
 #endif
         public void Show_correct_method_for_moveNext()
         {
-
             //namespace en name of current method
             const string currentMethodFullName = "NLog.UnitTests.LayoutRenderers.CallSiteTests.MoveNext";
 
@@ -877,7 +886,6 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             var logger = LogManager.GetCurrentClassLogger();
             logger.Warn("direct");
-
         }
 
         public class CompositeWrapper
@@ -954,7 +962,6 @@ namespace NLog.UnitTests.LayoutRenderers
             Assert.True(logger is MyLogger, "logger isn't MyLogger");
             logger.Debug("msg");
             AssertDebugLastMessage("debug", "NLog.UnitTests.LayoutRenderers.CallSiteTests.CallsiteBySubclass_interface msg");
-
         }
 
         [Fact]
@@ -973,7 +980,6 @@ namespace NLog.UnitTests.LayoutRenderers
             Assert.NotNull(logger);
             logger.Debug("msg");
             AssertDebugLastMessage("debug", "NLog.UnitTests.LayoutRenderers.CallSiteTests.CallsiteBySubclass_mylogger msg");
-
         }
 
         [Fact]
@@ -1050,7 +1056,6 @@ namespace NLog.UnitTests.LayoutRenderers
         public class NLogFactory
         {
             internal const string defaultConfigFileName = "nlog.config";
-
 
             /// <summary>
             ///   Initializes a new instance of the <see cref="NLogFactory" /> class.
@@ -1150,8 +1155,6 @@ namespace NLog.UnitTests.LayoutRenderers
 
             AsyncMethod5().GetAwaiter().GetResult();
 
-
-
             if (IsTravis())
             {
                 Console.WriteLine("[SKIP] LogAfterAwait_CleanNamesOfAsyncContinuationsIsFalse_ShouldNotCleanNames - test is unstable on Travis");
@@ -1161,7 +1164,6 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessageContains("debug", "NLog.UnitTests.LayoutRenderers.CallSiteTests");
             AssertDebugLastMessageContains("debug", "MoveNext");
             AssertDebugLastMessageContains("debug", "d__");
-
         }
 
         private async Task AsyncMethod5()
@@ -1219,7 +1221,6 @@ namespace NLog.UnitTests.LayoutRenderers
             {
                 Logger.Log(typeof(NLogLogger), new LogEventInfo(logLevel, Logger.Name, message));
             }
-
         }
     }
 }


### PR DESCRIPTION
Have an idea for how to optimize the callsite-layout-renderer, so it doesn't have to capture stacktrace for every logevent (only for the first logevent for a log-location).

One could use the caller-member-attributes to capture Member-Function, SourceFile-Name, SourceFile-LineNumber. And cache the ClassName-Lookup performed with StackTrace using the details from caller-member-attributes as cache-lookup-key (Maybe using MruCache).

To implement this correctly, then we need something like StackTraceUsage, but where it is WithCallSiteOnly, which is less than WithoutSource. Sadly enough any change to the StackTraceUsage will be a breaking change.

So instead one probably have to invent a new interface called IStackTraceUsageV2, and if a class implements both IStackTraceUsageV2 and IStackTraceUsage, then it will use IStackTraceUsageV2.

But all this interface-stuff will be a different PR. I just want to prepare for being able to provide the ClassName as CallSite-Information (Right now not a breaking change, as everything is still new in NLog 4.5).
