### PR TITLE
Attempt to make some unit-tests more stable

### DIFF
--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -1176,7 +1176,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
         private async Task AMinimalAsyncMethod()
         {
-            await Task.Run(() => { });
+            await Task.Delay(1);    // Ensure it always becomes async, and it is not inlined
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
@@ -124,8 +124,10 @@ namespace NLog.UnitTests.Targets.Wrappers
                     prevSequenceID = itemWrittenList[i];
                 }
 
-                if (!IsAppVeyor())
-                    Assert.True(elapsedMilliseconds < 750);    // Skip timing test when running within OpenCover.Console.exe
+#if NET4_5
+                if (!IsAppVeyor())  // Skip timing test when running within OpenCover.Console.exe
+#endif
+                    Assert.True(elapsedMilliseconds < 950);
 
                 targetWrapper.Flush(flushHandler);
                 for (int i = 0; i < 2000 && flushCounter != 2; ++i)


### PR DESCRIPTION
Attemp to improve the following unit-tests:

- AsyncTargetWrapperSyncTest_WhenTimeToSleepBetweenBatchesIsEqualToZero
- LogAfterAwait_CleanNamesOfAsyncContinuationsIsFalse_ShouldNotCleanNames
- BufferingTargetWrapperAsyncTest1 (Resolve #2206)
