### PR TITLE
NullAppender - Added missing SecuritySafeCritical

### DIFF
--- a/src/NLog/Internal/FileAppenders/NullAppender.cs
+++ b/src/NLog/Internal/FileAppenders/NullAppender.cs
@@ -31,15 +31,17 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-
 namespace NLog.Internal.FileAppenders
 {
+    using System;
+    using System.Security;
+
     /// <summary>
     /// Appender used to discard data for the FileTarget.
     /// Used mostly for testing entire stack except the actual writing to disk.
     /// Throws away all data.
     /// </summary>
+    [SecuritySafeCritical]
     internal class NullAppender : BaseFileAppender
     {
         public static readonly IFileAppenderFactory TheFactory = new Factory();

--- a/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/UnixMultiProcessFileAppender.cs
@@ -39,6 +39,7 @@ namespace NLog.Internal.FileAppenders
     using System.Collections;
     using System.Collections.Specialized;
     using System.IO;
+    using System.Security;
     using System.Text;
     using System.Threading;
     using System.Xml;
@@ -60,6 +61,7 @@ namespace NLog.Internal.FileAppenders
     /// processes are trying to write to the same file, because setting the file
     /// pointer to the end of the file and appending can be made one operation.
     /// </remarks>
+    [SecuritySafeCritical]
     internal class UnixMultiProcessFileAppender : BaseMutexFileAppender
     {
         private UnixStream _file;


### PR DESCRIPTION
Merges  #2926 to master for NLog 4.5.11