### PR TITLE
FileTarget - Dynamic archive mode with more strict file-mask for cleanup

### DIFF
--- a/tests/NLog.UnitTests/LogManagerTests.cs
+++ b/tests/NLog.UnitTests/LogManagerTests.cs
@@ -519,8 +519,8 @@ namespace NLog.UnitTests
         [Fact]
         public void ThreadSafe_getCurrentClassLogger_test()
         {
-            MemoryQueueTarget mTarget = new MemoryQueueTarget(1000);
-            MemoryQueueTarget mTarget2 = new MemoryQueueTarget(1000);
+            MemoryQueueTarget mTarget = new MemoryQueueTarget(1000) { Name = "memory" };
+            MemoryQueueTarget mTarget2 = new MemoryQueueTarget(1000) { Name = "memory2" };
 
             var task1 = Task.Run(() =>
             {
@@ -528,8 +528,8 @@ namespace NLog.UnitTests
                 LogManager.Configuration = new LoggingConfiguration();
                 LogManager.ThrowExceptions = true;
 
-                LogManager.Configuration.AddTarget("memory", mTarget);
-                LogManager.Configuration.LoggingRules.Add(new LoggingRule("*", LogLevel.Debug, mTarget));
+                LogManager.Configuration.AddTarget(mTarget.Name, mTarget);
+                LogManager.Configuration.AddRuleForAllLevels(mTarget.Name);
                 System.Threading.Thread.Sleep(1);
                 LogManager.ReconfigExistingLoggers();
                 System.Threading.Thread.Sleep(1);
@@ -538,8 +538,8 @@ namespace NLog.UnitTests
 
             var task2 = task1.ContinueWith((t) =>
             {
-                LogManager.Configuration.AddTarget("memory2", mTarget2);
-                LogManager.Configuration.LoggingRules.Add(new LoggingRule("*", LogLevel.Debug, mTarget2));
+                LogManager.Configuration.AddTarget(mTarget2.Name, mTarget2);
+                LogManager.Configuration.AddRuleForAllLevels(mTarget2.Name);
                 System.Threading.Thread.Sleep(1);
                 LogManager.ReconfigExistingLoggers();
                 System.Threading.Thread.Sleep(1);

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -124,6 +124,17 @@ namespace NLog.UnitTests.Targets
         [MemberData(nameof(SimpleFileTest_TestParameters))]
         public void SimpleFileDeleteTest(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool forceManaged, bool forceMutexConcurrentWrites, bool optimizeBufferReuse)
         {
+#if MONO
+            if (IsTravis())
+            {
+                if (concurrentWrites && keepFileOpen)
+                {
+                    Console.WriteLine("[SKIP] FileTargetTests.SimpleFileDeleteTest(concurrentWrites: True, keepFileOpen: True) because we are running in Travis");
+                    return;
+                }
+            }
+#endif
+
             var logFile = Path.GetTempFileName();
             var logFile2 = Path.Combine(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()), Path.GetFileName(logFile));
 
@@ -154,7 +165,7 @@ namespace NLog.UnitTests.Targets
                 File.Move(logFile, logFile2);
                 if (keepFileOpen)
 #if MONO
-                    Thread.Sleep(1000); // Allow AutoClose-Timer-Thread to react (FileWatcher depends on operating system, fallback to polling every 3 secs)
+                    Thread.Sleep(500); // Allow AutoClose-Timer-Thread to react (FileWatcher depends on operating system, fallback to polling every 3 secs)
 #else
                     Thread.Sleep(150);  // Allow AutoClose-Timer-Thread to react (FileWatcher schedules timer after 50 msec)
 #endif
@@ -2693,8 +2704,8 @@ namespace NLog.UnitTests.Targets
             const int maxArchiveFiles = 5;
 
             var tempPath = ArchiveFileNameHelper.GenerateTempPath();
-            var logFile1 = Path.Combine(tempPath, "FirstFile{0}.txt");
-            var logFile2 = Path.Combine(tempPath, "SecondFile{0}.txt");
+            var logFile1 = Path.Combine(tempPath, "log{0}.txt");
+            var logFile2 = Path.Combine(tempPath, "log-other{0}.txt");
 
             var defaultTimeSource = TimeSource.Current;
             try


### PR DESCRIPTION
Avoid too aggressive cleanup when having multiple log-archives in the same folder.

Make the NLog 4.5 archive logic more userfriendly.