### PR TITLE
XML Config: Support for constant variable in level attributes (level, minlevel, etc)

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -533,6 +533,7 @@ namespace NLog.Config
             }
 
             //check loglevel as first, as other properties could write (indirect) to the internal log.
+            //expanding variables not possible here, there are created later
             InternalLogger.LogLevel = LogLevel.FromString(nlogElement.GetOptionalAttribute("internalLogLevel", InternalLogger.LogLevel.Name));
 
 #pragma warning disable 618
@@ -557,7 +558,7 @@ namespace NLog.Config
             InternalLogger.LogToTrace = nlogElement.GetOptionalBooleanAttribute("internalLogToTrace", InternalLogger.LogToTrace);
 #endif
             InternalLogger.IncludeTimestamp = nlogElement.GetOptionalBooleanAttribute("internalLogIncludeTimestamp", InternalLogger.IncludeTimestamp);
-            LogFactory.GlobalThreshold = LogLevel.FromString(nlogElement.GetOptionalAttribute("globalThreshold", LogFactory.GlobalThreshold.Name));
+            LogFactory.GlobalThreshold = LogLevelFromString(nlogElement.GetOptionalAttribute("globalThreshold", LogFactory.GlobalThreshold.Name));
 
             var children = nlogElement.Children.ToList();
 
@@ -711,11 +712,16 @@ namespace NLog.Config
             }
         }
 
-        private static void ParseLevels(NLogXmlElement loggerElement, LoggingRule rule)
+        private LogLevel LogLevelFromString(string text)
+        {
+            return LogLevel.FromString(ExpandSimpleVariables(text));
+        }
+
+        private void ParseLevels(NLogXmlElement loggerElement, LoggingRule rule)
         {
             if (loggerElement.AttributeValues.TryGetValue("level", out var levelString))
             {
-                LogLevel level = LogLevel.FromString(levelString);
+                LogLevel level = LogLevelFromString(levelString);
                 rule.EnableLoggingForLevel(level);
             }
             else if (loggerElement.AttributeValues.TryGetValue("levels", out levelString))
@@ -727,7 +733,7 @@ namespace NLog.Config
                 {
                     if (!string.IsNullOrEmpty(token))
                     {
-                        LogLevel level = LogLevel.FromString(token);
+                        LogLevel level = LogLevelFromString(token);
                         rule.EnableLoggingForLevel(level);
                     }
                 }
@@ -739,12 +745,12 @@ namespace NLog.Config
 
                 if (loggerElement.AttributeValues.TryGetValue("minLevel", out var minLevelString))
                 {
-                    minLevel = LogLevel.FromString(minLevelString).Ordinal;
+                    minLevel = LogLevelFromString(minLevelString).Ordinal;
                 }
 
                 if (loggerElement.AttributeValues.TryGetValue("maxLevel", out var maxLevelString))
                 {
-                    maxLevel = LogLevel.FromString(maxLevelString).Ordinal;
+                    maxLevel = LogLevelFromString(maxLevelString).Ordinal;
                 }
 
                 for (int i = minLevel; i <= maxLevel; ++i)
@@ -1380,5 +1386,5 @@ namespace NLog.Config
 
             return ConfigurationItemFactory.Layouts.CreateInstance(ExpandSimpleVariables(layoutTypeName));
         }
-    }
-}
+            }
+        }

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -92,6 +92,53 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        public void VariablesTest_minLevel_expanding()
+        {
+            var configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+   <variable name='test' value='debug'/>
+    <rules>
+      <logger minLevel='${test}'/>
+    </rules>
+</nlog>");
+
+            var rule = configuration.LoggingRules[0];
+            Assert.NotNull(rule);
+            Assert.False(rule.IsLoggingEnabledForLevel(LogLevel.Trace));
+            Assert.True(rule.IsLoggingEnabledForLevel(LogLevel.Debug));
+            Assert.True(rule.IsLoggingEnabledForLevel(LogLevel.Info));
+            Assert.True(rule.IsLoggingEnabledForLevel(LogLevel.Warn));
+            Assert.True(rule.IsLoggingEnabledForLevel(LogLevel.Error));
+            Assert.True(rule.IsLoggingEnabledForLevel(LogLevel.Fatal));
+
+        }        
+        
+        /// <summary>
+        /// Expand of level attributes
+        /// </summary>
+        [Fact]
+        public void VariablesTest_Level_expanding()
+        {
+            var configuration = CreateConfigurationFromString(@"
+<nlog throwExceptions='true'>
+   <variable name='test' value='debug'/>
+    <rules>
+      <logger level='${test}'/>
+    </rules>
+</nlog>");
+
+            var rule = configuration.LoggingRules[0];
+            Assert.NotNull(rule);
+            Assert.False(rule.IsLoggingEnabledForLevel(LogLevel.Trace));
+            Assert.True(rule.IsLoggingEnabledForLevel(LogLevel.Debug));
+            Assert.False(rule.IsLoggingEnabledForLevel(LogLevel.Info));
+            Assert.False(rule.IsLoggingEnabledForLevel(LogLevel.Warn));
+            Assert.False(rule.IsLoggingEnabledForLevel(LogLevel.Error));
+            Assert.False(rule.IsLoggingEnabledForLevel(LogLevel.Fatal));
+
+        }
+
+        [Fact]
         public void Xml_configuration_returns_defined_variables()
         {
             var configuration = CreateConfigurationFromString(@"


### PR DESCRIPTION
allow ${loglevel} for minLevel, maxLevel, level and levels on `<logger>`


- [x] merge #2707 first
- [x] rebase then

fixes https://github.com/NLog/NLog/issues/2479