### PR TITLE
ReconfigExistingLoggers should not block for new Loggers

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -470,7 +470,9 @@ namespace NLog.Config
                 throw new ArgumentNullException(nameof(installationContext));
             }
 
-            InitializeAll();
+            var supportsInitializes = ValidateConfig();
+            InitializeAll(supportsInitializes);
+
             var configItemsList = GetInstallableItems();
             foreach (IInstallable installable in configItemsList)
             {
@@ -508,7 +510,8 @@ namespace NLog.Config
                 throw new ArgumentNullException(nameof(installationContext));
             }
 
-            InitializeAll();
+            var supportsInitializes = ValidateConfig();
+            InitializeAll(supportsInitializes);
 
             var configItemsList = GetInstallableItems();
             foreach (IInstallable installable in configItemsList)
@@ -543,6 +546,7 @@ namespace NLog.Config
             foreach (ISupportsInitialize initialize in supportsInitializesList)
             {
                 InternalLogger.Trace("Closing {0}", initialize);
+
                 try
                 {
                     initialize.Close();
@@ -555,8 +559,6 @@ namespace NLog.Config
                     {
                         throw;
                     }
-
-
                 }
             }
 
@@ -622,7 +624,7 @@ namespace NLog.Config
         /// <summary>
         /// Validates the configuration.
         /// </summary>
-        internal void ValidateConfig()
+        internal List<ISupportsInitialize> ValidateConfig()
         {
             var roots = new List<object>();
 
@@ -647,13 +649,12 @@ namespace NLog.Config
             {
                 PropertyHelper.CheckRequiredParameters(o);
             }
+
+            return GetSupportsInitializes(true);
         }
 
-        internal void InitializeAll()
+        internal void InitializeAll(List<ISupportsInitialize> supportsInitializes)
         {
-            ValidateConfig();
-
-            var supportsInitializes = GetSupportsInitializes(true);
             foreach (ISupportsInitialize initialize in supportsInitializes)
             {
                 InternalLogger.Trace("Initializing {0}", initialize);
@@ -675,11 +676,6 @@ namespace NLog.Config
                     }
                 }
             }
-        }
-
-        internal void EnsureInitialized()
-        {
-            InitializeAll();
         }
 
         private List<IInstallable> GetInstallableItems()

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -396,8 +396,9 @@ namespace NLog
                 lock (_syncRoot)
                 {
                     _globalThreshold = value;
-                    ReconfigExistingLoggers();
                 }
+
+                ReconfigExistingLoggers();
             }
         }
 
@@ -551,13 +552,15 @@ namespace NLog
         public void ReconfigExistingLoggers()
         {
             List<Logger> loggers;
+            List<ISupportsInitialize> supportsInitializes;
 
             lock (_syncRoot)
             {
-                _config?.InitializeAll();
-
+                supportsInitializes = _config?.ValidateConfig();
                 loggers = _loggerCache.GetLoggers();
             }
+
+            _config?.InitializeAll(supportsInitializes ?? Enumerable.Empty<ISupportsInitialize>().ToList());
 
             foreach (var logger in loggers)
             {

--- a/tests/NLog.UnitTests/Config/ConfigApiTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigApiTests.cs
@@ -210,7 +210,8 @@ namespace NLog.UnitTests.Config
             Assert.Single(config.AllTargets);
             Assert.Equal(fileTarget, config.AllTargets[0]);
 
-            config.InitializeAll();
+            var supportsInitializes = config.ValidateConfig();
+            config.InitializeAll(supportsInitializes);
 
             Assert.Single(config.AllTargets);
             Assert.Equal(fileTarget, config.AllTargets[0]);


### PR DESCRIPTION
Allow other threads to allocate new Loggers while ReconfigExistingLoggers are working on initializing targets.

The targets are protected by their own locks, and doesn't need the extra locking.