### PR TITLE
WebService target: added support for custom SOAPAction property (Soap11+Soap12 protocol)

### DIFF
--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -661,19 +661,18 @@ namespace NLog.Targets
 
             protected override void InitRequest(HttpWebRequest request)
             {
+                const string soapActionHeader = "SOAPAction";
                 base.InitRequest(request);
 
-                string soapAction;
-                if (Target.Namespace.EndsWith("/", StringComparison.Ordinal))
+                string soapAction = request.Headers[soapActionHeader];
+                if (string.IsNullOrEmpty(soapAction))
                 {
-                    soapAction = string.Concat(Target.Namespace, Target.MethodName);
-                }
-                else
-                {
-                    soapAction = string.Concat(Target.Namespace, "/", Target.MethodName);
+                    soapAction = Target.Namespace.EndsWith("/", StringComparison.Ordinal)
+                        ? string.Concat(Target.Namespace, Target.MethodName)
+                        : string.Concat(Target.Namespace, "/", Target.MethodName);
                 }
 
-                request.Headers["SOAPAction"] = soapAction;
+                request.Headers[soapActionHeader] = soapAction;
             }
         }
 

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -670,9 +670,8 @@ namespace NLog.Targets
                     soapAction = Target.Namespace.EndsWith("/", StringComparison.Ordinal)
                         ? string.Concat(Target.Namespace, Target.MethodName)
                         : string.Concat(Target.Namespace, "/", Target.MethodName);
+                    request.Headers[soapActionHeader] = soapAction;
                 }
-
-                request.Headers[soapActionHeader] = soapAction;
             }
         }
 

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -681,6 +681,14 @@ namespace NLog.Targets
             protected override string SoapEnvelopeNamespace => Soap12EnvelopeNamespaceUri;
 
             protected override string SoapName => "soap12";
+
+            protected override string ContentType => "application/soap+xml";
+
+            protected override void InitRequest(HttpWebRequest request)
+            {
+                base.InitRequest(request);
+                request.ContentType += $@"; action=""{GetSoapAction()}""";
+            }
         }
 
         private abstract class HttpPostSoapFormatterBase : HttpPostXmlFormatterBase

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -137,6 +137,12 @@ namespace NLog.Targets
         public string Namespace { get; set; }
 
         /// <summary>
+        /// Gets or sets the Web service soap action name. Only used with Soap.
+        /// </summary>
+        /// <docgen category='Web Service Options' order='10' />
+        public string SoapAction { get; set; }
+
+        /// <summary>
         /// Gets or sets the protocol to be used when calling web service.
         /// </summary>
         /// <docgen category='Web Service Options' order='10' />
@@ -661,17 +667,8 @@ namespace NLog.Targets
 
             protected override void InitRequest(HttpWebRequest request)
             {
-                const string soapActionHeader = "SOAPAction";
                 base.InitRequest(request);
-
-                string soapAction = request.Headers[soapActionHeader];
-                if (string.IsNullOrEmpty(soapAction))
-                {
-                    soapAction = Target.Namespace.EndsWith("/", StringComparison.Ordinal)
-                        ? string.Concat(Target.Namespace, Target.MethodName)
-                        : string.Concat(Target.Namespace, "/", Target.MethodName);
-                    request.Headers[soapActionHeader] = soapAction;
-                }
+                request.Headers["SOAPAction"] = GetSoapAction();
             }
         }
 
@@ -712,6 +709,19 @@ namespace NLog.Targets
                 xtw.WriteEndElement(); // Body
                 xtw.WriteEndElement(); // soap:Envelope
                 xtw.Flush();
+            }
+
+            protected string GetSoapAction()
+            {
+                string soapAction = Target.SoapAction;
+                if (string.IsNullOrEmpty(soapAction))
+                {
+                    soapAction = Target.Namespace.EndsWith("/", StringComparison.Ordinal)
+                        ? string.Concat(Target.Namespace, Target.MethodName)
+                        : string.Concat(Target.Namespace, "/", Target.MethodName);
+                }
+
+                return soapAction;
             }
         }
 

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -641,10 +641,10 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                                 methodName ='Ping'
                                 preAuthenticate='false'
                                 encoding ='UTF-8'
+                                soapAction = 'http://tempuri.org/custom-namespace/Ping'
                                >
                             <parameter name='param1' ParameterType='System.String' layout='${{message}}'/> 
                             <parameter name='param2' ParameterType='System.String' layout='${{level}}'/>
-                            <header name='SOAPAction' layout='http://tempuri.org/custom-namespace/Ping'/>
                         </target>
                     </targets>
                     <rules>
@@ -955,13 +955,9 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                         && Context.ExpectedParam3 == complexType.Param3
                         && Context.ExpectedParam4.Date == complexType.Param4.Date)
                     {
-                        if (Context.ExpectedHeaders != null && Context.ExpectedHeaders.Count > 0)
+                        if (!ValidateHeaders())
                         {
-                            foreach (var expectedHeader in Context.ExpectedHeaders)
-                            {
-                                if (Request.Headers.GetValues(expectedHeader.Key).First() != expectedHeader.Value)
-                                    return;
-                            }
+                            return;
                         }
                         Context.CountdownEvent.Signal();
                     }
@@ -984,16 +980,25 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
             {
                 if (Context!=null)
                 {
-                    if (Context.ExpectedHeaders?.Count > 0)
+                    if (ValidateHeaders())
                     {
-                        foreach (var expectedHeader in Context.ExpectedHeaders)
-                        {
-                            if (Request.Headers.GetValues(expectedHeader.Key).First() != expectedHeader.Value)
-                                return;
-                        }
+                        Context.CountdownEvent.Signal();
                     }
-                    Context.CountdownEvent.Signal();
                 }
+            }
+
+            private bool ValidateHeaders()
+            {
+                if (Context.ExpectedHeaders?.Count > 0)
+                {
+                    foreach (var expectedHeader in Context.ExpectedHeaders)
+                    {
+                        if (Request.Headers.GetValues(expectedHeader.Key).First() != expectedHeader.Value)
+                            return false;
+                    }
+                }
+
+                return true;
             }
 
             public class TestContext


### PR DESCRIPTION
Fixes #3081 
Processing of existing header SoapAction has been added.
Unit tests for default SoapAction and custom SoapAction have been added.