### PR TITLE
${Assembly-version} make GetAssembly protected and virtual

### DIFF
--- a/src/NLog/LayoutRenderers/AssemblyVersionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AssemblyVersionLayoutRenderer.cs
@@ -157,6 +157,7 @@ namespace NLog.LayoutRenderers
         {
             return System.Reflection.Assembly.Load(new System.Reflection.AssemblyName(Name));
         }
+
 #else
 
         private string GetVersion()
@@ -165,7 +166,11 @@ namespace NLog.LayoutRenderers
             return GetVersion(assembly);
         }
 
-        private System.Reflection.Assembly GetAssembly()
+        /// <summary>
+        /// Gets the assembly specified by <see cref="Name"/>, or entry assembly otherwise
+        /// </summary>
+        /// <returns>Found assembly</returns>
+        protected virtual System.Reflection.Assembly GetAssembly()
         {
             if (string.IsNullOrEmpty(Name))
             {
@@ -191,6 +196,8 @@ namespace NLog.LayoutRenderers
                     return assembly?.GetName().Version?.ToString();
             }
         }
+
 #endif
+
     }
 }

--- a/src/NLogAutoLoadExtension/NLogAutoLoadExtension.csproj
+++ b/src/NLogAutoLoadExtension/NLogAutoLoadExtension.csproj
@@ -1,9 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
     <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net45;net40-client;net35;netstandard1.5;netstandard2.0</TargetFrameworks>
+
+    <InformationalVersion>2.0.0.2</InformationalVersion>
 
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>

--- a/src/NLogAutoLoadExtension/Properties/AssemblyInfo.cs
+++ b/src/NLogAutoLoadExtension/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.1")]

--- a/tests/NLog.UnitTests/LayoutRenderers/AssemblyVersionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/AssemblyVersionTests.cs
@@ -68,8 +68,8 @@ namespace NLog.UnitTests.LayoutRenderers
         public void AssemblyNameVersionTypeTest()
         {
             AssertLayoutRendererOutput("${assembly-version:name=NLogAutoLoadExtension:type=assembly}", "2.0.0.0");
-            AssertLayoutRendererOutput("${assembly-version:name=NLogAutoLoadExtension:type=file}", "2.0.0.0");
-            AssertLayoutRendererOutput("${assembly-version:name=NLogAutoLoadExtension:type=informational}", "1.0.0");
+            AssertLayoutRendererOutput("${assembly-version:name=NLogAutoLoadExtension:type=file}", "2.0.0.1");
+            AssertLayoutRendererOutput("${assembly-version:name=NLogAutoLoadExtension:type=informational}", "2.0.0.2");
         }
 
 #if !NETSTANDARD


### PR DESCRIPTION
Pre-requisite for inheritance of AssemblyVersionLayoutRenderer in NLog.Web 


This provides the support required for NLog/NLog.Web#293 to progress by making `GetAssembly()` virtual.

It also sets File and Informational versions used by tests so they can be accurately differentiated from Assembly version.