### PR TITLE
WebService target allow override of SoapAction through Headers

### DIFF
--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -74,10 +74,7 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                if (useExplicitFileLoading)
-                    LogManager.Configuration = new XmlLoggingConfiguration(configFilePath);
-                else
-                    LogManager.LogFactory.SetCandidateConfigFilePaths(new string[] { configFilePath });
+                SetLogManagerConfiguration(useExplicitFileLoading, configFilePath);
 
                 Assert.False(((XmlLoggingConfiguration)LogManager.Configuration).AutoReload);
 
@@ -96,6 +93,14 @@ namespace NLog.UnitTests.Config
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
+        }
+
+        private static void SetLogManagerConfiguration(bool useExplicitFileLoading, string configFilePath)
+        {
+            if (useExplicitFileLoading)
+                LogManager.Configuration = new XmlLoggingConfiguration(configFilePath);
+            else
+                LogManager.LogFactory.SetCandidateConfigFilePaths(new string[] { configFilePath });
         }
 
         [Theory]
@@ -130,10 +135,7 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                if(useExplicitFileLoading)
-                    LogManager.Configuration = new XmlLoggingConfiguration(configFilePath);
-                else
-                    LogManager.LogFactory.SetCandidateConfigFilePaths(new string[] { configFilePath });
+                SetLogManagerConfiguration(useExplicitFileLoading, configFilePath);
 
                 Assert.True(((XmlLoggingConfiguration)LogManager.Configuration).AutoReload);
 
@@ -184,10 +186,7 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                if (useExplicitFileLoading)
-                    LogManager.Configuration = new XmlLoggingConfiguration(configFilePath);
-                else
-                    LogManager.LogFactory.SetCandidateConfigFilePaths(new string[] { configFilePath });
+                SetLogManagerConfiguration(useExplicitFileLoading, configFilePath);
 
                 var logger = LogManager.GetLogger("A");
                 logger.Debug("aaa");
@@ -254,10 +253,7 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                if (useExplicitFileLoading)
-                    LogManager.Configuration = new XmlLoggingConfiguration(configFilePath);
-                else
-                    LogManager.LogFactory.SetCandidateConfigFilePaths(new string[] { configFilePath });
+                SetLogManagerConfiguration(useExplicitFileLoading, configFilePath);
 
                 var logger = LogManager.GetLogger("A");
                 logger.Debug("aaa");
@@ -334,10 +330,7 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                if (useExplicitFileLoading)
-                    LogManager.Configuration = new XmlLoggingConfiguration(mainConfigFilePath);
-                else
-                    LogManager.LogFactory.SetCandidateConfigFilePaths(new string[] { mainConfigFilePath });
+                SetLogManagerConfiguration(useExplicitFileLoading, mainConfigFilePath);
 
                 var logger = LogManager.GetLogger("A");
                 logger.Debug("aaa");
@@ -403,10 +396,7 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                if (useExplicitFileLoading)
-                    LogManager.Configuration = new XmlLoggingConfiguration(mainConfigFilePath);
-                else
-                    LogManager.LogFactory.SetCandidateConfigFilePaths(new string[] { mainConfigFilePath });
+                SetLogManagerConfiguration(useExplicitFileLoading, mainConfigFilePath);
 
                 var logger = LogManager.GetLogger("A");
                 logger.Debug("aaa");
@@ -478,10 +468,7 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                if (useExplicitFileLoading)
-                    LogManager.Configuration = new XmlLoggingConfiguration(mainConfigFilePath);
-                else
-                    LogManager.LogFactory.SetCandidateConfigFilePaths(new string[] { mainConfigFilePath });
+                SetLogManagerConfiguration(useExplicitFileLoading, mainConfigFilePath);
 
                 var logger = LogManager.GetLogger("A");
                 logger.Debug("aaa");
@@ -552,10 +539,7 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                if (useExplicitFileLoading)
-                    LogManager.Configuration = new XmlLoggingConfiguration(mainConfigFilePath);
-                else
-                    LogManager.LogFactory.SetCandidateConfigFilePaths(new string[] { mainConfigFilePath });
+                SetLogManagerConfiguration(useExplicitFileLoading, mainConfigFilePath);
 
                 var logger = LogManager.GetLogger("A");
                 logger.Debug("aaa");

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -599,9 +599,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                         </target>
                     </targets>
                     <rules>
-                      <logger name='*' writeTo='ws'>
-                       
-                      </logger>
+                      <logger name='*' writeTo='ws' />
                     </rules>
                 </nlog>");
 
@@ -642,19 +640,16 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                                 methodName ='Ping'
                                 preAuthenticate='false'
                                 encoding ='UTF-8'
-                                soapAction = 'http://tempuri.org/custom-namespace/Ping'
                                >
+                            <header name='SOAPAction' layout='http://tempuri.org/custom-namespace/Ping'/>
                             <parameter name='param1' ParameterType='System.String' layout='${{message}}'/> 
                             <parameter name='param2' ParameterType='System.String' layout='${{level}}'/>
                         </target>
                     </targets>
                     <rules>
-                      <logger name='*' writeTo='ws'>
-                       
-                      </logger>
+                      <logger name='*' writeTo='ws' />
                     </rules>
                 </nlog>");
-
 
             LogManager.Configuration = configuration;
             var logger = LogManager.GetCurrentClassLogger();
@@ -698,9 +693,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                         </target>
                     </targets>
                     <rules>
-                      <logger name='*' writeTo='ws'>
-                       
-                      </logger>
+                      <logger name='*' writeTo='ws' />
                     </rules>
                 </nlog>");
 
@@ -720,54 +713,6 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
 
             Assert.Equal<int>(0, context.CountdownEvent.CurrentCount);
         }
-
-        /// <summary>
-        /// Test the Webservice with Soap11 api - <see cref="WebServiceProtocol.Soap11"/> 
-        /// </summary>
-        [Fact]
-        public void WebserviceTest_soap12_custom_soapaction()
-        {
-            var configuration = XmlLoggingConfiguration.CreateFromXmlString($@"
-                <nlog throwExceptions='true'>
-                    <targets>
-                        <target type='WebService'
-                                name='ws'
-                                url='{getWsAddress(1)}{"api/logdoc/soap12"}'
-                                protocol='Soap12'
-                                namespace='http://tempuri.org/'
-                                methodName ='Ping'
-                                preAuthenticate='false'
-                                encoding ='UTF-8'
-                                soapAction = 'http://tempuri.org/custom-namespace/Ping'
-                               >
-                            <parameter name='param1' ParameterType='System.String' layout='${{message}}'/> 
-                            <parameter name='param2' ParameterType='System.String' layout='${{level}}'/>
-                        </target>
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='ws'>
-                       
-                      </logger>
-                    </rules>
-                </nlog>");
-
-
-            LogManager.Configuration = configuration;
-            var logger = LogManager.GetCurrentClassLogger();
-
-            var txt = "test.message";   // Lets tease the Xml-Serializer, and see it can handle xml-tags
-            var count = 1;
-            var contentType = MediaTypeHeaderValue.Parse("application/soap+xml;charset=utf-8;action=\"http://tempuri.org/custom-namespace/Ping\"");
-            var context = new LogDocController.TestContext(1, count, true, null, null, null, true, DateTime.UtcNow, contentType);
-
-            StartOwinDocTest(context, () =>
-            {
-                logger.Info(txt);
-            });
-
-            Assert.Equal<int>(0, context.CountdownEvent.CurrentCount);
-        }
-
 
         /// <summary>
         /// Start/config route of WS


### PR DESCRIPTION
Follow up to #3081

And reduce string-allocations by only doing string.Concat once for ContentType and SoapAction (Unless overriding using Headers-Layout)