### PR TITLE
JsonSerializer - Generate valid Json when hitting the MaxRecursionLimit

### DIFF
--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -266,7 +266,10 @@ namespace NLog.Targets
 
             int nextDepth = objectsInPath.Count <= 1 ? depth : (depth + 1);
             if (nextDepth > options.MaxRecursionLimit)
+            {
+                destination.Append("{}");
                 return;
+            }
 
             int originalLength;
             destination.Append('{');
@@ -341,7 +344,10 @@ namespace NLog.Targets
 
             int nextDepth = objectsInPath.Count <= 1 ? depth : (depth + 1); // Allow serialization of list-items 
             if (nextDepth > options.MaxRecursionLimit)
+            {
+                destination.Append("[]");
                 return;
+            }
 
             int originalLength;
             destination.Append('[');

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -440,6 +440,28 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void IncludeAllJsonPropertiesMaxRecursionLimit()
+        {
+            var jsonLayout = new JsonLayout()
+            {
+                IncludeAllProperties = true,
+                MaxRecursionLimit = 1,
+            };
+
+            LogEventInfo logEventInfo = new LogEventInfo()
+            {
+                TimeStamp = new DateTime(2010, 01, 01, 12, 34, 56),
+                Level = LogLevel.Info,
+            };
+            logEventInfo.Properties["Message"] = new
+            {
+                data = new Dictionary<int, string>() { { 42, "Hello" } }
+            };
+
+            Assert.Equal(@"{ ""Message"": {""data"":{}} }", jsonLayout.Render(logEventInfo));
+        }
+
+        [Fact]
         public void IncludeMdcJsonProperties()
         {
             LogManager.Configuration = CreateConfigurationFromString(@"
@@ -628,7 +650,7 @@ namespace NLog.UnitTests.Layouts
 
             logger.Debug(logEventInfo3);
 
-            AssertDebugLastMessage("debug", "{ \"nestedObject\": [] }");  // No support for nested collections
+            AssertDebugLastMessage("debug", "{ \"nestedObject\": [[]] }");  // No support for nested collections
         }
 
         private static LogEventInfo CreateLogEventWithExcluded()


### PR DESCRIPTION
Truncate to empty collections instead of generating invalid Json.