### PR TITLE
RegisterItemsFromAssembly - Include assemblies from nuget packages

### DIFF
--- a/src/NLog/Internal/Fakeables/AppDomainWrapper.cs
+++ b/src/NLog/Internal/Fakeables/AppDomainWrapper.cs
@@ -37,6 +37,7 @@ namespace NLog.Internal.Fakeables
 {
     using System;
     using System.Collections.Generic;
+    using System.Reflection;
     using NLog.Common;
 
     /// <summary>
@@ -152,6 +153,20 @@ namespace NLog.Internal.Fakeables
         /// Gets an integer that uniquely identifies the application domain within the process. 
         /// </summary>
         public int Id { get; private set; }
+
+        /// <summary>
+        /// Gets the assemblies that have been loaded into the execution context of this application domain.
+        /// </summary>
+        /// <returns>A list of assemblies in this application domain.</returns>
+        public IEnumerable<Assembly> GetAssemblies()
+        {
+#if !SILVERLIGHT
+            if (_currentAppDomain != null)
+                return _currentAppDomain.GetAssemblies();
+            else
+#endif
+                return Internal.ArrayHelper.Empty<Assembly>();
+        }
 
         /// <summary>
         /// Process exit event.

--- a/src/NLog/Internal/Fakeables/FakeAppDomain.cs
+++ b/src/NLog/Internal/Fakeables/FakeAppDomain.cs
@@ -36,6 +36,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace NLog.Internal.Fakeables
 {
@@ -54,7 +55,7 @@ namespace NLog.Internal.Fakeables
 #endif
         }
 
-        #region Implementation of IAppDomain
+#region Implementation of IAppDomain
 
         /// <summary>
         /// Gets or sets the base directory that the assembly resolver uses to probe for assemblies.
@@ -80,6 +81,15 @@ namespace NLog.Internal.Fakeables
         /// Gets an integer that uniquely identifies the application domain within the process. 
         /// </summary>
         public int Id { get; set; }
+
+        /// <summary>
+        /// Gets the assemblies that have been loaded into the execution context of this application domain.
+        /// </summary>
+        /// <returns>A list of assemblies in this application domain.</returns>
+        public IEnumerable<Assembly> GetAssemblies()
+        {
+            return Internal.ArrayHelper.Empty<Assembly>();  // TODO NETSTANDARD1_6 has DependencyContext.RuntimeLibraries
+        }
 
         /// <summary>
         /// Process exit event.
@@ -136,7 +146,7 @@ namespace NLog.Internal.Fakeables
             if (handler != null) handler.Invoke(context, EventArgs.Empty);
         }
 #endif
-        #endregion
+#endregion
     }
 }
 

--- a/src/NLog/Internal/Fakeables/IAppDomain.cs
+++ b/src/NLog/Internal/Fakeables/IAppDomain.cs
@@ -34,6 +34,7 @@
 namespace NLog.Internal.Fakeables
 {
     using System;
+    using System.Reflection;
     using System.Collections.Generic;
 
     /// <summary>
@@ -65,6 +66,12 @@ namespace NLog.Internal.Fakeables
         /// Gets an integer that uniquely identifies the application domain within the process. 
         /// </summary>
         int Id { get; }
+
+        /// <summary>
+        /// Gets the assemblies that have been loaded into the execution context of this application domain.
+        /// </summary>
+        /// <returns>A list of assemblies in this application domain.</returns>
+        IEnumerable<Assembly> GetAssemblies();
 
         /// <summary>
         /// Process exit event.

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -319,6 +319,7 @@ NLog 4.5 adds structured logging and .NET Standard support/UPW without breaking 
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />
     <PackageReference Include="System.Data.Common" Version="4.1.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.0.1" />
     <PackageReference Include="System.IO.Compression" Version="4.1.0" />

--- a/tests/NLog.UnitTests/LayoutRenderers/BaseDirTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/BaseDirTests.cs
@@ -40,6 +40,7 @@ namespace NLog.UnitTests.LayoutRenderers
 {
     using System;
     using System.IO;
+    using System.Reflection;
     using Xunit;
 
     public class BaseDirTests : NLogTestBase
@@ -138,6 +139,8 @@ namespace NLog.UnitTests.LayoutRenderers
             /// Gets an integer that uniquely identifies the application domain within the process. 
             /// </summary>
             public int Id => _appDomain.Id;
+
+            public IEnumerable<Assembly> GetAssemblies() { return new Assembly[0]; }
 
             public event EventHandler<EventArgs> ProcessExit
             {


### PR DESCRIPTION
Attempt to resolve #2364 

Together with #2472, then you can configure NLog completely with just this line (netstandard2.0 + net45 only).

`var logger = LogManager.LoadConfiguration("nlog.config").GetCurrentClassLogger();`

Where it correctly loads extensions and ignores assemblies (without config reload etc.)
  