### PR TITLE
ExceptionLayoutRenderer - Skip "One or more errors occurred" for a AggregateException with a single exception

### DIFF
--- a/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
@@ -250,6 +250,9 @@ namespace NLog.UnitTests.LayoutRenderers
 
             logger.Debug(ex, "Foo");
             AssertDebugLastMessage("debug", "Foo," + ex.ToString());
+
+            logger.Debug(ex);
+            AssertDebugLastMessage("debug", ex.ToString());
         }
     }
 }


### PR DESCRIPTION
Skip AggregateException prefix "One or more errors occurred", when single InnerException.

Also improve logging when using `WithException` and the message-template is "{0}" and parameter is the same exception.