### PR TITLE
ObjectHandle - LifeTime avoid remoting exception: has been disconnected

### DIFF
--- a/src/NLog/Internal/ObjectHandleSerializer.cs
+++ b/src/NLog/Internal/ObjectHandleSerializer.cs
@@ -1,0 +1,108 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+
+namespace NLog.Internal
+{
+#if !NET4_6 && !NETSTANDARD && !SILVERLIGHT
+    using System;
+    using System.Runtime.Serialization;
+    using NLog.Common;
+
+    [Serializable]
+    internal class ObjectHandleSerializer : ISerializable
+    {
+        [NonSerialized]
+        private readonly object _wrapped;
+
+        public ObjectHandleSerializer()
+        {
+        }
+
+        public ObjectHandleSerializer(object wrapped)
+        {
+            _wrapped = wrapped;
+        }
+
+        protected ObjectHandleSerializer(SerializationInfo info, StreamingContext context)
+        {
+            Type type = null;
+            try
+            {
+                type = (Type)info.GetValue("wrappedtype", typeof(Type));
+                _wrapped = info.GetValue("wrappedvalue", type);
+            }
+            catch (Exception ex)
+            {
+                _wrapped = string.Empty;    // Type cannot be resolved in this AppDomain
+                InternalLogger.Info(ex, "ObjectHandleSerializer failed to deserialize object: {0}", type);
+            }
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            try
+            {
+                if (_wrapped is ISerializable || _wrapped.GetType().IsSerializable)
+                {
+                    info.AddValue("wrappedtype", _wrapped.GetType());
+                    info.AddValue("wrappedvalue", _wrapped);
+                }
+                else
+                {
+                    info.AddValue("wrappedtype", typeof(string));
+                    string serializedString = string.Empty;
+                    try
+                    {
+                        serializedString = _wrapped?.ToString();
+                    }
+                    finally
+                    {
+                        info.AddValue("wrappedvalue", serializedString ?? string.Empty);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // ToString on random object can throw exception
+                InternalLogger.Info(ex, "ObjectHandleSerializer failed to serialize object: {0}", _wrapped?.GetType());
+            }
+        }
+
+        public object Unwrap()
+        {
+            return _wrapped ?? string.Empty;
+        }
+    }
+#endif
+}

--- a/src/NLog/MappedDiagnosticsLogicalContext.cs
+++ b/src/NLog/MappedDiagnosticsLogicalContext.cs
@@ -138,10 +138,11 @@ namespace NLog
 #if NET4_6 || NETSTANDARD
             return value;
 #else
-            if (value is System.Runtime.Remoting.ObjectHandle objectHandle)
+            if (value is ObjectHandleSerializer objectHandle)
+            {
                 return objectHandle.Unwrap();
-            else
-                return value;
+            }
+            return value;
 #endif
         }
 
@@ -212,8 +213,9 @@ namespace NLog
 #else
             if (typeof(T).IsValueType || Convert.GetTypeCode(value) != TypeCode.Object)
                 logicalContext[item] = value;
-            else
-                logicalContext[item] = new System.Runtime.Remoting.ObjectHandle(value);
+            else 
+
+                logicalContext[item] = new ObjectHandleSerializer(value);
 #endif
         }
 
@@ -301,3 +303,4 @@ namespace NLog
 }
 
 #endif
+

--- a/src/NLog/NestedDiagnosticsLogicalContext.cs
+++ b/src/NLog/NestedDiagnosticsLogicalContext.cs
@@ -217,7 +217,7 @@ namespace NLog
                 if (typeof(T).IsValueType || Convert.GetTypeCode(value) != TypeCode.Object)
                     return new NestedContext<T>(parent, value);
                 else
-                    return new NestedContext<System.Runtime.Remoting.ObjectHandle>(parent, new System.Runtime.Remoting.ObjectHandle(value));
+                    return new NestedContext<ObjectHandleSerializer>(parent, new ObjectHandleSerializer(value));
 #endif
             }
 
@@ -228,10 +228,12 @@ namespace NLog
 #if NET4_6 || NETSTANDARD
                     return Value;
 #else
-                    if (Value is System.Runtime.Remoting.IObjectHandle objectHandle)
+                    object value = Value;
+                    if (value is ObjectHandleSerializer objectHandle)
+                    {
                         return objectHandle.Unwrap();
-                    else
-                        return Value;
+                    }
+                    return value;
 #endif
                 }
             }


### PR DESCRIPTION
or does not exist at the server. Followup to #2857 

The recommendation of using ObjectHandle from [David Fowler](https://github.com/Glimpse/Glimpse/issues/632#issuecomment-41484855) was a trap.

Instead perform ToString serialization on-demand when changing AppDomain (Deferring the overhead of remoting until actually AppDomain transfer). Avoid funny business with lifetime management. Avoid funny business with returning null in InitializeLifetimeService, and abusing the finalizer queue for cleanup.