### PR TITLE
FileTarget - Skip FileSystemWatcher unless ConcurrentWrites=true

### DIFF
--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -165,6 +165,7 @@ namespace NLog.Config
         /// <summary>
         /// Gets the collection of log levels enabled by this rule.
         /// </summary>
+        [NLogConfigurationIgnoreProperty]
         public ReadOnlyCollection<LogLevel> Levels
         {
             get
@@ -182,6 +183,7 @@ namespace NLog.Config
                 return levels.AsReadOnly();
             }
         }
+
         /// <summary>
         /// Default action if all filters won't match
         /// </summary>

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -293,7 +293,7 @@ namespace NLog.Config
         public override LoggingConfiguration Reload()
         {
             if (!string.IsNullOrEmpty(_originalFileName))
-                return new XmlLoggingConfiguration(_originalFileName);
+                return new XmlLoggingConfiguration(_originalFileName, LogFactory);
             else
                 return base.Reload();
         }
@@ -459,7 +459,7 @@ namespace NLog.Config
             nlogElement.AssertName("nlog");
 
             bool autoReload = nlogElement.GetOptionalBooleanValue("autoReload", autoReloadDefault);
-            if (filePath != null)
+            if (!string.IsNullOrEmpty(filePath))
                 _fileMustAutoReloadLookup[GetFileLookupKey(filePath)] = autoReload;
 
             try
@@ -483,8 +483,8 @@ namespace NLog.Config
             if (configSection.MatchesName("include"))
             {
                 string filePath = _currentFilePath.Peek();
-                bool autoLoad = filePath != null && _fileMustAutoReloadLookup[GetFileLookupKey(filePath)];
-                ParseIncludeElement(configSection, filePath != null ? Path.GetDirectoryName(filePath) : null, autoLoad);
+                bool autoLoad = !string.IsNullOrEmpty(filePath) && _fileMustAutoReloadLookup[GetFileLookupKey(filePath)];
+                ParseIncludeElement(configSection, !string.IsNullOrEmpty(filePath) ? Path.GetDirectoryName(filePath) : null, autoLoad);
                 return true;
             }
             else

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -324,20 +324,17 @@ namespace NLog.Internal.FileAppenders
         /// </summary>
         public void CloseAppenders(string reason)
         {
-            if (_appenders != null)
+            for (int i = 0; i < _appenders.Length; ++i)
             {
-                for (int i = 0; i < _appenders.Length; ++i)
+                var oldAppender = _appenders[i];
+                if (oldAppender == null)
                 {
-                    var oldAppender = _appenders[i];
-                    if (oldAppender == null)
-                    {
-                        break;
-                    }
-
-                    CloseAppender(oldAppender, reason, true);
-                    _appenders[i] = null;
-                    oldAppender.Dispose();  // Dispose of Archive Mutex
+                    break;
                 }
+
+                CloseAppender(oldAppender, reason, true);
+                _appenders[i] = null;
+                oldAppender.Dispose();  // Dispose of Archive Mutex
             }
         }
 

--- a/src/NLog/Internal/FileAppenders/ICreateFileParameters.cs
+++ b/src/NLog/Internal/FileAppenders/ICreateFileParameters.cs
@@ -95,5 +95,10 @@ namespace NLog.Internal.FileAppenders
         /// Should archive mutex be created?
         /// </summary>
         bool IsArchivingEnabled { get; }
+
+        /// <summary>
+        /// Should manual simple detection of file deletion be enabled?
+        /// </summary>
+        bool EnableFileDeleteSimpleMonitor { get; }
     }
 }

--- a/src/NLog/Internal/MultiFileWatcher.cs
+++ b/src/NLog/Internal/MultiFileWatcher.cs
@@ -131,7 +131,7 @@ namespace NLog.Internal
             var directory = Path.GetDirectoryName(fileName);
             if (!Directory.Exists(directory))
             {
-                InternalLogger.Warn("Cannot watch {0} for changes as it doesn't exist", directory);
+                InternalLogger.Warn("Cannot watch file {0} for changes as directory {1} doesn't exist", fileName, directory);
                 return;
             }
 


### PR DESCRIPTION
Trying to resolve #3321

When running on a non-Windows platform with ConcurrentWrites=false, then just use simple polling of `File.Exists()` before every file-write (throttled to only be done once every 1 sec).

The polling on non-windows-platform can be disabled by `KeepFileOpen=false` or `ConcurrentWrites=true` or `EnableFileDelete=false`.

PR #1878 introduced the use of `FileSystemWatcher` to improve `KeepFileOpen=true + EnableFileDelete=true` on Windows. But it was a mixed gift for other platforms.