### PR TITLE
Target.MergeEventProperties is now obsolete

### DIFF
--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -451,7 +451,15 @@ namespace NLog
         /// <returns>Instance of <see cref="LogEventInfo"/>.</returns>
         public static LogEventInfo Create(LogLevel logLevel, string loggerName, IFormatProvider formatProvider, object message)
         {
-            return new LogEventInfo(logLevel, loggerName, formatProvider, "{0}", new[] { message });
+            Exception exception = message as Exception;
+            if (exception == null && message is LogEventInfo logEvent)
+            {
+                logEvent.LoggerName = loggerName;
+                logEvent.Level = logLevel;
+                logEvent.FormatProvider = formatProvider ?? logEvent.FormatProvider;
+                return logEvent;
+            }
+            return new LogEventInfo(logLevel, loggerName, formatProvider, "{0}", new[] { message }, exception);
         }
 
         /// <summary>

--- a/src/NLog/Logger-V1Compat.cs
+++ b/src/NLog/Logger-V1Compat.cs
@@ -57,7 +57,7 @@ namespace NLog
         {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, "{0}", new object[] { value });
+                WriteToTargets(level, null, value);
             }
         }
 
@@ -72,7 +72,7 @@ namespace NLog
         {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, "{0}", new[] { value });
+                WriteToTargets(level, formatProvider, value);
             }
         }
 
@@ -549,7 +549,7 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, "{0}", new object[] { value });
+                WriteToTargets(LogLevel.Trace, null, value);
             }
         }
 
@@ -563,7 +563,7 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, "{0}", new[] { value });
+                WriteToTargets(LogLevel.Trace, formatProvider, value);
             }
         }
 
@@ -1012,7 +1012,7 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, "{0}", new object[] { value });
+                WriteToTargets(LogLevel.Debug, null, value);
             }
         }
 
@@ -1026,7 +1026,7 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, "{0}", new[] { value });
+                WriteToTargets(LogLevel.Debug, formatProvider, value);
             }
         }
 
@@ -1475,7 +1475,7 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, "{0}", new object[] { value });
+                WriteToTargets(LogLevel.Info, null, value);
             }
         }
 
@@ -1489,7 +1489,7 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, "{0}", new[] { value });
+                WriteToTargets(LogLevel.Info, formatProvider, value);
             }
         }
 
@@ -1938,7 +1938,7 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, "{0}", new object[] { value });
+                WriteToTargets(LogLevel.Warn, null, value);
             }
         }
 
@@ -1952,7 +1952,7 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, "{0}", new[] { value });
+                WriteToTargets(LogLevel.Warn, formatProvider, value);
             }
         }
 
@@ -2401,7 +2401,7 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, "{0}", new object[] { value });
+                WriteToTargets(LogLevel.Error, null, value);
             }
         }
 
@@ -2415,7 +2415,7 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, "{0}", new[] { value });
+                WriteToTargets(LogLevel.Error, formatProvider, value);
             }
         }
 
@@ -2864,7 +2864,7 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, "{0}", new object[] { value });
+                WriteToTargets(LogLevel.Fatal, null, value);
             }
         }
 
@@ -2878,7 +2878,7 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, "{0}", new[] { value });
+                WriteToTargets(LogLevel.Fatal, formatProvider, value);
             }
         }
 

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -569,12 +569,6 @@ namespace NLog
         private void WriteToTargets<T>(LogLevel level, IFormatProvider formatProvider, T value)
         {
             var logEvent = PrepareLogEventInfo(LogEventInfo.Create(level, Name, formatProvider, value));
-            var ex = value as Exception;
-            if (ex != null)
-            {
-                //also record exception
-                logEvent.Exception = ex;
-            }
             LoggerImpl.Write(_loggerType, GetTargetsForLevel(level), logEvent, Factory);
         }
 

--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -114,7 +114,6 @@ namespace NLog.Targets
                 return;
             }
 
-            MergeEventProperties(logEvent.LogEvent);
             PrecalculateVolatileLayouts(logEvent.LogEvent);
 
             _requestQueue.Enqueue(logEvent);

--- a/src/NLog/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog/Targets/LogReceiverWebServiceTarget.cs
@@ -251,7 +251,6 @@ namespace NLog.Targets
                 for (int i = 0; i < logEvents.Count; ++i)
                 {
                     var ev = logEvents[i].LogEvent;
-                    MergeEventProperties(ev);
 
                     if (ev.HasProperties)
                     {

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -492,8 +492,6 @@ namespace NLog.Targets
         {
             try
             {
-                MergeEventProperties(logEvent.LogEvent);
-
                 Write(logEvent.LogEvent);
                 logEvent.Continuation(null);
             }
@@ -638,6 +636,7 @@ namespace NLog.Targets
         /// parameters of the given event info object.
         /// </summary>
         /// <param name="logEvent">The event info object to perform the merge to.</param>
+        [Obsolete("Logger.Trace(logEvent) now automatically captures the logEvent Properties. Marked obsolete on NLog 4.6")]
         protected void MergeEventProperties(LogEventInfo logEvent)
         {
             if (logEvent.Parameters == null || logEvent.Parameters.Length == 0)

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -312,7 +312,6 @@ namespace NLog.Targets.Wrappers
         /// </remarks>
         protected override void Write(AsyncLogEventInfo logEvent)
         {
-            MergeEventProperties(logEvent.LogEvent);
             PrecalculateVolatileLayouts(logEvent.LogEvent);
             bool queueWasEmpty = RequestQueue.Enqueue(logEvent);
             if (queueWasEmpty && TimeToSleepBetweenBatches <= 0)

--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -204,7 +204,6 @@ namespace NLog.Targets.Wrappers
         /// <param name="logEvent">The log event.</param>
         protected override void Write(AsyncLogEventInfo logEvent)
         {
-            MergeEventProperties(logEvent.LogEvent);
             PrecalculateVolatileLayouts(logEvent.LogEvent);
 
             int count = _buffer.Append(logEvent);


### PR DESCRIPTION
Any NLog target that overrides the follow method will fail to handle `logger.Trace(logEvent)`:

`protected override void Write(AsyncLogEventInfo logEvent)`

Unless it remembers to call `MergeEventProperties`. Instead of the NLog target modifying the LogEventInfo, then it should be the Logger-logic.

Resolves #2573 and resolves  #1988 (Thinking NLog 4.6)

Extracted from #2527 