### PR TITLE
Improve EventLogTarget installation logic - handle MaximumKilobytes for apps without elevated privileges

### DIFF
--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -505,29 +505,21 @@ namespace NLog.Targets
         /// The implementation of <see cref="IEventLogStaticWrapper"/>, that uses Windows event log through <see cref="EventLog"/> static methods.
         /// </summary>
         /// <remarks>
-        /// <c>System.Lazy{T}</c> is not present in .net35, so using a nested constructor for the singleton implementation.
+        /// Details on the singleton implementation: http://csharpindepth.com/Articles/General/Singleton.aspx#cctor.
         /// </remarks>
         protected internal sealed class EventLogStaticWrapper : IEventLogStaticWrapper
         {
             #region Singleton implementation
+
+            // Explicit static constructor to tell C# compiler not to mark type as beforefieldinit.
+            static EventLogStaticWrapper() { }
 
             private EventLogStaticWrapper() { }
 
             /// <summary>
             /// Gets the singleton instance of <see cref="EventLogStaticWrapper"/>.
             /// </summary>
-            public static EventLogStaticWrapper Instance => Nested.Instance;
-
-            // ReSharper disable once ClassNeverInstantiated.Local
-            private class Nested
-            {
-                // Explicit static constructor to tell C# compiler not to mark type as beforefieldinit
-                static Nested()
-                {
-                }
-
-                internal static readonly EventLogStaticWrapper Instance = new EventLogStaticWrapper();
-            }
+            public static EventLogStaticWrapper Instance { get; } = new EventLogStaticWrapper();
 
             #endregion Singleton implementation
 

--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -99,6 +99,16 @@ namespace NLog.Targets
         /// <summary>
         /// Initializes a new instance of the <see cref="EventLogTarget"/> class.
         /// </summary>
+        /// <param name="appDomain"><see cref="IAppDomain"/>.<see cref="IAppDomain.FriendlyName"/> to be used as Source.</param>
+        [Obsolete("This constructor will be removed in NLog 5. Marked obsolete on NLog 4.6")]
+        public EventLogTarget(IAppDomain appDomain)
+            : this(null, appDomain)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventLogTarget"/> class.
+        /// </summary>
         internal EventLogTarget(IEventLogWrapper eventLogWrapper, IAppDomain appDomain)
         {
             _eventLogWrapper = eventLogWrapper ?? new EventLogWrapper();

--- a/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
@@ -115,6 +115,106 @@ namespace NLog.UnitTests.Targets
         }
 
         [Theory]
+        [InlineData(0)] // Is multiple of 64, but less than the min value of 64
+        [InlineData(65)] // Isn't multiple of 64
+        [InlineData(4194304)] // Is multiple of 64, but bigger than the max value of 4194240
+        public void Configuration_ShouldThrowException_WhenMaxKilobytesIsInvalid(long? maxKilobytes)
+        {
+            string configrationText = $@"
+            <nlog ThrowExceptions='true'>
+                <targets>
+                    <target type='EventLog' name='eventLog1' layout='${{message}}' maxKilobytes='{maxKilobytes}' />
+                </targets>
+                <rules>
+                      <logger name='*' writeTo='eventLog1' />
+                </rules>
+            </nlog>";
+
+            NLogConfigurationException ex = Assert.Throws<NLogConfigurationException>(() => XmlLoggingConfiguration.CreateFromXmlString(configrationText));
+            Assert.Equal("MaxKilobytes must be a multiple of 64, and between 64 and 4194240", ex.InnerException.InnerException.Message);
+        }
+
+        [Theory]
+        [InlineData(0)] // Is multiple of 64, but less than the min value of 64
+        [InlineData(65)] // Isn't multiple of 64
+        [InlineData(4194304)] // Is multiple of 64, but bigger than the max value of 4194240
+        public void MaxKilobytes_ShouldThrowException_WhenMaxKilobytesIsInvalid(long? maxKilobytes)
+        {
+            ArgumentException ex = Assert.Throws<ArgumentException>(() =>
+            {
+                var target = new EventLogTarget();
+                target.MaxKilobytes = maxKilobytes;
+            });
+
+            Assert.Equal("MaxKilobytes must be a multiple of 64, and between 64 and 4194240", ex.Message);
+        }
+
+        [Theory]
+        // 'null' case is omitted, as it isn't a valid value for Int64 XML property.
+        [InlineData(64)] // Min value
+        [InlineData(4194240)] // Max value
+        [InlineData(16384)] // Acceptable value
+        public void ConfigurationMaxKilobytes_ShouldBeAsSpecified_WhenMaxKilobytesIsValid(long? maxKilobytes)
+        {
+            var expectedMaxKilobytes = maxKilobytes;
+
+            string configrationText = $@"
+            <nlog ThrowExceptions='true'>
+                <targets>
+                    <target type='EventLog' name='eventLog1' layout='${{message}}' maxKilobytes='{maxKilobytes}' />
+                </targets>
+                <rules>
+                      <logger name='*' writeTo='eventLog1' />
+                </rules>
+            </nlog>";
+            LoggingConfiguration configuration = XmlLoggingConfiguration.CreateFromXmlString(configrationText);
+
+            var eventLog1 = configuration.FindTargetByName<EventLogTarget>("eventLog1");
+            Assert.Equal(expectedMaxKilobytes, eventLog1.MaxKilobytes);
+        }
+
+        [Theory]
+        [InlineData(null)] // A possible value, that should not change anything
+        [InlineData(64)] // Min value
+        [InlineData(4194240)] // Max value
+        [InlineData(16384)] // Acceptable value
+        public void MaxKilobytes_ShouldBeAsSpecified_WhenValueIsValid(long? maxKilobytes)
+        {
+            var expectedMaxKilobytes = maxKilobytes;
+
+            var target = new EventLogTarget();
+            target.MaxKilobytes = maxKilobytes;
+
+            Assert.Equal(expectedMaxKilobytes, target.MaxKilobytes);
+        }
+
+        [Theory]
+        [InlineData(32768, 16384, 32768)] // Should set MaxKilobytes when value is set and valid
+        [InlineData(16384, 32768, 32768)] // Should not change MaxKilobytes when initial MaximumKilobytes is bigger
+        [InlineData(null, EventLogInstanceStub.MaxKBytesDefValue, EventLogInstanceStub.MaxKBytesDefValue)] // Should not change MaxKilobytes when the value is null
+        public void ShouldSetMaxKilobytes_WhenNeeded(long? newValue, long initialValue, long expectedValue)
+        {
+            var target = CreateEventLogTarget<EventLogTarget>("NLog.UnitTests" + Guid.NewGuid().ToString("N"), EventLogTargetOverflowAction.Truncate, 16384);
+            var eventLogInstanceStub = new EventLogInstanceStub(target.Log, target.MachineName, target.GetFixedSource()) { MaximumKilobytes = initialValue };
+            var eventLogStaticMock = new EventLogStaticMock(
+                sourceExistsFunction: (source, machineName) => false,
+                deleteEventSourceFunction: (source, machineName) => { },
+                logNameFromSourceNameFunction: (source, machineName) => target.Log,
+                createEventSourceFunction: (sourceData) => { },
+                eventLogInstances: new Dictionary<string, EventLogTarget.IEventLogInstanceWrapper>
+                {
+                    {target.Log, eventLogInstanceStub}
+                });
+
+            target.EventLogStaticMethods = eventLogStaticMock;
+
+            target.MaxKilobytes = newValue;
+            target.Install(new InstallationContext());
+
+            Assert.Equal(expectedValue, eventLogInstanceStub.MaximumKilobytes);
+        }
+
+        [Theory]
         [InlineData(0)]
         [InlineData(-1)]
         public void ShouldThrowException_WhenMaxMessageLengthSetNegativeOrZero(int maxMessageLength)
@@ -128,156 +228,54 @@ namespace NLog.UnitTests.Targets
             Assert.Equal("MaxMessageLength cannot be zero or negative.", ex.Message);
         }
 
-
-        private void AssertMessageAndLogLevelForTruncatedMessages(LogLevel loglevel, EventLogEntryType expectedEventLogEntryType, string expectedMessage, Layout entryTypeLayout)
+        [Theory]
+        [InlineData(0, EventLogEntryType.Information, "AtInformationLevel_WhenNLogLevelIsTrace", null)]
+        [InlineData(1, EventLogEntryType.Information, "AtInformationLevel_WhenNLogLevelIsDebug", null)]
+        [InlineData(2, EventLogEntryType.Information, "AtInformationLevel_WhenNLogLevelIsInfo", null)]
+        [InlineData(3, EventLogEntryType.Warning, "AtWarningLevel_WhenNLogLevelIsWarn", null)]
+        [InlineData(4, EventLogEntryType.Error, "AtErrorLevel_WhenNLogLevelIsError", null)]
+        [InlineData(5, EventLogEntryType.Error, "AtErrorLevel_WhenNLogLevelIsFatal", null)]
+        [InlineData(3, EventLogEntryType.SuccessAudit, "AtSuccessAuditLevel_WhenEntryTypeLayoutSpecifiedAsSuccessAudit", "SuccessAudit")]
+        [InlineData(3, EventLogEntryType.SuccessAudit, "AtSuccessAuditLevel_WhenEntryTypeLayoutSpecifiedAsSuccessAudit_Uppercase", "SUCCESSAUDIT")]
+        [InlineData(1, EventLogEntryType.FailureAudit, "AtFailureAuditLevel_WhenEntryTypeLayoutSpecifiedAsFailureAudit", "FailureAudit")]
+        [InlineData(1, EventLogEntryType.Error, "AtErrorLevel_WhenEntryTypeLayoutSpecifiedAsError", "error")]
+        [InlineData(3, EventLogEntryType.Warning, "AtSpecifiedNLogLevel_WhenWrongEntryTypeLayoutSupplied", "fallback to auto determined")]
+        public void TruncatedMessagesShouldBeWrittenAtCorrenpondingNLogLevel(int logLevelOrdinal, EventLogEntryType expectedEventLogEntryType, string expectedMessage, string layoutString)
         {
-            var eventRecords = WriteWithMock(loglevel, expectedEventLogEntryType, expectedMessage, entryTypeLayout, EventLogTargetOverflowAction.Truncate).ToList();
+            LogLevel logLevel = LogLevel.FromOrdinal(logLevelOrdinal);
+            Layout entryTypeLayout = layoutString != null ? new SimpleLayout(layoutString) : null;
+
+            var eventRecords = WriteWithMock(logLevel, expectedEventLogEntryType, expectedMessage, entryTypeLayout, EventLogTargetOverflowAction.Truncate).ToList();
 
             Assert.Single(eventRecords);
             AssertWrittenMessage(eventRecords, expectedMessage);
         }
 
-        [Fact]
-        public void TruncatedMessagesShouldBeWrittenAtInformationLevel_WhenNLogLevelIsTrace()
+        [Theory]
+        [InlineData(0, EventLogEntryType.Information, null)] // AtInformationLevel_WhenNLogLevelIsTrace
+        [InlineData(1, EventLogEntryType.Information, null)] // AtInformationLevel_WhenNLogLevelIsDebug
+        [InlineData(2, EventLogEntryType.Information, null)] // AtInformationLevel_WhenNLogLevelIsInfo
+        [InlineData(3, EventLogEntryType.Warning, null)] // AtWarningLevel_WhenNLogLevelIsWarn
+        [InlineData(4, EventLogEntryType.Error, null)] // AtErrorLevel_WhenNLogLevelIsError
+        [InlineData(5, EventLogEntryType.Error, null)] // AtErrorLevel_WhenNLogLevelIsFatal
+        [InlineData(1, EventLogEntryType.SuccessAudit, "SuccessAudit")] // AtSuccessAuditLevel_WhenEntryTypeLayoutSpecifiedAsSuccessAudit
+        [InlineData(1, EventLogEntryType.FailureAudit, "FailureAudit")] // AtFailureLevel_WhenEntryTypeLayoutSpecifiedAsFailureAudit
+        [InlineData(1, EventLogEntryType.Error, "error")] // AtErrorLevel_WhenEntryTypeLayoutSpecifiedAsError
+        [InlineData(2, EventLogEntryType.Information, "wrong entry type level")] // AtSpecifiedNLogLevel_WhenWrongEntryTypeLayoutSupplied
+        public void SplitMessagesShouldBeWrittenAtCorrenpondingNLogLevel(int logLevelOrdinal, EventLogEntryType expectedEventLogEntryType, string layoutString)
         {
-            AssertMessageAndLogLevelForTruncatedMessages(LogLevel.Trace, EventLogEntryType.Information, "TruncatedMessagesShouldBeWrittenAtInformationLevel_WhenNLogLevelIsTrace", null);
-        }
+            LogLevel logLevel = LogLevel.FromOrdinal(logLevelOrdinal);
+            Layout entryTypeLayout = layoutString != null ? new SimpleLayout(layoutString) : null;
 
-        [Fact]
-        public void TruncatedMessagesShouldBeWrittenAtInformationLevel_WhenNLogLevelIsDebug()
-        {
-            AssertMessageAndLogLevelForTruncatedMessages(LogLevel.Debug, EventLogEntryType.Information, "TruncatedMessagesShouldBeWrittenAtInformationLevel_WhenNLogLevelIsDebug", null);
-        }
-
-        [Fact]
-        public void TruncatedMessagesShouldBeWrittenAtInformationLevel_WhenNLogLevelIsInfo()
-        {
-            AssertMessageAndLogLevelForTruncatedMessages(LogLevel.Info, EventLogEntryType.Information, "TruncatedMessagesShouldBeWrittenAtInformationLevel_WhenNLogLevelIsInfo", null);
-        }
-
-        [Fact]
-        public void TruncatedMessagesShouldBeWrittenAtWarningLevel_WhenNLogLevelIsWarn()
-        {
-            AssertMessageAndLogLevelForTruncatedMessages(LogLevel.Warn, EventLogEntryType.Warning, "TruncatedMessagesShouldBeWrittenAtWarningLevel_WhenNLogLevelIsWarn", null);
-        }
-
-        [Fact]
-        public void TruncatedMessagesShouldBeWrittenAtErrorLevel_WhenNLogLevelIsError()
-        {
-            AssertMessageAndLogLevelForTruncatedMessages(LogLevel.Error, EventLogEntryType.Error, "TruncatedMessagesShouldBeWrittenAtErrorLevel_WhenNLogLevelIsError", null);
-        }
-
-        [Fact]
-        public void TruncatedMessagesShouldBeWrittenAtErrorLevel_WhenNLogLevelIsFatal()
-        {
-            AssertMessageAndLogLevelForTruncatedMessages(LogLevel.Fatal, EventLogEntryType.Error, "TruncatedMessagesShouldBeWrittenAtErrorLevel_WhenNLogLevelIsFatal", null);
-        }
-
-        [Fact]
-        public void TruncatedMessagesShouldBeWrittenAtSuccessAuditLevel_WhenEntryTypeLayoutSpecifiedAsSuccessAudit()
-        {
-            AssertMessageAndLogLevelForTruncatedMessages(LogLevel.Warn, EventLogEntryType.SuccessAudit, "TruncatedMessagesShouldBeWrittenAtSuccessAuditLevel_WhenEntryTypeLayoutSpecifiedAsSuccessAudit", new SimpleLayout("SuccessAudit"));
-        }
-
-        [Fact]
-        public void TruncatedMessagesShouldBeWrittenAtSuccessAuditLevel_WhenEntryTypeLayoutSpecifiedAsSuccessAudit_Uppercase()
-        {
-            AssertMessageAndLogLevelForTruncatedMessages(LogLevel.Warn, EventLogEntryType.SuccessAudit, "TruncatedMessagesShouldBeWrittenAtSuccessAuditLevel_WhenEntryTypeLayoutSpecifiedAsSuccessAudit_Uppercase", new SimpleLayout("SUCCESSAUDIT"));
-        }
-
-        [Fact]
-        public void TruncatedMessagesShouldBeWrittenAtFailureAuditLevel_WhenEntryTypeLayoutSpecifiedAsFailureAudit()
-        {
-            AssertMessageAndLogLevelForTruncatedMessages(LogLevel.Debug, EventLogEntryType.FailureAudit, "TruncatedMessagesShouldBeWrittenAtFailureAuditLevel_WhenEntryTypeLayoutSpecifiedAsFailureAudit", new SimpleLayout("FailureAudit"));
-        }
-
-        [Fact]
-        public void TruncatedMessagesShouldBeWrittenAtErrorLevel_WhenEntryTypeLayoutSpecifiedAsError()
-        {
-            AssertMessageAndLogLevelForTruncatedMessages(LogLevel.Debug, EventLogEntryType.Error, "TruncatedMessagesShouldBeWrittenAtErrorLevel_WhenEntryTypeLayoutSpecifiedAsError", new SimpleLayout("error"));
-        }
-
-        [Fact]
-        public void TruncatedMessagesShouldBeWrittenAtSpecifiedNLogLevel_WhenWrongEntryTypeLayoutSupplied()
-        {
-            AssertMessageAndLogLevelForTruncatedMessages(LogLevel.Warn, EventLogEntryType.Warning, "TruncatedMessagesShouldBeWrittenAtSpecifiedNLogLevel_WhenWrongEntryTypeLayoutSupplied", new SimpleLayout("fallback to auto determined"));
-        }
-
-
-
-        private void AssertMessageCountAndLogLevelForSplittedMessages(LogLevel loglevel, EventLogEntryType expectedEventLogEntryType, Layout entryTypeLayout)
-        {
             const int maxMessageLength = 16384;
             const int expectedEntryCount = 2;
             string messagePart1 = string.Join("", Enumerable.Repeat("l", maxMessageLength));
-            string messagePart2 = "this part must be splitted";
+            string messagePart2 = "this part must be split";
             string testMessage = messagePart1 + messagePart2;
-            var entries = WriteWithMock(loglevel, expectedEventLogEntryType, testMessage, entryTypeLayout, EventLogTargetOverflowAction.Split, maxMessageLength).ToList();
+            var entries = WriteWithMock(logLevel, expectedEventLogEntryType, testMessage, entryTypeLayout, EventLogTargetOverflowAction.Split, maxMessageLength).ToList();
 
             Assert.Equal(expectedEntryCount, entries.Count);
         }
-
-        [Fact]
-        public void SplittedMessagesShouldBeWrittenAtInformationLevel_WhenNLogLevelIsTrace()
-        {
-            AssertMessageCountAndLogLevelForSplittedMessages(LogLevel.Trace, EventLogEntryType.Information, null);
-        }
-
-        [Fact]
-        public void SplittedMessagesShouldBeWrittenAtInformationLevel_WhenNLogLevelIsDebug()
-        {
-            AssertMessageCountAndLogLevelForSplittedMessages(LogLevel.Debug, EventLogEntryType.Information, null);
-        }
-
-        [Fact]
-        public void SplittedMessagesShouldBeWrittenAtInformationLevel_WhenNLogLevelIsInfo()
-        {
-            AssertMessageCountAndLogLevelForSplittedMessages(LogLevel.Info, EventLogEntryType.Information, null);
-        }
-
-        [Fact]
-        public void SplittedMessagesShouldBeWrittenAtWarningLevel_WhenNLogLevelIsWarn()
-        {
-            AssertMessageCountAndLogLevelForSplittedMessages(LogLevel.Warn, EventLogEntryType.Warning, null);
-        }
-
-        [Fact]
-        public void SplittedMessagesShouldBeWrittenAtErrorLevel_WhenNLogLevelIsError()
-        {
-            AssertMessageCountAndLogLevelForSplittedMessages(LogLevel.Error, EventLogEntryType.Error, null);
-        }
-
-        [Fact]
-        public void SplittedMessagesShouldBeWrittenAtErrorLevel_WhenNLogLevelIsFatal()
-        {
-            AssertMessageCountAndLogLevelForSplittedMessages(LogLevel.Fatal, EventLogEntryType.Error, null);
-        }
-
-        [Fact]
-        public void SplittedMessagesShouldBeWrittenAtSuccessAuditLevel_WhenEntryTypeLayoutSpecifiedAsSuccessAudit()
-        {
-            AssertMessageCountAndLogLevelForSplittedMessages(LogLevel.Debug, EventLogEntryType.SuccessAudit, new SimpleLayout("SuccessAudit"));
-        }
-
-        [Fact]
-        public void SplittedMessagesShouldBeWrittenAtFailureLevel_WhenEntryTypeLayoutSpecifiedAsFailureAudit()
-        {
-            AssertMessageCountAndLogLevelForSplittedMessages(LogLevel.Debug, EventLogEntryType.FailureAudit, new SimpleLayout("FailureAudit"));
-        }
-
-        [Fact]
-        public void SplittedMessagesShouldBeWrittenAtErrorLevel_WhenEntryTypeLayoutSpecifiedAsError()
-        {
-            AssertMessageCountAndLogLevelForSplittedMessages(LogLevel.Debug, EventLogEntryType.Error, new SimpleLayout("error"));
-        }
-
-
-        [Fact]
-        public void SplittedMessagesShouldBeWrittenAtSpecifiedNLogLevel_WhenWrongEntryTypeLayoutSupplied()
-        {
-            AssertMessageCountAndLogLevelForSplittedMessages(LogLevel.Info, EventLogEntryType.Information, new SimpleLayout("wrong entry type level"));
-        }
-
 
         [Fact]
         public void WriteEventLogEntryLargerThanMaxMessageLengthWithOverflowTruncate_TruncatesTheMessage()
@@ -305,7 +303,7 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
-        public void WriteEventLogEntryLargerThanMaxMessageLengthWithOverflowSplitEntries_TheMessageShouldBeSplitted()
+        public void WriteEventLogEntryLargerThanMaxMessageLengthWithOverflowSplitEntries_TheMessageShouldBeSplit()
         {
             const int maxMessageLength = 16384;
             const int expectedEntryCount = 5;
@@ -313,7 +311,7 @@ namespace NLog.UnitTests.Targets
             string messagePart2 = string.Join("", Enumerable.Repeat("b", maxMessageLength));
             string messagePart3 = string.Join("", Enumerable.Repeat("c", maxMessageLength));
             string messagePart4 = string.Join("", Enumerable.Repeat("d", maxMessageLength));
-            string messagePart5 = "this part must be splitted too";
+            string messagePart5 = "this part must be split too";
             string testMessage = messagePart1 + messagePart2 + messagePart3 + messagePart4 + messagePart5;
 
             var entries = WriteWithMock(LogLevel.Info, EventLogEntryType.Information, testMessage, null, EventLogTargetOverflowAction.Split, maxMessageLength).ToList();
@@ -328,7 +326,7 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
-        public void WriteEventLogEntryEqual2MaxMessageLengthWithOverflowSplitEntries_TheMessageShouldBeSplittedInTwoChunk()
+        public void WriteEventLogEntryEqualToMaxMessageLengthWithOverflowSplitEntries_TheMessageShouldBeSplitInTwoChunks()
         {
             const int maxMessageLength = 16384;
             const int expectedEntryCount = 2;
@@ -389,7 +387,7 @@ namespace NLog.UnitTests.Targets
             const int maxMessageLength = 10;
             string expectedMessage = string.Join("", Enumerable.Repeat("a", maxMessageLength));
 
-            var target = CreateEventLogTarget<EventLogTarget>(null, "NLog.UnitTests" + Guid.NewGuid().ToString("N"), EventLogTargetOverflowAction.Split, maxMessageLength);
+            var target = CreateEventLogTarget<EventLogTarget>("NLog.UnitTests" + Guid.NewGuid().ToString("N"), EventLogTargetOverflowAction.Split, maxMessageLength);
             target.Layout = new SimpleLayout("${message}");
             target.Source = new SimpleLayout("${event-properties:item=DynamicSource}");
             SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
@@ -426,7 +424,7 @@ namespace NLog.UnitTests.Targets
             var rnd = new Random();
             int eventId = rnd.Next(1, short.MaxValue);
             int category = rnd.Next(1, short.MaxValue);
-            var target = CreateEventLogTarget<EventLogTarget>(null, "NLog.UnitTests" + Guid.NewGuid().ToString("N"), EventLogTargetOverflowAction.Truncate, 5000);
+            var target = CreateEventLogTarget<EventLogTarget>("NLog.UnitTests" + Guid.NewGuid().ToString("N"), EventLogTargetOverflowAction.Truncate, 5000);
             target.EventId = new SimpleLayout(eventId.ToString());
             target.Category = new SimpleLayout(category.ToString());
             SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
@@ -451,7 +449,7 @@ namespace NLog.UnitTests.Targets
             var rnd = new Random();
             int eventId = rnd.Next(1, short.MaxValue);
             int category = rnd.Next(1, short.MaxValue);
-            var target = CreateEventLogTarget<EventLogTarget>(null, "NLog.UnitTests" + Guid.NewGuid().ToString("N"), EventLogTargetOverflowAction.Truncate, 5000);
+            var target = CreateEventLogTarget<EventLogTarget>("NLog.UnitTests" + Guid.NewGuid().ToString("N"), EventLogTargetOverflowAction.Truncate, 5000);
             target.EventId = new SimpleLayout("${event-properties:EventId}");
             target.Category = new SimpleLayout("${event-properties:Category}");
             SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
@@ -476,7 +474,7 @@ namespace NLog.UnitTests.Targets
         private static IEnumerable<EventRecord> WriteWithMock(LogLevel logLevel, EventLogEntryType expectedEventLogEntryType,
             string logMessage, Layout entryType = null, EventLogTargetOverflowAction overflowAction = EventLogTargetOverflowAction.Truncate, int maxMessageLength = 16384)
         {
-            var target = CreateEventLogTarget<EventLogTargetMock>(entryType, "NLog.UnitTests" + Guid.NewGuid().ToString("N"), overflowAction, maxMessageLength);
+            var target = CreateEventLogTarget<EventLogTargetMock>("NLog.UnitTests" + Guid.NewGuid().ToString("N"), overflowAction, maxMessageLength, entryType);
             SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
 
             var logger = LogManager.GetLogger("WriteEventLogEntry");
@@ -513,8 +511,6 @@ namespace NLog.UnitTests.Targets
                 LogName = logName;
                 ProviderName = providerName;
 
-
-
                 if (type == EventLogEntryType.FailureAudit)
                 {
                     Keywords = (long)StandardEventKeywords.AuditFailure;
@@ -534,13 +530,10 @@ namespace NLog.UnitTests.Targets
                         Level = (byte)StandardEventLevel.Informational;
                 }
 
-
                 var eventProperty = CreateEventProperty(message);
                 Properties = new List<EventProperty> { eventProperty };
-
-
-
             }
+
             /// <summary>
             /// EventProperty ctor is internal
             /// </summary>
@@ -695,7 +688,6 @@ namespace NLog.UnitTests.Targets
 
             internal override void WriteEntry(LogEventInfo logEventInfo, string message, EventLogEntryType entryType, int eventId, short category)
             {
-
                 var source = RenderSource(logEventInfo);
 
                 CapturedEvents.Add(new EventRecordMock(eventId, Log, source, entryType, message, category));
@@ -710,24 +702,23 @@ namespace NLog.UnitTests.Targets
             Assert.True(messages.Any(), $"Event records has not the expected message: '{expectedMessage}'");
         }
 
-        private static TEventLogTarget CreateEventLogTarget<TEventLogTarget>(Layout entryType, string sourceName, EventLogTargetOverflowAction overflowAction, int maxMessageLength)
+        private static TEventLogTarget CreateEventLogTarget<TEventLogTarget>(
+            string sourceName, EventLogTargetOverflowAction overflowAction, int maxMessageLength, Layout entryType = null)
             where TEventLogTarget : EventLogTarget, new()
         {
-            var target = new TEventLogTarget();
-            //The Log to write to is intentionally lower case!!
-            target.Log = "application";
-            // set the source explicitly to prevent random AppDomain name being used as the source name
-            target.Source = sourceName;
-            //Be able to check message length and content, the Layout is intentionally only ${message}.
-            target.Layout = new SimpleLayout("${message}");
+            var target = new TEventLogTarget
+            {
+                Log = "application", // The Log to write to is intentionally lower case!!
+                Source = sourceName, // set the source explicitly to prevent random AppDomain name being used as the source name
+                Layout = new SimpleLayout("${message}"), //Be able to check message length and content, the Layout is intentionally only ${message}.
+                OnOverflow = overflowAction,
+                MaxMessageLength = maxMessageLength,
+            };
+
             if (entryType != null)
             {
-                //set only when not default
                 target.EntryType = entryType;
             }
-
-            target.OnOverflow = overflowAction;
-            target.MaxMessageLength = maxMessageLength;
 
             return target;
         }
@@ -769,6 +760,80 @@ namespace NLog.UnitTests.Targets
                     return keywords.HasFlag(StandardEventKeywords.AuditFailure);
             }
             return false;
+        }
+
+        private class EventLogStaticMock : EventLogTarget.IEventLogStaticWrapper
+        {
+            public EventLogStaticMock(
+                Func<string, string, bool> sourceExistsFunction,
+                Action<string, string> deleteEventSourceFunction,
+                Func<string, string, string> logNameFromSourceNameFunction,
+                Action<EventSourceCreationData> createEventSourceFunction,
+                IDictionary<string, EventLogTarget.IEventLogInstanceWrapper> eventLogInstances)
+            {
+                SourceExistsFunction = sourceExistsFunction ?? throw new ArgumentNullException(nameof(sourceExistsFunction));
+                DeleteEventSourceFunction = deleteEventSourceFunction ?? throw new ArgumentNullException(nameof(deleteEventSourceFunction));
+                LogNameFromSourceNameFunction = logNameFromSourceNameFunction ?? throw new ArgumentNullException(nameof(logNameFromSourceNameFunction));
+                CreateEventSourceFunction = createEventSourceFunction ?? throw new ArgumentNullException(nameof(createEventSourceFunction));
+                EventLogInstances = eventLogInstances;
+            }
+
+            internal IDictionary<string, EventLogTarget.IEventLogInstanceWrapper> EventLogInstances { get; }
+
+            private Func<string, string, bool> SourceExistsFunction { get; }
+            private Action<string, string> DeleteEventSourceFunction { get; }
+            private Func<string, string, string> LogNameFromSourceNameFunction { get; }
+            private Action<EventSourceCreationData> CreateEventSourceFunction { get; }
+
+            /// <inheritdoc />
+            public EventLogTarget.IEventLogInstanceWrapper CreateEventLogInstanceWrapper(string logName, string machineName, string source)
+            {
+                return EventLogInstances[logName];
+            }
+
+            /// <inheritdoc />
+            public void DeleteEventSource(string source, string machineName) => DeleteEventSourceFunction(source, machineName);
+
+            /// <inheritdoc />
+            public bool SourceExists(string source, string machineName) => SourceExistsFunction(source, machineName);
+
+            /// <inheritdoc />
+            public string LogNameFromSourceName(string source, string machineName) => LogNameFromSourceNameFunction(source, machineName);
+
+            /// <inheritdoc />
+            public void CreateEventSource(EventSourceCreationData sourceData) => CreateEventSourceFunction(sourceData);
+        }
+
+        private class EventLogInstanceStub : EventLogTarget.IEventLogInstanceWrapper
+        {
+            public const long MaxKBytesDefValue = 512;
+
+            public EventLogInstanceStub(string logName, string machineName, string source)
+            {
+                Log = logName;
+                MachineName = machineName;
+                Source = source;
+            }
+
+            /// <inheritdoc />
+            public string Log { get; set; }
+
+            /// <inheritdoc />
+            public string MachineName { get; set; }
+
+            /// <inheritdoc />
+            public string Source { get; }
+
+            /// <inheritdoc />
+            public long MaximumKilobytes { get; set; } = MaxKBytesDefValue;
+
+            internal List<EventRecordMock> WrittenEntries { get; } = new List<EventRecordMock>();
+
+            /// <inheritdoc />
+            public void WriteEntry(string message, EventLogEntryType entryType, int eventId, short category)
+            {
+                WrittenEntries.Add(new EventRecordMock(eventId, Log, Source, entryType, message, category));
+            }
         }
     }
 }

--- a/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
@@ -202,7 +202,7 @@ namespace NLog.UnitTests.Targets
                 logNameFromSourceNameFunction: (source, machineName) => targetLog,
                 createEventSourceFunction: (sourceData) => { })
             { MaximumKilobytes = initialValue };
-            var target = new EventLogTarget(eventLogMock)
+            var target = new EventLogTarget(eventLogMock, null)
             {
                 Log = targetLog,
                 Source = "NLog.UnitTests" + Guid.NewGuid().ToString("N"), // set the source explicitly to prevent random AppDomain name being used as the source name


### PR DESCRIPTION
Remove MaximumKilobytes setting from GetEventLog(), because when app is run without elevated privileges, the method spams exceptions.
Move MaximumKilobytes setting to installation (and initialization) phase, when the application is typically run with elevated privileges.
Add logic to not override a bigger value of MaximumKilobytes, because the Event log can be used by multiple Sources, each having its own space requirements.