### PR TITLE
JsonLayout - Reduce allocations when needing to escape string (44% time improvement)

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
@@ -78,9 +78,9 @@ namespace NLog.LayoutRenderers.Wrappers
         {
             if (JsonEncode && RequiresJsonEncode(target))
             {
-                var result = Targets.DefaultJsonSerializer.EscapeString(target.ToString(), EscapeUnicode);
+                var str = target.ToString();
                 target.Length = 0;
-                target.Append(result);
+                Targets.DefaultJsonSerializer.AppendStringEscape(target, str, EscapeUnicode);
             }
         }
 

--- a/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
@@ -71,6 +71,23 @@ namespace NLog.LayoutRenderers.Wrappers
         public bool EscapeUnicode { get; set; }
 
         /// <summary>
+        /// Render to local target using Inner Layout, and then transform before final append
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="logEvent"></param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            if (JsonEncode)
+            {
+                base.Append(builder, logEvent);
+            }
+            else
+            {
+                RenderFormattedMessage(logEvent, builder);
+            }
+        }
+
+        /// <summary>
         /// Post-processes the rendered message. 
         /// </summary>
         /// <param name="target">The text to be JSON-encoded.</param>

--- a/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
@@ -64,17 +64,25 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <summary>
         /// Renders the inner layout contents.
         /// </summary>
+        /// <param name="builder"><see cref="StringBuilder"/> for the result</param>
         /// <param name="logEvent">The log event.</param>
-        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
-        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            int orgLength = target.Length;
-            base.RenderFormattedMessage(logEvent, target);
-            if (target.Length > orgLength)
-                return;
+            int orgLength = builder.Length;
+            try
+            {
+                base.RenderFormattedMessage(logEvent, builder);
+                if (builder.Length > orgLength)
+                    return;
 
-            // render WhenEmpty when the inner layout was empty
-            WhenEmpty.RenderAppendBuilder(logEvent, target);
+                // render WhenEmpty when the inner layout was empty
+                WhenEmpty.RenderAppendBuilder(logEvent, builder);
+            }
+            catch
+            {
+                builder.Length = orgLength; // Rewind/Truncate on exception
+                throw;
+            }
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
@@ -71,17 +71,26 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <summary>
         /// Renders the inner layout contents.
         /// </summary>
+        /// <param name="builder"><see cref="StringBuilder"/> for the result</param>
         /// <param name="logEvent">The log event.</param>
-        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
-        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            if (When == null || true.Equals(When.Evaluate(logEvent)))
+            int orgLength = builder.Length;
+            try
             {
-                base.RenderFormattedMessage(logEvent, target);
+                if (When == null || true.Equals(When.Evaluate(logEvent)))
+                {
+                    base.RenderFormattedMessage(logEvent, builder);
+                }
+                else if (Else != null)
+                {
+                    Else.RenderAppendBuilder(logEvent, builder);
+                }
             }
-            else if (Else != null)
+            catch
             {
-                Else.RenderAppendBuilder(logEvent, target);
+                builder.Length = orgLength; // Rewind/Truncate on exception
+                throw;
             }
         }
     }

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -330,10 +330,9 @@ namespace NLog.Layouts
                 if (Targets.DefaultJsonSerializer.RequiresJsonEscape(sb[i], false))
                 {
                     var jsonEscape = sb.ToString(valueStart + 1, sb.Length - valueStart - 2);
-                    jsonEscape = Targets.DefaultJsonSerializer.EscapeString(jsonEscape, false);
                     sb.Length = valueStart;
                     sb.Append('"');
-                    sb.Append(jsonEscape);
+                    Targets.DefaultJsonSerializer.AppendStringEscape(sb, jsonEscape, false);
                     sb.Append('"');
                     break;
                 }

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -563,22 +563,30 @@ namespace NLog.Targets
         /// <summary>
         /// Checks input string if it needs JSON escaping, and makes necessary conversion
         /// </summary>
-        /// <param name="sb">Destination Builder</param>
+        /// <param name="destination">Destination Builder</param>
         /// <param name="text">Input string</param>
         /// <param name="escapeUnicode">Should non-ascii characters be encoded</param>
         /// <returns>JSON escaped string</returns>
-        internal static void AppendStringEscape(StringBuilder sb, string text, bool escapeUnicode)
+        internal static void AppendStringEscape(StringBuilder destination, string text, bool escapeUnicode)
         {
             if (string.IsNullOrEmpty(text))
                 return;
+
+            StringBuilder sb = null;
 
             for (int i = 0; i < text.Length; ++i)
             {
                 char ch = text[i];
                 if (!RequiresJsonEscape(ch, escapeUnicode))
                 {
-                    sb.Append(ch);
+                    if (sb != null)
+                        sb.Append(ch);
                     continue;
+                }
+                else if (sb == null)
+                {
+                    sb = destination;
+                    sb.Append(text, 0, i);
                 }
 
                 switch (ch)
@@ -627,6 +635,9 @@ namespace NLog.Targets
                         break;
                 }
             }
+
+            if (sb == null)
+                destination.Append(text);   // Faster to make single Append
         }
 
         internal static bool RequiresJsonEscape(char ch, bool escapeUnicode)


### PR DESCRIPTION
Reuse truncated StringBuilder, instead of creating new.

Also skip the temporary StringBuilder, when using `Encode=false`. Performance optimization for nested JsonLayouts. But one can also consider using `Encode=false` for simple fields like `${longdate}` or `${level}` as it skips unnecessary validation.