### PR TITLE
IRawValue + dbNullLayoutRenderer

### DIFF
--- a/src/NLog/Internal/IRawValue.cs
+++ b/src/NLog/Internal/IRawValue.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,41 +31,19 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.LayoutRenderers
+namespace NLog.Internal
 {
-    using System.Globalization;
-    using System.Text;
-    using NLog.Config;
-	using NLog.Internal;
-
     /// <summary>
-    /// The Ticks value of current date and time.
+    /// Get the Raw, unformatted and unstrinyfied, value
     /// </summary>
-    [LayoutRenderer("ticks")]
-    [ThreadAgnostic]
-    [ThreadSafe]
-    public class TicksLayoutRenderer : LayoutRenderer, IRawValue
+    internal interface IRawValue
     {
         /// <summary>
-        /// Renders the ticks value of current time and appends it to the specified <see cref="StringBuilder" />.
+        /// Get the raw value
         /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
-        {
-            //no culture expected here
-            builder.Append(GetValue(logEvent).ToString(CultureInfo.InvariantCulture));
-        }
+        /// <param name="logEvent"></param>
+        /// <returns>null if not possible or unknown</returns>
+        object GetRawValue(LogEventInfo logEvent);
 
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetValue(logEvent);
-        }
-
-        private static long GetValue(LogEventInfo logEvent)
-        {
-            return logEvent.TimeStamp.Ticks;
-        }
     }
 }

--- a/src/NLog/LayoutRenderers/CallSiteLineNumberLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteLineNumberLayoutRenderer.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("callsite-linenumber")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class CallSiteLineNumberLayoutRenderer : LayoutRenderer, IUsesStackTrace
+    public class CallSiteLineNumberLayoutRenderer : LayoutRenderer, IUsesStackTrace, IRawValue
     {
         /// <summary>
         /// Gets or sets the number of frames to skip.
@@ -67,11 +67,26 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            if (logEvent.CallSiteInformation != null)
+            var lineNumber = GetLineNumber(logEvent);
+            if (lineNumber.HasValue)
+                builder.AppendInvariant(lineNumber.Value);
+        }
+
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetLineNumber(logEvent);
+        }
+
+        private int? GetLineNumber(LogEventInfo logEvent)
+        {
+            if (logEvent.CallSiteInformation == null)
             {
-                int linenumber = logEvent.CallSiteInformation.GetCallerLineNumber(SkipFrames);
-                builder.AppendInvariant(linenumber);
+                return null;
             }
+
+            return logEvent.CallSiteInformation.GetCallerLineNumber(SkipFrames);
         }
     }
 }

--- a/src/NLog/LayoutRenderers/CounterLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CounterLayoutRenderer.cs
@@ -43,7 +43,7 @@ namespace NLog.LayoutRenderers
     /// A counter value (increases on each layout rendering).
     /// </summary>
     [LayoutRenderer("counter")]
-    public class CounterLayoutRenderer : LayoutRenderer
+    public class CounterLayoutRenderer : LayoutRenderer, IRawValue
     {
         private static Dictionary<string, int> sequences = new Dictionary<string, int>();
 
@@ -83,6 +83,18 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
+            int v = GetNextValue(logEvent);
+
+            builder.AppendInvariant(v);
+        }
+
+        /// <summary>
+        /// Get raw value, updates the sequence
+        /// </summary>
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetNextValue(logEvent);
+
+        private int GetNextValue(LogEventInfo logEvent)
+        {
             int v;
 
             if (Sequence != null)
@@ -95,7 +107,7 @@ namespace NLog.LayoutRenderers
                 Value += Increment;
             }
 
-            builder.AppendInvariant(v);
+            return v;
         }
 
         private static int GetNextSequenceValue(string sequenceName, int defaultValue, int increment)

--- a/src/NLog/LayoutRenderers/DateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/DateLayoutRenderer.cs
@@ -38,6 +38,7 @@ namespace NLog.LayoutRenderers
     using System.Globalization;
     using System.Text;
     using NLog.Config;
+	using NLog.Internal;
 
     /// <summary>
     /// Current date and time.
@@ -45,7 +46,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("date")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class DateLayoutRenderer : LayoutRenderer
+    public class DateLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateLayoutRenderer" /> class.
@@ -101,11 +102,7 @@ namespace NLog.LayoutRenderers
         {
             var formatProvider = GetFormatProvider(logEvent, Culture);
 
-            var timestamp = logEvent.TimeStamp;
-            if (UniversalTime)
-            {
-                timestamp = timestamp.ToUniversalTime();
-            }
+            DateTime timestamp = GetDate(logEvent);
 
             var cachedDateFormatted = _cachedDateFormatted;
             if (!ReferenceEquals(formatProvider, CultureInfo.InvariantCulture) || cachedDateFormatted.Date == DateTime.MinValue)
@@ -128,6 +125,23 @@ namespace NLog.LayoutRenderers
             }
             builder.Append(formatTime);
         }
+
+        private DateTime GetDate(LogEventInfo logEvent)
+        {
+            var timestamp = logEvent.TimeStamp;
+            if (UniversalTime)
+            {
+                timestamp = timestamp.ToUniversalTime();
+            }
+
+            return timestamp;
+        }
+
+        /// <summary>
+        /// Get the raw value.
+        /// </summary>
+        /// <returns></returns>
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetDate(logEvent);
 
         private static bool IsLowTimeResolutionLayout(string dateTimeFormat)
         {

--- a/src/NLog/LayoutRenderers/DbNullLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/DbNullLayoutRenderer.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,41 +31,37 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+
+using System;
+using System.Text;
+using NLog.Config;
+using NLog.Internal;
+
 namespace NLog.LayoutRenderers
 {
-    using System.Globalization;
-    using System.Text;
-    using NLog.Config;
-	using NLog.Internal;
-
     /// <summary>
-    /// The Ticks value of current date and time.
+    /// DB null for a database
     /// </summary>
-    [LayoutRenderer("ticks")]
-    [ThreadAgnostic]
+    [LayoutRenderer("db-null")]
     [ThreadSafe]
-    public class TicksLayoutRenderer : LayoutRenderer, IRawValue
+    [ThreadAgnostic]
+    public class DbNullLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
-        /// Renders the ticks value of current time and appends it to the specified <see cref="StringBuilder" />.
+        /// Empty append
         /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <param name="builder"></param>
+        /// <param name="logEvent"></param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            //no culture expected here
-            builder.Append(GetValue(logEvent).ToString(CultureInfo.InvariantCulture));
+            
         }
+
 
         /// <inheritdoc />
         object IRawValue.GetRawValue(LogEventInfo logEvent)
         {
-            return GetValue(logEvent);
-        }
-
-        private static long GetValue(LogEventInfo logEvent)
-        {
-            return logEvent.TimeStamp.Ticks;
+            return DBNull.Value;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers
     [ThreadAgnostic]
     [ThreadSafe]
     [MutableUnsafe]
-    public class EventPropertiesLayoutRenderer : LayoutRenderer
+    public class EventPropertiesLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         ///  Log event context data with default options.
@@ -83,12 +83,26 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            object value;
-            if (logEvent.HasProperties && logEvent.Properties.TryGetValue(Item, out value))
+            if (GetValue(logEvent, out var value))
             {
                 var formatProvider = GetFormatProvider(logEvent, Culture);
                 builder.AppendFormattedValue(value, Format, formatProvider);
             }
+        }
+
+        private bool GetValue(LogEventInfo logEvent, out object value)
+        {
+            value = null;
+            return logEvent.HasProperties && logEvent.Properties.TryGetValue(Item, out value);
+        }
+
+        /// <summary>
+        /// Get raw value, updates the sequence
+        /// </summary>
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            GetValue(logEvent, out var value);
+            return value;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -49,7 +49,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("exception")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class ExceptionLayoutRenderer : LayoutRenderer
+    public class ExceptionLayoutRenderer : LayoutRenderer, IRawValue
     {
         private string _format;
         private string _innerFormat = string.Empty;
@@ -177,6 +177,11 @@ namespace NLog.LayoutRenderers
             get;
             private set;
         }
+
+        /// <summary>
+        /// Get raw value, updates the sequence
+        /// </summary>
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => logEvent.Exception;
 
         /// <summary>
         /// Renders the specified exception information and appends it to the specified <see cref="StringBuilder" />.

--- a/src/NLog/LayoutRenderers/GarbageCollectorInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GarbageCollectorInfoLayoutRenderer.cs
@@ -47,7 +47,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("gc")]
     [ThreadSafe]
-    public class GarbageCollectorInfoLayoutRenderer : LayoutRenderer
+    public class GarbageCollectorInfoLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GarbageCollectorInfoLayoutRenderer" /> class.
@@ -77,6 +77,22 @@ namespace NLog.LayoutRenderers
                 formatProvider = null;
             }
 
+            var value = GetValue();
+
+            if (formatProvider == null && value >= 0 && value < uint.MaxValue)
+                builder.AppendInvariant((uint)value);
+            else
+                builder.Append(Convert.ToString(value, formatProvider ?? CultureInfo.InvariantCulture));
+        }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue();
+        }
+
+        private long GetValue()
+        {
             long value = 0;
 
             switch (Property)
@@ -102,17 +118,16 @@ namespace NLog.LayoutRenderers
                     value = GC.CollectionCount(2);
                     break;
 #endif
-                
+
                 case GarbageCollectorProperty.MaxGeneration:
                     value = GC.MaxGeneration;
                     break;
             }
 
-            if (formatProvider == null && value >= 0 && value < uint.MaxValue)
-                builder.AppendInvariant((uint)value);
-            else
-                builder.Append(Convert.ToString(value, formatProvider ?? CultureInfo.InvariantCulture));
+            return value;
         }
+
+      
     }
 }
 

--- a/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
@@ -43,7 +43,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("gdc")]
     [ThreadSafe]
-    public class GdcLayoutRenderer : LayoutRenderer
+    public class GdcLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Gets or sets the name of the item.
@@ -66,10 +66,20 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            //don't use GlobalDiagnosticsContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
-            var value = GlobalDiagnosticsContext.GetObject(Item);
+            object value = GetValue();
             var formatProvider = GetFormatProvider(logEvent, null);
             builder.AppendFormattedValue(value, Format, formatProvider);
+        }
+
+        /// <summary>
+        /// Get raw value.
+        /// </summary>
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
+
+        private object GetValue()
+        {
+            //don't use GlobalDiagnosticsContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
+            return GlobalDiagnosticsContext.GetObject(Item);
         }
     }
 }

--- a/src/NLog/LayoutRenderers/GuidLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GuidLayoutRenderer.cs
@@ -37,13 +37,14 @@ namespace NLog.LayoutRenderers
     using System.ComponentModel;
     using System.Text;
     using NLog.Config;
+	using NLog.Internal;
 
     /// <summary>
     /// Globally-unique identifier (GUID).
     /// </summary>
     [LayoutRenderer("guid")]
     [ThreadSafe]
-    public class GuidLayoutRenderer : LayoutRenderer
+    public class GuidLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GuidLayoutRenderer" /> class.
@@ -68,12 +69,25 @@ namespace NLog.LayoutRenderers
         public bool GeneratedFromLogEvent { get; set; }
 
         /// <summary>
+        /// Get raw value
+        /// </summary>
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue(logEvent);
+
+        /// <summary>
         /// Renders a newly generated GUID string and appends it to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
+            Guid guid;
+            guid = GetValue(logEvent);
+            builder.Append(guid.ToString(Format));
+        }
+
+        private Guid GetValue(LogEventInfo logEvent)
+        {
+            Guid guid;
             if (GeneratedFromLogEvent)
             {
                 int hashCode = logEvent.GetHashCode();
@@ -88,12 +102,15 @@ namespace NLog.LayoutRenderers
                 byte i = (byte)((zeroDateTicks >> 16) & 0xFF);
                 byte j = (byte)((zeroDateTicks >> 8) & 0xFF);
                 byte k = (byte)(zeroDateTicks & 0XFF);
-                builder.Append(new Guid(logEvent.SequenceID, b, c, d, e, f, g, h, i, j, k).ToString(Format));
+                guid = new Guid(logEvent.SequenceID, b, c, d, e, f, g, h, i, j, k);
+
             }
             else
             {
-                builder.Append(Guid.NewGuid().ToString(Format));
+                guid = Guid.NewGuid();
             }
+
+            return guid;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/IdentityLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/IdentityLayoutRenderer.cs
@@ -40,13 +40,14 @@ namespace NLog.LayoutRenderers
     using System.Security.Principal;
     using System.Text;
     using NLog.Config;
+	using NLog.Internal;
 
     /// <summary>
     /// Thread identity information (name and authentication information).
     /// </summary>
     [LayoutRenderer("identity")]
     [ThreadSafe]
-    public class IdentityLayoutRenderer : LayoutRenderer
+    public class IdentityLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IdentityLayoutRenderer" /> class.
@@ -95,36 +96,45 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            IPrincipal principal = System.Threading.Thread.CurrentPrincipal;
-            if (principal != null)
+            IIdentity identity = GetValue();
+            if (identity != null)
             {
-                IIdentity identity = principal.Identity;
-                if (identity != null)
+                string separator = string.Empty;
+
+                if (IsAuthenticated)
                 {
-                    string separator = string.Empty;
+                    builder.Append(separator);
+                    separator = Separator;
 
-                    if (IsAuthenticated)
-                    {
-                        builder.Append(separator);
-                        separator = Separator;
+                    builder.Append(identity.IsAuthenticated ? "auth" : "notauth");
+                }
 
-                        builder.Append(identity.IsAuthenticated ? "auth" : "notauth");
-                    }
+                if (AuthType)
+                {
+                    builder.Append(separator);
+                    separator = Separator;
+                    builder.Append(identity.AuthenticationType);
+                }
 
-                    if (AuthType)
-                    {
-                        builder.Append(separator);
-                        separator = Separator;
-                        builder.Append(identity.AuthenticationType);
-                    }
-
-                    if (Name)
-                    {
-                        builder.Append(separator);
-                        builder.Append(identity.Name);
-                    }
+                if (Name)
+                {
+                    builder.Append(separator);
+                    builder.Append(identity.Name);
                 }
             }
+
+        }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue();
+        }
+
+        private static IIdentity GetValue()
+        {
+            var currentPrincipal = System.Threading.Thread.CurrentPrincipal;
+            return currentPrincipal?.Identity;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/InstallContextLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/InstallContextLayoutRenderer.cs
@@ -37,13 +37,14 @@ namespace NLog.LayoutRenderers
     using System.Globalization;
     using System.Text;
     using NLog.Config;
+	using NLog.Internal;
 
     /// <summary>
     /// Installation parameter (passed to InstallNLogConfig).
     /// </summary>
     [LayoutRenderer("install-context")]
     [ThreadSafe]
-    public class InstallContextLayoutRenderer : LayoutRenderer
+    public class InstallContextLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Gets or sets the name of the parameter.
@@ -60,13 +61,23 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            object value;
-
-            if (logEvent.Properties.TryGetValue(Parameter, out value))
+            var value = GetValue(logEvent);
+            if (value != null)
             {
                 var formatProvider = GetFormatProvider(logEvent);
                 builder.Append(Convert.ToString(value, formatProvider));
             }
+        }
+
+        private object GetValue(LogEventInfo logEvent)
+        {
+            return !logEvent.Properties.TryGetValue(Parameter, out var value) ? null : value;
+        }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue(logEvent);
         }
     }
 }

--- a/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
@@ -45,7 +45,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("level")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class LevelLayoutRenderer : LayoutRenderer
+    public class LevelLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Gets or sets a value indicating the output format of the level.
@@ -55,24 +55,36 @@ namespace NLog.LayoutRenderers
         public LevelFormat Format { get; set; }
 
         /// <summary>
+        /// Get the raw value.
+        /// </summary>
+        /// <returns></returns>
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue(logEvent);
+
+        /// <summary>
         /// Renders the current log level and appends it to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
+            LogLevel level = GetValue(logEvent);
             switch (Format)
             {
                 case LevelFormat.Name:
-                    builder.Append(logEvent.Level.ToString());
+                    builder.Append(level.ToString());
                     break;
                 case LevelFormat.FirstCharacter:
-                    builder.Append(logEvent.Level.ToString()[0]);
+                    builder.Append(level.ToString()[0]);
                     break;
                 case LevelFormat.Ordinal:
-                    builder.AppendInvariant(logEvent.Level.Ordinal);
+                    builder.AppendInvariant(level.Ordinal);
                     break;
             }
+        }
+
+        private static LogLevel GetValue(LogEventInfo logEvent)
+        {
+            return logEvent.Level;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
@@ -42,7 +42,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("mdc")]
     [ThreadSafe]
-    public class MdcLayoutRenderer : LayoutRenderer
+    public class MdcLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Gets or sets the name of the item.
@@ -66,9 +66,22 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             //don't use MappedDiagnosticsContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
-            var value = MappedDiagnosticsContext.GetObject(Item);
+            var value = GetValue();
             var formatProvider = GetFormatProvider(logEvent, null);
             builder.AppendFormattedValue(value, Format, formatProvider);
         }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue();
+        }
+
+        private object GetValue()
+        {
+            return MappedDiagnosticsContext.GetObject(Item);
+        }
+
+       
     }
 }

--- a/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
@@ -43,7 +43,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("mdlc")]
     [ThreadSafe]
-    public class MdlcLayoutRenderer : LayoutRenderer
+    public class MdlcLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Gets or sets the name of the item.
@@ -67,9 +67,20 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             //don't use MappedDiagnosticsLogicalContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
-            var value = MappedDiagnosticsLogicalContext.GetObject(Item);
+            var value = GetValue();
             var formatProvider = GetFormatProvider(logEvent, null);
             builder.AppendFormattedValue(value, Format, formatProvider);
+        }
+        
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue();
+        }
+
+        private object GetValue()
+        {
+            return MappedDiagnosticsLogicalContext.GetObject(Item);
         }
     }
 #endif

--- a/src/NLog/LayoutRenderers/PerformanceCounterLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/PerformanceCounterLayoutRenderer.cs
@@ -39,12 +39,13 @@ namespace NLog.LayoutRenderers
     using System.Globalization;
     using System.Text;
     using NLog.Config;
+	using NLog.Internal;
 
     /// <summary>
     /// The performance counter.
     /// </summary>
     [LayoutRenderer("performancecounter")]
-    public class PerformanceCounterLayoutRenderer : LayoutRenderer
+    public class PerformanceCounterLayoutRenderer : LayoutRenderer, IRawValue
     {
         private PerformanceCounter perfCounter;
 
@@ -112,7 +113,18 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var formatProvider = GetFormatProvider(logEvent);
-            builder.Append(perfCounter.NextValue().ToString(formatProvider));
+            builder.Append(GetValue().ToString(formatProvider));
+        }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue();
+        }
+
+        private float GetValue()
+        {
+            return perfCounter.NextValue();
         }
     }
 }

--- a/src/NLog/LayoutRenderers/ProcessIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessIdLayoutRenderer.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class ProcessIdLayoutRenderer : LayoutRenderer
+    public class ProcessIdLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Renders the current process ID.
@@ -55,7 +55,18 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            builder.AppendInvariant(ThreadIDHelper.Instance.CurrentProcessID);
+            builder.AppendInvariant(GetValue());
+        }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue();
+        }
+
+        private static int GetValue()
+        {
+            return ThreadIDHelper.Instance.CurrentProcessID;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
@@ -48,7 +48,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("processinfo")]
     [ThreadSafe]
-    public class ProcessInfoLayoutRenderer : LayoutRenderer
+    public class ProcessInfoLayoutRenderer : LayoutRenderer, IRawValue
     {
         private Process _process;
 
@@ -114,12 +114,25 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            if (_lateBoundPropertyGet != null)
+            var value = GetValue();
+
+            if (value != null)
             {
                 var formatProvider = GetFormatProvider(logEvent);
-                var value = _lateBoundPropertyGet(_process, null);
                 builder.AppendFormattedValue(value, Format, formatProvider);
             }
+
+        }
+
+        private object GetValue()
+        {
+            return _lateBoundPropertyGet?.Invoke(_process, null);
+        }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue();
         }
     }
 }

--- a/src/NLog/LayoutRenderers/ProcessTimeLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessTimeLayoutRenderer.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("processtime")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class ProcessTimeLayoutRenderer : LayoutRenderer
+    public class ProcessTimeLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Gets or sets a value indicating whether to output in culture invariant format
@@ -62,11 +62,17 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            TimeSpan ts = logEvent.TimeStamp.ToUniversalTime() - LogEventInfo.ZeroDate;
+            var ts = GetValue(logEvent);
             var culture = Invariant ? null : GetCulture(logEvent);
             WritetTimestamp(builder, ts, culture);
         }
 
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue(logEvent);
+        }
+        
         /// <summary>
         /// Write timestamp to builder with format hh:mm:ss:fff
         /// </summary>
@@ -110,6 +116,12 @@ namespace NLog.LayoutRenderers
             }
 
             builder.AppendInvariant(milliseconds);
+        }
+
+        private static TimeSpan GetValue(LogEventInfo logEvent)
+        {
+            TimeSpan ts = logEvent.TimeStamp.ToUniversalTime() - LogEventInfo.ZeroDate;
+            return ts;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/SequenceIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/SequenceIdLayoutRenderer.cs
@@ -43,7 +43,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("sequenceid")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class SequenceIdLayoutRenderer : LayoutRenderer
+    public class SequenceIdLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Renders the current log sequence ID and appends it to the specified <see cref="StringBuilder"/>.
@@ -52,7 +52,18 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            builder.AppendInvariant(logEvent.SequenceID);
+            builder.AppendInvariant(GetValue(logEvent));
+        }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue(logEvent);
+        }
+
+        private static int GetValue(LogEventInfo logEvent)
+        {
+            return logEvent.SequenceID;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/ThreadIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ThreadIdLayoutRenderer.cs
@@ -43,7 +43,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("threadid")]
     [ThreadSafe]
-    public class ThreadIdLayoutRenderer : LayoutRenderer
+    public class ThreadIdLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Renders the current thread identifier and appends it to the specified <see cref="StringBuilder" />.
@@ -53,7 +53,18 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             //no culture needed for ints
-            builder.AppendInvariant(AsyncHelpers.GetManagedThreadId());
+            builder.AppendInvariant(GetValue());
+        }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue();
+        }
+
+        private static int GetValue()
+        {
+            return AsyncHelpers.GetManagedThreadId();
         }
     }
 }

--- a/src/NLog/LayoutRenderers/TimeLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/TimeLayoutRenderer.cs
@@ -45,7 +45,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("time")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class TimeLayoutRenderer : LayoutRenderer
+    public class TimeLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Gets or sets a value indicating whether to output UTC time instead of local time.
@@ -68,11 +68,7 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            DateTime dt = logEvent.TimeStamp;
-            if (UniversalTime)
-            {
-                dt = dt.ToUniversalTime();
-            }
+            var dt = GetValue(logEvent);
 
             string timeSeparator = ":";
             string ticksSeparator = ".";
@@ -95,6 +91,23 @@ namespace NLog.LayoutRenderers
             builder.Append2DigitsZeroPadded(dt.Second);
             builder.Append(ticksSeparator);
             builder.Append4DigitsZeroPadded((int)(dt.Ticks % 10000000) / 1000);
+        }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue(logEvent);
+        }
+
+        private DateTime GetValue(LogEventInfo logEvent)
+        {
+            DateTime dt = logEvent.TimeStamp;
+            if (UniversalTime)
+            {
+                dt = dt.ToUniversalTime();
+            }
+
+            return dt;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/TraceActivityIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/TraceActivityIdLayoutRenderer.cs
@@ -40,13 +40,14 @@ namespace NLog.LayoutRenderers
     using System.Globalization;
     using System.Text;
     using NLog.Config;
+	using NLog.Internal;
 
     /// <summary>
     /// A renderer that puts into log a System.Diagnostics trace correlation id.
     /// </summary>
     [LayoutRenderer("activityid")]
     [ThreadSafe]
-    public class TraceActivityIdLayoutRenderer : LayoutRenderer
+    public class TraceActivityIdLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Renders the current trace activity ID.
@@ -55,9 +56,22 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            var activityId = Trace.CorrelationManager.ActivityId;
-            builder.Append(Guid.Empty.Equals(activityId) ?
-                string.Empty : activityId.ToString("D", CultureInfo.InvariantCulture));
+            var activityId = GetValue();
+            if (!Guid.Empty.Equals(activityId))
+            {
+                builder.Append(activityId.ToString("D", CultureInfo.InvariantCulture));
+            }
+        }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            return GetValue();
+        }
+
+        private static Guid GetValue()
+        {
+            return Trace.CorrelationManager.ActivityId;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/WindowsIdentityLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/WindowsIdentityLayoutRenderer.cs
@@ -77,7 +77,7 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent();
+            var currentIdentity = GetValue();
             if (currentIdentity != null)
             {
                 string output = string.Empty;
@@ -125,6 +125,12 @@ namespace NLog.LayoutRenderers
 
                 builder.Append(output);
             }
+        }
+
+        private static WindowsIdentity GetValue()
+        {
+            WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent();
+            return currentIdentity;
         }
     }
 }

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using NLog.LayoutRenderers;
+
 namespace NLog.Layouts
 {
     using System;
@@ -377,6 +379,18 @@ namespace NLog.Layouts
                 return string.Concat(GetType().Name, "=", string.Join("|", nestedNames));
             }
             return base.ToString();
+        }
+
+        /// <summary>
+        /// Try get value
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <param name="rawValue">rawValue if return result is true</param>
+        /// <returns>false if we could not determine the rawValue</returns>
+        public virtual bool TryGetRawValue(LogEventInfo logEvent, out object rawValue)
+        {
+            rawValue = null;
+            return false;
         }
     }
 }

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -240,6 +240,20 @@ namespace NLog.Layouts
             }
         }
 
+        /// <inheritdoc />
+        public override bool TryGetRawValue(LogEventInfo logEvent, out object rawValue)
+        {
+            if (Renderers.Count == 1 && Renderers[0] is IRawValue rawValueLayoutRenderer)
+            {
+                rawValue =  rawValueLayoutRenderer.GetRawValue(logEvent);
+                return true;
+            }
+
+            rawValue = null;
+            return false;
+        }
+
+
         /// <summary>
         /// Initializes the layout.
         /// </summary>

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
@@ -60,7 +60,7 @@ namespace NLog.UnitTests.Layouts
         {
             ConfigurationItemFactory configurationItemFactory = new ConfigurationItemFactory();
             configurationItemFactory.LayoutRenderers.RegisterDefinition("throwsException", typeof(ThrowsExceptionRenderer));
-            
+
             SimpleLayout l = new SimpleLayout("xx${throwsException}yy", configurationItemFactory);
             string output = l.Render(LogEventInfo.CreateNullEvent());
             Assert.Equal("xxyy", output);
@@ -90,7 +90,7 @@ namespace NLog.UnitTests.Layouts
         public void LayoutRendererThrows2()
         {
             string internalLogOutput = RunAndCaptureInternalLog(
-                () => 
+                () =>
                     {
                         ConfigurationItemFactory configurationItemFactory = new ConfigurationItemFactory();
                         configurationItemFactory.LayoutRenderers.RegisterDefinition("throwsException", typeof(ThrowsExceptionRenderer));
@@ -98,7 +98,7 @@ namespace NLog.UnitTests.Layouts
                         SimpleLayout l = new SimpleLayout("xx${throwsException:msg1}yy${throwsException:msg2}zz", configurationItemFactory);
                         string output = l.Render(LogEventInfo.CreateNullEvent());
                         Assert.Equal("xxyyzz", output);
-                    }, 
+                    },
                     LogLevel.Warn);
 
             Assert.True(internalLogOutput.IndexOf("msg1") >= 0, internalLogOutput);
@@ -151,6 +151,38 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(1, lr.InitCount);
             Assert.Equal(1, lr.CloseCount);
         }
+
+        [Fact]
+        public void TryGetRawValue_SingleLayoutRender_ShouldGiveRawValue()
+        {
+            // Arrange
+            SimpleLayout l = "${threadid}";
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+
+            // Act
+            var success = l.TryGetRawValue(logEventInfo, out var value);
+
+            // Assert
+            Assert.True(success, "success");
+            Assert.IsType<int>(value);
+            Assert.True((int)value >= 0, "(int)value >= 0");
+        }
+        [Fact]
+        public void TryGetRawValue_MultipleLayoutRender_ShouldGiveNullRawValue()
+        {
+            // Arrange
+            SimpleLayout l = "${threadid} ";
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+
+            // Act
+            var success = l.TryGetRawValue(logEventInfo, out var value);
+
+            // Assert
+            Assert.False(success);
+            Assert.Null(value);
+        }
+
+
 
         public class ThrowsExceptionRenderer : LayoutRenderer
         {


### PR DESCRIPTION
needed for #522 (see also #1435 or #2767)

Not sure if this is enough. How to log ${level} as int to the database? We like to prevent toString and int.parse.

options: 

1. database target aware of LogLevel type
2. or make IRawValue generic, e.g. IRawValue<LogLevel>, IRawValue<int>
3. or request type to GetRawValue, e.g. GetRawValue(typeof(int))  - could be optional.

todo decide

- [x] naming of getRawValue and IRawValue
- [x] also work with TypeCode? (provided or request), really useful is TypeCode.DBNull for the database target, see also https://github.com/NLog/NLog/issues/293
- [x] interface (IRawValue) or abstract class? Later for performance reasons. (also possible, virtual method on layout class, but could be tricky with null)

fixes #1332

todo 
 
- [x] impl for all needed layout renderers 
- [x] unit tests