### PR TITLE
Enabled SimpleFileDeleteTest on Travis - Verify that FileSystemWatcher works on .NET Core

### DIFF
--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -125,11 +125,13 @@ namespace NLog.UnitTests.Targets
         public void SimpleFileDeleteTest(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool forceManaged, bool forceMutexConcurrentWrites, bool optimizeBufferReuse)
         {
             bool isSimpleKeepFileOpen = keepFileOpen && !networkWrites && !concurrentWrites && IsTravis();
+#if MONO
             if (IsTravis() && concurrentWrites && keepFileOpen && !networkWrites)
             {
-                Console.WriteLine("[SKIP] Not supported on MONO on Travis, because of FileSystemWatcher not working");
+                Console.WriteLine("[SKIP] FileTargetTests.SimpleFileDeleteTest Not supported on MONO on Travis, because of FileSystemWatcher not working");
                 return;
             }
+#endif
 
             var logFile = Path.GetTempFileName();
             var logFile2 = Path.Combine(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()), Path.GetFileName(logFile));
@@ -3458,7 +3460,7 @@ namespace NLog.UnitTests.Targets
                 var app1DebugNm = "App1_Debug";
                 var app2Nm = "App2";
 
-                #region Create Mock Archive Files
+#region Create Mock Archive Files
                 var now = DateTime.Now;
                 var i = 0;
                 // create mock app1_trace archives (matches app1 config for trace target)
@@ -3499,7 +3501,7 @@ namespace NLog.UnitTests.Targets
                     }
                     i--;
                 }
-                #endregion
+#endregion
 
                 // Create same app1 Debug file as config defines. Will force archiving to happen on startup
                 File.WriteAllLines(logdir + "\\" + app1DebugNm + fileExt, new[] { "Write first app debug target. Startup will archive this file" }, Encoding.ASCII);
@@ -3598,7 +3600,7 @@ namespace NLog.UnitTests.Targets
                 var app1Nm = "App1";
                 var app2Nm = "App2";
 
-                #region Create Mock Archive Files
+#region Create Mock Archive Files
                 var now = DateTime.Now;
                 var i = 0;
                 // create mock app1 archives (matches app1 config for target)
@@ -3626,7 +3628,7 @@ namespace NLog.UnitTests.Targets
                     }
                     i--;
                 }
-                #endregion
+#endregion
 
                 // Create same app1 file as config defines. Will force archiving to happen on startup
                 File.WriteAllLines(Path.Combine(logdir, app1Nm + fileExt), new[] { "Write first app debug target. Startup will archive this file" }, Encoding.ASCII);


### PR DESCRIPTION
On Travis (when operating system is willing)