### PR TITLE
Added ${appsetting} - LayoutRenderer for easier access to app.config settings

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -560,19 +560,7 @@ namespace NLog.Config
 
                 // register types
                 string targetsNamespace = typeof(DebugTarget).Namespace;
-                _targets.RegisterNamedType("AspNetTrace", targetsNamespace + ".AspNetTraceTarget" + suffix);
                 _targets.RegisterNamedType("MSMQ", targetsNamespace + ".MessageQueueTarget" + suffix);
-                _targets.RegisterNamedType("AspNetBufferingWrapper", targetsNamespace + ".Wrappers.AspNetBufferingTargetWrapper" + suffix);
-
-                // register layout renderers
-                string layoutRenderersNamespace = typeof(MessageLayoutRenderer).Namespace;
-                _layoutRenderers.RegisterNamedType("appsetting", layoutRenderersNamespace + ".AppSettingLayoutRenderer" + suffix);
-                _layoutRenderers.RegisterNamedType("aspnet-application", layoutRenderersNamespace + ".AspNetApplicationValueLayoutRenderer" + suffix);
-                _layoutRenderers.RegisterNamedType("aspnet-request", layoutRenderersNamespace + ".AspNetRequestValueLayoutRenderer" + suffix);
-                _layoutRenderers.RegisterNamedType("aspnet-sessionid", layoutRenderersNamespace + ".AspNetSessionIDLayoutRenderer" + suffix);
-                _layoutRenderers.RegisterNamedType("aspnet-session", layoutRenderersNamespace + ".AspNetSessionValueLayoutRenderer" + suffix);
-                _layoutRenderers.RegisterNamedType("aspnet-user-authtype", layoutRenderersNamespace + ".AspNetUserAuthTypeLayoutRenderer" + suffix);
-                _layoutRenderers.RegisterNamedType("aspnet-user-identity", layoutRenderersNamespace + ".AspNetUserIdentityLayoutRenderer" + suffix);
             }
         }
 #endif

--- a/src/NLog/LayoutRenderers/AppSettingLayoutRenderer2.cs
+++ b/src/NLog/LayoutRenderers/AppSettingLayoutRenderer2.cs
@@ -1,0 +1,90 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD
+
+namespace NLog.LayoutRenderers
+{
+    using System.Collections.Specialized;
+    using System.Text;
+    using NLog.Config;
+    using NLog.Internal;
+
+    /// <summary>
+    /// Application setting.
+    /// </summary>
+    /// <remarks>
+    /// Use this layout renderer to insert the value of an application setting
+    /// stored in the application's App.config or Web.config file.
+    /// </remarks>
+    /// <code lang="NLog Layout Renderer">
+    /// ${appsetting:name=mysetting:default=mydefault} - produces "mydefault" if no appsetting
+    /// </code>
+    [LayoutRenderer("appsetting")]
+    public sealed class AppSettingLayoutRenderer2 : LayoutRenderer
+    {
+        ///<summary>
+        /// The AppSetting name.
+        ///</summary>
+        [RequiredParameter]
+        [DefaultParameter]
+        public string Name { get; set; }
+
+        ///<summary>
+        /// The default value to render if the AppSetting value is null.
+        ///</summary>
+        public string Default { get; set; }
+
+        internal IConfigurationManager ConfigurationManager { get; set; } = new ConfigurationManager();
+
+        /// <summary>
+        /// Renders the specified application setting or default value and appends it to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="logEvent">Logging event.</param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            if (Name == null)
+                return;
+
+            string value = ConfigurationManager.AppSettings[Name];
+            if (value == null && Default != null)
+                value = Default;
+
+            if (!string.IsNullOrEmpty(value))
+                builder.Append(value);
+        }
+    }
+}
+
+#endif

--- a/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
@@ -88,13 +88,13 @@ namespace NLog.UnitTests.Config
         {
             var layoutRenderers = ConfigurationItemFactory.Default.LayoutRenderers;
 
-            AssertInstance(layoutRenderers, "appsetting", "AppSettingLayoutRenderer");
+            AssertInstance(layoutRenderers, "appsetting", "AppSettingLayoutRenderer", "AppSettingLayoutRenderer2");
         }
 
-        private static void AssertInstance<T1, T2>(INamedItemFactory<T1, T2> targets, string itemName, string expectedTypeName)
+        private static void AssertInstance<T1, T2>(INamedItemFactory<T1, T2> targets, string itemName, params string[] expectedTypeNames)
             where T1 : class
         {
-            Assert.Equal(expectedTypeName, targets.CreateInstance(itemName).GetType().Name);
+            Assert.Contains(targets.CreateInstance(itemName).GetType().Name, expectedTypeNames);
         }
 #endif
     }

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -49,7 +49,7 @@ namespace NLog.UnitTests.Config
             using (new InternalLoggerScope())
             {
                 var xml = "<nlog></nlog>";
-                var config = XmlLoggingConfiguration.CreateFromXmlString(xml, Environment.CurrentDirectory);
+                var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
 
                 Assert.False(config.AutoReload);
                 Assert.True(config.InitializeSucceeded);
@@ -67,10 +67,10 @@ namespace NLog.UnitTests.Config
         {
             using (new InternalLoggerScope(true))
             {
-                var xml = "<nlog autoreload='true' logfile='test.txt' internalLogIncludeTimestamp='false' internalLogToConsole='true' internalLogToConsoleError='true'></nlog>";
+                var xml = "<nlog logfile='test.txt' internalLogIncludeTimestamp='false' internalLogToConsole='true' internalLogToConsoleError='true'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
 
-                Assert.True(config.AutoReload);
+                Assert.False(config.AutoReload);
                 Assert.True(config.InitializeSucceeded);
                 Assert.Equal("", InternalLogger.LogFile);
                 Assert.False(InternalLogger.IncludeTimestamp);
@@ -86,14 +86,14 @@ namespace NLog.UnitTests.Config
         {
             using (new InternalLoggerScope(true))
             {
-                var xml = "<nlog autoreload='true' internalLogFile='${CurrentDir}test.txt'></nlog>";
+                var xml = "<nlog internalLogFile='${CurrentDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
                 Assert.Contains(System.IO.Directory.GetCurrentDirectory(), InternalLogger.LogFile);
             }
 
             using (new InternalLoggerScope(true))
             {
-                var xml = "<nlog autoreload='true' internalLogFile='${BaseDir}test.txt'></nlog>";
+                var xml = "<nlog internalLogFile='${BaseDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
                 Assert.Contains(AppDomain.CurrentDomain.BaseDirectory, InternalLogger.LogFile);
             }
@@ -101,7 +101,7 @@ namespace NLog.UnitTests.Config
             using (new InternalLoggerScope(true))
             {
                 var userName = Environment.GetEnvironmentVariable("USERNAME") ?? string.Empty;
-                var xml = "<nlog autoreload='true' internalLogFile='%USERNAME%_test.txt'></nlog>";
+                var xml = "<nlog internalLogFile='%USERNAME%_test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
                 if (!string.IsNullOrEmpty(userName))
                     Assert.Contains(userName, InternalLogger.LogFile);
@@ -164,7 +164,7 @@ namespace NLog.UnitTests.Config
             using (new NoThrowNLogExceptions())
             {
                 // Arrange
-                var xml = @"<nlog internalLogLevel='oops' autoreload='woops' globalThreshold='noooos'>
+                var xml = @"<nlog internalLogLevel='oops' globalThreshold='noooos'>
                         <targets>
                             <target name='debug' type='Debug' layout='${message}' />
                         </targets>

--- a/tests/NLog.UnitTests/LayoutRenderers/AppSettingTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/AppSettingTests.cs
@@ -48,7 +48,7 @@ namespace NLog.UnitTests.LayoutRenderers
             var configurationManager = new MockConfigurationManager();
             const string expected = "appSettingTestValue";
             configurationManager.AppSettings["appSettingTestKey"] = expected;
-            var appSettingLayoutRenderer = new AppSettingLayoutRenderer
+            var appSettingLayoutRenderer = new AppSettingLayoutRenderer2
             {
                 ConfigurationManager = configurationManager,
                 Name = "appSettingTestKey",
@@ -65,7 +65,7 @@ namespace NLog.UnitTests.LayoutRenderers
             var configurationManager = new MockConfigurationManager();
             const string expected = "appSettingTestValue";
             configurationManager.AppSettings["appSettingTestKey"] = expected;
-            var appSettingLayoutRenderer = new AppSettingLayoutRenderer
+            var appSettingLayoutRenderer = new AppSettingLayoutRenderer2
             {
                 ConfigurationManager = configurationManager,
                 Name = "appSettingTestKey",
@@ -82,7 +82,7 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             var configurationManager = new MockConfigurationManager();
             const string expected = "UseDefault";
-            var appSettingLayoutRenderer = new AppSettingLayoutRenderer
+            var appSettingLayoutRenderer = new AppSettingLayoutRenderer2
             {
                 ConfigurationManager = configurationManager,
                 Name = "notFound",
@@ -98,7 +98,7 @@ namespace NLog.UnitTests.LayoutRenderers
         public void NoAppSettingTest()
         {
             var configurationManager = new MockConfigurationManager();
-            var appSettingLayoutRenderer = new AppSettingLayoutRenderer
+            var appSettingLayoutRenderer = new AppSettingLayoutRenderer2
             {
                 ConfigurationManager = configurationManager,
                 Name = "notFound",


### PR DESCRIPTION
After seeing that NetFramework will now enter maintenance mode, and NetCore will take over.

Then it doesn't make sense trying extract app.config-logic from NLog-core, as it will only be available for NetFramework (And not NetCore).

Also it is a little difficult to perform auto extension loading to ensure that nlog-config is automatically loaded from app.config.

This replaces #2919 and resolves #2335 

Other change included:
- Removed the optional baseDirectory-parameter from `CreateFromXmlString` as it doesn't make sense when it comes to autoreload config-file or use of include-files when giving of in-memory-config.
- Modified `RegisterExtendedItems` so it doesn't register non-existing class-types, and also prioritize the now builtin NLog-appsetting, instead of NLog.Extended-appsetting.

