### PR TITLE
FileTarget - ConcurrentWrites=false by default for better compatibility

### DIFF
--- a/src/NLog/Internal/FileAppenders/ICreateFileParameters.cs
+++ b/src/NLog/Internal/FileAppenders/ICreateFileParameters.cs
@@ -43,13 +43,13 @@ namespace NLog.Internal.FileAppenders
         /// <summary>
         /// Gets or sets the delay in milliseconds to wait before attempting to write to the file again.
         /// </summary>
-        int ConcurrentWriteAttemptDelay { get; }
+        int FileOpenRetryCount { get; }
 
         /// <summary>
         /// Gets or sets the number of times the write is appended on the file before NLog
         /// discards the log message.
         /// </summary>
-        int ConcurrentWriteAttempts { get; }
+        int FileOpenRetryDelay { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether concurrent writes to the log file by multiple processes on the same host.

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -163,7 +163,7 @@ namespace NLog.Targets
             ArchiveAboveSize = ArchiveAboveSizeDisabled;
             ArchiveOldFileOnStartupAboveSize = 0;
             ConcurrentWriteAttempts = 10;
-            ConcurrentWrites = true;
+            ConcurrentWrites = false;
             Encoding = Encoding.UTF8;
             BufferSize = 32768;
             AutoFlush = true;
@@ -347,6 +347,10 @@ namespace NLog.Targets
 
         bool ICreateFileParameters.IsArchivingEnabled => IsArchivingEnabled;
 
+        int ICreateFileParameters.FileOpenRetryCount => (!KeepFileOpen || ConcurrentWrites) ? ConcurrentWriteAttempts : 0;
+
+        int ICreateFileParameters.FileOpenRetryDelay => (!KeepFileOpen || ConcurrentWrites) ? ConcurrentWriteAttemptDelay : 1;
+
         /// <summary>
         /// Gets or sets the line ending mode.
         /// </summary>
@@ -424,7 +428,7 @@ namespace NLog.Targets
         /// that lets it keep the files open for writing.
         /// </remarks>
         /// <docgen category='Performance Tuning Options' order='10' />
-        [DefaultValue(true)]
+        [DefaultValue(false)]
         public bool ConcurrentWrites
         {
             get => _concurrentWrites;

--- a/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
@@ -61,7 +61,7 @@ namespace NLog.UnitTests.Targets
             FileTarget ft = new FileTarget();
             ft.FileName = fileName;
             ft.Layout = "${message}";
-            ft.KeepFileOpen = true;
+            ft.ConcurrentWrites = true;
             ft.OpenFileCacheTimeout = 10;
             ft.OpenFileCacheSize = 1;
             ft.LineEnding = LineEndingMode.LF;


### PR DESCRIPTION
See also #2742 and #2824 and #2925 and #3059 (Xamarin mobile platforms also don't like global mutex) and #3893

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/3048)
<!-- Reviewable:end -->
