### PR TITLE
Fix error with Embedded Assembly in LogAssemblyVersion

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -478,11 +478,12 @@ namespace NLog.Common
 #if SILVERLIGHT || __IOS__ || __ANDROID__ || NETSTANDARD1_0
                 Info(assembly.FullName);
 #else
-                var fileVersionInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location);
+                var fileVersionInfo = !string.IsNullOrEmpty(assembly.Location) ?
+                    System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location) : null;
                 Info("{0}. File version: {1}. Product version: {2}.",
                     assembly.FullName,
-                    fileVersionInfo.FileVersion,
-                    fileVersionInfo.ProductVersion);
+                    fileVersionInfo?.FileVersion,
+                    fileVersionInfo?.ProductVersion);
 #endif
             }
             catch (Exception ex)


### PR DESCRIPTION
with Embedded Assembly.Location can be null or empty

@304NotModified Bonus PR before NLog 4.6.1 ?

See also https://stackoverflow.com/questions/55424751/how-to-resolve-error-when-using-nlog-with-costura-fody#55424751

#736 + #1500 suffers from the same problem with `LogAssemblyVersion` throwing `The path is not of a legal form`