### PR TITLE
XmlLoggingConfiguration - Respect KeepVariablesOnReload for manual reload

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -483,6 +483,31 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Helper method to perform correct reload of log configuration with respect to <see cref="LogFactory.KeepVariablesOnReload"/>
+        /// </summary>
+        /// <param name="oldConfig">Current Configuration</param>
+        /// <returns>
+        /// A new instance of <see cref="LoggingConfiguration"/> that represents the updated configuration.
+        /// </returns>
+        public static LoggingConfiguration Reload(LoggingConfiguration oldConfig)
+        {
+            var newConfig = oldConfig?.Reload();
+            if (newConfig != null)
+            {
+                var logFactory = oldConfig.LogFactory ?? LogManager.LogFactory;
+                if (logFactory.KeepVariablesOnReload)
+                {
+                    var currentConfig = logFactory._config ?? oldConfig;
+                    if (!ReferenceEquals(newConfig, currentConfig))
+                    {
+                        newConfig.CopyVariables(currentConfig.Variables);
+                    }
+                }
+            }
+            return newConfig;
+        }
+
+        /// <summary>
         /// Removes the specified named target.
         /// </summary>
         /// <param name="name">Name of the target.</param>

--- a/src/NLog/Config/LoggingConfigurationWatchableFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationWatchableFileLoader.cs
@@ -156,7 +156,7 @@ namespace NLog.Config
                         return;
                     }
 
-                    newConfig = oldConfig.Reload();
+                    newConfig = LoggingConfiguration.Reload(oldConfig);
 
                     //problem: XmlLoggingConfiguration.Initialize eats exception with invalid XML. ALso XmlLoggingConfiguration.Reload never returns null.
                     //therefor we check the InitializeSucceeded property.
@@ -185,11 +185,6 @@ namespace NLog.Config
 
                     if (newConfig != null)
                     {
-                        if (_logFactory.KeepVariablesOnReload && _logFactory._config != null)
-                        {
-                            newConfig.CopyVariables(_logFactory._config.Variables);
-                        }
-
                         _logFactory.Configuration = newConfig;  // Triggers LogFactory to call Activated(...) that adds file-watch again
 
                         _logFactory?.NotifyConfigurationReloaded(new LoggingConfigurationReloadedEventArgs(true));

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -583,6 +583,11 @@ namespace NLog.UnitTests.Config
             Assert.Equal("new_value", logFactory.Configuration.Variables["var1"].OriginalText);
             Assert.Equal("keep_value", logFactory.Configuration.Variables["var2"].OriginalText);
             Assert.Equal("new_value3", logFactory.Configuration.Variables["var3"].OriginalText);
+
+            logFactory.Configuration = LoggingConfiguration.Reload(configuration);
+            Assert.Equal("new_value", logFactory.Configuration.Variables["var1"].OriginalText);
+            Assert.Equal("keep_value", logFactory.Configuration.Variables["var2"].OriginalText);
+            Assert.Equal("new_value3", logFactory.Configuration.Variables["var3"].OriginalText);
         }
 
         [Fact]
@@ -600,6 +605,10 @@ namespace NLog.UnitTests.Config
             logFactory.Configuration.Variables["var1"] = "new_value";
             logFactory.Configuration.Variables["var3"] = "new_value3";
             configLoader.ReloadConfigOnTimer(configuration);
+            Assert.Equal("", logFactory.Configuration.Variables["var1"].OriginalText);
+            Assert.Equal("keep_value", logFactory.Configuration.Variables["var2"].OriginalText);
+
+            logFactory.Configuration = LoggingConfiguration.Reload(configuration);
             Assert.Equal("", logFactory.Configuration.Variables["var1"].OriginalText);
             Assert.Equal("keep_value", logFactory.Configuration.Variables["var2"].OriginalText);
         }


### PR DESCRIPTION
Allow this to work:

```c#
LogManager.KeepVariablesOnReload = true;
LogManager.Configuration = LoggingConfiguration.Reload(LogManager.Configuration);
```

See also #3304

This is also useful for NLog.Extension.Logging.NLogLoggingConfiguration so it will also support `KeepVariablesOnReload`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/3306)
<!-- Reviewable:end -->
