### PR TITLE
JsonSerializer - Use ReferenceEquals instead of object.Equals

### DIFF
--- a/src/NLog/MessageTemplates/ValueFormatter.cs
+++ b/src/NLog/MessageTemplates/ValueFormatter.cs
@@ -33,6 +33,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Text;
 using NLog.Config;
 using NLog.Internal;
@@ -50,13 +51,14 @@ namespace NLog.MessageTemplates
             set => _instance = value ?? new ValueFormatter();
         }
         private static IValueFormatter _instance;
+        private static readonly IEqualityComparer<object> _referenceEqualsComparer = SingleItemOptimizedHashSet<object>.ReferenceEqualityComparer.Default;
 
         /// <summary>Singleton</summary>
         private ValueFormatter()
         {
         }
 
-        private const int MaxRecursionDepth = 10;
+        private const int MaxRecursionDepth = 2;
         private const int MaxValueLength = 512 * 1024;
         private const string LiteralFormatSymbol = "l";
 
@@ -230,13 +232,13 @@ namespace NLog.MessageTemplates
             IDictionary dictionary = collection as IDictionary;
             if (dictionary != null)
             {
-                using (new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(dictionary, ref objectsInPath, true))
+                using (new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(dictionary, ref objectsInPath, true, _referenceEqualsComparer))
                 {
                     return SerializeDictionaryObject(dictionary, format, formatProvider, builder, objectsInPath, depth);
                 }
             }
 
-            using (new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(collection, ref objectsInPath, true))
+            using (new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(collection, ref objectsInPath, true, _referenceEqualsComparer))
             {
                 return SerializeCollectionObject(collection, format, formatProvider, builder, objectsInPath, depth);
             }

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -60,6 +60,8 @@ namespace NLog.Targets
 
         private static readonly DefaultJsonSerializer instance;
 
+        private static readonly IEqualityComparer<object> _referenceEqualsComparer = SingleItemOptimizedHashSet<object>.ReferenceEqualityComparer.Default;
+
         /// <summary>
         /// Singleton instance of the serializer.
         /// </summary>
@@ -237,7 +239,7 @@ namespace NLog.Targets
 
         private static SingleItemOptimizedHashSet<object>.SingleItemScopedInsert StartScope(ref SingleItemOptimizedHashSet<object> objectsInPath, object value)
         {
-            return new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(value, ref objectsInPath, true);
+            return new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(value, ref objectsInPath, true, _referenceEqualsComparer);
         }
 
         private bool SerializeWithFormatProvider(object value, StringBuilder destination, JsonSerializeOptions options, IFormattable formattable, string format, bool hasFormat)
@@ -452,7 +454,7 @@ namespace NLog.Targets
                         options = instance._exceptionSerializeOptions;
                     }
 
-                    using (new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(value, ref objectsInPath, false))
+                    using (new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(value, ref objectsInPath, false, _referenceEqualsComparer))
                     {
                         return SerializeProperties(value, destination, options, objectsInPath, depth);
                     }

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTests.cs
@@ -587,6 +587,16 @@ namespace NLog.UnitTests.Targets
             {
                 return GetEnumerator();
             }
+
+            public override bool Equals(object obj)
+            {
+                throw new Exception("object.Equals should never be called");
+            }
+
+            public override int GetHashCode()
+            {
+                throw new Exception("GetHashCode should never be called");
+            }
         }
     }
 }


### PR DESCRIPTION
When checking for cyclic object loops. Resolves #2980