### PR TITLE
JSON encoding should create valid JSON for string dictionary-keys

### DIFF
--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -522,10 +522,15 @@ namespace NLog.Targets
 
         private bool SerializeSimpleTypeCodeValue(object value, TypeCode objTypeCode, StringBuilder destination, JsonSerializeOptions options, bool forceQuotes = false)
         {
-            if (IsNumericTypeCode(objTypeCode, false))
+            if (objTypeCode == TypeCode.String || objTypeCode == TypeCode.Char)
             {
-                Enum enumValue;
-                if (!options.EnumAsInteger && (enumValue = value as Enum) != null)
+                destination.Append('"');
+                AppendStringEscape(destination, value.ToString(), options.EscapeUnicode);
+                destination.Append('"');
+            }
+            else if (IsNumericTypeCode(objTypeCode, false))
+            {
+                if (!options.EnumAsInteger && value is Enum enumValue)
                 {
                     QuoteValue(destination, EnumAsString(enumValue));
                 }
@@ -552,16 +557,7 @@ namespace NLog.Targets
                 }
                 else
                 {
-                    if (objTypeCode == TypeCode.Char)
-                    {
-                        destination.Append('"');
-                        AppendStringEscape(destination, str, options.EscapeUnicode);
-                        destination.Append('"');
-                    }
-                    else
-                    {
-                        QuoteValue(destination, str);
-                    }
+                    QuoteValue(destination, str);
                 }
             }
             return true;

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
@@ -293,6 +293,16 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void SerializeBadStringKeyDict_Test()
+        {
+            var dictionary = new Dictionary<string, string>();
+            dictionary.Add("\t", "Tab");
+            dictionary.Add("\n", "Newline");
+            var actual = SerializeObject(dictionary);
+            Assert.Equal("{\"\\t\":\"Tab\",\"\\n\":\"Newline\"}", actual);
+        }
+
+        [Fact]
         public void SerializeNull_Test()
         {
             var actual = SerializeObject(null);


### PR DESCRIPTION
Followup to #2937 (Ensure strings are escaped when necessary)