### PR TITLE
Databasetarget install comand fix parameters usage

### DIFF
--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -621,38 +621,7 @@ namespace NLog.Targets
 
                     InternalLogger.Trace("DatabaseTarget(Name={0}): Executing {1}: {2}", Name, command.CommandType, command.CommandText);
 
-                    for (int i = 0; i < Parameters.Count; ++i)
-                    {
-                        DatabaseParameterInfo par = Parameters[i];
-                        IDbDataParameter p = command.CreateParameter();
-                        p.Direction = ParameterDirection.Input;
-                        if (par.Name != null)
-                        {
-                            p.ParameterName = par.Name;
-                        }
-
-                        if (par.Size != 0)
-                        {
-                            p.Size = par.Size;
-                        }
-
-                        if (par.Precision != 0)
-                        {
-                            p.Precision = par.Precision;
-                        }
-
-                        if (par.Scale != 0)
-                        {
-                            p.Scale = par.Scale;
-                        }
-
-                        string stringValue = RenderLogEvent(par.Layout, logEvent);
-
-                        p.Value = stringValue;
-                        command.Parameters.Add(p);
-
-                        InternalLogger.Trace("  DatabaseTarget: Parameter: '{0}' = '{1}' ({2})", p.ParameterName, p.Value, p.DbType);
-                    }
+                    AddParametersToCommand(command, Parameters, logEvent);
 
                     int result = command.ExecuteNonQuery();
                     InternalLogger.Trace("DatabaseTarget(Name={0}): Finished execution, result = {1}", Name, result);
@@ -773,10 +742,12 @@ namespace NLog.Targets
 
                     EnsureConnectionOpen(cs);
 
-                    using (var command = _activeConnection.CreateCommand())
+                    using (IDbCommand command = _activeConnection.CreateCommand())
                     {
                         command.CommandType = commandInfo.CommandType;
                         command.CommandText = RenderLogEvent(commandInfo.Text, logEvent);
+
+                        AddParametersToCommand(command, commandInfo.Parameters, logEvent);
 
                         try
                         {
@@ -808,6 +779,48 @@ namespace NLog.Targets
                 InternalLogger.Trace("DatabaseTarget(Name={0}): Close connection after install.", Name);
 
                 CloseConnection();
+            }
+        }
+
+        /// <summary>
+        /// Adds the given list of DatabaseParameterInfo to the given IDbCommand after transforming them into IDbDataParameters.
+        /// </summary>
+        /// <param name="command">The IDbCommand to add parameters to</param>
+        /// <param name="databaseParameterInfos">The list of DatabaseParameterInfo to transform into IDbDataParameters and to add to the IDbCommand</param>
+        /// <param name="logEvent">The log event to base the parameter's layout rendering on.</param>
+        private void AddParametersToCommand(IDbCommand command, IList<DatabaseParameterInfo> databaseParameterInfos, LogEventInfo logEvent)
+        {
+            for(int i = 0; i < databaseParameterInfos.Count; ++i)
+            {
+                DatabaseParameterInfo par = databaseParameterInfos[i];
+                IDbDataParameter p = command.CreateParameter();
+                p.Direction = ParameterDirection.Input;
+                if (par.Name != null)
+                {
+                    p.ParameterName = par.Name;
+                }
+
+                if (par.Size != 0)
+                {
+                    p.Size = par.Size;
+                }
+
+                if (par.Precision != 0)
+                {
+                    p.Precision = par.Precision;
+                }
+
+                if (par.Scale != 0)
+                {
+                    p.Scale = par.Scale;
+                }
+
+                string stringValue = RenderLogEvent(par.Layout, logEvent);
+
+                p.Value = stringValue;
+                command.Parameters.Add(p);
+
+                InternalLogger.Trace("  DatabaseTarget: Parameter: '{0}' = '{1}' ({2})", p.ParameterName, p.Value, p.DbType);
             }
         }
 

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -609,7 +609,7 @@ namespace NLog.Targets
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "It's up to the user to ensure proper quoting.")]
         private void WriteEventToDatabase(LogEventInfo logEvent)
         {
-            //Always suppress transaction so that the caller does not rollback loggin if they are rolling back their transaction.
+            //Always suppress transaction so that the caller does not rollback logging if they are rolling back their transaction.
             using (TransactionScope transactionScope = new TransactionScope(TransactionScopeOption.Suppress))
             {
                 EnsureConnectionOpen(BuildConnectionString(logEvent));

--- a/tests/NLog.UnitTests/NLog.UnitTests.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
@@ -54,7 +54,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.0.1" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
     <PackageReference Include="System.ServiceModel.Security" Version="4.4.0" />

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -346,6 +346,45 @@ Dispose()
         }
 
         [Fact]
+        public void InstallParameterTest()
+        {
+            MockDbConnection.ClearLog();
+
+            DatabaseCommandInfo installDbCommand = new DatabaseCommandInfo
+            {
+                Text = $"INSERT INTO dbo.SomeTable(SomeColumn) SELECT @paramOne WHERE NOT EXISTS(SELECT 1 FROM dbo.SomeOtherTable WHERE SomeColumn = @paramOne);"
+            };
+            installDbCommand.Parameters.Add(new DatabaseParameterInfo("paramOne", "SomeValue"));
+
+            DatabaseTarget dt = new DatabaseTarget()
+            {
+                DBProvider = typeof(MockDbConnection).AssemblyQualifiedName,
+                KeepConnection = true,
+                CommandText = "not_important"
+            };
+            dt.InstallDdlCommands.Add(installDbCommand);
+
+            dt.Initialize(null);
+
+            Assert.Same(typeof(MockDbConnection), dt.ConnectionType);
+
+            dt.Install(new InstallationContext());
+
+            string expectedLog = @"Open('Server=.;Trusted_Connection=SSPI;').
+CreateParameter(0)
+Parameter #0 Direction=Input
+Parameter #0 Name=paramOne
+Parameter #0 Value=SomeValue
+Add Parameter Parameter #0
+ExecuteNonQuery: INSERT INTO dbo.SomeTable(SomeColumn) SELECT @paramOne WHERE NOT EXISTS(SELECT 1 FROM dbo.SomeOtherTable WHERE SomeColumn = @paramOne);
+Close()
+Dispose()
+";
+
+            AssertLog(expectedLog);
+        }
+
+        [Fact]
         public void ParameterTest()
         {
             MockDbConnection.ClearLog();
@@ -850,7 +889,8 @@ Dispose()
 #endif
 
 #if NETSTANDARD
-        [Fact(Skip = "NETSTANDARD missing fully working Sqlite")]
+        //[Fact(Skip = "NETSTANDARD missing fully working Sqlite")]
+        [Fact]
 #else
         [Fact]
 #endif
@@ -930,7 +970,8 @@ Dispose()
         }
 
 #if NETSTANDARD
-        [Fact(Skip = "NETSTANDARD missing fully working Sqlite")]
+        //[Fact(Skip = "NETSTANDARD missing fully working Sqlite")]
+        [Fact]
 #else
         [Fact]
 #endif
@@ -994,6 +1035,117 @@ Dispose()
             }
         }
 
+        [Fact]
+        public void SQLite_InstallTest()
+        {
+            SQLiteTest sqlLite = new SQLiteTest("TestInstallXml.sqlite");
+
+            // delete database just in case
+            sqlLite.TryDropDatabase();
+            LogManager.ThrowExceptions = true;
+
+            try
+            {
+                sqlLite.CreateDatabase();
+
+                var connectionString = sqlLite.GetConnectionString();
+                string dbProvider = GetSQLiteDbProvider();
+
+                // Create log with xml config
+                LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog xmlns='http://www.nlog-project.org/schemas/NLog.xsd'
+                  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' throwExceptions='true'>
+                <targets>
+                    <target name='database' xsi:type='Database' dbProvider=""" + dbProvider + @""" connectionstring=""" + connectionString + @"""
+                        commandText='not_important'>
+<install-command ignoreFailures=""false""
+                 text=""CREATE TABLE NLogSqlLiteTestAppNames (
+    Id int PRIMARY KEY,
+    Name varchar(100) NULL
+);
+INSERT INTO NLogSqlLiteTestAppNames(Id, Name) VALUES (1, @appName);"">
+<parameter name='@appName' layout='MyApp' />
+</install-command>
+
+                    </target>
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='database' />
+                </rules>
+            </nlog>");
+
+                //install 
+                InstallationContext context = new InstallationContext();
+                LogManager.Configuration.Install(context);
+
+                // check so table is created
+                var tableName = sqlLite.IssueScalarQuery("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'NLogSqlLiteTestAppNames'");
+                Assert.Equal("NLogSqlLiteTestAppNames", tableName);
+
+                // returns long
+                var logcount = sqlLite.IssueScalarQuery("SELECT count(*) FROM NLogSqlLiteTestAppNames");
+                Assert.Equal((long)1, logcount);
+
+                // check if entry was correct
+                var entryValue = sqlLite.IssueScalarQuery("SELECT Name FROM NLogSqlLiteTestAppNames WHERE ID = 1");
+                Assert.Equal("MyApp", entryValue);
+            }
+            finally
+            {
+                sqlLite.TryDropDatabase();
+            }
+        }
+
+        [Fact]
+        public void SQLite_InstallProgramaticallyTest()
+        {
+            SQLiteTest sqlLite = new SQLiteTest("TestInstallProgram.sqlite");
+
+            // delete database just in case
+            sqlLite.TryDropDatabase();
+            LogManager.ThrowExceptions = true;
+
+            try
+            {
+                sqlLite.CreateDatabase();
+
+                var connectionString = sqlLite.GetConnectionString();
+                string dbProvider = GetSQLiteDbProvider();
+
+                DatabaseTarget testTarget = new DatabaseTarget("TestSqliteTargetInstallProgram");
+                testTarget.ConnectionString = connectionString;
+                testTarget.DBProvider = dbProvider;
+                
+                DatabaseCommandInfo installDbCommand = new DatabaseCommandInfo
+                {
+                    Text = "CREATE TABLE NLogSqlLiteTestAppNames (Id int PRIMARY KEY, Name varchar(100) NULL); " +
+                        "INSERT INTO NLogSqlLiteTestAppNames(Id, Name) SELECT 1, @paramOne WHERE NOT EXISTS(SELECT 1 FROM NLogSqlLiteTestAppNames WHERE Name = @paramOne);"
+                };
+                installDbCommand.Parameters.Add(new DatabaseParameterInfo("@paramOne", "MyApp"));
+                testTarget.InstallDdlCommands.Add(installDbCommand);
+
+                //install 
+                InstallationContext context = new InstallationContext();
+                testTarget.Install(context);
+
+                // check so table is created
+                var tableName = sqlLite.IssueScalarQuery("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'NLogSqlLiteTestAppNames'");
+                Assert.Equal("NLogSqlLiteTestAppNames", tableName);
+
+                // returns long
+                var logcount = sqlLite.IssueScalarQuery("SELECT count(*) FROM NLogSqlLiteTestAppNames");
+                Assert.Equal((long)1, logcount);
+
+                // check if entry was correct
+                var entryValue = sqlLite.IssueScalarQuery("SELECT Name FROM NLogSqlLiteTestAppNames WHERE ID = 1");
+                Assert.Equal("MyApp", entryValue);
+            }
+            finally
+            {
+                sqlLite.TryDropDatabase();
+            }
+        }
+
         private void SetupSqliteConfigWithInvalidInstallCommand(string databaseName)
         {
             var nlogXmlConfig = @"
@@ -1013,7 +1165,12 @@ Dispose()
 
             // Use an in memory SQLite database
             // See https://www.sqlite.org/inmemorydb.html
+#if NETSTANDARD
+            var connectionString = "Data Source=:memory:";
+#else
             var connectionString = "Uri=file::memory:;Version=3";
+#endif
+
 
             LogManager.Configuration = CreateConfigurationFromString(
                 String.Format(nlogXmlConfig, GetSQLiteDbProvider(), connectionString)
@@ -1036,7 +1193,8 @@ Dispose()
         }
 
 #if NETSTANDARD
-        [Fact(Skip = "NETSTANDARD missing fully working Sqlite")]
+        //[Fact(Skip = "NETSTANDARD missing fully working Sqlite")]
+        [Fact]
 #else
         [Fact]
 #endif
@@ -1707,7 +1865,11 @@ Dispose()
             public SQLiteTest(string dbName)
             {
                 this.dbName = dbName;
+#if NETSTANDARD
+                connectionString = "Data Source=" + this.dbName;
+#else
                 connectionString = "Data Source=" + this.dbName + ";Version=3;";
+#endif
             }
 
             public string GetConnectionString()

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -888,12 +888,7 @@ Dispose()
         }
 #endif
 
-#if NETSTANDARD
-        //[Fact(Skip = "NETSTANDARD missing fully working Sqlite")]
         [Fact]
-#else
-        [Fact]
-#endif
         public void SQLite_InstallAndLogMessageProgrammatically()
         {
             SQLiteTest sqlLite = new SQLiteTest("TestLogProgram.sqlite");
@@ -969,12 +964,7 @@ Dispose()
 #endif
         }
 
-#if NETSTANDARD
-        //[Fact(Skip = "NETSTANDARD missing fully working Sqlite")]
         [Fact]
-#else
-        [Fact]
-#endif
         public void SQLite_InstallAndLogMessage()
         {
             SQLiteTest sqlLite = new SQLiteTest("TestLogXml.sqlite");
@@ -1192,12 +1182,8 @@ INSERT INTO NLogSqlLiteTestAppNames(Id, Name) VALUES (1, @appName);"">
             Assert.Null(exRecorded);
         }
 
-#if NETSTANDARD
-        //[Fact(Skip = "NETSTANDARD missing fully working Sqlite")]
+
         [Fact]
-#else
-        [Fact]
-#endif
         public void RethrowingInstallExceptions()
         {
             SetupSqliteConfigWithInvalidInstallCommand("rethrowing_install_exceptions");


### PR DESCRIPTION
RunInstallCommands should now take into account all parameters passed to it.
WriteEventToDatabase and RunInstallCommands both use parameter looping logic, so that has been extracted into its own private method.

Various additions to the Unit tests. 
Added a reference to Microsoft.Data.Sqlite and removed Microsoft.Data.Sqlite.Core.
This should make all sqlite tests work for both 452 and netcore.