### PR TITLE
JSON encoding should create valid JSON for special double values (hotfix)

### DIFF
--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -126,7 +126,7 @@ namespace NLog.Targets
                     else
                     {
                         string xmlStr = XmlHelper.XmlConvertToString(value, objTypeCode);
-                        if (SkipQuotes(objTypeCode))
+                        if (SkipQuotes(value, objTypeCode))
                         {
                             return xmlStr;
                         }
@@ -242,7 +242,7 @@ namespace NLog.Targets
             try
             {
                 TypeCode objTypeCode = Convert.GetTypeCode(value);
-                bool includeQuotes = !SkipQuotes(objTypeCode);
+                bool includeQuotes = !SkipQuotes(value, objTypeCode);
                 if (includeQuotes)
                 {
                     destination.Append('"');
@@ -463,7 +463,7 @@ namespace NLog.Targets
                     {
                         return false;
                     }
-                    if (SkipQuotes(objTypeCode))
+                    if (SkipQuotes(value, objTypeCode))
                     {
                         destination.Append(str);
                     }
@@ -539,13 +539,32 @@ namespace NLog.Targets
         /// <summary>
         /// No quotes needed for this type?
         /// </summary>
-        /// <param name="objTypeCode"></param>
-        /// <returns></returns>
-        private static bool SkipQuotes(TypeCode objTypeCode)
+        private static bool SkipQuotes(object value, TypeCode objTypeCode)
         {
-            return objTypeCode != TypeCode.String && (objTypeCode == TypeCode.Empty  // Don't put quotes around null values
-                || objTypeCode == TypeCode.Boolean
-                || IsNumericTypeCode(objTypeCode, true));
+            if (objTypeCode != TypeCode.String)
+            {
+                if (objTypeCode == TypeCode.Empty || objTypeCode == TypeCode.Boolean)
+                    return true;    // Don't put quotes around null values
+
+                if (IsNumericTypeCode(objTypeCode, false) || objTypeCode == TypeCode.Decimal)
+                    return true;
+
+                if (objTypeCode == TypeCode.Double)
+                {
+                    double dblValue = (double)value;
+                    if (!double.IsNaN(dblValue) && !double.IsInfinity(dblValue))
+                        return true;
+                }
+
+                if (objTypeCode == TypeCode.Single)
+                {
+                    float floatValue = (float)value;
+                    if (!float.IsNaN(floatValue) && !float.IsInfinity(floatValue))
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -559,9 +559,9 @@ namespace NLog.UnitTests.Layouts
             logger.Debug(logEventInfo);
 
             AssertDebugLastMessage("debug", ExpectedIncludeAllPropertiesWithExcludes);
-        }     
-        
-        
+        }
+
+
         /// <summary>
         /// Serialize object deep
         /// </summary>
@@ -679,6 +679,39 @@ namespace NLog.UnitTests.Layouts
             logger.Debug(logEventInfo1);
 
             AssertDebugLastMessage("debug", "{ \"InvalidCharacters\": [\"|\",\"#\",\"{\",\"}\",\"%\",\"&\",\"\\\"\",\"~\",\"+\",\"\\\\\",\"\\/\",\":\",\"*\",\"?\",\"<\",\">\"] }");
+        }
+
+        [Fact]
+        public void EncodesInvalidDoubles()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog throwExceptions='true'>
+            <targets>
+                <target name='debug' type='Debug'  >
+                 <layout type=""JsonLayout"" IncludeAllProperties='true' >
+                 </layout>
+                </target>
+            </targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+
+            ILogger logger = LogManager.GetLogger("A");
+
+            var logEventInfo1 = new LogEventInfo();
+
+            logEventInfo1.Properties.Add("DoubleNaN", double.NaN);
+            logEventInfo1.Properties.Add("DoubleInfPositive", double.PositiveInfinity);
+            logEventInfo1.Properties.Add("DoubleInfNegative", double.NegativeInfinity);
+            logEventInfo1.Properties.Add("FloatNaN", float.NaN);
+            logEventInfo1.Properties.Add("FloatInfPositive", float.PositiveInfinity);
+            logEventInfo1.Properties.Add("FloatInfNegative", float.NegativeInfinity);
+
+            logger.Debug(logEventInfo1);
+
+            AssertDebugLastMessage("debug", "{ \"DoubleNaN\": \"NaN\", \"DoubleInfPositive\": \"Infinity\", \"DoubleInfNegative\": \"-Infinity\", \"FloatNaN\": \"NaN\", \"FloatInfPositive\": \"Infinity\", \"FloatInfNegative\": \"-Infinity\" }");
         }
 
         private static LogEventInfo CreateLogEventWithExcluded()

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -159,7 +159,7 @@ namespace NLog.UnitTests.Targets
             var actual = _serializer.SerializeObject(d);
 
             var cnt = Regex.Matches(actual, "\\[\"alpha\",\"bravo\"\\]").Count;
-            Assert.Equal(10, cnt);   
+            Assert.Equal(10, cnt);
         }
 
         [Fact]
@@ -181,8 +181,10 @@ namespace NLog.UnitTests.Targets
         [InlineData((ulong)32711520331, "32711520331")]
         [InlineData(3.14159265, "3.14159265")]
         [InlineData(2776145.7743, "2776145.7743")]
-        [InlineData(double.NaN, "NaN")]
-        [InlineData(double.PositiveInfinity, "Infinity")]
+        [InlineData(double.NaN, "\"NaN\"")]
+        [InlineData(double.PositiveInfinity, "\"Infinity\"")]
+        [InlineData(float.NaN, "\"NaN\"")]
+        [InlineData(float.PositiveInfinity, "\"Infinity\"")]
         public void SerializeNumber_Test(object o, string expected)
         {
             var actual = _serializer.SerializeObject(o);
@@ -501,7 +503,7 @@ namespace NLog.UnitTests.Targets
         {
             private string something = "something";
 
-#region Overrides of Object
+            #region Overrides of Object
 
             /// <summary>Returns a string that represents the current object.</summary>
             /// <returns>A string that represents the current object.</returns>
@@ -510,7 +512,7 @@ namespace NLog.UnitTests.Targets
                 return something;
             }
 
-#endregion
+            #endregion
         }
 
         private class ObjectWithExceptionAndPrivateSetter


### PR DESCRIPTION
Resolves #2860 by handling NaN and Infinity (Also for floats)