### PR TITLE
Split string -  avoid allocation of object array. Added StringHelpers.SplitAndTrimTokens

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -610,8 +610,8 @@ namespace NLog.Config
                         break;
                     case "LEVELS":
                         {
-                            string[] tokens = CleanSpaces(childProperty.Value).Split(',');
-                            enableLevels = tokens.Where(t => !string.IsNullOrEmpty(t)).Select(LogLevelFromString);
+                            string[] tokens = childProperty.Value.SplitAndTrimTokens(',');
+                            enableLevels = tokens.Select(LogLevelFromString);
                             break;
                         }
                     case "MINLEVEL":
@@ -680,12 +680,8 @@ namespace NLog.Config
             if (string.IsNullOrEmpty(writeTargets))
                 return;
 
-            foreach (string t in writeTargets.Split(','))
+            foreach (string targetName in writeTargets.SplitAndTrimTokens(','))
             {
-                string targetName = t.Trim();
-                if (string.IsNullOrEmpty(targetName))
-                    continue;
-
                 Target target = FindTargetByName(targetName);
                 if (target != null)
                 {
@@ -1227,19 +1223,7 @@ namespace NLog.Config
 
             return attributeValue.Substring(p + 1);
         }
-
-        /// <summary>
-        /// Remove all spaces, also in between text. 
-        /// </summary>
-        /// <param name="s">text</param>
-        /// <returns>text without spaces</returns>
-        /// <remarks>Tabs and other whitespace is not removed!</remarks>
-        private static string CleanSpaces(string s)
-        {
-            s = s.Replace(" ", string.Empty); // get rid of the whitespace
-            return s;
-        }
-
+       
         private static string GetName(Target target)
         {
             return string.IsNullOrEmpty(target.Name) ? target.GetType().Name : target.Name;

--- a/src/NLog/Internal/Fakeables/AppDomainWrapper.cs
+++ b/src/NLog/Internal/Fakeables/AppDomainWrapper.cs
@@ -118,7 +118,7 @@ namespace NLog.Internal.Fakeables
             string privateBinPath = appDomain.SetupInformation.PrivateBinPath;
             return string.IsNullOrEmpty(privateBinPath)
                                     ? ArrayHelper.Empty<string>()
-                                    : privateBinPath.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                                    : privateBinPath.SplitAndTrimTokens(';');
 #else
             return ArrayHelper.Empty<string>();
 #endif

--- a/src/NLog/Internal/PropertyHelper.cs
+++ b/src/NLog/Internal/PropertyHelper.cs
@@ -262,7 +262,7 @@ namespace NLog.Internal
 
                 foreach (string v in value.SplitAndTrimTokens(','))
                 {
-                    FieldInfo enumField = resultType.GetField(v.Trim(), BindingFlags.IgnoreCase | BindingFlags.Static | BindingFlags.FlattenHierarchy | BindingFlags.Public);
+                    FieldInfo enumField = resultType.GetField(v, BindingFlags.IgnoreCase | BindingFlags.Static | BindingFlags.FlattenHierarchy | BindingFlags.Public);
                     if (enumField == null)
                     {
                         throw new NLogConfigurationException($"Invalid enumeration value '{value}'.");

--- a/src/NLog/Internal/PropertyHelper.cs
+++ b/src/NLog/Internal/PropertyHelper.cs
@@ -260,7 +260,7 @@ namespace NLog.Internal
             {
                 ulong union = 0;
 
-                foreach (string v in value.Split(','))
+                foreach (string v in value.SplitAndTrimTokens(','))
                 {
                     FieldInfo enumField = resultType.GetField(v.Trim(), BindingFlags.IgnoreCase | BindingFlags.Static | BindingFlags.FlattenHierarchy | BindingFlags.Public);
                     if (enumField == null)

--- a/src/NLog/Internal/StackTraceUsageUtils.cs
+++ b/src/NLog/Internal/StackTraceUsageUtils.cs
@@ -156,7 +156,7 @@ namespace NLog.Internal
             className = GetClassFullName(stackFrame);
 #else
             var stackTrace = Environment.StackTrace;
-            var stackTraceLines = stackTrace.Replace("\r", "").Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            var stackTraceLines = stackTrace.Replace("\r", "").SplitAndTrimTokens('\n');
             for (int i = 0; i < stackTraceLines.Length; ++i)
             {
                 var callingClassAndMethod = stackTraceLines[i].Split(new[] { " ", "<>", "(", ")" }, StringSplitOptions.RemoveEmptyEntries)[1];

--- a/src/NLog/Internal/StringHelpers.cs
+++ b/src/NLog/Internal/StringHelpers.cs
@@ -32,7 +32,6 @@
 // 
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 
@@ -51,7 +50,6 @@ namespace NLog.Internal
         [ContractAnnotation("value:null => true")]
         internal static bool IsNullOrWhiteSpace(string value)
         {
-
 #if NET3_5
 
             if (value == null) return true;
@@ -60,6 +58,29 @@ namespace NLog.Internal
 #else
             return string.IsNullOrWhiteSpace(value);
 #endif
+        }
+
+        internal static string[] SplitAndTrimTokens(this string value, char delimiter)
+        {
+            if (IsNullOrWhiteSpace(value))
+                return ArrayHelper.Empty<string>();
+
+            if (value.IndexOf(delimiter) == -1)
+            {
+                return new[] { value.Trim() };
+            }
+
+            var result = value.Split(new char[] { delimiter }, StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i < result.Length; ++i)
+            {
+                if (char.IsWhiteSpace(result[i][0]) || char.IsWhiteSpace(result[i][result[i].Length - 1]))
+                {
+                    result[i] = result[i].Trim();
+                    if (string.IsNullOrEmpty(result[i]))
+                        return result.Where(s => !IsNullOrWhiteSpace(s)).Select(s => s.Trim()).ToArray();
+                }
+            }
+            return result;
         }
     }
 }

--- a/src/NLog/Internal/StringHelpers.cs
+++ b/src/NLog/Internal/StringHelpers.cs
@@ -73,12 +73,9 @@ namespace NLog.Internal
             var result = value.Split(new char[] { delimiter }, StringSplitOptions.RemoveEmptyEntries);
             for (int i = 0; i < result.Length; ++i)
             {
-                if (char.IsWhiteSpace(result[i][0]) || char.IsWhiteSpace(result[i][result[i].Length - 1]))
-                {
-                    result[i] = result[i].Trim();
-                    if (string.IsNullOrEmpty(result[i]))
-                        return result.Where(s => !IsNullOrWhiteSpace(s)).Select(s => s.Trim()).ToArray();
-                }
+                result[i] = result[i].Trim();
+                if (string.IsNullOrEmpty(result[i]))
+                    return result.Where(s => !IsNullOrWhiteSpace(s)).Select(s => s.Trim()).ToArray();
             }
             return result;
         }

--- a/src/NLog/LayoutRenderers/AssemblyVersionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AssemblyVersionLayoutRenderer.cs
@@ -148,7 +148,7 @@ namespace NLog.LayoutRenderers
                 return version;
             }
 
-            var versionParts = version.Split('.');
+            var versionParts = version.SplitAndTrimTokens('.');
             version = Format.Replace("major", versionParts[0])
                 .Replace("minor", versionParts.Length > 1 ? versionParts[1] : "0")
                 .Replace("build", versionParts.Length > 2 ? versionParts[2] : "0")

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -409,7 +409,7 @@ namespace NLog.LayoutRenderers
         private static List<ExceptionRenderingFormat> CompileFormat(string formatSpecifier)
         {
             List<ExceptionRenderingFormat> formats = new List<ExceptionRenderingFormat>();
-            string[] parts = formatSpecifier.Replace(" ", string.Empty).Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+            string[] parts = formatSpecifier.SplitAndTrimTokens(',');
 
             foreach (string s in parts)
             {

--- a/src/NLog/Targets/DatabaseParameterInfo.cs
+++ b/src/NLog/Targets/DatabaseParameterInfo.cs
@@ -167,7 +167,7 @@ namespace NLog.Targets
                 _dbTypeName = dbTypeName;
                 if (!StringHelpers.IsNullOrWhiteSpace(dbTypeName))
                 {
-                    string[] dbTypeNames = dbTypeName.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+                    string[] dbTypeNames = dbTypeName.SplitAndTrimTokens('.');
                     if (dbTypeNames.Length > 1 && !string.Equals(dbTypeNames[0], nameof(System.Data.DbType), StringComparison.OrdinalIgnoreCase))
                     {
                         PropertyInfo propInfo = dbParameterType.GetProperty(dbTypeNames[0], BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -681,7 +681,7 @@ namespace NLog.Targets
             var added = false;
             if (layout != null)
             {
-                foreach (string mail in layout.Render(logEvent).Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string mail in layout.Render(logEvent).SplitAndTrimTokens(';'))
                 {
                     mailAddressCollection.Add(mail);
                     added = true;

--- a/tests/NLog.UnitTests/Internal/StringHelpersTests.cs
+++ b/tests/NLog.UnitTests/Internal/StringHelpersTests.cs
@@ -54,5 +54,25 @@ namespace NLog.UnitTests.Internal
         {
             Assert.Equal(result, StringHelpers.IsNullOrWhiteSpace(input));
         }
+
+        [Theory]
+        [InlineData("", new string [0])]
+        [InlineData("  ", new string[0])]
+        [InlineData(" , ", new string[0])]
+        [InlineData("a", new string[] { "a" })]
+        [InlineData("a ", new string[] { "a" })]
+        [InlineData(" a", new string[] { "a" })]
+        [InlineData(" a,", new string[] { "a" })]
+        [InlineData(" a, ", new string[] { "a" })]
+        [InlineData("a,b", new string[] { "a", "b" })]
+        [InlineData("a ,b", new string[] { "a", "b" })]
+        [InlineData(" a ,b", new string[] { "a", "b" })]
+        [InlineData(" a , b ", new string[] { "a", "b" })]
+        [InlineData(" a b ", new string[] { "a b" })]
+        public void SplitAndTrimToken(string input, string[] expected)
+        {
+            var result = input.SplitAndTrimTokens(',');
+            Assert.Equal(expected, result);
+        }
     }
 }


### PR DESCRIPTION
Triggered by #3308 to avoid params-object-array unless needed. But also to encapsulate:

> stringValue.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);

In a simpler method:

> stringValue.SplitAndTrimTokens(';');

That also trims the tokens, and removes empty tokens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nlog/nlog/3311)
<!-- Reviewable:end -->
