### PR TITLE
LogEventInfo - HasProperties should allocate PropertiesDicitonary when needed

### DIFF
--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -331,7 +331,7 @@ namespace NLog
                 }
                 else
                 {
-                    return HasMessageTemplateParameters;
+                    return CreateOrUpdatePropertiesInternal(false)?.Count > 0;
                 }
             }
         }
@@ -353,11 +353,11 @@ namespace NLog
             var properties = _properties;
             if (properties == null)
             {
-                if (forceCreate || templateParameters?.Count > 0)
+                if (forceCreate || templateParameters?.Count > 0 || (templateParameters == null && HasMessageTemplateParameters))
                 {
                     properties = new PropertiesDictionary(templateParameters);
                     Interlocked.CompareExchange(ref _properties, properties, null);
-                    if (forceCreate && HasMessageTemplateParameters)
+                    if (templateParameters == null && (!forceCreate || HasMessageTemplateParameters))
                     {
                         // Trigger capture of MessageTemplateParameters from logevent-message
                         CalcFormattedMessage();


### PR DESCRIPTION
HasProperties checks HasMessageTemplateParameters (semi-expensive), but skips allocation of PropertiesDictionary even if properties are found.

Usually one checks LogEventInfo.HasProperties and if true, then requests LogEventInfo.Properties. LogEventInfo.Properites also performs HasMessageTemplateParameters-check.

Instead of calling HasMessageTemplateParameters twice, then just allocate the PropertiesDictionary upfront when HasProperties = true. Since HasProperties=true most likely means one is going to request LogEventInfo.Properties just right after.