### PR TITLE
Improve support for custom IDictionary implementation (JSON, XML and structured logging)

### DIFF
--- a/src/NLog/Internal/DictionaryEntryEnumerable.cs
+++ b/src/NLog/Internal/DictionaryEntryEnumerable.cs
@@ -1,0 +1,97 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NLog.Internal
+{
+    /// <summary>
+    /// Ensures that IDictionary.GetEnumerator returns DictionaryEntry values
+    /// </summary>
+    internal struct DictionaryEntryEnumerable : IEnumerable<DictionaryEntry>
+    {
+        private readonly IDictionary _dictionary;
+
+        public DictionaryEntryEnumerable(IDictionary dictionary)
+        {
+            _dictionary = dictionary;
+        }
+
+        public DictionaryEntryEnumerator GetEnumerator()
+        {
+            return new DictionaryEntryEnumerator(_dictionary?.Count > 0 ? _dictionary : null);
+        }
+
+        IEnumerator<DictionaryEntry> IEnumerable<DictionaryEntry>.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        internal struct DictionaryEntryEnumerator : IEnumerator<DictionaryEntry>
+        {
+            private readonly IDictionaryEnumerator _entryEnumerator;
+
+            public DictionaryEntry Current => _entryEnumerator.Entry;
+
+            public DictionaryEntryEnumerator(IDictionary dictionary)
+            {
+                _entryEnumerator = dictionary?.GetEnumerator();
+            }
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+                if (_entryEnumerator is IDisposable disposable)
+                    disposable.Dispose();
+            }
+
+            public bool MoveNext()
+            {
+                return _entryEnumerator?.MoveNext() ?? false;
+            }
+
+            public void Reset()
+            {
+                _entryEnumerator?.Reset();
+            }
+        }
+    }
+}

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -510,18 +510,18 @@ namespace NLog.Layouts
             }
         }
 
-        private void AppendXmlDictionaryObject(string propName, System.Collections.IDictionary dict, StringBuilder sb, int orgLength, SingleItemOptimizedHashSet<object> objectsInPath, int depth, bool ignorePropertiesElementName)
+        private void AppendXmlDictionaryObject(string propName, System.Collections.IDictionary dictionary, StringBuilder sb, int orgLength, SingleItemOptimizedHashSet<object> objectsInPath, int depth, bool ignorePropertiesElementName)
         {
             string propNameElement = AppendXmlPropertyValue(propName, null, TypeCode.Empty, sb, orgLength, true, ignorePropertiesElementName);
             if (!string.IsNullOrEmpty(propNameElement))
             {
-                foreach (System.Collections.DictionaryEntry entry in dict)
+                foreach (var item in new DictionaryEntryEnumerable(dictionary))
                 {
                     int beforeValueLength = sb.Length;
                     if (beforeValueLength > MaxXmlLength)
                         break;
 
-                    if (!AppendXmlPropertyObjectValue(entry.Key?.ToString(), entry.Value, Convert.GetTypeCode(entry.Value), sb, orgLength, objectsInPath, depth))
+                    if (!AppendXmlPropertyObjectValue(item.Key?.ToString(), item.Value, Convert.GetTypeCode(item.Value), sb, orgLength, objectsInPath, depth))
                     {
                         sb.Length = beforeValueLength;
                     }

--- a/src/NLog/MessageTemplates/ValueFormatter.cs
+++ b/src/NLog/MessageTemplates/ValueFormatter.cs
@@ -263,7 +263,7 @@ namespace NLog.MessageTemplates
         private bool SerializeDictionaryObject(IDictionary dictionary, string format, IFormatProvider formatProvider, StringBuilder builder, SingleItemOptimizedHashSet<object> objectsInPath, int depth)
         {
             bool separator = false;
-            foreach (DictionaryEntry item in dictionary)
+            foreach (var item in new DictionaryEntryEnumerable(dictionary))
             {
                 if (builder.Length > MaxValueLength)
                     return false;

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -301,7 +301,7 @@ namespace NLog.Targets
             }
         }
 
-        private void SerializeDictionaryObject(IDictionary value, StringBuilder destination, JsonSerializeOptions options, SingleItemOptimizedHashSet<object> objectsInPath, int depth)
+        private void SerializeDictionaryObject(IDictionary dictionary, StringBuilder destination, JsonSerializeOptions options, SingleItemOptimizedHashSet<object> objectsInPath, int depth)
         {
             bool first = true;
 
@@ -314,7 +314,7 @@ namespace NLog.Targets
 
             int originalLength;
             destination.Append('{');
-            foreach (DictionaryEntry de in value)
+            foreach (var item in new DictionaryEntryEnumerable(dictionary))
             {
                 originalLength = destination.Length;
                 if (originalLength > MaxJsonLength)
@@ -327,7 +327,7 @@ namespace NLog.Targets
                     destination.Append(',');
                 }
 
-                var itemKey = de.Key;
+                var itemKey = item.Key;
                 var itemKeyTypeCode = Convert.GetTypeCode(itemKey);
                 if (options.QuoteKeys)
                 {
@@ -361,7 +361,7 @@ namespace NLog.Targets
                 destination.Append(':');
 
                 //only serialize, if key and value are serialized without error (e.g. due to reference loop)
-                var itemValue = de.Value;
+                var itemValue = item.Value;
                 var itemValueTypeCode = Convert.GetTypeCode(itemValue);
                 if (!SerializeObject(itemValue, itemValueTypeCode, destination, options, objectsInPath, nextDepth))
                 {

--- a/tests/NLog.UnitTests/Internal/TrickyTestDictionary.cs
+++ b/tests/NLog.UnitTests/Internal/TrickyTestDictionary.cs
@@ -1,0 +1,142 @@
+﻿// 
+// Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.Internal
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Tricky implementation of IDictionary where GetEnumerator does not return expected DictionaryEntry by default
+    /// </summary>
+    internal class TrickyTestDictionary : IDictionary<object, object>, IDictionary
+    {
+        readonly Dictionary<object, object> _inner = new Dictionary<object, object>();
+
+        public object this[object key] { get => _inner[key]; set => _inner[key] = value; }
+
+        public ICollection<object> Keys => _inner.Keys;
+
+        public ICollection<object> Values => _inner.Values;
+
+        public int Count => _inner.Count;
+
+        public bool IsReadOnly => ((IDictionary)_inner).IsReadOnly;
+
+        public bool IsFixedSize => ((IDictionary)_inner).IsFixedSize;
+
+        public object SyncRoot => ((IDictionary)_inner).SyncRoot;
+
+        public bool IsSynchronized => ((IDictionary)_inner).IsSynchronized;
+
+        ICollection IDictionary.Keys => _inner.Keys;
+
+        ICollection IDictionary.Values => _inner.Values;
+
+        public void Add(object key, object value)
+        {
+            _inner.Add(key, value);
+        }
+
+        public void Add(KeyValuePair<object, object> item)
+        {
+            _inner.Add(item.Key, item.Value);
+        }
+
+        public void Clear()
+        {
+            _inner.Clear();
+        }
+
+        public bool Contains(KeyValuePair<object, object> item)
+        {
+            return ((IDictionary)_inner).Contains(item);
+        }
+
+        public bool Contains(object key)
+        {
+            return ((IDictionary)_inner).Contains(key);
+        }
+
+        public bool ContainsKey(object key)
+        {
+            return _inner.ContainsKey(key);
+        }
+
+        public void CopyTo(KeyValuePair<object, object>[] array, int arrayIndex)
+        {
+            ((IDictionary)_inner).CopyTo(array, arrayIndex);
+        }
+
+        public void CopyTo(Array array, int index)
+        {
+            ((IDictionary)_inner).CopyTo(array, index);
+        }
+
+        public IEnumerator<KeyValuePair<object, object>> GetEnumerator()
+        {
+            return _inner.GetEnumerator();
+        }
+
+        public bool Remove(object key)
+        {
+            return _inner.Remove(key);
+        }
+
+        public bool Remove(KeyValuePair<object, object> item)
+        {
+            return _inner.Remove(item.Key);
+        }
+
+        public bool TryGetValue(object key, out object value)
+        {
+            return _inner.TryGetValue(key, out value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _inner.GetEnumerator();
+        }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator()
+        {
+            return _inner.GetEnumerator();  // Non-standard enumerator returned. Should be: ((IDictionary)_inner).GetEnumerator()
+        }
+
+        void IDictionary.Remove(object key)
+        {
+            _inner.Remove(key);
+        }
+    }
+}

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -559,6 +559,36 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(10, cnt);
         }
 
+        [Fact]
+        public void XmlLayout_PropertiesElementNameFormat_RenderTrickyDictionary()
+        {
+            // Arrange
+            var xmlLayout = new XmlLayout()
+            {
+                Elements = { new XmlLayout("message", "${message}") },
+                PropertiesElementName = "{0}",
+                PropertiesElementKeyAttribute = "",
+                IncludeAllProperties = true,
+                MaxRecursionLimit = 10,
+            };
+
+            var logEventInfo = new LogEventInfo
+            {
+                Message = "Monster massage"
+            };
+            IDictionary<object, object> testDictionary = new Internal.TrickyTestDictionary();
+            testDictionary.Add("key1", 13);
+            testDictionary.Add("key 2", 1.3m);
+            logEventInfo.Properties["nlogPropertyKey"] = testDictionary;
+
+            // Act
+            var result = xmlLayout.Render(logEventInfo);
+
+            // Assert
+            const string expected = @"<logevent><message>Monster massage</message><nlogPropertyKey><key1>13</key1><key_2>1.3</key_2></nlogPropertyKey></logevent>";
+            Assert.Equal(expected, result);
+        }
+
         private class TestList : IEnumerable<System.Collections.IEnumerable>
         {
             static List<int> _list1 = new List<int> { 17, 3 };

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -2359,6 +2359,16 @@ namespace NLog.UnitTests
             return "object-to-string";
         }
 
+        [Fact]
+        public void LogEventTemplateHandleTrickyDictionary()
+        {
+            IDictionary<object, object> dictionary = new Internal.TrickyTestDictionary();
+            dictionary.Add("key1", 13);
+            dictionary.Add("key 2", 1.3m);
+            LogEventInfo logEventInfo = new LogEventInfo(LogLevel.Info, "Logger", null, "{mybad}", new object[] { dictionary });
+            var result = logEventInfo.FormattedMessage;
+            Assert.Contains("\"key1\"=13, \"key 2\"", result);
+        }
 
         [Fact]
         public void LogEventTemplateShouldHaveProperties()

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
@@ -263,6 +263,16 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void SerializeTrickyDict_Test()
+        {
+            IDictionary<object,object> dictionary = new Internal.TrickyTestDictionary();
+            dictionary.Add("key1", 13);
+            dictionary.Add("key 2", 1.3m);
+            var actual = SerializeObject(dictionary);
+            Assert.Equal("{\"key1\":13,\"key 2\":1.3}", actual);
+        }
+
+        [Fact]
         public void SerializeIntegerKeyDict_Test()
         {
             var dictionary = new Dictionary<int, string>();
@@ -316,8 +326,7 @@ namespace NLog.UnitTests.Targets
             var actual = SerializeObject(newGuid);
             Assert.Equal("\"" + newGuid.ToString() + "\"", actual);
         }
-
-
+        
         [Fact]
         public void SerializeEnum_Test()
         {
@@ -325,8 +334,6 @@ namespace NLog.UnitTests.Targets
             var actual = SerializeObject(val);
             Assert.Equal("\"Method\"", actual);
         }
-
-
 
         [Fact]
         public void SerializeFlagEnum_Test()


### PR DESCRIPTION
With non-default GetEnumerator-implementation that doesn't return DictionaryEntry-values (without some help).

See also: https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/issues/802