### PR TITLE
UWP with NetStandard2 on Net Native does not support Assembly.CodeBase + Handle native methods in StackTrace

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -481,23 +481,32 @@ namespace NLog.Config
 
                 fullName = assembly.FullName;
 
+#if NETSTANDARD
+                if (string.IsNullOrEmpty(assembly.Location))
+                {
+                    // Assembly with no actual location should be skipped (Avoid PlatformNotSupportedException)
+                    InternalLogger.Warn("Skipping auto loading location because location is empty: {0}", fullName);
+                    return string.Empty;
+                }
+#endif
+
                 Uri assemblyCodeBase;
                 if (!Uri.TryCreate(assembly.CodeBase, UriKind.RelativeOrAbsolute, out assemblyCodeBase))
                 {
-                    InternalLogger.Warn("Skipping auto loading location because code base is unknown: `{0}` ({1})", assembly.CodeBase, fullName);
+                    InternalLogger.Warn("Skipping auto loading location because code base is unknown: '{0}' ({1})", assembly.CodeBase, fullName);
                     return string.Empty;
                 }
 
                 var assemblyLocation = Path.GetDirectoryName(assemblyCodeBase.LocalPath);
                 if (string.IsNullOrEmpty(assemblyLocation))
                 {
-                    InternalLogger.Warn("Skipping auto loading location because it is not a valid directory: `{0}` ({1})", assemblyCodeBase.LocalPath, fullName);
+                    InternalLogger.Warn("Skipping auto loading location because it is not a valid directory: '{0}' ({1})", assemblyCodeBase.LocalPath, fullName);
                     return string.Empty;
                 }
 
                 if (!Directory.Exists(assemblyLocation))
                 {
-                    InternalLogger.Warn("Skipping auto loading location because directory doesn't exists: `{0}` ({1})", assemblyLocation, fullName);
+                    InternalLogger.Warn("Skipping auto loading location because directory doesn't exists: '{0}' ({1})", assemblyLocation, fullName);
                     return string.Empty;
                 }
 

--- a/src/NLog/Internal/StackTraceUsageUtils.cs
+++ b/src/NLog/Internal/StackTraceUsageUtils.cs
@@ -44,22 +44,14 @@ namespace NLog.Internal
     /// </summary>
     internal static class StackTraceUsageUtils
     {
+        private static readonly Assembly nlogAssembly = typeof(StackTraceUsageUtils).GetAssembly();
+        private static readonly Assembly mscorlibAssembly = typeof(string).GetAssembly();
+        private static readonly Assembly systemAssembly = typeof(Debug).GetAssembly();
+
         internal static StackTraceUsage Max(StackTraceUsage u1, StackTraceUsage u2)
         {
             return (StackTraceUsage)Math.Max((int)u1, (int)u2);
         }
-
-#if !NETSTANDARD1_0
-        /// <summary>
-        /// Get this stacktrace for inline unit test
-        /// </summary>
-        /// <param name="loggerType"></param>
-        /// <returns></returns>
-        internal static StackTrace GetWriteStackTrace(Type loggerType)
-        {
-            return new StackTrace();
-        }
-#endif
 
         public static int GetFrameCount(this StackTrace strackTrace)
         {
@@ -148,27 +140,12 @@ namespace NLog.Internal
             int framesToSkip = 2;
 
             string className = string.Empty;
-#if !NETSTANDARD1_0
-            Type declaringType;
-
-            do
-            {
 #if SILVERLIGHT
-                StackFrame frame = new StackTrace().GetFrame(framesToSkip);
-#else
-                StackFrame frame = new StackFrame(framesToSkip, false);
-#endif
-                MethodBase method = frame.GetMethod();
-                declaringType = method.DeclaringType;
-                if (declaringType == null)
-                {
-                    className = method.Name;
-                    break;
-                }
-
-                framesToSkip++;
-                className = declaringType.FullName;
-            } while (className.StartsWith("System.", StringComparison.Ordinal));
+            var stackFrame = new StackFrame(framesToSkip);
+            className = GetClassFullName(stackFrame);
+#elif !NETSTANDARD1_0
+            var stackFrame = new StackFrame(framesToSkip, false);
+            className = GetClassFullName(stackFrame);
 #else
             var stackTrace = Environment.StackTrace;
             var stackTraceLines = stackTrace.Replace("\r", "").Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
@@ -194,6 +171,94 @@ namespace NLog.Internal
             }
 #endif
             return className;
+        }
+
+#if !NETSTANDARD1_0
+        /// <summary>
+        /// Gets the fully qualified name of the class invoking the calling method, including the 
+        /// namespace but not the assembly.    
+        /// </summary>
+        /// <param name="stackFrame">StackFrame from the calling method</param>
+        /// <returns>Fully qualified class name</returns>
+        public static string GetClassFullName(StackFrame stackFrame)
+        {
+            string className = LookupClassNameFromStackFrame(stackFrame);
+            if (string.IsNullOrEmpty(className))
+            {
+#if SILVERLIGHT
+                var stackTrace = new StackTrace();
+#else
+                var stackTrace = new StackTrace(false);
+#endif
+                className = GetClassFullName(stackTrace);
+            }
+            return className;
+        }
+#endif
+
+        private static string GetClassFullName(StackTrace stackTrace)
+        {
+            foreach (StackFrame frame in stackTrace.GetFrames())
+            {
+                string className = LookupClassNameFromStackFrame(frame);
+                if (!string.IsNullOrEmpty(className))
+                {
+                    return className;
+                }
+            }
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Returns the assembly from the provided StackFrame (If not internal assembly)
+        /// </summary>
+        /// <returns>Valid asssembly, or null if assembly was internal</returns>
+        public static Assembly LookupAssemblyFromStackFrame(StackFrame stackFrame)
+        {
+            var method = stackFrame.GetMethod();
+            if (method == null)
+            {
+                return null;
+            }
+
+            var assembly = method.DeclaringType?.GetAssembly() ?? method.Module?.Assembly;
+            // skip stack frame if the method declaring type assembly is from hidden assemblies list
+            if (assembly == nlogAssembly)
+            {
+                return null;
+            }
+
+            if (assembly == mscorlibAssembly)
+            {
+                return null;
+            }
+
+            if (assembly == systemAssembly)
+            {
+                return null;
+            }
+
+            return assembly;
+        }
+
+        /// <summary>
+        /// Returns the classname from the provided StackFrame (If not from internal assembly)
+        /// </summary>
+        /// <param name="stackFrame"></param>
+        /// <returns>Valid class name, or empty string if assembly was internal</returns>
+        public static string LookupClassNameFromStackFrame(StackFrame stackFrame)
+        {
+            var method = stackFrame.GetMethod();
+            if (method != null && LookupAssemblyFromStackFrame(stackFrame) != null)
+            {
+                string className = GetStackFrameMethodClassName(method, true, true, true) ?? method.Name;
+                if (!string.IsNullOrEmpty(className) && !className.StartsWith("System.", StringComparison.Ordinal))
+                {
+                    return className;
+                }
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/StackTraceLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/StackTraceLayoutRenderer.cs
@@ -36,8 +36,8 @@ namespace NLog.LayoutRenderers
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Text;
-    using Config;
-    using Internal;
+    using NLog.Config;
+    using NLog.Internal;
 
     /// <summary>
     /// Stack trace renderer.
@@ -143,8 +143,13 @@ namespace NLog.LayoutRenderers
                     builder.Append(Separator);
                 }
 
-                var type = f.GetMethod().DeclaringType;
+                var method = f.GetMethod();
+                if (method == null)
+                {
+                    continue;   // Net Native can have StackFrames without managed methods
+                }
 
+                var type = method.DeclaringType;
                 if (type != null)
                 {
                     builder.Append(type.Name);
@@ -155,7 +160,7 @@ namespace NLog.LayoutRenderers
                 }
 
                 builder.Append(".");
-                builder.Append(f.GetMethod().Name);
+                builder.Append(method.Name);
                 first = false;
             }
         }
@@ -166,13 +171,18 @@ namespace NLog.LayoutRenderers
             for (int i = startingFrame; i >= endingFrame; --i)
             {
                 StackFrame f = logEvent.StackTrace.GetFrame(i);
+                var method = f.GetMethod();
+                if (method == null)
+                {
+                    continue;   // Net Native can have StackFrames without managed methods
+                }
+
                 if (!first)
                 {
                     builder.Append(Separator);
                 }
-
                 builder.Append("[");
-                builder.Append(f.GetMethod());
+                builder.Append(method);
                 builder.Append("]");
                 first = false;
             }

--- a/src/NLog/LogFactory-T.cs
+++ b/src/NLog/LogFactory-T.cs
@@ -64,16 +64,13 @@ namespace NLog
         public new T GetCurrentClassLogger()
         {
 #if NETSTANDARD1_0
-            return this.GetLogger(Internal.StackTraceUsageUtils.GetClassFullName());
+            var className = Internal.StackTraceUsageUtils.GetClassFullName();
+#elif SILVERLIGHT
+            var className = Internal.StackTraceUsageUtils.GetClassFullName(new StackFrame(1));
 #else
-#if SILVERLIGHT
-            StackFrame frame = new StackFrame(1);
-#else
-            StackFrame frame = new StackFrame(1, false);
+            var className = Internal.StackTraceUsageUtils.GetClassFullName(new StackFrame(1, false));
 #endif
-
-            return GetLogger(frame.GetMethod().DeclaringType.FullName);
-#endif
+            return GetLogger(className);
         }
     }
 }

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -459,16 +459,13 @@ namespace NLog
         public Logger GetCurrentClassLogger()
         {
 #if NETSTANDARD1_0
-            return this.GetLogger(StackTraceUsageUtils.GetClassFullName());
+            var className = StackTraceUsageUtils.GetClassFullName();
+#elif SILVERLIGHT
+            var className = StackTraceUsageUtils.GetClassFullName(new StackFrame(1));
 #else
-#if SILVERLIGHT
-            var frame = new StackFrame(1);
-#else
-            var frame = new StackFrame(1, false);
+            var className = StackTraceUsageUtils.GetClassFullName(new StackFrame(1, false));
 #endif
-
-            return GetLogger(frame.GetMethod().DeclaringType.FullName);
-#endif
+            return GetLogger(className);
         }
 
         /// <summary>
@@ -482,16 +479,13 @@ namespace NLog
         public T GetCurrentClassLogger<T>() where T : Logger
         {
 #if NETSTANDARD1_0
-            return (T)this.GetLogger(StackTraceUsageUtils.GetClassFullName(), typeof(T));
+            var className = StackTraceUsageUtils.GetClassFullName();
+#elif SILVERLIGHT
+            var className = StackTraceUsageUtils.GetClassFullName(new StackFrame(1));
 #else
-#if SILVERLIGHT
-            var frame = new StackFrame(1);
-#else
-            var frame = new StackFrame(1, false);
+            var className = StackTraceUsageUtils.GetClassFullName(new StackFrame(1, false));
 #endif
-
-            return (T)GetLogger(frame.GetMethod().DeclaringType.FullName, typeof(T));
-#endif
+            return (T)GetLogger(className, typeof(T));
         }
 
         /// <summary>
@@ -505,16 +499,13 @@ namespace NLog
         public Logger GetCurrentClassLogger(Type loggerType)
         {
 #if NETSTANDARD1_0
-            return this.GetLogger(StackTraceUsageUtils.GetClassFullName(), loggerType);
+            var className = StackTraceUsageUtils.GetClassFullName();
+#elif SILVERLIGHT
+            var className = StackTraceUsageUtils.GetClassFullName(new StackFrame(1));
 #else
-#if SILVERLIGHT
-            var frame = new StackFrame(1);
-#else
-            var frame = new StackFrame(1, false);
+            var className = StackTraceUsageUtils.GetClassFullName(new StackFrame(1, false));
 #endif
-
-            return GetLogger(frame.GetMethod().DeclaringType.FullName, loggerType);
-#endif
+            return GetLogger(className, loggerType);
         }
 
         /// <summary>

--- a/src/NLog/NLogTraceListener.cs
+++ b/src/NLog/NLogTraceListener.cs
@@ -48,7 +48,6 @@ namespace NLog
     /// </summary>
     public class NLogTraceListener : TraceListener
     {
-        private static readonly Assembly systemAssembly = typeof(Trace).Assembly;
         private LogFactory _logFactory;
         private LogLevel _defaultLogLevel = LogLevel.Debug;
         private bool _attributesLoaded;
@@ -391,35 +390,14 @@ namespace NLog
             if (AutoLoggerName)
             {
                 stackTrace = new StackTrace();
-                MethodBase userMethod = null;
-
                 for (int i = 0; i < stackTrace.FrameCount; ++i)
                 {
                     var frame = stackTrace.GetFrame(i);
-                    var method = frame.GetMethod();
-
-                    if (method.DeclaringType == GetType())
+                    loggerName = Internal.StackTraceUsageUtils.LookupClassNameFromStackFrame(frame);
+                    if (!string.IsNullOrEmpty(loggerName))
                     {
-                        // skip all methods of this type
-                        continue;
-                    }
-
-                    if (method.DeclaringType != null && method.DeclaringType.Assembly == systemAssembly)
-                    {
-                        // skip all methods from System.dll
-                        continue;
-                    }
-
-                    userFrameIndex = i;
-                    userMethod = method;
-                    break;
-                }
-
-                if (userFrameIndex >= 0)
-                {
-                    if (userMethod != null && userMethod.DeclaringType != null)
-                    {
-                        loggerName = userMethod.DeclaringType.FullName;
+                        userFrameIndex = i;
+                        break;
                     }
                 }
             }

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -846,7 +846,7 @@ namespace NLog.UnitTests.LayoutRenderers
             var logEvent = new LogEventInfo(LogLevel.Error, "logger1", "message1");
 #if !NETSTANDARD1_5
             Type loggerType = typeof(Logger);
-            var stacktrace = StackTraceUsageUtils.GetWriteStackTrace(loggerType);
+            var stacktrace = new System.Diagnostics.StackTrace();
             var stackFrames = stacktrace.GetFrames();
             var index = LoggerImpl.FindCallingMethodOnStackTrace(stackFrames, loggerType) ?? 0;
             int? indexLegacy = LoggerImpl.SkipToUserStackFrameLegacy(stackFrames, index);
@@ -1105,7 +1105,7 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             var logEvent = new LogEventInfo(LogLevel.Error, "logger1", "message1");
             Type loggerType = typeof(Logger);
-            var stacktrace = StackTraceUsageUtils.GetWriteStackTrace(loggerType);
+            var stacktrace = new System.Diagnostics.StackTrace();
             var stackFrames = stacktrace.GetFrames();
             var index = LoggerImpl.FindCallingMethodOnStackTrace(stackFrames, loggerType) ?? 0;
             int? indexLegacy = LoggerImpl.SkipToUserStackFrameLegacy(stackFrames, index);


### PR DESCRIPTION
Throws PlatformNotSupportedException when Net Native. Resolves #2632

https://github.com/dotnet/corert/blob/master/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ThunkedApis.cs#L63

And also fixed an issue with GetCurrentClassLogger that returned wrong classname. And also fixed an issue with callsite that threw NullReferenceExceptions. Happy days with Net Native.