### PR TITLE
Logging with mmm as intended (vs.mmmm)

### DIFF
--- a/src/NLog/LayoutRenderers/LongDateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LongDateLayoutRenderer.cs
@@ -82,7 +82,7 @@ namespace NLog.LayoutRenderers
             builder.Append(':');
             builder.Append2DigitsZeroPadded(dt.Second);
             builder.Append('.');
-            builder.Append4DigitsZeroPadded((int)(dt.Ticks % 10000000) / 1000);
+            builder.Append3DigitsZeroPadded((int)(dt.Ticks % 10000000) / 10000);
         }
     }
 }


### PR DESCRIPTION
I guess it's faster to move and then divide, but if you look at the output you will currently get 4 digits vs expected millisecond.