### PR TITLE
Rename internal EscapeEncodingFlags

### DIFF
--- a/src/NLog/Internal/UrlHelper.cs
+++ b/src/NLog/Internal/UrlHelper.cs
@@ -42,7 +42,7 @@ namespace NLog.Internal
     internal static class UrlHelper
     {
         [Flags]
-        public enum EscapeEncodingFlags
+        public enum EscapeEncodingOptions
         {
             None = 0,
             /// <summary>Allow UnreservedMarks instead of ReservedMarks, as specified by chosen RFC</summary>
@@ -62,16 +62,16 @@ namespace NLog.Internal
         /// </summary>
         /// <param name="source">unicode string-data to be encoded</param>
         /// <param name="target">target for the encoded result</param>
-        /// <param name="flags"><see cref="EscapeEncodingFlags"/>s for how to perform the encoding</param>
-        public static void EscapeDataEncode(string source, StringBuilder target, EscapeEncodingFlags flags)
+        /// <param name="options"><see cref="EscapeEncodingOptions"/>s for how to perform the encoding</param>
+        public static void EscapeDataEncode(string source, StringBuilder target, EscapeEncodingOptions options)
         {
             if (string.IsNullOrEmpty(source))
                 return;
 
           
-            bool isLowerCaseHex = Contains(flags, EscapeEncodingFlags.LowerCaseHex);
-            bool isSpaceAsPlus = Contains(flags, EscapeEncodingFlags.SpaceAsPlus);
-            bool isNLogLegacy = Contains(flags, EscapeEncodingFlags.NLogLegacy);
+            bool isLowerCaseHex = Contains(options, EscapeEncodingOptions.LowerCaseHex);
+            bool isSpaceAsPlus = Contains(options, EscapeEncodingOptions.SpaceAsPlus);
+            bool isNLogLegacy = Contains(options, EscapeEncodingOptions.NLogLegacy);
 
             char[] charArray = null;
             byte[] byteArray = null;
@@ -90,7 +90,7 @@ namespace NLog.Internal
                     continue;
                 }
 
-                if (IsAllowedChar(flags, ch))
+                if (IsAllowedChar(options, ch))
                 {
                     continue;
                 }
@@ -113,9 +113,9 @@ namespace NLog.Internal
             }
         }
 
-        private static bool Contains(EscapeEncodingFlags flags, EscapeEncodingFlags flag)
+        private static bool Contains(EscapeEncodingOptions options, EscapeEncodingOptions option)
         {
-            return (flags & flag) == flag;
+            return (options & option) == option;
         }
 
         /// <summary>
@@ -162,13 +162,13 @@ namespace NLog.Internal
         /// <summary>
         /// Is allowed?
         /// </summary>
-        /// <param name="flags"></param>
+        /// <param name="options"></param>
         /// <param name="ch"></param>
         /// <returns></returns>
-        private static bool IsAllowedChar(EscapeEncodingFlags flags, char ch)
+        private static bool IsAllowedChar(EscapeEncodingOptions options, char ch)
         {
-            bool isUriString = (flags & EscapeEncodingFlags.UriString) == EscapeEncodingFlags.UriString;
-            bool isLegacyRfc2396 = (flags & EscapeEncodingFlags.LegacyRfc2396) == EscapeEncodingFlags.LegacyRfc2396;
+            bool isUriString = (options & EscapeEncodingOptions.UriString) == EscapeEncodingOptions.UriString;
+            bool isLegacyRfc2396 = (options & EscapeEncodingOptions.LegacyRfc2396) == EscapeEncodingOptions.LegacyRfc2396;
             if (isUriString)
             {
                 if (!isLegacyRfc2396 && RFC3986UnreservedMarks.IndexOf(ch) >= 0)
@@ -208,16 +208,16 @@ namespace NLog.Internal
             { '0', '1', '2', '3', '4', '5', '6', '7',
             '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
-        public static EscapeEncodingFlags GetUriStringEncodingFlags(bool escapeDataNLogLegacy, bool spaceAsPlus, bool escapeDataRfc3986)
+        public static EscapeEncodingOptions GetUriStringEncodingFlags(bool escapeDataNLogLegacy, bool spaceAsPlus, bool escapeDataRfc3986)
         {
-            EscapeEncodingFlags encodingFlags = EscapeEncodingFlags.UriString;
+            EscapeEncodingOptions encodingOptions = EscapeEncodingOptions.UriString;
             if (escapeDataNLogLegacy)
-                encodingFlags |= EscapeEncodingFlags.LowerCaseHex | EscapeEncodingFlags.NLogLegacy;
+                encodingOptions |= EscapeEncodingOptions.LowerCaseHex | EscapeEncodingOptions.NLogLegacy;
             else if (!escapeDataRfc3986)
-                encodingFlags |= EscapeEncodingFlags.LowerCaseHex | EscapeEncodingFlags.LegacyRfc2396;
+                encodingOptions |= EscapeEncodingOptions.LowerCaseHex | EscapeEncodingOptions.LegacyRfc2396;
             if (spaceAsPlus)
-                encodingFlags |= EscapeEncodingFlags.SpaceAsPlus;
-            return encodingFlags;
+                encodingOptions |= EscapeEncodingOptions.SpaceAsPlus;
+            return encodingOptions;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/UrlEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/UrlEncodeLayoutRendererWrapper.cs
@@ -83,9 +83,9 @@ namespace NLog.LayoutRenderers.Wrappers
         {
             if (!string.IsNullOrEmpty(text))
             {
-                UrlHelper.EscapeEncodingFlags encodingFlags = UrlHelper.GetUriStringEncodingFlags(EscapeDataNLogLegacy, SpaceAsPlus, EscapeDataRfc3986);
+                UrlHelper.EscapeEncodingOptions encodingOptions = UrlHelper.GetUriStringEncodingFlags(EscapeDataNLogLegacy, SpaceAsPlus, EscapeDataRfc3986);
                 System.Text.StringBuilder sb = new System.Text.StringBuilder(text.Length + 20);
-                UrlHelper.EscapeDataEncode(text, sb, encodingFlags);
+                UrlHelper.EscapeDataEncode(text, sb, encodingOptions);
                 return sb.ToString();
             }
             return string.Empty;

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -491,8 +491,8 @@ namespace NLog.Targets
             using (var targetBuilder = OptimizeBufferReuse ? ReusableLayoutBuilder.Allocate() : ReusableLayoutBuilder.None)
             {
                 StringBuilder sb = targetBuilder.Result ?? new StringBuilder();
-                UrlHelper.EscapeEncodingFlags encodingFlags = UrlHelper.GetUriStringEncodingFlags(EscapeDataNLogLegacy, false, EscapeDataRfc3986);
-                BuildWebServiceQueryParameters(parameterValues, sb, encodingFlags);
+                UrlHelper.EscapeEncodingOptions encodingOptions = UrlHelper.GetUriStringEncodingFlags(EscapeDataNLogLegacy, false, EscapeDataRfc3986);
+                BuildWebServiceQueryParameters(parameterValues, sb, encodingOptions);
                 queryParameters = sb.ToString();
             }
 
@@ -511,7 +511,7 @@ namespace NLog.Targets
             return builder.Uri;
         }
 
-        private void BuildWebServiceQueryParameters(object[] parameterValues, StringBuilder sb, UrlHelper.EscapeEncodingFlags encodingFlags)
+        private void BuildWebServiceQueryParameters(object[] parameterValues, StringBuilder sb, UrlHelper.EscapeEncodingOptions encodingOptions)
         {
             string separator = string.Empty;
             for (int i = 0; i < Parameters.Count; i++)
@@ -522,7 +522,7 @@ namespace NLog.Targets
                 string parameterValue = XmlHelper.XmlConvertToString(parameterValues[i]);
                 if (!string.IsNullOrEmpty(parameterValue))
                 {
-                    UrlHelper.EscapeDataEncode(parameterValue, sb, encodingFlags);
+                    UrlHelper.EscapeDataEncode(parameterValue, sb, encodingOptions);
                 }
                 separator = "&";
             }
@@ -605,11 +605,11 @@ namespace NLog.Targets
 
         private class HttpPostFormEncodedFormatter : HttpPostTextFormatterBase
         {
-            readonly UrlHelper.EscapeEncodingFlags _encodingFlags;
+            readonly UrlHelper.EscapeEncodingOptions _encodingOptions;
 
             public HttpPostFormEncodedFormatter(WebServiceTarget target) : base(target)
             {
-                _encodingFlags = UrlHelper.GetUriStringEncodingFlags(target.EscapeDataNLogLegacy, true, target.EscapeDataRfc3986);
+                _encodingOptions = UrlHelper.GetUriStringEncodingFlags(target.EscapeDataNLogLegacy, true, target.EscapeDataRfc3986);
             }
 
             protected override string GetContentType(WebServiceTarget target)
@@ -619,7 +619,7 @@ namespace NLog.Targets
 
             protected override void WriteStringContent(StringBuilder builder, object[] parameterValues)
             {
-                Target.BuildWebServiceQueryParameters(parameterValues, builder, _encodingFlags);
+                Target.BuildWebServiceQueryParameters(parameterValues, builder, _encodingOptions);
             }
         }
 

--- a/tests/NLog.UnitTests/Internal/UrlHelperTests.cs
+++ b/tests/NLog.UnitTests/Internal/UrlHelperTests.cs
@@ -77,10 +77,10 @@ namespace NLog.UnitTests.Internal
         public void EscapeDataEncodeTestRfc2396(string input, bool spaceAsPlus, string result)
         {
             System.Text.StringBuilder builder = new System.Text.StringBuilder(input.Length + 20);
-            UrlHelper.EscapeEncodingFlags encodingFlags = UrlHelper.EscapeEncodingFlags.LowerCaseHex | UrlHelper.EscapeEncodingFlags.LegacyRfc2396 | UrlHelper.EscapeEncodingFlags.UriString;
+            UrlHelper.EscapeEncodingOptions encodingOptions = UrlHelper.EscapeEncodingOptions.LowerCaseHex | UrlHelper.EscapeEncodingOptions.LegacyRfc2396 | UrlHelper.EscapeEncodingOptions.UriString;
             if (spaceAsPlus)
-                encodingFlags |= UrlHelper.EscapeEncodingFlags.SpaceAsPlus;
-            UrlHelper.EscapeDataEncode(input, builder, encodingFlags);
+                encodingOptions |= UrlHelper.EscapeEncodingOptions.SpaceAsPlus;
+            UrlHelper.EscapeDataEncode(input, builder, encodingOptions);
             Assert.Equal(result, builder.ToString());
             Assert.Equal(input.Replace('+', ' '), DecodeUrlString(builder.ToString()));
         }
@@ -97,10 +97,10 @@ namespace NLog.UnitTests.Internal
         public void EscapeDataEncodeTestRfc3986(string input, bool spaceAsPlus, string result)
         {
             System.Text.StringBuilder builder = new System.Text.StringBuilder(input.Length + 20);
-            UrlHelper.EscapeEncodingFlags encodingFlags = UrlHelper.EscapeEncodingFlags.None;
+            UrlHelper.EscapeEncodingOptions encodingOptions = UrlHelper.EscapeEncodingOptions.None;
             if (spaceAsPlus)
-                encodingFlags |= UrlHelper.EscapeEncodingFlags.SpaceAsPlus;
-            UrlHelper.EscapeDataEncode(input, builder, encodingFlags);
+                encodingOptions |= UrlHelper.EscapeEncodingOptions.SpaceAsPlus;
+            UrlHelper.EscapeDataEncode(input, builder, encodingOptions);
             Assert.Equal(result, builder.ToString());
             Assert.Equal(input.Replace('+', ' '), DecodeUrlString(builder.ToString()));
         }

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
@@ -338,7 +338,7 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void SerializeFlagEnum_Test()
         {
-            var val = UrlHelper.EscapeEncodingFlags.LegacyRfc2396 | UrlHelper.EscapeEncodingFlags.LowerCaseHex;
+            var val = UrlHelper.EscapeEncodingOptions.LegacyRfc2396 | UrlHelper.EscapeEncodingOptions.LowerCaseHex;
             var actual = SerializeObject(val);
             Assert.Equal("\"LegacyRfc2396, LowerCaseHex\"", actual);
         }


### PR DESCRIPTION
Fixing "Enumeration type names should not have "Flags" or "Enum" suffixes" -> https://sonarcloud.io/organizations/default/rules?open=csharpsquid%3AS2344&rule_key=csharpsquid%3AS2344