### PR TITLE
InternalLogger.LogLevel should default to LogLevel.Off when not configured

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -341,7 +341,7 @@ namespace NLog.Common
         /// Determine if logging is enabled.
         /// </summary>
         /// <returns><c>true</c> if logging is enabled; otherwise, <c>false</c>.</returns>
-        private static bool HasActiveLoggers()
+        internal static bool HasActiveLoggers()
         {
             return !string.IsNullOrEmpty(LogFile) ||
                    LogToConsole ||

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -57,6 +57,7 @@ namespace NLog.UnitTests.Config
                 Assert.False(InternalLogger.LogToConsole);
                 Assert.False(InternalLogger.LogToConsoleError);
                 Assert.Null(InternalLogger.LogWriter);
+                Assert.Equal(LogLevel.Off, InternalLogger.LogLevel);
             }
         }
 
@@ -75,6 +76,7 @@ namespace NLog.UnitTests.Config
                 Assert.True(InternalLogger.LogToConsole);
                 Assert.True(InternalLogger.LogToConsoleError);
                 Assert.Null(InternalLogger.LogWriter);
+                Assert.Equal(LogLevel.Info, InternalLogger.LogLevel);
             }
         }
 

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -516,6 +516,8 @@ namespace NLog.UnitTests
 
             public InternalLoggerScope(bool redirectConsole = false)
             {
+                InternalLogger.LogLevel = LogLevel.Info;
+
                 if (redirectConsole)
                 {
                     ConsoleOutputWriter = new StringWriter() { NewLine = "\n" };


### PR DESCRIPTION
Resolves  #2913