### PR TITLE
Added support for dynamic layout renderer in log level filters (e.g. minLevel, maxLevel) 

### DIFF
--- a/src/NLog/Config/DynamicLogLevelFilter.cs
+++ b/src/NLog/Config/DynamicLogLevelFilter.cs
@@ -44,7 +44,7 @@ namespace NLog.Config
     /// </summary>
     internal class DynamicLogLevelFilter : ILoggingRuleLevelFilter
     {
-        private static readonly char[] _levelFilerSplitter = { ',' };
+        private static readonly char[] LevelFilerSplitter = { ',' };
         private readonly LoggingRule _loggingRule;
         private readonly SimpleLayout _levelFilter;
         private KeyValuePair<string, bool[]> _activeFilter;
@@ -113,7 +113,7 @@ namespace NLog.Config
 
         private bool[] ParseLevels(string levelFilter)
         {
-            var levels = levelFilter.Split(_levelFilerSplitter, StringSplitOptions.RemoveEmptyEntries);
+            var levels = levelFilter.Split(LevelFilerSplitter, StringSplitOptions.RemoveEmptyEntries);
             bool[] logLevels = new bool[LogLevel.MaxLevel.Ordinal + 1];
             foreach (var level in levels)
             {

--- a/src/NLog/Config/DynamicLogLevelFilter.cs
+++ b/src/NLog/Config/DynamicLogLevelFilter.cs
@@ -1,0 +1,140 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    using System;
+    using System.Collections.Generic;
+    using NLog.Common;
+    using NLog.Internal;
+    using NLog.Layouts;
+
+    /// <summary>
+    /// Dynamic filtering with a positive list of enabled levels
+    /// </summary>
+    internal class DynamicLogLevelFilter : ILoggingRuleLevelFilter
+    {
+        private static readonly char[] _levelFilerSplitter = { ',' };
+        private readonly LoggingRule _loggingRule;
+        private readonly SimpleLayout _levelFilter;
+        private KeyValuePair<string, bool[]> _activeFilter;
+
+        public bool[] LogLevels => GenerateLogLevels();
+
+        public DynamicLogLevelFilter(LoggingRule loggingRule, SimpleLayout levelFilter)
+        {
+            _loggingRule = loggingRule;
+            _levelFilter = levelFilter;
+            _activeFilter = new KeyValuePair<string, bool[]>(string.Empty, LoggingRuleLevelFilter.Off.LogLevels);
+        }
+
+        public LoggingRuleLevelFilter GetSimpleFilterForUpdate()
+        {
+            return new LoggingRuleLevelFilter(LogLevels);
+        }
+
+        private bool[] GenerateLogLevels()
+        {
+            var levelFilter = _levelFilter.Render(LogEventInfo.CreateNullEvent());
+            if (string.IsNullOrEmpty(levelFilter))
+                return LoggingRuleLevelFilter.Off.LogLevels;
+
+            var activeFilter = _activeFilter;
+            if (activeFilter.Key != levelFilter)
+            {
+                bool[] logLevels;
+                if (levelFilter.IndexOf(',') >= 0)
+                {
+                    logLevels = ParseLevels(levelFilter);
+                }
+                else
+                {
+                    logLevels = ParseSingleLevel(levelFilter);
+                    if (ReferenceEquals(logLevels, LoggingRuleLevelFilter.Off.LogLevels))
+                        return logLevels;
+                }
+                _activeFilter = activeFilter = new KeyValuePair<string, bool[]>(levelFilter, logLevels);
+            }
+
+            return activeFilter.Value;
+        }
+
+        private bool[] ParseSingleLevel(string levelFilter)
+        {
+            try
+            {
+                if (StringHelpers.IsNullOrWhiteSpace(levelFilter))
+                    return LoggingRuleLevelFilter.Off.LogLevels;
+
+                var logLevel = LogLevel.FromString(levelFilter.Trim());
+                if (logLevel == LogLevel.Off)
+                    return LoggingRuleLevelFilter.Off.LogLevels;
+
+                bool[] logLevels = new bool[LogLevel.MaxLevel.Ordinal + 1];
+                logLevels[logLevel.Ordinal] = true;
+                return logLevels;
+            }
+            catch (ArgumentException ex)
+            {
+                InternalLogger.Warn(ex, "Logging rule {0} with filter `{1}` has invalid level filter: {2}", _loggingRule.RuleName, _loggingRule.LoggerNamePattern, levelFilter);
+                return LoggingRuleLevelFilter.Off.LogLevels;
+            }
+        }
+
+        private bool[] ParseLevels(string levelFilter)
+        {
+            var levels = levelFilter.Split(_levelFilerSplitter, StringSplitOptions.RemoveEmptyEntries);
+            bool[] logLevels = new bool[LogLevel.MaxLevel.Ordinal + 1];
+            foreach (var level in levels)
+            {
+                try
+                {
+                    if (StringHelpers.IsNullOrWhiteSpace(level))
+                        continue;
+
+                    var logLevel = LogLevel.FromString(level.Trim());
+                    if (logLevel == LogLevel.Off)
+                        continue;
+
+                    logLevels[logLevel.Ordinal] = true;
+                }
+                catch (ArgumentException ex)
+                {
+                    InternalLogger.Warn(ex, "Logging rule {0} with filter `{1}` has invalid level filter: {2}", _loggingRule.RuleName, _loggingRule.LoggerNamePattern, levelFilter);
+                }
+            }
+
+            return logLevels;
+        }
+    }
+}

--- a/src/NLog/Config/DynamicRangeLevelFilter.cs
+++ b/src/NLog/Config/DynamicRangeLevelFilter.cs
@@ -1,0 +1,131 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    using System;
+    using System.Collections.Generic;
+    using NLog.Common;
+    using NLog.Layouts;
+
+    /// <summary>
+    /// Dynamic filtering with a minlevel and maxlevel range
+    /// </summary>
+    internal class DynamicRangeLevelFilter : ILoggingRuleLevelFilter
+    {
+        private readonly LoggingRule _loggingRule;
+        private readonly SimpleLayout _minLevel;
+        private readonly SimpleLayout _maxLevel;
+        private KeyValuePair<MinMaxLevels, bool[]> _activeFilter;
+
+        public bool[] LogLevels => GenerateLogLevels();
+
+        public DynamicRangeLevelFilter(LoggingRule loggingRule, SimpleLayout minLevel, SimpleLayout maxLevel)
+        {
+            _loggingRule = loggingRule;
+            _minLevel = minLevel;
+            _maxLevel = maxLevel;
+            _activeFilter = new KeyValuePair<MinMaxLevels, bool[]>(new MinMaxLevels(string.Empty, string.Empty), LoggingRuleLevelFilter.Off.LogLevels);
+        }
+
+        public LoggingRuleLevelFilter GetSimpleFilterForUpdate()
+        {
+            return new LoggingRuleLevelFilter(LogLevels);
+        }
+
+        private bool[] GenerateLogLevels()
+        {
+            var minLevelFilter = _minLevel?.Render(LogEventInfo.CreateNullEvent()) ?? string.Empty;
+            var maxLevelFilter = _maxLevel?.Render(LogEventInfo.CreateNullEvent()) ?? string.Empty;
+            if (string.IsNullOrEmpty(minLevelFilter) && string.IsNullOrEmpty(maxLevelFilter))
+                return LoggingRuleLevelFilter.Off.LogLevels;
+
+            var activeFilter = _activeFilter;
+            if (!activeFilter.Key.Equals(new MinMaxLevels(minLevelFilter, maxLevelFilter)))
+            {
+                bool[] logLevels = ParseLevelRange(minLevelFilter, maxLevelFilter);
+                _activeFilter = activeFilter = new KeyValuePair<MinMaxLevels, bool[]>(new MinMaxLevels(minLevelFilter, maxLevelFilter), logLevels);
+            }
+            return activeFilter.Value;
+        }
+
+        private bool[] ParseLevelRange(string minLevelFilter, string maxLevelFilter)
+        {
+            LogLevel minLevel = ParseLogLevel(minLevelFilter, LogLevel.MinLevel);
+            LogLevel maxLevel = ParseLogLevel(maxLevelFilter, LogLevel.MaxLevel);
+
+            bool[] logLevels = new bool[LogLevel.MaxLevel.Ordinal + 1];
+            if (minLevel != null && maxLevel != null)
+            {
+                for (int i = minLevel.Ordinal; i <= logLevels.Length - 1 && i <= maxLevel.Ordinal; ++i)
+                {
+                    logLevels[i] = true;
+                }
+            }
+            return logLevels;
+        }
+
+        private LogLevel ParseLogLevel(string logLevel, LogLevel levelIfEmpty)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(logLevel))
+                    return levelIfEmpty;
+
+                return LogLevel.FromString(logLevel.Trim());
+            }
+            catch (ArgumentException ex)
+            {
+                InternalLogger.Warn(ex, "Logging rule {0} with filter `{1}` has invalid level filter: {2}", _loggingRule.RuleName, _loggingRule.LoggerNamePattern, logLevel);
+                return null;
+            }
+        }
+
+        private struct MinMaxLevels : IEquatable<MinMaxLevels>
+        {
+            private readonly string MinLevel;
+            private readonly string MaxLevel;
+
+            public MinMaxLevels(string minLevel, string maxLevel)
+            {
+                MinLevel = minLevel;
+                MaxLevel = maxLevel;
+            }
+
+            public bool Equals(MinMaxLevels other)
+            {
+                return MinLevel == other.MinLevel && MaxLevel == other.MaxLevel;
+            }
+        }
+    }
+}

--- a/src/NLog/Config/DynamicRangeLevelFilter.cs
+++ b/src/NLog/Config/DynamicRangeLevelFilter.cs
@@ -113,18 +113,18 @@ namespace NLog.Config
 
         private struct MinMaxLevels : IEquatable<MinMaxLevels>
         {
-            private readonly string MinLevel;
-            private readonly string MaxLevel;
+            private readonly string _minLevel;
+            private readonly string _maxLevel;
 
             public MinMaxLevels(string minLevel, string maxLevel)
             {
-                MinLevel = minLevel;
-                MaxLevel = maxLevel;
+                _minLevel = minLevel;
+                _maxLevel = maxLevel;
             }
 
             public bool Equals(MinMaxLevels other)
             {
-                return MinLevel == other.MinLevel && MaxLevel == other.MaxLevel;
+                return _minLevel == other._minLevel && _maxLevel == other._maxLevel;
             }
         }
     }

--- a/src/NLog/Config/ILoggingRuleLevelFilter.cs
+++ b/src/NLog/Config/ILoggingRuleLevelFilter.cs
@@ -1,0 +1,48 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    internal interface ILoggingRuleLevelFilter
+    {
+        /// <summary>
+        /// Level enabled flags for each LogLevel ordinal
+        /// </summary>
+        bool[] LogLevels { get; }
+
+        /// <summary>
+        /// Converts the filter into a simple <see cref="LoggingRuleLevelFilter"/>
+        /// </summary>
+        LoggingRuleLevelFilter GetSimpleFilterForUpdate();
+    }
+}

--- a/src/NLog/Config/LoggingRuleLevelFilter.cs
+++ b/src/NLog/Config/LoggingRuleLevelFilter.cs
@@ -1,0 +1,71 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    using System;
+
+    /// <summary>
+    /// Default filtering with static level config
+    /// </summary>
+    internal class LoggingRuleLevelFilter : ILoggingRuleLevelFilter
+    {
+        public static readonly ILoggingRuleLevelFilter Off = new LoggingRuleLevelFilter();
+        public bool[] LogLevels { get; }
+
+        public LoggingRuleLevelFilter(bool[] logLevels = null)
+        {
+            LogLevels = new bool[LogLevel.MaxLevel.Ordinal + 1];
+            if (logLevels != null)
+            {
+                for (int i = 0; i < Math.Min(logLevels.Length, LogLevels.Length); ++i)
+                    LogLevels[i] = logLevels[i];
+            }
+        }
+
+        public LoggingRuleLevelFilter GetSimpleFilterForUpdate()
+        {
+            if (!ReferenceEquals(LogLevels, Off.LogLevels))
+                return this;
+            else
+                return new LoggingRuleLevelFilter();
+        }
+
+        public LoggingRuleLevelFilter SetLoggingLevels(LogLevel minLevel, LogLevel maxLevel, bool enable)
+        {
+            for (int i = minLevel.Ordinal; i <= maxLevel.Ordinal; ++i)
+                LogLevels[i] = enable;
+            return this;
+        }
+    }
+}

--- a/src/NLog/Config/LoggingRuleLevelFilter.cs
+++ b/src/NLog/Config/LoggingRuleLevelFilter.cs
@@ -57,8 +57,7 @@ namespace NLog.Config
         {
             if (!ReferenceEquals(LogLevels, Off.LogLevels))
                 return this;
-            else
-                return new LoggingRuleLevelFilter();
+            return new LoggingRuleLevelFilter();
         }
 
         public LoggingRuleLevelFilter SetLoggingLevels(LogLevel minLevel, LogLevel maxLevel, bool enable)

--- a/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
@@ -546,7 +546,7 @@ namespace NLog.UnitTests.Config
                     </rules>
                 </nlog>");
 
-                
+
                 AssertFileNotContains(tempFileName, "Unused target detected. Add a rule for this target to the configuration. TargetName: d2", Encoding.UTF8);
 
                 AssertFileNotContains(tempFileName, "Unused target detected. Add a rule for this target to the configuration. TargetName: d3", Encoding.UTF8);
@@ -583,9 +583,9 @@ namespace NLog.UnitTests.Config
             </nlog>");
 
             LogManager.Configuration = c;
-            Logger a = LogManager.GetLogger("a");
+            LogManager.GetLogger("a");
 
-            Assert.True(c.LoggingRules.Count == 2, "All rules should have been loaded.");
+            Assert.Equal(2, c.LoggingRules.Count);
             Assert.False(c.LoggingRules[0].IsLoggingEnabledForLevel(LogLevel.Off), "Log level Off should always return false.");
             // The two functions below should not throw an exception.
             c.LoggingRules[0].EnableLoggingForLevel(LogLevel.Debug);
@@ -622,25 +622,13 @@ namespace NLog.UnitTests.Config
 
             LogLevel expectedLogLevel = (NLog.Internal.StringHelpers.IsNullOrWhiteSpace(levelVariable) || levelVariable == "Wrong") ? LogLevel.Off : LogLevel.FromString(levelVariable.Trim());
 
-            for (int i = LogLevel.MinLevel.Ordinal; i <= LogLevel.MaxLevel.Ordinal; ++i)
-            {
-                if (LogLevel.FromOrdinal(i) == expectedLogLevel)
-                    Assert.True(logger.IsEnabled(LogLevel.FromOrdinal(i)));
-                else
-                    Assert.False(logger.IsEnabled(LogLevel.FromOrdinal(i)));
-            }
+            AssertLogLevelEnabled(logger, expectedLogLevel);
 
             // Verify that runtime override also works
             LogManager.Configuration.Variables["var_level"] = LogLevel.Fatal.ToString();
             LogManager.ReconfigExistingLoggers();
 
-            for (int i = LogLevel.MinLevel.Ordinal; i <= LogLevel.MaxLevel.Ordinal; ++i)
-            {
-                if (LogLevel.Fatal.Ordinal == i)
-                    Assert.True(logger.IsEnabled(LogLevel.FromOrdinal(i)));
-                else
-                    Assert.False(logger.IsEnabled(LogLevel.FromOrdinal(i)));
-            }
+            AssertLogLevelEnabled(logger, LogLevel.Fatal);
         }
 
         [Theory]
@@ -661,40 +649,28 @@ namespace NLog.UnitTests.Config
             LogManager.Configuration = config;
             var logger = LogManager.GetLogger(nameof(LoggingRule_LevelsLayout_ParseLevel));
 
-            for (int i = LogLevel.MinLevel.Ordinal; i <= LogLevel.MaxLevel.Ordinal; ++i)
-            {
-                if (expectedLevels.Contains(LogLevel.FromOrdinal(i)))
-                    Assert.True(logger.IsEnabled(LogLevel.FromOrdinal(i)));
-                else
-                    Assert.False(logger.IsEnabled(LogLevel.FromOrdinal(i)));
-            }
+            AssertLogLevelEnabled(logger, expectedLevels);
 
             // Verify that runtime override also works
             LogManager.Configuration.Variables["var_levels"] = LogLevel.Fatal.ToString();
             LogManager.ReconfigExistingLoggers();
 
-            for (int i = LogLevel.MinLevel.Ordinal; i <= LogLevel.MaxLevel.Ordinal; ++i)
-            {
-                if (LogLevel.Fatal.Ordinal == i)
-                    Assert.True(logger.IsEnabled(LogLevel.FromOrdinal(i)));
-                else
-                    Assert.False(logger.IsEnabled(LogLevel.FromOrdinal(i)));
-            }
+            AssertLogLevelEnabled(logger, LogLevel.Fatal);
         }
 
         public static IEnumerable<object[]> LoggingRule_LevelsLayout_ParseLevel_TestCases()
         {
-            yield return new object[] { "Off", new LogLevel[] { LogLevel.Off } };
-            yield return new object[] { "Off, Trace", new LogLevel[] { LogLevel.Off, LogLevel.Trace } };
-            yield return new object[] { " ", new LogLevel[] { LogLevel.Off } };
-            yield return new object[] { " , Debug", new LogLevel[] { LogLevel.Off, LogLevel.Debug } };
-            yield return new object[] { "", new LogLevel[] { LogLevel.Off } };
-            yield return new object[] { ",Info", new LogLevel[] { LogLevel.Off, LogLevel.Info } };
-            yield return new object[] { "Error, Error", new LogLevel[] { LogLevel.Error, LogLevel.Error } };
-            yield return new object[] { " error", new LogLevel[] { LogLevel.Error } };
-            yield return new object[] { " error, Warn", new LogLevel[] { LogLevel.Error, LogLevel.Warn } };
-            yield return new object[] { "Wrong", new LogLevel[] { LogLevel.Off } };
-            yield return new object[] { "Wrong, Fatal", new LogLevel[] { LogLevel.Off, LogLevel.Fatal } };
+            yield return new object[] { "Off", new[] { LogLevel.Off } };
+            yield return new object[] { "Off, Trace", new[] { LogLevel.Off, LogLevel.Trace } };
+            yield return new object[] { " ", new[] { LogLevel.Off } };
+            yield return new object[] { " , Debug", new[] { LogLevel.Off, LogLevel.Debug } };
+            yield return new object[] { "", new[] { LogLevel.Off } };
+            yield return new object[] { ",Info", new[] { LogLevel.Off, LogLevel.Info } };
+            yield return new object[] { "Error, Error", new[] { LogLevel.Error, LogLevel.Error } };
+            yield return new object[] { " error", new[] { LogLevel.Error } };
+            yield return new object[] { " error, Warn", new[] { LogLevel.Error, LogLevel.Warn } };
+            yield return new object[] { "Wrong", new[] { LogLevel.Off } };
+            yield return new object[] { "Wrong, Fatal", new[] { LogLevel.Off, LogLevel.Fatal } };
         }
 
         [Theory]
@@ -716,54 +692,59 @@ namespace NLog.UnitTests.Config
             LogManager.Configuration = config;
             var logger = LogManager.GetLogger(nameof(LoggingRule_MinMaxLayout_ParseLevel));
 
-            for (int i = LogLevel.MinLevel.Ordinal; i <= LogLevel.MaxLevel.Ordinal; ++i)
-            {
-                if (expectedLevels.Contains(LogLevel.FromOrdinal(i)))
-                    Assert.True(logger.IsEnabled(LogLevel.FromOrdinal(i)));
-                else
-                    Assert.False(logger.IsEnabled(LogLevel.FromOrdinal(i)));
-            }
+            AssertLogLevelEnabled(logger, expectedLevels);
 
             // Verify that runtime override also works
             LogManager.Configuration.Variables["var_minlevel"] = LogLevel.Fatal.ToString();
             LogManager.Configuration.Variables["var_maxlevel"] = LogLevel.Fatal.ToString();
             LogManager.ReconfigExistingLoggers();
 
-            for (int i = LogLevel.MinLevel.Ordinal; i <= LogLevel.MaxLevel.Ordinal; ++i)
-            {
-                if (LogLevel.Fatal.Ordinal == i)
-                    Assert.True(logger.IsEnabled(LogLevel.FromOrdinal(i)));
-                else
-                    Assert.False(logger.IsEnabled(LogLevel.FromOrdinal(i)));
-            }
+            AssertLogLevelEnabled(logger, LogLevel.Fatal);
         }
 
         public static IEnumerable<object[]> LoggingRule_MinMaxLayout_ParseLevel_TestCases2()
         {
-            yield return new object[] { "Off", "", new LogLevel[] {  } };
+            yield return new object[] { "Off", "", new LogLevel[] { } };
             yield return new object[] { "Off", "Fatal", new LogLevel[] { } };
             yield return new object[] { "Error", "Debug", new LogLevel[] { } };
             yield return new object[] { " ", "", new LogLevel[] { } };
             yield return new object[] { " ", "Fatal", new LogLevel[] { } };
             yield return new object[] { "", "", new LogLevel[] { } };
-            yield return new object[] { "", "Off", new LogLevel[] { LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal } };
-            yield return new object[] { "", "Fatal", new LogLevel[] { LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal } };
-            yield return new object[] { "", "Debug", new LogLevel[] { LogLevel.Trace, LogLevel.Debug } };
-            yield return new object[] { "", "Trace", new LogLevel[] { LogLevel.Trace } };
-            yield return new object[] { "", " error", new LogLevel[] { LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error } };
+            yield return new object[] { "", "Off", new[] { LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal } };
+            yield return new object[] { "", "Fatal", new[] { LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal } };
+            yield return new object[] { "", "Debug", new[] { LogLevel.Trace, LogLevel.Debug } };
+            yield return new object[] { "", "Trace", new[] { LogLevel.Trace } };
+            yield return new object[] { "", " error", new[] { LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error } };
             yield return new object[] { "", "Wrong", new LogLevel[] { } };
             yield return new object[] { "Wrong", "", new LogLevel[] { } };
             yield return new object[] { "Wrong", "Fatal", new LogLevel[] { } };
             yield return new object[] { " error", "Debug", new LogLevel[] { } };
-            yield return new object[] { " error", "Fatal", new LogLevel[] { LogLevel.Error, LogLevel.Fatal } };
-            yield return new object[] { " error", "", new LogLevel[] { LogLevel.Error, LogLevel.Fatal } };
-            yield return new object[] { "Error", "", new LogLevel[] { LogLevel.Error, LogLevel.Fatal } };
-            yield return new object[] { "Fatal", "", new LogLevel[] { LogLevel.Fatal } };
+            yield return new object[] { " error", "Fatal", new[] { LogLevel.Error, LogLevel.Fatal } };
+            yield return new object[] { " error", "", new[] { LogLevel.Error, LogLevel.Fatal } };
+            yield return new object[] { "Error", "", new[] { LogLevel.Error, LogLevel.Fatal } };
+            yield return new object[] { "Fatal", "", new[] { LogLevel.Fatal } };
             yield return new object[] { "Off", "", new LogLevel[] { } };
             yield return new object[] { "Trace", " ", new LogLevel[] { } };
-            yield return new object[] { "Trace", "", new LogLevel[] { LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal } };
-            yield return new object[] { "Trace", "Debug", new LogLevel[] { LogLevel.Trace, LogLevel.Debug } };
-            yield return new object[] { "Trace", "Trace", new LogLevel[] { LogLevel.Trace, LogLevel.Trace } };
+            yield return new object[] { "Trace", "", new[] { LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal } };
+            yield return new object[] { "Trace", "Debug", new[] { LogLevel.Trace, LogLevel.Debug } };
+            yield return new object[] { "Trace", "Trace", new[] { LogLevel.Trace, LogLevel.Trace } };
+        }
+
+        private static void AssertLogLevelEnabled(ILoggerBase logger, LogLevel expectedLogLevel)
+        {
+            AssertLogLevelEnabled(logger, new[] {expectedLogLevel });
+        }
+
+        private static void AssertLogLevelEnabled(ILoggerBase logger, LogLevel[] expectedLogLevels)
+        {
+            for (int i = LogLevel.MinLevel.Ordinal; i <= LogLevel.MaxLevel.Ordinal; ++i)
+            {
+                var logLevel = LogLevel.FromOrdinal(i);
+                if (expectedLogLevels.Contains(logLevel))
+                    Assert.True(logger.IsEnabled(logLevel),$"{logLevel} expected as true");
+                else
+                    Assert.False(logger.IsEnabled(logLevel),$"{logLevel} expected as false");
+            }
         }
     }
 }


### PR DESCRIPTION
Extending #2709 and resolves #1502

allowes:

```xml
<nlog>
   <variable name='myLevel' value='debug'/>
    <rules>
      <logger minLevel='${myLevel}'/>
    </rules>
</nlog>
```

And you do this:

```c#
LogManager.KeepVariablesOnReload = true;
LogManager.Configuration.Variables["myLevel"] = "Info";
LogManager.Configuration.Reload();
```


