### PR TITLE
LogFactory - GetLogger should null-check logger name

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -889,6 +889,9 @@ namespace NLog
 
         private Logger GetLoggerThreadSafe(string name, Type loggerType)
         {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Name of logger cannot be null");
+
             LoggerCacheKey cacheKey = new LoggerCacheKey(name, loggerType ?? typeof(Logger));
 
             lock (_syncRoot)

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -384,5 +384,12 @@ namespace NLog.UnitTests
             factory.ResumeLogging();
             Assert.True(factory.IsLoggingEnabled());
         }
+
+        [Fact]
+        public void LogFactory_GetLoggerWithNull_ShouldThrow()
+        {
+            LogFactory factory = new LogFactory();
+            Assert.Throws<ArgumentNullException>(() => factory.GetLogger(null));
+        }
     }
 }


### PR DESCRIPTION
Throw `ArgumentNullException` instead of throwing `NullReferenceException` here (When Name is null):

https://github.com/NLog/NLog/blob/3c16e69ae0bd6e33d16d1580882dce354c02d51c/src/NLog/LogFactory.cs#L1015

Could also consider doing fallback to string.Empty.