### PR TITLE
Faulty invalidate of FormattedMessage when getting PropertiesDictionary

### DIFF
--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -375,8 +375,13 @@ namespace NLog
         {
             get
             {
-                var logMessageFormatter = _messageFormatter?.Target as ILogMessageFormatter;
-                return logMessageFormatter?.HasProperties(this) ?? false;
+                // Have not yet parsed/rendered the FormattedMessage, so check with ILogMessageFormatter
+                if (_formattedMessage == null)
+                {
+                    var logMessageFormatter = _messageFormatter?.Target as ILogMessageFormatter;
+                    return logMessageFormatter?.HasProperties(this) ?? false;
+                }
+                return false;
             }
         }
 

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -1863,7 +1863,19 @@ namespace NLog.UnitTests
             AssertDebugLastMessage("debug", $"Process order {param1Value} for {param2Value}");
         }
 
-
+        [Fact]
+        public void StructuredParametersShouldHandleDeferredCheck()
+        {
+            System.Text.StringBuilder sb = new System.Text.StringBuilder("Test");
+            LogEventInfo logEventInfo = new LogEventInfo(LogLevel.Info, "Logger", null, "{0}", new object[] { sb });
+            sb.Clear();
+            string formattedMessage = logEventInfo.FormattedMessage;
+            Assert.Equal("Test", formattedMessage);
+            var properties = logEventInfo.Properties;
+            Assert.Empty(properties);
+            string formattedMessage2 = logEventInfo.FormattedMessage;
+            Assert.Equal("Test", formattedMessage2);
+        }
 
         [Theory]
         [InlineData(true)]
@@ -1879,7 +1891,6 @@ namespace NLog.UnitTests
             Assert.Equal(2, target.LastLogEvent.Parameters.Length);
             Assert.Equal("world", target.LastLogEvent.Parameters[0]);
             Assert.Equal("universe", target.LastLogEvent.Parameters[1]);
-
         }
 
         [Theory]


### PR DESCRIPTION
Found a bug in NLog 4.5, where the LogEventInfo.FormattedMessage is recalculated when PropertiesDictionary is accesed.

This doesn't work well with complex parameters that might change after the log-statement.