### PR TITLE
IsSafeToDeferFormatting - Convert.GetTypeCode is faster and better

### DIFF
--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -607,12 +607,7 @@ namespace NLog
 
         private static bool IsSafeToDeferFormatting(object value)
         {
-            if (value == null)
-            {
-                return true;
-            }
-
-            return value.GetType().IsPrimitive() || (value is string);
+            return value == null || Convert.GetTypeCode(value) != TypeCode.Object;
         }
 
         private static string GetStringFormatMessageFormatter(LogEventInfo logEvent)


### PR DESCRIPTION
Than GetType().IsPrimitive()

| Logger Name      | Messages   | Size | Args | Threads | Loggers |
|------------------|------------|------|------|---------|---------|
| NullLogger  | 50.000.000 |   64 |    3 |       1 |       1 |


| Test Name  | Time (ms) | Msgs/sec  | GC2 | GC1 | GC0 | CPU (ms) | Alloc (MB) |
|------------|-----------|-----------|-----|-----|-----|----------|------------|
| This PR (32 bit)   |    16.497 | 3.030.675 |   0 |   0 | 721 |   14.359 |    7.248,2 |
| Master (32 bit)   |    17.514 | 2.854.764 |   0 |   0 | 726 |   16.203 |    7.248,2 |
| This PR (64 bit)    |    15.437 | 3.238.959 |   0 |   0 | 489 |   14.468 |   14.114,7 |
| Master (64 bit)    |    15.923 | 3.139.958 |   0 |   0 | 481 |   15.203 |   14.114,7 |