### PR TITLE
Updating comments

### DIFF
--- a/src/NLog/LayoutRenderers/LongDateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LongDateLayoutRenderer.cs
@@ -41,7 +41,7 @@ namespace NLog.LayoutRenderers
     using NLog.Internal;
 
     /// <summary>
-    /// The date and time in a long, sortable format yyyy-MM-dd HH:mm:ss.mmm.
+    /// The date and time in a long, sortable format yyyy-MM-dd HH:mm:ss.ffff.
     /// </summary>
     [LayoutRenderer("longdate")]
     [ThreadAgnostic]
@@ -56,7 +56,7 @@ namespace NLog.LayoutRenderers
         public bool UniversalTime { get; set; }
 
         /// <summary>
-        /// Renders the date in the long format (yyyy-MM-dd HH:mm:ss.mmm) and appends it to the specified <see cref="StringBuilder" />.
+        /// Renders the date in the long format (yyyy-MM-dd HH:mm:ss.ffff) and appends it to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="logEvent">Logging event.</param>


### PR DESCRIPTION
Doesn't seem like a correct default behaviour (I guess you either need ms or ns) but as pointed out it would be breaking change and docs are defining longdate as ss.ffff already