### PR TITLE
FileTarget - Do not trust Last File Write TimeStamp when AutoFlush=false

### DIFF
--- a/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/SingleProcessFileAppender.cs
@@ -50,8 +50,6 @@ namespace NLog.Internal.FileAppenders
 
         private FileStream _file;
 
-        private DateTime _lastWriteTimeUtc;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SingleProcessFileAppender" /> class.
         /// </summary>
@@ -59,8 +57,6 @@ namespace NLog.Internal.FileAppenders
         /// <param name="parameters">The parameters.</param>
         public SingleProcessFileAppender(string fileName, ICreateFileParameters parameters) : base(fileName, parameters)
         {
-            var fileInfo = new FileInfo(fileName);
-            _lastWriteTimeUtc = fileInfo.Exists ? fileInfo.GetLastWriteTimeUtc() : DateTime.UtcNow;
             _file = CreateFileStream(false);
         }
 
@@ -78,8 +74,6 @@ namespace NLog.Internal.FileAppenders
             }
 
             _file.Write(bytes, offset, count);
-
-            _lastWriteTimeUtc = DateTime.UtcNow;
         }
 
         /// <summary>

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1472,13 +1472,19 @@ namespace NLog.Targets
             {
                 if (previousLogEventTimestamp > lastWriteTimeSource)
                 {
-                    InternalLogger.Trace("FileTarget(Name={0}): Using previous log event time (is more recent)", Name);
+                    InternalLogger.Trace("FileTarget(Name={0}): Using previous LogEvent-TimeStamp {1}, because more recent than File-LastModified {2}", Name, previousLogEventTimestamp, lastWriteTimeSource);
                     return previousLogEventTimestamp;
                 }
 
                 if (PreviousLogOverlappedPeriod(logEvent, previousLogEventTimestamp, lastWriteTimeSource))
                 {
-                    InternalLogger.Trace("FileTarget(Name={0}): Using previous log event time (previous log overlapped period)", Name);
+                    InternalLogger.Trace("FileTarget(Name={0}): Using previous LogEvent-TimeStamp {1}, because archive period is overlapping with File-LastModified {2}", Name, previousLogEventTimestamp, lastWriteTimeSource);
+                    return previousLogEventTimestamp;
+                }
+
+                if (!AutoFlush && KeepFileOpen && !ConcurrentWrites && !NetworkWrites && previousLogEventTimestamp < lastWriteTimeSource)
+                {
+                    InternalLogger.Trace("FileTarget(Name={0}): Using previous LogEvent-TimeStamp {1}, because AutoFlush=false affects File-LastModified {2}", Name, previousLogEventTimestamp, lastWriteTimeSource);
                     return previousLogEventTimestamp;
                 }
             }


### PR DESCRIPTION
Improve archive timestamp logic when AutoFlush = false. Where delayed flush can cause Last-File-Write-TimeStamp to be "wrongly" later than previous logevent-timestamp.