### PR TITLE
Cleanup unused ctor

### DIFF
--- a/src/NLog/NullLogger.cs
+++ b/src/NLog/NullLogger.cs
@@ -45,10 +45,6 @@ namespace NLog
     /// </summary>
     public sealed class NullLogger : Logger
     {
-        // Hides the default constructor of this class.
-        [SuppressMessage("ReSharper", "UnusedMember.Local")]
-        private NullLogger() { }
-
         /// <summary>
         /// Initializes a new instance of <see cref="NullLogger"/>.
         /// </summary>


### PR DESCRIPTION
There is another constructor, so no worries for the default constructor. 

See https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/constructors