### PR TITLE
File target: Handle UnauthorizedAccessException for multi-process mutexes (e.g. Xamarin and UWP)

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
@@ -136,7 +136,7 @@ namespace NLog.Internal.FileAppenders
         protected Mutex CreateSharableMutex(string mutexNamePrefix)
         {
             if (!PlatformDetector.SupportsSharableMutex)
-                throw new Exception("Creating Mutex not supported");
+                throw new NotSupportedException("Creating Mutex not supported");
 
             var name = GetMutexName(mutexNamePrefix);
 

--- a/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
@@ -131,6 +131,11 @@ namespace NLog.Internal.FileAppenders
 
             var name = GetMutexName(mutexNamePrefix);
 
+            return ForceCreateSharableMutex(name);
+        }
+
+        internal static Mutex ForceCreateSharableMutex(string name)
+        {
 #if !NETSTANDARD
             // Creates a mutex sharable by more than one process
             var mutexSecurity = new MutexSecurity();

--- a/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
@@ -43,6 +43,7 @@ namespace NLog.Internal.FileAppenders
     using System.Security;
     using System.Threading;
     using System.Text;
+    using JetBrains.Annotations;
 
 #if SupportsMutex
 #if !NETSTANDARD
@@ -50,8 +51,8 @@ namespace NLog.Internal.FileAppenders
     using System.Security.Principal;
 #endif
     using System.Security.Cryptography;
-    using Common;
 #endif
+    using Common;
 
     /// <summary>
     /// Base class for optimized file appenders which require the usage of a mutex. 
@@ -72,9 +73,16 @@ namespace NLog.Internal.FileAppenders
         {
             if (createParameters.IsArchivingEnabled)
             {
+                if (PlatformDetector.SupportsSharableMutex)
+                {
 #if SupportsMutex
-                ArchiveMutex = CreateArchiveMutex();
+                    ArchiveMutex = CreateArchiveMutex();
 #endif
+                }
+                else
+                {
+                    InternalLogger.Debug("Mutex for file archive not supported");
+                }
             }
         }
 
@@ -83,6 +91,7 @@ namespace NLog.Internal.FileAppenders
         /// Gets the mutually-exclusive lock for archiving files.
         /// </summary>
         /// <value>The mutex for archiving.</value>
+        [CanBeNull]
         public Mutex ArchiveMutex { get; private set; }
 
         private Mutex CreateArchiveMutex()
@@ -127,7 +136,7 @@ namespace NLog.Internal.FileAppenders
         protected Mutex CreateSharableMutex(string mutexNamePrefix)
         {
             if (!PlatformDetector.SupportsSharableMutex)
-                return new Mutex();
+                throw new Exception("Creating Mutex not supported");
 
             var name = GetMutexName(mutexNamePrefix);
 

--- a/src/NLog/Internal/PlatformDetector.cs
+++ b/src/NLog/Internal/PlatformDetector.cs
@@ -121,11 +121,11 @@ namespace NLog.Internal
                 {
 #if SupportsMutex
                     var mutex = BaseMutexFileAppender.ForceCreateSharableMutex("NLogMutexTester");
-                    mutex.Dispose();
+                    mutex.Close(); //"dispose"
 
                     runTimeSupportsSharableMutex = true;
 #else
-                    _RunTimeSupportsSharableMutex = false;
+                    runTimeSupportsSharableMutex = false;
 #endif
                 }
                 catch (Exception ex) 

--- a/src/NLog/Internal/PlatformDetector.cs
+++ b/src/NLog/Internal/PlatformDetector.cs
@@ -128,16 +128,16 @@ namespace NLog.Internal
                     runTimeSupportsSharableMutex = false;
 #endif
                 }
-                catch (Exception ex) 
+                catch (Exception ex)
                 {
                     InternalLogger.Debug(ex, "Failed to create sharable mutex processes");
                     runTimeSupportsSharableMutex = false;
                 }
 
                 return runTimeSupportsSharableMutex.Value;
-                }
-
             }
+
+        }
 
         private static RuntimeOS GetCurrentRuntimeOS()
         {

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -450,12 +450,7 @@ namespace NLog.Targets
             {
 #if SupportsMutex
 
-                if (!PlatformDetector.SupportsSharableMutex)
-                {
-                    return _concurrentWrites ?? false;  // Better user experience for mobile platforms
-                }
-
-                return _concurrentWrites ?? true;
+                return _concurrentWrites ?? PlatformDetector.SupportsSharableMutex;
 #else
                 return _concurrentWrites ?? false;  // Better user experience for mobile platforms
 #endif
@@ -1753,29 +1748,14 @@ namespace NLog.Targets
 #if SupportsMutex
                     try
                     {
-                        var mutexSupportedForArchive = true;
-                        if (archivedAppender is BaseMutexFileAppender mutexFileAppender)
+                        if (archivedAppender is BaseMutexFileAppender mutexFileAppender && mutexFileAppender.ArchiveMutex != null)
                         {
-
-                            if (mutexFileAppender.ArchiveMutex == null)
-                            {
-                                mutexSupportedForArchive = false;
-                            }
-                            else
-                            {
-                                mutexFileAppender.ArchiveMutex.WaitOne();
-                            }
+                            mutexFileAppender.ArchiveMutex.WaitOne();
                         }
-                        else if (!KeepFileOpen || ConcurrentWrites)
-                        {
-                            mutexSupportedForArchive = false;
-                        }
-
-                        if (!mutexSupportedForArchive)
+                        else
                         {
                             InternalLogger.Info("FileTarget(Name={0}): Archive mutex not available: {1}", Name, archiveFile);
                         }
-
 
                     }
                     catch (AbandonedMutexException)


### PR DESCRIPTION
detect creating Mutex also runtime.

alternative solution for #3048 

See #2742 and #2824 and #2925 and #3059

supersedes #3063 