### PR TITLE
Added MessageTemplateParameter IsValidTemplateTest unit test

### DIFF
--- a/tests/NLog.UnitTests/MessageTemplates/MessageTemplateParametersTests.cs
+++ b/tests/NLog.UnitTests/MessageTemplates/MessageTemplateParametersTests.cs
@@ -118,6 +118,45 @@ namespace NLog.UnitTests.MessageTemplates
             Assert.Equal(names, resultNames);
         }
 
+        [Theory]
+        [InlineData("", 0, true)] //empty OK
+        [InlineData("  ", 0, true)] //empty OK
+        [InlineData("", 1, false)]
+        [InlineData("{0}", 1, true)]
+        [InlineData("{A}", 1, true)]
+        [InlineData("{A}", 0, false)]
+        [InlineData("{A}", 2, false)]
+        [InlineData("{ 0}", 1, true)]
+        [InlineData("{0} {1}", 0, false)]
+        [InlineData("{0} {1}", 1, false)]
+        [InlineData("{0} {1}", 2, true)]
+        [InlineData("{0} {A}", 0, false)]
+        [InlineData("{0} {A}", 1, false)]
+        [InlineData("{0} {A}", 2, true)]
+        [InlineData("{A} {1}", 0, false)]
+        [InlineData("{A} {1}", 1, false)]
+        [InlineData("{A} {1}", 2, true)]
+        [InlineData("{A} {B}", 0, false)]
+        [InlineData("{A} {B}", 1, false)]
+        [InlineData("{A} {B}", 2, true)]
+        [InlineData("{0} {0}", 0, false)]
+        [InlineData("{0} {0}", 1, true)]
+        [InlineData("{0} {0}", 2, false)]
+        [InlineData("{A} {A}", 0, false)]
+        [InlineData("{A} {A}", 1, false)]
+        [InlineData("{A} {A}", 2, true)] //overwrite
+        public void IsValidTemplateTest(string input, int parameterCount, bool expected)
+        {
+            // Arrange
+            var parameters = CreateParameters(parameterCount);
+
+            // Act
+            var messageTemplateParameters = new MessageTemplateParameters(input, parameters);
+
+            // Assert
+            Assert.Equal(expected, messageTemplateParameters.IsValidTemplate);
+        }
+
         private static object[] CreateParameters(int count)
         {
             var parameters = new List<object>(count);


### PR DESCRIPTION
see https://github.com/NLog/NLog/issues/3181

todo:

- [x] rebase/skip after merge #3291

@snakefoot 

got some interesting results here:

![image](https://user-images.githubusercontent.com/5808377/55676396-fcda8080-58d4-11e9-9651-3136b146e581.png)

With an empty list as `object[] parameters` , is always says `IsValidTemplate=true` - independent of the message-template. Is this expected? It this for performance reasons?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/3286)
<!-- Reviewable:end -->
