### PR TITLE
LogBuilder - Support Fluent API where message-template (Fix bug)

### DIFF
--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -741,7 +741,8 @@ namespace NLog
             {
                 if (HasMessageTemplateParameters)
                     _properties.MessageProperties = null;
-                return true;
+
+                return _properties.MessageProperties.Count == 0;
             }
             return false;
         }


### PR DESCRIPTION
Fixes bug introduced with #2985. It caused custom MessageTemplate-parameters to be reset wrongly (Ex. from Microsoft Extension Logging).

See also https://ci.appveyor.com/project/nlog/nlog/builds/20063165