### PR TITLE
Added Xamarin PreserveAttribute for the entire Assembly to improve AOT-linking

### DIFF
--- a/src/NLog/Internal/Xamarin/PreserveAttribute.cs
+++ b/src/NLog/Internal/Xamarin/PreserveAttribute.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,25 +31,26 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Security;
-using NLog.Internal.Xamarin;
+namespace NLog.Internal.Xamarin
+{
+    using System;
 
-[assembly: Preserve]    // Automatic --linkskip=NLog
-[assembly: AssemblyCulture("")]
-[assembly: CLSCompliant(true)]
-[assembly: ComVisible(false)]
-#if __IOS__ || __ANDROID__
-//[assembly: InternalsVisibleTo("NLog.UnitTests")]
-#else
-[assembly: InternalsVisibleTo("NLog.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100ef8eab4fbdeb511eeb475e1659fe53f00ec1c1340700f1aa347bf3438455d71993b28b1efbed44c8d97a989e0cb6f01bcb5e78f0b055d311546f63de0a969e04cf04450f43834db9f909e566545a67e42822036860075a1576e90e1c43d43e023a24c22a427f85592ae56cac26f13b7ec2625cbc01f9490d60f16cfbb1bc34d9")]
-#endif
-#if !SILVERLIGHT4
-[assembly: AllowPartiallyTrustedCallers]
-#if !NET3_5 && !MONO_2_0 && !SILVERLIGHT5 && !__IOS__ && !__ANDROID__ && !WINDOWS_PHONE && !NETSTANDARD1_0
-[assembly: SecurityRules(SecurityRuleSet.Level1)]
-#endif
-#endif
+    /// <summary>
+    /// Prevents the Xamarin linker from linking the target.
+    /// </summary>
+    /// <remarks>
+    /// By applying this attribute all of the members of the target will be kept as if they had been referenced by the code.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.All)]
+    public sealed class PreserveAttribute : Attribute
+    {
+        /// <summary>
+        /// Ensures that all members of this type are preserved
+        /// </summary>
+        public bool AllMembers { get; } = true;
+        /// <summary>
+        /// Flags the method as a method to preserve during linking if the container class is pulled in.
+        /// </summary>
+        public bool Conditional { get; }
+    }
+}


### PR DESCRIPTION
Skip tree-shake on Ahead-of-Time (AOT) compile / linking. See also:

https://blog.xamarin.com/howto-partially-linking-monotouch-applications/
https://www.mvvmcross.com/documentation/fundamentals/linking

Should help improving these issues: #3036 + #2468 + #1599