### PR TITLE
LogManager.Shutdown - Should disable file watcher and avoid auto reload

### DIFF
--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -685,7 +685,7 @@ namespace NLog.UnitTests.Config
             var factory = LogManager.LogFactory;
 
             //reloadTimer should be set for ReloadConfigOnTimer
-            factory.reloadTimer = new Timer((a) => { });
+            factory._reloadTimer = new Timer((a) => { });
             factory.ReloadConfigOnTimer(this);
             _reloading = false;
             return factory.Configuration;


### PR DESCRIPTION
One might consider to call LogFactory.Close(), but that might be a breaking change as it would prevent the engine to startup again after shutdown (Would have to fix unit tests, so they don't call LogManager.Shutdown)

Adventure that continues from #1899 and #82

LogManager.Shutdown() was created to simulate Shutdown in Log4net.