### PR TITLE
PerformanceCounter - Improve behavior for CPU usage calculation + Format and Culture options

### DIFF
--- a/tests/NLog.UnitTests/LayoutRenderers/PerformanceCounterLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/PerformanceCounterLayoutRendererTests.cs
@@ -1,0 +1,64 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.LayoutRenderers
+{
+    using Xunit;
+
+#if !MONO && !NETSTANDARD
+
+    public class PerformanceCounterLayoutRendererTests : NLogTestBase
+    {
+        [Fact]
+        public void PerformanceCounterLayoutRendererTest()
+        {
+            LogManager.Configuration = CreateConfigurationFromString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${performancecounter:category=Process:counter=Working Set:format=F0}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("a");
+            Assert.NotEqual(0, long.Parse(GetDebugLastMessage("debug")));
+            logger.Debug("b");
+            logger.Debug("c");
+            logger.Debug("d");
+            Assert.NotEqual(0, long.Parse(GetDebugLastMessage("debug")));
+        }
+    }
+
+#endif
+}


### PR DESCRIPTION
A delay is required for sample calculation. See also #2911

It is not a perfect solution, as it would require a frequent timer, to update previous sample in the background. But if logging frequently, then there should be a valid previous sample, that gives non-zero result.

This is a throttled version of the normal `NextValue()` (See handling of oldSample):

https://referencesource.microsoft.com/#system/services/monitoring/system/diagnosticts/PerformanceCounter.cs,582

See also `The recommended delay time between calls to the NextValue method is one second`:

https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.performancecounter.nextvalue