### PR TITLE
Support for custom targets that implements IUsesStackTrace

### DIFF
--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -526,6 +526,8 @@ namespace NLog.Targets
                 _allLayoutsAreThreadSafe = _allLayouts.All(layout => layout.ThreadSafe);
             }
             StackTraceUsage = _allLayouts.DefaultIfEmpty().Max(layout => layout?.StackTraceUsage ?? StackTraceUsage.None);
+            if (this is IUsesStackTrace usesStackTrace && usesStackTrace.StackTraceUsage > StackTraceUsage)
+                StackTraceUsage = usesStackTrace.StackTraceUsage;
             _scannedForLayouts = true;
         }
 


### PR DESCRIPTION
Allow custom targets to request LogEventInfo.StackTrace without needing to use magically public properties. "Just" have to implement `NLog.Internal.IUsesStackTrace`

See also #2721. Fixes one more regression from #1310, but still doesn't fix this use-case:

https://github.com/GibraltarSoftware/Gibraltar.Agent.NLog2/blob/master/src/Agent.NLog2/GibraltarTarget.cs