### PR TITLE
LoggerCallSite - Optimized callsite capture

### DIFF
--- a/src/NLog/Internal/CallSiteInformation.cs
+++ b/src/NLog/Internal/CallSiteInformation.cs
@@ -157,7 +157,7 @@ namespace NLog.Internal
             return frame?.GetFileLineNumber() ?? 0;
         }
 
-        public string CallerClassName { get; private set; }
+        public string CallerClassName { get; internal set; }
         public string CallerMemberName { get; private set; }
         public string CallerFilePath { get; private set; }
         public int? CallerLineNumber { get; private set; }

--- a/src/NLog/Internal/PlatformDetector.cs
+++ b/src/NLog/Internal/PlatformDetector.cs
@@ -101,7 +101,7 @@ namespace NLog.Internal
             return RuntimeOS.Unknown;
 #else
             PlatformID platformID = Environment.OSVersion.Platform;
-            if ((int)platformID == 4 || (int)platformID == 128)
+            if ((int)platformID == 4 || (int)platformID == 6 || (int)platformID == 128)
             {
                 return RuntimeOS.Unix;
             }

--- a/src/NLog/LayoutRenderers/CallSiteFileNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteFileNameLayoutRenderer.cs
@@ -73,7 +73,7 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsage.WithSource;
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => SkipFrames == 0 ? StackTraceUsage.WithCallSiteSource : StackTraceUsage.WithSource;
 
         /// <summary>
         /// Renders the call site and appends it to the specified <see cref="StringBuilder" />.

--- a/src/NLog/LayoutRenderers/CallSiteLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteLayoutRenderer.cs
@@ -131,12 +131,10 @@ namespace NLog.LayoutRenderers
             {
 #if !SILVERLIGHT
                 if (FileName)
-                {
-                    return StackTraceUsage.Max;
-                }
+                    return SkipFrames == 0 ? StackTraceUsage.WithCallSiteSource : StackTraceUsage.WithSource;
+                else
 #endif
-
-                return StackTraceUsage.WithoutSource;
+                    return SkipFrames == 0 ? StackTraceUsage.WithCallSite : StackTraceUsage.WithoutSource;
             }
         }
 

--- a/src/NLog/LayoutRenderers/CallSiteLineNumberLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteLineNumberLayoutRenderer.cs
@@ -54,11 +54,11 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(0)]
         public int SkipFrames { get; set; }
-        
+
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsage.WithSource;
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => SkipFrames == 0 ? StackTraceUsage.WithCallSiteSource : StackTraceUsage.WithSource;
 
         /// <summary>
         /// Renders the call site and appends it to the specified <see cref="StringBuilder" />.

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -226,17 +226,12 @@ namespace NLog.LayoutRenderers
         {
             get
             {
+#if !SILVERLIGHT
                 if (IncludeSourceInfo)
-                {
-                    return StackTraceUsage.Max;
-                }
-
-                if (IncludeCallSite)
-                {
-                    return StackTraceUsage.WithoutSource;
-                }
-
-                return StackTraceUsage.None;
+                    return StackTraceUsage.WithCallSiteSource;
+                else
+#endif
+                    return StackTraceUsage.WithCallSite;
             }
         }
 

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -463,6 +463,10 @@ namespace NLog
                 logEvent.FormatProvider = formatProvider ?? logEvent.FormatProvider;
                 return logEvent;
             }
+            else if (exception != null && (formatProvider == null || ReferenceEquals(formatProvider, CultureInfo.InvariantCulture)))
+            {
+                message = exception.Message;
+            }
             return new LogEventInfo(logLevel, loggerName, formatProvider, "{0}", new[] { message }, exception);
         }
 

--- a/src/NLog/LogFactory-T.cs
+++ b/src/NLog/LogFactory-T.cs
@@ -41,7 +41,7 @@ namespace NLog
     /// </summary>
     /// <typeparam name="T">The type of the logger to be returned. Must inherit from <see cref="Logger"/>.</typeparam>
     public class LogFactory<T> : LogFactory 
-        where T : Logger
+        where T : LoggerBase, new()
     {
         /// <summary>
         /// Gets the logger with type <typeparamref name="T"/>.
@@ -50,7 +50,7 @@ namespace NLog
         /// <returns>An instance of <typeparamref name="T"/>.</returns>
         public new T GetLogger(string name)
         {
-            return (T)GetLogger(name, typeof(T));
+            return GetLogger<T>(name);
         }
 
         /// <summary>

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -224,7 +224,6 @@ namespace NLog
         /// Creates a logger that discards all log messages.
         /// </summary>
         /// <returns>Null logger which discards all log messages.</returns>
-        [CLSCompliant(false)]
         public static Logger CreateNullLogger()
         {
             return factory.CreateNullLogger();
@@ -235,7 +234,6 @@ namespace NLog
         /// </summary>
         /// <param name="name">Name of the logger.</param>
         /// <returns>The logger reference. Multiple calls to <c>GetLogger</c> with the same argument aren't guaranteed to return the same logger reference.</returns>
-        [CLSCompliant(false)]
         public static Logger GetLogger(string name)
         {
             return factory.GetLogger(name);
@@ -248,7 +246,6 @@ namespace NLog
         /// <param name="loggerType">The logger class. The class must inherit from <see cref="Logger" />.</param>
         /// <returns>The logger of type <paramref name="loggerType"/>. Multiple calls to <c>GetLogger</c> with the same argument aren't guaranteed to return the same logger reference.</returns>
         /// <remarks>The generic way for this method is <see cref="NLog.LogFactory{loggerType}.GetLogger(string)"/></remarks>
-        [CLSCompliant(false)]
         public static Logger GetLogger(string name, Type loggerType)
         {
             return factory.GetLogger(name, loggerType);

--- a/src/NLog/Logger-generated.cs
+++ b/src/NLog/Logger-generated.cs
@@ -42,60 +42,6 @@ namespace NLog
     /// </summary>
     public partial class Logger
     {
-        /// <summary>
-        /// Gets a value indicating whether logging is enabled for the <c>Trace</c> level.
-        /// </summary>
-        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Trace</c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool IsTraceEnabled
-        {
-            get { return _isTraceEnabled; }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether logging is enabled for the <c>Debug</c> level.
-        /// </summary>
-        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Debug</c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool IsDebugEnabled
-        {
-            get { return _isDebugEnabled; }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether logging is enabled for the <c>Info</c> level.
-        /// </summary>
-        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Info</c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool IsInfoEnabled
-        {
-            get { return _isInfoEnabled; }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether logging is enabled for the <c>Warn</c> level.
-        /// </summary>
-        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Warn</c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool IsWarnEnabled
-        {
-            get { return _isWarnEnabled; }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether logging is enabled for the <c>Error</c> level.
-        /// </summary>
-        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Error</c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool IsErrorEnabled
-        {
-            get { return _isErrorEnabled; }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether logging is enabled for the <c>Fatal</c> level.
-        /// </summary>
-        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Fatal</c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool IsFatalEnabled
-        {
-            get { return _isFatalEnabled; }
-        }
-
 
         #region Trace() overloads 
 
@@ -111,7 +57,7 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, null, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Trace, Name, null, value));
             }
         }
 
@@ -125,7 +71,7 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Trace, Name, formatProvider, value));
             }
         }
 
@@ -141,8 +87,7 @@ namespace NLog
                 {
                     throw new ArgumentNullException(nameof(messageFunc));
                 }
-
-                WriteToTargets(LogLevel.Trace, null, messageFunc());
+                WriteToTargets(LogLevel.Trace, messageFunc(), null);
             }
         }
 
@@ -181,7 +126,7 @@ namespace NLog
         { 
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, null, message);
+                WriteToTargets(LogLevel.Trace, message, null);
             }
         }
 
@@ -210,7 +155,7 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Trace, Name, exception, null, message, null));
             }
         }
 
@@ -223,7 +168,7 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Trace, Name, exception, null, message, null));
             }
         }
 
@@ -238,7 +183,7 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, exception, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Trace, Name, exception, null, message, args));
             }
         }
 
@@ -254,7 +199,7 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, exception, formatProvider, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Trace, Name, exception, formatProvider, message, args));
             }
         }
 
@@ -288,19 +233,18 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (_configuration.ExceptionLoggingOldStyle)
+                if (LoggerConfiguration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
-                    var exceptionCandidate = argument as Exception;		
-                    if (exceptionCandidate != null)		
+                    var exceptionCandidate = argument as Exception;
+                    if (exceptionCandidate != null)
                     {
-
                         // ReSharper disable CSharpWarnings::CS0618
                         #pragma warning disable 618
-                        Trace(message, exceptionCandidate);	
+                        Trace(message, exceptionCandidate);
                         #pragma warning restore 618
-                        // ReSharper restore CSharpWarnings::CS0618	
-                        return;		
+                        // ReSharper restore CSharpWarnings::CS0618
+                        return;
                     }
                 }
 
@@ -398,7 +342,7 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, null, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Debug, Name, null, value));
             }
         }
 
@@ -412,7 +356,7 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Debug, Name, formatProvider, value));
             }
         }
 
@@ -428,8 +372,7 @@ namespace NLog
                 {
                     throw new ArgumentNullException(nameof(messageFunc));
                 }
-
-                WriteToTargets(LogLevel.Debug, null, messageFunc());
+                WriteToTargets(LogLevel.Debug, messageFunc(), null);
             }
         }
 
@@ -468,7 +411,7 @@ namespace NLog
         { 
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, null, message);
+                WriteToTargets(LogLevel.Debug, message, null);
             }
         }
 
@@ -497,7 +440,7 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Debug, Name, exception, null, message, null));
             }
         }
 
@@ -510,7 +453,7 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Debug, Name, exception, null, message, null));
             }
         }
 
@@ -525,7 +468,7 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, exception, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Debug, Name, exception, null, message, args));
             }
         }
 
@@ -541,7 +484,7 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, exception, formatProvider, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Debug, Name, exception, formatProvider, message, args));
             }
         }
 
@@ -575,19 +518,18 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (_configuration.ExceptionLoggingOldStyle)
+                if (LoggerConfiguration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
-                    var exceptionCandidate = argument as Exception;		
-                    if (exceptionCandidate != null)		
+                    var exceptionCandidate = argument as Exception;
+                    if (exceptionCandidate != null)
                     {
-
                         // ReSharper disable CSharpWarnings::CS0618
                         #pragma warning disable 618
-                        Debug(message, exceptionCandidate);	
+                        Debug(message, exceptionCandidate);
                         #pragma warning restore 618
-                        // ReSharper restore CSharpWarnings::CS0618	
-                        return;		
+                        // ReSharper restore CSharpWarnings::CS0618
+                        return;
                     }
                 }
 
@@ -685,7 +627,7 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, null, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Info, Name, null, value));
             }
         }
 
@@ -699,7 +641,7 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Info, Name, formatProvider, value));
             }
         }
 
@@ -715,8 +657,7 @@ namespace NLog
                 {
                     throw new ArgumentNullException(nameof(messageFunc));
                 }
-
-                WriteToTargets(LogLevel.Info, null, messageFunc());
+                WriteToTargets(LogLevel.Info, messageFunc(), null);
             }
         }
 
@@ -755,7 +696,7 @@ namespace NLog
         { 
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, null, message);
+                WriteToTargets(LogLevel.Info, message, null);
             }
         }
 
@@ -784,7 +725,7 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Info, Name, exception, null, message, null));
             }
         }
 
@@ -797,7 +738,7 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Info, Name, exception, null, message, null));
             }
         }
 
@@ -812,7 +753,7 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, exception, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Info, Name, exception, null, message, args));
             }
         }
 
@@ -828,7 +769,7 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, exception, formatProvider, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Info, Name, exception, formatProvider, message, args));
             }
         }
 
@@ -862,19 +803,18 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (_configuration.ExceptionLoggingOldStyle)
+                if (LoggerConfiguration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
-                    var exceptionCandidate = argument as Exception;		
-                    if (exceptionCandidate != null)		
+                    var exceptionCandidate = argument as Exception;
+                    if (exceptionCandidate != null)
                     {
-
                         // ReSharper disable CSharpWarnings::CS0618
                         #pragma warning disable 618
-                        Info(message, exceptionCandidate);	
+                        Info(message, exceptionCandidate);
                         #pragma warning restore 618
-                        // ReSharper restore CSharpWarnings::CS0618	
-                        return;		
+                        // ReSharper restore CSharpWarnings::CS0618
+                        return;
                     }
                 }
 
@@ -972,7 +912,7 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, null, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Warn, Name, null, value));
             }
         }
 
@@ -986,7 +926,7 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Warn, Name, formatProvider, value));
             }
         }
 
@@ -1002,8 +942,7 @@ namespace NLog
                 {
                     throw new ArgumentNullException(nameof(messageFunc));
                 }
-
-                WriteToTargets(LogLevel.Warn, null, messageFunc());
+                WriteToTargets(LogLevel.Warn, messageFunc(), null);
             }
         }
 
@@ -1042,7 +981,7 @@ namespace NLog
         { 
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, null, message);
+                WriteToTargets(LogLevel.Warn, message, null);
             }
         }
 
@@ -1071,7 +1010,7 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Warn, Name, exception, null, message, null));
             }
         }
 
@@ -1084,7 +1023,7 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Warn, Name, exception, null, message, null));
             }
         }
 
@@ -1099,7 +1038,7 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, exception, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Warn, Name, exception, null, message, args));
             }
         }
 
@@ -1115,7 +1054,7 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, exception, formatProvider, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Warn, Name, exception, formatProvider, message, args));
             }
         }
 
@@ -1149,19 +1088,18 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (_configuration.ExceptionLoggingOldStyle)
+                if (LoggerConfiguration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
-                    var exceptionCandidate = argument as Exception;		
-                    if (exceptionCandidate != null)		
+                    var exceptionCandidate = argument as Exception;
+                    if (exceptionCandidate != null)
                     {
-
                         // ReSharper disable CSharpWarnings::CS0618
                         #pragma warning disable 618
-                        Warn(message, exceptionCandidate);	
+                        Warn(message, exceptionCandidate);
                         #pragma warning restore 618
-                        // ReSharper restore CSharpWarnings::CS0618	
-                        return;		
+                        // ReSharper restore CSharpWarnings::CS0618
+                        return;
                     }
                 }
 
@@ -1259,7 +1197,7 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, null, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Error, Name, null, value));
             }
         }
 
@@ -1273,7 +1211,7 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Error, Name, formatProvider, value));
             }
         }
 
@@ -1289,8 +1227,7 @@ namespace NLog
                 {
                     throw new ArgumentNullException(nameof(messageFunc));
                 }
-
-                WriteToTargets(LogLevel.Error, null, messageFunc());
+                WriteToTargets(LogLevel.Error, messageFunc(), null);
             }
         }
 
@@ -1329,7 +1266,7 @@ namespace NLog
         { 
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, null, message);
+                WriteToTargets(LogLevel.Error, message, null);
             }
         }
 
@@ -1358,7 +1295,7 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Error, Name, exception, null, message, null));
             }
         }
 
@@ -1371,7 +1308,7 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Error, Name, exception, null, message, null));
             }
         }
 
@@ -1386,7 +1323,7 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, exception, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Error, Name, exception, null, message, args));
             }
         }
 
@@ -1402,7 +1339,7 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, exception, formatProvider, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Error, Name, exception, formatProvider, message, args));
             }
         }
 
@@ -1436,19 +1373,18 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (_configuration.ExceptionLoggingOldStyle)
+                if (LoggerConfiguration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
-                    var exceptionCandidate = argument as Exception;		
-                    if (exceptionCandidate != null)		
+                    var exceptionCandidate = argument as Exception;
+                    if (exceptionCandidate != null)
                     {
-
                         // ReSharper disable CSharpWarnings::CS0618
                         #pragma warning disable 618
-                        Error(message, exceptionCandidate);	
+                        Error(message, exceptionCandidate);
                         #pragma warning restore 618
-                        // ReSharper restore CSharpWarnings::CS0618	
-                        return;		
+                        // ReSharper restore CSharpWarnings::CS0618
+                        return;
                     }
                 }
 
@@ -1546,7 +1482,7 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, null, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Fatal, Name, null, value));
             }
         }
 
@@ -1560,7 +1496,7 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Fatal, Name, formatProvider, value));
             }
         }
 
@@ -1576,8 +1512,7 @@ namespace NLog
                 {
                     throw new ArgumentNullException(nameof(messageFunc));
                 }
-
-                WriteToTargets(LogLevel.Fatal, null, messageFunc());
+                WriteToTargets(LogLevel.Fatal, messageFunc(), null);
             }
         }
 
@@ -1616,7 +1551,7 @@ namespace NLog
         { 
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, null, message);
+                WriteToTargets(LogLevel.Fatal, message, null);
             }
         }
 
@@ -1645,7 +1580,7 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Fatal, Name, exception, null, message, null));
             }
         }
 
@@ -1658,7 +1593,7 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Fatal, Name, exception, null, message, null));
             }
         }
 
@@ -1673,7 +1608,7 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, exception, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Fatal, Name, exception, null, message, args));
             }
         }
 
@@ -1689,7 +1624,7 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, exception, formatProvider, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.Fatal, Name, exception, formatProvider, message, args));
             }
         }
 
@@ -1723,19 +1658,18 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (_configuration.ExceptionLoggingOldStyle)
+                if (LoggerConfiguration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
-                    var exceptionCandidate = argument as Exception;		
-                    if (exceptionCandidate != null)		
+                    var exceptionCandidate = argument as Exception;
+                    if (exceptionCandidate != null)
                     {
-
                         // ReSharper disable CSharpWarnings::CS0618
                         #pragma warning disable 618
-                        Fatal(message, exceptionCandidate);	
+                        Fatal(message, exceptionCandidate);
                         #pragma warning restore 618
-                        // ReSharper restore CSharpWarnings::CS0618	
-                        return;		
+                        // ReSharper restore CSharpWarnings::CS0618
+                        return;
                     }
                 }
 

--- a/src/NLog/Logger-generated.tt
+++ b/src/NLog/Logger-generated.tt
@@ -56,22 +56,6 @@ namespace NLog
 
     foreach(var level in levels)
     { 
-#>
-        /// <summary>
-        /// Gets a value indicating whether logging is enabled for the <c><#=level#></c> level.
-        /// </summary>
-        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c><#=level#></c> level, otherwise it returns <see langword="false" />.</returns>
-        public bool Is<#=level#>Enabled
-        {
-            get { return _is<#=level#>Enabled; }
-        }
-
-<#
-
-    }
-
-    foreach(var level in levels)
-    { 
 
 
 #>
@@ -90,7 +74,7 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-                WriteToTargets(LogLevel.<#=level#>, null, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.<#=level#>, Name, null, value));
             }
         }
 
@@ -104,7 +88,7 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-                WriteToTargets(LogLevel.<#=level#>, formatProvider, value);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.<#=level#>, Name, formatProvider, value));
             }
         }
 
@@ -118,10 +102,9 @@ namespace NLog
             {
                 if (messageFunc == null)
                 {
-                    throw new ArgumentNullException("messageFunc");
+                    throw new ArgumentNullException(nameof(messageFunc));
                 }
-
-                WriteToTargets(LogLevel.<#=level#>, null, messageFunc());
+                WriteToTargets(LogLevel.<#=level#>, messageFunc(), null);
             }
         }
 
@@ -160,7 +143,7 @@ namespace NLog
         { 
             if (Is<#=level#>Enabled)
             {
-                WriteToTargets(LogLevel.<#=level#>, null, message);
+                WriteToTargets(LogLevel.<#=level#>, message, null);
             }
         }
 
@@ -189,7 +172,7 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-                WriteToTargets(LogLevel.<#=level#>, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.<#=level#>, Name, exception, null, message, null));
             }
         }
 
@@ -202,7 +185,7 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-                WriteToTargets(LogLevel.<#=level#>, exception, message, null);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.<#=level#>, Name, exception, null, message, null));
             }
         }
 
@@ -217,7 +200,7 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-                WriteToTargets(LogLevel.<#=level#>, exception, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.<#=level#>, Name, exception, null, message, args));
             }
         }
 
@@ -233,7 +216,7 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-                WriteToTargets(LogLevel.<#=level#>, exception, formatProvider, message, args);
+                WriteToTargets(null, LogEventInfo.Create(LogLevel.<#=level#>, Name, exception, formatProvider, message, args));
             }
         }
 
@@ -267,19 +250,18 @@ namespace NLog
 #pragma warning disable 618
            
             //todo log also these calls as warning?
-                if (_configuration.ExceptionLoggingOldStyle)
+                if (LoggerConfiguration.ExceptionLoggingOldStyle)
 #pragma warning restore 618
                 {   
-                    var exceptionCandidate = argument as Exception;		
-                    if (exceptionCandidate != null)		
+                    var exceptionCandidate = argument as Exception;
+                    if (exceptionCandidate != null)
                     {
-
                         // ReSharper disable CSharpWarnings::CS0618
                         #pragma warning disable 618
-                        <#=level#>(message, exceptionCandidate);	
+                        <#=level#>(message, exceptionCandidate);
                         #pragma warning restore 618
-                        // ReSharper restore CSharpWarnings::CS0618	
-                        return;		
+                        // ReSharper restore CSharpWarnings::CS0618
+                        return;
                     }
                 }
 

--- a/src/NLog/LoggerBase.cs
+++ b/src/NLog/LoggerBase.cs
@@ -1,0 +1,217 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog
+{
+    using System;
+    using NLog.Config;
+    using NLog.Internal;
+
+    /// <summary>
+    /// Logger interface with minimal interface (still some bonus properties for performance)
+    /// </summary>
+    public abstract class LoggerBase
+    {
+        private readonly Type _loggerType;
+        private LoggerConfiguration _configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoggerBase"/> class.
+        /// </summary>
+        protected LoggerBase()
+        {
+            _loggerType = GetType();
+        }
+
+        /// <summary>
+        /// Occurs when logger configuration changes.
+        /// </summary>
+        public event EventHandler<EventArgs> LoggerReconfigured;
+
+        /// <summary>
+        /// Gets the name of the logger.
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Gets the factory that created this logger.
+        /// </summary>
+        public LogFactory Factory { get; private set; }
+
+        /// <summary>
+        /// Gets the active LoggerConfiguration for the logger
+        /// </summary>
+        internal LoggerConfiguration LoggerConfiguration { get => _configuration; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the <c>Trace</c> level.
+        /// </summary>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Trace</c> level, otherwise it returns <see langword="false" />.</returns>
+        public bool IsTraceEnabled { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the <c>Debug</c> level.
+        /// </summary>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Debug</c> level, otherwise it returns <see langword="false" />.</returns>
+        public bool IsDebugEnabled { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the <c>Info</c> level.
+        /// </summary>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Info</c> level, otherwise it returns <see langword="false" />.</returns>
+        public bool IsInfoEnabled { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the <c>Warn</c> level.
+        /// </summary>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Warn</c> level, otherwise it returns <see langword="false" />.</returns>
+        public bool IsWarnEnabled { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the <c>Error</c> level.
+        /// </summary>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Error</c> level, otherwise it returns <see langword="false" />.</returns>
+        public bool IsErrorEnabled { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the <c>Fatal</c> level.
+        /// </summary>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Fatal</c> level, otherwise it returns <see langword="false" />.</returns>
+        public bool IsFatalEnabled { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the specified level.
+        /// </summary>
+        /// <param name="level">Log level to be checked.</param>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the specified level, otherwise it returns <see langword="false" />.</returns>
+        public bool IsEnabled(LogLevel level)
+        {
+            if (level == null)
+            {
+                throw new InvalidOperationException("Log level must be defined");
+            }
+
+            return GetTargetsForLevel(level) != null;
+        }
+
+        /// <summary>
+        /// Writes the specified log event.
+        /// </summary>
+        /// <param name="logEvent">Log event.</param>
+        public void Log(LogEventInfo logEvent)
+        {
+            if (IsEnabled(logEvent.Level))
+            {
+                WriteToTargets(_loggerType, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes the specified log event.
+        /// </summary>
+        /// <param name="wrapperType">The name of the type that wraps Logger.</param>
+        /// <param name="logEvent">Log event.</param>
+        public void Log(Type wrapperType, LogEventInfo logEvent)
+        {
+            if (IsEnabled(logEvent.Level))
+            {
+                WriteToTargets(wrapperType, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Checks the targets whether StackTrace is required
+        /// </summary>
+        /// <param name="level">Log level to be checked.</param>
+        /// <returns>Value indicating how stack trace should be captured when processing the log event</returns>
+        internal StackTraceUsage GetStackTraceUsage(LogLevel level)
+        {
+            return GetTargetsForLevel(level).GetStackTraceUsage();
+        }
+
+        /// <summary>
+        /// Writes the specified log event.
+        /// </summary>
+        /// <param name="wrapperType">The name of the type that wraps Logger.</param>
+        /// <param name="logEvent">Log event.</param>
+        protected void WriteToTargets(Type wrapperType, LogEventInfo logEvent)
+        {
+            LoggerImpl.Write(wrapperType ?? _loggerType, GetTargetsForLevel(logEvent.Level), PrepareLogEventInfo(logEvent), Factory);
+        }
+
+        private LogEventInfo PrepareLogEventInfo(LogEventInfo logEvent)
+        {
+            if (logEvent.FormatProvider == null)
+            {
+                logEvent.FormatProvider = Factory.DefaultCultureInfo;
+            }
+            return logEvent;
+        }
+
+        internal void Initialize(string name, LoggerConfiguration loggerConfiguration, LogFactory factory)
+        {
+            Name = name;
+            Factory = factory;
+            SetConfiguration(loggerConfiguration);
+        }
+
+        internal virtual void SetConfiguration(LoggerConfiguration newConfiguration)
+        {
+            _configuration = newConfiguration;
+
+            // pre-calculate 'enabled' flags
+            IsTraceEnabled = newConfiguration.IsEnabled(LogLevel.Trace);
+            IsDebugEnabled = newConfiguration.IsEnabled(LogLevel.Debug);
+            IsInfoEnabled = newConfiguration.IsEnabled(LogLevel.Info);
+            IsWarnEnabled = newConfiguration.IsEnabled(LogLevel.Warn);
+            IsErrorEnabled = newConfiguration.IsEnabled(LogLevel.Error);
+            IsFatalEnabled = newConfiguration.IsEnabled(LogLevel.Fatal);
+
+            OnLoggerReconfigured(EventArgs.Empty);
+        }
+
+        private TargetWithFilterChain GetTargetsForLevel(LogLevel level)
+        {
+            return _configuration.GetTargetsForLevel(level);
+        }
+
+        /// <summary>
+        /// Raises the event when the logger is reconfigured. 
+        /// </summary>
+        /// <param name="e">Event arguments</param>
+        protected virtual void OnLoggerReconfigured(EventArgs e)
+        {
+            LoggerReconfigured?.Invoke(this, e);
+        }
+    }
+}

--- a/src/NLog/LoggerCallSite-generated.cs
+++ b/src/NLog/LoggerCallSite-generated.cs
@@ -1,0 +1,5726 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog
+{
+    using System;
+    using System.ComponentModel;
+    using System.Runtime.CompilerServices;
+    using JetBrains.Annotations;
+
+    /// <summary>
+    /// Provides logging interface and utility functions.
+    /// </summary>
+    public partial class LoggerCallSite
+    {
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Log(LogLevel level, [Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, null, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Log(LogLevel level, Exception exception, [Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, null, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Log<T>(LogLevel level, T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = LogEventInfo.Create(level, Name, null, value);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Log<T>(LogLevel level, IFormatProvider formatProvider, T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = LogEventInfo.Create(level, Name, formatProvider, value);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided delegate
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Log(LogLevel level, LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsEnabled(level))
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(level, Name, null, messageFunc(), null, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message-delegate
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Log(LogLevel level, Exception exception, LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsEnabled(level))
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(level, Name, null, messageFunc(), null, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, [Localizable(false)] string message, params object[] args)
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message (without CallSite details)
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args)
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message (without CallSite details)
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1>(LogLevel level, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, new object[] { arg1 }, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1>(LogLevel level, Exception exception, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, new object[] { arg1 }, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1>(LogLevel level, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, new object[] { arg1 }, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, new object[] { arg1 }, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2>(LogLevel level, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, new object[] { arg1, arg2 }, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2>(LogLevel level, Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)  
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, new object[] { arg1, arg2 }, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2>(LogLevel level, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)  
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, new object[] { arg1, arg2 }, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)  
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, new object[] { arg1, arg2 }, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="arg3">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, new object[] { arg1, arg2, arg3 }, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="arg3">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)  
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="arg3">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)  
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="arg3">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)  
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Trace<T>(T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Trace, Name, null, value);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Trace<T>(IFormatProvider formatProvider, T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Trace, Name, formatProvider, value);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message-delegate
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Trace(LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, messageFunc(), null, null);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message-delegate
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Trace(Exception exception, LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, messageFunc(), null, exception);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace([Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, message);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace(Exception exception, [Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, null, exception);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace([Localizable(false)] string message, params object[] args)
+        { 
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace(Exception exception, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exeption and message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, formatProvider, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, formatProvider, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1>([Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, new object[] { arg1 });
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1>(Exception exception, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, new object[] { arg1 }, exception);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, formatProvider, message, new object[] { arg1 }, exception);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, formatProvider, message, new object[] { arg1 }, null);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, new object[] { arg1, arg2 });
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, new object[] { arg1, arg2 }, exception);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, formatProvider, message, new object[] { arg1, arg2 }, exception);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, formatProvider, message, new object[] { arg1, arg2 }, null);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, new object[] { arg1, arg2, arg3 });
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2, TArgument3>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2, TArgument3>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, null);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, new object[] { arg1, arg2, arg3, arg4 });
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2, TArgument3, TArgument4>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, null);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 });
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Trace</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsTraceEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Trace, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, null);
+                if (_isTraceCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Debug<T>(T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Debug, Name, null, value);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Debug<T>(IFormatProvider formatProvider, T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Debug, Name, formatProvider, value);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message-delegate
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Debug(LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, messageFunc(), null, null);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message-delegate
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Debug(Exception exception, LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, messageFunc(), null, exception);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, message);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug(Exception exception, [Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, null, exception);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)] string message, params object[] args)
+        { 
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug(Exception exception, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exeption and message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, formatProvider, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, formatProvider, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1>([Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, new object[] { arg1 });
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1>(Exception exception, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, new object[] { arg1 }, exception);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, formatProvider, message, new object[] { arg1 }, exception);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, formatProvider, message, new object[] { arg1 }, null);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, new object[] { arg1, arg2 });
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, new object[] { arg1, arg2 }, exception);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, formatProvider, message, new object[] { arg1, arg2 }, exception);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, formatProvider, message, new object[] { arg1, arg2 }, null);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, new object[] { arg1, arg2, arg3 });
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2, TArgument3>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2, TArgument3>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, null);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, new object[] { arg1, arg2, arg3, arg4 });
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, null);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 });
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Debug</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsDebugEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Debug, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, null);
+                if (_isDebugCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Info<T>(T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Info, Name, null, value);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Info<T>(IFormatProvider formatProvider, T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Info, Name, formatProvider, value);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message-delegate
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Info(LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, messageFunc(), null, null);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message-delegate
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Info(Exception exception, LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, messageFunc(), null, exception);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, message);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info(Exception exception, [Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, null, exception);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)] string message, params object[] args)
+        { 
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info(Exception exception, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exeption and message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, formatProvider, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, formatProvider, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1>([Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, new object[] { arg1 });
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1>(Exception exception, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, new object[] { arg1 }, exception);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, formatProvider, message, new object[] { arg1 }, exception);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, formatProvider, message, new object[] { arg1 }, null);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, new object[] { arg1, arg2 });
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, new object[] { arg1, arg2 }, exception);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, formatProvider, message, new object[] { arg1, arg2 }, exception);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, formatProvider, message, new object[] { arg1, arg2 }, null);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, new object[] { arg1, arg2, arg3 });
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2, TArgument3>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2, TArgument3>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, null);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, new object[] { arg1, arg2, arg3, arg4 });
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, null);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 });
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Info</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsInfoEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Info, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, null);
+                if (_isInfoCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Warn<T>(T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Warn, Name, null, value);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Warn<T>(IFormatProvider formatProvider, T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Warn, Name, formatProvider, value);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message-delegate
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Warn(LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, messageFunc(), null, null);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message-delegate
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Warn(Exception exception, LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, messageFunc(), null, exception);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, message);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn(Exception exception, [Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, null, exception);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)] string message, params object[] args)
+        { 
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn(Exception exception, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exeption and message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, formatProvider, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, formatProvider, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1>([Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, new object[] { arg1 });
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1>(Exception exception, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, new object[] { arg1 }, exception);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, formatProvider, message, new object[] { arg1 }, exception);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, formatProvider, message, new object[] { arg1 }, null);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, new object[] { arg1, arg2 });
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, new object[] { arg1, arg2 }, exception);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, formatProvider, message, new object[] { arg1, arg2 }, exception);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, formatProvider, message, new object[] { arg1, arg2 }, null);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, new object[] { arg1, arg2, arg3 });
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2, TArgument3>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2, TArgument3>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, null);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, new object[] { arg1, arg2, arg3, arg4 });
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, null);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 });
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Warn</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsWarnEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Warn, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, null);
+                if (_isWarnCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Error<T>(T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Error, Name, null, value);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Error<T>(IFormatProvider formatProvider, T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Error, Name, formatProvider, value);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message-delegate
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Error(LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, messageFunc(), null, null);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message-delegate
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Error(Exception exception, LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, messageFunc(), null, exception);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, message);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error(Exception exception, [Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, null, exception);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)] string message, params object[] args)
+        { 
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error(Exception exception, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exeption and message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, formatProvider, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, formatProvider, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1>([Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, new object[] { arg1 });
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1>(Exception exception, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, new object[] { arg1 }, exception);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, formatProvider, message, new object[] { arg1 }, exception);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, formatProvider, message, new object[] { arg1 }, null);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, new object[] { arg1, arg2 });
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, new object[] { arg1, arg2 }, exception);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, formatProvider, message, new object[] { arg1, arg2 }, exception);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, formatProvider, message, new object[] { arg1, arg2 }, null);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, new object[] { arg1, arg2, arg3 });
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2, TArgument3>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2, TArgument3>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, null);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, new object[] { arg1, arg2, arg3, arg4 });
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, null);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 });
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Error</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsErrorEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Error, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, null);
+                if (_isErrorCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Fatal<T>(T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Fatal, Name, null, value);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Fatal<T>(IFormatProvider formatProvider, T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Fatal, Name, formatProvider, value);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message-delegate
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Fatal(LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, messageFunc(), null, null);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message-delegate
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Fatal(Exception exception, LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, messageFunc(), null, exception);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, message);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal(Exception exception, [Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, null, exception);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)] string message, params object[] args)
+        { 
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal(Exception exception, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exeption and message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, formatProvider, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, formatProvider, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1>([Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, new object[] { arg1 });
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1>(Exception exception, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, new object[] { arg1 }, exception);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, formatProvider, message, new object[] { arg1 }, exception);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, formatProvider, message, new object[] { arg1 }, null);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, new object[] { arg1, arg2 });
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, new object[] { arg1, arg2 }, exception);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, formatProvider, message, new object[] { arg1, arg2 }, exception);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, formatProvider, message, new object[] { arg1, arg2 }, null);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, new object[] { arg1, arg2, arg3 });
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2, TArgument3>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2, TArgument3>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, null);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, new object[] { arg1, arg2, arg3, arg4 });
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, null);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 });
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c>Fatal</c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsFatalEnabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.Fatal, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, null);
+                if (_isFatalCallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+
+#if !NET45
+        /// <summary>
+        /// Support ILoggerBasicExtensions on NET35/NET40
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+        public class CallerMemberNameAttribute : Attribute
+        {
+        }
+
+        /// <summary>
+        /// Support ILoggerBasicExtensions on NET35/NET40
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+        public class CallerFilePathAttribute : Attribute
+        {
+        }
+
+        /// <summary>
+        /// Support ILoggerBasicExtensions on NET35/NET40
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+        public class CallerLineNumberAttribute : Attribute
+        {
+        }
+#endif
+
+        /// <summary>
+        /// The purpose of this type is to act as a guard between 
+        /// the actual parameter list and optional parameter list.
+        /// If you need to pass this type as an argument you are using
+        /// the wrong overload.
+        /// </summary>
+        public struct LogWithOptionalParameterList
+        {
+            // This type has no other purpose.
+        }
+
+        private static LogEventInfo PrepareLogEventInfo(LogEventInfo logEvent)
+        {
+            if (logEvent.FormatProvider == null)
+            {
+                logEvent.FormatProvider = LogManager.LogFactory.DefaultCultureInfo;
+            }
+            return logEvent;
+        }
+    }
+}

--- a/src/NLog/LoggerCallSite-generated.tt
+++ b/src/NLog/LoggerCallSite-generated.tt
@@ -1,0 +1,1539 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<# 
+    //Generation of overloads of all six levels
+    //T4 templates are built in Visual Studio. See https://msdn.microsoft.com/en-us/library/bb126445.aspx
+#>// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog
+{
+    using System;
+    using System.ComponentModel;
+    using System.Runtime.CompilerServices;
+    using JetBrains.Annotations;
+
+    /// <summary>
+    /// Provides logging interface and utility functions.
+    /// </summary>
+    public partial class LoggerCallSite
+    {
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Log(LogLevel level, [Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, null, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Log(LogLevel level, Exception exception, [Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, null, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Log<T>(LogLevel level, T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = LogEventInfo.Create(level, Name, null, value);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Log<T>(LogLevel level, IFormatProvider formatProvider, T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = LogEventInfo.Create(level, Name, formatProvider, value);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided delegate
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Log(LogLevel level, LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsEnabled(level))
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(level, Name, null, messageFunc(), null, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message-delegate
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void Log(LogLevel level, Exception exception, LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (IsEnabled(level))
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(level, Name, null, messageFunc(), null, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, [Localizable(false)] string message, params object[] args)
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message (without CallSite details)
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args)
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message (without CallSite details)
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1>(LogLevel level, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        {
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, new object[] { arg1 }, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1>(LogLevel level, Exception exception, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, new object[] { arg1 }, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1>(LogLevel level, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, new object[] { arg1 }, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, new object[] { arg1 }, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2>(LogLevel level, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, new object[] { arg1, arg2 }, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2>(LogLevel level, Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)  
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, new object[] { arg1, arg2 }, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2>(LogLevel level, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)  
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, new object[] { arg1, arg2 }, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)  
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, new object[] { arg1, arg2 }, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="arg3">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0) 
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, new object[] { arg1, arg2, arg3 }, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="arg3">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)  
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, null, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="arg3">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)  
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="arg1">The argument to format.</param>
+        /// <param name="arg2">The argument to format.</param>
+        /// <param name="arg3">The argument to format.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)  
+        { 
+            if (IsEnabled(level))
+            {
+                var logEvent = new LogEventInfo(level, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, null);
+                if (IsCallSiteEnabled(level))
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+<#
+    var levels = new string[]{"Trace", "Debug", "Info", "Warn", "Error", "Fatal"};
+
+    foreach(var level in levels)
+    { 
+#>
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void <#=level#><T>(T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.<#=level#>, Name, null, value);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at specified level using provided generic value
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void <#=level#><T>(IFormatProvider formatProvider, T value
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.<#=level#>, Name, formatProvider, value);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message-delegate
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void <#=level#>(LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, messageFunc(), null, null);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message-delegate
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        public void <#=level#>(Exception exception, LogMessageGenerator messageFunc
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                if (messageFunc == null)
+                {
+                    throw new ArgumentNullException("messageFunc");
+                }
+
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, messageFunc(), null, exception);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#>([Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, message);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#>(Exception exception, [Localizable(false)] string message
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, null, exception);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#>([Localizable(false)] string message, params object[] args)
+        { 
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#>(Exception exception, [Localizable(false)] string message, params object[] args)
+        { 
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exeption and message (without CallSite details)
+        /// </summary>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, formatProvider, message, args, exception);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message (without CallSite details)
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#>(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
+        { 
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, formatProvider, message, args, null);
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1>([Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, new object[] { arg1 });
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1>(Exception exception, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, new object[] { arg1 }, exception);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, formatProvider, message, new object[] { arg1 }, exception);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, formatProvider, message, new object[] { arg1 }, null);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, new object[] { arg1, arg2 });
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, new object[] { arg1, arg2 }, exception);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, formatProvider, message, new object[] { arg1, arg2 }, exception);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, formatProvider, message, new object[] { arg1, arg2 }, null);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, new object[] { arg1, arg2, arg3 });
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2, TArgument3>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2, TArgument3>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, exception);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, formatProvider, message, new object[] { arg1, arg2, arg3 }, null);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, new object[] { arg1, arg2, arg3, arg4 });
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, exception);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2, TArgument3, TArgument4>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4 }, null);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 });
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, null, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided exception and message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="exception">Exception to be logged.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, exception);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+        /// <summary>
+        /// Writes log-event at <c><#=level#></c> level using provided message
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument4">The type of the argument.</typeparam>
+        /// <typeparam name="TArgument5">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">Log event mesage</param>
+        /// <param name="arg1">Arguments to format</param>
+        /// <param name="arg2">Arguments to format</param>
+        /// <param name="arg3">Arguments to format</param>
+        /// <param name="arg4">Arguments to format</param>
+        /// <param name="arg5">Arguments to format</param>
+        /// <param name="_">Parameter Validation Helper</param>
+        /// <param name="callerMemberName">Capture Caller Method</param>
+        /// <param name="callerFilePath">Capture Caller FilePath</param>
+        /// <param name="callerLineNumber">Capture Caller LineNumber</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#><TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 arg1, TArgument2 arg2, TArgument3 arg3, TArgument4 arg4, TArgument5 arg5
+            , LogWithOptionalParameterList _ = default(LogWithOptionalParameterList)
+            , [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            if (Is<#=level#>Enabled)
+            {
+                var logEvent = new LogEventInfo(LogLevel.<#=level#>, Name, formatProvider, message, new object[] { arg1, arg2, arg3, arg4, arg5 }, null);
+                if (_is<#=level#>CallSiteEnabled)
+                {
+                    logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+                }
+                WriteToTargets(null, logEvent);
+            }
+        }
+
+
+<#
+    }
+    #>
+
+#if !NET45
+        /// <summary>
+        /// Support ILoggerBasicExtensions on NET35/NET40
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+        public class CallerMemberNameAttribute : Attribute
+        {
+        }
+
+        /// <summary>
+        /// Support ILoggerBasicExtensions on NET35/NET40
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+        public class CallerFilePathAttribute : Attribute
+        {
+        }
+
+        /// <summary>
+        /// Support ILoggerBasicExtensions on NET35/NET40
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+        public class CallerLineNumberAttribute : Attribute
+        {
+        }
+#endif
+
+        /// <summary>
+        /// The purpose of this type is to act as a guard between 
+        /// the actual parameter list and optional parameter list.
+        /// If you need to pass this type as an argument you are using
+        /// the wrong overload.
+        /// </summary>
+        public struct LogWithOptionalParameterList
+        {
+            // This type has no other purpose.
+        }
+
+        private static LogEventInfo PrepareLogEventInfo(LogEventInfo logEvent)
+        {
+            if (logEvent.FormatProvider == null)
+            {
+                logEvent.FormatProvider = LogManager.LogFactory.DefaultCultureInfo;
+            }
+            return logEvent;
+        }
+    }
+}

--- a/src/NLog/LoggerCallSite.cs
+++ b/src/NLog/LoggerCallSite.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,48 +31,46 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.Config
+namespace NLog
 {
+    using NLog.Config;
+    using NLog.Internal;
+
     /// <summary>
-    /// Value indicating how stack trace should be captured when processing the log event.
+    /// Provides logging interface and utility functions.
     /// </summary>
-    public enum StackTraceUsage
+    public partial class LoggerCallSite : LoggerBase
     {
         /// <summary>
-        /// Stack trace should not be captured.
+        /// Initializes a new instance of the <see cref="LoggerCallSite"/> class.
         /// </summary>
-        None = 0,
+        public LoggerCallSite()
+        {
+        }
 
-        /// <summary>
-        /// Stack trace should only be captured if callsite details are missing
-        /// </summary>
-        WithCallSite = 1,
+        internal override void SetConfiguration(LoggerConfiguration newConfiguration)
+        {
+            base.SetConfiguration(newConfiguration);
 
-        /// <summary>
-        /// Stack trace should be captured without source-level information.
-        /// </summary>
-        WithoutSource = 3,
+            // pre-calculate 'callsite' flags
+            _isTraceCallSiteEnabled = IsTraceEnabled && GetStackTraceUsage(LogLevel.Trace) != StackTraceUsage.None;
+            _isDebugCallSiteEnabled = IsDebugEnabled && GetStackTraceUsage(LogLevel.Debug) != StackTraceUsage.None;
+            _isInfoCallSiteEnabled = IsInfoEnabled && GetStackTraceUsage(LogLevel.Info) != StackTraceUsage.None;
+            _isWarnCallSiteEnabled = IsWarnEnabled && GetStackTraceUsage(LogLevel.Warn) != StackTraceUsage.None;
+            _isErrorCallSiteEnabled = IsErrorEnabled && GetStackTraceUsage(LogLevel.Error) != StackTraceUsage.None;
+            _isFatalCallSiteEnabled = IsFatalEnabled && GetStackTraceUsage(LogLevel.Fatal) != StackTraceUsage.None;
+        }
 
-#if !SILVERLIGHT
-        /// <summary>
-        /// Stack trace (with source) should only be captured if callsite details are missing
-        /// </summary>
-        WithCallSiteSource = 2,
+        private bool IsCallSiteEnabled(LogLevel level)
+        {
+            return GetStackTraceUsage(level) != StackTraceUsage.None;
+        }
 
-        /// <summary>
-        /// Stack trace should be captured including source-level information such as line numbers.
-        /// </summary>
-        WithSource = 4,
-
-        /// <summary>
-        /// Capture maximum amount of the stack trace information supported on the platform.
-        /// </summary>
-        Max = 4,
-#else
-        /// <summary>
-        /// Capture maximum amount of the stack trace information supported on the platform.
-        /// </summary>
-        Max = 3,
-#endif
+        bool _isTraceCallSiteEnabled;
+        bool _isDebugCallSiteEnabled;
+        bool _isInfoCallSiteEnabled;
+        bool _isWarnCallSiteEnabled;
+        bool _isErrorCallSiteEnabled;
+        bool _isFatalCallSiteEnabled;
     }
 }

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -294,6 +294,10 @@ Supported for each platform: https://github.com/NLog/NLog/wiki/platform-support
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>InternalLogger-generated.cs</LastGenOutput>
     </None>
+    <None Update="LoggerCallSite-generated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>LoggerCallSite-generated.cs</LastGenOutput>
+    </None>
     <None Update="Internal\LayoutHelpers-generated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>LayoutHelpers-generated.cs</LastGenOutput>
@@ -313,6 +317,11 @@ Supported for each platform: https://github.com/NLog/NLog/wiki/platform-support
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>InternalLogger-generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="LoggerCallSite-generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>LoggerCallSite-generated.tt</DependentUpon>
     </Compile>
     <Compile Update="Internal\LayoutHelpers-generated.cs">
       <DesignTime>True</DesignTime>

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -574,7 +574,7 @@ namespace NLog.Targets
 
                     if (IncludeCallSite)
                     {
-                        return StackTraceUsage.WithoutSource;
+                        return StackTraceUsage.WithCallSite;
                     }
                     return StackTraceUsage.None;
                 }

--- a/tests/NLog.UnitTests/GetLoggerTests.cs
+++ b/tests/NLog.UnitTests/GetLoggerTests.cs
@@ -53,12 +53,10 @@ namespace NLog.UnitTests
             MyLogger l1 = (MyLogger)lf.GetLogger("AAA", typeof(MyLogger));
             MyLogger l2 = lf.GetLogger<MyLogger>("AAA");
             ILogger l3 = lf.GetLogger("AAA", typeof(Logger));
-            ILogger l4 = lf.GetLogger<Logger>("AAA");
             ILogger l5 = lf.GetLogger("AAA");
             ILogger l6 = lf.GetLogger("AAA");
 
             Assert.Same(l1, l2);
-            Assert.Same(l3, l4);
             Assert.Same(l5, l6);
             Assert.Same(l3, l5);
 

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -1769,8 +1769,8 @@ namespace NLog.UnitTests
                     </rules>
                 </nlog>");
 
-            var singleLogger = LogManager.GetLogger("SingleTarget");
-            var dualLogger = LogManager.GetLogger("DualTarget");
+            var singleLogger = LogManager.LogFactory.GetLogger<LoggerCallSite>("SingleTarget");
+            var dualLogger = LogManager.LogFactory.GetLogger<LoggerCallSite>("DualTarget");
 
             ConfigurationItemFactory.Default.ParseMessageTemplates = null;
 


### PR DESCRIPTION
Proof of concept of how to capture callsite without using StackTrace-object (every time). To resolve #532

Introduced a new LoggerBase-class that makes it easier to make custom-loggers, without being disturbed by the default Logger-log-methods.

Minor breaking changes (So could be included in NLog 5.0), and resolves #962 

- Adds new() restriction to `LogFactory.GetLogger<T>()`
- Adds new() restriction to `LogFactory.GetCurrentClassLogger<T>()`
- Adds new() restriction to `LogFactory<T>.GetLogger()`

All methods are very rarely used, as they are hard to access in NLog 4.4 and because very few knows how to inherit from NLog-Logger, so it will have minimal breaking impact.

P.S. This also resolves #1150 and resolves #1988

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/2527)
<!-- Reviewable:end -->
