### PR TITLE
Blackhole LoggingRule without targets

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -703,6 +703,9 @@ namespace NLog.Config
                 foreach (string t in appendTo.Split(','))
                 {
                     string targetName = t.Trim();
+                    if (string.IsNullOrEmpty(targetName))
+                        continue;
+
                     Target target = FindTargetByName(targetName);
 
                     if (target != null)

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -2111,6 +2111,34 @@ namespace NLog.UnitTests
             AssertDebugLastMessage("debug", "Login request from \"John\" for \"BestApplicationEver\"{ \"Username\": \"John\", \"Application\": \"BestApplicationEver\" }");
         }
 
+        [Fact]
+        public void TestOptimizedBlackHoleLogger()
+        {
+            LogManager.ThrowExceptions = true;
+            LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog throwExceptions='true'>
+                    <targets>
+                        <target name='debug' type='Debug' layout='${message}' />
+                    </targets>
+                    <rules>
+                        <logger name='Microsoft*' maxLevel='Info' writeTo='' final='true' />
+                        <logger name='*' minlevel='Debug' writeTo='debug' />
+                    </rules>
+                </nlog>");
+
+            ILogger loggerMicrosoft = LogManager.GetLogger("Microsoft.NoiseGenerator");
+            ILogger loggerA = LogManager.GetLogger("A");
+
+            loggerMicrosoft.Warn("Important Noise");
+            AssertDebugLastMessage("debug", "Important Noise");
+            loggerMicrosoft.Debug("White Noise");
+            AssertDebugLastMessage("debug", "Important Noise");
+            loggerA.Debug("Good Noise");
+            AssertDebugLastMessage("debug", "Good Noise");
+            loggerA.Error("Important Noise");
+            AssertDebugLastMessage("debug", "Important Noise");
+        }
+
 
         private class Person
         {


### PR DESCRIPTION
Is faster than constantly allocating LogEvents for Null-target.