### PR TITLE
JsonLayout - Use capturetype and added MaxRecursionLimit and set default to 0

### DIFF
--- a/src/NLog/Internal/Fakeables/FakeAppDomain.cs
+++ b/src/NLog/Internal/Fakeables/FakeAppDomain.cs
@@ -57,7 +57,7 @@ namespace NLog.Internal.Fakeables
             {
                 FriendlyName = GetFriendlyNameFromEntryAssembly() ?? GetFriendlyNameFromProcessName() ?? "UnknownAppDomain";
             }
-            catch (Exception ex)
+            catch
             {
                 FriendlyName = "UnknownAppDomain";
             }
@@ -74,7 +74,7 @@ namespace NLog.Internal.Fakeables
                 string assemblyName =  Assembly.GetEntryAssembly()?.GetName()?.Name;
                 return string.IsNullOrEmpty(assemblyName) ? null : assemblyName;
             }
-            catch (Exception ex)
+            catch
             {
                 return null;
             }
@@ -87,7 +87,7 @@ namespace NLog.Internal.Fakeables
                 string processName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
                 return string.IsNullOrEmpty(processName) ? null : processName;
             }
-            catch (Exception ex)
+            catch
             {
                 return null;
             }

--- a/src/NLog/Internal/PropertiesDictionary.cs
+++ b/src/NLog/Internal/PropertiesDictionary.cs
@@ -478,7 +478,7 @@ namespace NLog.Internal
                         {
                             parameterName = "";
                         }
-                        return new MessageTemplateParameter(parameterName, _eventEnumerator.Current.Value.Value, null, CaptureType.Normal);
+                        return new MessageTemplateParameter(parameterName, _eventEnumerator.Current.Value.Value, null, CaptureType.Unknown);
                     }
                     throw new InvalidOperationException();
                 }

--- a/src/NLog/Layouts/JsonAttribute.cs
+++ b/src/NLog/Layouts/JsonAttribute.cs
@@ -65,6 +65,7 @@ namespace NLog.Layouts
             Name = name;
             Layout = layout;
             Encode = encode;
+            IncludeEmptyValue = false;
         }
 
         /// <summary>
@@ -79,7 +80,9 @@ namespace NLog.Layouts
         /// </summary>
         /// <docgen category='JSON Attribute Options' order='10' />
         [RequiredParameter]
-        public Layout Layout { get => LayoutWrapper.Inner;
+        public Layout Layout
+        {
+            get => LayoutWrapper.Inner;
             set => LayoutWrapper.Inner = value;
         }
 
@@ -87,7 +90,9 @@ namespace NLog.Layouts
         /// Determines wether or not this attribute will be Json encoded.
         /// </summary>
         /// <docgen category='JSON Attribute Options' order='100' />
-        public bool Encode { get => LayoutWrapper.JsonEncode;
+        public bool Encode
+        {
+            get => LayoutWrapper.JsonEncode;
             set => LayoutWrapper.JsonEncode = value;
         }
 
@@ -95,9 +100,17 @@ namespace NLog.Layouts
         /// Gets or sets a value indicating whether to escape non-ascii characters
         /// </summary>
         /// <docgen category='JSON Attribute Options' order='100' />
-        public bool EscapeUnicode { get => LayoutWrapper.EscapeUnicode;
+        public bool EscapeUnicode
+        {
+            get => LayoutWrapper.EscapeUnicode;
             set => LayoutWrapper.EscapeUnicode = value;
         }
+
+        /// <summary>
+        /// Gets or sets whether an attribute with empty value should be included in the output
+        /// </summary>
+        /// <docgen category='JSON Attribute Options' order='100' />
+        public bool IncludeEmptyValue { get; set; }
 
         internal readonly LayoutRenderers.Wrappers.JsonEncodeLayoutRendererWrapper LayoutWrapper = new LayoutRenderers.Wrappers.JsonEncodeLayoutRendererWrapper();
     }

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -46,18 +46,45 @@ namespace NLog.Layouts
     [AppDomainFixedOutput]
     public class JsonLayout : Layout
     {
-        private IJsonConverter JsonConverter
+        private LimitRecursionJsonConvert JsonConverter
         {
-            get => _jsonConverter ?? (_jsonConverter = ConfigurationItemFactory.Default.JsonConverter);
+            get => _jsonConverter ?? (_jsonConverter = new LimitRecursionJsonConvert(MaxRecursionLimit, ConfigurationItemFactory.Default.JsonConverter));
             set => _jsonConverter = value;
         }
-        private IJsonConverter _jsonConverter = null;
+        private LimitRecursionJsonConvert _jsonConverter = null;
         private IValueFormatter ValueFormatter
         {
             get => _valueFormatter ?? (_valueFormatter = ConfigurationItemFactory.Default.ValueFormatter);
             set => _valueFormatter = value;
         }
         private IValueFormatter _valueFormatter = null;
+
+        class LimitRecursionJsonConvert : IJsonConverter
+        {
+            readonly IJsonConverter _converter;
+            readonly Targets.DefaultJsonSerializer _serializer;
+            readonly Targets.JsonSerializeOptions _serializerOptions;
+
+            public LimitRecursionJsonConvert(int maxRecursionLimit, IJsonConverter converter)
+            {
+                _converter = converter;
+                _serializer = converter as Targets.DefaultJsonSerializer;
+                _serializerOptions = new Targets.JsonSerializeOptions() { MaxRecursionLimit = Math.Max(0, maxRecursionLimit) };
+            }
+
+            public bool SerializeObject(object value, StringBuilder builder)
+            {
+                if (_serializer != null)
+                    return _serializer.SerializeObject(value, builder, _serializerOptions);
+                else
+                    return _converter.SerializeObject(value, builder);
+            }
+
+            public bool SerializeObjectNoLimit(object value, StringBuilder builder)
+            {
+                return _converter.SerializeObject(value, builder);
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonLayout"/> class.
@@ -68,6 +95,7 @@ namespace NLog.Layouts
             RenderEmptyObject = true;
             IncludeAllProperties = false;
             ExcludeProperties = new HashSet<string>();
+            MaxRecursionLimit = 0;  // Will enumerate simple collections but not object properties. TODO NLog 5.0 change to 1 (or higher)
         }
 
         /// <summary>
@@ -120,6 +148,11 @@ namespace NLog.Layouts
 #endif
 
         /// <summary>
+        /// How far should the JSON serializer follow object references before backing off
+        /// </summary>
+        public int MaxRecursionLimit { get; set; }
+
+        /// <summary>
         /// Initializes the layout.
         /// </summary>
         protected override void InitializeLayout()
@@ -143,6 +176,7 @@ namespace NLog.Layouts
         protected override void CloseLayout()
         {
             JsonConverter = null;
+            ValueFormatter = null;
             base.CloseLayout();
         }
 
@@ -194,7 +228,7 @@ namespace NLog.Layouts
                     if (string.IsNullOrEmpty(key))
                         continue;
                     object propertyValue = MappedDiagnosticsContext.GetObject(key);
-                    AppendJsonPropertyValue(key, propertyValue, null, null, MessageTemplates.CaptureType.Normal, sb, sb.Length == orgLength);
+                    AppendJsonPropertyValue(key, propertyValue, null, null, MessageTemplates.CaptureType.Unknown, sb, sb.Length == orgLength);
                 }
             }
 
@@ -206,7 +240,7 @@ namespace NLog.Layouts
                     if (string.IsNullOrEmpty(key))
                         continue;
                     object propertyValue = MappedDiagnosticsLogicalContext.GetObject(key);
-                    AppendJsonPropertyValue(key, propertyValue, null, null, MessageTemplates.CaptureType.Normal, sb, sb.Length == orgLength);
+                    AppendJsonPropertyValue(key, propertyValue, null, null, MessageTemplates.CaptureType.Unknown, sb, sb.Length == orgLength);
                 }
             }
 #endif
@@ -259,31 +293,21 @@ namespace NLog.Layouts
         private void AppendJsonPropertyValue(string propName, object propertyValue, string format, IFormatProvider formatProvider, MessageTemplates.CaptureType captureType, StringBuilder sb, bool beginJsonMessage)
         {
             BeginJsonProperty(sb, propName, beginJsonMessage);
-            if (captureType == MessageTemplates.CaptureType.Serialize)
+            if (MaxRecursionLimit <= 1 && captureType == MessageTemplates.CaptureType.Serialize)
             {
-                JsonConverter.SerializeObject(propertyValue, sb);
+                // Overrides MaxRecursionLimit as message-template tells us it is safe
+                JsonConverter.SerializeObjectNoLimit(propertyValue, sb);
             }
-            else if (captureType == MessageTemplates.CaptureType.Stringify)
+            else if (MaxRecursionLimit <= 1 && captureType == MessageTemplates.CaptureType.Stringify)
             {
+                // Overrides MaxRecursionLimit as message-template tells us it is unsafe
                 int originalStart = sb.Length;
                 ValueFormatter.FormatValue(propertyValue, format, captureType, formatProvider, sb);
                 PerformJsonEscapeIfNeeded(sb, originalStart);
             }
             else
             {
-                TypeCode objTypeCode = Convert.GetTypeCode(propertyValue);
-                if (objTypeCode == TypeCode.Object)
-                {
-                    int originalStart = sb.Length;
-                    sb.Append('"');
-                    ValueFormatter.FormatValue(propertyValue, format, captureType, formatProvider, sb);
-                    sb.Append('"');
-                    PerformJsonEscapeIfNeeded(sb, originalStart);
-                }
-                else
-                {
-                    JsonConverter.SerializeObject(propertyValue, sb);
-                }
+                JsonConverter.SerializeObject(propertyValue, sb);
             }
         }
 

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -52,6 +52,12 @@ namespace NLog.Layouts
             set => _jsonConverter = value;
         }
         private IJsonConverter _jsonConverter = null;
+        private IValueFormatter ValueFormatter
+        {
+            get => _valueFormatter ?? (_valueFormatter = ConfigurationItemFactory.Default.ValueFormatter);
+            set => _valueFormatter = value;
+        }
+        private IValueFormatter _valueFormatter = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonLayout"/> class.
@@ -98,7 +104,7 @@ namespace NLog.Layouts
 #endif
 
         /// <summary>
-        /// Gets or sets the option to include all properties from the log events
+        /// Gets or sets the option to include all properties from the log event (as JSON)
         /// </summary>
         /// <docgen category='JSON Options' order='10' />
         public bool IncludeAllProperties { get; set; }
@@ -175,7 +181,7 @@ namespace NLog.Layouts
             {
                 var attrib = Attributes[i];
                 int beforeAttribLength = sb.Length;
-                if (!RenderAppendJsonPropertyValue(attrib, logEvent, false, sb, sb.Length == orgLength))
+                if (!RenderAppendJsonPropertyValue(attrib, logEvent, sb, sb.Length == orgLength))
                 {
                     sb.Length = beforeAttribLength;
                 }
@@ -188,7 +194,7 @@ namespace NLog.Layouts
                     if (string.IsNullOrEmpty(key))
                         continue;
                     object propertyValue = MappedDiagnosticsContext.GetObject(key);
-                    AppendJsonPropertyValue(key, propertyValue, sb, sb.Length == orgLength);
+                    AppendJsonPropertyValue(key, propertyValue, null, null, MessageTemplates.CaptureType.Normal, sb, sb.Length == orgLength);
                 }
             }
 
@@ -200,25 +206,23 @@ namespace NLog.Layouts
                     if (string.IsNullOrEmpty(key))
                         continue;
                     object propertyValue = MappedDiagnosticsLogicalContext.GetObject(key);
-                    AppendJsonPropertyValue(key, propertyValue, sb, sb.Length == orgLength);
+                    AppendJsonPropertyValue(key, propertyValue, null, null, MessageTemplates.CaptureType.Normal, sb, sb.Length == orgLength);
                 }
             }
 #endif
 
             if (IncludeAllProperties && logEvent.HasProperties)
             {
-                foreach (var prop in logEvent.Properties)
+                var propertiesList = logEvent.CreateOrUpdatePropertiesInternal(true) as IEnumerable<MessageTemplates.MessageTemplateParameter>;
+                foreach (var prop in propertiesList)
                 {
-                    //Determine property name
-                    string propName = Internal.XmlHelper.XmlConvertToString(prop.Key ?? string.Empty);
-                    if (string.IsNullOrEmpty(propName))
+                    if (string.IsNullOrEmpty(prop.Name))
                         continue;
 
-                    //Skips properties in the ExcludeProperties list
-                    if (ExcludeProperties.Contains(propName))
+                    if (ExcludeProperties.Contains(prop.Name))
                         continue;
 
-                    AppendJsonPropertyValue(propName, prop.Value, sb, sb.Length == orgLength);
+                    AppendJsonPropertyValue(prop.Name, prop.Value, prop.Format, logEvent.FormatProvider, prop.CaptureType, sb, sb.Length == orgLength);
                 }
             }
 
@@ -252,13 +256,58 @@ namespace NLog.Layouts
             sb.Append(SuppressSpaces ? "}" : " }");
         }
 
-        private void AppendJsonPropertyValue(string propName, object propertyValue, StringBuilder sb, bool beginJsonMessage)
+        private void AppendJsonPropertyValue(string propName, object propertyValue, string format, IFormatProvider formatProvider, MessageTemplates.CaptureType captureType, StringBuilder sb, bool beginJsonMessage)
         {
             BeginJsonProperty(sb, propName, beginJsonMessage);
-            JsonConverter.SerializeObject(propertyValue, sb);
+            if (captureType == MessageTemplates.CaptureType.Serialize)
+            {
+                JsonConverter.SerializeObject(propertyValue, sb);
+            }
+            else if (captureType == MessageTemplates.CaptureType.Stringify)
+            {
+                int originalStart = sb.Length;
+                ValueFormatter.FormatValue(propertyValue, format, captureType, formatProvider, sb);
+                PerformJsonEscapeIfNeeded(sb, originalStart);
+            }
+            else
+            {
+                TypeCode objTypeCode = Convert.GetTypeCode(propertyValue);
+                if (objTypeCode == TypeCode.Object)
+                {
+                    int originalStart = sb.Length;
+                    sb.Append('"');
+                    ValueFormatter.FormatValue(propertyValue, format, captureType, formatProvider, sb);
+                    sb.Append('"');
+                    PerformJsonEscapeIfNeeded(sb, originalStart);
+                }
+                else
+                {
+                    JsonConverter.SerializeObject(propertyValue, sb);
+                }
+            }
         }
 
-        private bool RenderAppendJsonPropertyValue(JsonAttribute attrib, LogEventInfo logEvent, bool renderEmptyValue, StringBuilder sb, bool beginJsonMessage)
+        private static void PerformJsonEscapeIfNeeded(StringBuilder sb, int valueStart)
+        {
+            if (sb.Length - valueStart <= 2)
+                return;
+
+            for (int i = valueStart + 1; i < sb.Length - 1; ++i)
+            {
+                if (Targets.DefaultJsonSerializer.RequiresJsonEscape(sb[i], false))
+                {
+                    var jsonEscape = sb.ToString(valueStart + 1, sb.Length - valueStart - 2);
+                    jsonEscape = Targets.DefaultJsonSerializer.EscapeString(jsonEscape, false);
+                    sb.Length = valueStart;
+                    sb.Append('"');
+                    sb.Append(jsonEscape);
+                    sb.Append('"');
+                    break;
+                }
+            }
+        }
+
+        private bool RenderAppendJsonPropertyValue(JsonAttribute attrib, LogEventInfo logEvent, StringBuilder sb, bool beginJsonMessage)
         {
             BeginJsonProperty(sb, attrib.Name, beginJsonMessage);
             if (attrib.Encode)
@@ -268,7 +317,7 @@ namespace NLog.Layouts
             }
             int beforeValueLength = sb.Length;
             attrib.LayoutWrapper.RenderAppendBuilder(logEvent, sb);
-            if (!renderEmptyValue && beforeValueLength == sb.Length)
+            if (!attrib.IncludeEmptyValue && beforeValueLength == sb.Length)
             {
                 return false;
             }

--- a/src/NLog/MessageTemplates/CaptureType.cs
+++ b/src/NLog/MessageTemplates/CaptureType.cs
@@ -39,6 +39,10 @@ namespace NLog.MessageTemplates
     public enum CaptureType : byte
     {
         /// <summary>
+        /// Not decided
+        /// </summary>
+        Unknown,
+        /// <summary>
         /// normal {x}
         /// </summary>
         Normal,

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -56,7 +56,6 @@ namespace NLog.Targets
         private readonly JsonSerializeOptions _exceptionSerializeOptions = new JsonSerializeOptions() { SanitizeDictionaryKeys = true };
         private readonly IFormatProvider _defaultFormatProvider = CreateFormatProvider();
 
-        private const int MaxRecursionDepth = 10;
         private const int MaxJsonLength = 512 * 1024;
 
         private static readonly DefaultJsonSerializer instance;
@@ -177,10 +176,6 @@ namespace NLog.Targets
             {
                 return false; // detected reference loop, skip serialization
             }
-            if (depth > MaxRecursionDepth)
-            {
-                return false; // reached maximum recursion level, no further serialization
-            }
 
             if (value == null)
             {
@@ -269,6 +264,10 @@ namespace NLog.Targets
         {
             bool first = true;
 
+            int nextDepth = objectsInPath.Count <= 1 ? depth : (depth + 1);
+            if (nextDepth > options.MaxRecursionLimit)
+                return;
+
             int originalLength;
             destination.Append('{');
             foreach (DictionaryEntry de in value)
@@ -285,7 +284,7 @@ namespace NLog.Targets
                 }
 
                 //only serialize, if key and value are serialized without error (e.g. due to reference loop)
-                if (!SerializeObject(de.Key, destination, options, objectsInPath, depth + 1))
+                if (!SerializeObject(de.Key, destination, options, objectsInPath, nextDepth))
                 {
                     destination.Length = originalLength;
                 }
@@ -304,7 +303,7 @@ namespace NLog.Targets
                     }
 
                     destination.Append(':');
-                    if (!SerializeObject(de.Value, destination, options, objectsInPath, depth + 1))
+                    if (!SerializeObject(de.Value, destination, options, objectsInPath, nextDepth))
                     {
                         destination.Length = originalLength;
                     }
@@ -340,6 +339,10 @@ namespace NLog.Targets
         {
             bool first = true;
 
+            int nextDepth = objectsInPath.Count <= 1 ? depth : (depth + 1); // Allow serialization of list-items 
+            if (nextDepth > options.MaxRecursionLimit)
+                return;
+
             int originalLength;
             destination.Append('[');
             foreach (var val in value)
@@ -355,7 +358,7 @@ namespace NLog.Targets
                     destination.Append(',');
                 }
 
-                if (!SerializeObject(val, destination, options, objectsInPath, depth + 1))
+                if (!SerializeObject(val, destination, options, objectsInPath, nextDepth))
                 {
                     destination.Length = originalLength;
                 }
@@ -389,24 +392,39 @@ namespace NLog.Targets
                         return false;
                     }
 
-                    try
+                    if (depth < options.MaxRecursionLimit)
                     {
-                        if (value is Exception && ReferenceEquals(options, instance._serializeOptions))
+                        try
                         {
-                            // Exceptions are seldom under control, and can include random Data-Dictionary-keys, so we sanitize by default
-                            options = instance._exceptionSerializeOptions;
-                        }
+                            if (value is Exception && ReferenceEquals(options, instance._serializeOptions))
+                            {
+                                // Exceptions are seldom under control, and can include random Data-Dictionary-keys, so we sanitize by default
+                                options = instance._exceptionSerializeOptions;
+                            }
 
-                        using (new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(value, ref objectsInPath, false))
+                            using (new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(value, ref objectsInPath, false))
+                            {
+                                return SerializeProperties(value, destination, options, objectsInPath, depth);
+                            }
+                        }
+                        catch
                         {
-                            return SerializeProperties(value, destination, options, objectsInPath, depth);
+                            //nothing to add, so return is OK
+                            destination.Length = originalLength;
+                            return false;
                         }
                     }
-                    catch
+                    else
                     {
-                        //nothing to add, so return is OK
-                        destination.Length = originalLength;
-                        return false;
+                        try
+                        {
+                            string str = EscapeString(Convert.ToString(value, CultureInfo.InvariantCulture), options.EscapeUnicode);
+                            QuoteValue(destination, str);
+                        }
+                        catch
+                        {
+                            return false;
+                        }
                     }
                 }
             }

--- a/src/NLog/Targets/JsonSerializeOptions.cs
+++ b/src/NLog/Targets/JsonSerializeOptions.cs
@@ -77,10 +77,17 @@ namespace NLog.Targets
         [DefaultValue(false)]
         public bool SanitizeDictionaryKeys { get; set; }
 
+        /// <summary>
+        /// How far down the rabbit hole should the Json Serializer go with object-reflection before stopping
+        /// </summary>
+        [DefaultValue(10)]
+        public int MaxRecursionLimit { get; set; }
+
         /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
         public JsonSerializeOptions()
         {
             QuoteKeys = true;
+            MaxRecursionLimit = 10;
         }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -559,11 +559,7 @@ namespace NLog.UnitTests.Layouts
 
             ILogger logger = LogManager.GetLogger("A");
 
-            var logEventInfo = new LogEventInfo();
-
-            logEventInfo.Properties.Add("nestedObject", new List<object> {new {val = "value1", val2 ="value2"}});
-
-            logger.Debug(logEventInfo);
+            logger.Debug("{@nestedObject}", new List<object> { new { val = "value1", val2 = "value2" } });
 
             AssertDebugLastMessage("debug", "{ \"nestedObject\": [{\"val\":\"value1\", \"val2\":\"value2\"}] }");
         }

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -541,13 +541,13 @@ namespace NLog.UnitTests.Layouts
         /// Serialize object deep
         /// </summary>
         [Fact]
-        public void SerializeObject()
+        public void SerializeObjectRecursionSingle()
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog throwExceptions='true'>
             <targets>
                 <target name='debug' type='Debug'  >
-                 <layout type=""JsonLayout"" IncludeAllProperties='true' >
+                 <layout type=""JsonLayout"" IncludeAllProperties='true' maxRecursionLimit='1' >
                  </layout>
                 </target>
             </targets>
@@ -559,9 +559,73 @@ namespace NLog.UnitTests.Layouts
 
             ILogger logger = LogManager.GetLogger("A");
 
-            logger.Debug("{@nestedObject}", new List<object> { new { val = "value1", val2 = "value2" } });
+            var logEventInfo1 = new LogEventInfo();
 
-            AssertDebugLastMessage("debug", "{ \"nestedObject\": [{\"val\":\"value1\", \"val2\":\"value2\"}] }");
+            logEventInfo1.Properties.Add("nestedObject", new List<object> { new { val = 1, val2 = "value2" }, new { val3 = 3, val4 = "value4" } });
+
+            logger.Debug(logEventInfo1);
+
+            AssertDebugLastMessage("debug", "{ \"nestedObject\": [{\"val\":1, \"val2\":\"value2\"},{\"val3\":3, \"val4\":\"value4\"}] }");
+
+            var logEventInfo2 = new LogEventInfo();
+
+            logEventInfo2.Properties.Add("nestedObject", new { val = 1, val2 = "value2" });
+
+            logger.Debug(logEventInfo2);
+
+            AssertDebugLastMessage("debug", "{ \"nestedObject\": {\"val\":1, \"val2\":\"value2\"} }");
+
+            var logEventInfo3 = new LogEventInfo();
+
+            logEventInfo3.Properties.Add("nestedObject", new List<object> { new List<object> { new { val = 1, val2 = "value2" } } });
+
+            logger.Debug(logEventInfo3);
+
+            AssertDebugLastMessage("debug", "{ \"nestedObject\": [[\"{ val = 1, val2 = value2 }\"]] }");  // Allows nested collection, but then only ToString
+        }
+
+        [Fact]
+        public void SerializeObjectRecursionZero()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog throwExceptions='true'>
+            <targets>
+                <target name='debug' type='Debug'  >
+                 <layout type=""JsonLayout"" IncludeAllProperties='true' maxRecursionLimit='0' >
+                 </layout>
+                </target>
+            </targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+
+            ILogger logger = LogManager.GetLogger("A");
+
+            var logEventInfo1 = new LogEventInfo();
+
+            logEventInfo1.Properties.Add("nestedObject", new List<object> { new { val = 1, val2 = "value2" }, new { val3 = 3, val4 = "value5" } });
+
+            logger.Debug(logEventInfo1);
+
+            AssertDebugLastMessage("debug", "{ \"nestedObject\": [\"{ val = 1, val2 = value2 }\",\"{ val3 = 3, val4 = value5 }\"] }");  // Allows single collection recursion
+
+            var logEventInfo2 = new LogEventInfo();
+
+            logEventInfo2.Properties.Add("nestedObject", new { val = 1, val2 = "value2" });
+
+            logger.Debug(logEventInfo2);
+
+            AssertDebugLastMessage("debug", "{ \"nestedObject\": \"{ val = 1, val2 = value2 }\" }");    // Never object recursion, only ToString
+
+            var logEventInfo3 = new LogEventInfo();
+
+            logEventInfo3.Properties.Add("nestedObject", new List<object> { new List<object> { new { val = 1, val2 = "value2" } } });
+
+            logger.Debug(logEventInfo3);
+
+            AssertDebugLastMessage("debug", "{ \"nestedObject\": [] }");  // No support for nested collections
         }
 
         private static LogEventInfo CreateLogEventWithExcluded()

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -2095,7 +2095,7 @@ namespace NLog.UnitTests
                         <target name='debug' type='Debug'  >
                               <layout type='CompoundLayout'>
                                 <layout type='SimpleLayout' text='${message}' />
-                                <layout type='JsonLayout' IncludeAllProperties='true' />
+                                <layout type='JsonLayout' IncludeAllProperties='true' maxRecursionLimit='0' />
                               </layout>
                         </target>
                     </targets>

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -2078,9 +2078,9 @@ namespace NLog.UnitTests
 
             ILogger logger = LogManager.GetLogger("A");
 
-            logger.Error("Login request from {Username} for {Application}", "John", "BestApplicationEver");
+            logger.Error("Login request from {@Username} for {$Application}", new Person("John"), "BestApplicationEver");
 
-            AssertDebugLastMessage("debug", "{ \"LogMessage\": \"Login request from {Username} for {Application}\", \"Username\": \"John\", \"Application\": \"BestApplicationEver\" }");
+            AssertDebugLastMessage("debug", "{ \"LogMessage\": \"Login request from {@Username} for {$Application}\", \"Username\": {\"Name\":\"John\"}, \"Application\": \"BestApplicationEver\" }");
         }
 
         /// <summary>
@@ -2106,9 +2106,9 @@ namespace NLog.UnitTests
 
             ILogger logger = LogManager.GetLogger("A");
 
-            logger.Error("Login request from {Username} for {Application}", "John", "BestApplicationEver");
+            logger.Error("Login request from {Username} for {Application}", new Person("\"John\""), "BestApplicationEver");
 
-            AssertDebugLastMessage("debug", "Login request from \"John\" for \"BestApplicationEver\"{ \"Username\": \"John\", \"Application\": \"BestApplicationEver\" }");
+            AssertDebugLastMessage("debug", "Login request from \"John\" for \"BestApplicationEver\"{ \"Username\": \"\\\"John\\\"\", \"Application\": \"BestApplicationEver\" }");
         }
 
         [Fact]
@@ -2155,6 +2155,7 @@ namespace NLog.UnitTests
 
             public List<Person> Childs { get; set; }
 
+            public override string ToString() { return Name; }
         }
 
         public abstract class BaseWrapper

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -159,7 +159,7 @@ namespace NLog.UnitTests.Targets
             var actual = _serializer.SerializeObject(d);
 
             var cnt = Regex.Matches(actual, "\\[\"alpha\",\"bravo\"\\]").Count;
-            Assert.Equal(9, cnt);       // maximum level is 10 => 10 recursion is skipped => count is 10 - 1    
+            Assert.Equal(10, cnt);   
         }
 
         [Fact]
@@ -437,6 +437,25 @@ namespace NLog.UnitTests.Targets
             Assert.Equal("{\"Name\":\"test name\"}", actual);
         }
 
+#if NETSTANDARD || NET462 || NET47
+        [Fact]
+        public void SerializeValueTuple_Test()
+        {
+            // Could perform reflection on fields, but one have to lookup TupleElementNamesAttribute to get names
+            // ValueTuples are for internal usage, better to use AnonymousObject for key/value-pairs
+            var object1 = (Name: "test name", Id: 1);
+            var actual = _serializer.SerializeObject(object1);
+            Assert.Equal("\"(test name, 1)\"", actual);
+        }
+#endif
+        [Fact]
+        public void SerializeAnonymousObject_Test()
+        {
+            var object1 = new { Name = "test name" };
+            var actual = _serializer.SerializeObject(object1);
+            Assert.Equal("{\"Name\":\"test name\"}", actual);
+        }
+
         [Fact]
         public void SingleItemOptimizedHashSetTest()
         {
@@ -482,7 +501,7 @@ namespace NLog.UnitTests.Targets
         {
             private string something = "something";
 
-            #region Overrides of Object
+#region Overrides of Object
 
             /// <summary>Returns a string that represents the current object.</summary>
             /// <returns>A string that represents the current object.</returns>
@@ -491,7 +510,7 @@ namespace NLog.UnitTests.Targets
                 return something;
             }
 
-            #endregion
+#endregion
         }
 
         private class ObjectWithExceptionAndPrivateSetter


### PR DESCRIPTION

update

default 0: 
  Will enumerate simple collections but not object properties. 

---


To avoid breaking change in NLog 4.5, then the JsonLayout should not by default perform aggressive serialization of object properties. This will avoid the Entity-framework pitfall: https://stackoverflow.com/questions/48516514

Added MaxRecursionLimit as new setting to JsonLayout. It will allow one to increase the recursion to also include object properties. To avoid breaking changes then default MaxRecursionLimit = 0 (No reflection on object properties). Maybe in NLog 5.0 it can be changed to MaxRecursionLimit = 1 (Limited reflection of object properties).

Implemented a special exception for MessageTemplate parameters where capturetype has been specified. If capture-type `@` tells us it is safe, then it will allow "full" reflection.