### PR TITLE
StringBuilderPool - Reduce memory overhead until required

### DIFF
--- a/src/NLog/Internal/StringBuilderPool.cs
+++ b/src/NLog/Internal/StringBuilderPool.cs
@@ -49,9 +49,9 @@ namespace NLog.Internal
         /// <param name="poolCapacity">Max number of items</param>
         /// <param name="initialBuilderCapacity">Initial StringBuilder Size</param>
         /// <param name="maxBuilderCapacity">Max StringBuilder Size</param>
-        public StringBuilderPool(int poolCapacity, int initialBuilderCapacity = 16 * 1024, int maxBuilderCapacity = 512 * 1024)
+        public StringBuilderPool(int poolCapacity, int initialBuilderCapacity = 1024, int maxBuilderCapacity = 512 * 1024)
         {
-            _fastPool = new StringBuilder(Math.Max(initialBuilderCapacity, 16 * 1024));
+            _fastPool = new StringBuilder(10 * initialBuilderCapacity);
             _slowPool = new StringBuilder[poolCapacity];
             for (int i = 0; i < _slowPool.Length; ++i)
             {

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -211,7 +211,7 @@ namespace NLog.Targets
 
                     if (_precalculateStringBuilderPool == null)
                     {
-                        System.Threading.Interlocked.CompareExchange(ref _precalculateStringBuilderPool, new StringBuilderPool(System.Environment.ProcessorCount * 4, 1024), null);
+                        System.Threading.Interlocked.CompareExchange(ref _precalculateStringBuilderPool, new StringBuilderPool(Environment.ProcessorCount * 2), null);
                     }
 
                     using (var targetBuilder = _precalculateStringBuilderPool.Acquire())


### PR DESCRIPTION
No need to capture (and hold) a lot of memory without knowing if it will be used.

Ex running console program on 56 core machine allocates 400 StringBuilders of 16K. Now it will allocate 300 stringbuilders of 1K (6MB vs 0.3MB)