### PR TITLE
Ignore DateArchive_UsesDateFromCurrentTimeSource on Travis with NetCore

### DIFF
--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -1290,6 +1290,14 @@ namespace NLog.UnitTests.Targets
         [MemberData(nameof(DateArchive_UsesDateFromCurrentTimeSource_TestParameters))]
         public void DateArchive_UsesDateFromCurrentTimeSource(DateTimeKind timeKind, bool includeDateInLogFilePath, bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool includeSequenceInArchive, bool forceManaged, bool forceMutexConcurrentWrites)
         {
+#if NETSTANDARD
+            if (IsTravis())
+            {
+                Console.WriteLine("[SKIP] FileTargetTests.DateArchive_UsesDateFromCurrentTimeSource because SetLastWriteTime is not working on Travis");
+                return;
+            }
+#endif
+
             const string archiveDateFormat = "yyyyMMdd";
             const int maxArchiveFiles = 3;
 


### PR DESCRIPTION
@304NotModified The first PR required for the master to build again. (on Travis)