### PR TITLE
Throw better error when target name is null

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -202,6 +202,8 @@ namespace NLog.Config
         public void AddTarget([NotNull] Target target)
         {
             if (target == null) { throw new ArgumentNullException(nameof(target)); }
+            if (target.Name == null) { throw new ArgumentNullException( nameof(target) + ".Name cannot be null." ); }
+
             AddTargetThreadSafe(target.Name, target, true);
         }
 


### PR DESCRIPTION
If target.Name is null the rest of the code throws some weird error about 'key' being null which is unrelated.