### PR TITLE
Variables ignore case

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -410,7 +410,7 @@ namespace NLog.Config
                 reader.MoveToContent();
                 var content = new NLogXmlElement(reader);
                 if (fileName != null)
-                {                    
+                {
                     ParseTopLevel(content, fileName, autoReloadDefault: false);
 
                     InternalLogger.Info("Configured from an XML element in {0}...", fileName);
@@ -908,7 +908,7 @@ namespace NLog.Config
             }
         }
 
-        private bool ParseTargetWrapper(Dictionary<string, NLogXmlElement> typeNameToDefaultTargetParameters, string name, NLogXmlElement childElement, 
+        private bool ParseTargetWrapper(Dictionary<string, NLogXmlElement> typeNameToDefaultTargetParameters, string name, NLogXmlElement childElement,
             WrapperTargetBase wrapper)
         {
             if (IsTargetRefElement(name))
@@ -951,7 +951,7 @@ namespace NLog.Config
             return false;
         }
 
-        private bool ParseCompoundTarget(Dictionary<string, NLogXmlElement> typeNameToDefaultTargetParameters, string name, NLogXmlElement childElement, 
+        private bool ParseCompoundTarget(Dictionary<string, NLogXmlElement> typeNameToDefaultTargetParameters, string name, NLogXmlElement childElement,
             CompoundTargetBase compound)
         {
             if (IsTargetRefElement(name))
@@ -1226,7 +1226,7 @@ namespace NLog.Config
             TimeSource.Current = newTimeSource;
         }
 
-#endregion
+        #endregion
 
         private static string GetFileLookupKey(string fileName)
         {
@@ -1428,14 +1428,12 @@ namespace NLog.Config
         {
             string output = input;
 
-            // TODO - make this case-insensitive, will probably require a different approach
             var variables = Variables.ToList();
             foreach (var kvp in variables)
             {
                 var layout = kvp.Value;
-                //this value is set from xml and that's a string. Because of that, we can use SimpleLayout here.
 
-                if (layout != null) output = output.Replace("${" + kvp.Key + "}", layout.OriginalText);
+                if (layout != null) output = output.Replace("${" + kvp.Key + "}", layout.OriginalText, StringComparison.CurrentCultureIgnoreCase);
             }
 
             return output;

--- a/src/NLog/Internal/StringHelpers.cs
+++ b/src/NLog/Internal/StringHelpers.cs
@@ -34,6 +34,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using JetBrains.Annotations;
 
 namespace NLog.Internal
 {
@@ -58,6 +60,73 @@ namespace NLog.Internal
 #else
             return string.IsNullOrWhiteSpace(value);
 #endif
+        }
+
+        /// <summary>
+        /// Replace string with <paramref name="comparison"/>
+        /// </summary>
+        /// <param name="str"></param>
+        /// <param name="oldValue"></param>
+        /// <param name="newValue"></param>
+        /// <param name="comparison"></param>
+        /// <returns>The same reference of nothing has been replaced.</returns>
+        public static string Replace([NotNull] this string str, [NotNull] string oldValue, string newValue, StringComparison comparison)
+        {
+            if (str == null)
+            {
+                throw new ArgumentNullException(nameof(str));
+            }
+
+            if (oldValue == null)
+            {
+                throw new ArgumentNullException(nameof(oldValue));
+            }
+
+            if (str.Length == 0)
+            {
+                //nothing todo
+                return str;
+            }
+
+            StringBuilder sb = null;
+
+            int previousIndex = 0;
+            int index = str.IndexOf(oldValue, comparison);
+            while (index != -1)
+            {
+                sb = sb ?? new StringBuilder(str.Length);
+
+                if (previousIndex >= str.Length)
+                {
+                    // for cases that 2 chars is one symbol
+                    break;
+                }
+                sb.Append(str.Substring(previousIndex, index - previousIndex));
+                sb.Append(newValue);
+                index += oldValue.Length;
+
+                previousIndex = index;
+                if (index >= str.Length)
+                {
+                    // for cases that 2 chars is one symbol
+                    break;
+                }
+
+                index = str.IndexOf(oldValue, index, comparison);
+            }
+
+            if (sb == null)
+            {
+                //nothing replaced
+                return str;
+            }
+
+            if (previousIndex < str.Length)
+            {
+                sb.Append(str.Substring(previousIndex));
+            }
+            return sb.ToString();
+           
         }
     }
 }

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -42,16 +42,19 @@ namespace NLog.UnitTests.Config
 
     public class VariableTests : NLogTestBase
     {
-        [Fact]
-        public void VariablesTest1()
+        [Theory]
+        [InlineData("${prefix}${message}${suffix}", "prefix")]
+        [InlineData("${prefix}${message}${suffix}", "Prefix")]
+        [InlineData("${PreFix}${MessAGE}${SUFFIX}", "Prefix")]
+        public void VariablesTest1(string targetLayout, string variableName1)
         {
-            var configuration = CreateConfigurationFromString(@"
+            var configuration = CreateConfigurationFromString($@"
 <nlog throwExceptions='true'>
-    <variable name='prefix' value='[[' />
+    <variable name='{variableName1}' value='[[' />
     <variable name='suffix' value=']]' />
 
     <targets>
-        <target name='d1' type='Debug' layout='${prefix}${message}${suffix}' />
+        <target name='d1' type='Debug' layout='{targetLayout}' />
     </targets>
 </nlog>");
 

--- a/tests/NLog.UnitTests/Internal/StringHelpersTests.cs
+++ b/tests/NLog.UnitTests/Internal/StringHelpersTests.cs
@@ -37,7 +37,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NLog.Internal;
 using Xunit;
-using Xunit.Extensions;
 
 namespace NLog.UnitTests.Internal
 {
@@ -53,6 +52,36 @@ namespace NLog.UnitTests.Internal
         public void IsNullOrWhiteSpaceTest(string input, bool result)
         {
             Assert.Equal(result, StringHelpers.IsNullOrWhiteSpace(input));
+        }
+
+        [Theory]
+        [InlineData("","","",StringComparison.InvariantCulture, "")]
+        [InlineData("","",null,StringComparison.InvariantCulture, "")]
+        [InlineData("a","a","b",StringComparison.InvariantCulture, "b")]
+        [InlineData("aa","a","b",StringComparison.InvariantCulture, "bb")]
+        [InlineData("aa","a","",StringComparison.InvariantCulture, "")]
+        [InlineData(" Caac ","a","",StringComparison.InvariantCulture, " Cc ")]
+        [InlineData(" Caac ","a"," ",StringComparison.InvariantCulture, " C  c ")]
+        [InlineData("aA","a","b",StringComparison.InvariantCulture, "bA")]
+        [InlineData("aA","a","b",StringComparison.InvariantCultureIgnoreCase, "bb")]
+        [InlineData("œ", "oe", "", StringComparison.InvariantCulture, "")]
+        [InlineData("œ", "oe", "", StringComparison.OrdinalIgnoreCase, "œ")]
+        [InlineData("var ${var}", "${var}", "2", StringComparison.InvariantCulture, "var 2")]
+        [InlineData("var ${var}", "${VAR}", "2", StringComparison.InvariantCulture, "var ${var}")]
+        [InlineData("var ${VAR}", "${var}", "2", StringComparison.InvariantCulture, "var ${VAR}")]  
+        [InlineData("var ${var}", "${VAR}", "2", StringComparison.InvariantCultureIgnoreCase, "var 2")]
+        [InlineData("var ${VAR}", "${var}", "2", StringComparison.InvariantCultureIgnoreCase, "var 2")]
+        public void ReplaceTest(string input, string search, string replace, StringComparison comparer, string result)
+        {
+            Assert.Equal(result, input.Replace(search, replace, comparer));
+        }
+
+        [Theory]
+        [InlineData(null,"","",StringComparison.InvariantCulture)]
+        [InlineData("",null,"",StringComparison.InvariantCulture)]
+        public void ReplaceTestThrowsNullException(string input, string search, string replace, StringComparison comparer)
+        {
+            Assert.Throws<ArgumentNullException>(() => input.Replace(search, replace, comparer));
         }
     }
 }


### PR DESCRIPTION
it was a todo, but maybe it's inconsistent.

doubting. Targetnames are case sensitive

but layout renderers aren't case sensitive?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/2708)
<!-- Reviewable:end -->
