### PR TITLE
Added truncate ambient property, e.g. ${message:truncate=80}

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
@@ -41,6 +41,7 @@ namespace NLog.LayoutRenderers.Wrappers
     /// Left part of a text
     /// </summary>
     [LayoutRenderer("left")]
+    [AmbientProperty("Truncate")]
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
@@ -52,6 +53,14 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <docgen category="Transformation Options" order="10"/>
         [RequiredParameter]
         public int Length { get; set; }
+
+        /// <summary>
+        /// Same as <see cref="Length"/>-property, so it can be used as ambient property.
+        /// </summary>
+        /// <example>
+        /// ${message:truncate=80}
+        /// </example>
+        public int Truncate { get => Length; set => Length = value; }
 
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/LeftLayoutRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/LeftLayoutRendererWrapperTests.cs
@@ -39,14 +39,18 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
     public class LeftLayoutRendererWrapperTests
     {
         [Theory]
-        [InlineData(":length=2", "12")]
-        [InlineData(":length=1000", "1234567890")]
-        [InlineData(":length=-1", "")]
-        [InlineData(":length=0", "")]
-        public void LeftWrapperTest(string options, string expected)
+        [InlineData(2, "12")]
+        [InlineData(1000, "1234567890")]
+        [InlineData(-1, "")]
+        [InlineData(0, "")]
+        public void LeftWrapperTest(int length, string expected)
         {
-            SimpleLayout l = $"${{left:${{message}}{options}}}";
+            SimpleLayout l = $"${{left:${{message}}:length={length}}}";
             var result = l.Render(LogEventInfo.Create(LogLevel.Debug, "substringTest", "1234567890"));
+            Assert.Equal(expected, result);
+
+            l = $"${{message:truncate={length}}}";
+            result = l.Render(LogEventInfo.Create(LogLevel.Debug, "substringTest", "1234567890"));
             Assert.Equal(expected, result);
         }
     }


### PR DESCRIPTION
LeftLayoutRendererWrapper - Added truncate as ambient property

Ex. `${message:truncate=80}`