### PR TITLE
Reduce string allocations for logevents with single target destination

### DIFF
--- a/src/NLog/Internal/ILogMessageFormatter.cs
+++ b/src/NLog/Internal/ILogMessageFormatter.cs
@@ -33,7 +33,7 @@
 
 namespace NLog.Internal
 {
-    using System;
+    using System.Text;
 
     /// <summary>
     /// Format a log message
@@ -53,5 +53,12 @@ namespace NLog.Internal
         /// <param name="logEvent">LogEvent with message to be formatted</param>
         /// <returns>formatted message</returns>
         bool HasProperties(LogEventInfo logEvent);
+
+        /// <summary>
+        /// Appends the logevent message to the provided StringBuilder
+        /// </summary>
+        /// <param name="logEvent">LogEvent with message to be formatted</param>
+        /// <param name="builder">The <see cref="StringBuilder"/> to append the formatted message.</param>
+        void AppendFormattedMessage(LogEventInfo logEvent, StringBuilder builder);
     }
 }

--- a/src/NLog/Internal/LogMessageTemplateFormatter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatter.cs
@@ -35,26 +35,32 @@ namespace NLog.Internal
 {
     using System;
     using System.Globalization;
+    using System.Text;
     using MessageTemplates;
 
     internal sealed class LogMessageTemplateFormatter : ILogMessageFormatter
     {
-        public static readonly LogMessageTemplateFormatter DefaultAuto = new LogMessageTemplateFormatter(false);
-        public static readonly LogMessageTemplateFormatter Default = new LogMessageTemplateFormatter(true);
+        public static readonly LogMessageTemplateFormatter DefaultAuto = new LogMessageTemplateFormatter(false, false);
+        public static readonly LogMessageTemplateFormatter Default = new LogMessageTemplateFormatter(true, false);
+        public static readonly LogMessageTemplateFormatter DefaultAutoSingleTarget = new LogMessageTemplateFormatter(false, true);
+        public static readonly LogMessageTemplateFormatter DefaultSingleTarget = new LogMessageTemplateFormatter(true, true);
         private static readonly StringBuilderPool _builderPool = new StringBuilderPool(Environment.ProcessorCount * 2);
 
         /// <summary>
         /// When true: Do not fallback to StringBuilder.Format for positional templates
         /// </summary>
         private readonly bool _forceTemplateRenderer;
+        private readonly bool _singleTargetOnly;
 
         /// <summary>
         /// New formatter
         /// </summary>
         /// <param name="forceTemplateRenderer">When true: Do not fallback to StringBuilder.Format for positional templates</param>
-        private LogMessageTemplateFormatter(bool forceTemplateRenderer)
+        /// <param name="singleTargetOnly"></param>
+        private LogMessageTemplateFormatter(bool forceTemplateRenderer, bool singleTargetOnly)
         {
             _forceTemplateRenderer = forceTemplateRenderer;
+            _singleTargetOnly = singleTargetOnly;
             MessageFormatter = FormatMessage;
         }
 
@@ -62,43 +68,61 @@ namespace NLog.Internal
         /// The MessageFormatter delegate
         /// </summary>
         public LogMessageFormatter MessageFormatter { get; }
-
+ 
         public bool HasProperties(LogEventInfo logEvent)
+        {
+            if (!HasParameters(logEvent))
+                return false;
+
+            if (_singleTargetOnly)
+            {
+                // Make quick check for valid message template parameter names
+                TemplateEnumerator holeEnumerator = new TemplateEnumerator(logEvent.Message);
+                if (holeEnumerator.MoveNext() && holeEnumerator.Current.Literal.Skip != 0 && holeEnumerator.Current.Hole.Index != -1)
+                {
+                    return false;   // Skip allocation of PropertiesDictionary
+                }
+            }
+
+            return true;    // Parse message template and allocate PropertiesDictionary
+        }
+
+        private bool HasParameters(LogEventInfo logEvent)
         {
             //if message is empty, there no parameters
             //null check cheapest, so in-front
             return logEvent.Parameters != null && !string.IsNullOrEmpty(logEvent.Message) && logEvent.Parameters.Length > 0;
         }
 
+        public void AppendFormattedMessage(LogEventInfo logEvent, StringBuilder builder)
+        {
+            if (!HasParameters(logEvent))
+            {
+                builder.Append(logEvent.Message ?? string.Empty);
+            }
+            else
+            {
+                logEvent.Message.Render(logEvent.FormatProvider ?? CultureInfo.CurrentCulture, logEvent.Parameters, _forceTemplateRenderer, builder, out var messageTemplateParameterList);
+            }
+        }
+
         public string FormatMessage(LogEventInfo logEvent)
         {
-            if (!HasProperties(logEvent))
+            if (!HasParameters(logEvent))
             {
                 return logEvent.Message;
             }
             using (var builder = _builderPool.Acquire())
             {
-                logEvent.Message.Render(logEvent.FormatProvider ?? CultureInfo.CurrentCulture, logEvent.Parameters, _forceTemplateRenderer, builder.Item, out var messageTemplateParameterList);
-                if (logEvent.PropertiesDictionary != null || messageTemplateParameterList != null)
-                {
-                    // Prevent multiple layouts on different targets to update the same properties
-                    lock (logEvent)
-                    {
-                        if (logEvent.PropertiesDictionary == null)
-                        {
-                            if (messageTemplateParameterList != null && messageTemplateParameterList.Count > 0)
-                            {
-                                logEvent.PropertiesDictionary = new PropertiesDictionary(messageTemplateParameterList);
-                            }
-                        }
-                        else
-                        {
-                            logEvent.PropertiesDictionary.MessageProperties = messageTemplateParameterList;
-                        }
-                    }
-                }
+                AppendToBuilder(logEvent, builder.Item);
                 return builder.Item.ToString();
             }
+        }
+
+        private void AppendToBuilder(LogEventInfo logEvent, StringBuilder builder)
+        {
+            logEvent.Message.Render(logEvent.FormatProvider ?? CultureInfo.CurrentCulture, logEvent.Parameters, _forceTemplateRenderer, builder, out var messageTemplateParameterList);
+            logEvent.CreateOrUpdatePropertiesInternal(false, messageTemplateParameterList ?? ArrayHelper.Empty<MessageTemplateParameter>());
         }
     }
 }

--- a/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
@@ -34,11 +34,9 @@
 namespace NLog.LayoutRenderers
 {
     using System;
-    using System.Diagnostics;
     using System.Text;
-
-    using Config;
-    using Internal;
+    using NLog.Config;
+    using NLog.Internal;
 
     /// <summary>
     /// The formatted log message.
@@ -81,9 +79,21 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             if (Raw)
+            {
                 builder.Append(logEvent.Message);
+            }
             else
-                builder.Append(logEvent.FormattedMessage);
+            {
+                if (ReferenceEquals(logEvent.MessageFormatter, LogEventInfo.DefaultMessageFormatterSingleTarget) && (logEvent.MessageFormatter.Target is ILogMessageFormatter messageFormatter))
+                {
+                    // Skip string-allocation of LogEventInfo.FormattedMessage, but just write directly to StringBuilder
+                    logEvent.AppendFormattedMessage(messageFormatter, builder);
+                }
+                else
+                {
+                    builder.Append(logEvent.FormattedMessage);
+                }
+            }
             if (WithException && logEvent.Exception != null)
             {
                 builder.Append(ExceptionSeparator);

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -37,7 +37,6 @@ namespace NLog
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Reflection;
-    using System.Threading;
     using JetBrains.Annotations;
     using NLog.Common;
     using NLog.Config;
@@ -99,6 +98,19 @@ namespace NLog
                         }
                     }
                 };
+            }
+
+            if (targets.NextInChain == null
+             && logEvent.Parameters != null
+             && logEvent.Parameters.Length > 0
+             && logEvent.Message?.Length < 128
+             && ReferenceEquals(logEvent.MessageFormatter, LogEventInfo.DefaultMessageFormatter))
+            {
+                // Signal MessageLayoutRenderer to skip string allocation of LogEventInfo.FormattedMessage
+                if (!ReferenceEquals(logEvent.MessageFormatter, LogEventInfo.StringFormatMessageFormatter))
+                {
+                    logEvent.MessageFormatter = LogEventInfo.DefaultMessageFormatterSingleTarget;
+                }
             }
 
             for (var t = targets; t != null; t = t.NextInChain)
@@ -299,33 +311,6 @@ namespace NLog
                 }
 
                 return FilterResult.Ignore;
-            }
-        }
-
-        /// <summary>
-        /// Stackframe with correspending index on the stracktrace
-        /// </summary>
-        private class StackFrameWithIndex
-        {
-            /// <summary>
-            /// Index of <see cref="StackFrame"/> on the stack.
-            /// </summary>
-            public int StackFrameIndex { get; private set; }
-
-            /// <summary>
-            /// A stackframe
-            /// </summary>
-            public StackFrame StackFrame { get; private set; }
-
-            /// <summary>
-            /// New item
-            /// </summary>
-            /// <param name="stackFrameIndex">Index of <paramref name="stackFrame"/> on the stack.</param>
-            /// <param name="stackFrame">A stackframe</param>
-            public StackFrameWithIndex(int stackFrameIndex, StackFrame stackFrame)
-            {
-                StackFrameIndex = stackFrameIndex;
-                StackFrame = stackFrame;
             }
         }
     }


### PR DESCRIPTION
Will make some performance tests later to see how it performs.

Should also reduce pressure on the internal StringBuilderPool, as it will just write directly to the final destination-StringBuilder.