### PR TITLE
JSON: Fixes issue where char types are not properly escaped

### DIFF
--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -98,18 +98,6 @@ namespace NLog.Targets
             {
                 return "null";
             }
-            else if (value is char c)
-            {
-                if (RequiresJsonEscape(c, options.EscapeUnicode))
-                {
-                   StringBuilder sb = new StringBuilder(5);
-                   sb.Append('"');
-                   AppendStringEscape(sb, c.ToString(), options.EscapeUnicode);
-                   sb.Append('"');
-                   return sb.ToString();
-                }
-                return QuoteValue(c.ToString());
-            }
             else if (value is string str)
             {
                 for (int i = 0; i < str.Length; ++i)
@@ -128,7 +116,7 @@ namespace NLog.Targets
             else
             {
                 TypeCode objTypeCode = Convert.GetTypeCode(value);
-                if (objTypeCode != TypeCode.Object && StringHelpers.IsNullOrWhiteSpace(options.Format) && options.FormatProvider == null)
+                if (objTypeCode != TypeCode.Object && objTypeCode != TypeCode.Char && StringHelpers.IsNullOrWhiteSpace(options.Format) && options.FormatProvider == null)
                 {
                     Enum enumValue;
                     if (!options.EnumAsInteger && IsNumericTypeCode(objTypeCode, false) && (enumValue = value as Enum) != null)
@@ -203,12 +191,6 @@ namespace NLog.Targets
             if (value == null)
             {
                 destination.Append("null");
-            }
-            else if (value is char c)
-            {
-                destination.Append('"');
-                AppendStringEscape(destination, c.ToString(), options.EscapeUnicode);
-                destination.Append('"');
             }
             else if (value is string str)
             {
@@ -487,7 +469,16 @@ namespace NLog.Targets
                     }
                     else
                     {
-                        QuoteValue(destination, str);
+                        if (objTypeCode == TypeCode.Char)
+                        {
+                            destination.Append('"');
+                            AppendStringEscape(destination, str, options.EscapeUnicode);
+                            destination.Append('"');
+                        }
+                        else
+                        {
+                            QuoteValue(destination, str);
+                        }
                     }
                 }
             }

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -98,6 +98,18 @@ namespace NLog.Targets
             {
                 return "null";
             }
+            else if (value is char c)
+            {
+                if (RequiresJsonEscape(c, options.EscapeUnicode))
+                {
+                   StringBuilder sb = new StringBuilder(5);
+                   sb.Append('"');
+                   AppendStringEscape(sb, c.ToString(), options.EscapeUnicode);
+                   sb.Append('"');
+                   return sb.ToString();
+                }
+                return QuoteValue(c.ToString());
+            }
             else if (value is string str)
             {
                 for (int i = 0; i < str.Length; ++i)
@@ -191,6 +203,12 @@ namespace NLog.Targets
             if (value == null)
             {
                 destination.Append("null");
+            }
+            else if (value is char c)
+            {
+                destination.Append('"');
+                AppendStringEscape(destination, c.ToString(), options.EscapeUnicode);
+                destination.Append('"');
             }
             else if (value is string str)
             {

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -653,6 +653,34 @@ namespace NLog.UnitTests.Layouts
             AssertDebugLastMessage("debug", "{ \"nestedObject\": [[]] }");  // No support for nested collections
         }
 
+        [Fact]
+        public void EncodesInvalidCharacters()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog throwExceptions='true'>
+            <targets>
+                <target name='debug' type='Debug'  >
+                 <layout type=""JsonLayout"" IncludeAllProperties='true' >
+                 </layout>
+                </target>
+            </targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+
+            ILogger logger = LogManager.GetLogger("A");
+
+            var logEventInfo1 = new LogEventInfo();
+
+            logEventInfo1.Properties.Add("InvalidCharacters", "|#{}%&\"~+\\/:*?<>".ToCharArray());
+
+            logger.Debug(logEventInfo1);
+
+            AssertDebugLastMessage("debug", "{ \"InvalidCharacters\": [\"|\",\"#\",\"{\",\"}\",\"%\",\"&\",\"\\\"\",\"~\",\"+\",\"\\\\\",\"\\/\",\":\",\"*\",\"?\",\"<\",\">\"] }");
+        }
+
         private static LogEventInfo CreateLogEventWithExcluded()
         {
             var logEventInfo = new LogEventInfo


### PR DESCRIPTION
DefaultJsonSerializer was not properly escaping 'char' types, which could result in invalid JSON.