### PR TITLE
Fix wrong warnings on <nlog> element

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -184,6 +184,16 @@ namespace NLog.Config
                             ? (bool?)null
                             : ParseBooleanValue(configItem.Key, configItem.Value, true);
                         break;
+
+                    case "INTERNALLOGLEVEL":
+                        // skip, read later
+                        break;
+                    case "XMLNS":
+                    case "XSI":
+                    case "SCHEMALOCATION":
+                    case "TYPE":
+                        // We could ignore these
+                        break;
                     default:
                         InternalLogger.Warn("Skipping unknown 'NLog' property {0}={1}", configItem.Key, configItem.Value);
                         break;
@@ -1003,7 +1013,7 @@ namespace NLog.Config
             return false;
         }
 
-      
+
         private void ConfigureObjectFromAttributes(object targetObject, ILoggingConfigurationElement element,
             bool ignoreType)
         {

--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -186,14 +186,19 @@ namespace NLog.Config
             {
                 do
                 {
-                    if (!AttributeValues.ContainsKey(reader.LocalName))
+                    var isXmlNamespaceAttribute = reader.Prefix.Equals("xmlns", StringComparison.OrdinalIgnoreCase);
+                    if (!isXmlNamespaceAttribute)
                     {
-                        AttributeValues.Add(reader.LocalName, reader.Value);
-                    }
-                    else
-                    {
-                        string message = $"Duplicate attribute detected. Attribute name: [{reader.LocalName}]. Duplicate value:[{reader.Value}], Current value:[{AttributeValues[reader.LocalName]}]";
-                        _parsingErrors.Add(message);
+                        if (!AttributeValues.ContainsKey(reader.LocalName))
+                        {
+                            AttributeValues.Add(reader.LocalName, reader.Value);
+                        }
+                        else
+                        {
+                            string message =
+                                $"Duplicate attribute detected. Attribute name: [{reader.LocalName}]. Duplicate value:[{reader.Value}], Current value:[{AttributeValues[reader.LocalName]}]";
+                            _parsingErrors.Add(message);
+                        }
                     }
                 }
                 while (reader.MoveToNextAttribute());

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -33,6 +33,7 @@
 
 
 using System;
+using System.IO;
 using NLog.Common;
 using NLog.Config;
 using NLog.Targets.Wrappers;
@@ -208,6 +209,42 @@ namespace NLog.UnitTests.Config
 
             Assert.Single(config.AllTargets);
             Assert.Equal(System.Text.Encoding.UTF8, (config.AllTargets[0] as NLog.Targets.FileTarget)?.Encoding);
+        }
+
+        [Fact]
+        public void XmlConfig_attributes_shouldNotLogWarningsToInternalLog()
+        {
+            // Arrange
+            var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<nlog xmlns=""http://www.nlog-project.org/schemas/NLog.xsd"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""somewhere"" xsi:type=""asa""
+      internalLogToConsole=""true"" internalLogLevel=""Warn"">
+</nlog>";
+
+
+            try
+            {
+                
+                // ReSharper disable once UnusedVariable
+                var factory = ConfigurationItemFactory.Default; // retrieve factory for calling preload and so won't assert those warnings
+              
+                TextWriter textWriter = new StringWriter();
+                InternalLogger.LogWriter = textWriter;
+                InternalLogger.IncludeTimestamp = false;
+
+                // Act
+                XmlLoggingConfiguration.CreateFromXmlString(xml);
+
+                // Assert
+                InternalLogger.LogWriter.Flush();
+
+                var warning = textWriter.ToString();
+                Assert.Equal("", warning);
+            }
+            finally
+            {
+                // cleanup
+                InternalLogger.LogWriter = null;
+            }
         }
     }
 }


### PR DESCRIPTION
@snakefoot

I have somebit the same solution 

But both solutions has the same issue:

fixes

```xml
<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="somewhere" xsi:type="asa"
      internalLogToConsole="true" internalLogLevel="Warn">
</nlog>

```

but won't fix

```xml
<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xs2="http://www.w3.org/2001/XMLSchema-instance" xs2:schemaLocation="somewhere" xs2:type="asa"
      internalLogToConsole="true" internalLogLevel="Warn">
</nlog>
```

I'm thinking to fully drop the warning on the `<nlog>` element...