### PR TITLE
ContextProperty with IncludeEmptyValue means default value for ValueType

### DIFF
--- a/src/NLog/Targets/MethodCallTargetBase.cs
+++ b/src/NLog/Targets/MethodCallTargetBase.cs
@@ -105,7 +105,7 @@ namespace NLog.Targets
         {
             var parameterType = param.ParameterType ?? typeof(string);
 
-            var parameterValue = RenderLogEvent(param.Layout, logEvent);
+            var parameterValue = RenderLogEvent(param.Layout, logEvent) ?? string.Empty;
             if (parameterType == typeof(string) || parameterType == typeof(object))
                 return parameterValue;
 

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -408,7 +408,7 @@ namespace NLog.Targets
                 }
             }
 
-            var propertyStringValue = RenderLogEvent(contextProperty.Layout, logEvent);
+            var propertyStringValue = RenderLogEvent(contextProperty.Layout, logEvent) ?? string.Empty;
             if (!contextProperty.IncludeEmptyValue && string.IsNullOrEmpty(propertyStringValue))
             {
                 propertyValue = null;

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -363,56 +363,72 @@ namespace NLog.Targets
             combinedProperties = combinedProperties ?? CreateNewDictionary(ContextProperties.Count);
             for (int i = 0; i < ContextProperties.Count; ++i)
             {
-                var attrib = ContextProperties[i];
-                if (string.IsNullOrEmpty(attrib?.Name) || attrib.Layout == null)
+                var contextProperty = ContextProperties[i];
+                if (string.IsNullOrEmpty(contextProperty?.Name) || contextProperty.Layout == null)
                     continue;
-
-                var attribType = attrib.PropertyType ?? typeof(string);
 
                 try
                 {
-                    var isStringType = attribType == typeof(string);
-                    if (!isStringType)
+                    if (TryGetContextPropertyValue(logEvent, contextProperty, out var propertyValue))
                     {
-                        if (TryGetAttributeRawValue(logEvent, attrib, attribType, out var rawValue))
-                        {
-                            combinedProperties[attrib.Name] = rawValue;
-                            continue;
-                        }
+                        combinedProperties[contextProperty.Name] = propertyValue;
                     }
-
-                    var attribStringValue = RenderLogEvent(attrib.Layout, logEvent);
-                    if (!attrib.IncludeEmptyValue && string.IsNullOrEmpty(attribStringValue))
-                        continue;
-
-                    
-                    combinedProperties[attrib.Name] = isStringType
-                        ? attribStringValue : PropertyTypeConverter.Convert(attribStringValue, attribType, null, CultureInfo.InvariantCulture);
                 }
                 catch (Exception ex)
                 {
                     if (ex.MustBeRethrownImmediately())
                         throw;
 
-                    Common.InternalLogger.Warn(ex, "{0}(Name={1}): Failed to add context property {2}", GetType(), Name, attrib.Name);
+                    Common.InternalLogger.Warn(ex, "{0}(Name={1}): Failed to add context property {2}", GetType(), Name, contextProperty.Name);
                 }
             }
 
             return combinedProperties;
         }
 
-        private static bool TryGetAttributeRawValue(LogEventInfo logEvent, TargetPropertyWithContext attrib, Type attribType, out object rawValue)
+        private bool TryGetContextPropertyValue(LogEventInfo logEvent, TargetPropertyWithContext contextProperty, out object propertyValue)
         {
-            var rawValue2 = false;
-            if (attrib.Layout.TryGetRawValue(logEvent, out rawValue))
+            var propertyType = contextProperty.PropertyType ?? typeof(string);
+
+            var isStringType = propertyType == typeof(string);
+            if (!isStringType)
             {
-                if (attribType == typeof(object) || rawValue?.GetType() == attribType)
+                if (contextProperty.Layout.TryGetRawValue(logEvent, out var rawValue))
                 {
-                    rawValue2 = true;
+                    if (propertyType == typeof(object))
+                    {
+                        propertyValue = rawValue;
+                        return contextProperty.IncludeEmptyValue || propertyValue != null;
+                    }
+                    else if (rawValue?.GetType() == propertyType)
+                    {
+                        propertyValue = rawValue;
+                        return true;
+                    }
                 }
             }
 
-            return rawValue2;
+            var propertyStringValue = RenderLogEvent(contextProperty.Layout, logEvent);
+            if (!contextProperty.IncludeEmptyValue && string.IsNullOrEmpty(propertyStringValue))
+            {
+                propertyValue = null;
+                return false;
+            }
+
+            if (isStringType)
+            {
+                propertyValue = propertyStringValue;
+                return true;
+            }
+
+            if (string.IsNullOrEmpty(propertyStringValue) && propertyType.IsValueType())
+            {
+                propertyValue = Activator.CreateInstance(propertyType);
+                return true;
+            }
+
+            propertyValue = PropertyTypeConverter.Convert(propertyStringValue, propertyType, null, CultureInfo.InvariantCulture);
+            return true;
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
+++ b/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
@@ -243,7 +243,11 @@ namespace NLog.UnitTests.Targets
                             <contextproperty name='threadid' layout='${threadid}' propertyType='System.Int32' />
                             <contextproperty name='processid' layout='${processid}' propertyType='System.Int32' />
                             <contextproperty name='timestamp' layout='${date}' propertyType='System.DateTime' />
-                        </target>
+                            <contextproperty name='int-non-existing' layout='${event-properties:non-existing}' propertyType='System.Int32' includeEmptyValue='true' />
+                            <contextproperty name='int-non-existing-empty' layout='${event-properties:non-existing}' propertyType='System.Int32' includeEmptyValue='false' />
+                            <contextproperty name='object-non-existing' layout='${event-properties:non-existing}' propertyType='System.Object' includeEmptyValue='true' />
+                            <contextproperty name='object-non-existing-empty' layout='${event-properties:non-existing}' propertyType='System.Object' includeEmptyValue='false' />
+                       </target>
                     </targets>
                     <rules>
                         <logger name='*' levels='Error' writeTo='debug' />
@@ -262,7 +266,10 @@ namespace NLog.UnitTests.Targets
             Assert.NotEmpty(lastCombinedProperties);
             Assert.Contains(new KeyValuePair<string, object>("threadid", System.Environment.CurrentManagedThreadId), lastCombinedProperties);
             Assert.Contains(new KeyValuePair<string, object>("processid", System.Diagnostics.Process.GetCurrentProcess().Id), lastCombinedProperties);
-            Assert.Contains(new KeyValuePair<string, object>("timestamp", logEvent.TimeStamp), lastCombinedProperties);
+            Assert.Contains(new KeyValuePair<string, object>("int-non-existing", 0), lastCombinedProperties);
+            Assert.DoesNotContain("int-non-existing-empty", lastCombinedProperties.Keys);
+            Assert.Contains(new KeyValuePair<string, object>("object-non-existing", null), lastCombinedProperties);
+            Assert.DoesNotContain("object-non-existing-empty", lastCombinedProperties.Keys);
         }
     }
 }


### PR DESCRIPTION
Convert empty-string and null-value to default value when ValueType with IncludeEmptyValue=true