### PR TITLE
Introduced NLog.AppConfig for .NET 45 + .NET Standard 2.0

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -39,6 +39,10 @@ msbuild /t:Restore,Pack .\src\NLog.WindowsIdentity\ /p:VersionPrefix=$versionPre
 if (-Not $LastExitCode -eq 0)
 	{ exit $LastExitCode }
 
+msbuild /t:Restore,Pack .\src\NLog.AppConfig\ /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:PackageOutputPath=..\..\artifacts /verbosity:minimal
+if (-Not $LastExitCode -eq 0)
+	{ exit $LastExitCode }
+
 msbuild /t:xsd /t:NuGetSchemaPackage /t:NuGetConfigPackage .\src\NLog.proj /p:Configuration=Release /p:BuildNetFX45=true /p:BuildVersion=$versionProduct /p:Configuration=Release /p:BuildLabelOverride=NONE /verbosity:minimal
 
 exit $LastExitCode

--- a/src/NLog.AppConfig/AppSettingLayoutRenderer.cs
+++ b/src/NLog.AppConfig/AppSettingLayoutRenderer.cs
@@ -1,0 +1,94 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.LayoutRenderers
+{
+    using System.Collections.Specialized;
+    using System.Text;
+    using NLog.Config;
+    using NLog.Internal;
+
+    /// <summary>
+    /// Application setting.
+    /// </summary>
+    /// <remarks>
+    /// Use this layout renderer to insert the value of an application setting
+    /// stored in the application's App.config or Web.config file.
+    /// </remarks>
+    /// <code lang="NLog Layout Renderer">
+    /// ${appsetting:name=mysetting:default=mydefault} - produces "mydefault" if no appsetting
+    /// </code>
+    [LayoutRenderer("appsetting")]
+    public class AppSettingLayoutRenderer : LayoutRenderer
+    {
+        ///<summary>
+        /// The AppSetting name.
+        ///</summary>
+        [RequiredParameter]
+        [DefaultParameter]
+        public string Name { get; set; }
+
+        ///<summary>
+        /// The default value to render if the AppSetting value is null.
+        ///</summary>
+        public string Default { get; set; }
+
+        internal IConfigurationManager ConfigurationManager { get; set; } = new AppSettingsManager();
+
+        /// <summary>
+        /// Renders the specified application setting or default value and appends it to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="logEvent">Logging event.</param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            if (Name == null)
+                return;
+
+            string value = ConfigurationManager.AppSettings[Name];
+            if (value == null && Default != null)
+                value = Default;
+
+            if (!string.IsNullOrEmpty(value))
+                builder.Append(value);
+        }
+
+        class AppSettingsManager : IConfigurationManager
+        {
+            /// <summary>
+            /// Gets the wrapper around ConfigurationManager.AppSettings.
+            /// </summary>
+            public NameValueCollection AppSettings => System.Configuration.ConfigurationManager.AppSettings;
+        }
+    }
+}

--- a/src/NLog.AppConfig/NLog.AppConfig.csproj
+++ b/src/NLog.AppConfig/NLog.AppConfig.csproj
@@ -1,0 +1,86 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net45;net40-client;net35;netstandard2.0</TargetFrameworks>
+
+    <Title>NLog.AppConfig</Title>
+    <Company>NLog</Company>
+    <Description>Wiki: https://github.com/nlog/nlog/wiki/AppSetting-Layout-Renderer
+    
+For appsettings.json etc. in ASP.NET core, use https://www.nuget.org/packages/NLog.Extensions.Configuration
+    </Description>
+    <Product>NLog.AppConfig v$(ProductVersion)</Product>
+    <InformationalVersion>$(ProductVersion)</InformationalVersion>
+    <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
+    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
+    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
+    
+    <PackageReleaseNotes>
+      Wiki:
+      https://github.com/NLog/NLog/wiki/AppSetting-Layout-Renderer
+    </PackageReleaseNotes>
+    <PackageTags>NLog;AppConfig;WebConfig;AppSettings;logging;log</PackageTags>
+    <PackageIconUrl>https://nlog-project.org/N.png</PackageIconUrl>
+    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/NLog/NLog/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
+
+    <SignAssembly>true</SignAssembly>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Title>NLog.AppConfig for .NET Framework 4.5</Title>
+    <DefineConstants>$(DefineConstants);NET4_5</DefineConstants>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net40-client' ">
+    <Title>NLog.AppConfig for .NET Framework 4</Title>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <DefineConstants>$(DefineConstants);NET4_0</DefineConstants>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">
+    <Title>NLog.AppConfig for .NET Framework 3.5</Title>
+    <DefineConstants>$(DefineConstants);NET3_5</DefineConstants>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <Title>NLog.AppConfig for NetStandard 2.0</Title>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(monobuild)' != '' ">
+    <Title>$(Title) - Mono</Title>
+    <DefineConstants>$(DefineConstants)MONO</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\NLog\Resources\NLog.ico" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NLog\NLog.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NLog.AppConfig/Properties/AssemblyInfo.cs
+++ b/src/NLog.AppConfig/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 // 
-// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// Copyright (c) 2004-2017 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
 // 
@@ -31,22 +31,23 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !NETSTANDARD1_0
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security;
 
-namespace NLog.Internal
-{
-    using System.Collections.Specialized;
-
-    /// <summary>
-    /// Interface for the wrapper around System.Configuration.ConfigurationManager.
-    /// </summary>
-    public interface IConfigurationManager
-    {
-        /// <summary>
-        /// Gets the wrapper around ConfigurationManager.AppSettings.
-        /// </summary>
-        NameValueCollection AppSettings { get; }
-    }
-}
-
+[assembly: AssemblyCulture("")]
+[assembly: CLSCompliant(true)]
+[assembly: ComVisible(false)]
+#if __IOS__ || __ANDROID__
+//[assembly: InternalsVisibleTo("NLog.UnitTests")]
+#else
+[assembly: InternalsVisibleTo("NLog.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100ef8eab4fbdeb511eeb475e1659fe53f00ec1c1340700f1aa347bf3438455d71993b28b1efbed44c8d97a989e0cb6f01bcb5e78f0b055d311546f63de0a969e04cf04450f43834db9f909e566545a67e42822036860075a1576e90e1c43d43e023a24c22a427f85592ae56cac26f13b7ec2625cbc01f9490d60f16cfbb1bc34d9")]
+#endif
+#if !SILVERLIGHT4
+[assembly: AllowPartiallyTrustedCallers]
+#if !NET3_5 && !MONO_2_0 && !SILVERLIGHT5 && !__IOS__ && !__ANDROID__ && !WINDOWS_PHONE && !NETSTANDARD1_5
+[assembly: SecurityRules(SecurityRuleSet.Level1)]
+#endif
 #endif

--- a/src/NLog.sln
+++ b/src/NLog.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2026
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog", "NLog\NLog.csproj", "{4B1D2AB8-04B9-4756-AF7C-F03EFC10806B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog", "NLog\NLog.csproj", "{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.UnitTests", "..\tests\NLog.UnitTests\NLog.UnitTests.csproj", "{0218D315-383E-4B09-BE73-FB62320FCA4C}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -16,14 +16,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLogAutoLoadExtension", "NL
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.Extended", "NLog.Extended\NLog.Extended.csproj", "{FEBC3D32-AB28-4ACC-8697-D3147B790D80}"
 	ProjectSection(ProjectDependencies) = postProject
-		{4B1D2AB8-04B9-4756-AF7C-F03EFC10806B} = {4B1D2AB8-04B9-4756-AF7C-F03EFC10806B}
+		{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66} = {A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.WindowsIdentity", "NLog.WindowsIdentity\NLog.WindowsIdentity.csproj", "{746E1B52-CBE6-4A57-A213-886A3660BE0A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.Wcf", "NLog.Wcf\NLog.Wcf.csproj", "{4692A3FF-5FF9-4B93-BFEB-82ADAA957725}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.WindowsEventLog", "NLog.WindowsEventLog\NLog.WindowsEventLog.csproj", "{99BCE294-CA56-41BD-AEBF-61795F5650AB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.WindowsEventLog", "NLog.WindowsEventLog\NLog.WindowsEventLog.csproj", "{99BCE294-CA56-41BD-AEBF-61795F5650AB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.AppConfig", "NLog.AppConfig\NLog.AppConfig.csproj", "{B1BEDB77-713F-40A8-89D1-9EAECBC01C78}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,10 +33,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{4B1D2AB8-04B9-4756-AF7C-F03EFC10806B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4B1D2AB8-04B9-4756-AF7C-F03EFC10806B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4B1D2AB8-04B9-4756-AF7C-F03EFC10806B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4B1D2AB8-04B9-4756-AF7C-F03EFC10806B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0218D315-383E-4B09-BE73-FB62320FCA4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0218D315-383E-4B09-BE73-FB62320FCA4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0218D315-383E-4B09-BE73-FB62320FCA4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -63,6 +65,10 @@ Global
 		{99BCE294-CA56-41BD-AEBF-61795F5650AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{99BCE294-CA56-41BD-AEBF-61795F5650AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{99BCE294-CA56-41BD-AEBF-61795F5650AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1BEDB77-713F-40A8-89D1-9EAECBC01C78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1BEDB77-713F-40A8-89D1-9EAECBC01C78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1BEDB77-713F-40A8-89D1-9EAECBC01C78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1BEDB77-713F-40A8-89D1-9EAECBC01C78}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NLog/Internal/ConfigurationManager.cs
+++ b/src/NLog/Internal/ConfigurationManager.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_0
 
 namespace NLog.Internal
 {
@@ -47,7 +47,11 @@ namespace NLog.Internal
         /// <summary>
         /// Gets the wrapper around ConfigurationManager.AppSettings.
         /// </summary>
+#if NETSTANDARD2_0
+        public NameValueCollection AppSettings { get; } = new NameValueCollection();
+#else
         public NameValueCollection AppSettings => System.Configuration.ConfigurationManager.AppSettings;
+#endif
     }
 }
 

--- a/tests/NLog.UnitTests/LayoutRenderers/AppSettingTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/AppSettingTests.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !NETSTANDARD
+#if !NETSTANDARD1_0
 
 namespace NLog.UnitTests.LayoutRenderers
 {

--- a/tests/NLog.UnitTests/NLog.UnitTests.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.csproj
@@ -66,6 +66,10 @@
     <ProjectReference Include="..\..\src\NLog.WindowsIdentity\NLog.WindowsIdentity.csproj">
       <Private>true</Private>
     </ProjectReference>
+
+    <ProjectReference Include="..\..\src\NLog.AppConfig\NLog.AppConfig.csproj">
+      <Private>true</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
Allow access to appsettings in app.config (or web.config) without using NLog.Extended (That depends on Msmq).

Also added support for NetStandard2.0 (See https://www.nuget.org/packages/System.Configuration.ConfigurationManager/4.4.0)

Decided not to make a file-link into NLog.Extended, because it enforced caching. Instead one have to manually use `${appsetting:cached=true:name=MySetting}`.