### PR TITLE
Add methods to enabling/disabling LogLevels

### DIFF
--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -261,6 +261,30 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Disables logging for particular levels between (included) <paramref name="minLevel"/> and <paramref name="maxLevel"/>.
+        /// </summary>
+        /// <param name="minLevel">Minimum log level to be disables.</param>
+        /// <param name="maxLevel">Maximum log level to de disabled.</param>
+        public void DisableLoggingForLevels(LogLevel minLevel, LogLevel maxLevel)
+        {
+            for (int i = minLevel.Ordinal; i <= maxLevel.Ordinal; i++)
+            {
+                DisableLoggingForLevel(LogLevel.FromOrdinal(i));
+            }
+        }
+
+        /// <summary>
+        /// Enables logging the levels between (included) <paramref name="minLevel"/> and <paramref name="maxLevel"/>. All the other levels will be disabled.
+        /// </summary>
+        /// <param name="minLevel">>Minimum log level needed to trigger this rule.</param>
+        /// <param name="maxLevel">Maximum log level needed to trigger this rule.</param>
+        public void SetLoggingLevels(LogLevel minLevel, LogLevel maxLevel)
+        {
+            DisableLoggingForLevels(LogLevel.MinLevel, LogLevel.MaxLevel);
+            EnableLoggingForLevels(minLevel, maxLevel);
+        }
+
+        /// <summary>
         /// Returns a string representation of <see cref="LoggingRule"/>. Used for debugging.
         /// </summary>
         /// <returns>

--- a/tests/NLog.UnitTests/Config/ConfigApiTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigApiTests.cs
@@ -262,5 +262,33 @@ namespace NLog.UnitTests.Config
             var s = loggingRule.ToString();
             Assert.Equal("logNamePattern: (namespace.comp1:Equals) levels: [ ] appendTo: [ file1 file2 ]", s);
         }
+
+        [Fact]
+        public void LogRuleSetLoggingLevels_enables()
+        {
+            var rule = new LoggingRule();
+            rule.SetLoggingLevels(LogLevel.Warn, LogLevel.Fatal);
+            Assert.Equal(rule.Levels, new[] { LogLevel.Warn, LogLevel.Error, LogLevel.Fatal });
+        }
+
+        [Fact]
+        public void LogRuleSetLoggingLevels_disables()
+        {
+            var rule = new LoggingRule();
+            rule.EnableLoggingForLevels(LogLevel.MinLevel, LogLevel.MaxLevel);
+
+            rule.SetLoggingLevels(LogLevel.Warn, LogLevel.Fatal);
+            Assert.Equal(rule.Levels, new[] { LogLevel.Warn, LogLevel.Error, LogLevel.Fatal });
+        }
+
+        [Fact]
+        public void LogRuleDisableLoggingLevels()
+        {
+            var rule = new LoggingRule();
+            rule.EnableLoggingForLevels(LogLevel.MinLevel, LogLevel.MaxLevel);
+
+            rule.DisableLoggingForLevels(LogLevel.Warn, LogLevel.Fatal);
+            Assert.Equal(rule.Levels, new[] { LogLevel.Trace, LogLevel.Debug, LogLevel.Info });
+        }
     }
 }


### PR DESCRIPTION
My attempt at implementing the functionality requested in #2427.

If someone was already working on this, please tell me and I'll close this PR.

I left the method `DisableLoggingForLevels` public because it seems that it could be useful on its own.

While we are at it, don't you think that `LogginRule.DisableLogging` and `LoggingRule.EnableLogging` methods could be added to provide an easier way to completely enable/disable the rule ?