### PR TITLE
Fix Opencover on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ test_script:
   - msbuild /t:rebuild .\tools\CheckSourceCode\src\ /p:Configuration=Release /verbosity:minimal
   - tools\CheckSourceCode\NLog.SourceCodeTests.exe no-interactive
   - ps: .\run-tests.ps1
-  - nuget.exe install OpenCover -ExcludeVersion -DependencyVersion Ignore
+  - nuget.exe install OpenCover -ExcludeVersion -Version 4.6.519 -DependencyVersion Ignore
   - OpenCover\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"\"C:\projects\nlog\tests\NLog.UnitTests\bin\debug\net452\NLog.UnitTests.dll\" -appveyor -noshadow"  -returntargetcode -filter:"+[NLog]* +[NLog.Extended]* -[NLog]JetBrains.Annotations.*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:coverage.xml
   - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
   - pip install codecov


### PR DESCRIPTION
OpenCover Version 4.6.519 until The process cannot access the file Nlog.dll has been resolved

to fix:

> NLog.UnitTests.LogManagerTests.GlobalThresholdTest [SKIP]
Side effects to other unit tests.
NLog.UnitTests.ConfigFileLocatorTests.NLogDotDllDotNLogInDirectoryWithSpaces [FAIL]
System.IO.IOException : The process cannot access the file 'NLog.dll' because it is being used by another process.

from: #3129