### PR TITLE
LogFactory.ServiceRepository for better dependency injection support

### DIFF
--- a/src/NLog/Config/ConfigItemCreator.cs
+++ b/src/NLog/Config/ConfigItemCreator.cs
@@ -1,0 +1,74 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    using System;
+
+    /// <summary>
+    /// Implements interface to instantiate configuration objects.
+    /// </summary>
+    class ConfigItemCreator : IConfigItemCreator
+    {
+        public static ConfigItemCreator Instance { get; } = new ConfigItemCreator();
+
+        public readonly ConfigurationItemCreator CreateInstanceMethod;
+
+        public ConfigItemCreator()
+            :this(ConfigurationItemCreator)
+        {
+        }
+
+        public ConfigItemCreator(ConfigurationItemCreator creator)
+        {
+            CreateInstanceMethod = creator ?? ConfigurationItemCreator;
+        }
+
+        public object CreateInstance(Type itemType)
+        {
+            return CreateInstanceMethod(itemType);
+        }
+
+        private static object ConfigurationItemCreator(Type itemType)
+        {
+            try
+            {
+                return Activator.CreateInstance(itemType);
+            }
+            catch (MissingMethodException exception)
+            {
+                throw new NLogConfigurationException($"Cannot access the constructor of type: {itemType.FullName}. Is the required permission granted?", exception);
+            }
+        }
+    }
+}

--- a/src/NLog/Config/Factory.cs
+++ b/src/NLog/Config/Factory.cs
@@ -37,8 +37,8 @@ namespace NLog.Config
 {
     using System;
     using System.Collections.Generic;
-    using Common;
-    using Internal;
+    using NLog.Common;
+    using NLog.Internal;
 
     /// <summary>
     /// Factory for class-based items.
@@ -50,11 +50,13 @@ namespace NLog.Config
         where TAttributeType : NameBaseAttribute
     {
         private readonly Dictionary<string, GetTypeDelegate> _items = new Dictionary<string, GetTypeDelegate>(StringComparer.OrdinalIgnoreCase);
-        private readonly ConfigurationItemFactory _parentFactory;
+        private readonly ServiceRepository _serviceRepository;
+        private readonly Factory<TBaseType, TAttributeType> _globalDefaultFactory;
 
-        internal Factory(ConfigurationItemFactory parentFactory)
+        internal Factory(ServiceRepository serviceRepository, Factory<TBaseType, TAttributeType> globalDefaultFactory)
         {
-            _parentFactory = parentFactory;
+            _serviceRepository = serviceRepository;
+            _globalDefaultFactory = globalDefaultFactory;
         }
 
         private delegate Type GetTypeDelegate();
@@ -142,6 +144,11 @@ namespace NLog.Config
 
             if (!_items.TryGetValue(itemName, out getTypeDelegate))
             {
+                if (_globalDefaultFactory != null && _globalDefaultFactory.TryGetDefinition(itemName, out result))
+                {
+                    return true;
+                }
+
                 result = null;
                 return false;
             }
@@ -180,7 +187,7 @@ namespace NLog.Config
                 return false;
             }
 
-            result = (TBaseType)_parentFactory.CreateInstance(type);
+            result = (TBaseType)_serviceRepository.ConfigItemCreator.CreateInstance(type);
             return true;
         }
 
@@ -213,18 +220,20 @@ namespace NLog.Config
     /// </summary>
     class LayoutRendererFactory : Factory<LayoutRenderer, LayoutRendererAttribute>
     {
-        public LayoutRendererFactory(ConfigurationItemFactory parentFactory) : base(parentFactory)
-        {
-        }
-
         private Dictionary<string, FuncLayoutRenderer> _funcRenderers;
+        private readonly LayoutRendererFactory _globalDefaultFactory;
+
+        public LayoutRendererFactory(ServiceRepository serviceRepository, LayoutRendererFactory globalDefaultFactory) : base(serviceRepository, globalDefaultFactory)
+        {
+            _globalDefaultFactory = globalDefaultFactory;
+        }
 
         /// <summary>
         /// Clear all func layouts
         /// </summary>
         public void ClearFuncLayouts()
         {
-            _funcRenderers = null;
+            _funcRenderers?.Clear();
         }
 
         /// <summary>
@@ -250,21 +259,20 @@ namespace NLog.Config
         public override bool TryCreateInstance(string itemName, out LayoutRenderer result)
         {
             //first try func renderers, as they should have the possiblity to overwrite a current one.
-            if (_funcRenderers != null)
+            FuncLayoutRenderer funcResult;
+            if (_funcRenderers != null && _funcRenderers.TryGetValue(itemName, out funcResult))
             {
-                FuncLayoutRenderer funcResult;
-                var succesAsFunc = _funcRenderers.TryGetValue(itemName, out funcResult);
-                if (succesAsFunc)
-                {
-                    result = funcResult;
-                    return true;
-                }
+                result = funcResult;
+                return true;
             }
 
-            var success = base.TryCreateInstance(itemName, out result);
+            if (_globalDefaultFactory?._funcRenderers != null && _globalDefaultFactory._funcRenderers.TryGetValue(itemName, out funcResult))
+            {
+                result = funcResult;
+                return true;
+            }
 
-            return success;
+            return base.TryCreateInstance(itemName, out result);
         }
-
     }
 }

--- a/src/NLog/Config/IConfigItemCreator.cs
+++ b/src/NLog/Config/IConfigItemCreator.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,30 +31,23 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.Internal
+namespace NLog.Config
 {
     using System;
-    using System.Reflection;
 
     /// <summary>
-    /// Object construction helper.
+    /// Interface to instantiate configuration objects.
     /// </summary>
-    internal class FactoryHelper
+    /// <remarks>
+    /// Create own custom implementation to perform dependency injection or custom initialization
+    /// </remarks>
+    public interface IConfigItemCreator
     {
-        private FactoryHelper()
-        {
-        }
-
-        internal static object CreateInstance(Type t)
-        {
-            try
-            {
-                return Activator.CreateInstance(t);
-            }
-            catch (MissingMethodException exception)
-            {
-                throw new NLogConfigurationException($"Cannot access the constructor of type: {t.FullName}. Is the required permission granted?", exception);
-            }
-        }
+        /// <summary>
+        /// Constructs a new instance the configuration item (target, layout, layout renderer, etc.) given its type.
+        /// </summary>
+        /// <param name="itemType">Type of the item.</param>
+        /// <returns>Created object of the specified type.</returns>
+        object CreateInstance(Type itemType);
     }
 }

--- a/src/NLog/Config/LoggingConfigurationHelper.cs
+++ b/src/NLog/Config/LoggingConfigurationHelper.cs
@@ -1,0 +1,43 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    internal static class LoggingConfigurationHelper
+    {
+        public static ServiceRepository GetServiceRepository(this LoggingConfiguration loggingConfiguration)
+        {
+            return loggingConfiguration?.LogFactory?.ServiceRepository ?? LogManager.LogFactory.ServiceRepository;
+        }
+    }
+}

--- a/src/NLog/Config/MethodFactory.cs
+++ b/src/NLog/Config/MethodFactory.cs
@@ -36,8 +36,8 @@ namespace NLog.Config
     using System;
     using System.Collections.Generic;
     using System.Reflection;
-    using Common;
-    using Internal;
+    using NLog.Common;
+    using NLog.Internal;
 
     /// <summary>
     /// Factory for locating methods.
@@ -49,6 +49,12 @@ namespace NLog.Config
         where TMethodAttributeType : NameBaseAttribute
     {
         private readonly Dictionary<string, MethodInfo> _nameToMethodInfo = new Dictionary<string, MethodInfo>();
+        private readonly MethodFactory<TClassAttributeType, TMethodAttributeType> _globalDefaultFactory;
+
+        public MethodFactory(MethodFactory<TClassAttributeType, TMethodAttributeType> globalDefaultFactory)
+        {
+            _globalDefaultFactory = globalDefaultFactory;
+        }
 
         /// <summary>
         /// Gets a collection of all registered items in the factory.
@@ -83,8 +89,6 @@ namespace NLog.Config
                     {
                         throw;
                     }
-
-                    
                 }
             }
         }
@@ -135,7 +139,7 @@ namespace NLog.Config
         /// <returns>A value of <c>true</c> if the method was found, <c>false</c> otherwise.</returns>
         public bool TryCreateInstance(string itemName, out MethodInfo result)
         {
-            return _nameToMethodInfo.TryGetValue(itemName, out result);
+            return TryGetDefinition(itemName, out result);
         }
 
         /// <summary>
@@ -163,7 +167,12 @@ namespace NLog.Config
         /// <returns>A value of <c>true</c> if the method was found, <c>false</c> otherwise.</returns>
         public bool TryGetDefinition(string itemName, out MethodInfo result)
         {
-            return _nameToMethodInfo.TryGetValue(itemName, out result);
+            if (_nameToMethodInfo.TryGetValue(itemName, out result))
+            {
+                return true;
+            }
+
+            return _globalDefaultFactory?.TryGetDefinition(itemName, out result) ?? false;
         }
     }
 }

--- a/src/NLog/Config/PropertyTypeConverter.cs
+++ b/src/NLog/Config/PropertyTypeConverter.cs
@@ -40,6 +40,11 @@ namespace NLog.Config
     /// </summary>
     class PropertyTypeConverter : IPropertyTypeConverter
     {
+        /// <summary>
+        /// Singleton instance of the serializer.
+        /// </summary>
+        public static PropertyTypeConverter Instance { get; } = new PropertyTypeConverter();
+
         /// <inheritdoc/>
         public object Convert(object propertyValue, Type propertyType, string format, IFormatProvider formatProvider)
         {

--- a/src/NLog/Config/ServiceRepository.cs
+++ b/src/NLog/Config/ServiceRepository.cs
@@ -1,0 +1,236 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using NLog.Internal;
+    using NLog.LayoutRenderers;
+    using NLog.Layouts;
+    using NLog.Targets;
+
+    /// <summary>
+    /// Repository of intefaces used by NLog to allow override for dependency injection
+    /// </summary>
+    public sealed class ServiceRepository
+    {
+        private readonly Dictionary<Type, object> _serviceRepository = new Dictionary<Type, object>();
+        private ConfigurationItemFactory _localItemFactory;
+
+        internal ConfigurationItemFactory ConfigurationItemFactory
+        {
+            get => _localItemFactory ?? (_localItemFactory = new ConfigurationItemFactory(this, ConfigurationItemFactory.Default, ArrayHelper.Empty<Assembly>()));
+            set => _localItemFactory = null;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceRepository"/> class.
+        /// </summary>
+        internal ServiceRepository()
+        {
+            RegisterService(typeof(IJsonConverter), DefaultJsonSerializer.Instance);
+            RegisterService(typeof(IValueFormatter), new MessageTemplates.ValueFormatter(this));
+            RegisterService(typeof(IPropertyTypeConverter), NLog.Config.PropertyTypeConverter.Instance);
+            RegisterService(typeof(IConfigItemCreator), NLog.Config.ConfigItemCreator.Instance);
+            // Maybe also include active TimeSource ? Could also be property on LogFactory
+        }
+
+        /// <summary>
+        /// Registers singleton-object as implementation of specific interface.
+        /// </summary>
+        /// <remarks>
+        /// If the same single-object implements multiple interfaces then it must be registered for each interface
+        /// </remarks>
+        /// <param name="interfaceType">Type of interface</param>
+        /// <param name="serviceInstance">Singleton object to use for override</param>
+        public void RegisterService(Type interfaceType, object serviceInstance)
+        {
+            if (!(interfaceType?.IsInterface() ?? false))
+            {
+                throw new ArgumentException($"{interfaceType} must be interface", nameof(interfaceType));
+            }
+            if (serviceInstance == null || !interfaceType.IsAssignableFrom(serviceInstance.GetType()))
+            {
+                throw new ArgumentException($"{serviceInstance} must be of type interface {interfaceType}", nameof(serviceInstance));
+            }
+            _serviceRepository[interfaceType] = serviceInstance;
+        }
+
+        /// <summary>
+        /// Lookup of singleton object that implements the specific interface 
+        /// </summary>
+        /// <param name="interfaceType">Type of interface</param>
+        /// <param name="serviceInstance">Singleton object found</param>
+        /// <returns>Lookup was succesful</returns>
+        public bool TryGetService(Type interfaceType, out object serviceInstance)
+        {
+            return _serviceRepository.TryGetValue(interfaceType, out serviceInstance);
+        }
+
+        private T TryGetService<T>() where T : class
+        {
+            if (TryGetService(typeof(T), out var serviceInstance))
+            {
+                return serviceInstance as T;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Register a custom layout renderer.
+        /// </summary>
+        /// <param name="layoutRendererType"> Type of the layout renderer.</param>
+        /// <param name="name"> Name of the layout renderer - without ${}.</param>
+        public void RegisterLayoutRenderer(string name, Type layoutRendererType)
+        {
+            ConfigurationItemFactory.LayoutRenderers.RegisterDefinition(name, layoutRendererType);
+        }
+
+        /// <summary>
+        /// Register a custom layout renderer with a callback function <paramref name="func"/>. The callback recieves the logEvent.
+        /// </summary>
+        /// <param name="name">Name of the layout renderer - without ${}.</param>
+        /// <param name="func">Callback that returns the value for the layout renderer.</param>
+        public void RegisterLayoutRenderer(string name, Func<LogEventInfo, object> func)
+        {
+            RegisterLayoutRenderer(name, (info, configuration) => func(info));
+        }
+
+        /// <summary>
+        /// Register a custom layout renderer with a callback function <paramref name="func"/>. The callback recieves the logEvent and the current configuration.
+        /// </summary>
+        /// <param name="name">Name of the layout renderer - without ${}.</param>
+        /// <param name="func">Callback that returns the value for the layout renderer.</param>
+        public void RegisterLayoutRenderer(string name, Func<LogEventInfo, LoggingConfiguration, object> func)
+        {
+            var layoutRenderer = new FuncLayoutRenderer(name, func);
+            ConfigurationItemFactory.GetLayoutRenderers().RegisterFuncLayout(name, layoutRenderer);
+        }
+
+        /// <summary>
+        /// Register a custom Target.
+        /// </summary>
+        /// <param name="targetType"> Type of the Target.</param>
+        /// <param name="name"> Name of the Target.</param>
+        public void RegisterTarget(string name, Type targetType)
+        {
+            ConfigurationItemFactory.Targets.RegisterDefinition(name, targetType);
+        }
+
+        /// <summary>
+        /// Gets or sets the JSON serializer to use with <see cref="WebServiceTarget"/> or <see cref="JsonLayout"/>
+        /// </summary>
+        public IJsonConverter JsonConverter
+        {
+            get => TryGetService<IJsonConverter>() ?? DefaultJsonSerializer.Instance;
+            set => RegisterService(typeof(IJsonConverter), value ?? DefaultJsonSerializer.Instance);
+        }
+
+        /// <summary>
+        /// Gets or sets the string serializer to use with <see cref="LogEventInfo.MessageTemplateParameters"/>
+        /// </summary>
+        public IValueFormatter ValueFormatter
+        {
+            get => TryGetService<IValueFormatter>() ?? MessageTemplates.ValueFormatter.Instance;
+            set
+            {
+                RegisterService(typeof(IValueFormatter), value ?? new MessageTemplates.ValueFormatter(this));
+                if (ReferenceEquals(this, LogManager.LogFactory.ServiceRepository))
+                {
+                    // Because of performance-reasons (and maybe bad design). See also static LogEventInfo.DefaultMessageFormatter
+                    MessageTemplates.ValueFormatter.Instance = value ?? new MessageTemplates.ValueFormatter(this);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the parameter converter to use with <see cref="DatabaseTarget"/>, <see cref="WebServiceTarget"/> or <see cref="TargetWithContext"/>
+        /// </summary>
+        public IPropertyTypeConverter PropertyTypeConverter
+        {
+            get => TryGetService<IPropertyTypeConverter>() ?? NLog.Config.PropertyTypeConverter.Instance;
+            set => RegisterService(typeof(IPropertyTypeConverter), value ?? NLog.Config.PropertyTypeConverter.Instance);
+        }
+
+        /// <summary>
+        /// Gets or sets the interface to instantiate configuration objects (target, layout, layout renderer, etc.)
+        /// </summary>
+        public IConfigItemCreator ConfigItemCreator
+        {
+            get => TryGetService<IConfigItemCreator>() ?? NLog.Config.ConfigItemCreator.Instance;
+            set => RegisterService(typeof(IConfigItemCreator), value ?? NLog.Config.ConfigItemCreator.Instance);
+        }
+
+        /// <summary>
+        /// Gets or sets the creator delegate used to instantiate configuration objects.
+        /// </summary>
+        /// <remarks>
+        /// By overriding this property, one can enable dependency injection or interception for created objects.
+        /// </remarks>
+        public ConfigurationItemCreator CreateInstance
+        {
+            get => (ConfigItemCreator as ConfigItemCreator)?.CreateInstanceMethod ?? NLog.Config.ConfigItemCreator.Instance.CreateInstanceMethod;
+            set => ConfigItemCreator = new ConfigItemCreator(value);
+        }
+
+        /// <summary>
+        /// Perform mesage template parsing and formatting of LogEvent messages (True = Always, False = Never, Null = Auto Detect)
+        /// </summary>
+        /// <remarks>
+        /// - Null (Auto Detect) : NLog-parser checks <see cref="LogEventInfo.Message"/> for positional parameters, and will then fallback to string.Format-rendering.
+        /// - True: Always performs the parsing of <see cref="LogEventInfo.Message"/> and rendering of <see cref="LogEventInfo.FormattedMessage"/> using the NLog-parser (Allows custom formatting with <see cref="ValueFormatter"/>)
+        /// - False: Always performs parsing and rendering using string.Format (Fastest if not using structured logging)
+        /// </remarks>
+        public bool? ParseMessageTemplates
+        {
+            get
+            {
+                if (ReferenceEquals(LogEventInfo.DefaultMessageFormatter, LogEventInfo.StringFormatMessageFormatter))
+                {
+                    return false;
+                }
+                else if (ReferenceEquals(LogEventInfo.DefaultMessageFormatter, LogMessageTemplateFormatter.Default.MessageFormatter))
+                {
+                    return true;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            set => LogEventInfo.SetDefaultMessageFormatter(value);
+        }
+    }
+}

--- a/src/NLog/Internal/ReflectionHelpers.cs
+++ b/src/NLog/Internal/ReflectionHelpers.cs
@@ -208,6 +208,15 @@ namespace NLog.Internal
 #endif
         }
 
+        public static bool IsInterface(this Type type)
+        {
+#if NETSTANDARD1_0
+            return type.GetTypeInfo().IsInterface;
+#else
+            return type.IsInterface;
+#endif
+        }
+
         public static bool IsClass(this Type type)
         {
 #if NETSTANDARD1_0

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -50,7 +50,8 @@ namespace NLog.Internal
         /// <param name="value">value to be appended</param>
         /// <param name="format">formatstring. If @, then serialize the value with the Default JsonConverter.</param>
         /// <param name="formatProvider">provider, for example culture</param>
-        public static void AppendFormattedValue(this StringBuilder builder, object value, string format, IFormatProvider formatProvider)
+        /// <param name="valueFormatter">NLog string.Format interface</param>
+        public static void AppendFormattedValue(this StringBuilder builder, object value, string format, IFormatProvider formatProvider, IValueFormatter valueFormatter)
         {
             string stringValue = value as string;
             if (stringValue != null && string.IsNullOrEmpty(format))
@@ -59,11 +60,11 @@ namespace NLog.Internal
             }
             else if (format == MessageTemplates.ValueFormatter.FormatAsJson)
             {
-                ValueFormatter.Instance.FormatValue(value, null, CaptureType.Serialize, formatProvider, builder);
+                valueFormatter.FormatValue(value, null, CaptureType.Serialize, formatProvider, builder);
             }
             else if (value != null)
             {
-                ValueFormatter.Instance.FormatValue(value, format, CaptureType.Normal, formatProvider, builder);
+                valueFormatter.FormatValue(value, format, CaptureType.Normal, formatProvider, builder);
             }
         }
 

--- a/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
@@ -55,6 +55,9 @@ namespace NLog.LayoutRenderers
         private string _afterKey;
         private string _afterValue;
 
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceRepository().ValueFormatter);
+        private IValueFormatter _valueFormatter;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AllEventPropertiesLayoutRenderer"/> class.
         /// </summary>
@@ -149,9 +152,9 @@ namespace NLog.LayoutRenderers
                     else
                     {
                         builder.Append(_beforeKey);
-                        builder.AppendFormattedValue(property.Key, null, formatProvider);
+                        builder.AppendFormattedValue(property.Key, null, formatProvider, ValueFormatter);
                         builder.Append(_afterKey);
-                        builder.AppendFormattedValue(property.Value, null, formatProvider);
+                        builder.AppendFormattedValue(property.Value, null, formatProvider, ValueFormatter);
                         builder.Append(_afterValue);
                     }
                 }

--- a/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
@@ -48,6 +48,9 @@ namespace NLog.LayoutRenderers
     [MutableUnsafe]
     public class EventPropertiesLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceRepository().ValueFormatter);
+        private IValueFormatter _valueFormatter;
+
         /// <summary>
         /// Gets or sets the name of the item.
         /// </summary>
@@ -74,7 +77,7 @@ namespace NLog.LayoutRenderers
             if (GetValue(logEvent, out var value))
             {
                 var formatProvider = GetFormatProvider(logEvent, Culture);
-                builder.AppendFormattedValue(value, Format, formatProvider);
+                builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
             }
         }
 

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -54,6 +54,9 @@ namespace NLog.LayoutRenderers
         private string _innerFormat = string.Empty;
         private readonly Dictionary<ExceptionRenderingFormat, Action<StringBuilder, Exception>> _renderingfunctions;
 
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceRepository().ValueFormatter);
+        private IValueFormatter _valueFormatter;
+
         private static readonly Dictionary<string, ExceptionRenderingFormat> _formatsMapping = new Dictionary<string, ExceptionRenderingFormat>(StringComparer.OrdinalIgnoreCase)
                                                                                                     {
                                                                                                         {"MESSAGE",ExceptionRenderingFormat.Message},
@@ -394,7 +397,7 @@ namespace NLog.LayoutRenderers
         /// <param name="ex">The Exception whose properties should be appended.</param>
         protected virtual void AppendSerializeObject(StringBuilder sb, Exception ex)
         {
-            ConfigurationItemFactory.Default.ValueFormatter.FormatValue(ex, null, MessageTemplates.CaptureType.Serialize, null, sb);
+            ValueFormatter.FormatValue(ex, null, MessageTemplates.CaptureType.Serialize, null, sb);
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
@@ -46,6 +46,9 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class GdcLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceRepository().ValueFormatter);
+        private IValueFormatter _valueFormatter;
+
         /// <summary>
         /// Gets or sets the name of the item.
         /// </summary>
@@ -64,8 +67,11 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             object value = GetValue();
-            var formatProvider = GetFormatProvider(logEvent, null);
-            builder.AppendFormattedValue(value, Format, formatProvider);
+            if (value != null || !string.IsNullOrEmpty(Format))
+            {
+                var formatProvider = GetFormatProvider(logEvent, null);
+                builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdcLayoutRenderer.cs
@@ -44,6 +44,9 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class MdcLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceRepository().ValueFormatter);
+        private IValueFormatter _valueFormatter;
+
         /// <summary>
         /// Gets or sets the name of the item.
         /// </summary>
@@ -63,7 +66,7 @@ namespace NLog.LayoutRenderers
         {
             var value = GetValue();
             var formatProvider = GetFormatProvider(logEvent, null);
-            builder.AppendFormattedValue(value, Format, formatProvider);
+            builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
         }
 
         /// <inheritdoc/>

--- a/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MdlcLayoutRenderer.cs
@@ -45,6 +45,9 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class MdlcLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceRepository().ValueFormatter);
+        private IValueFormatter _valueFormatter;
+
         /// <summary>
         /// Gets or sets the name of the item.
         /// </summary>
@@ -64,7 +67,7 @@ namespace NLog.LayoutRenderers
         {
             var value = GetValue();
             var formatProvider = GetFormatProvider(logEvent, null);
-            builder.AppendFormattedValue(value, Format, formatProvider);
+            builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
         }
         
         /// <inheritdoc/>

--- a/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
@@ -53,6 +53,9 @@ namespace NLog.LayoutRenderers
         private Process _process;
         private ReflectionHelpers.LateBoundMethod _lateBoundPropertyGet;
 
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceRepository().ValueFormatter);
+        private IValueFormatter _valueFormatter;
+
         /// <summary>
         /// Gets or sets the property to retrieve.
         /// </summary>
@@ -101,7 +104,7 @@ namespace NLog.LayoutRenderers
             if (value != null)
             {
                 var formatProvider = GetFormatProvider(logEvent);
-                builder.AppendFormattedValue(value, Format, formatProvider);
+                builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
             }
         }
 

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -48,13 +48,13 @@ namespace NLog.Layouts
     {
         private LimitRecursionJsonConvert JsonConverter
         {
-            get => _jsonConverter ?? (_jsonConverter = new LimitRecursionJsonConvert(MaxRecursionLimit, ConfigurationItemFactory.Default.JsonConverter));
+            get => _jsonConverter ?? (_jsonConverter = new LimitRecursionJsonConvert(MaxRecursionLimit, LoggingConfiguration.GetServiceRepository().JsonConverter));
             set => _jsonConverter = value;
         }
         private LimitRecursionJsonConvert _jsonConverter;
         private IValueFormatter ValueFormatter
         {
-            get => _valueFormatter ?? (_valueFormatter = ConfigurationItemFactory.Default.ValueFormatter);
+            get => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceRepository().ValueFormatter);
             set => _valueFormatter = value;
         }
         private IValueFormatter _valueFormatter;

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -389,7 +389,7 @@ namespace NLog.Layouts
                     //check for performance
                     if (InternalLogger.IsWarnEnabled || InternalLogger.IsErrorEnabled)
                     {
-                        InternalLogger.Warn(exception, "Exception in '{0}.Append()'", _stringValueRenderer?.GetType().FullName);
+                        InternalLogger.Warn(exception, "Exception in '{0}.GetFormattedString()'", _stringValueRenderer?.GetType().FullName);
                     }
 
                     if (exception.MustBeRethrown())

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -262,6 +262,11 @@ namespace NLog
         }
 
         /// <summary>
+        /// Repository of intefaces used by NLog to allow override for dependency injection
+        /// </summary>
+        public ServiceRepository ServiceRepository { get; } = new ServiceRepository();
+
+        /// <summary>
         /// Gets or sets the global log level threshold. Log events below this threshold are not logged.
         /// </summary>
         public LogLevel GlobalThreshold
@@ -922,7 +927,7 @@ namespace NLog
                         else
                         {
 
-                            var instance = FactoryHelper.CreateInstance(cacheKey.ConcreteType);
+                            var instance = ServiceRepository.ConfigItemCreator.CreateInstance(cacheKey.ConcreteType);
                             newLogger = instance as Logger;
                             if (newLogger == null)
                             {

--- a/src/NLog/MessageTemplates/ValueFormatter.cs
+++ b/src/NLog/MessageTemplates/ValueFormatter.cs
@@ -41,21 +41,25 @@ using NLog.Internal;
 namespace NLog.MessageTemplates
 {
     /// <summary>
-    /// Convert Render or serialize a value, with optionnally backwardscompatible with <see cref="string.Format(System.IFormatProvider,string,object[])"/>
+    /// Convert, Render or serialize a value, with optionally backwards compatible with <see cref="string.Format(System.IFormatProvider,string,object[])"/>
     /// </summary>
     internal class ValueFormatter : IValueFormatter
     {
         public static IValueFormatter Instance
         {
-            get => _instance ?? (_instance = new ValueFormatter());
-            set => _instance = value ?? new ValueFormatter();
+            get => _instance ?? (_instance = new ValueFormatter(null));
+            set => _instance = value ?? new ValueFormatter(null);
         }
         private static IValueFormatter _instance;
         private static readonly IEqualityComparer<object> _referenceEqualsComparer = SingleItemOptimizedHashSet<object>.ReferenceEqualityComparer.Default;
 
-        /// <summary>Singleton</summary>
-        private ValueFormatter()
+        private readonly ServiceRepository _serviceRepository;
+        private IJsonConverter JsonConverter => _jsonConverter ?? (_jsonConverter = _serviceRepository?.JsonConverter ?? LogManager.LogFactory.ServiceRepository.JsonConverter ?? NLog.Targets.DefaultJsonSerializer.Instance);
+        private IJsonConverter _jsonConverter;
+
+        internal ValueFormatter(ServiceRepository serviceRepository)
         {
+            _serviceRepository = serviceRepository;
         }
 
         private const int MaxRecursionDepth = 2;
@@ -82,7 +86,7 @@ namespace NLog.MessageTemplates
             {
                 case CaptureType.Serialize:
                     {
-                        return ConfigurationItemFactory.Default.JsonConverter.SerializeObject(value, builder);
+                        return JsonConverter.SerializeObject(value, builder);
                     }
                 case CaptureType.Stringify:
                     {

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -280,7 +280,7 @@ namespace NLog.Targets
 
         private IPropertyTypeConverter PropertyTypeConverter
         {
-            get => _propertyTypeConverter ?? (_propertyTypeConverter = ConfigurationItemFactory.Default.PropertyTypeConverter);
+            get => _propertyTypeConverter ?? (_propertyTypeConverter = LoggingConfiguration.GetServiceRepository().PropertyTypeConverter);
             set => _propertyTypeConverter = value;
         }
         private IPropertyTypeConverter _propertyTypeConverter;

--- a/src/NLog/Targets/MethodCallTargetBase.cs
+++ b/src/NLog/Targets/MethodCallTargetBase.cs
@@ -63,7 +63,7 @@ namespace NLog.Targets
 
         private IPropertyTypeConverter PropertyTypeConverter
         {
-            get => _propertyTypeConverter ?? (_propertyTypeConverter = ConfigurationItemFactory.Default.PropertyTypeConverter);
+            get => _propertyTypeConverter ?? (_propertyTypeConverter = LoggingConfiguration.GetServiceRepository().PropertyTypeConverter);
             set => _propertyTypeConverter = value;
         }
         private IPropertyTypeConverter _propertyTypeConverter;

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -112,7 +112,7 @@ namespace NLog.Targets
 
         private IPropertyTypeConverter PropertyTypeConverter
         {
-            get => _propertyTypeConverter ?? (_propertyTypeConverter = ConfigurationItemFactory.Default.PropertyTypeConverter);
+            get => _propertyTypeConverter ?? (_propertyTypeConverter = LoggingConfiguration.GetServiceRepository().PropertyTypeConverter);
             set => _propertyTypeConverter = value;
         }
         private IPropertyTypeConverter _propertyTypeConverter;

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -625,12 +625,12 @@ namespace NLog.Targets
 
         private class HttpPostJsonFormatter : HttpPostTextFormatterBase
         {
-            private IJsonConverter JsonConverter => _jsonConverter ?? (_jsonConverter = ConfigurationItemFactory.Default.JsonConverter);
-            private IJsonConverter _jsonConverter;
+            private readonly IJsonConverter _jsonConverter;
 
             public HttpPostJsonFormatter(WebServiceTarget target)
                 : base(target)
             {
+                _jsonConverter = target.LoggingConfiguration.GetServiceRepository().JsonConverter;
             }
 
             protected override string GetContentType(WebServiceTarget target)
@@ -656,7 +656,7 @@ namespace NLog.Targets
                         builder.Append('"');
                         builder.Append(parameter.Name);
                         builder.Append("\":");
-                        JsonConverter.SerializeObject(parameterValues[i], builder);
+                        _jsonConverter.SerializeObject(parameterValues[i], builder);
                         separator = ",";
                     }
                     builder.Append('}');

--- a/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
@@ -45,8 +45,8 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void ConfigurationItemFactoryDefaultTest()
         {
-            var cif = new ConfigurationItemFactory();
-            Assert.IsType<DebugTarget>(cif.CreateInstance(typeof(DebugTarget)));
+            var serviceRepository = new ServiceRepository();
+            Assert.IsType<DebugTarget>(serviceRepository.CreateInstance(typeof(DebugTarget)));
         }
 
         [Fact]
@@ -64,7 +64,9 @@ namespace NLog.UnitTests.Config
             var cif = new ConfigurationItemFactory();
             cif.RegisterType(typeof(DebugTarget), string.Empty);
             List<Type> resolvedTypes = new List<Type>();
-            cif.CreateInstance = t => { resolvedTypes.Add(t); return FactoryHelper.CreateInstance(t); };
+#pragma warning disable CS0618 // Type or member is obsolete
+            cif.CreateInstance = t => { resolvedTypes.Add(t); return Activator.CreateInstance(t); };
+#pragma warning restore CS0618 // Type or member is obsolete
             Target target = cif.Targets.CreateInstance("Debug");
             Assert.NotNull(target);
             Assert.Single(resolvedTypes);

--- a/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
@@ -1,0 +1,121 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.Config
+{
+    using System.IO;
+    using System.Text;
+    using System.Xml;
+    using NLog.Targets;
+    using Xunit;
+
+    public class ServiceRepositoryTests : NLogTestBase
+    {
+        [Fact]
+        public void SideBySideLogFactoryExternalInterfaceTest()
+        {
+            // Stage
+            LogFactory logFactory1 = new LogFactory();
+            logFactory1.ServiceRepository.RegisterService(typeof(IMyPrettyInterface), new MyPrettyImplementation() { Test = nameof(logFactory1) });
+
+            LogFactory logFactory2 = new LogFactory();
+            logFactory2.ServiceRepository.RegisterService(typeof(IMyPrettyInterface), new MyPrettyImplementation() { Test = nameof(logFactory2) });
+
+            // Act
+            logFactory1.ServiceRepository.TryGetService(typeof(IMyPrettyInterface), out var logFactory1service);
+            logFactory2.ServiceRepository.TryGetService(typeof(IMyPrettyInterface), out var logFactory2service);
+
+            // Assert
+            Assert.Equal(nameof(logFactory1), logFactory1service.ToString());
+            Assert.Equal(nameof(logFactory2), logFactory2service.ToString());
+        }
+
+        [Fact]
+        public void SideBySideLogFactoryInternalInterfaceTest()
+        {
+            // Stage
+            LogFactory logFactory1 = new LogFactory();
+            InitializeLogFactoryJsonConverter(logFactory1, nameof(logFactory1), out Logger logger1, out DebugTarget target1);
+
+            LogFactory logFactory2 = new LogFactory();
+            InitializeLogFactoryJsonConverter(logFactory2, nameof(logFactory2), out Logger logger2, out DebugTarget target2);
+
+            // Act
+            logger1.Info("Hello {user}", "Kenny");
+            logger2.Info("Hello {user}", "Kenny");
+
+            // Assert
+            Assert.Equal("Kenny" + "_" + nameof(logFactory1), target1.LastMessage);
+            Assert.Equal("Kenny" + "_" + nameof(logFactory2), target2.LastMessage);
+        }
+
+        private static void InitializeLogFactoryJsonConverter(LogFactory logFactory, string jsonOutput, out Logger logger, out DebugTarget target)
+        {
+            logFactory.ServiceRepository.RegisterService(typeof(IJsonConverter), new MySimpleJsonConverter() { Test = jsonOutput });
+            using (var stringReader = new StringReader(@"<nlog><targets><target type='debug' name='test' layout='${event-properties:user:format=@}'/></targets><rules><logger name='*' minLevel='Debug' writeTo='test'/></rules></nlog>"))
+            {
+                using (var reader = XmlReader.Create(stringReader))
+                {
+                    logFactory.Configuration = new NLog.Config.XmlLoggingConfiguration(reader, null, logFactory);
+                }
+            }
+            logger = logFactory.GetLogger(nameof(logFactory));
+            target = logFactory.Configuration.FindTargetByName("test") as DebugTarget;
+        }
+
+        interface IMyPrettyInterface
+        {
+            string Test { get; }
+        }
+
+        class MyPrettyImplementation : IMyPrettyInterface
+        {
+            public string Test { get; set; }
+            public override string ToString()
+            {
+                return Test;
+            }
+        }
+
+        class MySimpleJsonConverter : IJsonConverter
+        {
+            public string Test { get; set; }
+
+            public bool SerializeObject(object value, StringBuilder builder)
+            {
+                builder.Append(string.Concat(value.ToString(), "_", Test));
+                return true;
+            }
+        }
+    }
+}

--- a/tests/NLog.UnitTests/LoggerTests.cs
+++ b/tests/NLog.UnitTests/LoggerTests.cs
@@ -1797,7 +1797,7 @@ namespace NLog.UnitTests
             var singleLogger = LogManager.GetLogger("SingleTarget");
             var dualLogger = LogManager.GetLogger("DualTarget");
 
-            ConfigurationItemFactory.Default.ParseMessageTemplates = null;
+            LogManager.LogFactory.ServiceRepository.ParseMessageTemplates = null;
 
             singleLogger.Debug("Hello");
             AssertDebugLastMessage("target1", "SingleTarget|Hello");
@@ -1811,7 +1811,7 @@ namespace NLog.UnitTests
             AssertDebugLastMessage("target1", "DualTarget|Hello World");
             AssertDebugLastMessage("target2", "DualTarget|Hello World");
 
-            ConfigurationItemFactory.Default.ParseMessageTemplates = true;
+            LogManager.LogFactory.ServiceRepository.ParseMessageTemplates = true;
 
             singleLogger.Debug("Hello");
             AssertDebugLastMessage("target1", "SingleTarget|Hello");
@@ -1825,7 +1825,7 @@ namespace NLog.UnitTests
             AssertDebugLastMessage("target1", "DualTarget|Hello World");
             AssertDebugLastMessage("target2", "DualTarget|Hello World");
 
-            ConfigurationItemFactory.Default.ParseMessageTemplates = false;
+            LogManager.LogFactory.ServiceRepository.ParseMessageTemplates = false;
 
             singleLogger.Debug("Hello");
             AssertDebugLastMessage("target1", "SingleTarget|Hello");
@@ -1933,12 +1933,12 @@ namespace NLog.UnitTests
 
             if (parseMessageTemplates.HasValue)
             {
-                Assert.Equal(ConfigurationItemFactory.Default.ParseMessageTemplates, parseMessageTemplates.Value);
+                Assert.Equal(LogManager.LogFactory.ServiceRepository.ParseMessageTemplates, parseMessageTemplates.Value);
             }
 
             if (overrideParseMessageTemplates.HasValue)
             {
-                ConfigurationItemFactory.Default.ParseMessageTemplates = overrideParseMessageTemplates.Value;
+                LogManager.LogFactory.ServiceRepository.ParseMessageTemplates = overrideParseMessageTemplates.Value;
             }
 
             ILogger logger = LogManager.GetLogger("A");


### PR DESCRIPTION
Trying to improve on #3126. Allowing two LogFactory-object to have their own individual dependency-injection without being restricted by `ConfigurationItemFactory.Default`.

There are still some static variables that remains, which requires more work. This PR is mostly about naming and design.

This can also be used to replace the static variables for registering HttpContext in NLog.Web and IConfiguration in ConfigSetting-LayoutRenderer.

My goal is to make `ConfigurationItemFactory` into an internal-class, so no longer accessible by others.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/3128)
<!-- Reviewable:end -->
