### PR TITLE
TargetWithContext - Easier to capture snapshot of MDLC and NDLC context

### DIFF
--- a/src/NLog/Filters/WhenRepeatedFilter.cs
+++ b/src/NLog/Filters/WhenRepeatedFilter.cs
@@ -268,7 +268,7 @@ namespace NLog.Filters
         {
             if (targetBuilder != null)
             {
-                Layout.RenderAppendBuilder(logEvent, targetBuilder, false);
+                Layout.RenderAppendBuilder(logEvent, targetBuilder);
                 if (targetBuilder.Length > MaxLength)
                     targetBuilder.Length = MaxLength;
                 return new FilterInfoKey(targetBuilder, null);

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -166,9 +166,11 @@ namespace NLog.Internal
             {
                 if (!_layout.ThreadAgnostic)
                 {
-                    string cachedResult;
+                    object cachedResult;
                     if (logEvent.TryGetCachedLayoutValue(_layout, out cachedResult))
-                        return cachedResult;
+                    {
+                        return cachedResult?.ToString() ?? string.Empty;
+                    }
                 }
 
                 _layout.RenderAppendBuilder(logEvent, reusableBuilder);

--- a/src/NLog/Internal/ILogMessageFormatter.cs
+++ b/src/NLog/Internal/ILogMessageFormatter.cs
@@ -51,7 +51,7 @@ namespace NLog.Internal
         /// Has the logevent properties?
         /// </summary>
         /// <param name="logEvent">LogEvent with message to be formatted</param>
-        /// <returns>formatted message</returns>
+        /// <returns>False when logevent has no properties to be extracted</returns>
         bool HasProperties(LogEventInfo logEvent);
 
         /// <summary>

--- a/src/NLog/Internal/LogMessageTemplateFormatter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatter.cs
@@ -68,7 +68,8 @@ namespace NLog.Internal
         /// The MessageFormatter delegate
         /// </summary>
         public LogMessageFormatter MessageFormatter { get; }
- 
+
+        /// <inheritDoc/>
         public bool HasProperties(LogEventInfo logEvent)
         {
             if (!HasParameters(logEvent))

--- a/src/NLog/LayoutRenderers/NewLineLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/NewLineLayoutRenderer.cs
@@ -35,14 +35,15 @@ namespace NLog.LayoutRenderers
 {
     using System;
     using System.Text;
-    using Internal;
-    using Config;
+    using NLog.Internal;
+    using NLog.Config;
 
     /// <summary>
     /// A newline literal.
     /// </summary>
     [LayoutRenderer("newline")]
     [ThreadAgnostic]
+    [AppDomainFixedOutput]
     public class NewLineLayoutRenderer : LayoutRenderer
     {
         /// <summary>

--- a/src/NLog/Layouts/CompoundLayout.cs
+++ b/src/NLog/Layouts/CompoundLayout.cs
@@ -34,7 +34,6 @@
 
 namespace NLog.Layouts
 {
-    using System.Linq;
     using System.Collections.Generic;
     using System.Text;
     using NLog.Config;
@@ -43,6 +42,8 @@ namespace NLog.Layouts
     /// A layout containing one or more nested layouts.
     /// </summary>
     [Layout("CompoundLayout")]
+    [ThreadAgnostic]
+    [AppDomainFixedOutput]
     public class CompoundLayout : Layout
     {
         /// <summary>
@@ -68,6 +69,11 @@ namespace NLog.Layouts
             base.InitializeLayout();
             foreach (var layout in Layouts)
                 layout.Initialize(LoggingConfiguration);
+        }
+
+        internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+        {
+            if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
         }
 
         /// <summary>

--- a/src/NLog/Layouts/CsvLayout.cs
+++ b/src/NLog/Layouts/CsvLayout.cs
@@ -156,6 +156,11 @@ namespace NLog.Layouts
             _doubleQuoteChar = QuoteChar + QuoteChar;
         }
 
+        internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+        {
+            if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
+        }
+
         /// <summary>
         /// Formats the log event for write.
         /// </summary>
@@ -280,6 +285,11 @@ namespace NLog.Layouts
             public CsvHeaderLayout(CsvLayout parent)
             {
                 _parent = parent;
+            }
+
+            internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+            {
+                if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
             }
 
             /// <summary>

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -140,6 +140,11 @@ namespace NLog.Layouts
             base.CloseLayout();
         }
 
+        internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+        {
+            if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
+        }
+
         /// <summary>
         /// Formats the log event as a JSON document for writing.
         /// </summary>

--- a/src/NLog/Layouts/LayoutWithHeaderAndFooter.cs
+++ b/src/NLog/Layouts/LayoutWithHeaderAndFooter.cs
@@ -33,14 +33,15 @@
 
 namespace NLog.Layouts
 {
-    using Config;
-    using Internal;
+    using NLog.Config;
+    using NLog.Internal;
 
     /// <summary>
     /// A specialized layout that supports header and footer.
     /// </summary>
     [Layout("LayoutWithHeaderAndFooter")]
     [ThreadAgnostic]
+    [AppDomainFixedOutput]
     public class LayoutWithHeaderAndFooter : Layout
     {
         /// <summary>

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.Layouts
 {
+    using System.Text;
     using NLog.LayoutRenderers;
 
     /// <summary>
@@ -109,6 +110,11 @@ namespace NLog.Layouts
         }
 #endif
 
+        internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+        {
+            if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
+        }
+
         /// <summary>
         /// Renders the layout for the specified logging event by invoking layout renderers.
         /// </summary>
@@ -123,8 +129,8 @@ namespace NLog.Layouts
         /// Renders the layout for the specified logging event by invoking layout renderers.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>
-        /// <param name="target"><see cref="System.Text.StringBuilder"/> for the result</param>
-        protected override void RenderFormattedMessage(LogEventInfo logEvent, System.Text.StringBuilder target)
+        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             Renderer.RenderAppendBuilder(logEvent, target);
         }

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -35,7 +35,6 @@ namespace NLog.Layouts
 {
     using System;
     using System.Collections.ObjectModel;
-    using System.Linq;
     using System.Text;
     using NLog.Common;
     using NLog.Config;
@@ -270,6 +269,11 @@ namespace NLog.Layouts
             }
 
             base.InitializeLayout();
+        }
+
+        internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+        {
+            if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
         }
 
         /// <summary>

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -74,7 +74,7 @@ namespace NLog
         private object[] _parameters;
         private IFormatProvider _formatProvider;
         private LogMessageFormatter _messageFormatter = DefaultMessageFormatter;
-        private IDictionary<Layout, string> _layoutCache;
+        private IDictionary<Layout, object> _layoutCache;
         private PropertiesDictionary _properties;
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace NLog
         /// <summary>
         /// Gets the callsite class name
         /// </summary>
-        public string CallerClassName => CallSiteInformation?.CallerClassName;
+        public string CallerClassName => CallSiteInformation?.GetCallerClassName(null, true, true, true);
 
         /// <summary>
         /// Gets the callsite member function name
@@ -206,12 +206,12 @@ namespace NLog
         /// <summary>
         /// Gets the callsite source file path
         /// </summary>
-        public string CallerFilePath => CallSiteInformation?.CallerFilePath;
+        public string CallerFilePath => CallSiteInformation?.GetCallerFilePath(0);
 
         /// <summary>
         /// Gets the callsite source file line number
         /// </summary>
-        public int CallerLineNumber => CallSiteInformation?.CallerLineNumber ?? 0;
+        public int CallerLineNumber => CallSiteInformation?.GetCallerLineNumber(0) ?? 0;
 
         /// <summary>
         /// Gets or sets the exception information.
@@ -320,7 +320,7 @@ namespace NLog
         }
 
         /// <summary>
-        /// Checks if any per-event context properties (Without allocation)
+        /// Checks if any per-event properties (Without allocation)
         /// </summary>
         public bool HasProperties
         {
@@ -539,21 +539,19 @@ namespace NLog
             GetCallSiteInformationInternal().SetCallerInfo(callerClassName, callerMemberName, callerFilePath, callerLineNumber);
         }
 
-        internal string AddCachedLayoutValue(Layout layout, string value)
+        internal void AddCachedLayoutValue(Layout layout, object value)
         {
             if (_layoutCache == null)
             {
-                Interlocked.CompareExchange(ref _layoutCache, new Dictionary<Layout, string>(), null);
+                Interlocked.CompareExchange(ref _layoutCache, new Dictionary<Layout, object>(), null);
             }
             lock (_layoutCache)
             {
                 _layoutCache[layout] = value;
             }
-
-            return value;
         }
 
-        internal bool TryGetCachedLayoutValue(Layout layout, out string value)
+        internal bool TryGetCachedLayoutValue(Layout layout, out object value)
         {
             if (_layoutCache == null)
             {

--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -33,19 +33,18 @@
 
 namespace NLog.Targets
 {
+#if !NET3_5 && !SILVERLIGHT4
     using System;
     using System.Collections.Generic;
-    using System.Threading;
-
-#if !NET3_5 && !SILVERLIGHT4
-    using System.Threading.Tasks;
-    using Common;
     using System.ComponentModel;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NLog.Common;
 
     /// <summary>
     /// Abstract Target with async Task support
     /// </summary>
-    public abstract class AsyncTaskTarget : Target
+    public abstract class AsyncTaskTarget : TargetWithContext
     {
         private readonly Timer _taskTimeoutTimer;
         private CancellationTokenSource _cancelTokenSource;

--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -389,10 +389,10 @@ namespace NLog.Targets
         {
             if (OptimizeBufferReuse)
             {
-                if (!NewLine && logEvent.TryGetCachedLayoutValue(Layout, out string text))
+                if (!NewLine && logEvent.TryGetCachedLayoutValue(Layout, out var text))
                 {
                     InternalLogger.Trace("{0} - Sending {1}", this, text);
-                    return Encoding.GetBytes(text);
+                    return Encoding.GetBytes(text.ToString());
                 }
                 else
                 {

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -675,9 +675,17 @@ namespace NLog.Targets
                 if (simpleLayout != null && simpleLayout.IsFixedText)
                     return simpleLayout.Render(logEvent);
 
+                if (!layout.ThreadAgnostic)
+                {
+                    if (logEvent.TryGetCachedLayoutValue(layout, out var value))
+                    {
+                        return value?.ToString() ?? string.Empty;
+                    }
+                }
+
                 using (var localTarget = ReusableLayoutBuilder.Allocate())
                 {
-                    return layout.RenderAllocateBuilder(logEvent, localTarget.Result, false);
+                    return layout.RenderAllocateBuilder(logEvent, localTarget.Result);
                 }
             }
             else

--- a/src/NLog/Targets/TargetPropertyWithContext.cs
+++ b/src/NLog/Targets/TargetPropertyWithContext.cs
@@ -41,19 +41,19 @@ namespace NLog.Targets
     /// </summary>
     [NLogConfigurationItem]
     [ThreadAgnostic]
-    public class TargetWithContextProperty
+    public class TargetPropertyWithContext
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="TargetWithContextProperty" /> class.
+        /// Initializes a new instance of the <see cref="TargetPropertyWithContext" /> class.
         /// </summary>
-        public TargetWithContextProperty() : this(null, null) { }
+        public TargetPropertyWithContext() : this(null, null) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TargetWithContextProperty" /> class.
+        /// Initializes a new instance of the <see cref="TargetPropertyWithContext" /> class.
         /// </summary>
         /// <param name="name">The name of the attribute.</param>
         /// <param name="layout">The layout of the attribute's value.</param>
-        public TargetWithContextProperty(string name, Layout layout)
+        public TargetPropertyWithContext(string name, Layout layout)
         {
             Name = name;
             Layout = layout;

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -107,8 +107,8 @@ namespace NLog.Targets
         /// Gets the array of custom attributes to be passed into the logevent context
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
-        [ArrayParameter(typeof(TargetWithContextProperty), "contextproperty")]
-        public virtual IList<TargetWithContextProperty> ContextProperties { get; }
+        [ArrayParameter(typeof(TargetPropertyWithContext), "contextproperty")]
+        public virtual IList<TargetPropertyWithContext> ContextProperties { get; }
 
         /// <summary>
         /// Constructor

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -1,0 +1,797 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Targets
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Text;
+    using NLog.Config;
+    using NLog.Internal;
+    using NLog.Layouts;
+
+    /// <summary>
+    /// Represents target that supports context capture using MDLC, MDC, NDLC and NDC
+    /// </summary>
+    public abstract class TargetWithContext : TargetWithLayout, IIncludeContext
+    {
+        /// <inheritdoc/>
+        /// <docgen category='Layout Options' order='1' />
+        public sealed override Layout Layout
+        {
+            get { return _contextLayout; }
+            set
+            {
+                if (_contextLayout != null)
+                    _contextLayout.TargetLayout = value;
+                else
+                    _contextLayout = new TargetWithContextLayout(this, value);
+            }
+        }
+        private TargetWithContextLayout _contextLayout;
+
+        /// <inheritdoc/>
+        bool IIncludeContext.IncludeAllProperties { get => IncludeEventProperties; set => IncludeEventProperties = value; }
+
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeEventProperties { get => _contextLayout.IncludeAllProperties; set => _contextLayout.IncludeAllProperties = value; }
+
+        /// <inheritdoc/>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeMdc { get => _contextLayout.IncludeMdc; set => _contextLayout.IncludeMdc = value; }
+
+        /// <inheritdoc/>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeNdc { get => _contextLayout.IncludeNdc; set => _contextLayout.IncludeNdc = value; }
+
+#if !SILVERLIGHT
+        /// <inheritdoc/>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeMdlc { get => _contextLayout.IncludeMdlc; set => _contextLayout.IncludeMdlc = value; }
+
+        /// <inheritdoc/>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeNdlc { get => _contextLayout.IncludeNdlc; set => _contextLayout.IncludeNdlc = value; }
+#endif
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="GlobalDiagnosticsContext"/> dictionary
+        /// </summary>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeGdc { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include call site (class and method name) in the <see cref="LogEventInfo" />
+        /// </summary>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeCallSite { get => _contextLayout.IncludeCallSite; set => _contextLayout.IncludeCallSite = value; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include source info (file name and line number) in the <see cref="LogEventInfo" />
+        /// </summary>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeCallSiteStackTrace { get => _contextLayout.IncludeCallSiteStackTrace; set => _contextLayout.IncludeCallSiteStackTrace = value; }
+
+        /// <summary>
+        /// Gets the array of custom attributes to be passed into the logevent context
+        /// </summary>
+        /// <docgen category='Layout Options' order='10' />
+        [ArrayParameter(typeof(TargetWithContextProperty), "contextproperty")]
+        public virtual IList<TargetWithContextProperty> ContextProperties { get; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        protected TargetWithContext()
+        {
+            _contextLayout = _contextLayout ?? new TargetWithContextLayout(this, base.Layout);
+            OptimizeBufferReuse = true;
+        }
+
+        /// <summary>
+        /// Check if logevent has properties (or context properties)
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns>True if properties should be included</returns>
+        protected bool ShouldIncludeProperties(LogEventInfo logEvent)
+        {
+            return IncludeGdc
+            || IncludeMdc
+#if !SILVERLIGHT
+            || IncludeMdlc
+#endif
+            || (IncludeEventProperties && (logEvent?.HasProperties ?? false));
+        }
+
+        /// <summary>
+        /// Checks if any context properties, and if any returns them as a single dictionary
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns>Dictionary with any context properties for the logEvent (Null if none found)</returns>
+        protected IDictionary<string, object> GetContextProperties(LogEventInfo logEvent)
+        {
+            IDictionary<string, object> combinedProperties = null;
+            if (IncludeGdc)
+            {
+                combinedProperties = CaptureContextGdc(logEvent, null);
+            }
+
+            if (IncludeMdc)
+            {
+                if (!CombineProperties(logEvent, _contextLayout.MdcLayout, ref combinedProperties))
+                {
+                    combinedProperties = CaptureContextMdc(logEvent, combinedProperties);
+                }
+            }
+
+#if !SILVERLIGHT
+            if (IncludeMdlc)
+            {
+                if (!CombineProperties(logEvent, _contextLayout.MdlcLayout, ref combinedProperties))
+                {
+                    combinedProperties = CaptureContextMdlc(logEvent, combinedProperties);
+                }
+            }
+#endif
+
+            if (ContextProperties != null && ContextProperties.Count > 0)
+            {
+                combinedProperties = combinedProperties ?? new Dictionary<string, object>();
+                for (int i = 0; i < ContextProperties.Count; ++i)
+                {
+                    var attrib = ContextProperties[i];
+                    if (string.IsNullOrEmpty(attrib?.Name) || attrib.Layout == null)
+                        continue;
+
+                    var attribValue = RenderLogEvent(attrib.Layout, logEvent);
+                    if (!attrib.IncludeEmptyValue && string.IsNullOrEmpty(attribValue))
+                        continue;
+
+                    combinedProperties[attrib.Name] = attribValue;
+                }
+            }
+
+            return combinedProperties;
+        }
+
+        /// <summary>
+        /// Creates combined dictionary of all configured properties for logEvent
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns>Dictionary with all collected properties for logEvent</returns>
+        protected IDictionary<string, object> GetAllProperties(LogEventInfo logEvent)
+        {
+            IDictionary<string, object> combinedPropties = GetContextProperties(logEvent);
+            if (IncludeEventProperties && logEvent.HasProperties)
+            {
+                // TODO Make Dictionary-adapter for PropertiesDictionary to skip extra Dictionary-allocation
+                combinedPropties = combinedPropties ?? new Dictionary<string, object>();
+                foreach (var property in logEvent.Properties)
+                {
+                    string propertyKey = property.Key.ToString();
+                    if (string.IsNullOrEmpty(propertyKey))
+                        continue;
+                    combinedPropties[propertyKey] = property.Value;
+                }
+            }
+            return combinedPropties ?? new Dictionary<string, object>();
+        }
+
+        private static bool CombineProperties(LogEventInfo logEvent, Layout contextLayout, ref IDictionary<string, object> combinedPropties)
+        {
+            if (!logEvent.TryGetCachedLayoutValue(contextLayout, out object value))
+            {
+                return false;
+            }
+
+            var contextProperties = value as IDictionary<string, object>;
+            if (contextProperties != null)
+            {
+                if (combinedPropties != null)
+                {
+                    foreach (var property in contextProperties)
+                    {
+                        combinedPropties[property.Key] = property.Value;
+                    }
+                }
+                else
+                {
+                    combinedPropties = contextProperties;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Returns the captured snapshot of <see cref="MappedDiagnosticsContext"/> for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns>Dictionary with MDC context if any, else null</returns>
+        protected IDictionary<string, object> GetContextMdc(LogEventInfo logEvent)
+        {
+            if (logEvent.TryGetCachedLayoutValue(_contextLayout.MdcLayout, out object value))
+            {
+                return value as IDictionary<string, object>;
+            }
+            return CaptureContextMdc(logEvent, null);
+        }
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// Returns the captured snapshot of <see cref="MappedDiagnosticsLogicalContext"/> for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns>Dictionary with MDLC context if any, else null</returns>
+        protected IDictionary<string, object> GetContextMdlc(LogEventInfo logEvent)
+        {
+            if (logEvent.TryGetCachedLayoutValue(_contextLayout.MdlcLayout, out object value))
+            {
+                return value as IDictionary<string, object>;
+            }
+            return CaptureContextMdlc(logEvent, null);
+        }
+#endif
+
+        /// <summary>
+        /// Returns the captured snapshot of <see cref="NestedDiagnosticsContext"/> for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns>Dictionary with NDC context if any, else null</returns>
+        protected IList<object> GetContextNdc(LogEventInfo logEvent)
+        {
+            if (logEvent.TryGetCachedLayoutValue(_contextLayout.NdcLayout, out object value))
+            {
+                return value as IList<object>;
+            }
+            return CaptureContextNdc(logEvent);
+        }
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// Returns the captured snapshot of <see cref="NestedDiagnosticsLogicalContext"/> for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns>Dictionary with NDLC context if any, else null</returns>
+        protected IList<object> GetContextNdlc(LogEventInfo logEvent)
+        {
+            if (logEvent.TryGetCachedLayoutValue(_contextLayout.NdlcLayout, out object value))
+            {
+                return value as IList<object>;
+            }
+            return CaptureContextNdlc(logEvent);
+        }
+#endif
+
+        /// <summary>
+        /// Takes snapshot of <see cref="GlobalDiagnosticsContext"/> for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <param name="contextProperties">Optional pre-allocated dictionary for the snapshot</param>
+        /// <returns>Dictionary with GDC context if any, else null</returns>
+        protected virtual IDictionary<string, object> CaptureContextGdc(LogEventInfo logEvent, IDictionary<string, object> contextProperties)
+        {
+            var globalNames = GlobalDiagnosticsContext.GetNames();
+            if (globalNames.Count == 0)
+                return contextProperties;
+
+            contextProperties = contextProperties ?? new Dictionary<string, object>();
+            foreach (string propertyName in globalNames)
+            {
+                var propertyValue = GlobalDiagnosticsContext.GetObject(propertyName);
+                if (SerializeItemValue(logEvent, propertyName, propertyValue, out propertyValue))
+                {
+                    contextProperties[propertyName] = propertyValue;
+                }
+            }
+
+            return contextProperties;
+        }
+
+        /// <summary>
+        /// Takes snapshot of <see cref="MappedDiagnosticsContext"/> for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <param name="contextProperties">Optional pre-allocated dictionary for the snapshot</param>
+        /// <returns>Dictionary with MDC context if any, else null</returns>
+        protected virtual IDictionary<string, object> CaptureContextMdc(LogEventInfo logEvent, IDictionary<string, object> contextProperties)
+        {
+            var names = MappedDiagnosticsContext.GetNames();
+            if (names.Count == 0)
+                return contextProperties;
+
+            contextProperties = contextProperties ?? new Dictionary<string, object>();
+            foreach (var name in names)
+            {
+                object value = MappedDiagnosticsContext.GetObject(name);
+                if (SerializeMdcItem(logEvent, name, value, out var serializedValue))
+                {
+                    contextProperties[name] = serializedValue;
+                }
+            }
+            return contextProperties;
+        }
+
+        /// <summary>
+        /// Take snapshot of a single object value from <see cref="MappedDiagnosticsContext"/>
+        /// </summary>
+        /// <param name="logEvent">Log event</param>
+        /// <param name="name">MDC key</param>
+        /// <param name="value">MDC value</param>
+        /// <param name="serializedValue">Snapshot of MDC value</param>
+        /// <returns>Include object value in snapshot</returns>
+        protected virtual bool SerializeMdcItem(LogEventInfo logEvent, string name, object value, out object serializedValue)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                serializedValue = null;
+                return false;
+            }
+
+            return SerializeItemValue(logEvent, name, value, out serializedValue);
+        }
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// Takes snapshot of <see cref="MappedDiagnosticsLogicalContext"/> for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <param name="contextProperties">Optional pre-allocated dictionary for the snapshot</param>
+        /// <returns>Dictionary with MDLC context if any, else null</returns>
+        protected virtual IDictionary<string, object> CaptureContextMdlc(LogEventInfo logEvent, IDictionary<string, object> contextProperties)
+        {
+            var names = MappedDiagnosticsLogicalContext.GetNames();
+            if (names.Count == 0)
+                return contextProperties;
+
+            contextProperties = contextProperties ?? new Dictionary<string, object>();
+            foreach (var name in names)
+            {
+                object value = MappedDiagnosticsLogicalContext.GetObject(name);
+                if (SerializeMdlcItem(logEvent, name, value, out var serializedValue))
+                {
+                    contextProperties[name] = serializedValue;
+                }
+            }
+            return contextProperties;
+        }
+
+        /// <summary>
+        /// Take snapshot of a single object value from <see cref="MappedDiagnosticsLogicalContext"/>
+        /// </summary>
+        /// <param name="logEvent">Log event</param>
+        /// <param name="name">MDLC key</param>
+        /// <param name="value">MDLC value</param>
+        /// <param name="serializedValue">Snapshot of MDLC value</param>
+        /// <returns>Include object value in snapshot</returns>
+        protected virtual bool SerializeMdlcItem(LogEventInfo logEvent, string name, object value, out object serializedValue)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                serializedValue = null;
+                return false;
+            }
+
+            return SerializeItemValue(logEvent, name, value, out serializedValue);
+        }
+#endif
+
+        /// <summary>
+        /// Takes snapshot of <see cref="NestedDiagnosticsContext"/> for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns>Dictionary with NDC context if any, else null</returns>
+        protected virtual IList<object> CaptureContextNdc(LogEventInfo logEvent)
+        {
+            var stack = NestedDiagnosticsContext.GetAllObjects();
+            if (stack.Length == 0)
+                return stack;
+
+            IList<object> filteredStack = null;
+            for (int i = 0; i < stack.Length; ++i)
+            {
+                var ndcValue = stack[i];
+                if (SerializeNdcItem(logEvent, ndcValue, out var serializedValue))
+                {
+                    if (filteredStack != null)
+                        filteredStack.Add(serializedValue);
+                    else
+                        stack[i] = serializedValue;
+                }
+                else
+                {
+                    if (filteredStack == null)
+                    {
+                        filteredStack = new List<object>(stack.Length);
+                        for (int j = 0; j < i; ++j)
+                            filteredStack.Add(stack[j]);
+                    }
+                }
+            }
+            return filteredStack ?? stack;
+        }
+
+        /// <summary>
+        /// Take snapshot of a single object value from <see cref="NestedDiagnosticsContext"/>
+        /// </summary>
+        /// <param name="logEvent">Log event</param>
+        /// <param name="value">NDC value</param>
+        /// <param name="serializedValue">Snapshot of NDC value</param>
+        /// <returns>Include object value in snapshot</returns>
+        protected virtual bool SerializeNdcItem(LogEventInfo logEvent, object value, out object serializedValue)
+        {
+            return SerializeItemValue(logEvent, null, value, out serializedValue);
+        }
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// Takes snapshot of <see cref="NestedDiagnosticsLogicalContext"/> for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns>Dictionary with NDLC context if any, else null</returns>
+        protected virtual IList<object> CaptureContextNdlc(LogEventInfo logEvent)
+        {
+            var stack = NestedDiagnosticsLogicalContext.GetAllObjects();
+            if (stack.Length == 0)
+                return stack;
+
+            IList<object> filteredStack = null;
+            for (int i = 0; i < stack.Length; ++i)
+            {
+                var ndcValue = stack[i];
+                if (SerializeNdlcItem(logEvent, ndcValue, out var serializedValue))
+                {
+                    if (filteredStack != null)
+                        filteredStack.Add(serializedValue);
+                    else
+                        stack[i] = serializedValue;
+                }
+                else
+                {
+                    if (filteredStack == null)
+                    {
+                        filteredStack = new List<object>(stack.Length);
+                        for (int j = 0; j < i; ++j)
+                            filteredStack.Add(stack[j]);
+                    }
+                }
+            }
+            return filteredStack ?? stack;
+        }
+
+        /// <summary>
+        /// Take snapshot of a single object value from <see cref="NestedDiagnosticsLogicalContext"/>
+        /// </summary>
+        /// <param name="logEvent">Log event</param>
+        /// <param name="value">NDLC value</param>
+        /// <param name="serializedValue">Snapshot of NDLC value</param>
+        /// <returns>Include object value in snapshot</returns>
+        protected virtual bool SerializeNdlcItem(LogEventInfo logEvent, object value, out object serializedValue)
+        {
+            return SerializeItemValue(logEvent, null, value, out serializedValue);
+        }
+#endif
+
+        /// <summary>
+        /// Take snapshot of a single object value
+        /// </summary>
+        /// <param name="logEvent">Log event</param>
+        /// <param name="name">Key Name (null when NDC / NDLC)</param>
+        /// <param name="value">Object Value</param>
+        /// <param name="serializedValue">Snapshot of value</param>
+        /// <returns>Include object value in snapshot</returns>
+        protected virtual bool SerializeItemValue(LogEventInfo logEvent, string name, object value, out object serializedValue)
+        {
+            if (value == null)
+            {
+                serializedValue = null;
+                return true;
+            }
+
+            if (value is string || Convert.GetTypeCode(value) != TypeCode.Object || value is Guid || value is TimeSpan || value is DateTimeOffset)
+            {
+                serializedValue = value;    // Already immutable, snapshot is not needed
+                return true;
+            }
+
+            // Make snapshot of the context value
+            serializedValue = Convert.ToString(value, logEvent.FormatProvider ?? CultureInfo.CurrentCulture);
+            return true;
+        }
+
+        private class TargetWithContextLayout : Layout, IIncludeContext, IUsesStackTrace
+        {
+            public Layout TargetLayout { get => _targetLayout; set => _targetLayout = ReferenceEquals(this, value) ? _targetLayout : value; }
+            private Layout _targetLayout;
+
+            /// <summary>Internal Layout that allows capture of MDC context</summary>
+            internal LayoutContextMdc MdcLayout { get; }
+            /// <summary>Internal Layout that allows capture of NDC context</summary>
+            internal LayoutContextNdc NdcLayout { get; }
+#if !SILVERLIGHT
+            /// <summary>Internal Layout that allows capture of MDLC context</summary>
+            internal LayoutContextMdlc MdlcLayout { get; }
+            /// <summary>Internal Layout that allows capture of NDLC context</summary>
+            internal LayoutContextNdlc NdlcLayout { get; }
+#endif
+
+            public bool IncludeAllProperties { get; set; }
+            public bool IncludeCallSite { get; set; }
+            public bool IncludeCallSiteStackTrace { get; set; }
+
+            public bool IncludeMdc { get => MdcLayout.IsActive; set => MdcLayout.IsActive = value; }
+            public bool IncludeNdc { get => NdcLayout.IsActive; set => NdcLayout.IsActive = value; }
+
+#if !SILVERLIGHT
+            public bool IncludeMdlc { get => MdlcLayout.IsActive; set => MdlcLayout.IsActive = value; }
+            public bool IncludeNdlc { get => NdlcLayout.IsActive; set => NdlcLayout.IsActive = value; }
+#endif
+
+            StackTraceUsage IUsesStackTrace.StackTraceUsage
+            {
+                get
+                {
+                    if (IncludeCallSiteStackTrace)
+                    {
+#if !SILVERLIGHT
+                        return StackTraceUsage.WithSource;
+#else
+                        return StackTraceUsage.Max;
+#endif
+                    }
+
+                    if (IncludeCallSite)
+                    {
+                        return StackTraceUsage.WithoutSource;
+                    }
+                    return StackTraceUsage.None;
+                }
+            }
+
+            public TargetWithContextLayout(TargetWithContext owner, Layout targetLayout)
+            {
+                TargetLayout = targetLayout;
+
+                MdcLayout = new LayoutContextMdc(owner);
+                NdcLayout = new LayoutContextNdc(owner);
+#if !SILVERLIGHT
+                MdlcLayout = new LayoutContextMdlc(owner);
+                NdlcLayout = new LayoutContextNdlc(owner);
+#endif
+            }
+
+            protected override void InitializeLayout()
+            {
+                base.InitializeLayout();
+                ThreadAgnostic = IncludeMdc
+                    || IncludeNdc
+#if !SILVERLIGHT
+                    || IncludeMdlc
+                    || IncludeNdlc
+#endif
+                    ;
+            }
+
+            public override string ToString()
+            {
+                return TargetLayout?.ToString() ?? base.ToString();
+            }
+
+            public override void Precalculate(LogEventInfo logEvent)
+            {
+                if (!(TargetLayout?.ThreadAgnostic ?? true))
+                {
+                    TargetLayout.Precalculate(logEvent);
+                    if (logEvent.TryGetCachedLayoutValue(TargetLayout, out var cachedLayout))
+                    {
+                        // Also cache the result as belonging to this Layout, for fast lookup
+                        logEvent.AddCachedLayoutValue(this, cachedLayout);
+                    }
+                }
+
+                PrecalculateContext(logEvent);
+            }
+
+            internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+            {
+                if (!(TargetLayout?.ThreadAgnostic ?? true))
+                {
+                    TargetLayout.PrecalculateBuilder(logEvent, target);
+                    if (logEvent.TryGetCachedLayoutValue(TargetLayout, out var cachedLayout))
+                    {
+                        // Also cache the result as belonging to this Layout, for fast lookup
+                        logEvent.AddCachedLayoutValue(this, cachedLayout);
+                    }
+                }
+
+                PrecalculateContext(logEvent);
+            }
+
+            private void PrecalculateContext(LogEventInfo logEvent)
+            {
+                if (IncludeMdc)
+                    MdcLayout.Precalculate(logEvent);
+                if (IncludeNdc)
+                    NdcLayout.Precalculate(logEvent);
+#if !SILVERLIGHT
+                if (IncludeMdlc)
+                    MdlcLayout.Precalculate(logEvent);
+                if (IncludeNdlc)
+                    NdlcLayout.Precalculate(logEvent);
+#endif
+            }
+
+            protected override string GetFormattedMessage(LogEventInfo logEvent)
+            {
+                return TargetLayout?.Render(logEvent) ?? string.Empty;
+            }
+
+            protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+            {
+                TargetLayout?.RenderAppendBuilder(logEvent, target, false);
+            }
+
+            public class LayoutContextMdc : Layout
+            {
+                private readonly TargetWithContext _owner;
+
+                public bool IsActive { get; set; }
+
+                public LayoutContextMdc(TargetWithContext owner)
+                {
+                    _owner = owner;
+                }
+
+                protected override string GetFormattedMessage(LogEventInfo logEvent)
+                {
+                    CaptureContext(logEvent);
+                    return string.Empty;
+                }
+
+                public override void Precalculate(LogEventInfo logEvent)
+                {
+                    CaptureContext(logEvent);
+                }
+
+                private void CaptureContext(LogEventInfo logEvent)
+                {
+                    if (IsActive)
+                    {
+                        var contextMdc = _owner.CaptureContextMdc(logEvent, null);
+                        logEvent.AddCachedLayoutValue(this, contextMdc);
+                    }
+                }
+            }
+
+#if !SILVERLIGHT
+            public class LayoutContextMdlc : Layout
+            {
+                private readonly TargetWithContext _owner;
+
+                public bool IsActive { get; set; }
+
+                public LayoutContextMdlc(TargetWithContext owner)
+                {
+                    _owner = owner;
+                }
+
+                protected override string GetFormattedMessage(LogEventInfo logEvent)
+                {
+                    CaptureContext(logEvent);
+                    return string.Empty;
+                }
+
+                public override void Precalculate(LogEventInfo logEvent)
+                {
+                    CaptureContext(logEvent);
+                }
+
+                private void CaptureContext(LogEventInfo logEvent)
+                {
+                    if (IsActive)
+                    {
+                        var contextMdlc = _owner.CaptureContextMdlc(logEvent, null);
+                        logEvent.AddCachedLayoutValue(this, contextMdlc);
+                    }
+                }
+            }
+#endif
+
+            public class LayoutContextNdc : Layout
+            {
+                private readonly TargetWithContext _owner;
+
+                public bool IsActive { get; set; }
+
+                public LayoutContextNdc(TargetWithContext owner)
+                {
+                    _owner = owner;
+                }
+
+                protected override string GetFormattedMessage(LogEventInfo logEvent)
+                {
+                    CaptureContext(logEvent);
+                    return string.Empty;
+                }
+
+                public override void Precalculate(LogEventInfo logEvent)
+                {
+                    CaptureContext(logEvent);
+                }
+
+                private void CaptureContext(LogEventInfo logEvent)
+                {
+                    if (IsActive)
+                    {
+                        var contextNdc = _owner.CaptureContextNdc(logEvent);
+                        logEvent.AddCachedLayoutValue(this, contextNdc);
+                    }
+                }
+            }
+
+#if !SILVERLIGHT
+            public class LayoutContextNdlc : Layout
+            {
+                private readonly TargetWithContext _owner;
+
+                public bool IsActive { get; set; }
+
+                public LayoutContextNdlc(TargetWithContext owner)
+                {
+                    _owner = owner;
+                }
+
+                protected override string GetFormattedMessage(LogEventInfo logEvent)
+                {
+                    CaptureContext(logEvent);
+                    return string.Empty;
+                }
+
+                public override void Precalculate(LogEventInfo logEvent)
+                {
+                    CaptureContext(logEvent);
+                }
+
+                private void CaptureContext(LogEventInfo logEvent)
+                {
+                    if (IsActive)
+                    {
+                        var contextNdlc = _owner.CaptureContextNdlc(logEvent);
+                        logEvent.AddCachedLayoutValue(this, contextNdlc);
+                    }
+                }
+            }
+#endif
+        }
+    }
+}

--- a/src/NLog/Targets/TargetWithContextProperty.cs
+++ b/src/NLog/Targets/TargetWithContextProperty.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,45 +31,52 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog
+namespace NLog.Targets
 {
+    using NLog.Config;
+    using NLog.Layouts;
+
     /// <summary>
-    /// Include context properties
+    /// Attribute details for <see cref="TargetWithContext"/> 
     /// </summary>
-    internal interface IIncludeContext
+    [NLogConfigurationItem]
+    [ThreadAgnostic]
+    public class TargetWithContextProperty
     {
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsContext"/> dictionary.
+        /// Initializes a new instance of the <see cref="TargetWithContextProperty" /> class.
         /// </summary>
-        /// <docgen category='Payload Options' order='10' />
-        bool IncludeMdc { get; set; }
+        public TargetWithContextProperty() : this(null, null) { }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsContext"/> stack.
+        /// Initializes a new instance of the <see cref="TargetWithContextProperty" /> class.
         /// </summary>
-        /// <docgen category='Payload Options' order='10' />
-        bool IncludeNdc { get; set; }
+        /// <param name="name">The name of the attribute.</param>
+        /// <param name="layout">The layout of the attribute's value.</param>
+        public TargetWithContextProperty(string name, Layout layout)
+        {
+            Name = name;
+            Layout = layout;
+            IncludeEmptyValue = true;
+        }
 
         /// <summary>
-        /// Gets or sets the option to include all properties from the log events
+        /// Gets or sets the name of the attribute.
         /// </summary>
-        /// <docgen category='Payload Options' order='10' />
-        bool IncludeAllProperties { get; set; }
-
-#if !SILVERLIGHT
+        /// <docgen category='Property Options' order='10' />
+        [RequiredParameter]
+        public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
+        /// Gets or sets the layout that will be rendered as the attribute's value.
         /// </summary>
-        /// <docgen category='Payload Options' order='10' />
-        bool IncludeMdlc { get; set; }
+        /// <docgen category='Property Options' order='10' />
+        [RequiredParameter]
+        public Layout Layout { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsLogicalContext"/> stack.
+        /// Gets or sets when an empty value should cause the property to be included
         /// </summary>
-        /// <docgen category='Payload Options' order='10' />
-        bool IncludeNdlc { get; set; }
-
-#endif
+        public bool IncludeEmptyValue { get; set; }
     }
 }

--- a/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
+++ b/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
@@ -47,8 +47,6 @@ namespace NLog.UnitTests.Targets
     {
         class AsyncTaskTestTarget : AsyncTaskTarget
         {
-            public Layout Layout { get; set; }
-
             internal Queue<string> Logs = new Queue<string>();
 
             protected override Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken token)

--- a/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
+++ b/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
@@ -1,0 +1,194 @@
+﻿// 
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+
+namespace NLog.UnitTests.Targets
+{
+    using System.Linq;
+    using System.Collections.Generic;
+    using Xunit;
+    using NLog.Targets;
+    using NLog.Targets.Wrappers;
+
+    public class TargetWithContextTest : NLogTestBase
+    {
+        public class CustomTargetWithContext : TargetWithContext
+        {
+            public class CustomTargetWithContextProperty : TargetWithContextProperty
+            {
+                public string Hello { get; set; }
+            }
+
+            [NLog.Config.ArrayParameter(typeof(CustomTargetWithContextProperty), "contextproperty")]
+            public override IList<TargetWithContextProperty> ContextProperties { get;  }
+
+            public CustomTargetWithContext()
+            {
+                ContextProperties = new List<TargetWithContextProperty>();
+            }
+
+            public IDictionary<string, object> LastCombinedProperties;
+            public string LastMessage;
+
+            protected override void Write(LogEventInfo logEvent)
+            {
+                var test = MappedDiagnosticsLogicalContext.GetNames();
+                Assert.Empty(test);
+                Assert.True(logEvent.HasStackTrace);
+                LastCombinedProperties = base.GetAllProperties(logEvent);
+                LastMessage = base.RenderLogEvent(Layout, logEvent);
+            }
+        }
+
+        [Fact]
+        public void TargetWithContextAsyncTest()
+        {
+            CustomTargetWithContext target = new CustomTargetWithContext();
+            target.ContextProperties.Add(new TargetWithContextProperty("threadid", "${threadid}"));
+            target.IncludeMdlc = true;
+            target.IncludeMdc = true;
+            target.IncludeGdc = true;
+            target.IncludeNdc = true;
+            target.IncludeNdlc = true;
+            target.IncludeCallSite = true;
+
+            AsyncTargetWrapper wrapper = new AsyncTargetWrapper();
+            wrapper.WrappedTarget = target;
+            wrapper.TimeToSleepBetweenBatches = 0;
+
+            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(wrapper, LogLevel.Debug);
+
+            Logger logger = LogManager.GetLogger("Example");
+
+            GlobalDiagnosticsContext.Clear();
+            GlobalDiagnosticsContext.Set("TestKey", "Hello Global World");
+            GlobalDiagnosticsContext.Set("GlobalKey", "Hello Global World");
+            MappedDiagnosticsContext.Clear();
+            MappedDiagnosticsContext.Set("TestKey", "Hello Thread World");
+            MappedDiagnosticsContext.Set("ThreadKey", "Hello Thread World");
+            MappedDiagnosticsLogicalContext.Clear();
+            MappedDiagnosticsLogicalContext.Set("TestKey", "Hello Async World");
+            MappedDiagnosticsLogicalContext.Set("AsyncKey", "Hello Async World");
+            logger.Debug("log message");
+            System.Threading.Thread.Sleep(1);
+            for (int i = 0; i < 1000; ++i)
+            {
+                if (target.LastMessage != null)
+                    break;
+
+                System.Threading.Thread.Sleep(1);
+            }
+
+            Assert.NotEqual(0, target.LastMessage.Length);
+            Assert.NotNull(target.LastCombinedProperties);
+            Assert.NotEmpty(target.LastCombinedProperties);
+            Assert.Equal(5, target.LastCombinedProperties.Count);
+            Assert.Contains(new KeyValuePair<string, object>("GlobalKey", "Hello Global World"), target.LastCombinedProperties);
+            Assert.Contains(new KeyValuePair<string, object>("ThreadKey", "Hello Thread World"), target.LastCombinedProperties);
+            Assert.Contains(new KeyValuePair<string, object>("AsyncKey", "Hello Async World"), target.LastCombinedProperties);
+            Assert.Contains(new KeyValuePair<string, object>("TestKey", "Hello Async World"), target.LastCombinedProperties);
+            Assert.Contains(new KeyValuePair<string, object>("threadid", System.Environment.CurrentManagedThreadId.ToString()), target.LastCombinedProperties);
+        }
+
+        [Fact]
+        public void TargetWithContextConfigTest()
+        {
+            Target.Register("contexttarget", typeof(CustomTargetWithContext));
+
+            LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog throwExceptions='true'>
+                    <targets>
+                        <target name='debug' type='contexttarget' includeCallSite='true'>
+                            <contextproperty name='threadid' layout='${threadid}' hello='world' />
+                        </target>
+                    </targets>
+                    <rules>
+                        <logger name='*' levels='Error' writeTo='debug' />
+                    </rules>
+                </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            MappedDiagnosticsLogicalContext.Clear();
+            logger.Error("log message");
+            var target = LogManager.Configuration.FindTargetByName("debug") as CustomTargetWithContext;
+            Assert.NotEqual(0, target.LastMessage.Length);
+            var lastCombinedProperties = target.LastCombinedProperties;
+            Assert.NotEmpty(lastCombinedProperties);
+            Assert.Contains(new KeyValuePair<string, object>("threadid", System.Environment.CurrentManagedThreadId.ToString()), lastCombinedProperties);
+        }
+
+        [Fact]
+        public void TargetWithContextJsonTest()
+        {
+            Target.Register("contexttarget", typeof(CustomTargetWithContext));
+
+            LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog throwExceptions='true' optimizeBufferReuse='false'>
+                    <targets>
+                        <default-wrapper type='AsyncWrapper' timeToSleepBetweenBatches='0' overflowAction='Block' />
+                        <target name='debug' type='contexttarget' includeCallSite='true' optimizeBufferReuse='false'>
+                            <layout type='JsonLayout' includeMdc='true'>
+                                <attribute name='level' layout='${level:upperCase=true}'/>
+                                <attribute name='message' layout='${message}' />
+                                <attribute name='exception' layout='${exception}' />
+                                <attribute name='threadid' layout='${threadid}' />
+                            </layout>
+                        </target>
+                    </targets>
+                    <rules>
+                        <logger name='*' levels='Error' writeTo='debug' />
+                    </rules>
+                </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            MappedDiagnosticsLogicalContext.Clear();
+            MappedDiagnosticsContext.Clear();
+            MappedDiagnosticsContext.Set("TestKey", "Hello Thread World");
+            logger.Error("log message");
+            var target = LogManager.Configuration.AllTargets.OfType<CustomTargetWithContext>().FirstOrDefault();
+            System.Threading.Thread.Sleep(1);
+            for (int i = 0; i < 1000; ++i)
+            {
+                if (target.LastMessage != null)
+                    break;
+
+                System.Threading.Thread.Sleep(1);
+            }
+
+            Assert.NotEqual(0, target.LastMessage.Length);
+            Assert.Contains(System.Environment.CurrentManagedThreadId.ToString(), target.LastMessage);
+            var lastCombinedProperties = target.LastCombinedProperties;
+            Assert.Empty(lastCombinedProperties);
+        }
+    }
+}

--- a/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
+++ b/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
@@ -44,17 +44,17 @@ namespace NLog.UnitTests.Targets
     {
         public class CustomTargetWithContext : TargetWithContext
         {
-            public class CustomTargetWithContextProperty : TargetWithContextProperty
+            public class CustomTargetPropertyWithContext : TargetPropertyWithContext
             {
                 public string Hello { get; set; }
             }
 
-            [NLog.Config.ArrayParameter(typeof(CustomTargetWithContextProperty), "contextproperty")]
-            public override IList<TargetWithContextProperty> ContextProperties { get;  }
+            [NLog.Config.ArrayParameter(typeof(CustomTargetPropertyWithContext), "contextproperty")]
+            public override IList<TargetPropertyWithContext> ContextProperties { get;  }
 
             public CustomTargetWithContext()
             {
-                ContextProperties = new List<TargetWithContextProperty>();
+                ContextProperties = new List<TargetPropertyWithContext>();
             }
 
             public IDictionary<string, object> LastCombinedProperties;
@@ -74,7 +74,7 @@ namespace NLog.UnitTests.Targets
         public void TargetWithContextAsyncTest()
         {
             CustomTargetWithContext target = new CustomTargetWithContext();
-            target.ContextProperties.Add(new TargetWithContextProperty("threadid", "${threadid}"));
+            target.ContextProperties.Add(new TargetPropertyWithContext("threadid", "${threadid}"));
             target.IncludeMdlc = true;
             target.IncludeMdc = true;
             target.IncludeGdc = true;


### PR DESCRIPTION
Attempt to resolve #2466 and #2465

Guess one could also extend it to enable capture of GDC and Callsite.

Maybe implement a helper method than returns all context properties (IncludeAllProperties, IncludeMdlc, IncludeMdc, IncludeGdc).

Suddenly also become a bugfix for correct precalculation of async data for custom NLog-Layouts. Before it would be impossible for custom NLog-Layouts to correctly capture the async-state. Resolves #254

And a bugfix that allows custom NLog-Layouts to work correctly, when they override Layout.Precalculate and are used with Target.OptimizeBufferReuse = true.
  