### PR TITLE
Updated Nuget RepositoryUrl to https address

### DIFF
--- a/src/NLog.Extended/NLog.Extended.csproj
+++ b/src/NLog.Extended/NLog.Extended.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
@@ -12,7 +12,7 @@
     <InformationalVersion>$(ProductVersion)</InformationalVersion>
     <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
     <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - http://nlog-project.org/ </Copyright>
+    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
       News post:
@@ -22,11 +22,11 @@
       https://github.com/NLog/NLog/wiki/AppSetting-Layout-Renderer
     </PackageReleaseNotes>
     <PackageTags>NLog;MSMQ;AppSettings;logging;log</PackageTags>
-    <PackageIconUrl>http://nlog-project.org/N.png</PackageIconUrl>
-    <PackageProjectUrl>http://nlog-project.org/</PackageProjectUrl>
+    <PackageIconUrl>https://nlog-project.org/N.png</PackageIconUrl>
+    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/NLog/NLog/blob/master/LICENSE.txt</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/NLog/NLog</RepositoryUrl>
+    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>

--- a/src/NLog.Wcf/NLog.Wcf.csproj
+++ b/src/NLog.Wcf/NLog.Wcf.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
@@ -12,18 +12,18 @@
     <InformationalVersion>$(ProductVersion)</InformationalVersion>
     <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
     <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - http://nlog-project.org/ </Copyright>
+    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
       Wiki:
       https://github.com/NLog/NLog/wiki/LogReceiverService-target
     </PackageReleaseNotes>
     <PackageTags>NLog;WCF;ServiceModel;logging;log</PackageTags>
-    <PackageIconUrl>http://nlog-project.org/N.png</PackageIconUrl>
-    <PackageProjectUrl>http://nlog-project.org/</PackageProjectUrl>
+    <PackageIconUrl>https://nlog-project.org/N.png</PackageIconUrl>
+    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/NLog/NLog/blob/master/LICENSE.txt</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/NLog/NLog</RepositoryUrl>
+    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>

--- a/src/NLog.WindowsEventLog/NLog.WindowsEventLog.csproj
+++ b/src/NLog.WindowsEventLog/NLog.WindowsEventLog.csproj
@@ -12,18 +12,18 @@
     <InformationalVersion>$(ProductVersion)</InformationalVersion>
     <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
     <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - http://nlog-project.org/ </Copyright>
+    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
       Wiki:
       https://github.com/nlog/NLog/wiki/EventLog-target
     </PackageReleaseNotes>
     <PackageTags>NLog;EventLog;logging;log</PackageTags>
-    <PackageIconUrl>http://nlog-project.org/N.png</PackageIconUrl>
-    <PackageProjectUrl>http://nlog-project.org/</PackageProjectUrl>
+    <PackageIconUrl>https://nlog-project.org/N.png</PackageIconUrl>
+    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/NLog/NLog/blob/master/LICENSE.txt</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/NLog/NLog</RepositoryUrl>
+    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>

--- a/src/NLog.WindowsIdentity/NLog.WindowsIdentity.csproj
+++ b/src/NLog.WindowsIdentity/NLog.WindowsIdentity.csproj
@@ -12,18 +12,18 @@
     <InformationalVersion>$(ProductVersion)</InformationalVersion>
     <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
     <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - http://nlog-project.org/ </Copyright>
+    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
       Wiki:
       https://github.com/NLog/NLog/wiki/Windows-Identity-Layout-Renderer
     </PackageReleaseNotes>
     <PackageTags>NLog;WindowsIdentity;logging;log</PackageTags>
-    <PackageIconUrl>http://nlog-project.org/N.png</PackageIconUrl>
-    <PackageProjectUrl>http://nlog-project.org/</PackageProjectUrl>
+    <PackageIconUrl>https://nlog-project.org/N.png</PackageIconUrl>
+    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/NLog/NLog/blob/master/LICENSE.txt</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/NLog/NLog</RepositoryUrl>
+    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
@@ -29,7 +29,7 @@ For ASP.NET Core, check: https://www.nuget.org/packages/NLog.Web.AspNetCore
     <InformationalVersion>$(ProductVersion)</InformationalVersion>
     <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
     <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - http://nlog-project.org/ </Copyright>
+    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
     
     <PackageReleaseNotes>
 
@@ -45,11 +45,11 @@ Supported for each platform: https://github.com/NLog/NLog/wiki/platform-support
 
     </PackageReleaseNotes>
     <PackageTags>NLog;logging;log;structured;tracing;logfiles;database;eventlog;email;wcf;console</PackageTags>
-    <PackageIconUrl>http://nlog-project.org/N.png</PackageIconUrl>
-    <PackageProjectUrl>http://nlog-project.org/</PackageProjectUrl>
+    <PackageIconUrl>https://nlog-project.org/N.png</PackageIconUrl>
+    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/NLog/NLog/blob/master/LICENSE.txt</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/NLog/NLog</RepositoryUrl>
+    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>

--- a/src/NuGet/NLog.Config/NLog.Config.nuspec
+++ b/src/NuGet/NLog.Config/NLog.Config.nuspec
@@ -13,10 +13,10 @@
     <summary>Configuration file for NLog. </summary>
     <description>Xml file to get started with configuring NLog. This package is not mandatory to get started with NLog: the configuration file can created manually and the configuration can be created programmatically.  </description>
     <language>en-US</language>
-    <iconUrl>http://nlog-project.org/NConfig.png</iconUrl>
-    <projectUrl>http://nlog-project.org/</projectUrl>
+    <iconUrl>https://nlog-project.org/NConfig.png</iconUrl>
+    <projectUrl>https://nlog-project.org/</projectUrl>
     <repository type="git" url="https://github.com/NLog/NLog.git" />
-    <licenseUrl>http://raw.github.com/NLog/NLog/master/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/NLog/NLog/blob/master/LICENSE.txt</licenseUrl>
     <releaseNotes>NLog $BuildVersion$</releaseNotes>
     <dependencies>
       <dependency id="NLog" version="$BuildVersion$" />

--- a/src/NuGet/NLog.Schema/NLog.Schema.nuspec
+++ b/src/NuGet/NLog.Schema/NLog.Schema.nuspec
@@ -13,10 +13,10 @@
 Note: extensions to NLog will report XSD errors. Those can be ignored safely.  </description>
     <releaseNotes>NLog $BuildVersion$</releaseNotes>
     <language>en-US</language>
-    <iconUrl>http://nlog-project.org/NConfig.png</iconUrl>
-    <projectUrl>http://nlog-project.org/</projectUrl>
+    <iconUrl>https://nlog-project.org/NConfig.png</iconUrl>
+    <projectUrl>https://nlog-project.org/</projectUrl>
     <repository type="git" url="https://github.com/NLog/NLog.git" />
-    <licenseUrl>http://raw.github.com/NLog/NLog/master/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/NLog/NLog/blob/master/LICENSE.txt</licenseUrl>
     <tags>nlog, intellisense, xsd</tags>
       <contentFiles>
       <files include="**/*.*" buildAction="None" copyToOutput="false" flatten="true" />


### PR DESCRIPTION
Part of resolving #2873
```
    <RepositoryUrl>https://github.com/restsharp/RestSharp.git</RepositoryUrl>
    <RepositoryType>git</RepositoryType>
```
See also https://blog.nuget.org/20180827/Introducing-Source-Code-Link-for-NuGet-packages.html