### PR TITLE
SonarQube WARNING: The following projects do not have a valid ProjectGuid

### DIFF
--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -327,6 +327,8 @@ for what is supported in each platform, see https://github.com/NLog/NLog/wiki/pl
 
   <PropertyGroup>
     <AssemblyTitle>$(Title)</AssemblyTitle>
+    <!-- SonarQube WARNING: The following projects do not have a valid ProjectGuid and were not built using a valid solution (.sln) thus will be skipped from analysis… -->
+    <ProjectGuid>{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}</ProjectGuid>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Added ProjectGuid to see if it makes SonarScanner happy:

```
WARNING: The following projects do not have a valid ProjectGuid and were not built using a valid solution (.sln) thus will be skipped from analysis...

C:\projects\nlog\src\NLog\NLog.csproj

SonarScanner.MSBuild.exe : No analysable projects were found. SonarQube analysis will not be performed. Check the build summary report for details.
```

https://ci.appveyor.com/project/nlog/nlog/build/4.5.0-7605