### PR TITLE
LogEventInfo - Structured logging parameters are not always immutable

### DIFF
--- a/src/NLog/Config/MutableUnsafeAttribute.cs
+++ b/src/NLog/Config/MutableUnsafeAttribute.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,43 +31,17 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.LayoutRenderers
+namespace NLog.Config
 {
     using System;
-    using System.Text;
-    using NLog.Config;
 
     /// <summary>
-    /// Log event context data.
+    /// Marks the layout or layout renderer depends on mutable objects from the LogEvent
+    /// 
+    /// This can be <see cref="LogEventInfo.Properties"/> or <see cref="LogEventInfo.Exception"/>
     /// </summary>
-    /// <remarks>This class was marked as obsolete on NLog 2.0 and it may be removed in a future release.</remarks>
-    [LayoutRenderer("event-context")]
-    [MutableUnsafe]
-    [Obsolete("Use EventPropertiesLayoutRenderer class instead. Marked obsolete on NLog 2.0")]
-    public class EventContextLayoutRenderer : LayoutRenderer
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class MutableUnsafeAttribute : Attribute
     {
-        /// <summary>
-        /// Gets or sets the name of the item.
-        /// </summary>
-        /// <docgen category='Rendering Options' order='10' />
-        [RequiredParameter]
-        [DefaultParameter]
-        public string Item { get; set; }
-
-        /// <summary>
-        /// Renders the specified log event context item and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
-        {
-            object value;
-
-            if (logEvent.HasProperties && logEvent.Properties.TryGetValue(Item, out value))
-            {
-                var formatProvider = GetFormatProvider(logEvent);
-                builder.Append(Convert.ToString(value, formatProvider));
-            }
-        }
     }
 }

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -164,7 +164,7 @@ namespace NLog.Internal
 
             if (reusableBuilder != null)
             {
-                if (!_layout.ThreadAgnostic)
+                if (!_layout.ThreadAgnostic || _layout.MutableUnsafe)
                 {
                     object cachedResult;
                     if (logEvent.TryGetCachedLayoutValue(_layout, out cachedResult))

--- a/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
@@ -47,6 +47,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("all-event-properties")]
     [ThreadAgnostic]
     [ThreadSafe]
+    [MutableUnsafe]
     public class AllEventPropertiesLayoutRenderer : LayoutRenderer
     {
         private string _format;

--- a/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
@@ -45,6 +45,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("event-properties")]
     [ThreadAgnostic]
     [ThreadSafe]
+    [MutableUnsafe]
     public class EventPropertiesLayoutRenderer : LayoutRenderer
     {
         /// <summary>

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -52,6 +52,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("log4jxmlevent")]
     [ThreadSafe]
+    [MutableUnsafe]
     public class Log4JXmlEventLayoutRenderer : LayoutRenderer, IUsesStackTrace, IIncludeContext
     {
         private static readonly DateTime log4jDateBase = new DateTime(1970, 1, 1);

--- a/src/NLog/Layouts/CompoundLayout.cs
+++ b/src/NLog/Layouts/CompoundLayout.cs
@@ -74,7 +74,7 @@ namespace NLog.Layouts
 
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
-            if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
+            if (!ThreadAgnostic || MutableUnsafe) RenderAppendBuilder(logEvent, target, true);
         }
 
         /// <summary>

--- a/src/NLog/Layouts/CsvLayout.cs
+++ b/src/NLog/Layouts/CsvLayout.cs
@@ -158,7 +158,7 @@ namespace NLog.Layouts
 
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
-            if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
+            if (!ThreadAgnostic || MutableUnsafe) RenderAppendBuilder(logEvent, target, true);
         }
 
         /// <summary>
@@ -289,7 +289,7 @@ namespace NLog.Layouts
 
             internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
             {
-                if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
+                if (!ThreadAgnostic || MutableUnsafe) RenderAppendBuilder(logEvent, target, true);
             }
 
             /// <summary>

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -168,6 +168,10 @@ namespace NLog.Layouts
                 ThreadAgnostic = false;
             }
 #endif
+            if (IncludeAllProperties)
+            {
+                MutableUnsafe = true;
+            }
         }
 
         /// <summary>
@@ -182,7 +186,7 @@ namespace NLog.Layouts
 
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
-            if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
+            if (!ThreadAgnostic || MutableUnsafe) RenderAppendBuilder(logEvent, target, true);
         }
 
         /// <summary>

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -116,7 +116,7 @@ namespace NLog.Layouts
 
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
-            if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
+            if (!ThreadAgnostic || MutableUnsafe) RenderAppendBuilder(logEvent, target, true);
         }
 
         /// <summary>

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -274,7 +274,7 @@ namespace NLog.Layouts
 
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
-            if (!ThreadAgnostic) RenderAppendBuilder(logEvent, target, true);
+            if (!ThreadAgnostic || MutableUnsafe) RenderAppendBuilder(logEvent, target, true);
         }
 
         /// <summary>

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -601,6 +601,8 @@ namespace NLog.Targets
                 if (IncludeMdlc || IncludeNdlc)
                     ThreadAgnostic = false;
 #endif
+                if (IncludeAllProperties)
+                    MutableUnsafe = true;   // TODO Need to convert Properties to an immutable state
             }
 
             public override string ToString()
@@ -610,7 +612,7 @@ namespace NLog.Targets
 
             public override void Precalculate(LogEventInfo logEvent)
             {
-                if (!(TargetLayout?.ThreadAgnostic ?? true))
+                if (!(TargetLayout?.ThreadAgnostic ?? true) || (TargetLayout?.MutableUnsafe ?? false))
                 {
                     TargetLayout.Precalculate(logEvent);
                     if (logEvent.TryGetCachedLayoutValue(TargetLayout, out var cachedLayout))
@@ -625,7 +627,7 @@ namespace NLog.Targets
 
             internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
             {
-                if (!(TargetLayout?.ThreadAgnostic ?? true))
+                if (!(TargetLayout?.ThreadAgnostic ?? true) || (TargetLayout?.MutableUnsafe ?? false))
                 {
                     TargetLayout.PrecalculateBuilder(logEvent, target);
                     if (logEvent.TryGetCachedLayoutValue(TargetLayout, out var cachedLayout))

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -2147,6 +2147,37 @@ namespace NLog.UnitTests
         }
 
         /// <summary>
+        /// Only properties
+        /// </summary>
+        [Fact]
+        public void TestStructuredProperties_json_async()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+                <nlog throwExceptions='true'>
+                    <targets>
+                        <target name='debugbuffer' type='bufferingWrapper'>
+                            <target name='debug' type='Debug'  >
+                                    <layout type='JsonLayout' IncludeAllProperties='true'>
+                                        <attribute name='LogMessage' layout='${message:raw=true}' />
+                                    </layout>
+                            </target>
+                        </target>
+                    </targets>
+                    <rules>
+                        <logger name='*' levels='Error' writeTo='debugbuffer' />
+                    </rules>
+                </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+
+            System.Text.StringBuilder sb = new System.Text.StringBuilder("BestApplicationEver");
+            logger.Error("Login request from {@Username} for {$Application}", new Person("John"), sb);
+            sb.Clear();
+            LogManager.Flush();
+            AssertDebugLastMessage("debug", "{ \"LogMessage\": \"Login request from {@Username} for {$Application}\", \"Username\": {\"Name\":\"John\"}, \"Application\": \"BestApplicationEver\" }");
+        }
+
+        /// <summary>
         /// Properties and message
         /// </summary>
         [Fact]


### PR DESCRIPTION
The bugfix followup to #2688

Should also consider to implement the same handling for Exceptions, as they also mutate when rethrown after logging (changes stacktrace or the user can modify the Data-dictionary).

Little sad that I don't have a good fix for TargetWithContext.