### PR TITLE
LogBuilder - Fluent assignment of message-template after properties

### DIFF
--- a/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
@@ -181,10 +181,11 @@ namespace NLog.LayoutRenderers
 
         private IDictionary<object, object> GetProperties(LogEventInfo logEvent)
         {
+            var properties = logEvent.Properties;
 #if NET4_5
             if (IncludeCallerInformation)
             {
-                return logEvent.Properties;
+                return properties;
             }
 
             if (logEvent.CallSiteInformation != null)
@@ -192,16 +193,16 @@ namespace NLog.LayoutRenderers
                 // TODO NLog ver. 5 - Remove these properties. Instead output artificial properties, extracted from LogEventInfo.CallSiteInformation
                 foreach (string propertyName in CallerInformationAttributeNames)
                 {
-                    if (logEvent.Properties.ContainsKey(propertyName))
+                    if (properties.ContainsKey(propertyName))
                     {
-                        return logEvent.Properties.Where(p => !CallerInformationAttributeNames.Contains(p.Key)).ToDictionary(p => p.Key, p => p.Value);
+                        return properties.Where(p => !CallerInformationAttributeNames.Contains(p.Key)).ToDictionary(p => p.Key, p => p.Value);
                     }
                 }
             }
 
-            return logEvent.Properties;
+            return properties;
 #else
-            return logEvent.Properties;
+            return properties;
 #endif
         }
     }

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -737,9 +737,10 @@ namespace NLog
 
         private bool ResetMessageTemplateParameters()
         {
-            if (_properties != null && HasMessageTemplateParameters)
+            if (_properties != null)
             {
-                _properties.MessageProperties = null;
+                if (HasMessageTemplateParameters)
+                    _properties.MessageProperties = null;
                 return true;
             }
             return false;

--- a/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
+++ b/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
@@ -493,6 +493,15 @@ namespace NLog.UnitTests.Fluent
             AssertDebugLastMessage("t2", "Message with 4,1 4,001 31-12-2016 00:00:00 True");
         }
 
+        [Fact]
+        public void LogBuilder_Structured_Logging_Test()
+        {
+            var logEvent = _logger.Info().Property("Property1Key", "Property1Value").Message("{@message}", "My custom message").LogEventInfo;
+            Assert.NotEmpty(logEvent.Properties);
+            Assert.Contains("message", logEvent.Properties.Keys);
+            Assert.Contains("Property1Key", logEvent.Properties.Keys);
+        }
+
         ///<remarks>
         /// func because 1 logbuilder creates 1 message
         /// 


### PR DESCRIPTION
Replaces #2963 and resolves #2965, which is also reported here:

https://stackoverflow.com/questions/52819710/nlog-changes-behaviour-depending-on-logger-priority