### PR TITLE
TargetWithContext - Include all properties even when duplicate names (rename with postfix: _1, _2 etc)

### DIFF
--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -238,7 +238,7 @@ namespace NLog.Targets
         /// <param name="itemName">Duplicate item name</param>
         /// <param name="itemValue">Item Value</param>
         /// <param name="combinedProperties">Dictionary of context values</param>
-        /// <returns>New unique value (or null to skip value)</returns>
+        /// <returns>New (unique) value (or null to skip value). If the same value is used then the item will be overwritten</returns>
         protected virtual string GenerateUniqueItemName(LogEventInfo logEvent, string itemName, object itemValue, IDictionary<string, object> combinedProperties)
         {
             itemName = itemName ?? string.Empty;

--- a/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
+++ b/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
@@ -114,11 +114,13 @@ namespace NLog.UnitTests.Targets
             Assert.NotEqual(0, target.LastMessage.Length);
             Assert.NotNull(target.LastCombinedProperties);
             Assert.NotEmpty(target.LastCombinedProperties);
-            Assert.Equal(5, target.LastCombinedProperties.Count);
+            Assert.Equal(7, target.LastCombinedProperties.Count);
             Assert.Contains(new KeyValuePair<string, object>("GlobalKey", "Hello Global World"), target.LastCombinedProperties);
             Assert.Contains(new KeyValuePair<string, object>("ThreadKey", "Hello Thread World"), target.LastCombinedProperties);
             Assert.Contains(new KeyValuePair<string, object>("AsyncKey", "Hello Async World"), target.LastCombinedProperties);
             Assert.Contains(new KeyValuePair<string, object>("TestKey", "Hello Async World"), target.LastCombinedProperties);
+            Assert.Contains(new KeyValuePair<string, object>("TestKey_1", "Hello Thread World"), target.LastCombinedProperties);
+            Assert.Contains(new KeyValuePair<string, object>("TestKey_2", "Hello Global World"), target.LastCombinedProperties);
             Assert.Contains(new KeyValuePair<string, object>("threadid", System.Environment.CurrentManagedThreadId.ToString()), target.LastCombinedProperties);
         }
 


### PR DESCRIPTION
Less surprises when failing to provide unique property names (Without loosing properties)