### PR TITLE
LayoutRenderer - Introduced IStringValueRenderer-interface to skip extra string allocation, removed IRawValue from non-ThreadAgnostic layout renderers

### DIFF
--- a/src/NLog/Internal/FormatHelper.cs
+++ b/src/NLog/Internal/FormatHelper.cs
@@ -49,11 +49,10 @@ namespace NLog.Internal
         /// </remarks>
         internal static string ConvertToString(object o, IFormatProvider formatProvider)
         {
-
             // if no IFormatProvider is specified, use the Configuration.DefaultCultureInfo value.
             if (formatProvider == null)
             {
-                if (!ObjectSupportsFormatProvider(o))
+                if (SkipFormattableToString(o))
                     return o?.ToString() ?? string.Empty;
 
                 if (o is IFormattable)
@@ -69,19 +68,19 @@ namespace NLog.Internal
             return Convert.ToString(o, formatProvider);
         }
 
-        internal static bool ObjectSupportsFormatProvider(object o)
+        private static bool SkipFormattableToString(object o)
         {
             switch (Convert.GetTypeCode(o))
             {
-                case TypeCode.String:   return false;
-                case TypeCode.Empty:    return false;
-                default:                return true;
+                case TypeCode.String:   return true;
+                case TypeCode.Empty:    return true;
+                default:                return false;
             }
         }
 
         internal static string TryFormatToString(object value, string format, IFormatProvider formatProvider)
         {
-            if (!ObjectSupportsFormatProvider(value))
+            if (SkipFormattableToString(value))
                 return value?.ToString() ?? string.Empty;
 
             if (value is IFormattable formattable)

--- a/src/NLog/Internal/IRenderString.cs
+++ b/src/NLog/Internal/IRenderString.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,56 +31,18 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.LayoutRenderers
+namespace NLog.Internal
 {
-    using System;
-    using System.ComponentModel;
-    using System.Text;
-    using NLog.Config;
-    using NLog.Internal;
-
     /// <summary>
-    /// The log level.
+    /// Supports rendering of string value without allocation (or seldom)
     /// </summary>
-    [LayoutRenderer("level")]
-    [ThreadAgnostic]
-    [ThreadSafe]
-    public class LevelLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
+    interface IRenderString
     {
         /// <summary>
-        /// Gets or sets a value indicating the output format of the level.
+        /// Renders the value of layout renderer in the context of the specified log event
         /// </summary>
-        /// <docgen category='Rendering Options' order='10' />
-        [DefaultValue(LevelFormat.Name)]
-        public LevelFormat Format { get; set; }
-
-        /// <inheritdoc/>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
-        {
-            LogLevel level = GetValue(logEvent);
-            switch (Format)
-            {
-                case LevelFormat.Name:
-                    builder.Append(level.ToString());
-                    break;
-                case LevelFormat.FirstCharacter:
-                    builder.Append(level.ToString()[0]);
-                    break;
-                case LevelFormat.Ordinal:
-                    builder.AppendInvariant(level.Ordinal);
-                    break;
-            }
-        }
-
-        /// <inheritdoc/>
-        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue(logEvent);
-
-        /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent) => Format == LevelFormat.Name ? GetValue(logEvent).ToString() : null;
-
-        private static LogLevel GetValue(LogEventInfo logEvent)
-        {
-            return logEvent.Level;
-        }
+        /// <param name="logEvent"></param>
+        /// <returns>null if not possible or unknown</returns>
+        string GetFormattedString(LogEventInfo logEvent);
     }
 }

--- a/src/NLog/Internal/IStringValueRenderer.cs
+++ b/src/NLog/Internal/IStringValueRenderer.cs
@@ -34,9 +34,9 @@
 namespace NLog.Internal
 {
     /// <summary>
-    /// Supports rendering of string value without allocation (or seldom)
+    /// Supports rendering as string value with limited or no allocations (preferred)
     /// </summary>
-    interface IRenderString
+    interface IStringValueRenderer
     {
         /// <summary>
         /// Renders the value of layout renderer in the context of the specified log event

--- a/src/NLog/Internal/ReflectionHelpers.cs
+++ b/src/NLog/Internal/ReflectionHelpers.cs
@@ -181,6 +181,15 @@ namespace NLog.Internal
 #endif
         }
 
+        public static bool IsValueType(this Type type)
+        {
+#if NETSTANDARD1_0
+            return type.GetTypeInfo().IsValueType;
+#else
+            return type.IsValueType;
+#endif
+        }
+
         public static bool IsSealed(this Type type)
         {
 #if NETSTANDARD1_0

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -57,7 +57,7 @@ namespace NLog.Internal
             {
                 builder.Append(value);  // Avoid automatic quotes
             }
-            else if (format == "@")
+            else if (format == MessageTemplates.ValueFormatter.FormatAsJson)
             {
                 ValueFormatter.Instance.FormatValue(value, null, CaptureType.Serialize, formatProvider, builder);
             }

--- a/src/NLog/LayoutRenderers/AppDomainLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AppDomainLayoutRenderer.cs
@@ -45,6 +45,7 @@ namespace NLog.LayoutRenderers
     ///  Used to render the application domain name.
     ///  </summary>
     [LayoutRenderer("appdomain")]
+    [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
     public class AppDomainLayoutRenderer : LayoutRenderer
@@ -83,18 +84,14 @@ namespace NLog.LayoutRenderers
         [DefaultValue(LongFormatCode)]
         public string Format { get; set; }
 
-        /// <summary>
-        /// Initializes the layout renderer.
-        /// </summary>
+        /// <inheritdoc/>
         protected override void InitializeLayoutRenderer()
         {
             _assemblyName = null;
             base.InitializeLayoutRenderer();
         }
 
-        /// <summary>
-        /// Closes the layout renderer.
-        /// </summary>
+        /// <inheritdoc/>
         protected override void CloseLayoutRenderer()
         {
             _assemblyName = null;
@@ -103,11 +100,7 @@ namespace NLog.LayoutRenderers
 
         private string _assemblyName;
 
-        /// <summary>
-        /// Render the layout
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="logEvent"></param>
+        /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             if (_assemblyName == null)
@@ -118,11 +111,6 @@ namespace NLog.LayoutRenderers
             builder.Append(_assemblyName);
         }
 
-        /// <summary>
-        /// Convert the formatting string
-        /// </summary>
-        /// <param name="format"></param>
-        /// <returns></returns>
         private static string GetFormattingString(string format)
         {
             string formattingString;

--- a/src/NLog/LayoutRenderers/CallSiteFileNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteFileNameLayoutRenderer.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("callsite-filename")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class CallSiteFileNameLayoutRenderer : LayoutRenderer, IUsesStackTrace, IRenderString
+    public class CallSiteFileNameLayoutRenderer : LayoutRenderer, IUsesStackTrace, IStringValueRenderer
     {
         /// <summary>
         /// Gets or sets a value indicating whether to include source file path.
@@ -74,7 +74,7 @@ namespace NLog.LayoutRenderers
         }
 
         /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
 
         private string GetStringValue(LogEventInfo logEvent)
         {

--- a/src/NLog/LayoutRenderers/CallSiteFileNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteFileNameLayoutRenderer.cs
@@ -46,22 +46,14 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("callsite-filename")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class CallSiteFileNameLayoutRenderer : LayoutRenderer, IUsesStackTrace
+    public class CallSiteFileNameLayoutRenderer : LayoutRenderer, IUsesStackTrace, IRenderString
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CallSiteFileNameLayoutRenderer" /> class.
-        /// </summary>
-        public CallSiteFileNameLayoutRenderer()
-        {
-            IncludeSourcePath = true;
-        }
-
         /// <summary>
         /// Gets or sets a value indicating whether to include source file path.
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(true)]
-        public bool IncludeSourcePath { get; set; }
+        public bool IncludeSourcePath { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the number of frames to skip.
@@ -75,28 +67,26 @@ namespace NLog.LayoutRenderers
         /// </summary>
         StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsage.WithSource;
 
-        /// <summary>
-        /// Renders the call site and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            builder.Append(GetStringValue(logEvent));
+        }
+
+        /// <inheritdoc/>
+        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
+
+        private string GetStringValue(LogEventInfo logEvent)
         {
             if (logEvent.CallSiteInformation != null)
             {
                 string fileName = logEvent.CallSiteInformation.GetCallerFilePath(SkipFrames);
                 if (!string.IsNullOrEmpty(fileName))
                 {
-                    if (IncludeSourcePath)
-                    {
-                        builder.Append(fileName);
-                    }
-                    else
-                    {
-                        builder.Append(Path.GetFileName(fileName));
-                    }
+                    return IncludeSourcePath ? fileName : Path.GetFileName(fileName);
                 }
             }
+            return string.Empty;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/CallSiteLineNumberLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteLineNumberLayoutRenderer.cs
@@ -60,11 +60,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsage.WithSource;
 
-        /// <summary>
-        /// Renders the call site and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var lineNumber = GetLineNumber(logEvent);
@@ -72,12 +68,8 @@ namespace NLog.LayoutRenderers
                 builder.AppendInvariant(lineNumber.Value);
         }
 
-
         /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetLineNumber(logEvent);
-        }
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetLineNumber(logEvent);
 
         private int? GetLineNumber(LogEventInfo logEvent)
         {

--- a/src/NLog/LayoutRenderers/CounterLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CounterLayoutRenderer.cs
@@ -43,7 +43,7 @@ namespace NLog.LayoutRenderers
     /// A counter value (increases on each layout rendering).
     /// </summary>
     [LayoutRenderer("counter")]
-    public class CounterLayoutRenderer : LayoutRenderer, IRawValue
+    public class CounterLayoutRenderer : LayoutRenderer
     {
         private static Dictionary<string, int> sequences = new Dictionary<string, int>();
 
@@ -73,9 +73,6 @@ namespace NLog.LayoutRenderers
             int v = GetNextValue(logEvent);
             builder.AppendInvariant(v);
         }
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetNextValue(logEvent);
 
         private int GetNextValue(LogEventInfo logEvent)
         {

--- a/src/NLog/LayoutRenderers/CounterLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CounterLayoutRenderer.cs
@@ -48,27 +48,18 @@ namespace NLog.LayoutRenderers
         private static Dictionary<string, int> sequences = new Dictionary<string, int>();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CounterLayoutRenderer" /> class.
-        /// </summary>
-        public CounterLayoutRenderer()
-        {
-            Increment = 1;
-            Value = 1;
-        }
-
-        /// <summary>
         /// Gets or sets the initial value of the counter.
         /// </summary>
         /// <docgen category='Counter Options' order='10' />
         [DefaultValue(1)]
-        public int Value { get; set; }
+        public int Value { get; set; } = 1;
 
         /// <summary>
         /// Gets or sets the value to be added to the counter after each layout rendering.
         /// </summary>
         /// <docgen category='Counter Options' order='10' />
         [DefaultValue(1)]
-        public int Increment { get; set; }
+        public int Increment { get; set; } = 1;
 
         /// <summary>
         /// Gets or sets the name of the sequence. Different named sequences can have individual values.
@@ -76,21 +67,14 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Counter Options' order='10' />
         public Layout Sequence { get; set; }
 
-        /// <summary>
-        /// Renders the specified counter value and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             int v = GetNextValue(logEvent);
-
             builder.AppendInvariant(v);
         }
 
-        /// <summary>
-        /// Get raw value, updates the sequence
-        /// </summary>
+        /// <inheritdoc />
         object IRawValue.GetRawValue(LogEventInfo logEvent) => GetNextValue(logEvent);
 
         private int GetNextValue(LogEventInfo logEvent)

--- a/src/NLog/LayoutRenderers/CurrentDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CurrentDirLayoutRenderer.cs
@@ -44,7 +44,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("currentdir")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class CurrentDirLayoutRenderer : LayoutRenderer, IRenderString
+    public class CurrentDirLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
         /// <summary>
         /// Gets or sets the name of the file to be Path.Combine()'d with the current directory.
@@ -65,7 +65,7 @@ namespace NLog.LayoutRenderers
         }
 
         /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue();
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue();
 
         private string GetStringValue()
         {

--- a/src/NLog/LayoutRenderers/CurrentDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CurrentDirLayoutRenderer.cs
@@ -44,7 +44,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("currentdir")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class CurrentDirLayoutRenderer : LayoutRenderer
+    public class CurrentDirLayoutRenderer : LayoutRenderer, IRenderString
     {
         /// <summary>
         /// Gets or sets the name of the file to be Path.Combine()'d with the current directory.
@@ -58,16 +58,20 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Advanced Options' order='10' />
         public string Dir { get; set; }
 
-        /// <summary>
-        /// Renders the current directory and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            builder.Append(GetStringValue());
+        }
+
+        /// <inheritdoc/>
+        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue();
+
+        private string GetStringValue()
         {
             var currentDir = Directory.GetCurrentDirectory();
             var path = PathHelpers.CombinePaths(currentDir, Dir, File);
-            builder.Append(path);
+            return path;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/DateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/DateLayoutRenderer.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("date")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class DateLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
+    public class DateLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateLayoutRenderer" /> class.
@@ -103,7 +103,7 @@ namespace NLog.LayoutRenderers
         object IRawValue.GetRawValue(LogEventInfo logEvent) => GetDate(logEvent);
 
         /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
 
         private string GetStringValue(LogEventInfo logEvent)
         {

--- a/src/NLog/LayoutRenderers/DbNullLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/DbNullLayoutRenderer.cs
@@ -31,14 +31,13 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-
-using System;
-using System.Text;
-using NLog.Config;
-using NLog.Internal;
-
 namespace NLog.LayoutRenderers
 {
+    using System;
+    using System.Text;
+    using NLog.Config;
+    using NLog.Internal;
+
     /// <summary>
     /// DB null for a database
     /// </summary>
@@ -47,21 +46,12 @@ namespace NLog.LayoutRenderers
     [ThreadAgnostic]
     public class DbNullLayoutRenderer : LayoutRenderer, IRawValue
     {
-        /// <summary>
-        /// Empty append
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="logEvent"></param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            
         }
-
 
         /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return DBNull.Value;
-        }
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => DBNull.Value;
     }
 }

--- a/src/NLog/LayoutRenderers/EnvironmentLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EnvironmentLayoutRenderer.cs
@@ -45,7 +45,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("environment")]
     [ThreadSafe]
-    public class EnvironmentLayoutRenderer : LayoutRenderer, IRenderString
+    public class EnvironmentLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
         /// <summary>
         /// Gets or sets the name of the environment variable.
@@ -70,12 +70,12 @@ namespace NLog.LayoutRenderers
         }
 
         /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent)
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent)
         {
             var simpleLayout = GetSimpleLayout();
             if (simpleLayout == null)
                 return string.Empty;
-            if (simpleLayout.IsFixedText || simpleLayout.IsSimpleString)
+            if (simpleLayout.IsFixedText || simpleLayout.IsSimpleStringText)
                 return simpleLayout.Render(logEvent);
             return null;
         } 

--- a/src/NLog/LayoutRenderers/EnvironmentLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EnvironmentLayoutRenderer.cs
@@ -45,7 +45,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("environment")]
     [ThreadSafe]
-    public class EnvironmentLayoutRenderer : LayoutRenderer
+    public class EnvironmentLayoutRenderer : LayoutRenderer, IRenderString
     {
         /// <summary>
         /// Gets or sets the name of the environment variable.
@@ -63,12 +63,24 @@ namespace NLog.LayoutRenderers
 
         private System.Collections.Generic.KeyValuePair<string, SimpleLayout> _cachedValue;
 
-        /// <summary>
-        /// Renders the specified environment variable and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            GetSimpleLayout()?.RenderAppendBuilder(logEvent, builder);
+        }
+
+        /// <inheritdoc/>
+        string IRenderString.GetFormattedString(LogEventInfo logEvent)
+        {
+            var simpleLayout = GetSimpleLayout();
+            if (simpleLayout == null)
+                return string.Empty;
+            if (simpleLayout.IsFixedText || simpleLayout.IsSimpleString)
+                return simpleLayout.Render(logEvent);
+            return null;
+        } 
+
+        private SimpleLayout GetSimpleLayout()
         {
             if (Variable != null)
             {
@@ -86,9 +98,11 @@ namespace NLog.LayoutRenderers
                         _cachedValue = cachedValue;
                     }
 
-                    cachedValue.Value.RenderAppendBuilder(logEvent, builder);
+                    return cachedValue.Value;
                 }
             }
+
+            return null;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers
     [ThreadAgnostic]
     [ThreadSafe]
     [MutableUnsafe]
-    public class EventPropertiesLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
+    public class EventPropertiesLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {
         /// <summary>
         /// Gets or sets the name of the item.
@@ -86,7 +86,7 @@ namespace NLog.LayoutRenderers
         }
 
         /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
 
         private bool GetValue(LogEventInfo logEvent, out object value)
         {
@@ -96,7 +96,7 @@ namespace NLog.LayoutRenderers
 
         private string GetStringValue(LogEventInfo logEvent)
         {
-            if (Format != "@")
+            if (Format != MessageTemplates.ValueFormatter.FormatAsJson)
             {
                 if (GetValue(logEvent, out var value))
                 {

--- a/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
@@ -46,16 +46,8 @@ namespace NLog.LayoutRenderers
     [ThreadAgnostic]
     [ThreadSafe]
     [MutableUnsafe]
-    public class EventPropertiesLayoutRenderer : LayoutRenderer, IRawValue
+    public class EventPropertiesLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
     {
-        /// <summary>
-        ///  Log event context data with default options.
-        /// </summary>
-        public EventPropertiesLayoutRenderer()
-        {
-            Culture = CultureInfo.InvariantCulture;
-        }
-
         /// <summary>
         /// Gets or sets the name of the item.
         /// </summary>
@@ -74,13 +66,9 @@ namespace NLog.LayoutRenderers
         /// Gets or sets the culture used for rendering. 
         /// </summary>
         /// <docgen category='Rendering Options' order='100' />
-        public CultureInfo Culture { get; set; }
+        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
 
-        /// <summary>
-        /// Renders the specified log event context item and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             if (GetValue(logEvent, out var value))
@@ -90,19 +78,34 @@ namespace NLog.LayoutRenderers
             }
         }
 
+        /// <inheritdoc/>
+        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        {
+            GetValue(logEvent, out var value);
+            return value;
+        }
+
+        /// <inheritdoc/>
+        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
+
         private bool GetValue(LogEventInfo logEvent, out object value)
         {
             value = null;
             return logEvent.HasProperties && logEvent.Properties.TryGetValue(Item, out value);
         }
 
-        /// <summary>
-        /// Get raw value, updates the sequence
-        /// </summary>
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        private string GetStringValue(LogEventInfo logEvent)
         {
-            GetValue(logEvent, out var value);
-            return value;
+            if (Format != "@")
+            {
+                if (GetValue(logEvent, out var value))
+                {
+                    string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, Culture));
+                    return stringValue;
+                }
+                return string.Empty;
+            }
+            return null;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -38,7 +38,6 @@ namespace NLog.LayoutRenderers
     using System.ComponentModel;
     using System.Text;
     using NLog.Common;
-    using NLog.Conditions;
     using NLog.Config;
     using NLog.Internal;
 
@@ -178,16 +177,10 @@ namespace NLog.LayoutRenderers
             private set;
         }
 
-        /// <summary>
-        /// Get raw value, updates the sequence
-        /// </summary>
+        /// <inheritdoc />
         object IRawValue.GetRawValue(LogEventInfo logEvent) => logEvent.Exception;
 
-        /// <summary>
-        /// Renders the specified exception information and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             Exception primaryException = logEvent.Exception;

--- a/src/NLog/LayoutRenderers/FuncLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/FuncLayoutRenderer.cs
@@ -31,13 +31,13 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-using System.Text;
-using NLog.Config;
-using NLog.Internal;
-
 namespace NLog.LayoutRenderers
 {
+    using System;
+    using System.Text;
+    using NLog.Config;
+    using NLog.Internal;
+
     /// <summary>
     /// A layout renderer which could have different behavior per instance by using a <see cref="Func{TResult}"/>.
     /// </summary>
@@ -64,13 +64,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         public Func<LogEventInfo, LoggingConfiguration, object> RenderMethod { get; private set; }
 
-        #region Overrides of LayoutRenderer
-
-        /// <summary>
-        /// Renders the specified environmental information and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var value = GetValue(logEvent);
@@ -80,18 +74,13 @@ namespace NLog.LayoutRenderers
             }
         }
 
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue(logEvent);
+
         private object GetValue(LogEventInfo logEvent)
         {
             var renderMethod = RenderMethod?.Invoke(logEvent, LoggingConfiguration);
             return renderMethod;
-        }
-
-        #endregion
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetValue(logEvent);
         }
     }
 }

--- a/src/NLog/LayoutRenderers/FuncLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/FuncLayoutRenderer.cs
@@ -41,7 +41,7 @@ namespace NLog.LayoutRenderers
     /// <summary>
     /// A layout renderer which could have different behavior per instance by using a <see cref="Func{TResult}"/>.
     /// </summary>
-    public class FuncLayoutRenderer : LayoutRenderer, IRawValue
+    public class FuncLayoutRenderer : LayoutRenderer
     {
         /// <summary>
         /// Create a new.
@@ -73,9 +73,6 @@ namespace NLog.LayoutRenderers
                 builder.Append(value);
             }
         }
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue(logEvent);
 
         private object GetValue(LogEventInfo logEvent)
         {

--- a/src/NLog/LayoutRenderers/GarbageCollectorInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GarbageCollectorInfoLayoutRenderer.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("gc")]
     [ThreadSafe]
-    public class GarbageCollectorInfoLayoutRenderer : LayoutRenderer, IRawValue
+    public class GarbageCollectorInfoLayoutRenderer : LayoutRenderer
     {
         /// <summary>
         /// Gets or sets the property to retrieve.
@@ -63,12 +63,6 @@ namespace NLog.LayoutRenderers
                 builder.AppendInvariant((uint)value);
             else
                 builder.Append(value.ToString());
-        }
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetValue();
         }
 
         private long GetValue()

--- a/src/NLog/LayoutRenderers/GarbageCollectorInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GarbageCollectorInfoLayoutRenderer.cs
@@ -37,7 +37,6 @@ namespace NLog.LayoutRenderers
 {
     using System;
     using System.ComponentModel;
-    using System.Globalization;
     using System.Text;
     using NLog.Config;
     using NLog.Internal;
@@ -50,39 +49,20 @@ namespace NLog.LayoutRenderers
     public class GarbageCollectorInfoLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="GarbageCollectorInfoLayoutRenderer" /> class.
-        /// </summary>
-        public GarbageCollectorInfoLayoutRenderer()
-        {
-            Property = GarbageCollectorProperty.TotalMemory;
-        }
-
-        /// <summary>
         /// Gets or sets the property to retrieve.
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue("TotalMemory")]
-        public GarbageCollectorProperty Property { get; set; }
-        
-        /// <summary>
-        /// Renders the selected process information.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        public GarbageCollectorProperty Property { get; set; } = GarbageCollectorProperty.TotalMemory;
+
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            var formatProvider = GetFormatProvider(logEvent);
-            if (ReferenceEquals(formatProvider, CultureInfo.InvariantCulture))
-            {
-                formatProvider = null;
-            }
-
             var value = GetValue();
-
-            if (formatProvider == null && value >= 0 && value < uint.MaxValue)
+            if (value >= 0 && value < uint.MaxValue)
                 builder.AppendInvariant((uint)value);
             else
-                builder.Append(Convert.ToString(value, formatProvider ?? CultureInfo.InvariantCulture));
+                builder.Append(value.ToString());
         }
 
         /// <inheritdoc />
@@ -126,8 +106,6 @@ namespace NLog.LayoutRenderers
 
             return value;
         }
-
-      
     }
 }
 

--- a/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
@@ -42,8 +42,9 @@ namespace NLog.LayoutRenderers
     /// Global Diagnostics Context item. Provided for compatibility with log4net.
     /// </summary>
     [LayoutRenderer("gdc")]
+    [ThreadAgnostic]
     [ThreadSafe]
-    public class GdcLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
+    public class GdcLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {
         /// <summary>
         /// Gets or sets the name of the item.
@@ -71,11 +72,11 @@ namespace NLog.LayoutRenderers
         object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
 
         /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
 
         private string GetStringValue(LogEventInfo logEvent)
         {
-            if (Format != "@")
+            if (Format != MessageTemplates.ValueFormatter.FormatAsJson)
             {
                 object value = GetValue();
                 string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, null));

--- a/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
@@ -43,7 +43,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("gdc")]
     [ThreadSafe]
-    public class GdcLayoutRenderer : LayoutRenderer, IRawValue
+    public class GdcLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
     {
         /// <summary>
         /// Gets or sets the name of the item.
@@ -59,11 +59,7 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Rendering Options' order='50' />
         public string Format { get; set; }
 
-        /// <summary>
-        /// Renders the specified Global Diagnostics Context item and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             object value = GetValue();
@@ -71,10 +67,22 @@ namespace NLog.LayoutRenderers
             builder.AppendFormattedValue(value, Format, formatProvider);
         }
 
-        /// <summary>
-        /// Get raw value.
-        /// </summary>
+        /// <inheritdoc/>
         object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
+
+        /// <inheritdoc/>
+        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
+
+        private string GetStringValue(LogEventInfo logEvent)
+        {
+            if (Format != "@")
+            {
+                object value = GetValue();
+                string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, null));
+                return stringValue;
+            }
+            return null;
+        }
 
         private object GetValue()
         {

--- a/src/NLog/LayoutRenderers/GuidLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GuidLayoutRenderer.cs
@@ -44,22 +44,14 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("guid")]
     [ThreadSafe]
-    public class GuidLayoutRenderer : LayoutRenderer, IRawValue
+    public class GuidLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GuidLayoutRenderer" /> class.
-        /// </summary>
-        public GuidLayoutRenderer()
-        {
-            Format = "N";
-        }
-
         /// <summary>
         /// Gets or sets the GUID format as accepted by Guid.ToString() method.
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue("N")]
-        public string Format { get; set; }
+        public string Format { get; set; } = "N";
 
         /// <summary>
         /// Generate the Guid from the NLog LogEvent (Will be the same for all targets)
@@ -68,21 +60,21 @@ namespace NLog.LayoutRenderers
         [DefaultValue(false)]
         public bool GeneratedFromLogEvent { get; set; }
 
-        /// <summary>
-        /// Get raw value
-        /// </summary>
-        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue(logEvent);
-
-        /// <summary>
-        /// Renders a newly generated GUID string and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            Guid guid;
-            guid = GetValue(logEvent);
-            builder.Append(guid.ToString(Format));
+            builder.Append(GetStringValue(logEvent));
+        }
+
+        /// <inheritdoc/>
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue(logEvent);
+
+        /// <inheritdoc/>
+        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
+
+        private string GetStringValue(LogEventInfo logEvent)
+        {
+            return GetValue(logEvent).ToString(Format);
         }
 
         private Guid GetValue(LogEventInfo logEvent)
@@ -103,7 +95,6 @@ namespace NLog.LayoutRenderers
                 byte j = (byte)((zeroDateTicks >> 8) & 0xFF);
                 byte k = (byte)(zeroDateTicks & 0XFF);
                 guid = new Guid(logEvent.SequenceID, b, c, d, e, f, g, h, i, j, k);
-
             }
             else
             {

--- a/src/NLog/LayoutRenderers/GuidLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GuidLayoutRenderer.cs
@@ -44,7 +44,8 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("guid")]
     [ThreadSafe]
-    public class GuidLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
+    [ThreadAgnostic]
+    public class GuidLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {
         /// <summary>
         /// Gets or sets the GUID format as accepted by Guid.ToString() method.
@@ -70,7 +71,7 @@ namespace NLog.LayoutRenderers
         object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue(logEvent);
 
         /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
 
         private string GetStringValue(LogEventInfo logEvent)
         {

--- a/src/NLog/LayoutRenderers/IdentityLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/IdentityLayoutRenderer.cs
@@ -50,50 +50,35 @@ namespace NLog.LayoutRenderers
     public class IdentityLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="IdentityLayoutRenderer" /> class.
-        /// </summary>
-        public IdentityLayoutRenderer()
-        {
-            Name = true;
-            AuthType = true;
-            IsAuthenticated = true;
-            Separator = ":";
-        }
-
-        /// <summary>
         /// Gets or sets the separator to be used when concatenating 
         /// parts of identity information.
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(":")]
-        public string Separator { get; set; }
+        public string Separator { get; set; } = ":";
 
         /// <summary>
         /// Gets or sets a value indicating whether to render Thread.CurrentPrincipal.Identity.Name.
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(true)]
-        public bool Name { get; set; }
+        public bool Name { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether to render Thread.CurrentPrincipal.Identity.AuthenticationType.
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(true)]
-        public bool AuthType { get; set; }
+        public bool AuthType { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether to render Thread.CurrentPrincipal.Identity.IsAuthenticated.
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(true)]
-        public bool IsAuthenticated { get; set; }
+        public bool IsAuthenticated { get; set; } = true;
 
-        /// <summary>
-        /// Renders the specified identity information and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             IIdentity identity = GetValue();

--- a/src/NLog/LayoutRenderers/IdentityLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/IdentityLayoutRenderer.cs
@@ -47,7 +47,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("identity")]
     [ThreadSafe]
-    public class IdentityLayoutRenderer : LayoutRenderer, IRawValue
+    public class IdentityLayoutRenderer : LayoutRenderer
     {
         /// <summary>
         /// Gets or sets the separator to be used when concatenating 
@@ -108,12 +108,6 @@ namespace NLog.LayoutRenderers
                 }
             }
 
-        }
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetValue();
         }
 
         private static IIdentity GetValue()

--- a/src/NLog/LayoutRenderers/InstallContextLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/InstallContextLayoutRenderer.cs
@@ -44,7 +44,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("install-context")]
     [ThreadSafe]
-    public class InstallContextLayoutRenderer : LayoutRenderer, IRawValue
+    public class InstallContextLayoutRenderer : LayoutRenderer
     {
         /// <summary>
         /// Gets or sets the name of the parameter.
@@ -72,12 +72,6 @@ namespace NLog.LayoutRenderers
         private object GetValue(LogEventInfo logEvent)
         {
             return !logEvent.Properties.TryGetValue(Parameter, out var value) ? null : value;
-        }
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetValue(logEvent);
         }
     }
 }

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -151,7 +151,7 @@ namespace NLog.LayoutRenderers
         }
 
         /// <summary>
-        /// Renders the the value of layout renderer in the context of the specified log event.
+        /// Renders the value of layout renderer in the context of the specified log event.
         /// </summary>
         /// <param name="logEvent">The log event.</param>
         /// <param name="builder">The layout render output is appended to builder</param>
@@ -179,7 +179,7 @@ namespace NLog.LayoutRenderers
         }
 
         /// <summary>
-        /// Renders the specified environmental information and appends it to the specified <see cref="StringBuilder" />.
+        /// Renders the value of layout renderer in the context of the specified log event into <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="logEvent">Logging event.</param>

--- a/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
@@ -45,7 +45,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("level")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class LevelLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
+    public class LevelLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {
         /// <summary>
         /// Gets or sets a value indicating the output format of the level.
@@ -76,7 +76,7 @@ namespace NLog.LayoutRenderers
         object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue(logEvent);
 
         /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent) => Format == LevelFormat.Name ? GetValue(logEvent).ToString() : null;
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => Format == LevelFormat.Name ? GetValue(logEvent).ToString() : null;
 
         private static LogLevel GetValue(LogEventInfo logEvent)
         {

--- a/src/NLog/LayoutRenderers/LoggerNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LoggerNameLayoutRenderer.cs
@@ -44,7 +44,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("logger")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class LoggerNameLayoutRenderer : LayoutRenderer, IRenderString
+    public class LoggerNameLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
         /// <summary>
         /// Gets or sets a value indicating whether to render short logger name (the part after the trailing dot character).
@@ -58,7 +58,7 @@ namespace NLog.LayoutRenderers
         {
             if (ShortName)
             {
-                int lastDot = logEvent.LoggerName?.LastIndexOf('.') ?? -1;
+                int lastDot = TryGetLastDotForShortName(logEvent);
                 if (lastDot >= 0)
                 {
                     builder.Append(logEvent.LoggerName, lastDot + 1, logEvent.LoggerName.Length - lastDot - 1);
@@ -69,17 +69,22 @@ namespace NLog.LayoutRenderers
         }
 
         /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent)
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent)
         {
             if (ShortName)
             {
-                int lastDot = logEvent.LoggerName?.LastIndexOf('.') ?? -1;
+                int lastDot = TryGetLastDotForShortName(logEvent);
                 if (lastDot >= 0)
                 {
                     return logEvent.LoggerName.Substring(lastDot + 1);
                 }
             }
             return logEvent.LoggerName ?? string.Empty;
+        }
+
+        private int TryGetLastDotForShortName(LogEventInfo logEvent)
+        {
+            return logEvent.LoggerName?.LastIndexOf('.') ?? -1;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/LoggerNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LoggerNameLayoutRenderer.cs
@@ -36,6 +36,7 @@ namespace NLog.LayoutRenderers
     using System.ComponentModel;
     using System.Text;
     using NLog.Config;
+    using NLog.Internal;
 
     /// <summary>
     /// The logger name.
@@ -43,7 +44,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("logger")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class LoggerNameLayoutRenderer : LayoutRenderer
+    public class LoggerNameLayoutRenderer : LayoutRenderer, IRenderString
     {
         /// <summary>
         /// Gets or sets a value indicating whether to render short logger name (the part after the trailing dot character).
@@ -52,29 +53,33 @@ namespace NLog.LayoutRenderers
         [DefaultValue(false)]
         public bool ShortName { get; set; }
 
-        /// <summary>
-        /// Renders the logger name and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             if (ShortName)
             {
-                int lastDot = logEvent.LoggerName.LastIndexOf('.');
-                if (lastDot < 0)
-                {
-                    builder.Append(logEvent.LoggerName);
-                }
-                else
+                int lastDot = logEvent.LoggerName?.LastIndexOf('.') ?? -1;
+                if (lastDot >= 0)
                 {
                     builder.Append(logEvent.LoggerName, lastDot + 1, logEvent.LoggerName.Length - lastDot - 1);
+                    return;
                 }
             }
-            else
+            builder.Append(logEvent.LoggerName);
+        }
+
+        /// <inheritdoc/>
+        string IRenderString.GetFormattedString(LogEventInfo logEvent)
+        {
+            if (ShortName)
             {
-                builder.Append(logEvent.LoggerName);
+                int lastDot = logEvent.LoggerName?.LastIndexOf('.') ?? -1;
+                if (lastDot >= 0)
+                {
+                    return logEvent.LoggerName.Substring(lastDot + 1);
+                }
             }
+            return logEvent.LoggerName ?? string.Empty;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/MachineNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MachineNameLayoutRenderer.cs
@@ -48,7 +48,7 @@ namespace NLog.LayoutRenderers
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class MachineNameLayoutRenderer : LayoutRenderer, IRenderString
+    public class MachineNameLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
         internal string MachineName { get; private set; }
 
@@ -83,7 +83,7 @@ namespace NLog.LayoutRenderers
         }
 
         /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent) => MachineName;
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => MachineName;
     }
 }
 

--- a/src/NLog/LayoutRenderers/MachineNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MachineNameLayoutRenderer.cs
@@ -48,13 +48,11 @@ namespace NLog.LayoutRenderers
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class MachineNameLayoutRenderer : LayoutRenderer
+    public class MachineNameLayoutRenderer : LayoutRenderer, IRenderString
     {
         internal string MachineName { get; private set; }
 
-        /// <summary>
-        /// Initializes the layout renderer.
-        /// </summary>
+        /// <inheritdoc/>
         protected override void InitializeLayoutRenderer()
         {
             base.InitializeLayoutRenderer();
@@ -78,15 +76,14 @@ namespace NLog.LayoutRenderers
             }
         }
 
-        /// <summary>
-        /// Renders the machine name and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             builder.Append(MachineName);
         }
+
+        /// <inheritdoc/>
+        string IRenderString.GetFormattedString(LogEventInfo logEvent) => MachineName;
     }
 }
 

--- a/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
@@ -42,7 +42,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("mdc")]
     [ThreadSafe]
-    public class MdcLayoutRenderer : LayoutRenderer, IRawValue
+    public class MdcLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
     {
         /// <summary>
         /// Gets or sets the name of the item.
@@ -58,30 +58,35 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Rendering Options' order='50' />
         public string Format { get; set; }
 
-        /// <summary>
-        /// Renders the specified MDC item and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            //don't use MappedDiagnosticsContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
             var value = GetValue();
             var formatProvider = GetFormatProvider(logEvent, null);
             builder.AppendFormattedValue(value, Format, formatProvider);
         }
 
         /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
+
+        /// <inheritdoc/>
+        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
+
+        private string GetStringValue(LogEventInfo logEvent)
         {
-            return GetValue();
+            if (Format != "@")
+            {
+                object value = GetValue();
+                string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, null));
+                return stringValue;
+            }
+            return null;
         }
 
         private object GetValue()
         {
+            //don't use MappedDiagnosticsContext.Get to ensure we are not locking the Factory (indirect by LogManager.Configuration).
             return MappedDiagnosticsContext.GetObject(Item);
         }
-
-       
     }
 }

--- a/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
@@ -42,7 +42,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("mdc")]
     [ThreadSafe]
-    public class MdcLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
+    public class MdcLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
         /// <summary>
         /// Gets or sets the name of the item.
@@ -66,15 +66,12 @@ namespace NLog.LayoutRenderers
             builder.AppendFormattedValue(value, Format, formatProvider);
         }
 
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
-
         /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
 
         private string GetStringValue(LogEventInfo logEvent)
         {
-            if (Format != "@")
+            if (Format != MessageTemplates.ValueFormatter.FormatAsJson)
             {
                 object value = GetValue();
                 string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, null));

--- a/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
@@ -43,7 +43,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("mdlc")]
     [ThreadSafe]
-    public class MdlcLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
+    public class MdlcLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
         /// <summary>
         /// Gets or sets the name of the item.
@@ -66,16 +66,13 @@ namespace NLog.LayoutRenderers
             var formatProvider = GetFormatProvider(logEvent, null);
             builder.AppendFormattedValue(value, Format, formatProvider);
         }
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
         
         /// <inheritdoc/>
-        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
 
         private string GetStringValue(LogEventInfo logEvent)
         {
-            if (Format != "@")
+            if (Format != MessageTemplates.ValueFormatter.FormatAsJson)
             {
                 object value = GetValue();
                 string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, null));

--- a/src/NLog/LayoutRenderers/PerformanceCounterLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/PerformanceCounterLayoutRenderer.cs
@@ -47,7 +47,7 @@ namespace NLog.LayoutRenderers
     /// The performance counter.
     /// </summary>
     [LayoutRenderer("performancecounter")]
-    public class PerformanceCounterLayoutRenderer : LayoutRenderer, IRawValue
+    public class PerformanceCounterLayoutRenderer : LayoutRenderer
     {
         private PerformanceCounter _perfCounter;
         private CounterSample _prevSample = CounterSample.Empty;
@@ -171,9 +171,6 @@ namespace NLog.LayoutRenderers
             var formatProvider = GetFormatProvider(logEvent, Culture);
             builder.Append(GetValue().ToString(Format, formatProvider));
         }
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
 
         private float GetValue()
         {

--- a/src/NLog/LayoutRenderers/PerformanceCounterLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/PerformanceCounterLayoutRenderer.cs
@@ -91,9 +91,7 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Rendering Options' order='100' />
         public CultureInfo Culture { get; set; }
 
-        /// <summary>
-        /// Initializes the layout renderer.
-        /// </summary>
+        /// <inheritdoc />
         protected override void InitializeLayoutRenderer()
         {
             base.InitializeLayoutRenderer();
@@ -154,9 +152,7 @@ namespace NLog.LayoutRenderers
             return string.Empty;
         }
 
-        /// <summary>
-        /// Closes the layout renderer.
-        /// </summary>
+        /// <inheritdoc />
         protected override void CloseLayoutRenderer()
         {
             base.CloseLayoutRenderer();
@@ -169,11 +165,7 @@ namespace NLog.LayoutRenderers
             _nextSample = CounterSample.Empty;
         }
 
-        /// <summary>
-        /// Renders the specified environment variable and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var formatProvider = GetFormatProvider(logEvent, Culture);
@@ -181,10 +173,7 @@ namespace NLog.LayoutRenderers
         }
 
         /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetValue();
-        }
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
 
         private float GetValue()
         {

--- a/src/NLog/LayoutRenderers/ProcessIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessIdLayoutRenderer.cs
@@ -48,21 +48,14 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class ProcessIdLayoutRenderer : LayoutRenderer, IRawValue
     {
-        /// <summary>
-        /// Renders the current process ID.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             builder.AppendInvariant(GetValue());
         }
 
         /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetValue();
-        }
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
 
         private static int GetValue()
         {

--- a/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
@@ -51,23 +51,14 @@ namespace NLog.LayoutRenderers
     public class ProcessInfoLayoutRenderer : LayoutRenderer, IRawValue
     {
         private Process _process;
-
         private ReflectionHelpers.LateBoundMethod _lateBoundPropertyGet;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ProcessInfoLayoutRenderer" /> class.
-        /// </summary>
-        public ProcessInfoLayoutRenderer()
-        {
-            Property = ProcessInfoProperty.Id;
-        }
 
         /// <summary>
         /// Gets or sets the property to retrieve.
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue("Id"), DefaultParameter]
-        public ProcessInfoProperty Property { get; set; }
+        public ProcessInfoProperty Property { get; set; } = ProcessInfoProperty.Id;
 
         /// <summary>
         /// Gets or sets the format-string to use if the property supports it (Ex. DateTime / TimeSpan / Enum)
@@ -76,9 +67,7 @@ namespace NLog.LayoutRenderers
         [DefaultValue(null)]
         public string Format { get; set; }
 
-        /// <summary>
-        /// Initializes the layout renderer.
-        /// </summary>
+        /// <inheritdoc />
         protected override void InitializeLayoutRenderer()
         {
             base.InitializeLayoutRenderer();
@@ -93,9 +82,7 @@ namespace NLog.LayoutRenderers
             _process = Process.GetCurrentProcess();
         }
 
-        /// <summary>
-        /// Closes the layout renderer.
-        /// </summary>
+        /// <inheritdoc />
         protected override void CloseLayoutRenderer()
         {
             if (_process != null)
@@ -107,32 +94,23 @@ namespace NLog.LayoutRenderers
             base.CloseLayoutRenderer();
         }
 
-        /// <summary>
-        /// Renders the selected process information.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var value = GetValue();
-
             if (value != null)
             {
                 var formatProvider = GetFormatProvider(logEvent);
                 builder.AppendFormattedValue(value, Format, formatProvider);
             }
-
         }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
 
         private object GetValue()
         {
             return _lateBoundPropertyGet?.Invoke(_process, null);
-        }
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetValue();
         }
     }
 }

--- a/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
@@ -48,7 +48,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("processinfo")]
     [ThreadSafe]
-    public class ProcessInfoLayoutRenderer : LayoutRenderer, IRawValue
+    public class ProcessInfoLayoutRenderer : LayoutRenderer
     {
         private Process _process;
         private ReflectionHelpers.LateBoundMethod _lateBoundPropertyGet;
@@ -104,9 +104,6 @@ namespace NLog.LayoutRenderers
                 builder.AppendFormattedValue(value, Format, formatProvider);
             }
         }
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
 
         private object GetValue()
         {

--- a/src/NLog/LayoutRenderers/ProcessTimeLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessTimeLayoutRenderer.cs
@@ -55,11 +55,7 @@ namespace NLog.LayoutRenderers
         [DefaultValue(false)]
         public bool Invariant { get; set; }
 
-        /// <summary>
-        /// Renders the current process running time and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var ts = GetValue(logEvent);
@@ -68,17 +64,11 @@ namespace NLog.LayoutRenderers
         }
 
         /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetValue(logEvent);
-        }
-        
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue(logEvent);
+
         /// <summary>
         /// Write timestamp to builder with format hh:mm:ss:fff
         /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="ts"></param>
-        /// <param name="culture"></param>
         internal static void WritetTimestamp(StringBuilder builder, TimeSpan ts, CultureInfo culture)
         {
             string timeSeparator = ":";

--- a/src/NLog/LayoutRenderers/QueryPerformanceCounterLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/QueryPerformanceCounterLayoutRenderer.cs
@@ -53,23 +53,12 @@ namespace NLog.LayoutRenderers
         private double frequency = 1;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="QueryPerformanceCounterLayoutRenderer" /> class.
-        /// </summary>
-        public QueryPerformanceCounterLayoutRenderer()
-        {
-            Normalize = true;
-            Difference = false;
-            Precision = 4;
-            AlignDecimalPoint = true;
-        }
-
-        /// <summary>
         /// Gets or sets a value indicating whether to normalize the result by subtracting 
         /// it from the result of the first call (so that it's effectively zero-based).
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(true)]
-        public bool Normalize { get; set; }
+        public bool Normalize { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether to output the difference between the result 
@@ -96,18 +85,16 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(4)]
-        public int Precision { get; set; }
+        public int Precision { get; set; } = 4;
 
         /// <summary>
         /// Gets or sets a value indicating whether to align decimal point (emit non-significant zeros).
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(true)]
-        public bool AlignDecimalPoint { get; set; }
+        public bool AlignDecimalPoint { get; set; } = true;
 
-        /// <summary>
-        /// Initializes the layout renderer.
-        /// </summary>
+        /// <inheritdoc />
         protected override void InitializeLayoutRenderer()
         {
             base.InitializeLayoutRenderer();
@@ -131,11 +118,7 @@ namespace NLog.LayoutRenderers
             lastQpcValue = qpcValue;
         }
 
-        /// <summary>
-        /// Renders the ticks value of current time and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var qpcValue = GetValue();

--- a/src/NLog/LayoutRenderers/QueryPerformanceCounterLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/QueryPerformanceCounterLayoutRenderer.cs
@@ -45,7 +45,7 @@ namespace NLog.LayoutRenderers
     /// High precision timer, based on the value returned from QueryPerformanceCounter() optionally converted to seconds.
     /// </summary>
     [LayoutRenderer("qpc")]
-    public class QueryPerformanceCounterLayoutRenderer : LayoutRenderer, IRawValue
+    public class QueryPerformanceCounterLayoutRenderer : LayoutRenderer
     {
         private bool raw;
         private ulong firstQpcValue;
@@ -152,18 +152,6 @@ namespace NLog.LayoutRenderers
 
                 builder.Append(stringValue);
             }
-        }
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            var value = GetValue();
-            if (value.HasValue && Seconds)
-            {
-                return ToSeconds(value.Value);
-            }
-
-            return value;
         }
 
         private double ToSeconds(ulong qpcValue)

--- a/src/NLog/LayoutRenderers/SequenceIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/SequenceIdLayoutRenderer.cs
@@ -45,11 +45,7 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class SequenceIdLayoutRenderer : LayoutRenderer, IRawValue
     {
-        /// <summary>
-        /// Renders the current log sequence ID and appends it to the specified <see cref="StringBuilder"/>.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             builder.AppendInvariant(GetValue(logEvent));

--- a/src/NLog/LayoutRenderers/ThreadIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ThreadIdLayoutRenderer.cs
@@ -43,7 +43,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("threadid")]
     [ThreadSafe]
-    public class ThreadIdLayoutRenderer : LayoutRenderer, IRawValue
+    public class ThreadIdLayoutRenderer : LayoutRenderer
     {
         /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
@@ -51,9 +51,6 @@ namespace NLog.LayoutRenderers
             //no culture needed for ints
             builder.AppendInvariant(GetValue());
         }
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
 
         private static int GetValue()
         {

--- a/src/NLog/LayoutRenderers/ThreadIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ThreadIdLayoutRenderer.cs
@@ -45,11 +45,7 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class ThreadIdLayoutRenderer : LayoutRenderer, IRawValue
     {
-        /// <summary>
-        /// Renders the current thread identifier and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             //no culture needed for ints
@@ -57,10 +53,7 @@ namespace NLog.LayoutRenderers
         }
 
         /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetValue();
-        }
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
 
         private static int GetValue()
         {

--- a/src/NLog/LayoutRenderers/ThreadNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ThreadNameLayoutRenderer.cs
@@ -42,7 +42,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("threadname")]
     [ThreadSafe]
-    public class ThreadNameLayoutRenderer : LayoutRenderer, IRenderString
+    public class ThreadNameLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
         /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
@@ -59,6 +59,6 @@ namespace NLog.LayoutRenderers
 #endif
         }
 
-        string IRenderString.GetFormattedString(LogEventInfo _) => GetStringValue();
+        string IStringValueRenderer.GetFormattedString(LogEventInfo _) => GetStringValue();
     }
 }

--- a/src/NLog/LayoutRenderers/ThreadNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ThreadNameLayoutRenderer.cs
@@ -35,24 +35,30 @@ namespace NLog.LayoutRenderers
 {
     using System.Text;
     using NLog.Config;
+    using NLog.Internal;
 
     /// <summary>
     /// The name of the current thread.
     /// </summary>
     [LayoutRenderer("threadname")]
     [ThreadSafe]
-    public class ThreadNameLayoutRenderer : LayoutRenderer
+    public class ThreadNameLayoutRenderer : LayoutRenderer, IRenderString
     {
-        /// <summary>
-        /// Renders the current thread name and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
+            builder.Append(GetStringValue());
+        }
+
+        private static string GetStringValue()
+        {
 #if !NETSTANDARD1_3
-            builder.Append(System.Threading.Thread.CurrentThread.Name);
+            return System.Threading.Thread.CurrentThread.Name;
+#else
+            return string.Empty;
 #endif
         }
+
+        string IRenderString.GetFormattedString(LogEventInfo _) => GetStringValue();
     }
 }

--- a/src/NLog/LayoutRenderers/TicksLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/TicksLayoutRenderer.cs
@@ -46,11 +46,7 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class TicksLayoutRenderer : LayoutRenderer, IRawValue
     {
-        /// <summary>
-        /// Renders the ticks value of current time and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             //no culture expected here
@@ -58,10 +54,7 @@ namespace NLog.LayoutRenderers
         }
 
         /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetValue(logEvent);
-        }
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue(logEvent);
 
         private static long GetValue(LogEventInfo logEvent)
         {

--- a/src/NLog/LayoutRenderers/TimeLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/TimeLayoutRenderer.cs
@@ -61,11 +61,7 @@ namespace NLog.LayoutRenderers
         [DefaultValue(false)]
         public bool Invariant { get; set; }
 
-        /// <summary>
-        /// Renders time in the 24-h format (HH:mm:ss.mmm) and appends it to the specified <see cref="StringBuilder" />.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var dt = GetValue(logEvent);

--- a/src/NLog/LayoutRenderers/TraceActivityIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/TraceActivityIdLayoutRenderer.cs
@@ -40,33 +40,35 @@ namespace NLog.LayoutRenderers
     using System.Globalization;
     using System.Text;
     using NLog.Config;
-	using NLog.Internal;
+    using NLog.Internal;
 
     /// <summary>
     /// A renderer that puts into log a System.Diagnostics trace correlation id.
     /// </summary>
     [LayoutRenderer("activityid")]
     [ThreadSafe]
-    public class TraceActivityIdLayoutRenderer : LayoutRenderer, IRawValue
+    public class TraceActivityIdLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
     {
-        /// <summary>
-        /// Renders the current trace activity ID.
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
+        /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            builder.Append(GetStringValue());
+        }
+
+        /// <inheritdoc />
+        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
+
+        /// <inheritdoc />
+        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue();
+
+        private static string GetStringValue()
         {
             var activityId = GetValue();
             if (!Guid.Empty.Equals(activityId))
             {
-                builder.Append(activityId.ToString("D", CultureInfo.InvariantCulture));
+                return activityId.ToString("D", CultureInfo.InvariantCulture);
             }
-        }
-
-        /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent)
-        {
-            return GetValue();
+            return string.Empty;
         }
 
         private static Guid GetValue()

--- a/src/NLog/LayoutRenderers/TraceActivityIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/TraceActivityIdLayoutRenderer.cs
@@ -47,7 +47,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("activityid")]
     [ThreadSafe]
-    public class TraceActivityIdLayoutRenderer : LayoutRenderer, IRawValue, IRenderString
+    public class TraceActivityIdLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
         /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
@@ -56,10 +56,7 @@ namespace NLog.LayoutRenderers
         }
 
         /// <inheritdoc />
-        object IRawValue.GetRawValue(LogEventInfo logEvent) => GetValue();
-
-        /// <inheritdoc />
-        string IRenderString.GetFormattedString(LogEventInfo logEvent) => GetStringValue();
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue();
 
         private static string GetStringValue()
         {

--- a/src/NLog/LayoutRenderers/Wrappers/CachedLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/CachedLayoutRendererWrapper.cs
@@ -36,6 +36,7 @@ namespace NLog.LayoutRenderers.Wrappers
     using System;
     using System.ComponentModel;
     using NLog.Config;
+    using NLog.Internal;
     using NLog.Layouts;
 
     /// <summary>
@@ -48,7 +49,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AmbientProperty("Cached")]
     [AmbientProperty("ClearCache")] 
     [ThreadAgnostic]
-    public sealed class CachedLayoutRendererWrapper : WrapperLayoutRendererBase
+    public sealed class CachedLayoutRendererWrapper : WrapperLayoutRendererBase, IStringValueRenderer
     {
         /// <summary>
         /// A value indicating when the cache is cleared.
@@ -148,5 +149,8 @@ namespace NLog.LayoutRenderers.Wrappers
                 return base.RenderInner(logEvent);
             }
         }
+
+        /// <inheritdoc/>
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => Cached ? RenderInner(logEvent) : null;
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
@@ -55,6 +55,13 @@ namespace NLog.LayoutRenderers.Wrappers
         public Layout WhenEmpty { get; set; }
 
         /// <inheritdoc/>
+        protected override void InitializeLayoutRenderer()
+        {
+            base.InitializeLayoutRenderer();
+            WhenEmpty?.Initialize(LoggingConfiguration);
+        }
+
+        /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
             Inner.RenderAppendBuilder(logEvent, builder);

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBase.cs
@@ -58,6 +58,13 @@ namespace NLog.LayoutRenderers.Wrappers
         [DefaultParameter]
         public Layout Inner { get; set; }
 
+        /// <inheritdoc/>
+        protected override void InitializeLayoutRenderer()
+        {
+            base.InitializeLayoutRenderer();
+            Inner?.Initialize(LoggingConfiguration);
+        }
+
         /// <summary>
         /// Renders the inner message, processes it and appends it to the specified <see cref="StringBuilder" />.
         /// </summary>

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -54,7 +54,7 @@ namespace NLog.Layouts
         /// <summary>
         /// Is this layout initialized? See <see cref="Initialize(NLog.Config.LoggingConfiguration)"/>
         /// </summary>
-        private bool _isInitialized;
+        internal bool _isInitialized;
         private bool _scannedForObjects;
 
         /// <summary>

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -56,6 +56,8 @@ namespace NLog.Layouts
     {
         private string _fixedText;
         private string _layoutText;
+        private IRawValue _rawValueRenderer;
+        private IRenderString _stringValueRenderer;
         private readonly ConfigurationItemFactory _configurationItemFactory;
 
         /// <summary>
@@ -128,6 +130,7 @@ namespace NLog.Layouts
                 SetRenderers(renderers, txt);
             }
         }
+
         /// <summary>
         /// Is the message fixed? (no Layout renderers used)
         /// </summary>
@@ -137,6 +140,11 @@ namespace NLog.Layouts
         /// Get the fixed text. Only set when <see cref="IsFixedText"/> is <c>true</c>
         /// </summary>
         public string FixedText => _fixedText;
+
+        /// <summary>
+        /// Is the message a simple formatted string? (Can skip StringBuilder)
+        /// </summary>
+        internal bool IsSimpleString => _stringValueRenderer != null;
 
         /// <summary>
         /// Gets a collection of <see cref="LayoutRenderer"/> objects that make up this layout.
@@ -222,14 +230,28 @@ namespace NLog.Layouts
         {
             Renderers = new ReadOnlyCollection<LayoutRenderer>(renderers);
 
-            if (Renderers.Count == 1 && Renderers[0] is LiteralLayoutRenderer renderer)
+            //todo fixedText = null is also used if the text is fixed, but is a empty renderers not fixed?
+            _fixedText = null;
+            _rawValueRenderer = null;
+            _stringValueRenderer = null;
+
+            if (Renderers.Count == 1)
             {
-                _fixedText = renderer.Text;
-            }
-            else
-            {
-                //todo fixedText = null is also used if the text is fixed, but is a empty renderers not fixed?
-                _fixedText = null;
+                if (Renderers[0] is LiteralLayoutRenderer renderer)
+                {
+                    _fixedText = renderer.Text;
+                }
+                else
+                {
+                    if (Renderers[0] is IRawValue rawValueRendrer)
+                    {
+                        _rawValueRenderer = rawValueRendrer;
+                    }
+                    if (Renderers[0] is IRenderString stringValueRendrer)
+                    {
+                        _stringValueRenderer = stringValueRendrer;
+                    }
+                }
             }
 
             _layoutText = text;
@@ -243,20 +265,53 @@ namespace NLog.Layouts
         /// <inheritdoc />
         public override bool TryGetRawValue(LogEventInfo logEvent, out object rawValue)
         {
-            if (Renderers.Count == 1 && Renderers[0] is IRawValue rawValueLayoutRenderer)
+            if (!ThreadAgnostic || MutableUnsafe)
             {
-                rawValue =  rawValueLayoutRenderer.GetRawValue(logEvent);
-                return true;
+                object cachedValue;
+                if (logEvent.TryGetCachedLayoutValue(this, out cachedValue))
+                {
+                    rawValue = cachedValue?.ToString() ?? string.Empty;
+                    return true;
+                }
+            }
+
+            try
+            {
+                if (_rawValueRenderer != null)
+                {
+                    rawValue = _rawValueRenderer.GetRawValue(logEvent);
+                    return true;
+                }
+
+                if (_stringValueRenderer != null)
+                {
+                    rawValue = _stringValueRenderer.GetFormattedString(logEvent);
+                    if (rawValue != null)
+                        return true;
+                    _stringValueRenderer = null;    // Optimization is not possible
+                }
+            }
+            catch (Exception exception)
+            {
+                //also check IsErrorEnabled, otherwise 'MustBeRethrown' writes it to Error
+
+                //check for performance
+                if (InternalLogger.IsWarnEnabled || InternalLogger.IsErrorEnabled)
+                {
+                    InternalLogger.Warn(exception, "Exception in '{0}.InitializeLayout()'", Renderers.Count > 0 ? Renderers[0].GetType().FullName : null);
+                }
+
+                if (exception.MustBeRethrown())
+                {
+                    throw;
+                }
             }
 
             rawValue = null;
             return false;
         }
 
-
-        /// <summary>
-        /// Initializes the layout.
-        /// </summary>
+        /// <inheritdoc />
         protected override void InitializeLayout()
         {
             for (int i = 0; i < Renderers.Count; i++)
@@ -291,17 +346,38 @@ namespace NLog.Layouts
             PrecalculateBuilderInternal(logEvent, target);
         }
 
-        /// <summary>
-        /// Renders the layout for the specified logging event by invoking layout renderers
-        /// that make up the event.
-        /// </summary>
-        /// <param name="logEvent">The logging event.</param>
-        /// <returns>The rendered layout.</returns>
+        /// <inheritdoc />
         protected override string GetFormattedMessage(LogEventInfo logEvent)
         {
             if (IsFixedText)
             {
                 return _fixedText;
+            }
+
+            if (_stringValueRenderer != null)
+            {
+                try
+                {
+                    string stringValue = _stringValueRenderer.GetFormattedString(logEvent);
+                    if (stringValue != null)
+                        return stringValue;
+
+                    _stringValueRenderer = null;    // Optimization is not possible
+                }
+                catch (Exception exception)
+                {
+                    //also check IsErrorEnabled, otherwise 'MustBeRethrown' writes it to Error
+                    //check for performance
+                    if (InternalLogger.IsWarnEnabled || InternalLogger.IsErrorEnabled)
+                    {
+                        InternalLogger.Warn(exception, "Exception in '{0}.Append()'", _stringValueRenderer.GetType().FullName);
+                    }
+
+                    if (exception.MustBeRethrown())
+                    {
+                        throw;
+                    }
+                }
             }
 
             return RenderAllocateBuilder(logEvent);
@@ -336,12 +412,7 @@ namespace NLog.Layouts
             }
         }
 
-        /// <summary>
-        /// Renders the layout for the specified logging event by invoking layout renderers
-        /// that make up the event.
-        /// </summary>
-        /// <param name="logEvent">The logging event.</param>
-        /// <param name="target"><see cref="StringBuilder"/> for the result</param>
+        /// <inheritdoc />
         protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             if (IsFixedText)

--- a/src/NLog/MessageTemplates/ValueFormatter.cs
+++ b/src/NLog/MessageTemplates/ValueFormatter.cs
@@ -64,6 +64,9 @@ namespace NLog.MessageTemplates
 
         private readonly MruCache<Enum, string> _enumCache = new MruCache<Enum, string>(1500);
 
+        public const string FormatAsJson = "@";
+        public const string FormatAsString = "$";
+
         /// <summary>
         /// Serialization of an object, e.g. JSON and append to <paramref name="builder"/>
         /// </summary>

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -734,7 +734,9 @@ namespace NLog.Targets
             {
                 SimpleLayout simpleLayout = layout as SimpleLayout;
                 if (simpleLayout != null && simpleLayout.IsFixedText)
+                {
                     return simpleLayout.Render(logEvent);
+                }
 
                 if (!layout.ThreadAgnostic || layout.MutableUnsafe)
                 {
@@ -742,6 +744,11 @@ namespace NLog.Targets
                     {
                         return value?.ToString() ?? string.Empty;
                     }
+                }
+
+                if (simpleLayout != null && simpleLayout.IsSimpleString)
+                {
+                    return simpleLayout.Render(logEvent);
                 }
 
                 using (var localTarget = ReusableLayoutBuilder.Allocate())

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -746,7 +746,7 @@ namespace NLog.Targets
                     }
                 }
 
-                if (simpleLayout != null && simpleLayout.IsSimpleString)
+                if (simpleLayout != null && simpleLayout.IsSimpleStringText)
                 {
                     return simpleLayout.Render(logEvent);
                 }

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
@@ -162,7 +162,7 @@ namespace NLog.UnitTests.Layouts
         public void TryGetRawValue_SingleLayoutRender_ShouldGiveRawValue()
         {
             // Arrange
-            SimpleLayout l = "${threadid}";
+            SimpleLayout l = "${sequenceid}";
             var logEventInfo = LogEventInfo.CreateNullEvent();
 
             // Act
@@ -173,11 +173,12 @@ namespace NLog.UnitTests.Layouts
             Assert.IsType<int>(value);
             Assert.True((int)value >= 0, "(int)value >= 0");
         }
+
         [Fact]
         public void TryGetRawValue_MultipleLayoutRender_ShouldGiveNullRawValue()
         {
             // Arrange
-            SimpleLayout l = "${threadid} ";
+            SimpleLayout l = "${sequenceid} ";
             var logEventInfo = LogEventInfo.CreateNullEvent();
 
             // Act
@@ -188,7 +189,41 @@ namespace NLog.UnitTests.Layouts
             Assert.Null(value);
         }
 
+        [Fact]
+        public void TryGetRawValue_MutableLayoutRender_ShouldGiveNullRawValue()
+        {
+            // Arrange
+            SimpleLayout l = "${event-properties:builder}";
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            logEventInfo.Properties["builder"] = new StringBuilder("mybuilder");
+            l.Precalculate(logEventInfo);
 
+            // Act
+            var success = l.TryGetRawValue(logEventInfo, out var value);
+
+            // Assert
+            Assert.False(success);
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void TryGetRawValue_ImmutableLayoutRender_ShouldGiveRawValue()
+        {
+            // Arrange
+            SimpleLayout l = "${event-properties:correlationid}";
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            var correlationId = Guid.NewGuid();
+            logEventInfo.Properties["correlationid"] = correlationId;
+            l.Precalculate(logEventInfo);
+
+            // Act
+            var success = l.TryGetRawValue(logEventInfo, out var value);
+
+            // Assert
+            Assert.True(success, "success");
+            Assert.IsType<Guid>(value);
+            Assert.Equal(correlationId, value);
+        }
 
         public class ThrowsExceptionRenderer : LayoutRenderer
         {


### PR DESCRIPTION
SimpleLayout with single LayoutRenderer can sometimes convert directly to string without first writing to StringBuilder and then allocating new string:

The most important once are ${logger} and ${level} but there are also settings lookups ${gdc}, ${mdc}, ${mdlc}:

- LevelLayoutRenderer
- LoggerNameLayoutRenderer
- EventPropertiesLayoutRenderer
- GdcLayoutRenderer
- MdlcLayoutRenderer
- MdcLayoutRenderer

Others also included in the optimization:

- TraceActivityIdLayoutRenderer
- ThreadNameLayoutRenderer
- MachineNameLayoutRenderer
- GuidLayoutRenderer
- EnvironmentLayoutRenderer
- DateLayoutRenderer
- CurrentDirLayoutRenderer
- CallSiteFileNameLayoutRenderer

This optimizes Target.RenderLogEvent and Layout.Render for simple layouts that just contains a single dynamic value (based on the above layoutrenderers)