### PR TITLE
Better Async performance with many concurrent logger threads (up to 500%+)  - Async attribute and AsyncWrapper

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
+++ b/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
@@ -35,12 +35,12 @@ namespace NLog.Targets.Wrappers
 {
     using System;
     using System.Collections.Generic;
-    using Common;
+    using NLog.Common;
 
     /// <summary>
     /// Asynchronous request queue.
     /// </summary>
-	internal class AsyncRequestQueue
+	internal class AsyncRequestQueue : IAsyncRequestQueue
     {
         private readonly Queue<AsyncLogEventInfo> _logEventInfoQueue = new Queue<AsyncLogEventInfo>();
 
@@ -79,6 +79,8 @@ namespace NLog.Targets.Wrappers
                 }
             }
         }
+
+        public bool IsEmpty => RequestCount == 0;
 
         /// <summary>
         /// Enqueues another item. If the queue is overflown the appropriate

--- a/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
+++ b/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
@@ -1,0 +1,258 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if NET4_5 || NET4_0
+
+namespace NLog.Targets.Wrappers
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Threading;
+    using NLog.Common;
+
+    /// <summary>
+    /// Concurrent Asynchronous request queue based on <see cref="ConcurrentQueue{T}"/>
+    /// </summary>
+	internal class ConcurrentRequestQueue : IAsyncRequestQueue
+    {
+        private readonly ConcurrentQueue<AsyncLogEventInfo> _logEventInfoQueue = new ConcurrentQueue<AsyncLogEventInfo>();
+
+        /// <summary>
+        /// Initializes a new instance of the AsyncRequestQueue class.
+        /// </summary>
+        /// <param name="requestLimit">Request limit.</param>
+        /// <param name="overflowAction">The overflow action.</param>
+        public ConcurrentRequestQueue(int requestLimit, AsyncTargetWrapperOverflowAction overflowAction)
+        {
+            RequestLimit = requestLimit;
+            OnOverflow = overflowAction;
+        }
+
+        /// <summary>
+        /// Gets or sets the request limit.
+        /// </summary>
+        public int RequestLimit { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action to be taken when there's no more room in
+        /// the queue and another request is enqueued.
+        /// </summary>
+        public AsyncTargetWrapperOverflowAction OnOverflow { get; set; }
+
+        public bool IsEmpty => _logEventInfoQueue.IsEmpty && Interlocked.Read(ref _count) == 0;
+
+        /// <summary>
+        /// Gets the number of requests currently in the queue.
+        /// </summary>
+        /// <remarks>
+        /// Only for debugging purposes
+        /// </remarks>
+        public int Count => (int)_count;
+        private long _count;
+
+        /// <summary>
+        /// Enqueues another item. If the queue is overflown the appropriate
+        /// action is taken as specified by <see cref="OnOverflow"/>.
+        /// </summary>
+        /// <param name="logEventInfo">The log event info.</param>
+        /// <returns>Queue was empty before enqueue</returns>
+        public bool Enqueue(AsyncLogEventInfo logEventInfo)
+        {
+            long currentCount = Interlocked.Increment(ref _count);
+            if (currentCount > RequestLimit)
+            {
+                InternalLogger.Debug("Async queue is full");
+                switch (OnOverflow)
+                {
+                    case AsyncTargetWrapperOverflowAction.Discard:
+                        {
+                            do
+                            {
+                                if (_logEventInfoQueue.TryDequeue(out var _))
+                                {
+                                    InternalLogger.Debug("Discarding one element from queue");
+                                    currentCount = Interlocked.Decrement(ref _count);
+                                    break;
+                                }
+                                currentCount = Interlocked.Read(ref _count);
+                            } while (currentCount > RequestLimit);
+                        }
+                        break;
+                    case AsyncTargetWrapperOverflowAction.Block:
+                        {
+                            currentCount = WaitForBelowRequestLimit();
+                        }
+                        break;
+                }
+            }
+            _logEventInfoQueue.Enqueue(logEventInfo);
+            return currentCount == 1;
+        }
+
+        private long WaitForBelowRequestLimit()
+        {
+            long currentCount = 0;
+            bool lockTaken = false;
+            try
+            {
+                // Attempt to yield using SpinWait
+                bool firstYield = true;
+                SpinWait spinWait = new SpinWait();
+                for (int i = 0; i <= 20; ++i)
+                {
+                    if (spinWait.NextSpinWillYield)
+                    {
+                        if (firstYield)
+                            InternalLogger.Debug("Yielding because the overflow action is Block...");
+                        firstYield = false;
+                    }
+
+                    spinWait.SpinOnce();
+                    currentCount = Interlocked.Read(ref _count);
+                    if (currentCount <= RequestLimit)
+                        break;
+                }
+
+                // If yield did not help, then wait on a lock
+                while (currentCount > RequestLimit)
+                {
+                    if (!lockTaken)
+                    {
+                        InternalLogger.Debug("Blocking because the overflow action is Block...");
+                        Monitor.Enter(this);
+                        lockTaken = true;
+                        InternalLogger.Trace("Entered critical section.");
+                    }
+                    else
+                    {
+                        InternalLogger.Debug("Blocking because the overflow action is Block...");
+                        if (!Monitor.Wait(this, 100))
+                            lockTaken = false;
+                        else
+                            InternalLogger.Trace("Entered critical section.");
+                    }
+                    currentCount = Interlocked.Read(ref _count);
+                }
+
+                if (lockTaken)
+                {
+                    Monitor.PulseAll(this);
+                }
+            }
+            finally
+            {
+                if (lockTaken)
+                    Monitor.Exit(this);
+            }
+
+            return currentCount;
+        }
+
+        /// <summary>
+        /// Dequeues a maximum of <c>count</c> items from the queue
+        /// and adds returns the list containing them.
+        /// </summary>
+        /// <param name="count">Maximum number of items to be dequeued (-1 means everything).</param>
+        /// <returns>The array of log events.</returns>
+        public AsyncLogEventInfo[] DequeueBatch(int count)
+        {
+            if (_logEventInfoQueue.IsEmpty)
+                return Internal.ArrayHelper.Empty<AsyncLogEventInfo>();
+
+            if (_count < count)
+                count = Math.Min(count, Count);
+
+            var resultEvents = new List<AsyncLogEventInfo>(count);
+
+            DequeueBatch(count, resultEvents);
+
+            if (resultEvents.Count == 0)
+                return Internal.ArrayHelper.Empty<AsyncLogEventInfo>();
+            else
+                return resultEvents.ToArray();
+        }
+
+        /// <summary>
+        /// Dequeues into a preallocated array, instead of allocating a new one
+        /// </summary>
+        /// <param name="count">Maximum number of items to be dequeued</param>
+        /// <param name="result">Preallocated list</param>
+        public void DequeueBatch(int count, IList<AsyncLogEventInfo> result)
+        {
+            bool dequeueBatch = OnOverflow == AsyncTargetWrapperOverflowAction.Block;
+
+            for (int i = 0; i < count; ++i)
+            {
+                if (_logEventInfoQueue.TryDequeue(out var item))
+                {
+                    if (!dequeueBatch)
+                        Interlocked.Decrement(ref _count);
+                    result.Add(item);
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (dequeueBatch)
+            {
+                bool lockTaken = Monitor.TryEnter(this);    // Try to throttle
+                try
+                {
+                    for (int i = 0; i < result.Count; ++i)
+                        Interlocked.Decrement(ref _count);
+                    if (lockTaken)
+                        Monitor.PulseAll(this);
+                }
+                finally
+                {
+                    if (lockTaken)
+                        Monitor.Exit(this);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears the queue.
+        /// </summary>
+        public void Clear()
+        {
+            while (!_logEventInfoQueue.IsEmpty)
+                _logEventInfoQueue.TryDequeue(out var _);
+            Interlocked.Exchange(ref _count, 0);
+        }
+    }
+}
+#endif

--- a/src/NLog/Targets/Wrappers/IAsyncRequestQueue.cs
+++ b/src/NLog/Targets/Wrappers/IAsyncRequestQueue.cs
@@ -1,0 +1,50 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Targets.Wrappers
+{
+    using System.Collections.Generic;
+    using NLog.Common;
+
+    internal interface IAsyncRequestQueue
+    {
+        bool IsEmpty { get; }
+        int RequestLimit { get; set; }
+        AsyncTargetWrapperOverflowAction OnOverflow { get; set; }
+
+        bool Enqueue(AsyncLogEventInfo logEventInfo);
+        AsyncLogEventInfo[] DequeueBatch(int count);
+        void DequeueBatch(int count, IList<AsyncLogEventInfo> result);
+        void Clear();
+    }
+}

--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
@@ -69,11 +69,22 @@ namespace NLog.UnitTests.Targets.Wrappers
             Assert.Equal(200, targetWrapper.BatchSize);
         }
 
+        [Fact]
+        public void AsyncTargetWrapperSyncTest_WithLock_WhenTimeToSleepBetweenBatchesIsEqualToZero()
+        {
+            AsyncTargetWrapperSyncTest_WhenTimeToSleepBetweenBatchesIsEqualToZero(true);
+        }
+
+        [Fact]
+        public void AsyncTargetWrapperSyncTest_NoLock_WhenTimeToSleepBetweenBatchesIsEqualToZero()
+        {
+            AsyncTargetWrapperSyncTest_WhenTimeToSleepBetweenBatchesIsEqualToZero(false);
+        }
+
         /// <summary>
         /// Test Fix for https://github.com/NLog/NLog/issues/1069
         /// </summary>
-        [Fact]
-        public void AsyncTargetWrapperSyncTest_WhenTimeToSleepBetweenBatchesIsEqualToZero()
+        private void AsyncTargetWrapperSyncTest_WhenTimeToSleepBetweenBatchesIsEqualToZero(bool forceLockingQueue)
         {
             LogManager.ThrowConfigExceptions = true;
 
@@ -81,8 +92,12 @@ namespace NLog.UnitTests.Targets.Wrappers
             var targetWrapper = new AsyncTargetWrapper() {
                 WrappedTarget = myTarget,
                 TimeToSleepBetweenBatches = 0,
-                BatchSize = 4,
-                QueueLimit = 2, // Will make it "sleep" between every second write
+#if NET4_5
+                ForceLockingQueue = forceLockingQueue,
+                OptimizeBufferReuse = !forceLockingQueue,
+#endif
+                BatchSize = 3,
+                QueueLimit = 5, // Will make it "sleep" between every second write
                 OverflowAction = AsyncTargetWrapperOverflowAction.Block
             };
             targetWrapper.Initialize(null);


### PR DESCRIPTION
ConcurrentQueue works very well in NetCore2. But not sure when the improvements will get to NetFramework.

When 8 threads are attacking the same async-wrapper, then the ConcurrentRequestQueue performs twice as fast on NetCore2.