### PR TITLE
Replace WINDOWS_UWP with NETSTANDARD1_3 to support UWP10 shared libraries

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -12,7 +12,7 @@ $versionProduct = $versionPrefix;
 if (-Not $versionSuffix.Equals(""))
 	{ $versionProduct = $versionProduct + "-" + $versionSuffix }
 
-msbuild /t:Restore,Pack .\src\NLog\ /p:targetFrameworks='"net45;net40-client;net35;netstandard1.5;netstandard2.0;uap10.0;sl4;sl5;wp8;monoandroid44;xamarinios10"' /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:PackageOutputPath=..\..\artifacts /verbosity:minimal
+msbuild /t:Restore,Pack .\src\NLog\ /p:targetFrameworks='"net45;net40-client;net35;netstandard1.3;netstandard1.5;netstandard2.0;sl4;sl5;wp8;monoandroid44;xamarinios10"' /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:PackageOutputPath=..\..\artifacts /verbosity:minimal
 if (-Not $LastExitCode -eq 0)
 	{ exit $LastExitCode }
 

--- a/src/NLog/Common/AsyncHelpers.cs
+++ b/src/NLog/Common/AsyncHelpers.cs
@@ -46,7 +46,7 @@ namespace NLog.Common
     {
         internal static int GetManagedThreadId()
         {
-#if WINDOWS_UWP
+#if NETSTANDARD1_3
             return System.Environment.CurrentManagedThreadId;
 #else
             return Thread.CurrentThread.ManagedThreadId;
@@ -64,7 +64,7 @@ namespace NLog.Common
 
         internal static void WaitForDelay(TimeSpan delay)
         {
-#if WINDOWS_UWP
+#if NETSTANDARD1_3
             System.Threading.Tasks.Task.Delay(delay).Wait();
 #else
             Thread.Sleep(delay);

--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -258,12 +258,12 @@ namespace NLog.Common
                 WriteToLogFile(msg);
                 WriteToTextWriter(msg);
 
-#if !WINDOWS_UWP
+#if !NETSTANDARD1_3
                 WriteToConsole(msg);
                 WriteToErrorConsole(msg);
 #endif
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
                 WriteToTrace(msg);
 #endif
             }
@@ -390,7 +390,7 @@ namespace NLog.Common
             }
         }
 
-#if !WINDOWS_UWP
+#if !NETSTANDARD1_3
         /// <summary>
         /// Write internal messages to the <see cref="System.Console"/>.
         /// </summary>
@@ -413,7 +413,7 @@ namespace NLog.Common
         }
 #endif
 
-#if !WINDOWS_UWP
+#if !NETSTANDARD1_3
         /// <summary>
         /// Write internal messages to the <see cref="System.Console.Error"/>.
         /// </summary>
@@ -437,7 +437,7 @@ namespace NLog.Common
         }
 #endif
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
         /// <summary>
         /// Write internal messages to the <see cref="System.Diagnostics.Trace"/>.
         /// </summary>

--- a/src/NLog/Conditions/ConditionRelationalExpression.cs
+++ b/src/NLog/Conditions/ConditionRelationalExpression.cs
@@ -111,7 +111,7 @@ namespace NLog.Conditions
 #if !NETSTANDARD1_0
             StringComparer comparer = StringComparer.InvariantCulture;
 #else
-            var comparer = new System.Collections.Comparer(CultureInfo.InvariantCulture);
+            var comparer = System.Collections.Comparer.DefaultInvariant;
 #endif
             PromoteTypes(ref leftValue, ref rightValue);
             switch (relationalOperator)

--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -362,7 +362,7 @@ namespace NLog.Config
             var factory = new ConfigurationItemFactory(nlogAssembly);
             factory.RegisterExtendedItems();
 
-#if !SILVERLIGHT && !WINDOWS_UWP
+#if !SILVERLIGHT && !NETSTANDARD1_3
             try
             {
                 var assemblyLocation = GetAssemblyFileLocation(nlogAssembly);
@@ -470,7 +470,7 @@ namespace NLog.Config
             return factory;
         }
 
-#if !SILVERLIGHT && !WINDOWS_UWP
+#if !SILVERLIGHT && !NETSTANDARD1_3
         private static string GetAssemblyFileLocation(Assembly assembly)
         {
             try

--- a/src/NLog/Config/InstallationContext.cs
+++ b/src/NLog/Config/InstallationContext.cs
@@ -46,7 +46,7 @@ namespace NLog.Config
     /// </summary>
     public sealed class InstallationContext : IDisposable
     {
-#if !SILVERLIGHT && !WINDOWS_UWP
+#if !SILVERLIGHT && !NETSTANDARD1_3
         /// <summary>
         /// Mapping between log levels and console output colors.
         /// </summary>
@@ -195,7 +195,7 @@ namespace NLog.Config
                     message = string.Format(CultureInfo.InvariantCulture, message, arguments);
                 }
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
                 var oldColor = Console.ForegroundColor;
                 Console.ForegroundColor = logLevel2ConsoleColor[logLevel];
 

--- a/src/NLog/Config/LoggingConfigurationReloadedEventArgs.cs
+++ b/src/NLog/Config/LoggingConfigurationReloadedEventArgs.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
 
 namespace NLog.Config
 {

--- a/src/NLog/Config/SimpleConfigurator.cs
+++ b/src/NLog/Config/SimpleConfigurator.cs
@@ -43,7 +43,7 @@ namespace NLog.Config
     /// </summary>
     public static class SimpleConfigurator
     {
-#if !WINDOWS_UWP
+#if !NETSTANDARD1_3
         /// <summary>
         /// Configures NLog for console logging so that all messages above and including
         /// the <see cref="NLog.LogLevel.Info"/> level are output to the console.

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -1029,7 +1029,7 @@ namespace NLog.Config
                     }
                 }
 
-#if !WINDOWS_UWP
+#if !NETSTANDARD1_3
                 string assemblyFile = addElement.GetOptionalAttribute("assemblyFile", null);
                 if (assemblyFile != null)
                 {
@@ -1071,7 +1071,7 @@ namespace NLog.Config
             }
         }
 
-#if !WINDOWS_UWP
+#if !NETSTANDARD1_3
         private void ParseExtensionWithAssemblyFle(string baseDirectory, string assemblyFile, string prefix)
         {
             try

--- a/src/NLog/Internal/AssemblyHelpers.cs
+++ b/src/NLog/Internal/AssemblyHelpers.cs
@@ -46,7 +46,7 @@ using System.Windows;
     /// </summary>
     internal static class AssemblyHelpers
     {
-#if !WINDOWS_UWP
+#if !NETSTANDARD1_3
         /// <summary>
         /// Load from url
         /// </summary>

--- a/src/NLog/Internal/EnvironmentHelper.cs
+++ b/src/NLog/Internal/EnvironmentHelper.cs
@@ -54,6 +54,27 @@ namespace NLog.Internal
             }
         }
 
+        internal static string GetMachineName()
+        {
+            try
+            {
+#if SILVERLIGHT
+                return "SilverLight";
+#elif NETSTANDARD1_3
+                var machineName = EnvironmentHelper.GetSafeEnvironmentVariable("COMPUTERNAME") ?? string.Empty;
+                if (string.IsNullOrEmpty(machineName))
+                    machineName = EnvironmentHelper.GetSafeEnvironmentVariable("HOSTNAME") ?? string.Empty;
+                return machineName;
+#else
+                return Environment.MachineName;
+#endif
+            }
+            catch (System.Security.SecurityException)
+            {
+                return string.Empty;
+            }
+        }
+
         internal static string GetSafeEnvironmentVariable(string name)
         {
 #if !SILVERLIGHT

--- a/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__ANDROID__ && !__IOS__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__ANDROID__ && !__IOS__ && !NETSTANDARD1_3
 // Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) 
 #define SupportsMutex
 #endif

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__ANDROID__ && !__IOS__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__ANDROID__ && !__IOS__ && !NETSTANDARD1_3
 // Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) so the BaseFileAppender class now throws an exception in the constructor.
 #define SupportsMutex
 #endif
@@ -51,7 +51,7 @@ namespace NLog.Internal.FileAppenders
         private readonly BaseFileAppender[] _appenders;
         private Timer _autoClosingTimer;
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
         private string _archiveFilePatternToWatch = null;
         private readonly MultiFileWatcher _externalFileArchivingWatcher = new MultiFileWatcher(NotifyFilters.DirectoryName | NotifyFilters.FileName);
         private bool _logFileWasArchived = false;
@@ -88,12 +88,12 @@ namespace NLog.Internal.FileAppenders
 
             _autoClosingTimer = new Timer(AutoClosingTimerCallback, null, Timeout.Infinite, Timeout.Infinite);
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
             _externalFileArchivingWatcher.FileChanged += ExternalFileArchivingWatcher_OnFileChanged;
 #endif
         }
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
         private void ExternalFileArchivingWatcher_OnFileChanged(object sender, FileSystemEventArgs e)
         {
             if (_logFileWasArchived || CheckCloseAppenders == null || _autoClosingTimer == null)
@@ -296,7 +296,7 @@ namespace NLog.Internal.FileAppenders
 
                 if (CheckCloseAppenders != null)
                 {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
                     if (freeSpot == 0)
                         _logFileWasArchived = false;
                     if (!string.IsNullOrEmpty(_archiveFilePatternToWatch))
@@ -347,7 +347,7 @@ namespace NLog.Internal.FileAppenders
         /// <param name="expireTime">The time which prior the appenders considered expired</param>
         public void CloseAppenders(DateTime expireTime)
         {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
             if (_logFileWasArchived)
             {
                 _logFileWasArchived = false;
@@ -554,7 +554,7 @@ namespace NLog.Internal.FileAppenders
                 // No active appenders, deactivate background tasks
                 _autoClosingTimer.Change(Timeout.Infinite, Timeout.Infinite);
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
                 _externalFileArchivingWatcher.StopWatching();
                 _logFileWasArchived = false;
             }
@@ -571,7 +571,7 @@ namespace NLog.Internal.FileAppenders
         {
             CheckCloseAppenders = null;
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
             _externalFileArchivingWatcher.Dispose();
             _logFileWasArchived = false;
 #endif

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__ANDROID__ && !__IOS__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__ANDROID__ && !__IOS__ && !NETSTANDARD1_3
 // Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) so the BaseFileAppender class now throws an exception in the constructor.
 #define SupportsMutex
 #endif

--- a/src/NLog/Internal/MultiFileWatcher.cs
+++ b/src/NLog/Internal/MultiFileWatcher.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
 
 namespace NLog.Internal
 {

--- a/src/NLog/Internal/PlatformDetector.cs
+++ b/src/NLog/Internal/PlatformDetector.cs
@@ -75,11 +75,9 @@ namespace NLog.Internal
         {
             get
             {
-#if WINDOWS_UWP
-                return false;
-#elif NETSTANDARD1_0
+#if NETSTANDARD1_5
                 return true;
-#elif !SILVERLIGHT && !__ANDROID__ && !__IOS__
+#elif !SILVERLIGHT && !__ANDROID__ && !__IOS__ && !NETSTANDARD1_3
                 // Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) 
                 if (IsMono && Environment.Version.Major < 4)
                     return false;   // MONO ver. 4 is needed for named Mutex to work

--- a/src/NLog/Internal/PortableThreadIDHelper.cs
+++ b/src/NLog/Internal/PortableThreadIDHelper.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__IOS__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !NETSTANDARD1_3
 
 namespace NLog.Internal
 {

--- a/src/NLog/Internal/PropertyHelper.cs
+++ b/src/NLog/Internal/PropertyHelper.cs
@@ -193,7 +193,7 @@ namespace NLog.Internal
         {
             try
             {
-#if !WINDOWS_UWP
+#if !NETSTANDARD1_3
                 if (Type.GetTypeCode(resultType) != TypeCode.Object)
 #else
                 if (resultType.IsPrimitive() || resultType == typeof(string))
@@ -378,7 +378,7 @@ namespace NLog.Internal
 
         private static bool TryTypeConverterConversion(Type type, string value, out object newValue)
         {
-#if !SILVERLIGHT && !WINDOWS_UWP
+#if !SILVERLIGHT && !NETSTANDARD1_3
             var converter = TypeDescriptor.GetConverter(type);
             if (converter.CanConvertFrom(typeof(string)))
             {

--- a/src/NLog/Internal/ThreadIDHelper.cs
+++ b/src/NLog/Internal/ThreadIDHelper.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__IOS__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !NETSTANDARD1_3
 
 namespace NLog.Internal
 {

--- a/src/NLog/LayoutRenderers/AssemblyVersionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AssemblyVersionLayoutRenderer.cs
@@ -116,7 +116,7 @@ namespace NLog.LayoutRenderers
             }
         }
 
-#elif WINDOWS_UWP && !NETSTANDARD1_5
+#elif NETSTANDARD1_3
 
         private string GetVersion()
         {
@@ -135,7 +135,6 @@ namespace NLog.LayoutRenderers
         {
             return System.Reflection.Assembly.Load(new System.Reflection.AssemblyName(Name));
         }
-
 #else
 
         private string GetVersion()

--- a/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
@@ -50,7 +50,7 @@ namespace NLog.LayoutRenderers
     {
         private readonly string _baseDir;
 
-#if !SILVERLIGHT && !WINDOWS_UWP
+#if !SILVERLIGHT && !NETSTANDARD1_3
 
         /// <summary>
         /// cached
@@ -101,7 +101,7 @@ namespace NLog.LayoutRenderers
         {
 
             var dir = _baseDir;
-#if !SILVERLIGHT && !WINDOWS_UWP
+#if !SILVERLIGHT && !NETSTANDARD1_3
             if (ProcessDir)
             {
                 dir = _processDir ?? (_processDir = Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName));

--- a/src/NLog/LayoutRenderers/MachineNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MachineNameLayoutRenderer.cs
@@ -59,18 +59,15 @@ namespace NLog.LayoutRenderers
             base.InitializeLayoutRenderer();
             try
             {
-#if WINDOWS_UWP
-                MachineName = EnvironmentHelper.GetSafeEnvironmentVariable("COMPUTERNAME") ?? string.Empty;
+                MachineName = EnvironmentHelper.GetMachineName();
                 if (string.IsNullOrEmpty(MachineName))
-                    MachineName = EnvironmentHelper.GetSafeEnvironmentVariable("HOSTNAME") ?? string.Empty;
-#else
-                MachineName = Environment.MachineName;
-#endif
+                {
+                    InternalLogger.Info("MachineName is not available.");
+                }
             }
             catch (Exception exception)
             {
                 InternalLogger.Error(exception, "Error getting machine name.");
-
                 if (exception.MustBeRethrown())
                 {
                     throw;

--- a/src/NLog/LayoutRenderers/NLogDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/NLogDirLayoutRenderer.cs
@@ -33,7 +33,7 @@
 
 using NLog.Internal;
 
-#if !SILVERLIGHT && !WINDOWS_UWP
+#if !SILVERLIGHT && !NETSTANDARD1_3
 
 namespace NLog.LayoutRenderers
 {

--- a/src/NLog/LayoutRenderers/ProcessIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessIdLayoutRenderer.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__IOS__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !NETSTANDARD1_3
 
 namespace NLog.LayoutRenderers
 {

--- a/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !WINDOWS_UWP
+#if !SILVERLIGHT && !NETSTANDARD1_3
 
 namespace NLog.LayoutRenderers
 {

--- a/src/NLog/LayoutRenderers/ProcessNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessNameLayoutRenderer.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__IOS__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !NETSTANDARD1_3
 
 namespace NLog.LayoutRenderers
 {

--- a/src/NLog/LayoutRenderers/ThreadNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ThreadNameLayoutRenderer.cs
@@ -48,7 +48,7 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-#if !WINDOWS_UWP
+#if !NETSTANDARD1_3
             builder.Append(System.Threading.Thread.CurrentThread.Name);
 #endif
         }

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -61,7 +61,7 @@ namespace NLog
     /// </summary>
     public class LogFactory : IDisposable
     {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
         private const int ReconfigAfterFileChangedTimeout = 1000;
         internal Timer reloadTimer;
         private readonly MultiFileWatcher _watcher;
@@ -94,7 +94,7 @@ namespace NLog
         /// </summary>
         public event EventHandler<LoggingConfigurationChangedEventArgs> ConfigurationChanged;
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
         /// <summary>
         /// Occurs when logging <see cref="Configuration" /> gets reloaded.
         /// </summary>
@@ -103,7 +103,7 @@ namespace NLog
 
         private static event EventHandler<EventArgs> LoggerShutdown;
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
         /// <summary>
         /// Initializes static members of the LogManager class.
         /// </summary>
@@ -119,7 +119,7 @@ namespace NLog
         /// </summary>
         public LogFactory()
         {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
             _watcher = new MultiFileWatcher();
             _watcher.FileChanged += ConfigFileChanged;
             LoggerShutdown += OnStopLogging;
@@ -230,7 +230,7 @@ namespace NLog
                         {
                             _config.Dump();
                             ReconfigExistingLoggers();
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
                             TryWachtingConfigFile();
 #endif
                             LogConfigurationInitialized();
@@ -247,7 +247,7 @@ namespace NLog
 
             set
             {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
                 try
                 {
                     _watcher.StopWatching();
@@ -285,7 +285,7 @@ namespace NLog
                         {
                             _config.Dump();
                             ReconfigExistingLoggers();
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
                             TryWachtingConfigFile();
 #endif
                         }
@@ -300,7 +300,7 @@ namespace NLog
             }
         }
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
         private void TryWachtingConfigFile()
         {
             try
@@ -763,7 +763,7 @@ namespace NLog
             ConfigurationChanged?.Invoke(this, e);
         }
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
         /// <summary>
         /// Raises the event when the configuration is reloaded. 
         /// </summary>
@@ -774,7 +774,7 @@ namespace NLog
         }
 #endif
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
         internal void ReloadConfigOnTimer(object state)
         {
             if (reloadTimer == null && _isDisposing)
@@ -954,7 +954,7 @@ namespace NLog
 
             _isDisposing = true;
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
             LoggerShutdown -= OnStopLogging;
             ConfigurationReloaded = null;   // Release event listeners
 
@@ -969,7 +969,7 @@ namespace NLog
             {
                 try
                 {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
                     var currentTimer = reloadTimer;
                     if (currentTimer != null)
                     {
@@ -1000,7 +1000,7 @@ namespace NLog
         {
             try
             {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP && !MONO
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3 && !MONO
                 bool attemptClose = true;
                 if (flushTimeout != TimeSpan.Zero && !PlatformDetector.IsMono)
                 {
@@ -1271,7 +1271,7 @@ namespace NLog
             return xmlConfig;
         }
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
         private void ConfigFileChanged(object sender, EventArgs args)
         {
             InternalLogger.Info("Configuration file change detected! Reloading in {0}ms...", ReconfigAfterFileChangedTimeout);

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -80,7 +80,7 @@ namespace NLog
             remove => factory.ConfigurationChanged -= value;
         }
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
         /// <summary>
         /// Occurs when logging <see cref="Configuration" /> gets reloaded.
         /// </summary>

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -66,10 +66,10 @@ namespace NLog
             if (stu != StackTraceUsage.None && !logEvent.HasStackTrace)
             {
                 StackTrace stackTrace;
-#if WINDOWS_UWP
-                stackTrace = null;
-#elif NETSTANDARD1_5
+#if NETSTANDARD1_5
                 stackTrace = (StackTrace)Activator.CreateInstance(typeof(StackTrace), new object[] { stu == StackTraceUsage.WithSource });
+#elif NETSTANDARD1_0
+                stackTrace = null;
 #elif !SILVERLIGHT
                 stackTrace = new StackTrace(StackTraceSkipMethods, stu == StackTraceUsage.WithSource);
 #else

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -174,25 +174,10 @@ NLog 4.5 adds structured logging and .NET Standard support/UPW without breaking 
     <DefineConstants>$(DefineConstants);NET3_5;WCF_SUPPORTED</DefineConstants>
   </PropertyGroup>
   
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <Title>NLog for UWP</Title>
-    <NugetTargetMoniker>UAP,Version=v10.0</NugetTargetMoniker>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <DefineConstants>$(DefineConstants);NET4_5;NETSTANDARD;NETSTANDARD1_0;WINDOWS_UWP</DefineConstants>
-    <TargetFrameworkIdentifier>.NETCore</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
-    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.15083.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
-  </PropertyGroup>
-  
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <!-- Artificial TargetFramework to simulate restricted uap10.0. NetStandard1.3 will never support auto-flush-on-shutdown -->
     <Title>NLog for NetStandard 1.3</Title>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <DefineConstants>$(DefineConstants);NET4_5;NETSTANDARD;NETSTANDARD1_0;WINDOWS_UWP</DefineConstants>
+    <DefineConstants>$(DefineConstants);NET4_5;NETSTANDARD;NETSTANDARD1_0;NETSTANDARD1_3</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
@@ -368,30 +353,15 @@ NLog 4.5 adds structured logging and .NET Standard support/UPW without breaking 
     <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="5.2.2" />
-  </ItemGroup>
-  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />
-    <PackageReference Include="System.Data.Common" Version="4.1.0" />
-    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.0.1" />
-    <PackageReference Include="System.IO.Compression" Version="4.1.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.0.0" />
-    <PackageReference Include="System.Net.Requests" Version="4.0.11" />
-    <PackageReference Include="System.Net.Sockets" Version="4.1.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.1.0" />
-    <PackageReference Include="System.Threading" Version="4.0.11" />
-    <PackageReference Include="System.Threading.Timer" Version="4.0.1" />
-  </ItemGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' or '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.0.1" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.1.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
+    <PackageReference Include="System.Data.Common" Version="4.1.0" />
+    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.0.1" />
+    <PackageReference Include="System.Net.NameResolution" Version="4.0.0" />
+    <PackageReference Include="System.Net.Requests" Version="4.0.11" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1" />
   </ItemGroup>
   

--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -33,7 +33,7 @@
 
 using NLog.Common;
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
 
 namespace NLog.Targets
 {

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !WINDOWS_UWP
+#if !NETSTANDARD1_3
 
 namespace NLog.Targets
 {

--- a/src/NLog/Targets/ConsoleTargetHelper.cs
+++ b/src/NLog/Targets/ConsoleTargetHelper.cs
@@ -72,7 +72,7 @@ namespace NLog.Targets
 
         public static Encoding GetConsoleOutputEncoding(Encoding currentEncoding, bool isInitialized, bool pauseLogging)
         {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
             string reason;
             if (currentEncoding != null)
                 return currentEncoding;
@@ -90,7 +90,7 @@ namespace NLog.Targets
 
         public static bool SetConsoleOutputEncoding(Encoding newEncoding, bool isInitialized, bool pauseLogging)
         {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
             if (!isInitialized)
             {
                 return true;    // Waiting for console target to be initialized

--- a/src/NLog/Targets/ConsoleWordHighlightingRule.cs
+++ b/src/NLog/Targets/ConsoleWordHighlightingRule.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !WINDOWS_UWP
+#if !SILVERLIGHT && !NETSTANDARD1_3
 
 namespace NLog.Targets
 {

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__ANDROID__ && !__IOS__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__ANDROID__ && !__IOS__ && !NETSTANDARD1_3
 // Unfortunately, Xamarin Android and Xamarin iOS don't support mutexes (see https://github.com/mono/mono/blob/3a9e18e5405b5772be88bfc45739d6a350560111/mcs/class/corlib/System.Threading/Mutex.cs#L167) so the BaseFileAppender class now throws an exception in the constructor.
 #define SupportsMutex
 #endif
@@ -758,7 +758,7 @@ namespace NLog.Targets
                 if (KeepFileOpen)
                     _fileAppenderCache.CheckCloseAppenders += AutoClosingTimerCallback;
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
                 bool mustWatchArchiving = IsArchivingEnabled && ConcurrentWrites && KeepFileOpen;
                 if (mustWatchArchiving)
                 {
@@ -1669,14 +1669,14 @@ namespace NLog.Targets
                         archivedAppender = archivedAppender ?? fileAppender;
                     }
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
                     // Closes all file handles if any archive operation has been detected by file-watcher
                     _fileAppenderCache.InvalidateAppendersForArchivedFiles();
 #endif
                 }
                 else
                 {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !WINDOWS_UWP
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
                     _fileAppenderCache.InvalidateAppendersForArchivedFiles();
 #endif
                 }

--- a/src/NLog/Targets/LineEndingMode.cs
+++ b/src/NLog/Targets/LineEndingMode.cs
@@ -42,7 +42,7 @@ namespace NLog.Targets
     /// <summary>
     /// Line ending mode.
     /// </summary>
-#if !WINDOWS_UWP
+#if !NETSTANDARD1_3
     [TypeConverter(typeof(LineEndingModeConverter))]
 #endif
     public sealed class LineEndingMode : IEquatable<LineEndingMode>
@@ -226,7 +226,7 @@ namespace NLog.Targets
             return string.Equals(_newLineCharacters, other._newLineCharacters);
         }
 
-#if !WINDOWS_UWP
+#if !NETSTANDARD1_3
         /// <summary>
         /// Provides a type converter to convert <see cref="LineEndingMode"/> objects to and from other representations.
         /// </summary>

--- a/src/NLog/Targets/TraceTarget.cs
+++ b/src/NLog/Targets/TraceTarget.cs
@@ -33,7 +33,7 @@
 
 #define TRACE
 
-#if !SILVERLIGHT && !WINDOWS_UWP
+#if !SILVERLIGHT && !NETSTANDARD1_3
 
 namespace NLog.Targets
 {


### PR DESCRIPTION
Right now NLog cannot be used by any shared NetStandard14-library that wants to support UWP10. See also #2440

I guess the easy solution would be isolating the logger-interface into a separate assembly, but that is for NLog 6.0.