### PR TITLE
Single Target optimization should only be done when parseMessageTemplate = null

### DIFF
--- a/src/NLog/Internal/LogMessageTemplateFormatter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatter.cs
@@ -43,7 +43,6 @@ namespace NLog.Internal
         public static readonly LogMessageTemplateFormatter DefaultAuto = new LogMessageTemplateFormatter(false, false);
         public static readonly LogMessageTemplateFormatter Default = new LogMessageTemplateFormatter(true, false);
         public static readonly LogMessageTemplateFormatter DefaultAutoSingleTarget = new LogMessageTemplateFormatter(false, true);
-        public static readonly LogMessageTemplateFormatter DefaultSingleTarget = new LogMessageTemplateFormatter(true, true);
         private static readonly StringBuilderPool _builderPool = new StringBuilderPool(Environment.ProcessorCount * 2);
 
         /// <summary>
@@ -77,11 +76,13 @@ namespace NLog.Internal
 
             if (_singleTargetOnly)
             {
-                // Make quick check for valid message template parameter names
+                // Perform quick check for valid message template parameter names (No support for rewind if mixed message-template)
                 TemplateEnumerator holeEnumerator = new TemplateEnumerator(logEvent.Message);
-                if (holeEnumerator.MoveNext() && holeEnumerator.Current.Literal.Skip != 0 && holeEnumerator.Current.Hole.Index != -1)
+                if (holeEnumerator.MoveNext())
                 {
-                    return false;   // Skip allocation of PropertiesDictionary
+                    var currentHole = holeEnumerator.Current;
+                    if (currentHole.Literal.Skip != 0 && currentHole.Hole.Index != -1 && currentHole.Hole.CaptureType == CaptureType.Normal)
+                        return false;   // Skip allocation of PropertiesDictionary
                 }
             }
 

--- a/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
@@ -84,10 +84,10 @@ namespace NLog.LayoutRenderers
             }
             else
             {
-                if (ReferenceEquals(logEvent.MessageFormatter, LogEventInfo.DefaultMessageFormatterSingleTarget) && (logEvent.MessageFormatter.Target is ILogMessageFormatter messageFormatter))
+                if (ReferenceEquals(logEvent.MessageFormatter, LogMessageTemplateFormatter.DefaultAutoSingleTarget.MessageFormatter))
                 {
                     // Skip string-allocation of LogEventInfo.FormattedMessage, but just write directly to StringBuilder
-                    logEvent.AppendFormattedMessage(messageFormatter, builder);
+                    logEvent.AppendFormattedMessage(LogMessageTemplateFormatter.DefaultAutoSingleTarget, builder);
                 }
                 else
                 {

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -57,7 +57,6 @@ namespace NLog
         public static readonly DateTime ZeroDate = DateTime.UtcNow;
         internal static readonly LogMessageFormatter StringFormatMessageFormatter = GetStringFormatMessageFormatter;
         internal static LogMessageFormatter DefaultMessageFormatter { get; private set; } = LogMessageTemplateFormatter.DefaultAuto.MessageFormatter;
-        internal static LogMessageFormatter DefaultMessageFormatterSingleTarget { get; private set; } = LogMessageTemplateFormatter.DefaultAutoSingleTarget.MessageFormatter;
 
         private static int globalSequenceId;
 
@@ -695,20 +694,17 @@ namespace NLog
             {
                 InternalLogger.Info("Message Template Format always enabled");
                 DefaultMessageFormatter = LogMessageTemplateFormatter.Default.MessageFormatter;
-                DefaultMessageFormatterSingleTarget = LogMessageTemplateFormatter.DefaultSingleTarget.MessageFormatter;
             }
             else if (mode == false)
             {
                 InternalLogger.Info("Message Template String Format always enabled");
                 DefaultMessageFormatter = StringFormatMessageFormatter;
-                DefaultMessageFormatterSingleTarget = null; // No single target optimization
             }
             else
             {
                 //null = auto
                 InternalLogger.Info("Message Template Auto Format enabled");
                 DefaultMessageFormatter = LogMessageTemplateFormatter.DefaultAuto.MessageFormatter;
-                DefaultMessageFormatterSingleTarget = LogMessageTemplateFormatter.DefaultAutoSingleTarget.MessageFormatter;
             }
         }
     }

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -103,14 +103,10 @@ namespace NLog
             if (targets.NextInChain == null
              && logEvent.Parameters != null
              && logEvent.Parameters.Length > 0
-             && logEvent.Message?.Length < 128
-             && ReferenceEquals(logEvent.MessageFormatter, LogEventInfo.DefaultMessageFormatter))
+             && logEvent.Message?.Length < 256
+             && ReferenceEquals(logEvent.MessageFormatter, LogMessageTemplateFormatter.DefaultAuto.MessageFormatter))
             {
-                // Signal MessageLayoutRenderer to skip string allocation of LogEventInfo.FormattedMessage
-                if (!ReferenceEquals(logEvent.MessageFormatter, LogEventInfo.StringFormatMessageFormatter))
-                {
-                    logEvent.MessageFormatter = LogEventInfo.DefaultMessageFormatterSingleTarget;
-                }
+                logEvent.MessageFormatter = LogMessageTemplateFormatter.DefaultAutoSingleTarget.MessageFormatter;
             }
 
             for (var t = targets; t != null; t = t.NextInChain)


### PR DESCRIPTION
Fixes #2507 so mixed-mode templates also works in single-target scenario. See also #2544