### PR TITLE
RegisterItemsFromAssembly - Include assemblies from nuget packages (Strict)

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -395,6 +395,7 @@ namespace NLog.Config
 
                 InternalLogger.Debug("Start auto loading, location: {0}", assemblyLocation);
                 HashSet<string> alreadyRegistered = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                alreadyRegistered.Add(nlogAssembly.FullName);
                 foreach (var extensionDll in extensionDlls)
                 {
                     InternalLogger.Info("Auto loading assembly file: {0}", extensionDll);
@@ -435,10 +436,13 @@ namespace NLog.Config
                         }
                     }
 
-                    if ( assembly.FullName.StartsWith("NLog.Extensions.Logging", StringComparison.OrdinalIgnoreCase)
-                      || assembly.FullName.StartsWith("NLog.Web", StringComparison.OrdinalIgnoreCase)
-                      || assembly.FullName.StartsWith("Microsoft.Extensions.Logging", StringComparison.OrdinalIgnoreCase)
-                      || assembly.FullName.StartsWith("Microsoft.Logging", StringComparison.OrdinalIgnoreCase))
+                    if ( assembly.FullName.StartsWith("NLog.Extensions.Logging,", StringComparison.OrdinalIgnoreCase)
+                      || assembly.FullName.StartsWith("NLog.Web,", StringComparison.OrdinalIgnoreCase)
+                      || assembly.FullName.StartsWith("NLog.Web.AspNetCore,", StringComparison.OrdinalIgnoreCase)
+                      || assembly.FullName.StartsWith("Microsoft.Extensions.Logging,", StringComparison.OrdinalIgnoreCase)
+                      || assembly.FullName.StartsWith("Microsoft.Extensions.Logging.Abstractions,", StringComparison.OrdinalIgnoreCase)
+                      || assembly.FullName.StartsWith("Microsoft.Extensions.Logging.Filter,", StringComparison.OrdinalIgnoreCase)
+                      || assembly.FullName.StartsWith("Microsoft.Logging,", StringComparison.OrdinalIgnoreCase))
                     {
                         LogManager.AddHiddenAssembly(assembly);
                     }

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -195,6 +195,8 @@ namespace NLog
                     assembly
                 };
             }
+
+            InternalLogger.Trace("Hidden Assembly ignored in CallSite StackTrace: {0}", assembly?.FullName);
         }
 
         /// <summary>

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -196,7 +196,7 @@ namespace NLog
                 };
             }
 
-            InternalLogger.Trace("Hidden Assembly ignored in CallSite StackTrace: {0}", assembly?.FullName);
+            InternalLogger.Trace("Assembly '{0}' will be hidden in callsite stacktrace", assembly?.FullName);
         }
 
         /// <summary>


### PR DESCRIPTION
Less aggressive, so NLog.Extensions.Logging.Tests doesn't get marked as hidden assembly.