### PR TITLE
SimpleStringReader: fix DebuggerDisplay value

### DIFF
--- a/src/NLog/Internal/SimpleStringReader.cs
+++ b/src/NLog/Internal/SimpleStringReader.cs
@@ -40,10 +40,10 @@ namespace NLog.Internal
     /// </summary>
 
 #if DEBUG
-     [System.Diagnostics.DebuggerDisplay("{" + nameof(CurrentState) + "}")]
+    [System.Diagnostics.DebuggerDisplay("{" + nameof(CurrentState) + "}")]
 #endif
-	internal class SimpleStringReader
-	{
+    internal class SimpleStringReader
+    {
         private readonly string _text;
 
         /// <summary>
@@ -67,14 +67,20 @@ namespace NLog.Internal
         internal string Text => _text;
 
 #if DEBUG
-        string CurrentState
+        internal static string BuildCurrentState(string done, char current, string todo)
+            => $"done: '{done}'.   current: '{current}'.   todo: '{todo}'";
+        internal string CurrentState
         {
             get
             {
                 var current = (char)Peek();
-                var done = Substring(0, Position - 1);
-                var todo = ((Position > _text.Length) ? Text.Substring(Position + 1) : "");
-                return $"done: '{done}'.   current: '{current}'.   todo: '{todo}'";
+                if (Position < 0 || Position > Text.Length)
+                {
+                    return BuildCurrentState(done: "INVALID_CURRENT_STATE", current: char.MaxValue, todo: "INVALID_CURRENT_STATE");
+                }
+                var done = Substring(0, Position);
+                var todo = ((Position < _text.Length) ? Text.Substring(Position) : "");
+                return BuildCurrentState(done: done, current: current, todo: todo);
             }
         }
 #endif

--- a/src/NLog/Internal/SimpleStringReader.cs
+++ b/src/NLog/Internal/SimpleStringReader.cs
@@ -79,7 +79,7 @@ namespace NLog.Internal
                     return BuildCurrentState(done: "INVALID_CURRENT_STATE", current: char.MaxValue, todo: "INVALID_CURRENT_STATE");
                 }
                 var done = Substring(0, Position);
-                var todo = ((Position < _text.Length) ? Text.Substring(Position) : "");
+                var todo = ((Position < _text.Length - 1) ? Text.Substring(Position + 1) : "");
                 return BuildCurrentState(done: done, current: current, todo: todo);
             }
         }

--- a/tests/NLog.UnitTests/Internal/SimpleStringReaderTests.cs
+++ b/tests/NLog.UnitTests/Internal/SimpleStringReaderTests.cs
@@ -53,7 +53,7 @@ namespace NLog.UnitTests
         /// <summary>
         /// https://github.com/NLog/NLog/issues/3194
         /// </summary>
-        public void DebugView_CurrentState(string input, Int32 position, string expectedDone, char expectedCurrent, string expectedTodo)
+        public void DebugView_CurrentState(string input, int position, string expectedDone, char expectedCurrent, string expectedTodo)
         {
             var reader = new SimpleStringReader(input);
             reader.Position = position;

--- a/tests/NLog.UnitTests/Internal/SimpleStringReaderTests.cs
+++ b/tests/NLog.UnitTests/Internal/SimpleStringReaderTests.cs
@@ -42,7 +42,7 @@ namespace NLog.UnitTests
     using Xunit;
 
 #if DEBUG
-    public class SimpleStringReaderDebugViewTests : NLogTestBase
+    public class SimpleStringReaderTests : NLogTestBase
     {
         [Theory]
         [InlineData("", 0, "", char.MaxValue, "" )]
@@ -53,12 +53,12 @@ namespace NLog.UnitTests
         /// <summary>
         /// https://github.com/NLog/NLog/issues/3194
         /// </summary>
-        public void DebugView_CurrentState(string input, Int32 position, string done, char current, string todo)
+        public void DebugView_CurrentState(string input, Int32 position, string expectedDone, char expectedCurrent, string expectedTodo)
         {
             var reader = new SimpleStringReader(input);
             reader.Position = position;
             Assert.Equal(
-                SimpleStringReader.BuildCurrentState(done, current, todo), 
+                SimpleStringReader.BuildCurrentState(expectedDone, expectedCurrent, expectedTodo), 
                 reader.CurrentState);
         }
 

--- a/tests/NLog.UnitTests/Internal/SimpleStringReaderTests.cs
+++ b/tests/NLog.UnitTests/Internal/SimpleStringReaderTests.cs
@@ -46,8 +46,8 @@ namespace NLog.UnitTests
     {
         [Theory]
         [InlineData("", 0, "", char.MaxValue, "" )]
-        [InlineData("abcdef", 0, "", 'a', "abcdef")]
-        [InlineData("abcdef", 2, "ab", 'c', "cdef")]
+        [InlineData("abcdef", 0, "", 'a', "bcdef")]
+        [InlineData("abcdef", 2, "ab", 'c', "def")]
         [InlineData("abcdef", 6, "abcdef", char.MaxValue, "")]
         [InlineData("abcdef", 7, "INVALID_CURRENT_STATE", char.MaxValue, "INVALID_CURRENT_STATE")]
         /// <summary>

--- a/tests/NLog.UnitTests/Internal/SimpleStringReaderTests.cs
+++ b/tests/NLog.UnitTests/Internal/SimpleStringReaderTests.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.UnitTests
+namespace NLog.UnitTests.Internal
 {
     using NLog.Internal;
     using System;

--- a/tests/NLog.UnitTests/SimpleStringReaderDebugViewTests.cs
+++ b/tests/NLog.UnitTests/SimpleStringReaderDebugViewTests.cs
@@ -1,0 +1,42 @@
+﻿using NLog.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NLog.UnitTests
+{
+#if DEBUG
+    public class SimpleStringReaderDebugViewTests : NLogTestBase
+    {
+        [Theory]
+        [InlineData("", 0, "", char.MaxValue, "" )]
+        [InlineData("abcdef", 0, "", 'a', "abcdef")]
+        [InlineData("abcdef", 2, "ab", 'c', "cdef")]
+        [InlineData("abcdef", 6, "abcdef", char.MaxValue, "")]
+        [InlineData("abcdef", 7, "INVALID_CURRENT_STATE", char.MaxValue, "INVALID_CURRENT_STATE")]
+        /// <summary>
+        /// https://github.com/NLog/NLog/issues/3194
+        /// </summary>
+        public void DebugView_CurrentState(string input, Int32 position, string done, char current, string todo)
+        {
+            var reader = new SimpleStringReader(input);
+            reader.Position = position;
+            Assert.Equal(
+                SimpleStringReader.BuildCurrentState(done, current, todo), 
+                reader.CurrentState);
+        }
+
+        [Fact]
+        public void DebugView_CurrentState_NegativePosition()
+        {
+            Assert.Throws<IndexOutOfRangeException>(() => new SimpleStringReader("abcdef")
+            {
+                Position = -1,
+            }.CurrentState);
+        }
+    }
+#endif
+}

--- a/tests/NLog.UnitTests/SimpleStringReaderDebugViewTests.cs
+++ b/tests/NLog.UnitTests/SimpleStringReaderDebugViewTests.cs
@@ -1,13 +1,46 @@
-﻿using NLog.Internal;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit;
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
 
 namespace NLog.UnitTests
 {
+    using NLog.Internal;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Xunit;
+
 #if DEBUG
     public class SimpleStringReaderDebugViewTests : NLogTestBase
     {


### PR DESCRIPTION
fixes #3194 

```csharp

#if DEBUG
        internal static string BuildCurrentState(string done, char current, string todo)
            => $"done: '{done}'.   current: '{current}'.   todo: '{todo}'";
        internal string CurrentState
        {
            get
            {
                var current = (char)Peek();
                if (Position < 0 || Position > Text.Length)
                {
                    return BuildCurrentState(done: "INVALID_CURRENT_STATE", current: char.MaxValue, todo: "INVALID_CURRENT_STATE");
                }
                var done = Substring(0, Position);
                var todo = ((Position < _text.Length) ? Text.Substring(Position) : "");
                return BuildCurrentState(done: done, current: current, todo: todo);
            }
        }
#endif

```