### PR TITLE
Filetarget: default encoding changed to UTF8 - was Encoding.Default

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -155,11 +155,7 @@ namespace NLog.Targets
             ArchiveAboveSize = ArchiveAboveSizeDisabled;
             ConcurrentWriteAttempts = 10;
             ConcurrentWrites = true;
-#if SILVERLIGHT || NETSTANDARD1_0
             Encoding = Encoding.UTF8;
-#else
-            Encoding = Encoding.Default;
-#endif
             BufferSize = 32768;
             AutoFlush = true;
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__


### PR DESCRIPTION
fixes https://github.com/NLog/NLog/issues/2536