### PR TITLE
NLog - Fix Callsite when wrapping ILogger in Microsoft Extension Logging

### DIFF
--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -216,7 +216,7 @@ namespace NLog
         {
             var method = frame.GetMethod();
             Type declaringType = method.DeclaringType;
-            var isLoggerType = declaringType != null && (loggerType == declaringType || declaringType.IsSubclassOf(loggerType) || declaringType.IsSubclassOf(typeof(ILogger)));
+            var isLoggerType = declaringType != null && (loggerType == declaringType || declaringType.IsSubclassOf(loggerType) || loggerType.IsAssignableFrom(declaringType));
             return isLoggerType;
         }
 

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -939,11 +939,10 @@ namespace NLog.UnitTests.LayoutRenderers
             }
         }
 
-#endregion
+        #endregion
 
         private class MyLogger : Logger
         {
-
         }
 
         [Fact]
@@ -1042,12 +1041,25 @@ namespace NLog.UnitTests.LayoutRenderers
             LogManager.Flush();
             logMessage = target.Logs[2];
             Assert.Contains("ThreadId=" + Thread.CurrentThread.ManagedThreadId.ToString(), logMessage);
+
+            // See that interface logging also works (Improve support for Microsoft.Extension.Logging.ILogger replacement)
+            INLogLogger ilogger = logger;
+            WriteLogMessage(ilogger);
+            LogManager.Flush();
+            logMessage = target.Logs[3];
+            Assert.Contains("CallSiteTests.WriteLogMessage", logMessage);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void WriteLogMessage(NLogLogger logger)
         {
             logger.Debug("something");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void WriteLogMessage(INLogLogger logger)
+        {
+            logger.Log(LogLevel.Debug, "something");
         }
 
         /// <summary>
@@ -1179,10 +1191,25 @@ namespace NLog.UnitTests.LayoutRenderers
             await Task.Run(() => { });
         }
 
+        public interface INLogLogger
+        {
+            void Log(LogLevel logLevel, string message);
+        }
+
+        public abstract class NLogLoggerBase : INLogLogger
+        {
+            protected abstract Logger Logger { get; }
+
+            void INLogLogger.Log(LogLevel logLevel, string message)
+            {
+                Logger.Log(typeof(INLogLogger), new LogEventInfo(logLevel, Logger.Name, message));
+            }
+        }
+
         /// <summary>
         ///   Implementation of <see cref="ILogger" /> for NLog.
         /// </summary>
-        public class NLogLogger
+        public class NLogLogger : NLogLoggerBase
         {
             /// <summary>
             ///   Initializes a new instance of the <see cref="NLogLogger" /> class.
@@ -1197,7 +1224,7 @@ namespace NLog.UnitTests.LayoutRenderers
             ///   Gets or sets the logger.
             /// </summary>
             /// <value> The logger. </value>
-            protected internal Logger Logger { get; set; }
+            protected override Logger Logger { get; }
 
             /// <summary>
             ///   Returns a <see cref="string" /> that represents this instance.


### PR DESCRIPTION
Fix the issue shown here:

https://tpodolak.com/blog/2018/03/01/asp-net-core-custom-iloggert-nlog-callsite-layout-renderer-issue/

Then in the NLog.Extension.Logging the following line needs to be changed in NLogLogger.cs:

> _logger.Log(eventInfo);

To this:

> _logger.Log(typeof(Microsoft.Extensions.Logging.ILogger), eventInfo);

And then callsite will work for custom Loggers, without needing hidden assembly-logic (and moving custom Logger into separate assembly)
