### PR TITLE
upgrade to C# 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 
 mono: 5.2.0
-dotnet: 2.0.0
+dotnet: 2.1.105
 dist: trusty
 
 

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -370,6 +370,7 @@ Supported can be found on https://nlog-project.org/config/
     <AssemblyTitle>$(Title)</AssemblyTitle>
     <!-- SonarQube WARNING: The following projects do not have a valid ProjectGuid and were not built using a valid solution (.sln) thus will be skipped from analysis… -->
     <ProjectGuid>{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}</ProjectGuid>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
fails "MediumTrustWithExternalClass" test

works on: 7.0 and 7.1
fails on 7.2 and 7.3


most important exceptions:

```
System.Security.SecurityException
  HResult=0x8013150A
  Message=Request for the permission of type 'System.Security.Permissions.FileIOPermission, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' failed.
  Source=mscorlib
  StackTrace:
   at System.Security.CodeAccessSecurityEngine.Check(Object demand, StackCrawlMark& stackMark, Boolean isPermSet)
   at System.Security.CodeAccessPermission.Demand()
   at System.AppDomainSetup.VerifyDir(String dir, Boolean normalize)
   at System.AppDomain.get_BaseDirectory()
   at NLog.Internal.Fakeables.AppDomainWrapper.LookupBaseDirectory(AppDomain appDomain) in D:\nlog\nlog\src\NLog\Internal\Fakeables\AppDomainWrapper.cs:line 100

System.Security.SecurityException
  HResult=0x8013150A
  Message=Request for the permission of type 'System.Security.Permissions.EnvironmentPermission, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' failed.
  Source=mscorlib
  StackTrace:
   at System.Security.CodeAccessSecurityEngine.Check(Object demand, StackCrawlMark& stackMark, Boolean isPermSet)
   at System.Security.CodeAccessPermission.Demand()
   at System.Environment.GetEnvironmentVariable(String variable)
   at NLog.Internal.EnvironmentHelper.GetSafeEnvironmentVariable(String name) in D:\nlog\nlog\src\NLog\Internal\EnvironmentHelper.cs:line 83

System.Security.SecurityException
  HResult=0x8013150A
  Message=Request for the permission of type 'System.Security.Permissions.EnvironmentPermission, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' failed.
  Source=mscorlib
  StackTrace:
   at System.Security.CodeAccessSecurityEngine.Check(Object demand, StackCrawlMark& stackMark, Boolean isPermSet)
   at System.Security.CodeAccessPermission.Demand()
   at System.Environment.GetEnvironmentVariable(String variable)
   at NLog.Internal.EnvironmentHelper.GetSafeEnvironmentVariable(String name) in D:\nlog\nlog\src\NLog\Internal\EnvironmentHelper.cs:line 83

System.Security.SecurityException
  HResult=0x8013150A
  Message=Request for the permission of type 'System.Security.Permissions.FileIOPermission, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' failed.
  Source=mscorlib
  StackTrace:
   at System.Security.CodeAccessSecurityEngine.Check(Object demand, StackCrawlMark& stackMark, Boolean isPermSet)
   at System.Security.CodeAccessPermission.Demand()
   at System.AppDomainSetup.VerifyDir(String dir, Boolean normalize)
   at NLog.Internal.Fakeables.AppDomainWrapper.LookupConfigurationFile(AppDomain appDomain) in D:\nlog\nlog\src\NLog\Internal\Fakeables\AppDomainWrapper.cs:line 109


System.Security.SecurityException
  HResult=0x8013150A
  Message=Request for the permission of type 'System.Security.Permissions.FileIOPermission, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' failed.
  Source=mscorlib
  StackTrace:
   at System.Security.CodeAccessSecurityEngine.Check(Object demand, StackCrawlMark& stackMark, Boolean isPermSet)
   at System.Security.CodeAccessPermission.Demand()
   at System.Reflection.RuntimeAssembly.VerifyCodeBaseDiscovery(String codeBase)
   at System.Reflection.RuntimeAssembly.get_CodeBase()
   at NLog.Internal.AssemblyHelpers.GetAssemblyFileLocation(Assembly assembly) in D:\nlog\nlog\src\NLog\Internal\AssemblyHelpers.cs:line 134


System.Security.SecurityException
  HResult=0x8013150A
  Message=Request for the permission of type 'System.Security.Permissions.FileIOPermission, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' failed.
  Source=mscorlib
  StackTrace:
   at System.Security.CodeAccessSecurityEngine.Check(Object demand, StackCrawlMark& stackMark, Boolean isPermSet)
   at System.Security.CodeAccessPermission.Demand()
   at System.Reflection.RuntimeAssembly.VerifyCodeBaseDiscovery(String codeBase)
   at System.Reflection.RuntimeAssembly.get_CodeBase()
   at NLog.Internal.AssemblyHelpers.GetAssemblyFileLocation(Assembly assembly) in D:\nlog\nlog\src\NLog\Internal\AssemblyHelpers.cs:line 134



System.Reflection.ReflectionTypeLoadException
  HResult=0x80131602
  Message=Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
  Source=mscorlib
  StackTrace:
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.Assembly.GetTypes()
   at NLog.Internal.ReflectionHelpers.SafeGetTypes(Assembly assembly) in D:\nlog\nlog\src\NLog\Internal\ReflectionHelpers.cs:line 58


System.Security.SecurityException
  HResult=0x8013150A
  Message=Request failed.
  Source=NLog
  StackTrace:
   at NLog.Common.InternalLogger.LogAssemblyVersion(Assembly assembly) in D:\nlog\nlog\src\NLog\Common\InternalLogger.cs:line 492
   at NLog.LogFactory.LogConfigurationInitialized() in D:\nlog\nlog\src\NLog\LogFactory.cs:line 302


System.Security.VerificationException
  HResult=0x8013150D
  Message=Operation could destabilize the runtime.
  Source=NLog
  StackTrace:
   at NLog.Internal.AppendBuilderCreator.get_Builder() in D:\nlog\nlog\src\NLog\Internal\AppendBuilderCreator.cs:line 50


System.Security.VerificationException
  HResult=0x8013150D
  Message=Operation could destabilize the runtime.
  Source=NLog
  StackTrace:
   at NLog.Internal.AppendBuilderCreator.Dispose() in D:\nlog\nlog\src\NLog\Internal\AppendBuilderCreator.cs:line 68


System.Threading.ThreadAbortException
  HResult=0x80131530
  Message=Thread was being aborted.
  Source=NLog
  StackTrace:
   at NLog.Targets.Target.WriteAsyncLogEvents(IList`1 logEvents) in D:\nlog\nlog\src\NLog\Targets\Target.cs:line 393


```