### PR TITLE
AsyncTaskTarget - Retry WriteAsyncTask should be protected with SyncRoot

### DIFF
--- a/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
+++ b/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
@@ -48,7 +48,7 @@ namespace NLog.UnitTests.Targets
         {
             internal Queue<string> Logs = new Queue<string>();
             internal int WriteTasks => _writeTasks;
-            int _writeTasks;
+            protected int _writeTasks;
 
             protected override Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken token)
             {
@@ -56,10 +56,12 @@ namespace NLog.UnitTests.Targets
                 return WriteLogQueue(logEvent, token);
             }
 
-            private async Task WriteLogQueue(LogEventInfo logEvent, CancellationToken token)
+            protected async Task WriteLogQueue(LogEventInfo logEvent, CancellationToken token)
             {
                 if (logEvent.Message == "EXCEPTION")
-                    await Task.Delay(10, token).ContinueWith((t) => { throw new InvalidOperationException("AsyncTaskTargetTest Failed"); }).ConfigureAwait(false);
+                    throw new InvalidOperationException("AsyncTaskTargetTest Failure");
+                else if (logEvent.Message == "ASYNCEXCEPTION")
+                    await Task.Delay(10, token).ContinueWith((t) => { throw new InvalidOperationException("AsyncTaskTargetTest Async Failure"); }).ConfigureAwait(false);
                 else if (logEvent.Message == "TIMEOUT")
                     await Task.Delay(15000, token).ConfigureAwait(false);
                 else
@@ -67,12 +69,8 @@ namespace NLog.UnitTests.Targets
             }
         }
 
-        class AsyncTaskBatchTestTarget : AsyncTaskTarget
+        class AsyncTaskBatchTestTarget : AsyncTaskTestTarget
         {
-            internal Queue<string> Logs = new Queue<string>();
-            internal int WriteTasks => _writeTasks;
-            int _writeTasks;
-
             protected override async Task WriteAsyncTask(IList<LogEventInfo> logEvents, CancellationToken cancellationToken)
             {
                 Interlocked.Increment(ref _writeTasks);
@@ -83,16 +81,6 @@ namespace NLog.UnitTests.Targets
             protected override Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
-            }
-
-            private async Task WriteLogQueue(LogEventInfo logEvent, CancellationToken token)
-            {
-                if (logEvent.Message == "EXCEPTION")
-                    await Task.Delay(10, token).ContinueWith((t) => { throw new InvalidOperationException("AsyncTaskTargetTest Failed"); }).ConfigureAwait(false);
-                else if (logEvent.Message == "TIMEOUT")
-                    await Task.Delay(15000, token).ConfigureAwait(false);
-                else
-                    await Task.Delay(10, token).ContinueWith((t) => Logs.Enqueue(RenderLogEvent(Layout, logEvent)), token).ContinueWith(async (t) => await Task.Delay(10).ConfigureAwait(false)).ConfigureAwait(false);
             }
         }
 
@@ -114,7 +102,7 @@ namespace NLog.UnitTests.Targets
             logger.Warn("WWW");
             logger.Error("EEE");
             logger.Fatal("FFF");
-            Thread.Sleep(50);
+            Thread.Sleep(75);
             Assert.True(asyncTarget.Logs.Count != 0);
             LogManager.Flush();
             Assert.True(asyncTarget.Logs.Count == 6);
@@ -128,19 +116,20 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
-        public void AsyncTaskTarget_TestException()
+        public void AsyncTaskTarget_TestAsyncException()
         {
             ILogger logger = LogManager.GetCurrentClassLogger();
 
             var asyncTarget = new AsyncTaskTestTarget();
             asyncTarget.Layout = "${level}";
+            asyncTarget.RetryDelayMilliseconds = 50;
 
             SimpleConfigurator.ConfigureForTargetLogging(asyncTarget, LogLevel.Trace);
             Assert.True(asyncTarget.Logs.Count == 0);
 
             foreach (var logLevel in LogLevel.AllLoggingLevels)
-                logger.Log(logLevel, logLevel == LogLevel.Debug ? "EXCEPTION" : logLevel.Name.ToUpperInvariant());
-            Thread.Sleep(50);
+                logger.Log(logLevel, logLevel == LogLevel.Debug ? "ASYNCEXCEPTION" : logLevel.Name.ToUpperInvariant());
+            Thread.Sleep(75);
             Assert.True(asyncTarget.Logs.Count != 0);
             LogManager.Flush();
             Assert.Equal(LogLevel.MaxLevel.Ordinal, asyncTarget.Logs.Count);
@@ -176,7 +165,7 @@ namespace NLog.UnitTests.Targets
             logger.Warn("WWW");
             logger.Error("EEE");
             logger.Fatal("FFF");
-            Thread.Sleep(50);
+            Thread.Sleep(75);
             Assert.True(asyncTarget.Logs.Count != 0);
             LogManager.Flush();
             Assert.True(asyncTarget.Logs.Count == 5);
@@ -184,6 +173,41 @@ namespace NLog.UnitTests.Targets
             {
                 string logEventMessage = asyncTarget.Logs.Dequeue();
                 Assert.Equal(-1, logEventMessage.IndexOf("Debug|"));
+            }
+
+            LogManager.Configuration = null;
+        }
+
+        [Fact]
+        public void AsyncTaskTarget_TestRetryAsyncException()
+        {
+            ILogger logger = LogManager.GetCurrentClassLogger();
+
+            var asyncTarget = new AsyncTaskTestTarget();
+            asyncTarget.Layout = "${level}";
+            asyncTarget.RetryDelayMilliseconds = 10;
+            asyncTarget.RetryCount = 3;
+
+            SimpleConfigurator.ConfigureForTargetLogging(asyncTarget, LogLevel.Trace);
+            Assert.True(asyncTarget.Logs.Count == 0);
+
+            foreach (var logLevel in LogLevel.AllLoggingLevels)
+                logger.Log(logLevel, logLevel == LogLevel.Debug ? "ASYNCEXCEPTION" : logLevel.Name.ToUpperInvariant());
+            Thread.Sleep(75);
+            Assert.True(asyncTarget.Logs.Count != 0);
+            LogManager.Flush();
+            Assert.Equal(LogLevel.MaxLevel.Ordinal, asyncTarget.Logs.Count);
+            Assert.Equal(LogLevel.MaxLevel.Ordinal + 4, asyncTarget.WriteTasks);
+
+            int ordinal = 0;
+            while (asyncTarget.Logs.Count > 0)
+            {
+                string logEventMessage = asyncTarget.Logs.Dequeue();
+                var logLevel = LogLevel.FromString(logEventMessage);
+                Assert.NotEqual(LogLevel.Debug, logLevel);
+                Assert.Equal(ordinal++, logLevel.Ordinal);
+                if (ordinal == LogLevel.Debug.Ordinal)
+                    ++ordinal;
             }
 
             LogManager.Configuration = null;
@@ -204,7 +228,7 @@ namespace NLog.UnitTests.Targets
 
             foreach (var logLevel in LogLevel.AllLoggingLevels)
                 logger.Log(logLevel, logLevel == LogLevel.Debug ? "EXCEPTION" : logLevel.Name.ToUpperInvariant());
-            Thread.Sleep(50);
+            Thread.Sleep(75);
             Assert.True(asyncTarget.Logs.Count != 0);
             LogManager.Flush();
             Assert.Equal(LogLevel.MaxLevel.Ordinal, asyncTarget.Logs.Count);
@@ -239,7 +263,7 @@ namespace NLog.UnitTests.Targets
 
             foreach (var logLevel in LogLevel.AllLoggingLevels)
                 logger.Log(logLevel, logLevel.Name.ToUpperInvariant());
-            Thread.Sleep(100);
+            Thread.Sleep(75);
             Assert.True(asyncTarget.Logs.Count != 0);
             LogManager.Flush();
             Assert.Equal(LogLevel.MaxLevel.Ordinal + 1, asyncTarget.Logs.Count);
@@ -271,7 +295,7 @@ namespace NLog.UnitTests.Targets
 
             foreach (var logLevel in LogLevel.AllLoggingLevels)
                 logger.Log(logLevel, logLevel.Name.ToUpperInvariant());
-            Thread.Sleep(100);
+            Thread.Sleep(75);
             Assert.True(asyncTarget.Logs.Count != 0);
             LogManager.Flush();
             Assert.Equal(LogLevel.MaxLevel.Ordinal + 1, asyncTarget.Logs.Count);


### PR DESCRIPTION
Minor fixes to #2909:

- Retry should also lock SyncRoot to protect Layouts against concurrent usage (If needed)
- RetryFailedAsyncTask is now always called on Exceptions, even if RetryCount = 0 (Can be used for target recovery on error, and perform delay before starting next task).
- Retry should also happen when WriteAsyncTask throws exception without returning a Task