### PR TITLE
JSON encoding should create valid JSON for non-string dictionary-keys

### DIFF
--- a/tests/NLog.UnitTests/Config/ConfigApiTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigApiTests.cs
@@ -301,7 +301,7 @@ namespace NLog.UnitTests.Config
             Assert.Same(rule, ruleLookup);
             Assert.True(config.RemoveRuleByName("hello"));
             ruleLookup = config.FindRuleByName("hello");
-            Assert.Same(null, ruleLookup);
+            Assert.Null(ruleLookup);
             Assert.False(config.RemoveRuleByName("hello"));
         }
     }

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
@@ -263,6 +263,36 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void SerializeIntegerKeyDict_Test()
+        {
+            var dictionary = new Dictionary<int, string>();
+            dictionary.Add(1, "One");
+            dictionary.Add(2, "Two");
+            var actual = SerializeObject(dictionary);
+            Assert.Equal("{\"1\":\"One\",\"2\":\"Two\"}", actual);
+        }
+
+        [Fact]
+        public void SerializeEnumKeyDict_Test()
+        {
+            var dictionary = new Dictionary<ExceptionRenderingFormat, int>();
+            dictionary.Add(ExceptionRenderingFormat.Method, 4);
+            dictionary.Add(ExceptionRenderingFormat.StackTrace, 5);
+            var actual = SerializeObject(dictionary);
+            Assert.Equal("{\"Method\":4,\"StackTrace\":5}", actual);
+        }
+
+        [Fact]
+        public void SerializeObjectKeyDict_Test()
+        {
+            var dictionary = new Dictionary<object, string>();
+            dictionary.Add(new { Name = "Hello" }, "World");
+            dictionary.Add(new { Name = "Goodbye" }, "Money");
+            var actual = SerializeObject(dictionary);
+            Assert.Equal("{\"{ Name = Hello }\":\"World\",\"{ Name = Goodbye }\":\"Money\"}", actual);
+        }
+
+        [Fact]
         public void SerializeNull_Test()
         {
             var actual = SerializeObject(null);


### PR DESCRIPTION
Resolve #2936 (See also https://www.newtonsoft.com/json/help/html/SerializationGuide.htm#Dictionarys)

> When serializing a dictionary, the keys of the dictionary are converted to strings and used as the JSON object property names. The string written for a key can be customized by overriding ToString()