### PR TITLE
XmlLayout - Render LogEventInfo.Properties as XML 

### DIFF
--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -339,26 +339,15 @@ namespace NLog.Internal
             }
         }
 
-        internal static void TrimRight(this StringBuilder sb)
+        public static void TrimRight(this StringBuilder sb, int startPos = 0)
         {
             int i = sb.Length - 1;
-            for (; i >= 0; i--)
+            for (; i >= startPos; i--)
                 if (!char.IsWhiteSpace(sb[i]))
                     break;
 
             if (i < sb.Length - 1)
                 sb.Length = i + 1;
-        }
-
-        internal static void TrimLeft(this StringBuilder sb)
-        {
-            int i = 0;
-            for (; i < sb.Length; i++)
-                if (!char.IsWhiteSpace(sb[i]))
-                    break;
-
-            if (i > 0)
-                sb.Remove(0, i);
         }
     }
 }

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -338,5 +338,27 @@ namespace NLog.Internal
                     break;
             }
         }
+
+        internal static void TrimRight(this StringBuilder sb)
+        {
+            int i = sb.Length - 1;
+            for (; i >= 0; i--)
+                if (!char.IsWhiteSpace(sb[i]))
+                    break;
+
+            if (i < sb.Length - 1)
+                sb.Length = i + 1;
+        }
+
+        internal static void TrimLeft(this StringBuilder sb)
+        {
+            int i = 0;
+            for (; i < sb.Length; i++)
+                if (!char.IsWhiteSpace(sb[i]))
+                    break;
+
+            if (i > 0)
+                sb.Remove(0, i);
+        }
     }
 }

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -314,24 +314,24 @@ namespace NLog.Internal
                 case TypeCode.Int16: sb.AppendInvariant((short)value); break;
                 case TypeCode.Int32: sb.AppendInvariant((int)value); break;
                 case TypeCode.Int64:
-                {
-                    long int64 = (long)value;
-                    if (int64 < int.MaxValue && int64 > int.MinValue)
-                        sb.AppendInvariant((int)int64);
-                    else
-                        sb.Append(int64);
-                }
+                    {
+                        long int64 = (long)value;
+                        if (int64 < int.MaxValue && int64 > int.MinValue)
+                            sb.AppendInvariant((int)int64);
+                        else
+                            sb.Append(int64);
+                    }
                     break;
                 case TypeCode.UInt16: sb.AppendInvariant((ushort)value); break;
                 case TypeCode.UInt32: sb.AppendInvariant((uint)value); break;
                 case TypeCode.UInt64:
-                {
-                    ulong uint64 = (ulong)value;
-                    if (uint64 < uint.MaxValue)
-                        sb.AppendInvariant((uint)uint64);
-                    else
-                        sb.Append(uint64);
-                }
+                    {
+                        ulong uint64 = (ulong)value;
+                        if (uint64 < uint.MaxValue)
+                            sb.AppendInvariant((uint)uint64);
+                        else
+                            sb.Append(uint64);
+                    }
                     break;
                 default:
                     sb.Append(XmlHelper.XmlConvertToString(value, objTypeCode));

--- a/src/NLog/Internal/XmlHelper.cs
+++ b/src/NLog/Internal/XmlHelper.cs
@@ -283,7 +283,7 @@ namespace NLog.Internal
         /// </summary>
         /// <param name="value">Object value</param>
         /// <param name="objTypeCode">Object TypeCode</param>
-        /// <param name="safeConversion">Object TypeCode</param>
+        /// <param name="safeConversion">Check and remove unusual unicode characters from the result string.</param>
         /// <returns>Object value converted to string</returns>
         internal static string XmlConvertToString(object value, TypeCode objTypeCode, bool safeConversion = false)
         {

--- a/src/NLog/Internal/XmlHelper.cs
+++ b/src/NLog/Internal/XmlHelper.cs
@@ -37,6 +37,7 @@ namespace NLog.Internal
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Xml;
+    using NLog.Internal;
 
     /// <summary>
     ///  Helper class for XML

--- a/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
@@ -82,7 +82,7 @@ namespace NLog.LayoutRenderers.Wrappers
 
         private static void TransformTrimWhiteSpaces(StringBuilder builder, int startPos)
         {
-            TrimRight(builder, startPos);  // Fast
+            builder.TrimRight(startPos);  // Fast
             if (builder.Length > startPos)
             {
                 if (char.IsWhiteSpace(builder[startPos]))
@@ -92,17 +92,6 @@ namespace NLog.LayoutRenderers.Wrappers
                     builder.Append(str.Trim());
                 }
             }
-        }
-
-        private static void TrimRight(StringBuilder sb, int startPos)
-        {
-            int i = sb.Length - 1;
-            for (; i >= startPos; i--)
-                if (!char.IsWhiteSpace(sb[i]))
-                    break;
-
-            if (i < sb.Length - 1)
-                sb.Length = i + 1;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
@@ -37,6 +37,7 @@ namespace NLog.LayoutRenderers.Wrappers
     using System.ComponentModel;
     using System.Text;
     using NLog.Config;
+    using NLog.Internal;
 
     /// <summary>
     /// Trims the whitespace from the result of another layout renderer.

--- a/src/NLog/LayoutRenderers/Wrappers/XmlEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/XmlEncodeLayoutRendererWrapper.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AmbientProperty("XmlEncode")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public sealed class XmlEncodeLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    public sealed class XmlEncodeLayoutRendererWrapper : WrapperLayoutRendererBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="XmlEncodeLayoutRendererWrapper" /> class.
@@ -83,9 +83,13 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        protected override string Transform(string text)
         {
+            if (XmlEncode)
+            {
+                return XmlHelper.EscapeXmlString(text, XmlEncodeNewlines);
+            }
+            return text;
         }
 
         private bool RequiresXmlEncode(StringBuilder target, int startPos = 0)

--- a/src/NLog/LayoutRenderers/Wrappers/XmlEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/XmlEncodeLayoutRendererWrapper.cs
@@ -86,24 +86,20 @@ namespace NLog.LayoutRenderers.Wrappers
                     case '&':
                     case '\'':
                     case '"':
-                        {
-                            string escapeString = target.ToString();
-                            target.Length = 0;
-                            XmlHelper.EscapeXmlString(escapeString, XmlEncodeNewlines, target);
-                            return;
-                        }
+                        break;
                     case '\r':
                     case '\n':
-                        {
-                            if (XmlEncodeNewlines)
-                            {
-                                string escapeString = target.ToString();
-                                target.Length = 0;
-                                XmlHelper.EscapeXmlString(escapeString, true, target);
-                                return;
-                            }
-                        } break;
+                        if (XmlEncodeNewlines)
+                            break;
+                        continue;
+                    default:
+                        continue;
                 }
+
+                string escapeString = target.ToString();
+                target.Length = 0;
+                XmlHelper.EscapeXmlString(escapeString, XmlEncodeNewlines, target);
+                return;
             }
         }
     }

--- a/src/NLog/LayoutRenderers/Wrappers/XmlEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/XmlEncodeLayoutRendererWrapper.cs
@@ -58,6 +58,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <summary>
         /// Gets or sets a value indicating whether to apply XML encoding.
         /// </summary>
+        /// <remarks>Ensures always valid XML, but gives a performance hit</remarks>
         /// <docgen category="Transformation Options" order="10"/>
         [DefaultValue(true)]
         public bool XmlEncode { get; set; }
@@ -67,6 +68,23 @@ namespace NLog.LayoutRenderers.Wrappers
         /// </summary>
         [DefaultValue(false)]
         public bool XmlEncodeNewlines { get; set; }
+
+        /// <summary>
+        /// Render to local target using Inner Layout, and then transform before final append
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="logEvent"></param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            if (XmlEncode)
+            {
+                base.Append(builder, logEvent);
+            }
+            else
+            {
+                RenderFormattedMessage(logEvent, builder);
+            }
+        }
 
         /// <summary>
         /// Post-processes the rendered message. 

--- a/src/NLog/Layouts/XmlAttribute.cs
+++ b/src/NLog/Layouts/XmlAttribute.cs
@@ -1,0 +1,111 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Layouts
+{
+    using NLog.Config;
+    using NLog.Internal;
+
+    /// <summary>
+    /// JSON attribute.
+    /// </summary>
+    [NLogConfigurationItem]
+    [ThreadAgnostic]
+    [ThreadSafe]
+    public class XmlAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmlAttribute" /> class.
+        /// </summary>
+        public XmlAttribute() : this(null, null, true) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmlAttribute" /> class.
+        /// </summary>
+        /// <param name="name">The name of the attribute.</param>
+        /// <param name="layout">The layout of the attribute's value.</param>
+        public XmlAttribute(string name, Layout layout) : this(name, layout, true) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmlAttribute" /> class.
+        /// </summary>
+        /// <param name="name">The name of the attribute.</param>
+        /// <param name="layout">The layout of the attribute's value.</param>
+        /// <param name="encode">Encode value with json-encode</param>
+        public XmlAttribute(string name, Layout layout, bool encode)
+        {
+            Name = name;
+            Layout = layout;
+            Encode = encode;
+            IncludeEmptyValue = false;
+            LayoutWrapper.XmlEncodeNewlines = true;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the attribute.
+        /// </summary>
+        /// <docgen category='XML Attribute Options' order='10' />
+        [RequiredParameter]
+        public string Name { get => _name; set => _name = XmlHelper.XmlConvertToElementName(value?.Trim(), true); }
+        private string _name;
+
+        /// <summary>
+        /// Gets or sets the layout that will be rendered as the attribute's value.
+        /// </summary>
+        /// <docgen category='XML Attribute Options' order='10' />
+        [RequiredParameter]
+        public Layout Layout
+        {
+            get => LayoutWrapper.Inner;
+            set => LayoutWrapper.Inner = value;
+        }
+
+        /// <summary>
+        /// Determines wether or not this attribute will be Json encoded.
+        /// </summary>
+        /// <docgen category='XML Attribute Options' order='100' />
+        public bool Encode
+        {
+            get => LayoutWrapper.XmlEncode;
+            set => LayoutWrapper.XmlEncode = value;
+        }
+
+        /// <summary>
+        /// Gets or sets whether an attribute with empty value should be included in the output
+        /// </summary>
+        /// <docgen category='XML Attribute Options' order='100' />
+        public bool IncludeEmptyValue { get; set; }
+
+        internal readonly LayoutRenderers.Wrappers.XmlEncodeLayoutRendererWrapper LayoutWrapper = new LayoutRenderers.Wrappers.XmlEncodeLayoutRendererWrapper();
+    }
+}

--- a/src/NLog/Layouts/XmlAttribute.cs
+++ b/src/NLog/Layouts/XmlAttribute.cs
@@ -37,7 +37,7 @@ namespace NLog.Layouts
     using NLog.Internal;
 
     /// <summary>
-    /// JSON attribute.
+    /// XML attribute.
     /// </summary>
     [NLogConfigurationItem]
     [ThreadAgnostic]
@@ -61,7 +61,7 @@ namespace NLog.Layouts
         /// </summary>
         /// <param name="name">The name of the attribute.</param>
         /// <param name="layout">The layout of the attribute's value.</param>
-        /// <param name="encode">Encode value with json-encode</param>
+        /// <param name="encode">Encode value with xml-encode</param>
         public XmlAttribute(string name, Layout layout, bool encode)
         {
             Name = name;
@@ -91,7 +91,7 @@ namespace NLog.Layouts
         }
 
         /// <summary>
-        /// Determines wether or not this attribute will be Json encoded.
+        /// Determines wether or not this attribute will be Xml encoded.
         /// </summary>
         /// <docgen category='XML Attribute Options' order='100' />
         public bool Encode

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -102,6 +102,7 @@ namespace NLog.Layouts
         /// Auto indent and create new lines
         /// </summary>
         /// <docgen category='XML Options' order='10' />
+        [DefaultValue(false)]
         public bool IndentXml { get; set; }
 
         /// <summary>
@@ -122,12 +123,14 @@ namespace NLog.Layouts
         /// Gets or sets whether a ElementValue with empty value should be included in the output
         /// </summary>
         /// <docgen category='XML Options' order='10' />
+        [DefaultValue(false)]
         public bool IncludeEmptyValue { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsContext"/> dictionary.
         /// </summary>
         /// <docgen category='LogEvent Properties XML Options' order='10' />
+        [DefaultValue(false)]
         public bool IncludeMdc { get; set; }
 
 #if !SILVERLIGHT
@@ -135,6 +138,7 @@ namespace NLog.Layouts
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
         /// <docgen category='LogEvent Properties XML Options' order='10' />
+        [DefaultValue(false)]
         public bool IncludeMdlc { get; set; }
 #endif
 
@@ -142,6 +146,7 @@ namespace NLog.Layouts
         /// Gets or sets the option to include all properties from the log event (as XML)
         /// </summary>
         /// <docgen category='LogEvent Properties XML Options' order='10' />
+        [DefaultValue(false)]
         public bool IncludeAllProperties { get; set; }
 
         /// <summary>
@@ -307,8 +312,6 @@ namespace NLog.Layouts
                     else
                     {
                         sb.Append('>');
-                        if (IndentXml)
-                            sb.AppendLine();
                     }
                 }
 
@@ -317,7 +320,7 @@ namespace NLog.Layouts
                     int beforeElementLength = sb.Length;
                     if (sb.Length == orgLength)
                     {
-                        BeginXmlDocument(sb, ElementName);
+                        RenderStartElement(sb, ElementName);
                     }
                     int beforeValueLength = sb.Length;
                     ElementValue.RenderAppendBuilder(logEvent, sb);
@@ -326,6 +329,9 @@ namespace NLog.Layouts
                         sb.Length = beforeElementLength;
                     }
                 }
+
+                if (IndentXml && sb.Length != orgLength)
+                    sb.AppendLine();
             }
 
             //Memory profiling pointed out that using a foreach-loop was allocating

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -496,9 +496,9 @@ namespace NLog.Layouts
             return true;
         }
 
-        private bool RenderAppendXmlAttributeValue(XmlAttribute attrib, LogEventInfo logEvent, StringBuilder sb, bool beginXmlDocument)
+        private bool RenderAppendXmlAttributeValue(XmlAttribute attributes, LogEventInfo logEvent, StringBuilder sb, bool beginXmlDocument)
         {
-            string xmlKeyString = attrib.Name;
+            string xmlKeyString = attributes.Name;
             if (string.IsNullOrEmpty(xmlKeyString))
                 return false;
 
@@ -513,8 +513,8 @@ namespace NLog.Layouts
             sb.Append("=\"");
 
             int beforeValueLength = sb.Length;
-            attrib.LayoutWrapper.RenderAppendBuilder(logEvent, sb);
-            if (sb.Length == beforeValueLength && !attrib.IncludeEmptyValue)
+            attributes.LayoutWrapper.RenderAppendBuilder(logEvent, sb);
+            if (sb.Length == beforeValueLength && !attributes.IncludeEmptyValue)
                 return false;
 
             sb.Append('\"');
@@ -543,7 +543,7 @@ namespace NLog.Layouts
             if (Elements.Count > 0)
                 return ToStringWithNestedItems(Elements, l => l.ToString());
             else if (Attributes.Count > 0)
-                return ToStringWithNestedItems(Attributes, a => "Attrib:" + a.Name);
+                return ToStringWithNestedItems(Attributes, a => "Attributes:" + a.Name);
             else if (ElementName != null)
                 return ToStringWithNestedItems(new[] { this }, n => "Element:" + n.ElementName);
             else

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -155,23 +155,27 @@ namespace NLog.Layouts
         private bool _propertiesElementNameHasFormat;
 
         /// <summary>
-        /// XML attribute format to use when rendering property-key
+        /// XML attribute name to use when rendering property-key
         /// </summary>
         /// <remarks>
-        /// Replaces newlines with &#13;&#10;
+        /// Attribute not included when assigned null or empty string
+        /// 
+        /// Will replace newlines in attribute-value with &#13;&#10;
         /// </remarks>
         /// <docgen category='LogEvent Properties XML Options' order='10' />
         public string PropertiesElementKeyAttribute { get; set; } = "key";
 
         /// <summary>
-        /// XML attribute format to use when rendering property-value
+        /// XML attribute name to use when rendering property-value
         /// 
         /// When null (or empty) then value is formatted as XML-element-value
         /// </summary>
         /// <remarks>
-        /// Replaces newlines with &#13;&#10;
+        /// Attribute not included when assigned null or empty string
         /// 
         /// Skips closing element tag when using attribute for value
+        ///
+        /// Will replace newlines in attribute-value with &#13;&#10;
         /// </remarks>
         /// <docgen category='LogEvent Properties XML Options' order='10' />
         public string PropertiesElementValueAttribute { get; set; }

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -86,6 +86,13 @@ namespace NLog.Layouts
         private readonly LayoutRenderers.Wrappers.XmlEncodeLayoutRendererWrapper _elementValueWrapper = new LayoutRenderers.Wrappers.XmlEncodeLayoutRendererWrapper();
 
         /// <summary>
+        /// Xml Encode the value for the top level XML element
+        /// </summary>
+        /// <remarks>Ensures always valid XML, but gives a performance hit</remarks>
+        [DefaultValue(true)]
+        public bool ElementEncode { get => _elementValueWrapper.XmlEncode; set => _elementValueWrapper.XmlEncode = value; }
+
+        /// <summary>
         /// Auto indent and create new lines
         /// </summary>
         /// <docgen category='XML Options' order='10' />

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -432,7 +432,6 @@ namespace NLog.Layouts
 
             if (RenderAttribute(sb, PropertiesElementValueAttribute, xmlValueString))
             {
-
                 sb.Append("/>");
             }
             else
@@ -440,10 +439,8 @@ namespace NLog.Layouts
                 sb.Append('>');
                 XmlHelper.EscapeXmlString(xmlValueString, false, sb);
                 sb.Append("</");
-                if (_propertiesElementNameHasFormat)
-                    sb.AppendFormat(PropertiesElementName, propNameElement);
-                else
-                    sb.AppendFormat(PropertiesElementName, PropertiesElementName);
+                var value = _propertiesElementNameHasFormat ? propNameElement : PropertiesElementName;
+                sb.AppendFormat(PropertiesElementName, value);
                 sb.Append('>');
             }
             if (IndentXml)

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -156,10 +156,10 @@ namespace NLog.Layouts
 
         /// <summary>
         /// XML attribute name to use when rendering property-key
+        ///
+        /// When null (or empty) then key-attribute is not included
         /// </summary>
         /// <remarks>
-        /// Attribute not included when assigned null or empty string
-        /// 
         /// Will replace newlines in attribute-value with &#13;&#10;
         /// </remarks>
         /// <docgen category='LogEvent Properties XML Options' order='10' />
@@ -168,11 +168,10 @@ namespace NLog.Layouts
         /// <summary>
         /// XML attribute name to use when rendering property-value
         /// 
-        /// When null (or empty) then value is formatted as XML-element-value
+        /// When null (or empty) then value-attribute is not included and
+        /// value is formatted as XML-element-value
         /// </summary>
         /// <remarks>
-        /// Attribute not included when assigned null or empty string
-        /// 
         /// Skips closing element tag when using attribute for value
         ///
         /// Will replace newlines in attribute-value with &#13;&#10;
@@ -227,7 +226,7 @@ namespace NLog.Layouts
 
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
-            if (!ThreadAgnostic || MutableUnsafe) RenderAppendBuilder(logEvent, target, true);
+            PrecalculateBuilderInternal(logEvent, target);
         }
 
         /// <summary>

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -1,0 +1,443 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Layouts
+{
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Text;
+    using NLog.Config;
+    using NLog.Internal;
+
+    /// <summary>
+    /// A specialized layout that renders XML-formatted events.
+    /// </summary>
+    [Layout("XmlLayout")]
+    [ThreadAgnostic]
+    [ThreadSafe]
+    public class XmlLayout : Layout
+    {
+        /// <summary>
+        /// Name of the top level XML element
+        /// </summary>
+        /// <docgen category='XML Options' order='10' />
+        [DefaultValue("logevent")]
+        public string NodeName { get => _nodename; set => _nodename = XmlHelper.XmlConvertToElementName(value?.Trim(), true); }
+        private string _nodename;
+
+        /// <summary>
+        /// Value inside the top level XML element
+        /// </summary>
+        /// <docgen category='XML Options' order='10' />
+        public Layout NodeValue { get => NodeValueWrapper.Inner; set => NodeValueWrapper.Inner = value; }
+        internal readonly LayoutRenderers.Wrappers.XmlEncodeLayoutRendererWrapper NodeValueWrapper = new LayoutRenderers.Wrappers.XmlEncodeLayoutRendererWrapper();
+
+        /// <summary>
+        /// Auto indent and create new lines
+        /// </summary>
+        /// <docgen category='XML Options' order='10' />
+        public bool IndentXml { get; set; }
+
+        /// <summary>
+        /// Gets the array of 'nodes' configurations.
+        /// </summary>
+        /// <docgen category='XML Options' order='10' />
+        [ArrayParameter(typeof(XmlLayout), "node")]
+        public IList<XmlLayout> Nodes { get; private set; }
+
+        /// <summary>
+        /// Gets the array of 'attributes' configurations for the <see cref="NodeName"/>
+        /// </summary>
+        /// <docgen category='XML Options' order='10' />
+        [ArrayParameter(typeof(XmlAttribute), "attribute")]
+        public IList<XmlAttribute> Attributes { get; private set; }
+
+        /// <summary>
+        /// Gets or sets whether a NodeValue with empty value should be included in the output
+        /// </summary>
+        /// <docgen category='XML Options' order='10' />
+        public bool IncludeEmptyValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsContext"/> dictionary.
+        /// </summary>
+        /// <docgen category='LogEvent Properties XML Options' order='10' />
+        public bool IncludeMdc { get; set; }
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
+        /// </summary>
+        /// <docgen category='LogEvent Properties XML Options' order='10' />
+        public bool IncludeMdlc { get; set; }
+#endif
+
+        /// <summary>
+        /// Gets or sets the option to include all properties from the log event (as XML)
+        /// </summary>
+        /// <docgen category='LogEvent Properties XML Options' order='10' />
+        public bool IncludeAllProperties { get; set; }
+
+        /// <summary>
+        /// List of property names to exclude when <see cref="IncludeAllProperties"/> is true
+        /// </summary>
+        /// <docgen category='LogEvent Properties XML Options' order='10' />
+#if NET3_5
+        public HashSet<string> ExcludeProperties { get; set; }
+#else
+        public ISet<string> ExcludeProperties { get; set; }
+#endif
+
+        /// <summary>
+        /// XML tag name to use when rendering properties
+        /// </summary>
+        /// <remarks>
+        /// Support string-format where {0} means property-key-name
+        /// 
+        /// Skips closing element tag when having configured <see cref="PropertiesFormatValueAttribute"/>
+        /// </remarks>
+        /// <docgen category='LogEvent Properties XML Options' order='10' />
+        public string PropertiesFormatElementName { get; set; } = "property";
+
+        /// <summary>
+        /// XML attribute format to use when rendering property-key
+        /// </summary>
+        /// <remarks>
+        /// Support string-format where {0} means property-key-name
+        /// 
+        /// Replaces newlines with underscore (_)
+        /// </remarks>
+        /// <docgen category='LogEvent Properties XML Options' order='10' />
+        public string PropertiesFormatKeyAttribute { get; set; } = "key=\"{0}\"";
+
+        /// <summary>
+        /// XML attribute format to use when rendering property-value
+        /// 
+        /// When null (or empty) then value is formatted as XML-element-value
+        /// </summary>
+        /// <remarks>
+        /// Support string-format where {0} means property-value
+        /// 
+        /// Replaces newlines with &#13;&#10;
+        /// 
+        /// Skips closing element tag when using attribute for value
+        /// </remarks>
+        /// <docgen category='LogEvent Properties XML Options' order='10' />
+        public string PropertiesFormatValueAttribute { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmlLayout"/> class.
+        /// </summary>
+        public XmlLayout()
+            :this("logevent", null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmlLayout"/> class.
+        /// </summary>
+        /// <param name="nodeName">The name of the top XML node</param>
+        /// <param name="nodeValue">The value of the top XML node</param>
+        public XmlLayout(string nodeName, Layout nodeValue)
+        {
+            NodeName = nodeName;
+            NodeValue = nodeValue;
+            Attributes = new List<XmlAttribute>();
+            Nodes = new List<XmlLayout>();
+            ExcludeProperties = new HashSet<string>();
+        }
+
+        /// <summary>
+        /// Initializes the layout.
+        /// </summary>
+        protected override void InitializeLayout()
+        {
+            base.InitializeLayout();
+            if (IncludeMdc)
+            {
+                ThreadAgnostic = false;
+            }
+#if !SILVERLIGHT
+            if (IncludeMdlc)
+            {
+                ThreadAgnostic = false;
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Closes the layout.
+        /// </summary>
+        protected override void CloseLayout()
+        {
+            base.CloseLayout();
+        }
+
+        internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+        {
+            if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
+        }
+
+        /// <summary>
+        /// Formats the log event as a XML document for writing.
+        /// </summary>
+        /// <param name="logEvent">The logging event.</param>
+        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        {
+            int orgLength = target.Length;
+            RenderXmlFormattedMessage(logEvent, target);
+            if (target.Length == orgLength && IncludeEmptyValue && !string.IsNullOrEmpty(NodeName))
+            {
+                BeginXmlDocument(target, NodeName);
+                EndXmlDocument(target, NodeName);
+            }
+        }
+
+        /// <summary>
+        /// Formats the log event as a XML document for writing.
+        /// </summary>
+        /// <param name="logEvent">The log event to be formatted.</param>
+        /// <returns>A XML string representation of the log event.</returns>
+        protected override string GetFormattedMessage(LogEventInfo logEvent)
+        {
+            return RenderAllocateBuilder(logEvent);
+        }
+
+        private void RenderXmlFormattedMessage(LogEventInfo logEvent, StringBuilder sb)
+        {
+            int orgLength = sb.Length;
+
+            // Attributes without element-names should be added to the top XML element
+            if (!string.IsNullOrEmpty(NodeName))
+            {
+                for (int i = 0; i < Attributes.Count; i++)
+                {
+                    var attrib = Attributes[i];
+                    int beforeAttribLength = sb.Length;
+                    if (!RenderAppendXmlAttributeValue(attrib, logEvent, sb, sb.Length == orgLength))
+                    {
+                        sb.Length = beforeAttribLength;
+                    }
+                }
+                if (sb.Length != orgLength)
+                {
+                    sb.Append('>');
+                    if (IndentXml)
+                        sb.AppendLine();
+                }
+                if (NodeValue != null)
+                {
+                    int beforeNodeLength = sb.Length;
+                    if (sb.Length == orgLength)
+                    {
+                        BeginXmlDocument(sb, NodeName);
+                    }
+                    int beforeValueLength = sb.Length;
+                    NodeValue.RenderAppendBuilder(logEvent, sb);
+                    if (beforeValueLength == sb.Length && !IncludeEmptyValue)
+                    {
+                        sb.Length = beforeNodeLength;
+                    }
+                }
+            }
+
+            //Memory profiling pointed out that using a foreach-loop was allocating
+            //an Enumerator. Switching to a for-loop avoids the memory allocation.
+            for (int i = 0; i < Nodes.Count; i++)
+            {
+                var node = Nodes[i];
+                int beforeAttribLength = sb.Length;
+                if (!RenderAppendXmlNodeValue(node, logEvent, sb, sb.Length == orgLength))
+                {
+                    sb.Length = beforeAttribLength;
+                }
+            }
+
+            if (IncludeMdc)
+            {
+                foreach (string key in MappedDiagnosticsContext.GetNames())
+                {
+                    if (string.IsNullOrEmpty(key))
+                        continue;
+                    object propertyValue = MappedDiagnosticsContext.GetObject(key);
+                    AppendXmlPropertyValue(key, propertyValue, sb, sb.Length == orgLength);
+                }
+            }
+
+#if !SILVERLIGHT
+            if (IncludeMdlc)
+            {
+                foreach (string key in MappedDiagnosticsLogicalContext.GetNames())
+                {
+                    if (string.IsNullOrEmpty(key))
+                        continue;
+                    object propertyValue = MappedDiagnosticsLogicalContext.GetObject(key);
+                    AppendXmlPropertyValue(key, propertyValue, sb, sb.Length == orgLength);
+                }
+            }
+#endif
+
+            if (IncludeAllProperties && logEvent.HasProperties)
+            {
+                var propertiesList = logEvent.CreateOrUpdatePropertiesInternal(true) as IEnumerable<MessageTemplates.MessageTemplateParameter>;
+                foreach (var prop in propertiesList)
+                {
+                    if (string.IsNullOrEmpty(prop.Name))
+                        continue;
+
+                    if (ExcludeProperties.Contains(prop.Name))
+                        continue;
+
+                    AppendXmlPropertyValue(prop.Name, prop.Value, sb, sb.Length == orgLength);
+                }
+            }
+
+            if (sb.Length > orgLength && !string.IsNullOrEmpty(NodeName))
+            {
+                EndXmlDocument(sb, NodeName);
+            }
+        }
+
+        private void AppendXmlPropertyValue(string propName, object propertyValue, StringBuilder sb, bool beginXmlDocument)
+        {
+            if (string.IsNullOrEmpty(PropertiesFormatElementName))
+                return; // Not supported
+
+            string xmlKeyString = XmlHelper.XmlConvertToElementName(propName?.Trim(), false);
+            if (string.IsNullOrEmpty(xmlKeyString))
+                return;
+
+            if (beginXmlDocument && !string.IsNullOrEmpty(NodeName))
+            {
+                BeginXmlDocument(sb, NodeName);
+            }
+
+            if (IndentXml && !string.IsNullOrEmpty(NodeName))
+                sb.Append("  ");
+
+            string xmlValueString = XmlHelper.XmlConvertToStringSafe(propertyValue);
+
+            sb.Append('<');
+            sb.AppendFormat(PropertiesFormatElementName, xmlKeyString);
+            if (!string.IsNullOrEmpty(PropertiesFormatKeyAttribute))
+            {
+                sb.Append(' ');
+                sb.AppendFormat(PropertiesFormatKeyAttribute, xmlKeyString);
+            }
+
+            if (!string.IsNullOrEmpty(PropertiesFormatValueAttribute))
+            {
+                xmlValueString = XmlHelper.EscapeXmlString(xmlValueString, true);
+                sb.Append(' ');
+                sb.AppendFormat(PropertiesFormatValueAttribute, xmlValueString);
+                sb.Append(" />");
+            }
+            else
+            {
+                sb.Append('>');
+                XmlHelper.EscapeXmlString(xmlValueString, false, sb);
+                sb.Append("</");
+                sb.AppendFormat(PropertiesFormatElementName, xmlKeyString);
+                sb.Append('>');
+            }
+            if (IndentXml)
+                sb.AppendLine();
+        }
+
+        private bool RenderAppendXmlNodeValue(XmlLayout xmlNode, LogEventInfo logEvent, StringBuilder sb, bool beginXmlDocument)
+        {
+            string xmlElementName = xmlNode.NodeName;
+            if (string.IsNullOrEmpty(xmlElementName))
+                return false;
+
+            if (beginXmlDocument && !string.IsNullOrEmpty(NodeName))
+            {
+                BeginXmlDocument(sb, NodeName);
+            }
+
+            if (IndentXml && !string.IsNullOrEmpty(NodeName))
+                sb.Append("  ");
+
+            int beforeValueLength = sb.Length;
+            xmlNode.RenderAppendBuilder(logEvent, sb, false);
+            if (sb.Length == beforeValueLength && !xmlNode.IncludeEmptyValue)
+                return false;
+
+            if (IndentXml)
+                sb.AppendLine();
+            return true;
+        }
+
+        private bool RenderAppendXmlAttributeValue(XmlAttribute attrib, LogEventInfo logEvent, StringBuilder sb, bool beginXmlDocument)
+        {
+            string xmlKeyString = attrib.Name;
+            if (string.IsNullOrEmpty(xmlKeyString))
+                return false;
+
+            if (beginXmlDocument)
+            {
+                sb.Append('<');
+                sb.Append(NodeName);
+            }
+
+            sb.Append(' ');
+            sb.Append(xmlKeyString);
+            sb.Append("=\"");
+
+            int beforeValueLength = sb.Length;
+            attrib.LayoutWrapper.RenderAppendBuilder(logEvent, sb);
+            if (sb.Length == beforeValueLength && !attrib.IncludeEmptyValue)
+                return false;
+
+            sb.Append('\"');
+            return true;
+        }
+
+        private void BeginXmlDocument(StringBuilder sb, string xmlName)
+        {
+            sb.Append('<');
+            sb.Append(xmlName);
+            sb.Append('>');
+            if (IndentXml)
+                sb.AppendLine();
+        }
+
+        private void EndXmlDocument(StringBuilder sb, string xmlName)
+        {
+            sb.Append("</");
+            sb.Append(xmlName);
+            sb.Append('>');
+        }
+    }
+}

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -257,11 +257,10 @@ namespace NLog.Layouts
             RenderXmlFormattedMessage(logEvent, target);
             if (target.Length == orgLength && IncludeEmptyValue && !string.IsNullOrEmpty(ElementName))
             {
-                target.Append('<');
-                target.Append(ElementName);
-                target.Append("/>");
+                RenderSelfClosingElement(target, ElementName);
             }
         }
+
 
         /// <summary>
         /// Formats the log event as a XML document for writing.
@@ -415,23 +414,13 @@ namespace NLog.Layouts
                 sb.Append(PropertiesElementName);
             }
 
-            if (!string.IsNullOrEmpty(PropertiesElementKeyAttribute))
-            {
-                sb.Append(' ');
-                sb.Append(PropertiesElementKeyAttribute);
-                sb.Append("=\"");
-                XmlHelper.EscapeXmlString(propName, true, sb);
-                sb.Append('\"');
-            }
+            RenderAttribute(sb, PropertiesElementKeyAttribute, propName);
 
             string xmlValueString = XmlHelper.XmlConvertToStringSafe(propertyValue);
-            if (!string.IsNullOrEmpty(PropertiesElementValueAttribute))
+
+            if (RenderAttribute(sb, PropertiesElementValueAttribute, xmlValueString))
             {
-                sb.Append(' ');
-                sb.Append(PropertiesElementValueAttribute);
-                sb.Append("=\"");
-                XmlHelper.EscapeXmlString(xmlValueString, true, sb);
-                sb.Append('\"');
+
                 sb.Append("/>");
             }
             else
@@ -447,6 +436,28 @@ namespace NLog.Layouts
             }
             if (IndentXml)
                 sb.AppendLine();
+        }
+
+        /// <summary>
+        /// write attribute, only if <paramref name="attributeName"/> is not empty
+        /// </summary>
+        /// <param name="sb"></param>
+        /// <param name="attributeName"></param>
+        /// <param name="value"></param>
+        /// <returns>rendered</returns>
+        private static bool RenderAttribute(StringBuilder sb, string attributeName, string value)
+        {
+            if (!string.IsNullOrEmpty(attributeName))
+            {
+                sb.Append(' ');
+                sb.Append(attributeName);
+                sb.Append("=\"");
+                XmlHelper.EscapeXmlString(value, true, sb);
+                sb.Append('\"');
+                return true;
+            }
+
+            return false;
         }
 
         private bool RenderAppendXmlElementValue(XmlLayout xmlElement, LogEventInfo logEvent, StringBuilder sb, bool beginXmlDocument)
@@ -500,18 +511,15 @@ namespace NLog.Layouts
 
         private void BeginXmlDocument(StringBuilder sb, string elementName)
         {
-            sb.Append('<');
-            sb.Append(elementName);
-            sb.Append('>');
+            RenderStartElement(sb, elementName);
             if (IndentXml)
                 sb.AppendLine();
         }
 
+
         private void EndXmlDocument(StringBuilder sb, string elementName)
         {
-            sb.Append("</");
-            sb.Append(elementName);
-            sb.Append('>');
+            RenderEndElement(sb, elementName);
         }
 
         /// <summary>
@@ -528,6 +536,28 @@ namespace NLog.Layouts
                 return ToStringWithNestedItems(new[] { this }, n => "Element:" + n.ElementName);
             else
                 return GetType().Name;
+        }
+
+
+        private static void RenderSelfClosingElement(StringBuilder target, string elementName)
+        {
+            target.Append('<');
+            target.Append(elementName);
+            target.Append("/>");
+        }
+
+        private static void RenderStartElement(StringBuilder sb, string elementName)
+        {
+            sb.Append('<');
+            sb.Append(elementName);
+            sb.Append('>');
+        }
+
+        private static void RenderEndElement(StringBuilder sb, string elementName)
+        {
+            sb.Append("</");
+            sb.Append(elementName);
+            sb.Append('>');
         }
     }
 }

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -136,12 +136,10 @@ namespace NLog.Layouts
         /// XML attribute format to use when rendering property-key
         /// </summary>
         /// <remarks>
-        /// Support string-format where {0} means property-key-name
-        /// 
-        /// Replaces newlines with underscore (_)
+        /// Replaces newlines with &#13;&#10;
         /// </remarks>
         /// <docgen category='LogEvent Properties XML Options' order='10' />
-        public string PropertiesNodeKeyAttribute { get; set; } = "key=\"{0}\"";
+        public string PropertiesNodeKeyAttribute { get; set; } = "key";
 
         /// <summary>
         /// XML attribute format to use when rendering property-value
@@ -149,8 +147,6 @@ namespace NLog.Layouts
         /// When null (or empty) then value is formatted as XML-element-value
         /// </summary>
         /// <remarks>
-        /// Support string-format where {0} means property-value
-        /// 
         /// Replaces newlines with &#13;&#10;
         /// 
         /// Skips closing element tag when using attribute for value
@@ -277,7 +273,7 @@ namespace NLog.Layouts
                         (IncludeAllProperties && logEvent.HasProperties);
                     if (!hasNodes)
                     {
-                        sb.Append(" />");
+                        sb.Append("/>");
                         return;
                     }
                     else
@@ -392,18 +388,22 @@ namespace NLog.Layouts
 
             if (!string.IsNullOrEmpty(PropertiesNodeKeyAttribute))
             {
-                string propNameAttribute = ReferenceEquals(propName, propNameElement) ? propName : XmlHelper.EscapeXmlString(propName, true);
                 sb.Append(' ');
-                sb.AppendFormat(PropertiesNodeKeyAttribute, propNameAttribute);
+                sb.Append(PropertiesNodeKeyAttribute);
+                sb.Append("=\"");
+                XmlHelper.EscapeXmlString(propName, true, sb);
+                sb.Append('\"');
             }
 
             string xmlValueString = XmlHelper.XmlConvertToStringSafe(propertyValue);
             if (!string.IsNullOrEmpty(PropertiesNodeValueAttribute))
             {
-                xmlValueString = XmlHelper.EscapeXmlString(xmlValueString, true);
                 sb.Append(' ');
-                sb.AppendFormat(PropertiesNodeValueAttribute, xmlValueString);
-                sb.Append(" />");
+                sb.Append(PropertiesNodeValueAttribute);
+                sb.Append("=\"");
+                XmlHelper.EscapeXmlString(xmlValueString, true, sb);
+                sb.Append('\"');
+                sb.Append("/>");
             }
             else
             {

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -171,7 +171,13 @@ namespace NLog.Layouts
         public string PropertiesElementName
         {
             get => _propertiesElementName;
-            set { _propertiesElementName = value; _propertiesElementNameHasFormat = value?.IndexOf('{') >= 0; }
+            set
+            {
+                _propertiesElementName = value;
+                _propertiesElementNameHasFormat = value?.IndexOf('{') >= 0;
+                if (!_propertiesElementNameHasFormat)
+                    _propertiesElementName = XmlHelper.XmlConvertToElementName(value?.Trim(), true);
+            }
         }
         private string _propertiesElementName = DefaultPropertyName;
         private bool _propertiesElementNameHasFormat;
@@ -418,7 +424,7 @@ namespace NLog.Layouts
             string propNameElement = null;
             if (_propertiesElementNameHasFormat)
             {
-                propNameElement = XmlHelper.XmlConvertToStringSafe(propName);
+                propNameElement = XmlHelper.XmlConvertToElementName(propName, true);
                 sb.AppendFormat(PropertiesElementName, propNameElement);
             }
             else

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -186,16 +186,24 @@ namespace NLog.Layouts
         protected override void InitializeLayout()
         {
             base.InitializeLayout();
+
             if (IncludeMdc)
             {
                 ThreadAgnostic = false;
             }
+
 #if !SILVERLIGHT
             if (IncludeMdlc)
             {
                 ThreadAgnostic = false;
             }
 #endif
+
+            if (IncludeAllProperties)
+            {
+                MutableUnsafe = true;
+            }
+
             if (Attributes.Count > 1)
             {
                 HashSet<string> attributeValidator = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -219,7 +227,7 @@ namespace NLog.Layouts
 
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
-            if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
+            if (!ThreadAgnostic || MutableUnsafe) RenderAppendBuilder(logEvent, target, true);
         }
 
         /// <summary>

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -357,16 +357,16 @@ namespace NLog.Layouts
 
             if (IncludeAllProperties && logEvent.HasProperties)
             {
-                var propertiesList = logEvent.CreateOrUpdatePropertiesInternal(true) as IEnumerable<MessageTemplates.MessageTemplateParameter>;
-                foreach (var prop in propertiesList)
+                foreach (var property in logEvent.Properties)
                 {
-                    if (string.IsNullOrEmpty(prop.Name))
+                    string propertyKey = property.Key.ToString();
+                    if (string.IsNullOrEmpty(propertyKey))
                         continue;
 
-                    if (ExcludeProperties.Contains(prop.Name))
+                    if (ExcludeProperties.Contains(propertyKey))
                         continue;
 
-                    AppendXmlPropertyValue(prop.Name, prop.Value, sb, sb.Length == orgLength);
+                    AppendXmlPropertyValue(propertyKey, property.Value, sb, sb.Length == orgLength);
                 }
             }
 

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -152,7 +152,7 @@ namespace NLog.UnitTests.Layouts
                 },
                 IndentXml = true,
                 IncludeAllProperties = true,
-                ExcludeProperties = new HashSet<string>{"prop2"}
+                ExcludeProperties = new HashSet<string> { "prop2" }
             };
 
             var logEventInfo = new LogEventInfo
@@ -216,7 +216,7 @@ namespace NLog.UnitTests.Layouts
             var xmlLayout = new XmlLayout()
             {
                 IndentXml = true,
-                IncludeAllProperties = true, 
+                IncludeAllProperties = true,
                 PropertiesElementName = "p",
                 PropertiesElementKeyAttribute = "k",
                 PropertiesElementValueAttribute = "v",
@@ -243,8 +243,48 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
-        public void XmlLayout_DoubleNestElements_RendersAllElements()
+        public void XmlLayout_DoubleNestedElements_RendersAllElements()
         {
+            // Arrange
+            var xmlLayout = new XmlLayout()
+            {
+                Elements =
+                {
+                    new XmlLayout("message", "${message}")
+                    {
+                        Elements =
+                        {
+                            new XmlLayout("level", "${level}")
+                        },
+                        IncludeAllProperties = true,
+                        IndentXml = true
+                    }
+
+                },
+                IndentXml = true
+            };
+
+            var logEventInfo = new LogEventInfo
+            {
+                Level = LogLevel.Debug,
+                Message = "message 1"
+            };
+            logEventInfo.Properties["prop1"] = "a";
+            logEventInfo.Properties["prop2"] = "b";
+
+            // Act
+            var result = xmlLayout.Render(logEventInfo);
+
+            // Assert
+            const string expected =
+@"<logevent>
+  <message>message 1<level>Debug</level>
+    <property key=""prop1"">a</property>
+    <property key=""prop2"">b</property>
+    </message>
+</logevent>";
+
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -104,5 +104,25 @@ namespace NLog.UnitTests.Layouts
             var target = LogManager.Configuration.FindTargetByName<NLog.Targets.DebugTarget>("debug");
             Assert.Equal(@"<log4j:event logger=""A"" level=""DEBUG""><log4j:message>some message</log4j:message><log4j:locationInfo class=""NLog.UnitTests.Layouts.XmlLayoutTests""/><log4j:data name=""foo1"" value=""bar1""/><log4j:data name=""foo2"" value=""bar2""/><log4j:data name=""foo3"" value=""bar3""/><log4j:data name=""nlogPropertyKey"" value=""&lt;nlog&#13;&#10;PropertyValue&gt;""/></log4j:event>", target.LastMessage);
         }
+
+        [Fact]
+        public void XmlLayout_IncludeEmptyValue_RenderEmptyValue()
+        {
+        }
+
+        [Fact]
+        public void XmlLayout_ExcludeProperties_RenderNotProperty()
+        {
+        }
+
+        [Fact]
+        public void XmlLayout_OnlyLogEventProperties_RenderRootCorrect()
+        {
+        }
+
+        [Fact]
+        public void XmlLayout_PropertiesElementNameFormat_RenderPropertyName()
+        {
+        }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -77,12 +77,13 @@ namespace NLog.UnitTests.Layouts
                 Nodes = 
                     {
                         new XmlLayout("log4j:message", "${message}"),
-                        new XmlLayout("log4j:throwable", "${exception:format=tostring}") { IncludeEmptyValue = false },
+                        new XmlLayout("log4j:throwable", "${exception:format=tostring}"),
+                        new XmlLayout("log4j:locationInfo", null) { Attributes = { new XmlAttribute("class", "${callsite:methodName=false}") { IncludeEmptyValue = true } } },
                     },
             };
-            xmlLayout.PropertiesFormatElementName = "log4j:data";
-            xmlLayout.PropertiesFormatKeyAttribute = "name=\"{0}\"";
-            xmlLayout.PropertiesFormatValueAttribute = "value=\"{0}\"";
+            xmlLayout.PropertiesNodeName = "log4j:data";
+            xmlLayout.PropertiesNodeKeyAttribute = "name=\"{0}\"";
+            xmlLayout.PropertiesNodeValueAttribute = "value=\"{0}\"";
             xmlLayout.IncludeAllProperties = true;
             xmlLayout.IncludeMdc = true;
             xmlLayout.IncludeMdlc = true;
@@ -97,7 +98,7 @@ namespace NLog.UnitTests.Layouts
             var logEventInfo = LogEventInfo.Create(LogLevel.Debug, "A", null, null, "some message");
             logEventInfo.Properties["nlogPropertyKey"] = "<nlog\r\nPropertyValue>";
 
-            Assert.Equal(@"<log4j:event logger=""A"" level=""DEBUG""><log4j:message>some message</log4j:message><log4j:data name=""foo1"" value=""bar1"" /><log4j:data name=""foo2"" value=""bar2"" /><log4j:data name=""foo3"" value=""bar3"" /><log4j:data name=""nlogPropertyKey"" value=""&lt;nlog&#13;&#10;PropertyValue&gt;"" /></log4j:event>", xmlLayout.Render(logEventInfo));
+            Assert.Equal(@"<log4j:event logger=""A"" level=""DEBUG""><log4j:message>some message</log4j:message><log4j:locationInfo class="""" /><log4j:data name=""foo1"" value=""bar1"" /><log4j:data name=""foo2"" value=""bar2"" /><log4j:data name=""foo3"" value=""bar3"" /><log4j:data name=""nlogPropertyKey"" value=""&lt;nlog&#13;&#10;PropertyValue&gt;"" /></log4j:event>", xmlLayout.Render(logEventInfo));
         }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Collections.Generic;
+
 namespace NLog.UnitTests.Layouts
 {
     using System;
@@ -141,6 +143,38 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void XmlLayout_ExcludeProperties_RenderNotProperty()
         {
+            // Arrange
+            var xmlLayout = new XmlLayout()
+            {
+                Elements =
+                {
+                    new XmlLayout("message", "${message}"),
+                },
+                IndentXml = true,
+                IncludeAllProperties = true,
+                ExcludeProperties = new HashSet<string>{"prop2"}
+            };
+
+            var logEventInfo = new LogEventInfo
+            {
+                Message = "message 1"
+            };
+            logEventInfo.Properties["prop1"] = "a";
+            logEventInfo.Properties["prop2"] = "b";
+            logEventInfo.Properties["prop3"] = "c";
+
+            // Act
+            var result = xmlLayout.Render(logEventInfo);
+
+            // Assert
+            const string expected =
+ @"<logevent>
+  <message>message 1</message>
+  <property key=""prop1"">a</property>
+  <property key=""prop3"">c</property>
+</logevent>";
+
+            Assert.Equal(expected, result);
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -108,6 +108,34 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void XmlLayout_IncludeEmptyValue_RenderEmptyValue()
         {
+            // Arrange
+            var xmlLayout = new XmlLayout()
+            {
+                Elements =
+                {
+                    new XmlLayout("message", "${message}"),
+                },
+                IndentXml = true,
+                IncludeAllProperties = true,
+            };
+
+            var logEventInfo = new LogEventInfo
+            {
+                Message = ""
+            };
+            logEventInfo.Properties["nlogPropertyKey"] = null;
+
+            // Act
+            var result = xmlLayout.Render(logEventInfo);
+
+            // Assert
+            const string expected =
+ @"<logevent>
+  <message></message>
+  <property key=""nlogPropertyKey"">null</property>
+</logevent>";
+
+            Assert.Equal(expected, result);
         }
 
         [Fact]
@@ -122,6 +150,11 @@ namespace NLog.UnitTests.Layouts
 
         [Fact]
         public void XmlLayout_PropertiesElementNameFormat_RenderPropertyName()
+        {
+        }
+
+        [Fact]
+        public void XmlLayout_DoubleNestElements_RendersAllElements()
         {
         }
     }

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -212,6 +212,34 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void XmlLayout_PropertiesElementNameFormat_RenderPropertyName()
         {
+            // Arrange
+            var xmlLayout = new XmlLayout()
+            {
+                IndentXml = true,
+                IncludeAllProperties = true, 
+                PropertiesElementName = "p",
+                PropertiesElementKeyAttribute = "k",
+                PropertiesElementValueAttribute = "v",
+            };
+
+            var logEventInfo = new LogEventInfo
+            {
+                Message = "message 1"
+            };
+            logEventInfo.Properties["prop1"] = "a";
+            logEventInfo.Properties["prop2"] = "b";
+
+            // Act
+            var result = xmlLayout.Render(logEventInfo);
+
+            // Assert
+            const string expected =
+                @"<logevent>
+  <p k=""prop1"" v=""a""></p>
+  <p k=""prop2"" v=""b""></p>
+</logevent>";
+
+            Assert.Equal(expected, result);
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -44,13 +44,14 @@ namespace NLog.UnitTests.Layouts
         {
             var xmlLayout = new XmlLayout()
             {
-                Nodes =
+                Elements =
                     {
                         new XmlLayout("date", "${longdate}"),
                         new XmlLayout("level", "${level}"),
                         new XmlLayout("message", "${message}"),
                     },
                 IndentXml = true,
+                IncludeAllProperties = true,
             };
 
             var logEventInfo = new LogEventInfo
@@ -59,8 +60,9 @@ namespace NLog.UnitTests.Layouts
                 Level = LogLevel.Info,
                 Message = "hello, world"
             };
+            logEventInfo.Properties["nlogPropertyKey"] = "nlogPropertyValue";
 
-            Assert.Equal(string.Format(System.Globalization.CultureInfo.InvariantCulture, @"<logevent>{0}{1}<date>2010-01-01 12:34:56.0000</date>{0}{1}<level>Info</level>{0}{1}<message>hello, world</message>{0}</logevent>", Environment.NewLine, "  "), xmlLayout.Render(logEventInfo));
+            Assert.Equal(string.Format(System.Globalization.CultureInfo.InvariantCulture, @"<logevent>{0}{1}<date>2010-01-01 12:34:56.0000</date>{0}{1}<level>Info</level>{0}{1}<message>hello, world</message>{0}{1}<property key=""nlogPropertyKey"">nlogPropertyValue</property>{0}</logevent>", Environment.NewLine, "  "), xmlLayout.Render(logEventInfo));
         }
 
         [Fact]
@@ -70,14 +72,14 @@ namespace NLog.UnitTests.Layouts
                 <nlog throwExceptions='true'>
                     <targets>
                         <target name='debug' type='debug'>
-                            <layout type='xmllayout' nodeName='log4j:event' propertiesNodeName='log4j:data' propertiesNodeKeyAttribute='name' propertiesNodeValueAttribute='value' includeAllProperties='true' includeMdc='true' includeMdlc='true' >
+                            <layout type='xmllayout' elementName='log4j:event' propertiesElementName='log4j:data' propertiesElementKeyAttribute='name' propertiesElementValueAttribute='value' includeAllProperties='true' includeMdc='true' includeMdlc='true' >
                                 <attribute name='logger' layout='${logger}' includeEmptyValue='true' />
                                 <attribute name='level' layout='${uppercase:${level}}' includeEmptyValue='true' />
-                                <node nodeName='log4j:message' nodeValue='${message}' />
-                                <node nodeName='log4j:throwable' nodeValue='${exception:format=tostring}' />
-                                <node nodeName='log4j:locationInfo'>
+                                <element elementName='log4j:message' elementValue='${message}' />
+                                <element elementName='log4j:throwable' elementValue='${exception:format=tostring}' />
+                                <element elementName='log4j:locationInfo'>
                                     <attribute name='class' layout='${callsite:methodName=false}' includeEmptyValue='true' />
-                                </node>
+                                </element>
                             </layout>
                         </target>
                     </targets>

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -227,6 +227,34 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void XmlLayout_InvalidXmlPropertyName_RenderNameCorrect()
+        {
+            // Arrange
+            var xmlLayout = new XmlLayout()
+            {
+                IncludeAllProperties = true,
+                PropertiesElementName = "{0}",
+                PropertiesElementKeyAttribute = "",
+            };
+
+            var logEventInfo = new LogEventInfo
+            {
+                Message = "message 1"
+            };
+            logEventInfo.Properties["1prop"] = "a";
+            logEventInfo.Properties["_2prop"] = "b";
+            logEventInfo.Properties[" 3prop"] = "c";
+            logEventInfo.Properties["_4 prop"] = "d";
+
+            // Act
+            var result = xmlLayout.Render(logEventInfo);
+
+            // Assert
+            const string expected = @"<logevent><_1prop>a</_1prop><_2prop>b</_2prop><_3prop>c</_3prop><_4_prop>d</_4_prop></logevent>";
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
         public void XmlLayout_PropertiesAttributeNames_RenderPropertyName()
         {
             // Arrange

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -95,9 +95,9 @@ namespace NLog.UnitTests.Layouts
             MappedDiagnosticsLogicalContext.Set("foo3", "bar3");
 
             var logEventInfo = LogEventInfo.Create(LogLevel.Debug, "A", null, null, "some message");
-            logEventInfo.Properties["nlogPropertyKey"] = "<nlogPropertyValue>";
+            logEventInfo.Properties["nlogPropertyKey"] = "<nlog\r\nPropertyValue>";
 
-            Assert.Equal(@"<log4j:event logger=""A"" level=""DEBUG""><log4j:message>some message</log4j:message><log4j:data name=""foo1"" value=""bar1"" /><log4j:data name=""foo2"" value=""bar2"" /><log4j:data name=""foo3"" value=""bar3"" /><log4j:data name=""nlogPropertyKey"" value=""&lt;nlogPropertyValue&gt;"" /></log4j:event>", xmlLayout.Render(logEventInfo));
+            Assert.Equal(@"<log4j:event logger=""A"" level=""DEBUG""><log4j:message>some message</log4j:message><log4j:data name=""foo1"" value=""bar1"" /><log4j:data name=""foo2"" value=""bar2"" /><log4j:data name=""foo3"" value=""bar3"" /><log4j:data name=""nlogPropertyKey"" value=""&lt;nlog&#13;&#10;PropertyValue&gt;"" /></log4j:event>", xmlLayout.Render(logEventInfo));
         }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -140,6 +140,42 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(expected, result);
         }
 
+        
+        [Fact]
+        public void XmlLayout_NoIndent_RendersOneLine()
+        {
+            // Arrange
+            var xmlLayout = new XmlLayout()
+            {
+                Elements =
+                {
+                    new XmlLayout("level", "${level}"),
+                    new XmlLayout("message", "${message}"),
+                },
+                IndentXml = false,
+                IncludeAllProperties = true,
+            };
+
+            var logEventInfo = new LogEventInfo
+            {
+                Message = "message 1",
+                Level =  LogLevel.Debug
+            };
+
+            logEventInfo.Properties["prop1"] = "a";
+            logEventInfo.Properties["prop2"] = "b";
+            logEventInfo.Properties["prop3"] = "c";
+
+            // Act
+            var result = xmlLayout.Render(logEventInfo);
+
+            // Assert
+            const string expected =
+                @"<logevent><level>Debug</level><message>message 1</message><property key=""prop1"">a</property><property key=""prop2"">b</property><property key=""prop3"">c</property></logevent>";
+
+            Assert.Equal(expected, result);
+        }
+
         [Fact]
         public void XmlLayout_ExcludeProperties_RenderNotProperty()
         {

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -70,7 +70,7 @@ namespace NLog.UnitTests.Layouts
                 <nlog throwExceptions='true'>
                     <targets>
                         <target name='debug' type='debug'>
-                            <layout type='xmllayout' nodeName='log4j:event' propertiesNodeName='log4j:data' propertiesNodeKeyAttribute='name=&quot;{0}&quot;' propertiesNodeValueAttribute='value=&quot;{0}&quot;' includeAllProperties='true' includeMdc='true' includeMdlc='true' >
+                            <layout type='xmllayout' nodeName='log4j:event' propertiesNodeName='log4j:data' propertiesNodeKeyAttribute='name' propertiesNodeValueAttribute='value' includeAllProperties='true' includeMdc='true' includeMdlc='true' >
                                 <attribute name='logger' layout='${logger}' includeEmptyValue='true' />
                                 <attribute name='level' layout='${uppercase:${level}}' includeEmptyValue='true' />
                                 <node nodeName='log4j:message' nodeValue='${message}' />
@@ -100,7 +100,7 @@ namespace NLog.UnitTests.Layouts
             logger.Log(logEventInfo);
 
             var target = LogManager.Configuration.FindTargetByName<NLog.Targets.DebugTarget>("debug");
-            Assert.Equal(@"<log4j:event logger=""A"" level=""DEBUG""><log4j:message>some message</log4j:message><log4j:locationInfo class=""NLog.UnitTests.Layouts.XmlLayoutTests"" /><log4j:data name=""foo1"" value=""bar1"" /><log4j:data name=""foo2"" value=""bar2"" /><log4j:data name=""foo3"" value=""bar3"" /><log4j:data name=""nlogPropertyKey"" value=""&lt;nlog&#13;&#10;PropertyValue&gt;"" /></log4j:event>", target.LastMessage);
+            Assert.Equal(@"<log4j:event logger=""A"" level=""DEBUG""><log4j:message>some message</log4j:message><log4j:locationInfo class=""NLog.UnitTests.Layouts.XmlLayoutTests""/><log4j:data name=""foo1"" value=""bar1""/><log4j:data name=""foo2"" value=""bar2""/><log4j:data name=""foo3"" value=""bar3""/><log4j:data name=""nlogPropertyKey"" value=""&lt;nlog&#13;&#10;PropertyValue&gt;""/></log4j:event>", target.LastMessage);
         }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -180,6 +180,33 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void XmlLayout_OnlyLogEventProperties_RenderRootCorrect()
         {
+            // Arrange
+            var xmlLayout = new XmlLayout()
+            {
+                IndentXml = true,
+                IncludeAllProperties = true
+            };
+
+            var logEventInfo = new LogEventInfo
+            {
+                Message = "message 1"
+            };
+            logEventInfo.Properties["prop1"] = "a";
+            logEventInfo.Properties["prop2"] = "b";
+            logEventInfo.Properties["prop3"] = "c";
+
+            // Act
+            var result = xmlLayout.Render(logEventInfo);
+
+            // Assert
+            const string expected =
+@"<logevent>
+  <property key=""prop1"">a</property>
+  <property key=""prop2"">b</property>
+  <property key=""prop3"">c</property>
+</logevent>";
+
+            Assert.Equal(expected, result);
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -115,10 +115,10 @@ namespace NLog.UnitTests.Layouts
             {
                 Elements =
                 {
-                    new XmlLayout("message", "${message}"),
+                    new XmlLayout("message", "${message}") { IncludeEmptyValue = true },
                 },
-                IndentXml = true,
                 IncludeAllProperties = true,
+                IncludeEmptyValue = true,
             };
 
             var logEventInfo = new LogEventInfo
@@ -131,16 +131,11 @@ namespace NLog.UnitTests.Layouts
             var result = xmlLayout.Render(logEventInfo);
 
             // Assert
-            const string expected =
- @"<logevent>
-  <message></message>
-  <property key=""nlogPropertyKey"">null</property>
-</logevent>";
-
+            const string expected = @"<logevent><message></message><property key=""nlogPropertyKey"">null</property></logevent>";
             Assert.Equal(expected, result);
         }
 
-        
+
         [Fact]
         public void XmlLayout_NoIndent_RendersOneLine()
         {
@@ -159,7 +154,7 @@ namespace NLog.UnitTests.Layouts
             var logEventInfo = new LogEventInfo
             {
                 Message = "message 1",
-                Level =  LogLevel.Debug
+                Level = LogLevel.Debug
             };
 
             logEventInfo.Properties["prop1"] = "a";
@@ -186,7 +181,6 @@ namespace NLog.UnitTests.Layouts
                 {
                     new XmlLayout("message", "${message}"),
                 },
-                IndentXml = true,
                 IncludeAllProperties = true,
                 ExcludeProperties = new HashSet<string> { "prop2" }
             };
@@ -203,13 +197,7 @@ namespace NLog.UnitTests.Layouts
             var result = xmlLayout.Render(logEventInfo);
 
             // Assert
-            const string expected =
- @"<logevent>
-  <message>message 1</message>
-  <property key=""prop1"">a</property>
-  <property key=""prop3"">c</property>
-</logevent>";
-
+            const string expected = @"<logevent><message>message 1</message><property key=""prop1"">a</property><property key=""prop3"">c</property></logevent>";
             Assert.Equal(expected, result);
         }
 
@@ -219,8 +207,7 @@ namespace NLog.UnitTests.Layouts
             // Arrange
             var xmlLayout = new XmlLayout()
             {
-                IndentXml = true,
-                IncludeAllProperties = true
+                IncludeAllProperties = true,
             };
 
             var logEventInfo = new LogEventInfo
@@ -235,23 +222,16 @@ namespace NLog.UnitTests.Layouts
             var result = xmlLayout.Render(logEventInfo);
 
             // Assert
-            const string expected =
-@"<logevent>
-  <property key=""prop1"">a</property>
-  <property key=""prop2"">b</property>
-  <property key=""prop3"">c</property>
-</logevent>";
-
+            const string expected = @"<logevent><property key=""prop1"">a</property><property key=""prop2"">b</property><property key=""prop3"">c</property></logevent>";
             Assert.Equal(expected, result);
         }
 
         [Fact]
-        public void XmlLayout_PropertiesElementNameFormat_RenderPropertyName()
+        public void XmlLayout_PropertiesAttributeNames_RenderPropertyName()
         {
             // Arrange
             var xmlLayout = new XmlLayout()
             {
-                IndentXml = true,
                 IncludeAllProperties = true,
                 PropertiesElementName = "p",
                 PropertiesElementKeyAttribute = "k",
@@ -269,12 +249,34 @@ namespace NLog.UnitTests.Layouts
             var result = xmlLayout.Render(logEventInfo);
 
             // Assert
-            const string expected =
-                @"<logevent>
-  <p k=""prop1"" v=""a""></p>
-  <p k=""prop2"" v=""b""></p>
-</logevent>";
+            const string expected = @"<logevent><p k=""prop1"" v=""a""/><p k=""prop2"" v=""b""/></logevent>";
+            Assert.Equal(expected, result);
+        }
 
+        [Fact]
+        public void XmlLayout_PropertiesElementNameFormat_RenderPropertyName()
+        {
+            // Arrange
+            var xmlLayout = new XmlLayout()
+            {
+                IncludeAllProperties = true,
+                PropertiesElementName = "{0}",
+                PropertiesElementKeyAttribute = "",
+                PropertiesElementValueAttribute = "v",
+            };
+
+            var logEventInfo = new LogEventInfo
+            {
+                Message = "message 1"
+            };
+            logEventInfo.Properties["prop1"] = "a";
+            logEventInfo.Properties["prop2"] = "b";
+
+            // Act
+            var result = xmlLayout.Render(logEventInfo);
+
+            // Assert
+            const string expected = @"<logevent><prop1 v=""a""/><prop2 v=""b""/></logevent>";
             Assert.Equal(expected, result);
         }
 
@@ -293,11 +295,9 @@ namespace NLog.UnitTests.Layouts
                             new XmlLayout("level", "${level}")
                         },
                         IncludeAllProperties = true,
-                        IndentXml = true
                     }
 
                 },
-                IndentXml = true
             };
 
             var logEventInfo = new LogEventInfo
@@ -312,14 +312,7 @@ namespace NLog.UnitTests.Layouts
             var result = xmlLayout.Render(logEventInfo);
 
             // Assert
-            const string expected =
-@"<logevent>
-  <message>message 1<level>Debug</level>
-    <property key=""prop1"">a</property>
-    <property key=""prop2"">b</property>
-    </message>
-</logevent>";
-
+            string expected = @"<logevent><message>message 1<level>Debug</level><property key=""prop1"">a</property><property key=""prop2"">b</property></message></logevent>";
             Assert.Equal(expected, result);
         }
     }

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -1,0 +1,103 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.Layouts
+{
+    using System;
+    using NLog.Layouts;
+    using Xunit;
+
+    public class XmlLayoutTests
+    {
+        [Fact]
+        public void XmlLayoutRendering()
+        {
+            var xmlLayout = new XmlLayout()
+            {
+                Nodes =
+                    {
+                        new XmlLayout("date", "${longdate}"),
+                        new XmlLayout("level", "${level}"),
+                        new XmlLayout("message", "${message}"),
+                    },
+                IndentXml = true,
+            };
+
+            var logEventInfo = new LogEventInfo
+            {
+                TimeStamp = new DateTime(2010, 01, 01, 12, 34, 56),
+                Level = LogLevel.Info,
+                Message = "hello, world"
+            };
+
+            Assert.Equal(string.Format(System.Globalization.CultureInfo.InvariantCulture, @"<logevent>{0}{1}<date>2010-01-01 12:34:56.0000</date>{0}{1}<level>Info</level>{0}{1}<message>hello, world</message>{0}</logevent>", Environment.NewLine, "  "), xmlLayout.Render(logEventInfo));
+        }
+
+        [Fact]
+        public void XmlLayoutLog4j()
+        {
+            var xmlLayout = new XmlLayout()
+            {
+                NodeName = "log4j:event",
+                Attributes =
+                    {
+                        new XmlAttribute("logger", "${logger}") { IncludeEmptyValue = true },
+                        new XmlAttribute("level", "${uppercase:${level}}") { IncludeEmptyValue = true },
+                    },
+                Nodes = 
+                    {
+                        new XmlLayout("log4j:message", "${message}"),
+                        new XmlLayout("log4j:throwable", "${exception:format=tostring}") { IncludeEmptyValue = false },
+                    },
+            };
+            xmlLayout.PropertiesFormatElementName = "log4j:data";
+            xmlLayout.PropertiesFormatKeyAttribute = "name=\"{0}\"";
+            xmlLayout.PropertiesFormatValueAttribute = "value=\"{0}\"";
+            xmlLayout.IncludeAllProperties = true;
+            xmlLayout.IncludeMdc = true;
+            xmlLayout.IncludeMdlc = true;
+
+            MappedDiagnosticsContext.Clear();
+            MappedDiagnosticsContext.Set("foo1", "bar1");
+            MappedDiagnosticsContext.Set("foo2", "bar2");
+
+            MappedDiagnosticsLogicalContext.Clear();
+            MappedDiagnosticsLogicalContext.Set("foo3", "bar3");
+
+            var logEventInfo = LogEventInfo.Create(LogLevel.Debug, "A", null, null, "some message");
+            logEventInfo.Properties["nlogPropertyKey"] = "<nlogPropertyValue>";
+
+            Assert.Equal(@"<log4j:event logger=""A"" level=""DEBUG""><log4j:message>some message</log4j:message><log4j:data name=""foo1"" value=""bar1"" /><log4j:data name=""foo2"" value=""bar2"" /><log4j:data name=""foo3"" value=""bar3"" /><log4j:data name=""nlogPropertyKey"" value=""&lt;nlogPropertyValue&gt;"" /></log4j:event>", xmlLayout.Render(logEventInfo));
+        }
+    }
+}

--- a/tools/DumpApiXml/DocFileBuilder.cs
+++ b/tools/DumpApiXml/DocFileBuilder.cs
@@ -447,7 +447,10 @@
                         writer.WriteStartElement("elementType");
                         writer.WriteAttributeString("name", GetTypeName(elementType));
                         writer.WriteAttributeString("elementTag", elementTag);
-                        this.DumpTypeMembers(writer, elementType);
+                        if (elementType != type)
+                        {
+                            this.DumpTypeMembers(writer, elementType);
+                        }
                         writer.WriteEndElement();
                     }
                     else


### PR DESCRIPTION
Ex. SQL XML Column

```xml
<properties>
  <property key="Action">GetUsers</property>
  <property key="Controller">UserController</property>
</properties>
```

```sql
SELECT 	[Message]
  , [TimeStamp]
  , [Exception]
  , [Properties].value('(//property[@key="Action"]/node())[1]', 'nvarchar(max)') as Action
FROM [Logs]
WHERE [Properties].value('(//property[@key="Controller"]/node())[1]', 'nvarchar(max)') = 'UserController'
```

Ex. SMTP mails with advanced XHTML-formatting (colors etc):

`msg.BodyFormat = MailFormat.Html;`