### PR TITLE
Auto-flush on process exit improvements

### DIFF
--- a/src/NLog/Internal/AsyncHelpersTask.cs
+++ b/src/NLog/Internal/AsyncHelpersTask.cs
@@ -1,0 +1,54 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+
+namespace NLog.Internal
+{
+#if NETSTANDARD1_0
+    using AsyncDelegate = System.Action<object>;
+#else
+    using AsyncDelegate = System.Threading.WaitCallback;
+#endif
+
+    /// <summary>
+    /// Forward declare of system delegate type for use by other classes
+    /// </summary>
+    internal struct AsyncHelpersTask
+    {
+        public readonly AsyncDelegate AsyncDelegate;
+        public AsyncHelpersTask(AsyncDelegate asyncDelegate)
+        {
+            AsyncDelegate = asyncDelegate;
+        }
+    }
+}

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -257,11 +257,11 @@ namespace NLog.Targets.Wrappers
         protected override void FlushAsync(AsyncContinuation asyncContinuation)
         {
             if (_flushEventsInQueueDelegate == null)
-                _flushEventsInQueueDelegate = FlushEventsInQueue;
-            AsyncHelpers.StartAsyncTask(_flushEventsInQueueDelegate, asyncContinuation);
+                _flushEventsInQueueDelegate = new AsyncHelpersTask(FlushEventsInQueue);
+            AsyncHelpers.StartAsyncTask(_flushEventsInQueueDelegate.Value, asyncContinuation);
         }
-        
-        private Action<object> _flushEventsInQueueDelegate;
+
+        private AsyncHelpersTask? _flushEventsInQueueDelegate;
 
         /// <summary>
         /// Initializes the target by starting the lazy writer timer.


### PR DESCRIPTION
AsyncHelpers.StartAsyncTask defaults to ThreadPool.QueueUserWorkItem 

See also #3200 Tasks doesn't flush well on process-exit-event. Reverting back to NLog 4.4 behavior.