### PR TITLE
${AppSetting} for .NET standard 2 (NLog.Extended)

### DIFF
--- a/src/NLog.Extended/LayoutRenderers/AppSettingLayoutRenderer.cs
+++ b/src/NLog.Extended/LayoutRenderers/AppSettingLayoutRenderer.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+
+
 #if !SILVERLIGHT
 
 namespace NLog.LayoutRenderers
@@ -38,6 +40,10 @@ namespace NLog.LayoutRenderers
 	using System.Text;
 	using Config;
 	using Internal;
+
+#if NETSTANDARD2_0
+	using System.Configuration;
+#endif
 
 	/// <summary>
 	/// Application setting.
@@ -52,7 +58,17 @@ namespace NLog.LayoutRenderers
 	[LayoutRenderer("appsetting")]
 	public class AppSettingLayoutRenderer : LayoutRenderer
 	{
+        #if !NETSTANDARD2_0
+
 		private IConfigurationManager configurationManager = new ConfigurationManager();
+
+	    internal IConfigurationManager ConfigurationManager
+	    {
+	        get => configurationManager;
+	        set => configurationManager = value;
+	    }
+
+        #endif
 
 		///<summary>
 		/// The AppSetting name.
@@ -65,13 +81,7 @@ namespace NLog.LayoutRenderers
 		/// The default value to render if the AppSetting value is null.
 		///</summary>
 		public string Default { get; set; }
-
-		internal IConfigurationManager ConfigurationManager
-		{
-			get => configurationManager;
-		    set => configurationManager = value;
-		}
-
+        
 		/// <summary>
 		/// Renders the specified application setting or default value and appends it to the specified <see cref="StringBuilder" />.
 		/// </summary>

--- a/src/NLog.Extended/NLog.Extended.csproj
+++ b/src/NLog.Extended/NLog.Extended.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net45;net40-client;net35</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net45;net40-client;net35;netstandard2.0</TargetFrameworks>
 
     <Title>NLog for Extended Profile</Title>
     <Company>NLog</Company>
@@ -59,11 +59,21 @@
     <DefineConstants>$(DefineConstants);NET3_5</DefineConstants>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
+    
+    
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <Title>NLog for NetStandard 2.0 Extended Profile</Title>
+        <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD2_0</DefineConstants>
+    </PropertyGroup>
 
   <PropertyGroup Condition=" '$(monobuild)' != '' ">
     <Title>$(Title) - Mono</Title>
     <DefineConstants>$(DefineConstants)MONO</DefineConstants>
   </PropertyGroup>
+    
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\NLog\NLog.csproj" />

--- a/src/NLog.Extended/Targets/MessageQueueTarget.cs
+++ b/src/NLog.Extended/Targets/MessageQueueTarget.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD2_0
 
 namespace NLog.Targets
 {


### PR DESCRIPTION
In NLog.Extended

using https://www.nuget.org/packages/System.Configuration.ConfigurationManager/

- [ ] adapt current unit tests (if there are)
- [ ] move `IConfigurationManager` and `ConfigurationManager` from NLog to NLog.Extended