### PR TITLE
Database target: dropped UseRawValue option on parameters, introduced ${myRenderer:noRawValue=true}

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/NoRawValueLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/NoRawValueLayoutRendererWrapper.cs
@@ -1,0 +1,72 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.LayoutRenderers.Wrappers
+{
+    using System;
+    using System.ComponentModel;
+    using System.Text;
+    using NLog.Config;
+    using NLog.Internal;
+
+    /// <summary>
+    /// Left part of a text
+    /// </summary>
+    [LayoutRenderer("norawvalue")]
+    [AmbientProperty("NoRawValue")]
+    [AppDomainFixedOutput]
+    [ThreadAgnostic]
+    [ThreadSafe]
+    public sealed class NoRawValueLayoutRendererWrapper : WrapperLayoutRendererBase
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to disable the IRawValue-interface
+        /// </summary>
+        /// <value>A value of <c>true</c> if IRawValue-interface should be ignored; otherwise, <c>false</c>.</value>
+        /// <docgen category='Transformation Options' order='10' />
+        [DefaultValue(true)]
+        public bool NoRawValue { get; set; } = true;
+
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
+        {
+            Inner?.RenderAppendBuilder(logEvent, builder);
+        }
+
+        /// <inheritdoc/>
+        protected override string Transform(string text)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/NLog/Targets/DatabaseParameterInfo.cs
+++ b/src/NLog/Targets/DatabaseParameterInfo.cs
@@ -121,18 +121,6 @@ namespace NLog.Targets
         private Type _parameterType;
 
         /// <summary>
-        /// Use raw value
-        ///
-        /// If null, then rawValue will be used when the dbtype isn't a string-like (that's:
-        /// <see cref="System.Data.DbType.String"/>
-        /// <see cref="System.Data.DbType.AnsiString"/>
-        /// <see cref="System.Data.DbType.StringFixedLength"/>
-        /// <see cref="System.Data.DbType.AnsiStringFixedLength"/>
-        /// </summary>
-        /// <docgen category='Parameter Options' order='7' />
-        public bool? UseRawValue { get; set; }
-
-        /// <summary>
         /// Gets or sets convert format of the database parameter value .
         /// </summary>
         /// <docgen category='Parameter Options' order='8' />

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -881,14 +881,14 @@ namespace NLog.Targets
         protected internal virtual object GetDatabaseParameterValue(LogEventInfo logEvent, DatabaseParameterInfo parameterInfo)
         {
             Type dbParameterType = parameterInfo.ParameterType;
-            if (string.IsNullOrEmpty(parameterInfo.Format) && dbParameterType == typeof(string) && !(parameterInfo.UseRawValue ?? false))
+            if (string.IsNullOrEmpty(parameterInfo.Format) && dbParameterType == typeof(string))
             {
                 return RenderLogEvent(parameterInfo.Layout, logEvent) ?? string.Empty;
             }
 
             IFormatProvider dbParameterCulture = GetDbParameterCulture(logEvent, parameterInfo);
 
-            if ((parameterInfo.UseRawValue ?? true) && TryGetConvertedRawValue(logEvent, parameterInfo, dbParameterType, dbParameterCulture, out var value))
+            if (TryGetConvertedRawValue(logEvent, parameterInfo, dbParameterType, dbParameterCulture, out var value))
             {
                 return value ?? CreateDefaultValue(dbParameterType);
             }


### PR DESCRIPTION
NoRawValueLayoutRendererWrapper can be used by "many".

After seeing the trouble in making IRawValue work with wrappers. Then why not make a wrapper where the purpose is to disable the IRawValue-interface.

Another unreleased breaking change.