### PR TITLE
Fix AutoReload (never released bug)

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -1092,6 +1092,18 @@ namespace NLog
 
                 return values;
             }
+            public void Reset()
+            {
+                _loggerCache.Clear();
+            }
+        }
+
+        /// <remarks>
+        /// Internal for unit tests
+        /// </remarks>
+        internal void ResetLoggerCache()
+        {
+            _loggerCache.Reset();
         }
 
         /// <summary>

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -209,6 +209,7 @@ namespace NLog
                         try
                         {
                             _config = config;
+                            _configLoader.Activated(this, _config);
                             _config.Dump();
                             ReconfigExistingLoggers();
                             LogConfigurationInitialized();

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -111,20 +111,12 @@ namespace NLog.UnitTests.Config
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempPath);
 
-
             string configFilePath = Path.Combine(tempPath, "reload.nlog");
-
-            var pp = Path.GetDirectoryName(typeof(LogManager).Assembly.Location);
-            configFilePath = Path.Combine(pp, "NLog.dll.nlog");
-
             WriteConfigFile(configFilePath, config1);
 
-
             try
-            {
-                
-                //LogManager.Configuration = new XmlLoggingConfiguration(configFilePath);
-
+            {                
+                LogManager.Configuration = new XmlLoggingConfiguration(configFilePath);
                 Assert.True(((XmlLoggingConfiguration)LogManager.Configuration).AutoReload);
 
                 var logger = LogManager.GetLogger("A");

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -45,6 +45,13 @@ namespace NLog.UnitTests.Config
 
     public class ReloadTests : NLogTestBase
     {
+        public ReloadTests()
+        {
+            if (LogManager.LogFactory != null)
+            {
+                LogManager.LogFactory.ResetLoggerCache();
+            }
+        }
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -115,8 +115,9 @@ namespace NLog.UnitTests.Config
             WriteConfigFile(configFilePath, config1);
 
             try
-            {                
+            {
                 LogManager.Configuration = new XmlLoggingConfiguration(configFilePath);
+
                 Assert.True(((XmlLoggingConfiguration)LogManager.Configuration).AutoReload);
 
                 var logger = LogManager.GetLogger("A");

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -67,6 +67,7 @@ namespace NLog.UnitTests
             if (LogManager.LogFactory != null)
             {
                 LogManager.LogFactory.ResetCandidateConfigFilePath();
+                LogManager.LogFactory.ResetLoggerCache();
             }
 
             LogManager.Configuration = null;

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -67,7 +67,6 @@ namespace NLog.UnitTests
             if (LogManager.LogFactory != null)
             {
                 LogManager.LogFactory.ResetCandidateConfigFilePath();
-                LogManager.LogFactory.ResetLoggerCache();
             }
 
             LogManager.Configuration = null;


### PR DESCRIPTION
autoReload does not work when using config files in default location (i.e. NLog.config or NLog.dll.nlog)