### PR TITLE
LogManager.LoadConfiguration - Prepare for custom config file readers

### DIFF
--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -35,17 +35,14 @@ namespace NLog
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;
-    using System.Threading;
 
     using NLog.Common;
     using NLog.Config;
     using NLog.Internal;
-    using NLog.Internal.Fakeables;
 
     /// <summary>
     /// Creates and manages instances of <see cref="T:NLog.Logger" /> objects.
@@ -128,7 +125,6 @@ namespace NLog
             set => factory.KeepVariablesOnReload = value;
         }
 
-
         /// <summary>
         /// Gets or sets the current logging configuration.
         /// <see cref="NLog.LogFactory.Configuration" />
@@ -137,6 +133,17 @@ namespace NLog
         {
             get => factory.Configuration;
             set => factory.Configuration = value;
+        }
+
+        /// <summary>
+        /// Loads logging configuration from file (Currently only XML configuration files supported)
+        /// </summary>
+        /// <param name="configFile">Configuration file to be read</param>
+        /// <returns>LogFactory instance for fluent interface</returns>
+        public static LogFactory LoadConfiguration(string configFile)
+        {
+            factory.LoadConfiguration(configFile);
+            return factory;
         }
 
         /// <summary>


### PR DESCRIPTION
Thinking that custom config file readers could be registered in NLog, that include their own candidate paths, but also allow direct file loading depending on file-extension (and priority in registration)

Instead of NLog.Extension.Logging and Nlog.Web creates XmlLoggingConfiguration, then they should just call:

`LogManager.LoadConfiguration(configFile);`

In the future NLog can then be extended to load custom config-files, without needing to change NLog.Extension.Logging and NLog.Web.