### PR TITLE
Allocation improvement in precalculating layouts

### DIFF
--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -618,15 +618,12 @@ namespace NLog
             if (Exception != null || _formattedMessage != null)
                 return false;
 
-            if (!HasProperties)
-                return true; // No mutable state, no need to precalculate
-
             var properties = CreateOrUpdatePropertiesInternal(false);
             if (properties == null || properties.Count == 0)
                 return true; // No mutable state, no need to precalculate
 
             if (properties.Count > 5)
-                return false;
+                return false; // too many properties, too costly to check
 
             if (properties.Count == _parameters?.Length && properties.Count == properties.MessageProperties.Count)
                 return true; // Already checked formatted message, no need to do it twice

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -89,12 +89,9 @@ namespace NLog
                 };
             }
 
-            if (targets.NextInChain == null
-             && logEvent.Parameters != null
-             && logEvent.Parameters.Length > 0
-             && logEvent.Message?.Length < 256
-             && ReferenceEquals(logEvent.MessageFormatter, LogMessageTemplateFormatter.DefaultAuto.MessageFormatter))
+            if (targets.NextInChain == null && logEvent.CanLogEventDeferMessageFormat())
             {
+                // Change MessageFormatter so it writes directly to StringBuilder without string-allocation
                 logEvent.MessageFormatter = LogMessageTemplateFormatter.DefaultAutoSingleTarget.MessageFormatter;
             }
 

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -195,7 +195,7 @@ namespace NLog.Targets
         {
             if (_allLayoutsAreThreadAgnostic)
             {
-                if (!_oneLayoutIsMutableUnsafe || IsLogEventMutableSafe(logEvent))
+                if (!_oneLayoutIsMutableUnsafe || logEvent.IsLogEventMutableSafe())
                     return;
             }
 
@@ -261,36 +261,6 @@ namespace NLog.Targets
                     }
                 }
             }
-        }
-
-        private bool IsLogEventMutableSafe(LogEventInfo logEvent)
-        {
-            if (logEvent.Exception == null)
-            {
-                if (!logEvent.HasProperties)
-                    return true; // No mutable state, no need to precalculate
-
-                var properties = logEvent.CreateOrUpdatePropertiesInternal(false);
-                if (properties == null || properties.Count == 0)
-                    return true; // No mutable state, no need to precalculate
-
-                if (properties.Count <= 5)
-                {
-                    bool immutableProperties = true;
-                    foreach (var property in properties)
-                    {
-                        if (Convert.GetTypeCode(property.Value) == TypeCode.Object)
-                        {
-                            immutableProperties = false;
-                            break;
-                        }
-                    }
-                    if (immutableProperties)
-                        return true; // No mutable state, no need to precalculate
-                }
-            }
-
-            return false;
         }
 
         /// <summary>

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -520,13 +520,10 @@ namespace NLog.Targets
             _allLayouts = ObjectGraphScanner.FindReachableObjects<Layout>(false, this);
             InternalLogger.Trace("{0} has {1} layouts", this, _allLayouts.Count);
             _allLayoutsAreThreadAgnostic = _allLayouts.All(layout => layout.ThreadAgnostic);
-            if (!_allLayoutsAreThreadAgnostic)
+            _oneLayoutIsMutableUnsafe = _allLayoutsAreThreadAgnostic && _allLayouts.Any(layout => layout.MutableUnsafe);
+            if (!_allLayoutsAreThreadAgnostic || _oneLayoutIsMutableUnsafe)
             {
                 _allLayoutsAreThreadSafe = _allLayouts.All(layout => layout.ThreadSafe);
-            }
-            else
-            {
-                _oneLayoutIsMutableUnsafe = _allLayouts.Any(layout => layout.MutableUnsafe);
             }
             StackTraceUsage = _allLayouts.DefaultIfEmpty().Max(layout => layout?.StackTraceUsage ?? StackTraceUsage.None);
             _scannedForLayouts = true;


### PR DESCRIPTION
Skip enumerator allocation. Maybe consider creating a struct-enumerator for the PropertiesDictionary.

I have dared to increase the allowed parameter count in defer-formatting-check from 3 to 5, after the optimization introduced with  #2595