### PR TITLE
Log4JXml - Removed redundant logging of exception, default IncludeNLogData to false

### DIFF
--- a/src/NLog/Internal/XmlHelper.cs
+++ b/src/NLog/Internal/XmlHelper.cs
@@ -352,7 +352,7 @@ namespace NLog.Internal
         /// <param name="value"></param>
         public static void WriteAttributeSafeString(this XmlWriter writer, string prefix, string localName, string ns, string value)
         {
-            writer.WriteAttributeString(RemoveInvalidXmlChars(prefix), RemoveInvalidXmlChars(localName), RemoveInvalidXmlChars(ns), RemoveInvalidXmlChars(value));
+            writer.WriteAttributeString(prefix, localName, ns, RemoveInvalidXmlChars(value));
         }
 
         /// <summary>
@@ -363,7 +363,7 @@ namespace NLog.Internal
         /// <param name="value"></param>
         public static void WriteAttributeSafeString(this XmlWriter writer, string localName, string value)
         {
-            writer.WriteAttributeString(RemoveInvalidXmlChars(localName), RemoveInvalidXmlChars(value));
+            writer.WriteAttributeString(localName, RemoveInvalidXmlChars(value));
         }
 
         /// <summary>
@@ -376,18 +376,17 @@ namespace NLog.Internal
         /// <param name="value"></param>
         public static void WriteElementSafeString(this XmlWriter writer, string prefix, string localName, string ns, string value)
         {
-            writer.WriteElementString(RemoveInvalidXmlChars(prefix), RemoveInvalidXmlChars(localName), RemoveInvalidXmlChars(ns),
-                                      RemoveInvalidXmlChars(value));
+            writer.WriteElementString(prefix, localName, ns, RemoveInvalidXmlChars(value));
         }
 
         /// <summary>
         /// Safe version of WriteCData
         /// </summary>
         /// <param name="writer"></param>
-        /// <param name="text"></param>
-        public static void WriteSafeCData(this XmlWriter writer, string text)
+        /// <param name="value"></param>
+        public static void WriteSafeCData(this XmlWriter writer, string value)
         {
-            writer.WriteCData(RemoveInvalidXmlChars(text));
+            writer.WriteCData(RemoveInvalidXmlChars(value));
         }
     }
 }

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -114,6 +114,24 @@ namespace NLog.Layouts
         }
 #endif
 
+        /// <summary>
+        /// Gets or sets the log4j:event logger-xml-attribute (Default ${logger})
+        /// </summary>
+        public Layout LoggerName
+        {
+            get => Renderer.LoggerName;
+            set => Renderer.LoggerName = value;
+        }
+
+        /// <summary>
+        ///  Gets or sets whether the log4j:throwable xml-element should be written as CDATA
+        /// </summary>
+        public bool WriteThrowableCData
+        {
+            get => Renderer.WriteThrowableCData;
+            set => Renderer.WriteThrowableCData = value;
+        }
+
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
             PrecalculateBuilderInternal(logEvent, target);

--- a/src/NLog/Targets/ChainsawTarget.cs
+++ b/src/NLog/Targets/ChainsawTarget.cs
@@ -66,7 +66,6 @@ namespace NLog.Targets
         /// </summary>
         public ChainsawTarget()
         {
-            IncludeNLogData = false;
             OptimizeBufferReuse = GetType() == typeof(ChainsawTarget);  // Class not sealed, reduce breaking changes
         }
 

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -82,6 +82,7 @@ namespace NLog.Targets
             OnConnectionOverflow = NetworkTargetConnectionsOverflowAction.Block;
             MaxConnections = 16;
             NewLine = false;
+            IncludeNLogData = true;
             OptimizeBufferReuse = GetType() == typeof(NLogViewerTarget);    // Class not sealed, reduce breaking changes
         }
 


### PR DESCRIPTION
 Skip NLog-namespace handling when IncludeNLogData = false.

For NLog 5.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/2672)
<!-- Reviewable:end -->
