### PR TITLE
Better performance with Activator.CreateInstance

### DIFF
--- a/src/NLog/Internal/FactoryHelper.cs
+++ b/src/NLog/Internal/FactoryHelper.cs
@@ -47,14 +47,13 @@ namespace NLog.Internal
 
         internal static object CreateInstance(Type t)
         {
-            ConstructorInfo constructor = t.GetConstructor(ArrayHelper.Empty<Type>());
-            if (constructor != null)
+            try
             {
-                return constructor.Invoke(ArrayHelper.Empty<object>());
+                return Activator.CreateInstance(t);
             }
-            else
+            catch (MissingMethodException exception)
             {
-                throw new NLogConfigurationException($"Cannot access the constructor of type: {t.FullName}. Is the required permission granted?");
+                throw new NLogConfigurationException($"Cannot access the constructor of type: {t.FullName}. Is the required permission granted?", exception);
             }
         }
     }


### PR DESCRIPTION
`Activator.CreateInstance` is faster than `ConstructorInfo.Invoke`



Test code:
```c#
   public  class CreateInstanceBenchamrker
   {

       private static readonly Type s_type = typeof(TestClass);


       [Benchmark]
        public object CreateInstance_By_FactoryHelper()
        {
            return FactoryHelper.CreateInstance(s_type);
        }

       [Benchmark]
       public object CreateInstance_By_Activator()
       {
           return Activator.CreateInstance(s_type);
       }
    }


    public class TestClass
    {

    }
```


``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.14393.2339 (1607/AnniversaryUpdate/Redstone1)
Intel Core i5-8400 CPU 2.80GHz (Coffee Lake), 1 CPU, 6 logical and 6 physical cores
Frequency=2742183 Hz, Resolution=364.6730 ns, Timer=TSC
.NET Core SDK=2.2.100-preview1-009015
  [Host]     : .NET Core 2.1.0 (CoreCLR 4.6.26515.07, CoreFX 4.6.26515.06), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0 (CoreCLR 4.6.26515.07, CoreFX 4.6.26515.06), 64bit RyuJIT


```
|                          Method |      Mean |     Error |    StdDev |
|-------------------------------- |----------:|----------:|----------:|
| CreateInstance_By_FactoryHelper | 147.57 ns | 0.4914 ns | 0.4597 ns |
|     CreateInstance_By_Activator |  37.62 ns | 0.3379 ns | 0.3160 ns |
