### PR TITLE
Fixed potential memory issue with large strings

### DIFF
--- a/src/NLog/Internal/StringBuilderPool.cs
+++ b/src/NLog/Internal/StringBuilderPool.cs
@@ -99,11 +99,9 @@ namespace NLog.Internal
                 {
                     stringBuilder = new StringBuilder(maxBuilderCapacity / 2);
                 }
-            } 
-            else
-            {
-                stringBuilder.Length = 0;
             }
+
+            stringBuilder.Length = 0;
 
             if (poolIndex == -1)
             {


### PR DESCRIPTION
StringBuilderPool - Allow FastPool-object to have larger capacity, but missing reset

Serious bug introduced with #2934

If writing very large log-message, then NLog will never forget it.

Will try later to make a unit-test for this special logic about releasing StringBuilders that have become too big.