### PR TITLE
Invalid attribute values in the `<NLog>` element should not break logging & better attribute parsing order

### DIFF
--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -33,13 +33,12 @@
 
 using System.Linq;
 using System.Text;
+using NLog.Common;
 
 namespace NLog.Config
 {
-    using Internal;
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Xml;
 
     /// <summary>
@@ -145,82 +144,6 @@ namespace NLog.Config
             }
 
             return result;
-        }
-
-        /// <summary>
-        /// Gets the required attribute.
-        /// </summary>
-        /// <param name="attributeName">Name of the attribute.</param>
-        /// <returns>Attribute value.</returns>
-        /// <remarks>Throws if the attribute is not specified.</remarks>
-        public string GetRequiredAttribute(string attributeName)
-        {
-            string value = GetOptionalAttribute(attributeName, null);
-            if (value == null)
-            {
-                throw new NLogConfigurationException("Expected " + attributeName + " on <" + LocalName + " />");
-            }
-
-            return value;
-        }
-
-        /// <summary>
-        /// Gets the optional boolean attribute value.
-        /// </summary>
-        /// <param name="attributeName">Name of the attribute.</param>
-        /// <param name="defaultValue">Default value to return if the attribute is not found.</param>
-        /// <returns>Boolean attribute value or default.</returns>
-        public bool GetOptionalBooleanAttribute(string attributeName, bool defaultValue)
-        {
-            if (!AttributeValues.TryGetValue(attributeName, out var value))
-            {
-                return defaultValue;
-            }
-
-            return Convert.ToBoolean(value, CultureInfo.InvariantCulture);
-        }
-
-        /// <summary>
-        /// Gets the optional boolean attribute value. If whitespace, then returning <c>null</c>.
-        /// </summary>
-        /// <param name="attributeName">Name of the attribute.</param>
-        /// <param name="defaultValue">Default value to return if the attribute is not found.</param>
-        /// <returns>Boolean attribute value or default.</returns>
-        public bool? GetOptionalBooleanAttribute(string attributeName, bool? defaultValue)
-        {
-            string value;
-
-            if (!AttributeValues.TryGetValue(attributeName, out value))
-            {
-                //not defined, don't override default
-                return defaultValue;
-            }
-
-            if (StringHelpers.IsNullOrWhiteSpace(value))
-            {
-                //not default otherwise no difference between not defined and empty value.
-                return null;
-            }
-
-            return Convert.ToBoolean(value, CultureInfo.InvariantCulture);
-        }
-
-        /// <summary>
-        /// Gets the optional attribute value.
-        /// </summary>
-        /// <param name="attributeName">Name of the attribute.</param>
-        /// <param name="defaultValue">The default value.</param>
-        /// <returns>Value of the attribute or default value.</returns>
-        public string GetOptionalAttribute(string attributeName, string defaultValue)
-        {
-            string value;
-
-            if (!AttributeValues.TryGetValue(attributeName, out value))
-            {
-                value = defaultValue;
-            }
-
-            return value;
         }
 
         /// <summary>


### PR DESCRIPTION
+dead code removal

fixes #2930 
