### PR TITLE
Database target: support for DbType for parameters (including SqlDbType, OracleDbType etc.)

### DIFF
--- a/src/NLog/Internal/DatabaseParameterTypeSetter.cs
+++ b/src/NLog/Internal/DatabaseParameterTypeSetter.cs
@@ -31,20 +31,21 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__
 
-namespace NLog.Targets
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Data;
-    using System.Reflection;
-    using Internal;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Reflection;
+using NLog.Targets;
 
+namespace NLog.Internal
+{
     /// <summary>
     /// Set dbType on correct property (e.g. DbType, OleDbType, etc)
     /// </summary>
-    public class DatabaseParameterTypeSetter
+    internal class DatabaseParameterTypeSetter
     {
         private bool _defaultDbProperty;
 

--- a/src/NLog/Targets/DatabaseParameterInfo.cs
+++ b/src/NLog/Targets/DatabaseParameterInfo.cs
@@ -79,8 +79,9 @@ namespace NLog.Targets
         public Layout Layout { get; set; }
 
         /// <summary>
-        /// Use raw value.
-        /// If null, then use the rawValue when the dbtype isn't a string-like (that's:
+        /// Use raw value
+        ///
+        /// If null, then rawValue will be used when the dbtype isn't a string-like (that's:
         /// <see cref="System.Data.DbType.String"/>
         /// <see cref="System.Data.DbType.AnsiString"/>
         /// <see cref="System.Data.DbType.StringFixedLength"/>

--- a/src/NLog/Targets/DatabaseParameterInfo.cs
+++ b/src/NLog/Targets/DatabaseParameterInfo.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
 
 namespace NLog.Targets
 {
@@ -67,35 +67,60 @@ namespace NLog.Targets
         /// <summary>
         /// Gets or sets the database parameter name.
         /// </summary>
-        /// <docgen category='Parameter Options' order='10' />
+        /// <docgen category='Parameter Options' order='0' />
         [RequiredParameter]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the layout that should be use to calcuate the value for the parameter.
         /// </summary>
-        /// <docgen category='Parameter Options' order='10' />
+        /// <docgen category='Parameter Options' order='1' />
         [RequiredParameter]
         public Layout Layout { get; set; }
 
         /// <summary>
+        /// Use raw value.
+        /// If null, then use the rawValue when the dbtype isn't a string-like (that's:
+        /// <see cref="System.Data.DbType.String"/>
+        /// <see cref="System.Data.DbType.AnsiString"/>
+        /// <see cref="System.Data.DbType.StringFixedLength"/>
+        /// <see cref="System.Data.DbType.AnsiStringFixedLength"/>
+        /// )
+        /// </summary>
+        public bool? UseRawValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the database parameter DbType.
+        /// </summary>
+        /// <docgen category='Parameter Options' order='2' />
+        [DefaultValue(null)]
+        public string DbType { get; set; }
+
+        /// <summary>
+        /// Gets or sets convert format of the database parameter value .
+        /// </summary>
+        /// <docgen category='Parameter Options' order='3' />
+        [DefaultValue(null)]
+        public string Format { get; set; }
+
+        /// <summary>
         /// Gets or sets the database parameter size.
         /// </summary>
-        /// <docgen category='Parameter Options' order='10' />
+        /// <docgen category='Parameter Options' order='4' />
         [DefaultValue(0)]
         public int Size { get; set; }
 
         /// <summary>
         /// Gets or sets the database parameter precision.
         /// </summary>
-        /// <docgen category='Parameter Options' order='10' />
+        /// <docgen category='Parameter Options' order='5' />
         [DefaultValue(0)]
         public byte Precision { get; set; }
 
         /// <summary>
         /// Gets or sets the database parameter scale.
         /// </summary>
-        /// <docgen category='Parameter Options' order='10' />
+        /// <docgen category='Parameter Options' order='6' />
         [DefaultValue(0)]
         public byte Scale { get; set; }
     }

--- a/src/NLog/Targets/DatabaseParameterTypeSetter.cs
+++ b/src/NLog/Targets/DatabaseParameterTypeSetter.cs
@@ -1,0 +1,117 @@
+// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+
+namespace NLog.Targets
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Reflection;
+    using Internal;
+
+    /// <summary>
+    /// Set dbType on correct property (e.g. DbType, OleDbType, etc)
+    /// </summary>
+    public class DatabaseParameterTypeSetter
+    {
+        private bool _defaultDbProperty;
+
+        /// <summary>
+        /// SQL Command Parameter DbType Property
+        /// </summary>
+        private PropertyInfo _dbTypeProperty;
+
+        /// <summary>
+        /// SQL Command Parameter instance DbType Property Values
+        /// </summary>
+        private Dictionary<DatabaseParameterInfo, int> _propertyDbTypeValues;
+        /// <summary>
+        /// Resolve Parameter DbType Property and DbType Value
+        /// </summary>
+        /// <docgen category='Parameter Options' order='10' />
+        public void Resolve(IDbDataParameter parameter, string dbTypePropertyName, IList<DatabaseParameterInfo> parametersInfo)
+        {
+            Type propertyType;
+            if (string.IsNullOrEmpty(dbTypePropertyName) ||
+                dbTypePropertyName.Equals(nameof(IDataParameter.DbType), StringComparison.OrdinalIgnoreCase))
+            {
+                _defaultDbProperty = true;
+                propertyType = typeof(DbType);
+            }
+            else
+            {
+                _defaultDbProperty = false;
+                if (!PropertyHelper.TryGetPropertyInfo(parameter, dbTypePropertyName, out var dbTypeProperty))
+                {
+                    throw new NLogConfigurationException(
+                        "Type '" + parameter.GetType().Name + "' has no property '" + dbTypePropertyName + "'.");
+                }
+
+                _dbTypeProperty = dbTypeProperty;
+                propertyType = dbTypeProperty.PropertyType;
+            }
+
+            _propertyDbTypeValues = new Dictionary<DatabaseParameterInfo, int>();
+            foreach (var par in parametersInfo)
+            {
+                if (!string.IsNullOrEmpty(par.DbType))
+                {
+                    var dbTypeValue = Enum.Parse(propertyType, par.DbType);
+                    _propertyDbTypeValues[par] = (int)dbTypeValue;
+                }
+            }
+        }
+        /// <summary>
+        /// Set Parameter DbType
+        /// </summary>
+        public void SetParameterDbType(IDbDataParameter p, DatabaseParameterInfo par)
+        {
+            if (_propertyDbTypeValues.TryGetValue(par, out var dbType))
+            {
+                if (_defaultDbProperty)
+                {
+                    p.DbType = (DbType)dbType;
+                }
+                else
+                {
+                    _dbTypeProperty.SetValue(p, dbType, null);
+                }
+            }
+        }
+
+
+    }
+}
+#endif

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -853,7 +853,7 @@ namespace NLog.Targets
         /// <param name="parameterInfo">Parameter configuration info.</param>
         /// <param name="logEvent">Current logevent.</param>
         /// <returns></returns>
-        protected IDbDataParameter CreateDatabaseParameter(IDbCommand command, DatabaseParameterInfo parameterInfo, LogEventInfo logEvent)
+        protected virtual IDbDataParameter CreateDatabaseParameter(IDbCommand command, DatabaseParameterInfo parameterInfo, LogEventInfo logEvent)
         {
             IDbDataParameter dbParameter = command.CreateParameter();
             EnsureParameterSetter(dbParameter);

--- a/src/NLog/Targets/DatabaseValueConverter.cs
+++ b/src/NLog/Targets/DatabaseValueConverter.cs
@@ -1,0 +1,227 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using NLog.Common;
+
+namespace NLog.Targets
+{
+    /// <summary>
+    /// Convert values for the database target
+    /// </summary>
+    internal class DatabaseValueConverter : IDatabaseValueConverter
+    {
+        /// <summary>
+        /// Map from DbType to Type, see also
+        ///
+        /// https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/configuring-parameters-and-parameter-data-types
+        /// </summary>
+        private static readonly Dictionary<DbType, Type> TypeMap = new Dictionary<DbType, Type>();
+
+        /// <inheritdoc />
+        static DatabaseValueConverter()
+        {
+            void AddToMapping(DbType dbtype, Type t)
+            {
+                TypeMap.Add(dbtype, t);
+            }
+
+            AddToMapping(DbType.AnsiString, typeof(string));
+            AddToMapping(DbType.Binary, typeof(byte[]));
+            AddToMapping(DbType.Byte, typeof(byte));
+            AddToMapping(DbType.Boolean, typeof(bool));
+            AddToMapping(DbType.Currency, typeof(decimal));
+            AddToMapping(DbType.Date, typeof(DateTime));
+            AddToMapping(DbType.DateTime, typeof(DateTime));
+            AddToMapping(DbType.DateTime2, typeof(DateTime));
+            AddToMapping(DbType.DateTimeOffset, typeof(DateTimeOffset));
+            AddToMapping(DbType.Decimal, typeof(decimal));
+            AddToMapping(DbType.Double, typeof(float));
+            AddToMapping(DbType.Guid, typeof(Guid));
+            AddToMapping(DbType.Int16, typeof(short));
+            AddToMapping(DbType.Int32, typeof(int));
+            AddToMapping(DbType.Int64, typeof(long));
+            AddToMapping(DbType.SByte, typeof(sbyte));
+            AddToMapping(DbType.Single, typeof(float));
+            AddToMapping(DbType.String, typeof(string));
+            AddToMapping(DbType.StringFixedLength, typeof(string));
+            AddToMapping(DbType.UInt16, typeof(ushort));
+            AddToMapping(DbType.UInt32, typeof(uint));
+            AddToMapping(DbType.UInt64, typeof(ulong));
+            AddToMapping(DbType.VarNumeric, typeof(decimal));
+            AddToMapping(DbType.AnsiStringFixedLength, typeof(string));
+            AddToMapping(DbType.Xml, typeof(string));
+
+        }
+
+
+
+
+        /// <inheritdoc />
+        public object ConvertFromString(string value, DbType dbType, DatabaseParameterInfo parameterInfo)
+        {
+
+            if (value == null)
+            {
+                return null;
+            }
+
+            var format = parameterInfo.Format;
+
+            switch (dbType)
+            {
+                case DbType.String:
+                case DbType.AnsiString:
+                case DbType.AnsiStringFixedLength:
+                    return value;
+            }
+
+            var trimmedValue = value.Trim();
+
+
+            switch (dbType)
+            {
+                case DbType.Boolean:
+                    return bool.Parse(trimmedValue);
+                case DbType.Decimal:
+                case DbType.Currency:
+                case DbType.VarNumeric:
+                    return decimal.Parse(trimmedValue);
+                case DbType.Double:
+                    return double.Parse(trimmedValue);
+                case DbType.Single:
+                    return float.Parse(trimmedValue);
+                case DbType.Time:
+                    return TimeSpan.Parse(trimmedValue);
+                case DbType.DateTime:
+                case DbType.DateTime2:
+                case DbType.Date:
+                    if (string.IsNullOrEmpty(format))
+                        return DateTime.Parse(trimmedValue, CultureInfo.InvariantCulture);
+                    else
+                        return DateTime.ParseExact(trimmedValue, format, null);
+                case DbType.DateTimeOffset:
+                    if (string.IsNullOrEmpty(format))
+                        return DateTimeOffset.Parse(trimmedValue, CultureInfo.InvariantCulture);
+                    else
+                        return DateTimeOffset.ParseExact(trimmedValue, format, null);
+                case DbType.Guid:
+#if NET3_5
+                    return new Guid(trimmedValue);
+#else
+                    return string.IsNullOrEmpty(format) ? Guid.Parse(trimmedValue) : Guid.ParseExact(trimmedValue, format);
+#endif
+                case DbType.Byte:
+                    return byte.Parse(trimmedValue);
+                case DbType.SByte:
+                    return sbyte.Parse(trimmedValue);
+                case DbType.Int16:
+                    return short.Parse(trimmedValue);
+                case DbType.Int32:
+                    return int.Parse(trimmedValue);
+                case DbType.Int64:
+                    return long.Parse(trimmedValue);
+                case DbType.UInt16:
+                    return ushort.Parse(trimmedValue);
+                case DbType.UInt32:
+                    return uint.Parse(trimmedValue);
+                case DbType.UInt64:
+                    return ulong.Parse(trimmedValue);
+                case DbType.Binary:
+                    return ConvertToBinary(trimmedValue);
+                default:
+                    return value;
+            }
+        }
+
+        /// <inheritdoc />
+        public object ConvertFromObject(object rawValue, DbType dbType, DatabaseParameterInfo parameterInfo)
+        {
+            if (rawValue == null) return null;
+
+            if (TypeMap.TryGetValue(dbType, out Type t) && CanChangeType(rawValue, t))
+            {
+                try
+                {
+                    return Convert.ChangeType(rawValue, t);
+                }
+                catch (Exception ex)
+                {
+                    InternalLogger.Debug(ex, "convert type {0} to type {1} (dbtype {2} for parameter {3} failed", rawValue.GetType(), t, dbType, parameterInfo.Name);
+                }
+            }
+
+            return rawValue;
+        }
+
+
+        private static bool CanChangeType(object value, Type conversionType)
+        {
+            if (conversionType == null)
+            {
+                return false;
+            }
+
+            IConvertible convertible = value as IConvertible;
+
+            if (convertible == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// convert layout value to parameter value
+        /// </summary>
+        private static object ConvertToBinary(string value)
+        {
+            var byteCount = value.Length / 2;
+            var buffer = new byte[byteCount];
+            for (int i = 0; i < byteCount; i++)
+            {
+                buffer[i] = byte.Parse(value.Substring(i * 2, 2), NumberStyles.AllowHexSpecifier);
+            }
+            return buffer;
+        }
+
+
+    }
+}
+#endif

--- a/src/NLog/Targets/IDatabaseValueConverter.cs
+++ b/src/NLog/Targets/IDatabaseValueConverter.cs
@@ -1,0 +1,66 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__
+
+using System.Data;
+using JetBrains.Annotations;
+
+namespace NLog.Targets
+{
+    /// <summary>
+    /// Convert values for the database target
+    /// </summary>
+    public interface IDatabaseValueConverter
+    {
+        /// <summary>
+        /// Convert layout value to parameter value
+        /// </summary>
+        /// <param name="value">Current value after rendering.</param>
+        /// <param name="dbType">Configured DbType, or DbType after setting the SqlDbType/OracleDyType property</param>
+        /// <param name="parameterInfo">The configured parameterInfo.</param>
+        /// <returns>Converted object that suits with <paramref name="dbType"/>.</returns>
+        object ConvertFromString(string value, DbType dbType, [NotNull] DatabaseParameterInfo parameterInfo);
+
+        /// <summary>
+        /// Convert rawvalue to parameter value
+        /// </summary>
+        /// <param name="rawValue">Current rawvalue after rendering raw (non-string).</param>
+        /// <param name="dbType">Configured DbType, or DbType after setting the SqlDbType/OracleDyType property</param>
+        /// <param name="parameterInfo">The configured parameterInfo.</param>
+        /// <returns>Converted object that suits with <paramref name="dbType"/>.</returns>
+        object ConvertFromObject(object rawValue, DbType dbType, [NotNull] DatabaseParameterInfo parameterInfo);
+    }
+}
+
+#endif

--- a/tests/NLog.UnitTests/Targets/DatabaseValueConverterTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseValueConverterTests.cs
@@ -1,0 +1,113 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.Threading;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.UnitTests.Targets
+{
+    public class DatabaseValueConverterTests
+    {
+        [Theory]
+        [MemberData(nameof(ConvertFromStringTestCases))]
+        public void ConvertFromString(string value, DbType dbType, object expected, string format = null)
+        {
+
+            var culture = Thread.CurrentThread.CurrentCulture;
+
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("NL-nl");
+
+                // Arrange
+                var databaseValueConverter = new DatabaseValueConverter();
+                var databaseParameterInfo = new DatabaseParameterInfo("@test", "test layout")
+                {
+                    Format = format
+                };
+
+                // Act
+                var result = databaseValueConverter.ConvertFromString(value, dbType, databaseParameterInfo);
+
+                // Assert
+                Assert.Equal(expected, result);
+            }
+            finally
+            {
+                // Restore
+                Thread.CurrentThread.CurrentCulture = culture;
+            }
+        }
+
+        public static IEnumerable<object[]> ConvertFromStringTestCases()
+        {
+            yield return new object[] { "true", DbType.Boolean, true };
+            yield return new object[] { "True", DbType.Boolean, true };
+            yield return new object[] { "1,2", DbType.VarNumeric, (decimal)1.2 };
+            yield return new object[] { "1,2", DbType.Currency, (decimal)1.2 };
+            yield return new object[] { "1,2", DbType.Decimal, (decimal)1.2 };
+            yield return new object[] { "1,2", DbType.Double, (double)1.2 };
+            yield return new object[] { "1,2", DbType.Single, (Single)1.2 };
+            yield return new object[] { "2:30", DbType.Time, new TimeSpan(0, 2, 30, 0), };
+            yield return new object[] { "2018-12-23 22:56", DbType.DateTime, new DateTime(2018, 12, 23, 22, 56, 0), };
+            yield return new object[] { "2018-12-23 22:56", DbType.DateTime2, new DateTime(2018, 12, 23, 22, 56, 0), };
+            yield return new object[] { "23-12-2018 22:56", DbType.DateTime, new DateTime(2018, 12, 23, 22, 56, 0), "dd-MM-yyyy HH:mm" };
+            yield return new object[] { new DateTime(2018, 12, 23, 22, 56, 0).ToString(CultureInfo.InvariantCulture), DbType.DateTime, new DateTime(2018, 12, 23, 22, 56, 0), };
+            yield return new object[] { "2018-12-23", DbType.Date, new DateTime(2018, 12, 23, 0, 0, 0), };
+            yield return new object[] { "2018-12-23 +2:30", DbType.DateTimeOffset, new DateTimeOffset(2018, 12, 23, 0, 0, 0, new TimeSpan(2, 30, 0)) };
+            yield return new object[] { "23-12-2018 22:56 +2:30", DbType.DateTimeOffset, new DateTimeOffset(2018, 12, 23, 22, 56, 0, new TimeSpan(2, 30, 0)), "dd-MM-yyyy HH:mm zzz" };
+            yield return new object[] { "3888CCA3-D11D-45C9-89A5-E6B72185D287", DbType.Guid, Guid.Parse("3888CCA3-D11D-45C9-89A5-E6B72185D287") };
+            yield return new object[] { "3888CCA3D11D45C989A5E6B72185D287", DbType.Guid, Guid.Parse("3888CCA3-D11D-45C9-89A5-E6B72185D287") };
+            yield return new object[] { "3888CCA3D11D45C989A5E6B72185D287", DbType.Guid, Guid.Parse("3888CCA3-D11D-45C9-89A5-E6B72185D287"), "N" };
+            yield return new object[] { "3", DbType.Byte, (byte)3 };
+            yield return new object[] { "3", DbType.SByte, (sbyte)3 };
+            yield return new object[] { "3", DbType.Int16, (short)3 };
+            yield return new object[] { " 3 ", DbType.Int16, (short)3 };
+            yield return new object[] { "3", DbType.Int32, 3 };
+            yield return new object[] { "3", DbType.Int64, (long)3 };
+            yield return new object[] { "3", DbType.UInt16, (ushort)3 };
+            yield return new object[] { "3", DbType.UInt32, (uint)3 };
+            yield return new object[] { "3", DbType.UInt64, (ulong)3 };
+            yield return new object[] { "3", DbType.AnsiString, "3" };
+            //todo binary
+            //todo default
+
+        }
+
+    }
+}


### PR DESCRIPTION
todo:

- [x] fix state in DatabaseParameterTypeSetter -> no problem, parameters are also shared
- [x] DatabaseParameterTypeSetter internal?
- [x] need conversion for rawValue? -> not for now. Injection point is there
- [x] static converter injection
- [x] fix headers
- [x] fix tests for new dummy "createParameter"
- [x] naming IDatabaseValueConverter
- [x] naming ParameterValueConverter
- [x] docs IDatabaseValueConverter, naming methodes, parameters check
- [x] IDatabaseValueConverter pass DatabaseParameterInfo?
- [ ] unit tests for DatabaseValueConverter -> partly now
- [ ] unit tests for DatabaseTarget.GetParameterValue (fallbacks) -> partly now
- [ ] DatabaseValueConverter - object todo, json case?
- [x] unit test for rawValue usage
- [x] skip rawValue if the param-dbType is a string/not set. 
- [x] fix NLog.UnitTests.Targets.DatabaseTargetTests.LevelParameterTest test + create variant