### PR TITLE
ShortDateLayoutRenderer with support for IRawValue + IStringValueRenderer

### DIFF
--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -654,6 +654,7 @@ Dispose()
             yield return new object[] { "${db-null}", DbType.DateTime, DBNull.Value };
             yield return new object[] { "${event-properties:userid}", DbType.Int32, 0 };
             yield return new object[] { "${date:universalTime=true:format=yyyy-MM:norawvalue=true}", DbType.DateTime, DateTime.SpecifyKind(DateTime.UtcNow.Date.AddDays(-DateTime.UtcNow.Day + 1), DateTimeKind.Unspecified)};
+            yield return new object[] { "${shortdate:universalTime=true}", DbType.DateTime, DateTime.UtcNow.Date };
         }
 
         [Fact]


### PR DESCRIPTION
Makes it possible to get current date as raw-value (Without time-part)

Makes it possible to use `${ShortDate}` in `cacheKey` for https://github.com/NLog/NLog/wiki/Cached-Layout-Renderer with reduced string-allocations.