### PR TITLE
ConsoleTarget & ColoredConsoleTarget  - Added AutoFlush and improve default flush behavior

### DIFF
--- a/tests/NLog.UnitTests/Targets/ConsoleTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ConsoleTargetTests.cs
@@ -70,6 +70,7 @@ namespace NLog.UnitTests.Targets
                     new LogEventInfo(LogLevel.Info, "Logger2", "message5").WithContinuation(exceptions.Add),
                     new LogEventInfo(LogLevel.Info, "Logger1", "message6").WithContinuation(exceptions.Add));
                 Assert.Equal(6, exceptions.Count);
+                target.Flush((ex) => { });
                 target.Close();
             }
             finally
@@ -116,6 +117,7 @@ namespace NLog.UnitTests.Targets
                     new LogEventInfo(LogLevel.Info, "Logger2", "message5").WithContinuation(exceptions.Add),
                     new LogEventInfo(LogLevel.Info, "Logger1", "message6").WithContinuation(exceptions.Add));
                 Assert.Equal(6, exceptions.Count);
+                target.Flush((ex) => { });
                 target.Close();
             }
             finally


### PR DESCRIPTION
Added AutoFlush to enable flush after each Console.WriteLine (Default = false)

When doing pipe to file or have assigned a custom TextWriter to Console.Out (without StreamWriter.AutoFlush = true) then extra help is needed.

See also: https://stackoverflow.com/questions/16791167/console-writeline-c-sharp-loses-stdout-when-logging 