### PR TITLE
WebService-Target fails internally with PlatformNotSupportedException on NetCore

### DIFF
--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -120,21 +120,14 @@ namespace NLog.UnitTests.Targets
             }
         }
 
+#if !MONO
         [Theory]
+#else
+        [Theory(Skip="Not supported on MONO on Travis, because of FileSystemWatcher not working")]
+#endif
         [MemberData(nameof(SimpleFileTest_TestParameters))]
         public void SimpleFileDeleteTest(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool forceManaged, bool forceMutexConcurrentWrites, bool optimizeBufferReuse)
         {
-#if MONO
-            if (IsTravis())
-            {
-                if (concurrentWrites && keepFileOpen)
-                {
-                    Console.WriteLine("[SKIP] FileTargetTests.SimpleFileDeleteTest(concurrentWrites: True, keepFileOpen: True) because we are running in Travis");
-                    return;
-                }
-            }
-#endif
-
             var logFile = Path.GetTempFileName();
             var logFile2 = Path.Combine(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()), Path.GetFileName(logFile));
 


### PR DESCRIPTION
WebRequest.GetSystemWebProxy fails when attempting to use Default-proxy on NetCore

See also https://github.com/dotnet/corefx/issues/7037

Changed default value for ProxyType to be NoProxy on NetCore (Avoid internal exception on every request)