### PR TITLE
AppDomainWrapper - BaseDirectory = null for Xamarin Android

### DIFF
--- a/src/NLog/Internal/Fakeables/AppDomainWrapper.cs
+++ b/src/NLog/Internal/Fakeables/AppDomainWrapper.cs
@@ -60,7 +60,7 @@ namespace NLog.Internal.Fakeables
 #endif
             try
             {
-                BaseDirectory = LookupBaseDirectory(appDomain);
+                BaseDirectory = LookupBaseDirectory(appDomain) ?? string.Empty;
             }
             catch (Exception ex)
             {

--- a/tests/NLog.UnitTests/NLog.UnitTests.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.csproj
@@ -49,7 +49,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">


### PR DESCRIPTION
Ensure `string.Empty` to avoid `NullReferenceException` 