### PR TITLE
LogFactory - Assign Configuration should only perform a single InitializeAll

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -228,12 +228,11 @@ namespace NLog
                     {
                         try
                         {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
                             _config.Dump();
+                            ReconfigExistingLoggers();
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
                             TryWachtingConfigFile();
 #endif
-                            _config.InitializeAll();
-
                             LogConfigurationInitialized();
                         }
                         finally
@@ -285,8 +284,6 @@ namespace NLog
                         try
                         {
                             _config.Dump();
-
-                            _config.InitializeAll();
                             ReconfigExistingLoggers();
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
                             TryWachtingConfigFile();
@@ -433,7 +430,6 @@ namespace NLog
             {
                 InternalLogger.Debug(ex, "Not running in full trust");
             }
-
         }
 
         /// <summary>


### PR DESCRIPTION
Right now the following is written to the Internal Logger during startup:

```
2018-02-25 16:23:25.4148 Info Configured from an XML element in C:\Users\snakefoot\Source\Repos\NLog.Web\examples\ASP.NET Core 2\Visual Studio 2017\ASP.NET Core 2 - VS2017\bin\Release\netcoreapp2.0\nlog.config...
2018-02-25 16:23:25.4377 Info Found 55 configuration items
2018-02-25 16:23:25.4499 Info Found 55 configuration items
```
