### PR TITLE
New Substring, Left & Right Wrappers

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
@@ -55,13 +55,16 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            if (Length > 0)
+            if (Length <= 0)
             {
-                Inner.RenderAppendBuilder(logEvent, builder);
-                if (builder.Length - orgLength > Length)
-                {
-                    builder.Length = orgLength + Length;
-                }
+                return;
+            }
+
+            Inner.RenderAppendBuilder(logEvent, builder);
+            var renderedLength = builder.Length - orgLength;
+            if (renderedLength > Length)
+            {
+                builder.Length = orgLength + Length;
             }
         }
 

--- a/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
@@ -68,7 +68,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override string Transform(string text)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
@@ -1,0 +1,71 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.LayoutRenderers.Wrappers
+{
+    using System;
+    using System.Text;
+    using NLog.Config;
+
+    /// <summary>
+    /// Left part of a text
+    /// </summary>
+    [LayoutRenderer("left")]
+    [ThreadAgnostic]
+    [ThreadSafe]
+    public sealed class LeftLayoutRendererWrapper : WrapperLayoutRendererBase
+    {
+        /// <summary>
+        /// Gets or sets the length in characters. 
+        /// </summary>
+        /// <docgen category="Transformation Options" order="10"/>
+        [RequiredParameter]
+        public int Length { get; set; }
+
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
+        {
+            Inner.RenderAppendBuilder(logEvent, builder);
+            if (Length > 0 && builder.Length - orgLength > Length)
+            {
+                builder.Length = orgLength + Length;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override string Transform(string text)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
@@ -55,10 +55,13 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            Inner.RenderAppendBuilder(logEvent, builder);
-            if (Length > 0 && builder.Length - orgLength > Length)
+            if (Length > 0)
             {
-                builder.Length = orgLength + Length;
+                Inner.RenderAppendBuilder(logEvent, builder);
+                if (builder.Length - orgLength > Length)
+                {
+                    builder.Length = orgLength + Length;
+                }
             }
         }
 

--- a/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
@@ -1,0 +1,73 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.LayoutRenderers.Wrappers
+{
+    using System;
+    using System.Text;
+    using NLog.Config;
+
+    /// <summary>
+    /// Right part of a text
+    /// </summary>
+    [LayoutRenderer("right")]
+    [ThreadAgnostic]
+    [ThreadSafe]
+    public sealed class RightLayoutRendererWrapper : WrapperLayoutRendererBase
+    {
+        /// <summary>
+        /// Gets or sets the length in characters. 
+        /// </summary>
+        /// <docgen category="Transformation Options" order="10"/>
+        [RequiredParameter]
+        public int Length { get; set; }
+
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
+        {
+            Inner.RenderAppendBuilder(logEvent, builder);
+            if (Length > 0 && builder.Length - orgLength > Length)
+            {
+                var str = builder.ToString(orgLength, builder.Length - orgLength);
+                builder.Length = orgLength;
+                builder.Append(str.Substring(str.Length - Length, Length));
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override string Transform(string text)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
@@ -60,9 +60,9 @@ namespace NLog.LayoutRenderers.Wrappers
                 Inner.RenderAppendBuilder(logEvent, builder);
                 if (builder.Length - orgLength > Length)
                 {
-                    var str = builder.ToString(orgLength, builder.Length - orgLength);
+                    var rightStr = builder.ToString(builder.Length - Length, Length);
                     builder.Length = orgLength;
-                    builder.Append(str.Substring(str.Length - Length, Length));
+                    builder.Append(rightStr);
                 }
             }
         }

--- a/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
@@ -55,15 +55,18 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            if (Length > 0)
+            if (Length <= 0)
             {
-                Inner.RenderAppendBuilder(logEvent, builder);
-                if (builder.Length - orgLength > Length)
-                {
-                    var rightStr = builder.ToString(builder.Length - Length, Length);
-                    builder.Length = orgLength;
-                    builder.Append(rightStr);
-                }
+                return;
+            }
+
+            Inner.RenderAppendBuilder(logEvent, builder);
+            var renderedLength = builder.Length - orgLength;
+            if (renderedLength > Length)
+            {
+                var rightStr = builder.ToString(builder.Length - Length, Length);
+                builder.Length = orgLength;
+                builder.Append(rightStr);
             }
         }
 

--- a/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
@@ -70,7 +70,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override string Transform(string text)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
@@ -1,0 +1,142 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.LayoutRenderers.Wrappers
+{
+    using System;
+    using System.ComponentModel;
+    using NLog.Config;
+    using System.Text;
+
+    /// <summary>
+    /// Substring the result
+    /// </summary>
+    /// <example>
+    /// ${substring:${level}:start=2:length=2}
+    /// ${substring:${level}:start=-2:length=2}
+    /// ${substring:Inner=${level}:start=2:length=2}
+    /// </example>
+    [LayoutRenderer("substring")]
+    [ThreadAgnostic]
+    public class SubstringLayoutRendererWrapper : WrapperLayoutRendererBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UppercaseLayoutRendererWrapper" /> class.
+        /// </summary>
+        public SubstringLayoutRendererWrapper()
+        {
+            Start = 0;
+        }
+
+        /// <summary>
+        /// Gets or sets the start index. 
+        /// </summary>
+        /// <value>Index</value>
+        /// <docgen category='Transformation Options' order='10' />
+        [DefaultValue(0)]
+        public int Start { get; set; }
+
+        /// <summary>
+        /// Gets or sets the length in characters. If <c>null</c>, then the whole string
+        /// </summary>
+        /// <value>Index</value>
+        /// <docgen category='Transformation Options' order='10' />
+        [DefaultValue(null)]
+        [RequiredParameter]
+        public int? Length { get; set; }
+
+
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
+        {
+            if (Length == 0)
+            {
+                return;
+            }
+
+            Inner.RenderAppendBuilder(logEvent, builder);
+            var renderedLength = builder.Length - orgLength;
+
+            if (renderedLength > 0)
+            {
+                var start = CalcStart(renderedLength);
+                var length = CalcLength(renderedLength, start);
+
+                var substring = builder.ToString(orgLength + start, length);
+                builder.Length = orgLength;
+                builder.Append(substring);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override string Transform(string text)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Calculate start position
+        /// </summary>
+        /// <returns>0 or positive number</returns>
+        private int CalcStart(int textLength)
+        {
+            var start = Start;
+            //start <0, then from end
+            if (start < 0)
+            {
+                start = (textLength + start);
+            }
+
+            if (start < 0)
+            {
+                start = 0;
+            }
+            return start;
+        }
+
+        /// <summary>
+        /// Calculate needed length
+        /// </summary>
+        /// <returns>0 or positive number</returns>
+        private int CalcLength(int textLength, int start)
+        {
+            var length = textLength - start;
+
+            if (Length.HasValue && textLength > Length.Value + start)
+            {
+                length = Length.Value;
+            }
+            return length;
+        }
+    }
+}

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/LeftLayoutRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/LeftLayoutRendererWrapperTests.cs
@@ -31,46 +31,23 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.LayoutRenderers.Wrappers
+using NLog.Layouts;
+using Xunit;
+
+namespace NLog.UnitTests.LayoutRenderers.Wrappers
 {
-    using System;
-    using System.Text;
-    using NLog.Config;
-
-    /// <summary>
-    /// Right part of a text
-    /// </summary>
-    [LayoutRenderer("right")]
-    [ThreadAgnostic]
-    [ThreadSafe]
-    public sealed class RightLayoutRendererWrapper : WrapperLayoutRendererBase
+    public class LeftLayoutRendererWrapperTests
     {
-        /// <summary>
-        /// Gets or sets the length in characters. 
-        /// </summary>
-        /// <docgen category="Transformation Options" order="10"/>
-        [RequiredParameter]
-        public int Length { get; set; }
-
-        /// <inheritdoc/>
-        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
+        [Theory]
+        [InlineData(":length=2", "12")]
+        [InlineData(":length=1000", "1234567890")]
+        [InlineData(":length=-1", "")]
+        [InlineData(":length=0", "")]
+        public void LeftWrapperTest(string options, string expected)
         {
-            if (Length > 0)
-            {
-                Inner.RenderAppendBuilder(logEvent, builder);
-                if (builder.Length - orgLength > Length)
-                {
-                    var str = builder.ToString(orgLength, builder.Length - orgLength);
-                    builder.Length = orgLength;
-                    builder.Append(str.Substring(str.Length - Length, Length));
-                }
-            }
-        }
-
-        /// <inheritdoc/>
-        protected override string Transform(string text)
-        {
-            throw new NotImplementedException();
+            SimpleLayout l = $"${{left:${{message}}{options}}}";
+            var result = l.Render(LogEventInfo.Create(LogLevel.Debug, "substringTest", "1234567890"));
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/RightLayoutRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/RightLayoutRendererWrapperTests.cs
@@ -31,46 +31,23 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.LayoutRenderers.Wrappers
+using NLog.Layouts;
+using Xunit;
+
+namespace NLog.UnitTests.LayoutRenderers.Wrappers
 {
-    using System;
-    using System.Text;
-    using NLog.Config;
-
-    /// <summary>
-    /// Right part of a text
-    /// </summary>
-    [LayoutRenderer("right")]
-    [ThreadAgnostic]
-    [ThreadSafe]
-    public sealed class RightLayoutRendererWrapper : WrapperLayoutRendererBase
+    public class RightLayoutRendererWrapperTests
     {
-        /// <summary>
-        /// Gets or sets the length in characters. 
-        /// </summary>
-        /// <docgen category="Transformation Options" order="10"/>
-        [RequiredParameter]
-        public int Length { get; set; }
-
-        /// <inheritdoc/>
-        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
+        [Theory]
+        [InlineData(":length=2", "90")]
+        [InlineData(":length=-1", "")]
+        [InlineData(":length=1000", "1234567890")]
+        [InlineData(":length=0", "")]
+        public void RightWrapperTest(string options, string expected)
         {
-            if (Length > 0)
-            {
-                Inner.RenderAppendBuilder(logEvent, builder);
-                if (builder.Length - orgLength > Length)
-                {
-                    var str = builder.ToString(orgLength, builder.Length - orgLength);
-                    builder.Length = orgLength;
-                    builder.Append(str.Substring(str.Length - Length, Length));
-                }
-            }
-        }
-
-        /// <inheritdoc/>
-        protected override string Transform(string text)
-        {
-            throw new NotImplementedException();
+            SimpleLayout l = $"${{right:${{message}}{options}}}";
+            var result = l.Render(LogEventInfo.Create(LogLevel.Debug, "substringTest", "1234567890"));
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapperTests.cs
@@ -1,0 +1,66 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using NLog.Layouts;
+using Xunit;
+using Xunit.Extensions;
+
+namespace NLog.UnitTests.LayoutRenderers.Wrappers
+{
+    public class SubstringLayoutRendererWrapperTests
+    {
+
+        [Theory]
+        [InlineData(":length=2", "12")]
+        [InlineData(":length=0", "")]
+        [InlineData(":start=10", "")]
+        [InlineData(":start=9", "0")]
+        [InlineData(":length=3", "before123", "before")]
+        [InlineData(":length=3", "before123end", "before", "end")]
+        [InlineData(":length=2:start=1", "23")]
+        [InlineData(":length=2:start=100", "")]
+        [InlineData(":length=100", "1234567890")]
+        [InlineData("", "1234567890")]
+        [InlineData(":start=0", "1234567890")]
+        [InlineData(":start=-2:length=2", "90")]
+        [InlineData(":start=-2", "90")]
+        [InlineData(":start=-1:length=2", "0")] //won't take chars from start after starting at end.
+        [InlineData(":length=-1", "")]
+        public void SubstringWrapperTest(string options, string expected, string prefixText = null, string afterText = null)
+        {
+            SimpleLayout l = $"{prefixText}${{substring:${{message}}{options}}}{afterText}";
+            var result = l.Render(LogEventInfo.Create(LogLevel.Debug, "substringTest", "1234567890"));
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
Examples:
```c#
${substring:${level}:start=2:length=2}    // from index 2, length 2
${substring:${level}:start=-2:length=2}   // from end -2, length 2
${left:${level}:length=2}    // from start, length 2
${right:${level}:length=2}   // from end, length 2
```
