### PR TITLE
WrapperLayoutRendererBuilderBase methods marked as obsolete

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/FileSystemNormalizeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/FileSystemNormalizeLayoutRendererWrapper.cs
@@ -74,6 +74,7 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
@@ -86,6 +86,7 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
@@ -82,6 +82,7 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -83,6 +83,7 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/Rot13LayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/Rot13LayoutRendererWrapper.cs
@@ -86,6 +86,7 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
@@ -74,6 +74,7 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
@@ -87,6 +87,7 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
@@ -66,6 +66,7 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
@@ -75,6 +75,7 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected override void TransformFormattedMesssage(StringBuilder target)
         {
         }

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
@@ -66,6 +66,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// </summary>
         /// <param name="logEvent"></param>
         /// <param name="target">Output to be transform.</param>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected virtual void TransformFormattedMesssage(LogEventInfo logEvent, StringBuilder target)
         {
             TransformFormattedMesssage(target);
@@ -75,6 +76,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// Transforms the output of another layout.
         /// </summary>
         /// <param name="target">Output to be transform.</param>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected abstract void TransformFormattedMesssage(StringBuilder target);
 
         /// <summary>
@@ -82,6 +84,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// </summary>
         /// <param name="logEvent"></param>
         /// <param name="target"><see cref="StringBuilder"/> for the result</param>
+        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected virtual void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             Inner.RenderAppendBuilder(logEvent, target);


### PR DESCRIPTION
Follow up to #2817 for NLog 4.6