### PR TITLE
Include Entry Assembly File Location when loading candidate NLog.config

### DIFF
--- a/src/NLog/Internal/AssemblyHelpers.cs
+++ b/src/NLog/Internal/AssemblyHelpers.cs
@@ -107,5 +107,81 @@ using System.Windows;
 #endif
         }
 
+#if !SILVERLIGHT && !NETSTANDARD1_3
+        public static string GetAssemblyFileLocation(Assembly assembly)
+        {
+            string fullName = string.Empty;
+
+            try
+            {
+                if (assembly == null)
+                {
+                    return string.Empty;
+                }
+
+                fullName = assembly.FullName;
+
+#if NETSTANDARD
+                if (string.IsNullOrEmpty(assembly.Location))
+                {
+                    // Assembly with no actual location should be skipped (Avoid PlatformNotSupportedException)
+                    InternalLogger.Warn("Ignoring assembly location because location is empty: {0}", fullName);
+                    return string.Empty;
+                }
+#endif
+
+                Uri assemblyCodeBase;
+                if (!Uri.TryCreate(assembly.CodeBase, UriKind.RelativeOrAbsolute, out assemblyCodeBase))
+                {
+                    InternalLogger.Warn("Ignoring assembly location because code base is unknown: '{0}' ({1})", assembly.CodeBase, fullName);
+                    return string.Empty;
+                }
+
+                var assemblyLocation = Path.GetDirectoryName(assemblyCodeBase.LocalPath);
+                if (string.IsNullOrEmpty(assemblyLocation))
+                {
+                    InternalLogger.Warn("Ignoring assembly location because it is not a valid directory: '{0}' ({1})", assemblyCodeBase.LocalPath, fullName);
+                    return string.Empty;
+                }
+
+                DirectoryInfo directoryInfo = new DirectoryInfo(assemblyLocation);
+                if (!directoryInfo.Exists)
+                {
+                    InternalLogger.Warn("Ignoring assembly location because directory doesn't exists: '{0}' ({1})", assemblyLocation, fullName);
+                    return string.Empty;
+                }
+
+                InternalLogger.Debug("Found assembly location directory: '{0}' ({1})", directoryInfo.FullName, fullName);
+                return directoryInfo.FullName;
+            }
+            catch (System.PlatformNotSupportedException ex)
+            {
+                InternalLogger.Warn(ex, "Ignoring assembly location because assembly lookup is not supported: {0}", fullName);
+                if (ex.MustBeRethrown())
+                {
+                    throw;
+                }
+                return string.Empty;
+            }
+            catch (System.Security.SecurityException ex)
+            {
+                InternalLogger.Warn(ex, "Ignoring assembly location because assembly lookup is not allowed: {0}", fullName);
+                if (ex.MustBeRethrown())
+                {
+                    throw;
+                }
+                return string.Empty;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                InternalLogger.Warn(ex, "Ignoring assembly location because assembly lookup is not allowed: {0}", fullName);
+                if (ex.MustBeRethrown())
+                {
+                    throw;
+                }
+                return string.Empty;
+            }
+        }
+#endif
     }
 }

--- a/src/NLog/Internal/PathHelpers.cs
+++ b/src/NLog/Internal/PathHelpers.cs
@@ -57,5 +57,20 @@ namespace NLog.Internal
             }
             return path;
         }
+
+        /// <summary>
+        /// Cached directory separator char array to avoid memory allocation on each method call.
+        /// </summary>
+        private static readonly char[] DirectorySeparatorChars = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
+        /// <summary>
+        /// Trims directory separators from the path
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public static string TrimDirectorySeparators(string path)
+        {
+            return path?.TrimEnd(DirectorySeparatorChars) ?? string.Empty;
+        }
     }
 }

--- a/src/NLog/Internal/PathHelpers.cs
+++ b/src/NLog/Internal/PathHelpers.cs
@@ -66,8 +66,8 @@ namespace NLog.Internal
         /// <summary>
         /// Trims directory separators from the path
         /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
+        /// <param name="path">path, could be null</param>
+        /// <returns>never null</returns>
         public static string TrimDirectorySeparators(string path)
         {
             return path?.TrimEnd(DirectorySeparatorChars) ?? string.Empty;

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -1112,25 +1112,6 @@ namespace NLog
                         yield return Path.Combine(entryAssemblyLocation, "nlog.config");
                 }
             }
-
-            var nlogAssembly = typeof(LogFactory).GetAssembly();
-            if (!string.IsNullOrEmpty(nlogAssembly?.Location))
-            {
-#if !NETSTANDARD1_0
-                if (!nlogAssembly.GlobalAssemblyCache)
-#endif
-                {
-                    var nlogAssemblyLocation = PathHelpers.TrimDirectorySeparators(AssemblyHelpers.GetAssemblyFileLocation(nlogAssembly));
-                    if (!string.IsNullOrEmpty(nlogAssemblyLocation)
-                        && !string.Equals(nlogAssemblyLocation, baseDirectory, StringComparison.OrdinalIgnoreCase)
-                        && !string.Equals(nlogAssemblyLocation, entryAssemblyLocation, StringComparison.OrdinalIgnoreCase))
-                    {
-                        yield return Path.Combine(nlogAssemblyLocation, "NLog.config");
-                        if (!platformFileSystemCaseInsensitive)
-                            yield return Path.Combine(nlogAssemblyLocation, "nlog.config");
-                    }
-                }
-            }
 #endif
 
             if (string.IsNullOrEmpty(baseDirectory))
@@ -1168,16 +1149,12 @@ namespace NLog
                 }
             }
 
-#if !SILVERLIGHT && !NETSTANDARD1_3
+#if !SILVERLIGHT && !NETSTANDARD1_0
             // Get path to NLog.dll.nlog only if the assembly is not in the GAC
-            if (!string.IsNullOrEmpty(nlogAssembly?.Location))
+            var nlogAssembly = typeof(LogFactory).GetAssembly();
+            if (!string.IsNullOrEmpty(nlogAssembly?.Location) && !nlogAssembly.GlobalAssemblyCache)
             {
-#if !NETSTANDARD1_0
-                if (!nlogAssembly.GlobalAssemblyCache)
-#endif
-                {
-                    yield return nlogAssembly.Location + ".nlog";
-                }
+                yield return nlogAssembly.Location + ".nlog";
             }
 #endif
         }


### PR DESCRIPTION
Improve the NetCore experience where the BaseDirectory is often different from the bin-location (But the Bin-location is where nlog.config is copied to by default)

Also improve the logic for recognizing identical paths (with or without ending directory-separator)

Think this will resolve #1342 (Atleast for NetStandard1.5 and NetStandard2.0)