### PR TITLE
AsyncTaskTarget: Added support for BatchSize and RetryCount

### DIFF
--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -40,6 +40,8 @@ namespace NLog.Targets
     using System.Threading;
     using System.Threading.Tasks;
     using NLog.Common;
+    using NLog.Internal;
+    using NLog.Targets.Wrappers;
 
     /// <summary>
     /// Abstract Target with async Task support
@@ -48,17 +50,76 @@ namespace NLog.Targets
     {
         private readonly Timer _taskTimeoutTimer;
         private CancellationTokenSource _cancelTokenSource;
-        private readonly Queue<AsyncLogEventInfo> _requestQueue;
-        private readonly Action _taskStartNext;
+        IAsyncRequestQueue _requestQueue;
         private readonly Action _taskCancelledToken;
         private readonly Action<Task, object> _taskCompletion;
         private Task _previousTask;
+        private Timer _lazyWriterTimer;
+        private readonly ReusableAsyncLogEventList _reusableAsyncLogEventList = new ReusableAsyncLogEventList(200);
+        private System.Tuple<List<LogEventInfo>, List<AsyncContinuation>> _reusableLogEvents;
+
+        /// <summary>
+        /// How many milliseconds to delay the actual write operation to optimize for batching
+        /// </summary>
+        [DefaultValue(1)]
+        public int TaskDelayMilliseconds { get; set; }
 
         /// <summary>
         /// How many seconds a Task is allowed to run before it is cancelled.
         /// </summary>
         [DefaultValue(150)]
         public int TaskTimeoutSeconds { get; set; }
+
+        /// <summary>
+        /// How many attempts to retry the same Task, before it is aborted
+        /// </summary>
+        [DefaultValue(0)]
+        public int RetryCount { get; set; }
+
+        /// <summary>
+        /// How many milliseconds to wait before next retry (will double with each retry)
+        /// </summary>
+        [DefaultValue(1000)]
+        public int RetryDelayMilliseconds { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to use the locking queue, instead of a lock-free concurrent queue
+        /// The locking queue is less concurrent when many logger threads, but reduces memory allocation
+        /// </summary>
+        [DefaultValue(false)]
+        public bool ForceLockingQueue { get => _forceLockingQueue ?? false; set => _forceLockingQueue = value; }
+        private bool? _forceLockingQueue;
+
+        /// <summary>
+        /// Gets or sets the action to be taken when the lazy writer thread request queue count
+        /// exceeds the set limit.
+        /// </summary>
+        /// <docgen category='Buffering Options' order='100' />
+        [DefaultValue("Discard")]
+        public AsyncTargetWrapperOverflowAction OverflowAction
+        {
+            get => _requestQueue.OnOverflow;
+            set => _requestQueue.OnOverflow = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the limit on the number of requests in the lazy writer thread request queue.
+        /// </summary>
+        /// <docgen category='Buffering Options' order='100' />
+        [DefaultValue(10000)]
+        public int QueueLimit
+        {
+            get => _requestQueue.RequestLimit;
+            set => _requestQueue.RequestLimit = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the number of log events that should be processed in a batch
+        /// by the lazy writer thread.
+        /// </summary>
+        /// <docgen category='Buffering Options' order='100' />
+        [DefaultValue(1)]
+        public int BatchSize { get; set; }
 
         /// <summary>
         /// Task Scheduler used for processing async Tasks
@@ -70,15 +131,59 @@ namespace NLog.Targets
         /// </summary>
         protected AsyncTaskTarget()
         {
+            OptimizeBufferReuse = true;
             TaskTimeoutSeconds = 150;
+            TaskDelayMilliseconds = 1;
+            BatchSize = 1;
+            RetryDelayMilliseconds = 1000;
 
-            _taskStartNext = () => TaskStartNext(null);
             _taskCompletion = TaskCompletion;
             _taskCancelledToken = TaskCancelledToken;
             _taskTimeoutTimer = new Timer(TaskTimeout, null, Timeout.Infinite, Timeout.Infinite);
             _cancelTokenSource = new CancellationTokenSource();
             _cancelTokenSource.Token.Register(_taskCancelledToken);
-            _requestQueue = new Queue<AsyncLogEventInfo>(10000);
+
+#if NETSTANDARD2_0
+            // NetStandard20 includes many optimizations for ConcurrentQueue:
+            //  - See: https://blogs.msdn.microsoft.com/dotnet/2017/06/07/performance-improvements-in-net-core/
+            // Net40 ConcurrencyQueue can seem to leak, because it doesn't clear properly on dequeue
+            //  - See: https://blogs.msdn.microsoft.com/pfxteam/2012/05/08/concurrentqueuet-holding-on-to-a-few-dequeued-elements/
+            _requestQueue = new ConcurrentRequestQueue(10000, AsyncTargetWrapperOverflowAction.Discard);
+#else
+            _requestQueue = new AsyncRequestQueue(10000, AsyncTargetWrapperOverflowAction.Discard);
+#endif
+
+            _lazyWriterTimer = new Timer(TaskStartNext, null, Timeout.Infinite, Timeout.Infinite);
+        }
+
+        /// <summary>
+        /// Initializes the internal queue for pending logevents
+        /// </summary>
+        protected override void InitializeTarget()
+        {
+            base.InitializeTarget();
+
+            if (BatchSize <= 0)
+            {
+                BatchSize = 1;
+            }
+
+            if (!ForceLockingQueue && OverflowAction == AsyncTargetWrapperOverflowAction.Block && BatchSize * 1.5m > QueueLimit)
+            {
+                ForceLockingQueue = true;   // ConcurrentQueue does not perform well if constantly hitting QueueLimit
+            }
+
+#if NET4_5 || NET4_0
+            if (_forceLockingQueue.HasValue && _forceLockingQueue.Value != (_requestQueue is AsyncRequestQueue))
+            {
+                _requestQueue = ForceLockingQueue ? (IAsyncRequestQueue)new AsyncRequestQueue(QueueLimit, OverflowAction) : new ConcurrentRequestQueue(QueueLimit, OverflowAction);
+            }
+#endif
+
+            if (BatchSize > QueueLimit)
+            {
+                BatchSize = QueueLimit;     // Avoid too much throttling 
+            }
         }
 
         /// <summary>
@@ -103,6 +208,47 @@ namespace NLog.Targets
         protected abstract Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Override this to create the actual logging task for handling batch of logevents
+        /// </summary>
+        /// <param name="logEvents">A batch of logevents.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns></returns>
+        protected virtual Task WriteAsyncTask(IList<LogEventInfo> logEvents, CancellationToken cancellationToken)
+        {
+            if (logEvents.Count == 1)
+            {
+                return WriteAsyncTask(logEvents[0], cancellationToken);
+            }
+            else
+            {
+                // Should never come here. Only here if someone by mistake configured BatchSize > 1 for target that only handles single LogEventInfo
+                Task taskChain = null;
+                for (int i = 0; i < logEvents.Count; ++i)
+                {
+                    LogEventInfo logEvent = logEvents[i];
+                    if (taskChain == null)
+                        taskChain = WriteAsyncTask(logEvent, cancellationToken);
+                    else
+                        taskChain = taskChain.ContinueWith(t => WriteAsyncTask(logEvent, cancellationToken), cancellationToken, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler).Unwrap();
+                }
+                return taskChain;
+            }
+        }
+
+        /// <summary>
+        /// Handle cleanup after failed write operation
+        /// </summary>
+        /// <param name="exception">Exception from previous failed Task</param>
+        /// <param name="retryCountRemaining">Number of retries remaining</param>
+        /// <param name="retryDelay">Time to sleep before retrying</param>
+        /// <returns>Should attempt retry</returns>
+        protected virtual bool RetryFailedAsyncTask(Exception exception, int retryCountRemaining, out TimeSpan retryDelay)
+        {
+            retryDelay = TimeSpan.FromMilliseconds(RetryDelayMilliseconds * (RetryCount - retryCountRemaining) * 2 - RetryDelayMilliseconds);
+            return true;
+        }
+
+        /// <summary>
         /// Schedules the LogEventInfo for async writing
         /// </summary>
         /// <param name="logEvent">The log event.</param>
@@ -116,10 +262,37 @@ namespace NLog.Targets
 
             PrecalculateVolatileLayouts(logEvent.LogEvent);
 
-            _requestQueue.Enqueue(logEvent);
-            if (_previousTask == null)
+            bool queueWasEmpty = _requestQueue.Enqueue(logEvent);
+            if (queueWasEmpty)
             {
-                _previousTask = Task.Factory.StartNew(_taskStartNext, _cancelTokenSource.Token, TaskCreationOptions.None, TaskScheduler);
+                lock (SyncRoot)
+                {
+                    if (_previousTask == null)
+                    {
+                        _lazyWriterTimer.Change(TaskDelayMilliseconds, Timeout.Infinite);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Write to queue without locking <see cref="Target.SyncRoot"/> 
+        /// </summary>
+        /// <param name="logEvent"></param>
+        protected override void WriteAsyncThreadSafe(AsyncLogEventInfo logEvent)
+        {
+            try
+            {
+                Write(logEvent);
+            }
+            catch (Exception exception)
+            {
+                if (exception.MustBeRethrown())
+                {
+                    throw;
+                }
+
+                logEvent.Continuation(exception);
             }
         }
 
@@ -129,15 +302,16 @@ namespace NLog.Targets
         /// <param name="asyncContinuation"></param>
         protected override void FlushAsync(AsyncContinuation asyncContinuation)
         {
-            if (_previousTask == null)
+            if (_previousTask?.IsCompleted == false)
             {
-                InternalLogger.Debug("{0} Flushing Nothing", Name);
-                asyncContinuation(null);
+                InternalLogger.Debug("{0} Flushing {1}", Name, _requestQueue.IsEmpty ? "empty queue" : "pending queue items");
+                _requestQueue.Enqueue(new AsyncLogEventInfo(null, asyncContinuation));
+                _lazyWriterTimer.Change(0, Timeout.Infinite);
             }
             else
             {
-                InternalLogger.Debug("{0} Flushing {1} items", Name, _requestQueue.Count + 1);
-                _requestQueue.Enqueue(new AsyncLogEventInfo(null, asyncContinuation));
+                InternalLogger.Debug("{0} Flushing Nothing", Name);
+                asyncContinuation(null);
             }
         }
 
@@ -164,6 +338,7 @@ namespace NLog.Targets
             {
                 _cancelTokenSource.Dispose();
                 _taskTimeoutTimer.WaitForDispose(TimeSpan.Zero);
+                _lazyWriterTimer.WaitForDispose(TimeSpan.Zero);
             }
         }
 
@@ -171,92 +346,185 @@ namespace NLog.Targets
         /// Checks the internal queue for the next <see cref="LogEventInfo"/> to create a new task for
         /// </summary>
         /// <param name="previousTask">Used for race-condition validation betweewn task-completion and timeout</param>
-        private void TaskStartNext(Task previousTask)
+        private void TaskStartNext(object previousTask)
         {
-            AsyncLogEventInfo logEvent;
             do
             {
                 lock (SyncRoot)
                 {
+                    if (previousTask != null)
+                    {
+                        if (_previousTask != null && !ReferenceEquals(previousTask, _previousTask))
+                            break;
+
+                        _previousTask = null;
+                        previousTask = null;
+                    }
+                    else
+                    {
+                        if (_previousTask?.IsCompleted == false)
+                            break;
+                    }
+
                     if (!IsInitialized)
                         break;
 
-                    if (previousTask != null && !ReferenceEquals(previousTask, _previousTask))
-                        break;
-
-                    if (_requestQueue.Count == 0)
+                    if (_requestQueue.IsEmpty)
                     {
                         _previousTask = null;
                         break;
                     }
 
-                    logEvent = _requestQueue.Dequeue();
+                    using (var targetList = _reusableAsyncLogEventList.Allocate())
+                    {
+                        var logEvents = targetList.Result;
+                        _requestQueue.DequeueBatch(BatchSize, logEvents);
+                        if (logEvents.Count > 0)
+                        {
+                            if (TaskCreation(logEvents))
+                                break;
+                        }
+                    }
                 }
-            } while (!TaskCreation(logEvent));
+            } while (!_requestQueue.IsEmpty);
+        }
+
+        /// <summary>
+        /// Generates recursive task-chain to perform retry of writing logevents with increasing retry-delay
+        /// </summary>
+        internal Task WriteAsyncTaskWithRetry(Task firstTask, IList<LogEventInfo> logEvents, CancellationToken cancellationToken, int retryCount)
+        {
+            var tcs = new TaskCompletionSource<object>();
+
+            try
+            {
+                return firstTask.ContinueWith(t =>
+                {
+                    if (t.IsFaulted || t.IsCanceled)
+                    {
+                        if (t.Exception != null)
+                            tcs.TrySetException(t.Exception);
+
+                        if (retryCount >= 1 && !cancellationToken.IsCancellationRequested)
+                        {
+                            if (RetryFailedAsyncTask(t.Exception, retryCount - 1, out var retryDelay))
+                            {
+                                InternalLogger.Warn(t.Exception, "{0}: Write operation failed. {1} attempts left. Sleep {2} ms", Name, retryCount, retryDelay.TotalMilliseconds);
+                                AsyncHelpers.WaitForDelay(retryDelay);
+                                if (!cancellationToken.IsCancellationRequested)
+                                    return WriteAsyncTaskWithRetry(WriteAsyncTask(logEvents, cancellationToken), logEvents, cancellationToken, retryCount - 1);
+                            }
+                        }
+
+                        InternalLogger.Warn(t.Exception, "{0}: Write operation failed after {1} retries", Name, RetryCount - retryCount);
+                    }
+                    else
+                    {
+                        tcs.SetResult(null);
+                    }
+                    return tcs.Task;
+                }, cancellationToken, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler).Unwrap();
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+
+            return tcs.Task;
         }
 
         /// <summary>
         /// Creates new task to handle the writing of the input <see cref="LogEventInfo"/>
         /// </summary>
-        /// <param name="logEvent">LogEvent to write</param>
+        /// <param name="logEvents">LogEvents to write</param>
         /// <returns>New Task created [true / false]</returns>
-        private bool TaskCreation(AsyncLogEventInfo logEvent)
+        private bool TaskCreation(IList<AsyncLogEventInfo> logEvents)
         {
+            System.Tuple<List<LogEventInfo>, List<AsyncContinuation>> reusableLogEvents = null;
+
             try
             {
                 if (_cancelTokenSource.IsCancellationRequested)
                 {
-                    logEvent.Continuation(null);
+                    for (int i = 0; i < logEvents.Count; ++i)
+                        logEvents[i].Continuation(null);
                     return false;
                 }
 
-                if (logEvent.LogEvent == null)
+                reusableLogEvents = Interlocked.CompareExchange(ref _reusableLogEvents, null, _reusableLogEvents) ?? System.Tuple.Create(new List<LogEventInfo>(), new List<AsyncContinuation>());
+
+                for (int i = 0; i < logEvents.Count; ++i)
                 {
+                    if (logEvents[i].LogEvent == null)
+                    {
+                        // Flush Request
+                        reusableLogEvents.Item2.Add(logEvents[i].Continuation);
+                    }
+                    else
+                    {
+                        reusableLogEvents.Item1.Add(logEvents[i].LogEvent);
+                        reusableLogEvents.Item2.Add(logEvents[i].Continuation);
+                    }
+                }
+
+                if (reusableLogEvents.Item1.Count == 0)
+                {
+                    // Everything was flush events, no need to schedule write
+                    NotifyTaskCompletion(reusableLogEvents.Item2, null);
+                    reusableLogEvents.Item2.Clear();
+                    Interlocked.CompareExchange(ref _reusableLogEvents, reusableLogEvents, null);
                     InternalLogger.Debug("{0} Flush Completed", Name);
-                    logEvent.Continuation(null);
                     return false;
                 }
 
-                var newTask = WriteAsyncTask(logEvent.LogEvent, _cancelTokenSource.Token);
+                Task newTask = WriteAsyncTask(reusableLogEvents.Item1, _cancelTokenSource.Token);
+                if (newTask?.Status == TaskStatus.Created)
+                    newTask.Start(TaskScheduler);
+
                 if (newTask == null)
                 {
                     InternalLogger.Debug("{0} WriteAsyncTask returned null", Name);
+                    NotifyTaskCompletion(reusableLogEvents.Item2, null);
                 }
                 else
                 {
-                    lock (SyncRoot)
-                    {
-                        _previousTask = newTask;
+                    if (RetryCount > 0)
+                        newTask = WriteAsyncTaskWithRetry(newTask, reusableLogEvents.Item1, _cancelTokenSource.Token, RetryCount);
 
-                        if (TaskTimeoutSeconds > 0)
-                            _taskTimeoutTimer.Change(TaskTimeoutSeconds * 1000, Timeout.Infinite);
+                    _previousTask = newTask;
 
-                        // NOTE - Not using _cancelTokenSource for ContinueWith, or else they will also be cancelled on timeout
+                    if (TaskTimeoutSeconds > 0)
+                        _taskTimeoutTimer.Change(TaskTimeoutSeconds * 1000, Timeout.Infinite);
+
+                    // NOTE - Not using _cancelTokenSource for ContinueWith, or else they will also be cancelled on timeout
 #if (SILVERLIGHT && !WINDOWS_PHONE) || NET4_0
-                        var continuation = logEvent.Continuation;
-                        _previousTask.ContinueWith(completedTask => TaskCompletion(completedTask, continuation));
+                    newTask.ContinueWith(completedTask => TaskCompletion(completedTask, reusableLogEvents));
 #else
-                        _previousTask.ContinueWith(_taskCompletion, logEvent.Continuation);
+                    newTask.ContinueWith(_taskCompletion, reusableLogEvents);
 #endif
-                        if (_previousTask.Status == TaskStatus.Created)
-                            _previousTask.Start(TaskScheduler);
-                    }
                     return true;
                 }
             }
             catch (Exception ex)
             {
-                try
-                {
-                    InternalLogger.Error(ex, "{0} WriteAsyncTask failed on creation", Name);
-                    logEvent.Continuation(ex);
-                }
-                catch
-                {
-                    // Don't wanna die
-                }
+                _previousTask = null;
+                InternalLogger.Error(ex, "{0} WriteAsyncTask failed on creation", Name);
+                NotifyTaskCompletion(reusableLogEvents?.Item2, ex);
             }
             return false;
+        }
+
+        private void NotifyTaskCompletion(IList<AsyncContinuation> reusableContinuations, Exception ex)
+        {
+            try
+            {
+                for (int i = 0; i < reusableContinuations?.Count; ++i)
+                    reusableContinuations[i](ex);
+            }
+            catch
+            {
+                // Don't wanna die
+            }
         }
 
         /// <summary>
@@ -266,23 +534,29 @@ namespace NLog.Targets
         /// <param name="continuation">AsyncContinuation to notify of success or failure</param>
         private void TaskCompletion(Task completedTask, object continuation)
         {
+            bool success = true;
+
             try
             {
                 if (ReferenceEquals(completedTask, _previousTask))
-                { 
+                {
                     if (TaskTimeoutSeconds > 0)
                     {
+                        // Prevent timeout-timer from triggering task cancellation token
                         _taskTimeoutTimer.Change(Timeout.Infinite, Timeout.Infinite);
                     }
                 }
                 else
                 {
+                    // Not the expected task to complete, most likely noise from retry/recovery
+                    success = false;
                     if (!IsInitialized)
                         return;
                 }
 
                 if (completedTask.IsCanceled)
                 {
+                    success = false;
                     if (completedTask.Exception != null)
                         InternalLogger.Warn(completedTask.Exception, "{0} WriteAsyncTask was cancelled", Name);
                     else
@@ -290,11 +564,26 @@ namespace NLog.Targets
                 }
                 else if (completedTask.Exception != null)
                 {
+                    success = false;
                     InternalLogger.Warn(completedTask.Exception, "{0} WriteAsyncTask failed on completion", Name);
                 }
 
-                var asyncContinuation = (AsyncContinuation)continuation;
-                asyncContinuation(completedTask.Exception);
+                var reusableLogEvents = continuation as System.Tuple<List<LogEventInfo>, List<AsyncContinuation>>;
+                if (reusableLogEvents != null)
+                    NotifyTaskCompletion(reusableLogEvents.Item2, null);
+                else
+                    success = false;
+
+                if (success)
+                {
+                    if (OptimizeBufferReuse)
+                    {
+                        // The expected Task completed with success, allow buffer reuse
+                        reusableLogEvents.Item1.Clear();
+                        reusableLogEvents.Item2.Clear();
+                        Interlocked.CompareExchange(ref _reusableLogEvents, reusableLogEvents, null);
+                    }
+                }
             }
             finally
             {
@@ -320,6 +609,7 @@ namespace NLog.Targets
                 {
                     lock (SyncRoot)
                     {
+                        // Check if active Task changed while waiting for SyncRoot-lock
                         if (previousTask != null && ReferenceEquals(previousTask, _previousTask))
                         {
                             _previousTask = null;
@@ -327,6 +617,7 @@ namespace NLog.Targets
                         }
                         else
                         {
+                            // Not the expected task to timeout, most likely noise from retry/recovery
                             previousTask = null;
                         }
                     }
@@ -349,10 +640,7 @@ namespace NLog.Targets
                     InternalLogger.Debug(ex, "{0} WriteAsyncTask had timeout. Task failed to cancel properly.", Name);
                 }
 
-                if (previousTask != null)
-                {
-                    TaskStartNext(null);
-                }
+                TaskStartNext(null);
             }
             catch (Exception ex)
             {

--- a/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
+++ b/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
@@ -40,7 +40,6 @@ namespace NLog.UnitTests.Targets
     using System.Threading.Tasks;
     using Xunit;
     using NLog.Config;
-    using NLog.Layouts;
     using NLog.Targets;
 
     public class AsyncTaskTargetTest : NLogTestBase
@@ -48,10 +47,42 @@ namespace NLog.UnitTests.Targets
         class AsyncTaskTestTarget : AsyncTaskTarget
         {
             internal Queue<string> Logs = new Queue<string>();
+            internal int WriteTasks => _writeTasks;
+            int _writeTasks;
 
             protected override Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken token)
             {
+                Interlocked.Increment(ref _writeTasks);
                 return WriteLogQueue(logEvent, token);
+            }
+
+            private async Task WriteLogQueue(LogEventInfo logEvent, CancellationToken token)
+            {
+                if (logEvent.Message == "EXCEPTION")
+                    await Task.Delay(10, token).ContinueWith((t) => { throw new InvalidOperationException("AsyncTaskTargetTest Failed"); }).ConfigureAwait(false);
+                else if (logEvent.Message == "TIMEOUT")
+                    await Task.Delay(15000, token).ConfigureAwait(false);
+                else
+                    await Task.Delay(10, token).ContinueWith((t) => Logs.Enqueue(RenderLogEvent(Layout, logEvent)), token).ContinueWith(async (t) => await Task.Delay(10).ConfigureAwait(false)).ConfigureAwait(false);
+            }
+        }
+
+        class AsyncTaskBatchTestTarget : AsyncTaskTarget
+        {
+            internal Queue<string> Logs = new Queue<string>();
+            internal int WriteTasks => _writeTasks;
+            int _writeTasks;
+
+            protected override async Task WriteAsyncTask(IList<LogEventInfo> logEvents, CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _writeTasks);
+                for (int i = 0; i < logEvents.Count; ++i)
+                    await WriteLogQueue(logEvents[i], cancellationToken);
+            }
+
+            protected override Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
             }
 
             private async Task WriteLogQueue(LogEventInfo logEvent, CancellationToken token)
@@ -74,6 +105,8 @@ namespace NLog.UnitTests.Targets
             asyncTarget.Layout = "${threadid}|${level}|${message}";
 
             SimpleConfigurator.ConfigureForTargetLogging(asyncTarget, LogLevel.Trace);
+            NLog.Common.InternalLogger.LogLevel = LogLevel.Off;
+
             Assert.True(asyncTarget.Logs.Count == 0);
             logger.Trace("TTT");
             logger.Debug("DDD");
@@ -100,25 +133,27 @@ namespace NLog.UnitTests.Targets
             ILogger logger = LogManager.GetCurrentClassLogger();
 
             var asyncTarget = new AsyncTaskTestTarget();
-            asyncTarget.Layout = "${threadid}|${level}|${message}";
+            asyncTarget.Layout = "${level}";
 
             SimpleConfigurator.ConfigureForTargetLogging(asyncTarget, LogLevel.Trace);
             Assert.True(asyncTarget.Logs.Count == 0);
-            logger.Trace("TTT");
-            logger.Debug("EXCEPTION");
-            logger.Info("III");
-            logger.Warn("WWW");
-            logger.Error("EEE");
-            logger.Fatal("FFF");
+
+            foreach (var logLevel in LogLevel.AllLoggingLevels)
+                logger.Log(logLevel, logLevel == LogLevel.Debug ? "EXCEPTION" : logLevel.Name.ToUpperInvariant());
             Thread.Sleep(50);
             Assert.True(asyncTarget.Logs.Count != 0);
             LogManager.Flush();
-            Assert.True(asyncTarget.Logs.Count == 5);
+            Assert.Equal(LogLevel.MaxLevel.Ordinal, asyncTarget.Logs.Count);
+
+            int ordinal = 0;
             while (asyncTarget.Logs.Count > 0)
             {
                 string logEventMessage = asyncTarget.Logs.Dequeue();
-                Assert.Equal(-1, logEventMessage.IndexOf("|Debug|"));
-                Assert.Equal(0, logEventMessage.IndexOf(Thread.CurrentThread.ManagedThreadId.ToString() + "|"));
+                var logLevel = LogLevel.FromString(logEventMessage);
+                Assert.NotEqual(LogLevel.Debug, logLevel);
+                Assert.Equal(ordinal++, logLevel.Ordinal);
+                if (ordinal == LogLevel.Debug.Ordinal)
+                    ++ordinal;
             }
 
             LogManager.Configuration = null;
@@ -130,7 +165,7 @@ namespace NLog.UnitTests.Targets
             ILogger logger = LogManager.GetCurrentClassLogger();
 
             var asyncTarget = new AsyncTaskTestTarget();
-            asyncTarget.Layout = "${threadid}|${level}|${message}";
+            asyncTarget.Layout = "${level}";
             asyncTarget.TaskTimeoutSeconds = 1;
 
             SimpleConfigurator.ConfigureForTargetLogging(asyncTarget, LogLevel.Trace);
@@ -148,8 +183,106 @@ namespace NLog.UnitTests.Targets
             while (asyncTarget.Logs.Count > 0)
             {
                 string logEventMessage = asyncTarget.Logs.Dequeue();
-                Assert.Equal(-1, logEventMessage.IndexOf("|Debug|"));
-                Assert.Equal(0, logEventMessage.IndexOf(Thread.CurrentThread.ManagedThreadId.ToString() + "|"));
+                Assert.Equal(-1, logEventMessage.IndexOf("Debug|"));
+            }
+
+            LogManager.Configuration = null;
+        }
+
+        [Fact]
+        public void AsyncTaskTarget_TestRetryException()
+        {
+            ILogger logger = LogManager.GetCurrentClassLogger();
+
+            var asyncTarget = new AsyncTaskTestTarget();
+            asyncTarget.Layout = "${level}";
+            asyncTarget.RetryDelayMilliseconds = 10;
+            asyncTarget.RetryCount = 3;
+
+            SimpleConfigurator.ConfigureForTargetLogging(asyncTarget, LogLevel.Trace);
+            Assert.True(asyncTarget.Logs.Count == 0);
+
+            foreach (var logLevel in LogLevel.AllLoggingLevels)
+                logger.Log(logLevel, logLevel == LogLevel.Debug ? "EXCEPTION" : logLevel.Name.ToUpperInvariant());
+            Thread.Sleep(50);
+            Assert.True(asyncTarget.Logs.Count != 0);
+            LogManager.Flush();
+            Assert.Equal(LogLevel.MaxLevel.Ordinal, asyncTarget.Logs.Count);
+            Assert.Equal(LogLevel.MaxLevel.Ordinal + 4, asyncTarget.WriteTasks);
+
+            int ordinal = 0;
+            while (asyncTarget.Logs.Count > 0)
+            {
+                string logEventMessage = asyncTarget.Logs.Dequeue();
+                var logLevel = LogLevel.FromString(logEventMessage);
+                Assert.NotEqual(LogLevel.Debug, logLevel);
+                Assert.Equal(ordinal++, logLevel.Ordinal);
+                if (ordinal == LogLevel.Debug.Ordinal)
+                    ++ordinal;
+            }
+
+            LogManager.Configuration = null;
+        }
+
+        [Fact]
+        public void AsyncTaskTarget_TestBatchWriting()
+        {
+            ILogger logger = LogManager.GetCurrentClassLogger();
+
+            var asyncTarget = new AsyncTaskBatchTestTarget();
+            asyncTarget.Layout = "${level}";
+            asyncTarget.BatchSize = 3;
+            asyncTarget.TaskDelayMilliseconds = 10;
+
+            SimpleConfigurator.ConfigureForTargetLogging(asyncTarget, LogLevel.Trace);
+            Assert.True(asyncTarget.Logs.Count == 0);
+
+            foreach (var logLevel in LogLevel.AllLoggingLevels)
+                logger.Log(logLevel, logLevel.Name.ToUpperInvariant());
+            Thread.Sleep(100);
+            Assert.True(asyncTarget.Logs.Count != 0);
+            LogManager.Flush();
+            Assert.Equal(LogLevel.MaxLevel.Ordinal + 1, asyncTarget.Logs.Count);
+            Assert.Equal(LogLevel.MaxLevel.Ordinal / 2, asyncTarget.WriteTasks);
+
+            int ordinal = 0;
+            while (asyncTarget.Logs.Count > 0)
+            {
+                string logEventMessage = asyncTarget.Logs.Dequeue();
+                var logLevel = LogLevel.FromString(logEventMessage);
+                Assert.Equal(ordinal++, logLevel.Ordinal);
+            }
+
+            LogManager.Configuration = null;
+        }
+
+        [Fact]
+        public void AsyncTaskTarget_TestFakeBatchWriting()
+        {
+            ILogger logger = LogManager.GetCurrentClassLogger();
+
+            var asyncTarget = new AsyncTaskTestTarget();
+            asyncTarget.Layout = "${level}";
+            asyncTarget.BatchSize = 3;
+            asyncTarget.TaskDelayMilliseconds = 10;
+
+            SimpleConfigurator.ConfigureForTargetLogging(asyncTarget, LogLevel.Trace);
+            Assert.True(asyncTarget.Logs.Count == 0);
+
+            foreach (var logLevel in LogLevel.AllLoggingLevels)
+                logger.Log(logLevel, logLevel.Name.ToUpperInvariant());
+            Thread.Sleep(100);
+            Assert.True(asyncTarget.Logs.Count != 0);
+            LogManager.Flush();
+            Assert.Equal(LogLevel.MaxLevel.Ordinal + 1, asyncTarget.Logs.Count);
+            Assert.Equal(LogLevel.MaxLevel.Ordinal + 1, asyncTarget.WriteTasks);
+
+            int ordinal = 0;
+            while (asyncTarget.Logs.Count > 0)
+            {
+                string logEventMessage = asyncTarget.Logs.Dequeue();
+                var logLevel = LogLevel.FromString(logEventMessage);
+                Assert.Equal(ordinal++, logLevel.Ordinal);
             }
 
             LogManager.Configuration = null;


### PR DESCRIPTION
Made it possible to perform batching using async Tasks. Also improved the concurrency when loggers writes  to the internal target-buffer.

Just configure BatchSize=50 in constructor and override this method:

```
protected override Task WriteAsyncTask(IList<LogEventInfo> logEvents, CancellationToken cancellationToken)
{
    // Blah blah
}
```