### PR TITLE
${event-properties}: Added evaluateAsNestedProperties option

### DIFF
--- a/src/NLog/Internal/PropertyReader.cs
+++ b/src/NLog/Internal/PropertyReader.cs
@@ -1,0 +1,75 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Linq;
+
+namespace NLog.Internal
+{
+
+    internal static class PropertyReader
+    {
+        internal static object GetNestedPropertyOfValue(object value, List<string> path)
+        {
+            if (value == null || path == null || path.Count <= 0)
+            {
+                return value;
+            }
+
+            for (var i = 0; i < path.Count; i++)
+            {
+                var propertyName = path[i];
+                var propertyInfo = GetPropertyInfo(value, propertyName);
+                value = propertyInfo?.GetValue(value, null);
+                if (value == null)
+                {
+                    break;
+                }
+            }
+
+            return value;
+        }
+
+        private static PropertyInfo GetPropertyInfo(object value, string propertyName)
+        {
+            var propertyInfos = value?.GetType().GetProperties();
+            // try case senstive first, then case insenstive
+            return propertyInfos?.FirstOrDefault(p => p.Name.Equals(propertyName, StringComparison.Ordinal))
+                   ?? propertyInfos?.FirstOrDefault(p => p.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}
+

--- a/tests/NLog.UnitTests/LayoutRenderers/EventPropertiesTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/EventPropertiesTests.cs
@@ -127,5 +127,24 @@ namespace NLog.UnitTests.LayoutRenderers
             logEvent.Properties["prop1"] = new string[] { "Hello", "World" };
             Assert.Equal("[\"Hello\",\"World\"]", layout.Render(logEvent));
         }
+
+        [Theory]
+        [InlineData("prop1", "{ Id = 1, id = 2, Name = test, Nested = { Id = 3 } }")]
+        [InlineData("prop1.Id", "1")]
+        [InlineData("prop1.id", "2")] //correc casing
+        [InlineData("prop1.Nested.Id", "3")]
+        [InlineData("prop1.Id.Wrong", "")] //don't crash on nesting
+        [InlineData("prop1.Name", "test")]
+        [InlineData("prop1.name", "test")] //ignore case
+        [InlineData("prop1.Name ", "test")] // trimend
+        [InlineData("prop1. Name ", "")] // don't trim between
+        [InlineData("prop1.NameWrong", "")]
+        public void NestedProperty(string item, string expectedValue)
+        {
+            Layout layout = "${event-properties:" + item + ":evaluateAsNestedProperties=true}";
+            LogEventInfo logEvent = LogEventInfo.Create(LogLevel.Info, "logger1", "message1");
+            logEvent.Properties["prop1"] = new { Id = 1, id = 2, Name = "test", Nested = new { Id = 3 } };
+            Assert.Equal(expectedValue, layout.Render(logEvent));
+        }
     }
 }


### PR DESCRIPTION
I was triggered by https://github.com/NLog/NLog/issues/3314,

example: 

    ${event-properties:key1.prop1:evaluateAsNestedProperties=true}

As (maybe naive) implementation to support this.

Choices to be made:

1. Is this a suitable feature and place? (${event-properties})
2. How should I name this? EvaluateAsNestedProperties is from NLog.Web
3. Is this config logical, or should we configure the path separately? e.g. `${event-properties:key1:path=prop1}`
4. Should be support arrays in the future? (e.g.`key1[prop1]`)
5. Do we need (fancy) caching (now or in the future)? Is the `ObjectReflectionCache` suitable for this?
6. What do you think about the case-sensitive-case-insensitive lookup? (best for configuration, not for performance, although we could improve that with 2 dictionaries)

@snakefoot you opinion please :)