### PR TITLE
${GDC} reading is now lockfree

### DIFF
--- a/src/NLog/GlobalDiagnosticsContext.cs
+++ b/src/NLog/GlobalDiagnosticsContext.cs
@@ -65,7 +65,8 @@ namespace NLog
         {
             lock (_dict)
             {
-                GetWritableDict(_dictReadOnly != null && !_dict.ContainsKey(item))[item] = value;
+                bool requireCopyOnWrite = _dictReadOnly != null && !_dict.ContainsKey(item); // Overwiting existing value is ok (no resize)
+                GetWritableDict(requireCopyOnWrite)[item] = value;
             }
         }
 
@@ -130,7 +131,8 @@ namespace NLog
         {
             lock (_dict)
             {
-                GetWritableDict(_dictReadOnly != null && _dict.ContainsKey(item)).Remove(item);
+                bool requireCopyOnWrite = _dictReadOnly != null && _dict.ContainsKey(item);
+                GetWritableDict(requireCopyOnWrite).Remove(item);
             }
         }
 
@@ -141,7 +143,8 @@ namespace NLog
         {
             lock (_dict)
             {
-                GetWritableDict(_dictReadOnly != null && _dict.Count > 0, true).Clear();
+                bool requireCopyOnWrite = _dictReadOnly != null && _dict.Count > 0;
+                GetWritableDict(requireCopyOnWrite, true).Clear();
             }
         }
 
@@ -158,9 +161,9 @@ namespace NLog
             return readOnly;
         }
 
-        private static Dictionary<string, object> GetWritableDict(bool mustCreateNew, bool clearDictionary = false)
+        private static Dictionary<string, object> GetWritableDict(bool requireCopyOnWrite, bool clearDictionary = false)
         {
-            if (mustCreateNew)
+            if (requireCopyOnWrite)
             {
                 Dictionary<string, object> newDict = CopyDictionaryOnWrite(clearDictionary);
                 _dict = newDict;

--- a/src/NLog/GlobalDiagnosticsContext.cs
+++ b/src/NLog/GlobalDiagnosticsContext.cs
@@ -53,10 +53,7 @@ namespace NLog
         /// <param name="value">Item value.</param>
         public static void Set(string item, string value)
         {
-            lock (_dict)
-            {
-                GetWritableDict(_dictReadOnly != null && !_dict.ContainsKey(item))[item] = value;
-            }
+            Set(item, (object)value);
         }
 
         /// <summary>

--- a/src/NLog/GlobalDiagnosticsContext.cs
+++ b/src/NLog/GlobalDiagnosticsContext.cs
@@ -43,8 +43,8 @@ namespace NLog
     /// </summary>
     public static class GlobalDiagnosticsContext
     {
-        private static Dictionary<string, object> dict = new Dictionary<string, object>();
-        private static Dictionary<string, object> dictReadOnly;  // Reset cache on change
+        private static Dictionary<string, object> _dict = new Dictionary<string, object>();
+        private static Dictionary<string, object> _dictReadOnly;  // Reset cache on change
 
         /// <summary>
         /// Sets the Global Diagnostics Context item to the specified value.
@@ -53,9 +53,9 @@ namespace NLog
         /// <param name="value">Item value.</param>
         public static void Set(string item, string value)
         {
-            lock (dict)
+            lock (_dict)
             {
-                GetWritableDict(dictReadOnly != null && !dict.ContainsKey(item))[item] = value;
+                GetWritableDict(_dictReadOnly != null && !_dict.ContainsKey(item))[item] = value;
             }
         }
 
@@ -66,9 +66,9 @@ namespace NLog
         /// <param name="value">Item value.</param>
         public static void Set(string item, object value)
         {
-            lock (dict)
+            lock (_dict)
             {
-                GetWritableDict(dictReadOnly != null && !dict.ContainsKey(item))[item] = value;
+                GetWritableDict(_dictReadOnly != null && !_dict.ContainsKey(item))[item] = value;
             }
         }
 
@@ -131,9 +131,9 @@ namespace NLog
         /// <param name="item">Item name.</param>
         public static void Remove(string item)
         {
-            lock (dict)
+            lock (_dict)
             {
-                GetWritableDict(dictReadOnly != null && dict.ContainsKey(item)).Remove(item);
+                GetWritableDict(_dictReadOnly != null && _dict.ContainsKey(item)).Remove(item);
             }
         }
 
@@ -142,20 +142,20 @@ namespace NLog
         /// </summary>
         public static void Clear()
         {
-            lock (dict)
+            lock (_dict)
             {
-                GetWritableDict(dictReadOnly != null && dict.Count > 0, false).Clear();
+                GetWritableDict(_dictReadOnly != null && _dict.Count > 0, false).Clear();
             }
         }
 
         private static Dictionary<string, object> GetReadOnlyDict()
         {
-            var readOnly = dictReadOnly;
+            var readOnly = _dictReadOnly;
             if (readOnly == null)
             {
-                lock (dict)
+                lock (_dict)
                 {
-                    readOnly = dictReadOnly = dict;
+                    readOnly = _dictReadOnly = _dict;
                 }
             }
             return readOnly;
@@ -165,17 +165,17 @@ namespace NLog
         {
             if (mustCreateNew)
             {
-                var newDict = new Dictionary<string, object>(clone ? dict.Count + 1 : 0);
+                var newDict = new Dictionary<string, object>(clone ? _dict.Count + 1 : 0);
                 if (clone)
                 {
                     // Less allocation with enumerator than Dictionary-constructor
-                    foreach (var item in dict)
+                    foreach (var item in _dict)
                         newDict[item.Key] = item.Value;
                 }
-                dict = newDict;
-                dictReadOnly = null;
+                _dict = newDict;
+                _dictReadOnly = null;
             }
-            return dict;
+            return _dict;
         }
     }
 }

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -563,7 +563,12 @@ namespace NLog
         {
             if (_layoutCache == null)
             {
-                Interlocked.CompareExchange(ref _layoutCache, new Dictionary<Layout, object>(), null);
+                var dictionary = new Dictionary<Layout, object>();
+                dictionary[layout] = value; // Faster than collection initializer
+                if (Interlocked.CompareExchange(ref _layoutCache, dictionary, null) == null)
+                {
+                    return; // No need to use lock
+                }
             }
             lock (_layoutCache)
             {


### PR DESCRIPTION
GlobalDiagnosticsContext - Use copy-on-write and lockfree read

See also #3197 

Noticed that NLog 4.5.11 often showed threads in progress with GDC-Lookups. On NLog 4.6 one didn't see it because GDC is marked as ThreadAgnostic.

But if using GDC in a Layout with other LayoutRenderers that are not ThreadAgnostic, then the lock-punishment will be back.

Added GDC-Lookup to the file-target-layout and now they get stuck with NLog 4.6:
![image](https://user-images.githubusercontent.com/11509660/55036137-fcf79800-5019-11e9-898d-cf86c84b24db.png)