### PR TITLE
Fix: NLog.config build-action and copy for non-core projects, it's now "copy if newer"

### DIFF
--- a/src/NuGet/NLog.Config/NLog.Config.nuspec
+++ b/src/NuGet/NLog.Config/NLog.Config.nuspec
@@ -29,5 +29,6 @@
   <files>
     <file src="content\**" target="contentFiles\any\any" />
     <file src="content\**" target="content\" /> <!-- legacy -->
+    <file src="tools\**" target="tools\" /> <!-- legacy, need install.ps1 for non-core projects -->
   </files>
 </package>

--- a/src/NuGet/NLog.Config/tools/Install.ps1
+++ b/src/NuGet/NLog.Config/tools/Install.ps1
@@ -4,7 +4,7 @@ $configItem = $project.ProjectItems.Item("NLog.config")
 
 # set 'Copy To Output Directory' to 'Copy if newer'
 $copyToOutput = $configItem.Properties.Item("CopyToOutputDirectory")
-$copyToOutput.Value = 1
+$copyToOutput.Value = 2
 
 # set 'Build Action' to 'Content'
 $buildAction = $configItem.Properties.Item("BuildAction")


### PR DESCRIPTION
fixes #2686 

PS: no need to update nlog.schema