### PR TITLE
NLog config file loading: use process name (e.g. applicationname.exe.nlog) when app.config is not available

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -64,7 +64,7 @@ namespace NLog.Config
         /// <summary>
         /// Prefix for assets in Xamarin Android
         /// </summary>
-        internal const string AssetsPrefix = "assets/";
+        private const string AssetsPrefix = "assets/";
 #endif
 
         private readonly Dictionary<string, bool> _fileMustAutoReloadLookup = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);

--- a/src/NLog/Internal/Fakeables/AppEnvironmentWrapper.cs
+++ b/src/NLog/Internal/Fakeables/AppEnvironmentWrapper.cs
@@ -31,24 +31,39 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-using NLog.Internal.Fakeables;
-
-namespace NLog.UnitTests.Mocks
+namespace NLog.Internal.Fakeables
 {
-    public class FileMock : IFile
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Xml;
+
+    internal class AppEnvironmentWrapper : IAppEnvironment
     {
+        /// <inheritdoc />
+        public string AppDomainBaseDirectory => LogFactory.CurrentAppDomain.BaseDirectory;
+        /// <inheritdoc />
+        public string AppDomainConfigurationFile => LogFactory.CurrentAppDomain.ConfigurationFile;
+#if !NETSTANDARD1_3 && !SILVERLIGHT
+        /// <inheritdoc />
+        public string CurrentProcessFilePath => ProcessIDHelper.Instance.CurrentProcessFilePath;
+        /// <inheritdoc />
+        public string EntryAssemblyLocation => AssemblyHelpers.GetAssemblyFileLocation(System.Reflection.Assembly.GetEntryAssembly());
+        /// <inheritdoc />
+        public string EntryAssemblyFileName => Path.GetFileName(System.Reflection.Assembly.GetEntryAssembly().Location ?? string.Empty);
+#endif
+        /// <inheritdoc />
+        public IEnumerable<string> PrivateBinPath => LogFactory.CurrentAppDomain.PrivateBinPath;
 
-        private readonly Func<string, bool> _exists;
-
-        public FileMock(Func<string, bool> exists)
+        /// <inheritdoc />
+        public bool FileExists(string path)
         {
-            _exists = exists;
+            return System.IO.File.Exists(path);
         }
 
-        public bool Exists(string path)
+        /// <inheritdoc />
+        public XmlReader LoadXmlFile(string path)
         {
-            return _exists(path);
+            return XmlReader.Create(path);
         }
     }
 }

--- a/src/NLog/Internal/Fakeables/IAppEnvironment.cs
+++ b/src/NLog/Internal/Fakeables/IAppEnvironment.cs
@@ -33,14 +33,20 @@
 
 namespace NLog.Internal.Fakeables
 {
+    using System.Collections.Generic;
+
     /// <summary>
-    /// Abstract calls to File
+    /// Abstract calls for the application environment
     /// </summary>
-    internal interface IFile
+    internal interface IAppEnvironment : IFileSystem
     {
-        /// <summary>Determines whether the specified file exists.</summary>
-        /// <param name="path">The file to check. </param>
-        /// <returns></returns>
-        bool Exists(string path);
+        string AppDomainBaseDirectory { get; }
+        string AppDomainConfigurationFile { get; }
+#if !NETSTANDARD1_3 && !SILVERLIGHT
+        string CurrentProcessFilePath { get; }
+        string EntryAssemblyLocation { get; }
+        string EntryAssemblyFileName { get; }
+#endif
+        IEnumerable<string> PrivateBinPath { get; }
     }
 }

--- a/src/NLog/Internal/Fakeables/IFileSystem.cs
+++ b/src/NLog/Internal/Fakeables/IFileSystem.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,17 +31,20 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.IO;
-
 namespace NLog.Internal.Fakeables
 {
-    class FileWrapper : IFile
-    {
-        /// <inheritdoc />
-        public bool Exists(string path)
-        {
-            return File.Exists(path);
-        }
+    using System.Xml;
 
+    /// <summary>
+    /// Abstract calls to FileSystem
+    /// </summary>
+    internal interface IFileSystem
+    {
+        /// <summary>Determines whether the specified file exists.</summary>
+        /// <param name="path">The file to check.</param>
+        bool FileExists(string path);
+        /// <summary>Returns the content of the specified file</summary>
+        /// <param name="path">The file to load.</param>
+        XmlReader LoadXmlFile(string path);
     }
 }

--- a/src/NLog/Internal/PortableProcessIDHelper.cs
+++ b/src/NLog/Internal/PortableProcessIDHelper.cs
@@ -31,55 +31,50 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__IOS__ && !NETSTANDARD1_3
+#if !SILVERLIGHT && !NETSTANDARD1_3
 
 namespace NLog.Internal
 {
-    using NLog.Config;
+    using System;
+    using System.Diagnostics;
 
     /// <summary>
-    /// Returns details about current process and thread in a portable manner.
+    /// Portable implementation of <see cref="ProcessIDHelper"/>.
     /// </summary>
-    internal abstract class ThreadIDHelper
+    internal class PortableProcessIDHelper : ProcessIDHelper
     {
+        private readonly int _currentProcessId;
+        private readonly string _currentProcessFilePath = string.Empty;
+
         /// <summary>
-        /// Initializes static members of the ThreadIDHelper class.
+        /// Initializes a new instance of the <see cref="PortableProcessIDHelper" /> class.
         /// </summary>
-        static ThreadIDHelper()
+        public PortableProcessIDHelper()
         {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD
-            if (PlatformDetector.IsWin32)
+            try
             {
-                Instance = new Win32ThreadIDHelper();
+                var currentProcess = Process.GetCurrentProcess();
+                _currentProcessId = currentProcess?.Id ?? 0;
+                _currentProcessFilePath = currentProcess?.MainModule.FileName ?? string.Empty;
             }
-            else
-#endif
+            catch (Exception ex)
             {
-                Instance = new PortableThreadIDHelper();
+                if (ex.MustBeRethrownImmediately())
+                    throw;
             }
         }
 
         /// <summary>
-        /// Gets the singleton instance of PortableThreadIDHelper or
-        /// Win32ThreadIDHelper depending on runtime environment.
-        /// </summary>
-        /// <value>The instance.</value>
-        public static ThreadIDHelper Instance { get; private set; }
-
-        /// <summary>
         /// Gets current process ID.
         /// </summary>
-        public abstract int CurrentProcessID { get; }
+        /// <value></value>
+        public override int CurrentProcessID => _currentProcessId;
 
         /// <summary>
         /// Gets current process name.
         /// </summary>
-        public abstract string CurrentProcessName { get; }
-
-        /// <summary>
-        /// Gets current process name (excluding filename extension, if any).
-        /// </summary>
-        public abstract string CurrentProcessBaseName { get; }
+        /// <value></value>
+        public override string CurrentProcessFilePath => _currentProcessFilePath;
     }
 }
 

--- a/src/NLog/Internal/Win32ProcessIDHelper.cs
+++ b/src/NLog/Internal/Win32ProcessIDHelper.cs
@@ -36,28 +36,24 @@
 namespace NLog.Internal
 {
     using System;
-    using System.IO;
     using System.Security;
     using System.Text;
 
     /// <summary>
-    /// Win32-optimized implementation of <see cref="ThreadIDHelper"/>.
+    /// Win32-optimized implementation of <see cref="ProcessIDHelper"/>.
     /// </summary>
     [SecuritySafeCritical]
-    internal class Win32ThreadIDHelper : ThreadIDHelper
+    internal class Win32ProcessIDHelper : ProcessIDHelper
     {
-        private readonly int currentProcessID;
-
-        private readonly string currentProcessName;
-
-        private readonly string currentProcessBaseName;
+        private readonly int _currentProcessId;
+        private readonly string _currentProcessFilePath = string.Empty;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Win32ThreadIDHelper" /> class.
+        /// Initializes a new instance of the <see cref="Win32ProcessIDHelper" /> class.
         /// </summary>
-        public Win32ThreadIDHelper()
+        public Win32ProcessIDHelper()
         {
-            currentProcessID = NativeMethods.GetCurrentProcessId();
+            _currentProcessId = NativeMethods.GetCurrentProcessId();
 
             var sb = new StringBuilder(512);
             if (0 == NativeMethods.GetModuleFileName(IntPtr.Zero, sb, sb.Capacity))
@@ -65,27 +61,18 @@ namespace NLog.Internal
                 throw new InvalidOperationException("Cannot determine program name.");
             }
 
-            currentProcessName = sb.ToString();
-            currentProcessBaseName = Path.GetFileNameWithoutExtension(currentProcessName);
+            _currentProcessFilePath = sb.ToString();
         }
 
         /// <summary>
         /// Gets current process ID.
         /// </summary>
-        /// <value></value>
-        public override int CurrentProcessID => currentProcessID;
+        public override int CurrentProcessID => _currentProcessId;
 
         /// <summary>
-        /// Gets current process name.
+        /// Gets current process absolute file path.
         /// </summary>
-        /// <value></value>
-        public override string CurrentProcessName => currentProcessName;
-
-        /// <summary>
-        /// Gets current process name (excluding filename extension, if any).
-        /// </summary>
-        /// <value></value>
-        public override string CurrentProcessBaseName => currentProcessBaseName;
+        public override string CurrentProcessFilePath => _currentProcessFilePath;
     }
 }
 

--- a/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
@@ -105,7 +105,7 @@ namespace NLog.LayoutRenderers
 #if !SILVERLIGHT && !NETSTANDARD1_3
             if (ProcessDir)
             {
-                dir = _processDir ?? (_processDir = Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName));
+                dir = _processDir ?? (_processDir = Path.GetDirectoryName(ProcessIDHelper.Instance.CurrentProcessFilePath));
             }
 #endif
 

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -92,7 +92,7 @@ namespace NLog.LayoutRenderers
                 CultureInfo.InvariantCulture,
                 "{0}({1})",
                 appDomain.FriendlyName,
-                ThreadIDHelper.Instance.CurrentProcessID);
+                ProcessIDHelper.Instance.CurrentProcessID);
 #endif
 
             Parameters = new List<NLogViewerParameterInfo>();

--- a/src/NLog/LayoutRenderers/MachineNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MachineNameLayoutRenderer.cs
@@ -50,7 +50,7 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class MachineNameLayoutRenderer : LayoutRenderer
     {
-        internal string MachineName { get; private set; }
+        private string _machineName;
 
         /// <inheritdoc/>
         protected override void InitializeLayoutRenderer()
@@ -58,8 +58,8 @@ namespace NLog.LayoutRenderers
             base.InitializeLayoutRenderer();
             try
             {
-                MachineName = EnvironmentHelper.GetMachineName();
-                if (string.IsNullOrEmpty(MachineName))
+                _machineName = EnvironmentHelper.GetMachineName();
+                if (string.IsNullOrEmpty(_machineName))
                 {
                     InternalLogger.Info("MachineName is not available.");
                 }
@@ -72,14 +72,14 @@ namespace NLog.LayoutRenderers
                     throw;
                 }
 
-                MachineName = string.Empty;
+                _machineName = string.Empty;
             }
         }
 
         /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            builder.Append(MachineName);
+            builder.Append(_machineName);
         }
     }
 }

--- a/src/NLog/LayoutRenderers/ProcessIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessIdLayoutRenderer.cs
@@ -61,9 +61,9 @@ namespace NLog.LayoutRenderers
             return true;
         }
 
-        private static int GetValue()
+        private int GetValue()
         {
-            return ThreadIDHelper.Instance.CurrentProcessID;
+            return ProcessIDHelper.Instance.CurrentProcessID;
         }
     }
 }

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -384,43 +384,5 @@ namespace NLog.UnitTests
             factory.ResumeLogging();
             Assert.True(factory.IsLoggingEnabled());
         }
-
-
-        [Theory]
-        [MemberData(nameof(GetConfigFile_absolutePath_loads_testData))]
-        public void GetConfigFile_absolutePath_loads(string filename, string accepts, string expected, string baseDir)
-        {
-            // Arrange
-            var fileMock = new FileMock(f => f == accepts);
-            var fileLoader = new LoggingConfigurationFileLoader(fileMock);
-            var appDomain = LogFactory.CurrentAppDomain;
-
-            try
-            {
-                LogFactory.CurrentAppDomain = new AppDomainMock(baseDir);
-
-                // Act
-                var result = fileLoader.GetConfigFile(filename);
-
-                // Assert
-                Assert.Equal(expected, result);
-            }
-            finally
-            {
-                //restore
-                LogFactory.CurrentAppDomain = appDomain;
-            }
-
-        }
-
-        public static IEnumerable<object[]> GetConfigFile_absolutePath_loads_testData()
-        {
-            var d = Path.DirectorySeparatorChar;
-            var baseDir = Path.GetTempPath();
-            var dirInBaseDir = $"{baseDir}dir1";
-            yield return new object[] { $"{baseDir}configfile", $"{baseDir}configfile", $"{baseDir}configfile", dirInBaseDir };
-            yield return new object[] { "nlog.config", $"{baseDir}dir1{d}nlog.config", $"{baseDir}dir1{d}nlog.config", dirInBaseDir }; //exists
-            yield return new object[] { "nlog.config", $"{baseDir}dir1{d}nlog2.config", "nlog.config", dirInBaseDir}; //not existing, fallback
-        }
     }
 }

--- a/tests/NLog.UnitTests/Mocks/AppEnvironmentMock.cs
+++ b/tests/NLog.UnitTests/Mocks/AppEnvironmentMock.cs
@@ -31,50 +31,44 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !SILVERLIGHT && !__IOS__ && !NETSTANDARD1_3
+using System;
+using System.Collections.Generic;
+using System.Xml;
+using NLog.Internal.Fakeables;
 
-namespace NLog.LayoutRenderers
+namespace NLog.UnitTests.Mocks
 {
-    using System.ComponentModel;
-    using System.Text;
-    using NLog.Config;
-    using NLog.Internal;
-
-    /// <summary>
-    /// The name of the current process.
-    /// </summary>
-    [LayoutRenderer("processname")]
-    [AppDomainFixedOutput]
-    [ThreadAgnostic]
-    [ThreadSafe]
-    public class ProcessNameLayoutRenderer : LayoutRenderer
+    internal class AppEnvironmentMock : IAppEnvironment
     {
-        /// <summary>
-        /// Gets or sets a value indicating whether to write the full path to the process executable.
-        /// </summary>
-        /// <docgen category='Rendering Options' order='10' />
-        [DefaultValue(false)]
-        public bool FullName { get; set; }
+        private readonly Func<string, bool> _fileexists;
+        private readonly Func<string, XmlReader> _fileload;
 
-        /// <summary>
-        /// Renders the current process name (optionally with a full path).
-        /// </summary>
-        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
-        /// <param name="logEvent">Logging event.</param>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        public AppEnvironmentMock(Func<string, bool> fileExists, Func<string, XmlReader> fileLoad)
         {
-            string output;
-            if (FullName)
-            {
-                output = ProcessIDHelper.Instance.CurrentProcessFilePath;
-            }
-            else
-            {
-                output = ProcessIDHelper.Instance.CurrentProcessBaseName;
-            }
-            builder.Append(output);
+            _fileexists = fileExists;
+            _fileload = fileLoad;
+        }
+
+        public string AppDomainBaseDirectory { get; set; } = string.Empty;
+
+        public string AppDomainConfigurationFile { get; set; } = string.Empty;
+
+        public string CurrentProcessFilePath { get; set; } = string.Empty;
+
+        public string EntryAssemblyLocation { get; set; } = string.Empty;
+
+        public string EntryAssemblyFileName { get; set; } = string.Empty;
+
+        public IEnumerable<string> PrivateBinPath { get; set; } = NLog.Internal.ArrayHelper.Empty<string>();
+
+        public bool FileExists(string path)
+        {
+            return _fileexists(path);
+        }
+
+        public XmlReader LoadXmlFile(string path)
+        {
+            return _fileload(path);
         }
     }
 }
-
-#endif

--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
@@ -356,7 +356,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                                     mre.Set();
                                 }
                             });
-                        Assert.True(mre.WaitOne());
+                        Assert.True(mre.WaitOne(5000), InternalLogger.LogWriter?.ToString() ?? string.Empty);
                     },
                     LogLevel.Trace);
 


### PR DESCRIPTION
Trying to resolve #3156 for NetCore