### PR TITLE
Optimize LayoutRendererWrappers to reduce string allocations

### DIFF
--- a/src/NLog/Filters/WhenRepeatedFilter.cs
+++ b/src/NLog/Filters/WhenRepeatedFilter.cs
@@ -413,18 +413,7 @@ namespace NLog.Filters
                     // StringBuilder.Equals only works when StringBuilder.Capacity is the same
                     if (_stringBuffer.Capacity != other._stringBuffer.Capacity)
                     {
-                        if (_stringBuffer.Length != other._stringBuffer.Length)
-                            return false;
-
-                        for (int x = 0; x < _stringBuffer.Length; ++x)
-                        {
-                            if (_stringBuffer[x] != other._stringBuffer[x])
-                            {
-                                return false;
-                            }
-                        }
-
-                        return true;
+                        return _stringBuffer.EqualTo(other._stringBuffer);
                     }
                     return _stringBuffer.Equals(other._stringBuffer);
                 }

--- a/src/NLog/Internal/FilePathLayout.cs
+++ b/src/NLog/Internal/FilePathLayout.cs
@@ -175,18 +175,10 @@ namespace NLog.Internal
 
                 _layout.RenderAppendBuilder(logEvent, reusableBuilder);
 
-                if (_cachedPrevRawFileName != null && _cachedPrevRawFileName.Length == reusableBuilder.Length)
+                if (_cachedPrevRawFileName != null)
                 {
                     // If old filename matches the newly rendered, then no need to call StringBuilder.ToString()
-                    for (int i = 0; i < _cachedPrevRawFileName.Length; ++i)
-                    {
-                        if (_cachedPrevRawFileName[i] != reusableBuilder[i])
-                        {
-                            _cachedPrevRawFileName = null;
-                            break;
-                        }
-                    }
-                    if (_cachedPrevRawFileName != null)
+                    if (reusableBuilder.EqualTo(_cachedPrevRawFileName))
                         return _cachedPrevRawFileName;
                 }
 

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -34,7 +34,6 @@
 using System;
 using System.IO;
 using System.Text;
-using NLog.Config;
 using NLog.MessageTemplates;
 
 namespace NLog.Internal
@@ -236,6 +235,47 @@ namespace NLog.Internal
                 if (builder[i] == needle)
                     return i;
             return -1;
+        }
+
+        /// <summary>
+        /// Compares the contents of two StringBuilders
+        /// </summary>
+        /// <remarks>
+        /// Correct implementation of <see cref="StringBuilder.Equals(StringBuilder)" /> that also works when <see cref="StringBuilder.Capacity"/> is not the same
+        /// </remarks>
+        /// <returns>True when content is the same</returns>
+        public static bool EqualTo(this StringBuilder builder, StringBuilder other)
+        {
+            if (builder.Length != other.Length)
+                return false;
+
+            for (int x = 0; x < builder.Length; ++x)
+            {
+                if (builder[x] != other[x])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Compares the contents of a StringBuilder and a String
+        /// </summary>
+        /// <returns>True when content is the same</returns>
+        public static bool EqualTo(this StringBuilder builder, string other)
+        {
+            if (builder.Length != other.Length)
+                return false;
+
+            for (int i = 0; i < other.Length; ++i)
+            {
+                if (builder[i] != other[i])
+                    return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -224,6 +224,21 @@ namespace NLog.Internal
         }
 
         /// <summary>
+        /// Scans the StringBuilder for the position of needle character
+        /// </summary>
+        /// <param name="builder">StringBuilder source</param>
+        /// <param name="needle">needle character to search for</param>
+        /// <param name="startPos"></param>
+        /// <returns>Index of the first occurrence (Else -1)</returns>
+        public static int IndexOf(this StringBuilder builder, char needle, int startPos = 0)
+        {
+            for (int i = startPos; i < builder.Length; ++i)
+                if (builder[i] == needle)
+                    return i;
+            return -1;
+        }
+
+        /// <summary>
         /// Append a number and pad with 0 to 2 digits
         /// </summary>
         /// <param name="builder">append to this</param>

--- a/src/NLog/LayoutRenderers/EnvironmentLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EnvironmentLayoutRenderer.cs
@@ -78,13 +78,15 @@ namespace NLog.LayoutRenderers
 
                 if (!string.IsNullOrEmpty(environmentVariable))
                 {
-                    if (string.CompareOrdinal(_cachedValue.Key, environmentVariable) != 0)
+                    var cachedValue = _cachedValue;
+                    if (string.CompareOrdinal(cachedValue.Key, environmentVariable) != 0)
                     {
-                        _cachedValue = new System.Collections.Generic.KeyValuePair<string, SimpleLayout>(environmentVariable,
+                        cachedValue = new System.Collections.Generic.KeyValuePair<string, SimpleLayout>(environmentVariable,
                             new SimpleLayout(environmentVariable));
+                        _cachedValue = cachedValue;
                     }
 
-                    _cachedValue.Value.RenderAppendBuilder(logEvent, builder);
+                    cachedValue.Value.RenderAppendBuilder(logEvent, builder);
                 }
             }
         }

--- a/src/NLog/LayoutRenderers/TraceActivityIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/TraceActivityIdLayoutRenderer.cs
@@ -55,8 +55,9 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            builder.Append(Guid.Empty.Equals(Trace.CorrelationManager.ActivityId) ?
-                string.Empty : Trace.CorrelationManager.ActivityId.ToString("D", CultureInfo.InvariantCulture));
+            var activityId = Trace.CorrelationManager.ActivityId;
+            builder.Append(Guid.Empty.Equals(activityId) ?
+                string.Empty : activityId.ToString("D", CultureInfo.InvariantCulture));
         }
     }
 }

--- a/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
@@ -33,8 +33,8 @@
 
 namespace NLog.LayoutRenderers
 {
-    using System.Collections.Generic;
     using System.Text;
+    using NLog.Common;
     using NLog.Config;
     using NLog.Layouts;
 
@@ -70,6 +70,10 @@ namespace NLog.LayoutRenderers
             {
                 //pass loggingConfiguration to layout
                 layout.Initialize(LoggingConfiguration);
+                if (!layout.ThreadSafe)
+                {
+                    InternalLogger.Warn("${{var={0}}} should be declared as <variable name=\"var_{0}\" value=\"...\" /> and used like this ${var_{{0}}}. Because of unsafe Layout={1}", Name, layout);
+                }
             }
 
             base.InitializeLayoutRenderer();
@@ -82,18 +86,15 @@ namespace NLog.LayoutRenderers
         /// <returns></returns>
         private bool TryGetLayout(out SimpleLayout layout)
         {
+            layout = null;
             if (Name != null)
             {
                 //don't use LogManager (locking, recursion)
-                var loggingConfiguration = LoggingConfiguration;
-                var vars = loggingConfiguration?.Variables;
-                if (vars != null && vars.TryGetValue(Name, out layout))
+                if (LoggingConfiguration?.Variables?.TryGetValue(Name, out layout) == true)
                 {
                     return true;
                 }
-
             }
-            layout = null;
             return false;
         }
 
@@ -113,8 +114,8 @@ namespace NLog.LayoutRenderers
                     //todo in later stage also layout as values?
                     //ignore NULL, but it set, so don't use default.
                     if (layout != null)
-                    {
-                        builder.Append(layout.Render(logEvent));
+                    { 
+                        layout.RenderAppendBuilder(logEvent, builder);
                     }
                 }
                 else if (Default != null)

--- a/src/NLog/LayoutRenderers/Wrappers/FileSystemNormalizeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/FileSystemNormalizeLayoutRendererWrapper.cs
@@ -74,7 +74,6 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/FileSystemNormalizeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/FileSystemNormalizeLayoutRendererWrapper.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.LayoutRenderers.Wrappers
 {
+    using System;
     using System.ComponentModel;
     using System.Text;
     using NLog.Config;
@@ -62,39 +63,20 @@ namespace NLog.LayoutRenderers.Wrappers
         [DefaultValue(true)]
         public bool FSNormalize { get; set; }
 
-        /// <summary>
-        /// Render to local target using Inner Layout, and replaces all non-safe characters with underscore to make valid filepath
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="logEvent"></param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            int orgLength = builder.Length;
-            try
+            Inner.RenderAppendBuilder(logEvent, builder);
+            if (FSNormalize && builder.Length > orgLength)
             {
-                RenderFormattedMessage(logEvent, builder);
-                if (FSNormalize)
-                {
-                    TransformFileSystemNormalize(builder, orgLength);
-                }
-            }
-            catch
-            {
-                builder.Length = orgLength; // Unwind/Truncate on exception
-                throw;
+                TransformFileSystemNormalize(builder, orgLength);
             }
         }
 
-        /// <summary>
-        /// Replaces all non-safe characters with underscore to make valid filepath
-        /// </summary>
-        /// <param name="target">Output to be transformed.</param>
+        /// <inheritdoc/>
+        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
-            if (FSNormalize && target?.Length > 0)
-            {
-                TransformFileSystemNormalize(target, 0);
-            }
         }
 
         private static void TransformFileSystemNormalize(StringBuilder builder, int startPos)

--- a/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
@@ -86,7 +86,6 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.LayoutRenderers.Wrappers
 {
+    using System;
     using System.ComponentModel;
     using System.Globalization;
     using System.Text;
@@ -70,39 +71,20 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <docgen category='Transformation Options' order='10' />
         public CultureInfo Culture { get; set; }
 
-        /// <summary>
-        /// Render to local target using Inner Layout, and then transform before final append
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="logEvent"></param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            int orgLength = builder.Length;
-            try
+            Inner.RenderAppendBuilder(logEvent, builder);
+            if (Lowercase && builder.Length > orgLength)
             {
-                RenderFormattedMessage(logEvent, builder);
-                if (Lowercase)
-                {
-                    TransformToLowerCase(builder, orgLength);
-                }
-            }
-            catch
-            {
-                builder.Length = orgLength; // Unwind/Truncate on exception
-                throw;
+                TransformToLowerCase(builder, orgLength);
             }
         }
 
-        /// <summary>
-        /// Post-processes the rendered message. 
-        /// </summary>
-        /// <param name="target">Output to be post-processed.</param>
+        /// <inheritdoc/>
+        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
-            if (Lowercase && target?.Length > 0)
-            {
-                TransformToLowerCase(target, 0);
-            }
         }
 
         private void TransformToLowerCase(StringBuilder target, int startPos)

--- a/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
@@ -82,7 +82,6 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/OnExceptionLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/OnExceptionLayoutRendererWrapper.cs
@@ -44,25 +44,12 @@ namespace NLog.LayoutRenderers.Wrappers
     [ThreadSafe]
     public sealed class OnExceptionLayoutRendererWrapper : WrapperLayoutRendererBase
     {
-        /// <summary>
-        /// Renders the inner layout contents.
-        /// </summary>
-        /// <param name="builder"><see cref="StringBuilder"/> for the result</param>
-        /// <param name="logEvent">The log event.</param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            int orgLength = builder.Length;
-            try
+            if (logEvent.Exception != null)
             {
-                if (logEvent.Exception != null)
-                {
-                    Inner.RenderAppendBuilder(logEvent, builder);
-                }
-            }
-            catch
-            {
-                builder.Length = orgLength; // Rewind/Truncate on exception
-                throw;
+                Inner.RenderAppendBuilder(logEvent, builder);
             }
         }
 
@@ -74,23 +61,6 @@ namespace NLog.LayoutRenderers.Wrappers
         protected override string Transform(string text)
         {
             return text;
-        }
-
-        /// <summary>
-        /// Renders the inner layout contents.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <returns>
-        /// Contents of inner layout.
-        /// </returns>
-        protected override string RenderInner(LogEventInfo logEvent)
-        {
-            if (logEvent.Exception != null)
-            {
-                return base.RenderInner(logEvent);
-            }
-
-            return string.Empty;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/OnExceptionLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/OnExceptionLayoutRendererWrapper.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.LayoutRenderers.Wrappers
 {
+    using System.Text;
     using NLog.Config;
 
     /// <summary>
@@ -43,6 +44,28 @@ namespace NLog.LayoutRenderers.Wrappers
     [ThreadSafe]
     public sealed class OnExceptionLayoutRendererWrapper : WrapperLayoutRendererBase
     {
+        /// <summary>
+        /// Renders the inner layout contents.
+        /// </summary>
+        /// <param name="builder"><see cref="StringBuilder"/> for the result</param>
+        /// <param name="logEvent">The log event.</param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            int orgLength = builder.Length;
+            try
+            {
+                if (logEvent.Exception != null)
+                {
+                    Inner.RenderAppendBuilder(logEvent, builder);
+                }
+            }
+            catch
+            {
+                builder.Length = orgLength; // Rewind/Truncate on exception
+                throw;
+            }
+        }
+
         /// <summary>
         /// Transforms the output of another layout.
         /// </summary>

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceLayoutRendererWrapper.cs
@@ -132,11 +132,15 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <returns>Post-processed text.</returns>
         protected override string Transform(string text)
         {
-            var replacer = new Replacer(text, ReplaceGroupName, ReplaceWith);
-
-            return string.IsNullOrEmpty(ReplaceGroupName) ?
-                _regex.Replace(text, ReplaceWith)
-                : _regex.Replace(text, replacer.EvaluateMatch);
+            if (string.IsNullOrEmpty(ReplaceGroupName))
+            {
+                return _regex.Replace(text, ReplaceWith);
+            }
+            else
+            {
+                var replacer = new Replacer(text, ReplaceGroupName, ReplaceWith);
+                return _regex.Replace(text, replacer.EvaluateMatch);
+            }
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -83,7 +83,6 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/Rot13LayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/Rot13LayoutRendererWrapper.cs
@@ -86,7 +86,6 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/Rot13LayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/Rot13LayoutRendererWrapper.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.LayoutRenderers.Wrappers
 {
+    using System;
     using System.Text;
     using NLog.Config;
     using NLog.Layouts;
@@ -74,40 +75,25 @@ namespace NLog.LayoutRenderers.Wrappers
             return sb.ToString();
         }
 
-        /// <summary>
-        /// Render to local target using Inner Layout, and transforms into ROT-13-encoded string
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="logEvent"></param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            int orgLength = builder.Length;
-            try
+            Inner.RenderAppendBuilder(logEvent, builder);
+            if (builder.Length > orgLength)
             {
-                RenderFormattedMessage(logEvent, builder);
                 DecodeRot13(builder, orgLength);
-            }
-            catch
-            {
-                builder.Length = orgLength; // Unwind/Truncate on exception
-                throw;
             }
         }
 
-        /// <summary>
-        /// Post-processes the rendered message. 
-        /// </summary>
-        /// <param name="target">Output to be transform.</param>
+        /// <inheritdoc/>
+        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
-            DecodeRot13(target, 0);
         }
 
         /// <summary>
         /// Encodes/Decodes ROT-13-encoded string.
         /// </summary>
-        /// <param name="encodedValue">The string to be encoded/decoded.</param>
-        /// <param name="startPos">The string to be encoded/decoded.</param>
         internal static void DecodeRot13(StringBuilder encodedValue, int startPos)
         {
             if (encodedValue == null)

--- a/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
@@ -74,7 +74,6 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.LayoutRenderers.Wrappers
 {
+    using System;
     using System.ComponentModel;
     using System.Text;
     using NLog.Config;
@@ -62,39 +63,20 @@ namespace NLog.LayoutRenderers.Wrappers
         [DefaultValue(true)]
         public bool TrimWhiteSpace { get; set; }
 
-        /// <summary>
-        /// Render to local target using Inner Layout, and then transform before final append
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="logEvent"></param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            int orgLength = builder.Length;
-            try
+            Inner.RenderAppendBuilder(logEvent, builder);
+            if (TrimWhiteSpace && builder.Length > orgLength)
             {
-                RenderFormattedMessage(logEvent, builder);
-                if (TrimWhiteSpace)
-                {
-                    TransformTrimWhiteSpaces(builder, orgLength);
-                }
-            }
-            catch
-            {
-                builder.Length = orgLength; // Unwind/Truncate on exception
-                throw;
+                TransformTrimWhiteSpaces(builder, orgLength);
             }
         }
 
-        /// <summary>
-        /// Removes white-spaces from both sides of the provided target
-        /// </summary>
-        /// <param name="target">Output to be transform.</param>
+        /// <inheritdoc/>
+        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
-            if (TrimWhiteSpace && target?.Length > 0)
-            {
-                TransformTrimWhiteSpaces(target, 0);
-            }
         }
 
         private static void TransformTrimWhiteSpaces(StringBuilder builder, int startPos)

--- a/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
@@ -35,6 +35,7 @@ namespace NLog.LayoutRenderers.Wrappers
 {
     using System.ComponentModel;
     using System.Globalization;
+    using System.Text;
     using NLog.Config;
 
     /// <summary>
@@ -75,35 +76,63 @@ namespace NLog.LayoutRenderers.Wrappers
         public CultureInfo Culture { get; set; }
 
         /// <summary>
+        /// Render to local target using Inner Layout, and then transform before final append
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="logEvent"></param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            int orgLength = builder.Length;
+            try
+            {
+                RenderFormattedMessage(logEvent, builder);
+                if (Uppercase)
+                {
+                    TransformToUpperCase(builder, orgLength);
+                }
+            }
+            catch
+            {
+                builder.Length = orgLength; // Unwind/Truncate on exception
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Post-processes the rendered message. 
         /// </summary>
         /// <param name="target">Output to be post-processed.</param>
-        protected override void TransformFormattedMesssage(System.Text.StringBuilder target)
+        protected override void TransformFormattedMesssage(StringBuilder target)
         {
-            if (Uppercase)
+            if (Uppercase && target?.Length > 0)
             {
-                CultureInfo culture = Culture;
+                TransformToUpperCase(target, 0);
+            }
+        }
+
+        private void TransformToUpperCase(StringBuilder target, int startPos)
+        {
+            CultureInfo culture = Culture;
 
 #if NETSTANDARD1_0
-                string stringToUpper = null;
-                if (culture != null && culture != CultureInfo.InvariantCulture)
-                {
-                    stringToUpper = target.ToString();
-                    stringToUpper = culture.TextInfo.ToUpper(stringToUpper);
-                }
+            string stringToUpper = null;
+            if (culture != null && culture != CultureInfo.InvariantCulture)
+            {
+                stringToUpper = target.ToString(startPos, target.Length - startPos);
+                stringToUpper = culture.TextInfo.ToUpper(stringToUpper);
+            }
 #endif
 
-                for (int i = 0; i < target.Length; ++i)
-                {
+            for (int i = startPos; i < target.Length; ++i)
+            {
 #if NETSTANDARD1_0
-                    if (stringToUpper != null)
-                        target[i] = stringToUpper[i];    //no char.ToUpper with culture
-                    else
-                        target[i] = char.ToUpperInvariant(target[i]);                      
+                if (stringToUpper != null)
+                    target[i] = stringToUpper[i];    //no char.ToUpper with culture
+                else
+                    target[i] = char.ToUpperInvariant(target[i]);
 #else
-                    target[i] = char.ToUpper(target[i], culture);
+                target[i] = char.ToUpper(target[i], culture);
 #endif
-                }
             }
         }
     }

--- a/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.LayoutRenderers.Wrappers
 {
+    using System;
     using System.ComponentModel;
     using System.Globalization;
     using System.Text;
@@ -75,39 +76,20 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <docgen category='Transformation Options' order='10' />
         public CultureInfo Culture { get; set; }
 
-        /// <summary>
-        /// Render to local target using Inner Layout, and then transform before final append
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="logEvent"></param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            int orgLength = builder.Length;
-            try
+            Inner.RenderAppendBuilder(logEvent, builder);
+            if (Uppercase && builder.Length > orgLength)
             {
-                RenderFormattedMessage(logEvent, builder);
-                if (Uppercase)
-                {
-                    TransformToUpperCase(builder, orgLength);
-                }
-            }
-            catch
-            {
-                builder.Length = orgLength; // Unwind/Truncate on exception
-                throw;
+                TransformToUpperCase(builder, orgLength);
             }
         }
 
-        /// <summary>
-        /// Post-processes the rendered message. 
-        /// </summary>
-        /// <param name="target">Output to be post-processed.</param>
+        /// <inheritdoc/>
+        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
-            if (Uppercase && target?.Length > 0)
-            {
-                TransformToUpperCase(target, 0);
-            }
         }
 
         private void TransformToUpperCase(StringBuilder target, int startPos)

--- a/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
@@ -87,7 +87,6 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.LayoutRenderers.Wrappers
 {
+    using System;
     using System.Text;
     using NLog.Config;
     using NLog.Layouts;
@@ -53,36 +54,21 @@ namespace NLog.LayoutRenderers.Wrappers
         [RequiredParameter]
         public Layout WhenEmpty { get; set; }
 
-        /// <summary>
-        /// Transforms the output of another layout.
-        /// </summary>
-        /// <param name="target">Output to be transform.</param>
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
+            Inner.RenderAppendBuilder(logEvent, builder);
+            if (builder.Length > orgLength)
+                return;
+
+            // render WhenEmpty when the inner layout was empty
+            WhenEmpty.RenderAppendBuilder(logEvent, builder);
         }
 
-        /// <summary>
-        /// Renders the inner layout contents.
-        /// </summary>
-        /// <param name="builder"><see cref="StringBuilder"/> for the result</param>
-        /// <param name="logEvent">The log event.</param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        /// <inheritdoc/>
+        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
+        protected override void TransformFormattedMesssage(StringBuilder target)
         {
-            int orgLength = builder.Length;
-            try
-            {
-                base.RenderFormattedMessage(logEvent, builder);
-                if (builder.Length > orgLength)
-                    return;
-
-                // render WhenEmpty when the inner layout was empty
-                WhenEmpty.RenderAppendBuilder(logEvent, builder);
-            }
-            catch
-            {
-                builder.Length = orgLength; // Rewind/Truncate on exception
-                throw;
-            }
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
@@ -66,7 +66,6 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
@@ -75,7 +75,6 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.LayoutRenderers.Wrappers
 {
+    using System;
     using System.Text;
     using NLog.Conditions;
     using NLog.Config;
@@ -60,38 +61,23 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <docgen category="Transformation Options" order="10"/>
         public Layout Else { get; set; }
 
-        /// <summary>
-        /// Transforms the output of another layout.
-        /// </summary>
-        /// <param name="target">Output to be transform.</param>
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
+            if (When == null || true.Equals(When.Evaluate(logEvent)))
+            {
+                Inner.RenderAppendBuilder(logEvent, builder);
+            }
+            else if (Else != null)
+            {
+                Else.RenderAppendBuilder(logEvent, builder);
+            }
         }
 
-        /// <summary>
-        /// Renders the inner layout contents.
-        /// </summary>
-        /// <param name="builder"><see cref="StringBuilder"/> for the result</param>
-        /// <param name="logEvent">The log event.</param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        /// <inheritdoc/>
+        [Obsolete("Replaced by override of RenderInnerAndTransform().")]
+        protected override void TransformFormattedMesssage(StringBuilder target)
         {
-            int orgLength = builder.Length;
-            try
-            {
-                if (When == null || true.Equals(When.Evaluate(logEvent)))
-                {
-                    base.RenderFormattedMessage(logEvent, builder);
-                }
-                else if (Else != null)
-                {
-                    Else.RenderAppendBuilder(logEvent, builder);
-                }
-            }
-            catch
-            {
-                builder.Length = orgLength; // Rewind/Truncate on exception
-                throw;
-            }
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBase.cs
@@ -64,6 +64,26 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
+            int orgLength = builder.Length;
+            try
+            {
+                RenderInnerAndTransform(logEvent, builder, orgLength);
+            }
+            catch
+            {
+                builder.Length = orgLength; // Rewind/Truncate on exception
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Appends the rendered output from <see cref="Inner"/>-layout and transforms the added output (when necessary)
+        /// </summary>
+        /// <param name="logEvent">Logging event.</param>
+        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="orgLength">Start position for any necessary transformation of <see cref="StringBuilder"/>.</param>
+        protected virtual void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
+        {
             string msg = RenderInner(logEvent);
             builder.Append(Transform(logEvent, msg));
         }

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
@@ -31,6 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System;
 using System.Text;
 
 namespace NLog.LayoutRenderers.Wrappers
@@ -42,17 +43,21 @@ namespace NLog.LayoutRenderers.Wrappers
     /// </summary>
     public abstract class WrapperLayoutRendererBuilderBase : WrapperLayoutRendererBase
     {
-        /// <summary>
-        /// Render to local target using Inner Layout, and then transform before final append
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="logEvent"></param>
+        /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            base.Append(builder, logEvent);
+        }
+
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
             using (var localTarget = new Internal.AppendBuilderCreator(builder, true))
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 RenderFormattedMessage(logEvent, localTarget.Builder);
                 TransformFormattedMesssage(logEvent, localTarget.Builder);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 
@@ -61,6 +66,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// </summary>
         /// <param name="logEvent"></param>
         /// <param name="target">Output to be transform.</param>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead")]
         protected virtual void TransformFormattedMesssage(LogEventInfo logEvent, StringBuilder target)
         {
             TransformFormattedMesssage(target);
@@ -70,6 +76,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// Transforms the output of another layout.
         /// </summary>
         /// <param name="target">Output to be transform.</param>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead")]
         protected abstract void TransformFormattedMesssage(StringBuilder target);
 
         /// <summary>
@@ -77,6 +84,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// </summary>
         /// <param name="logEvent"></param>
         /// <param name="target"><see cref="StringBuilder"/> for the result</param>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead")]
         protected virtual void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             Inner.RenderAppendBuilder(logEvent, target);
@@ -89,7 +97,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <returns></returns>
         protected sealed override string Transform(string text)
         {
-            throw new System.NotSupportedException("Use TransformFormattedMesssage");
+            throw new NotSupportedException("Use TransformFormattedMesssage");
         }
 
         /// <summary>
@@ -99,7 +107,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <returns></returns>
         protected sealed override string RenderInner(LogEventInfo logEvent)
         {
-            throw new System.NotSupportedException("Use RenderFormattedMessage");
+            throw new NotSupportedException("Use RenderFormattedMessage");
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
@@ -66,7 +66,6 @@ namespace NLog.LayoutRenderers.Wrappers
         /// </summary>
         /// <param name="logEvent"></param>
         /// <param name="target">Output to be transform.</param>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead")]
         protected virtual void TransformFormattedMesssage(LogEventInfo logEvent, StringBuilder target)
         {
             TransformFormattedMesssage(target);
@@ -76,7 +75,6 @@ namespace NLog.LayoutRenderers.Wrappers
         /// Transforms the output of another layout.
         /// </summary>
         /// <param name="target">Output to be transform.</param>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead")]
         protected abstract void TransformFormattedMesssage(StringBuilder target);
 
         /// <summary>
@@ -84,7 +82,6 @@ namespace NLog.LayoutRenderers.Wrappers
         /// </summary>
         /// <param name="logEvent"></param>
         /// <param name="target"><see cref="StringBuilder"/> for the result</param>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead")]
         protected virtual void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             Inner.RenderAppendBuilder(logEvent, target);


### PR DESCRIPTION
And skip usage of the StringBuilderPool:

- FileSystemNormalizeLayoutRendererWrapper
- LowercaseLayoutRendererWrapper
- Rot13LayoutRendererWrapper
- TrimWhiteSpaceLayoutRendererWrapper
- UppercaseLayoutRendererWrapper
- ReplaceNewLinesLayoutRendererWrapper (Minor change to recognize Unix-Newlines on Windows)
- OnExceptionLayoutRendererWrapper
- VariableLayoutRenderer

Followup to #2743 where new transform-method was introduced for JsonLayout.