### PR TITLE
Fix XmlLoggingConfiguration reloading

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -406,11 +406,11 @@ namespace NLog.Config
             try
             {
                 InitializeSucceeded = null;
+                _originalFileName = fileName;
                 reader.MoveToContent();
                 var content = new NLogXmlElement(reader);
                 if (fileName != null)
-                {
-                    _originalFileName = fileName;
+                {                    
                     ParseTopLevel(content, fileName, autoReloadDefault: false);
 
                     InternalLogger.Info("Configured from an XML element in {0}...", fileName);

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -564,6 +564,39 @@ namespace NLog.UnitTests.Config
 
         }
 
+        [Fact]
+        public void TestReloadingInvalidConfiguration()
+        {
+            var validXmlConfig = @"<nlog>
+                    <targets><target name='debug' type='Debug' layout='${message}' /></targets>
+                    <rules>
+                        <logger name='*' minlevel='Debug' writeTo='debug' />
+                    </rules>
+                </nlog>";
+            var invalidXmlConfig = "";
+
+            string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempPath);
+
+            try {
+                var nlogConfigFile = Path.Combine(tempPath, "NLog.config");
+                WriteConfigFile(nlogConfigFile, invalidXmlConfig);
+
+                var invalidConfiguration = new XmlLoggingConfiguration(nlogConfigFile);
+                Assert.False(invalidConfiguration.InitializeSucceeded);
+
+                WriteConfigFile(nlogConfigFile, validXmlConfig);
+                var validReloadedConfiguration = (XmlLoggingConfiguration)invalidConfiguration.Reload();
+                Assert.True(validReloadedConfiguration.InitializeSucceeded);                
+            }
+            finally
+            {
+                if (Directory.Exists(tempPath))
+                {
+                    Directory.Delete(tempPath, true);
+                }
+            }
+        }
 
         private static void WriteConfigFile(string configFilePath, string config)
         {


### PR DESCRIPTION
Fixes #2279 

In the XmlLoggingConfiguration :
In case the file contains an invalid xml, an exception is thrown in the Initialize method and the _originalFileName was never saved. Since Reload() uses the _originalFileName to read the xml file, it was impossible to reload the config.