### PR TITLE
FallbackGroupTarget: handle async state on fallback correctly

### DIFF
--- a/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
@@ -33,9 +33,8 @@
 
 namespace NLog.Targets.Wrappers
 {
-    using System;
+    using System.Threading;
     using NLog.Common;
-    using NLog.Internal;
 
     /// <summary>
     /// Provides fallback-on-error.
@@ -58,8 +57,7 @@ namespace NLog.Targets.Wrappers
     [Target("FallbackGroup", IsCompound = true)]
     public class FallbackGroupTarget : CompoundTargetBase
     {
-        private int _currentTarget;
-        private readonly object _lockObject = new object();
+        private long _currentTarget;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FallbackGroupTarget"/> class.
@@ -97,6 +95,15 @@ namespace NLog.Targets.Wrappers
         public bool ReturnToFirstOnSuccess { get; set; }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="logEvent"></param>
+        protected override void WriteAsyncThreadSafe(AsyncLogEventInfo logEvent)
+        {
+            Write(logEvent);
+        }
+
+        /// <summary>
         /// Forwards the log event to the sub-targets until one of them succeeds.
         /// </summary>
         /// <param name="logEvent">The log event.</param>
@@ -118,15 +125,16 @@ namespace NLog.Targets.Wrappers
                     if (ex == null)
                     {
                         // success
-                        lock (_lockObject)
+                        if (ReturnToFirstOnSuccess)
                         {
-                            if (_currentTarget != 0)
+#if !SILVERLIGHT || WINDOWS_PHONEs
+                            if (Interlocked.Read(ref _currentTarget) != 0)
+#else
+                            if (Interlocked.CompareExchange(ref _currentTarget, 0, 0) != 0)
+#endif
                             {
-                                if (ReturnToFirstOnSuccess)
-                                {
-                                    InternalLogger.Debug("Fallback: target '{0}' succeeded. Returning to the first one.", Targets[targetToInvoke]);
-                                    _currentTarget = 0;
-                                }
+                                InternalLogger.Debug("Fallback: target '{0}' succeeded. Returning to the first one.", Targets[targetToInvoke]);
+                                Interlocked.Exchange(ref _currentTarget, 0);
                             }
                         }
 
@@ -135,19 +143,19 @@ namespace NLog.Targets.Wrappers
                     }
 
                     // failure
-                    lock (_lockObject)
+                    InternalLogger.Warn(ex, "Fallback: target '{0}' failed. Proceeding to the next one.", Targets[targetToInvoke]);
+
+                    // error while writing, go to the next one
+                    tryCounter++;
+                    int nextTarget = (targetToInvoke + 1) % Targets.Count;
+                    Interlocked.CompareExchange(ref _currentTarget, nextTarget, targetToInvoke);
+                    if (tryCounter >= Targets.Count)
                     {
-                        InternalLogger.Warn(ex, "Fallback: target '{0}' failed. Proceeding to the next one.", Targets[targetToInvoke]);
-
-                        // error while writing, go to the next one
-                        _currentTarget = (targetToInvoke + 1) % Targets.Count;
-
-                        tryCounter++;
-                        targetToInvoke = _currentTarget;
-                        if (tryCounter >= Targets.Count)
-                        {
-                            targetToInvoke = -1;
-                        }
+                        targetToInvoke = -1;
+                    }
+                    else
+                    {
+                        targetToInvoke = nextTarget;
                     }
 
                     if (targetToInvoke >= 0)
@@ -160,9 +168,18 @@ namespace NLog.Targets.Wrappers
                     }
                 };
 
-            lock (_lockObject)
+#if !SILVERLIGHT || WINDOWS_PHONE
+            targetToInvoke = (int)Interlocked.Read(ref _currentTarget);
+#else
+            targetToInvoke = (int)Interlocked.CompareExchange(ref _currentTarget, 0, 0);
+#endif
+
+            for (int i = 0; i < Targets.Count; ++i)
             {
-                targetToInvoke = _currentTarget;
+                if (i != targetToInvoke)
+                {
+                    Targets[i].PrecalculateVolatileLayouts(logEvent.LogEvent);
+                }
             }
 
             Targets[targetToInvoke].WriteAsyncLogEvent(logEvent.LogEvent.WithContinuation(continuation));


### PR DESCRIPTION
FallbackGroupTarget must call PrecalculateVolatileLayouts upfront to support async state.

Changed the concurrency-logic a little to reduce the congestion while waiting for PrecalculateVolatileLayouts to complete.

This will increase the overhead when using targets that depends on async state in their Layouts. Because it will allocate upfront for the fallback target even if it will not be needed.