### PR TITLE
XmlLayout - Fixed missing encode of xml element value

### DIFF
--- a/src/NLog/Layouts/XmlAttribute.cs
+++ b/src/NLog/Layouts/XmlAttribute.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.Layouts
 {
+    using System.ComponentModel;
     using NLog.Config;
     using NLog.Internal;
 
@@ -40,6 +41,7 @@ namespace NLog.Layouts
     /// XML attribute.
     /// </summary>
     [NLogConfigurationItem]
+    [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
     public class XmlAttribute
@@ -94,6 +96,7 @@ namespace NLog.Layouts
         /// Determines wether or not this attribute will be Xml encoded.
         /// </summary>
         /// <docgen category='XML Attribute Options' order='100' />
+        [DefaultValue(true)]
         public bool Encode
         {
             get => LayoutWrapper.XmlEncode;

--- a/src/NLog/Layouts/XmlElement.cs
+++ b/src/NLog/Layouts/XmlElement.cs
@@ -40,6 +40,7 @@ namespace NLog.Layouts
     /// A XML Element
     /// </summary>
     [NLogConfigurationItem]
+    [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
     public class XmlElement : XmlElementBase
@@ -73,6 +74,16 @@ namespace NLog.Layouts
         {
             get => base.ElementValueInternal;
             set => base.ElementValueInternal = value;
+        }
+
+        /// <summary>
+        /// Determines wether or not this attribute will be Xml encoded.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool Encode
+        {
+            get => base.ElementEncodeInternal;
+            set => base.ElementEncodeInternal = value;
         }
     }
 }

--- a/src/NLog/Layouts/XmlElementBase.cs
+++ b/src/NLog/Layouts/XmlElementBase.cs
@@ -87,8 +87,7 @@ namespace NLog.Layouts
         /// </summary>
         /// <remarks>Ensures always valid XML, but gives a performance hit</remarks>
         /// <docgen category='XML Options' order='10' />
-        [DefaultValue(true)]
-        public bool ElementEncode { get => _elementValueWrapper.XmlEncode; set => _elementValueWrapper.XmlEncode = value; }
+        internal bool ElementEncodeInternal { get => _elementValueWrapper.XmlEncode; set => _elementValueWrapper.XmlEncode = value; }
 
         /// <summary>
         /// Auto indent and create new lines
@@ -337,7 +336,7 @@ namespace NLog.Layouts
                         RenderStartElement(sb, ElementNameInternal);
                     }
                     int beforeValueLength = sb.Length;
-                    ElementValueInternal.RenderAppendBuilder(logEvent, sb);
+                    _elementValueWrapper.RenderAppendBuilder(logEvent, sb);
                     if (beforeValueLength == sb.Length && !IncludeEmptyValue)
                     {
                         sb.Length = beforeElementLength;

--- a/src/NLog/Layouts/XmlLayout.cs
+++ b/src/NLog/Layouts/XmlLayout.cs
@@ -81,8 +81,15 @@ namespace NLog.Layouts
             set => base.ElementValueInternal = value;
         }
 
-
-
-      
+        /// <summary>
+        /// Determines wether or not this attribute will be Xml encoded.
+        /// </summary>
+        /// <docgen category='XML Options' order='100' />
+        [DefaultValue(true)]
+        public bool ElementEncode
+        {
+            get => base.ElementEncodeInternal;
+            set => base.ElementEncodeInternal = value;
+        }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -109,6 +109,50 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void XmlLayout_EncodeValue_RenderXmlMessage()
+        {
+            // Arrange
+            var xmlLayout = new XmlLayout()
+            {
+                Elements =
+                {
+                    new XmlElement("message", "${message}"),
+                },
+            };
+
+            var logEventInfo = new LogEventInfo {  Message = @"<hello planet=""earth""/>" };
+
+            // Act
+            var result = xmlLayout.Render(logEventInfo);
+
+            // Assert
+            const string expected = @"<logevent><message>&lt;hello planet=&quot;earth&quot;/&gt;</message></logevent>";
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void XmlLayout_SkipEncodeValue_RenderXmlMessage()
+        {
+            // Arrange
+            var xmlLayout = new XmlLayout()
+            {
+                Elements =
+                {
+                    new XmlElement("message", "${message}") { Encode = false }
+                },
+            };
+
+            var logEventInfo = new LogEventInfo { Message = @"<hello planet=""earth""/>" };
+
+            // Act
+            var result = xmlLayout.Render(logEventInfo);
+
+            // Assert
+            const string expected = @"<logevent><message><hello planet=""earth""/></message></logevent>";
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
         public void XmlLayout_IncludeEmptyValue_RenderEmptyValue()
         {
             // Arrange


### PR DESCRIPTION
Bug introduced with the last major refactoring before NLog 4.6