### PR TITLE
Implement FasterAccurateLocalTimeSource

### DIFF
--- a/src/NLog/Time/FastAccurateLocalTimeSource.cs
+++ b/src/NLog/Time/FastAccurateLocalTimeSource.cs
@@ -76,22 +76,21 @@ namespace NLog.Time
 
         private DateTime GetTime()
         {
-            DateTime utc = DateTime.UtcNow;
+            long utcTicks = DateTime.UtcNow.Ticks;
 #if !SILVERLIGHT || WINDOWS_PHONE
-            long deltaTicks = utc.Ticks - Interlocked.Read(ref _lastUpdated);
+            long deltaTicks = utcTicks - Interlocked.Read(ref _lastUpdated);
 #else
-            long deltaTicks = utc.Ticks - Interlocked.CompareExchange(ref _lastUpdated, 0, 0);
+            long deltaTicks = utcTicks - Interlocked.CompareExchange(ref _lastUpdated, 0, 0);
 #endif
             long ticksOffset = _ticksOffset;
 
             if (deltaTicks > TimeSpan.TicksPerSecond || deltaTicks < -TimeSpan.TicksPerSecond)
             {
-                _ticksOffset = ticksOffset = (DateTime.Now - utc).Ticks;
-                _lastUpdated = utc.Ticks;
+                _ticksOffset = ticksOffset = (DateTime.Now.Ticks - utcTicks);
+                _lastUpdated = utcTicks;
             }
 
-            long ticks = utc.Ticks + ticksOffset;
-            return new DateTime(ticks, DateTimeKind.Local);
+            return new DateTime(utcTicks + ticksOffset, DateTimeKind.Local);
         }
     }
 }

--- a/src/NLog/Time/FastAccurateLocalTimeSource.cs
+++ b/src/NLog/Time/FastAccurateLocalTimeSource.cs
@@ -40,8 +40,8 @@ namespace NLog.Time
     /// <summary>
     /// Current local time retrieved from DateTime.UtcNow with local time offset
     /// </summary>
-    [TimeSource("FasterAccurateLocal")]
-    public class FasterAccurateLocalTimeSource : TimeSource
+    [TimeSource("FastAccurateLocal")]
+    public class FastAccurateLocalTimeSource : TimeSource
     {
         private long _ticksOffset;
         private long _lastUpdated;
@@ -49,7 +49,7 @@ namespace NLog.Time
         /// <summary>
         /// Initializes TimeSource with offset from utc to local time
         /// </summary>
-        public FasterAccurateLocalTimeSource()
+        public FastAccurateLocalTimeSource()
         {
             DateTime utc = DateTime.UtcNow;
             _ticksOffset = (DateTime.Now - utc).Ticks;

--- a/src/NLog/Time/FasterAccurateLocalTimeSource.cs
+++ b/src/NLog/Time/FasterAccurateLocalTimeSource.cs
@@ -1,0 +1,97 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+
+namespace NLog.Time
+{
+    using System;
+    using System.Threading;
+
+    /// <summary>
+    /// Current local time retrieved from DateTime.UtcNow with local time offset
+    /// </summary>
+    [TimeSource("FasterAccurateLocal")]
+    public class FasterAccurateLocalTimeSource : TimeSource
+    {
+        private long _ticksOffset;
+        private long _lastUpdated;
+
+        /// <summary>
+        /// Initializes TimeSource with offset from utc to local time
+        /// </summary>
+        public FasterAccurateLocalTimeSource()
+        {
+            DateTime utc = DateTime.UtcNow;
+            _ticksOffset = (DateTime.Now - utc).Ticks;
+            _lastUpdated = utc.Ticks;
+        }
+
+        /// <summary>
+        /// Gets current local time directly from DateTime.Now.
+        /// </summary>
+        public override DateTime Time => GetTime();
+
+
+        /// <summary>
+        ///  Converts the specified system time to the same form as the time value originated from this time source.
+        /// </summary>
+        /// <param name="systemTime">The system originated time value to convert.</param>
+        /// <returns>
+        ///  The value of <paramref name="systemTime"/> converted to local time.
+        /// </returns>
+        public override DateTime FromSystemTime(DateTime systemTime)
+        {
+            return systemTime.ToLocalTime();
+        }
+
+        private DateTime GetTime()
+        {
+            DateTime utc = DateTime.UtcNow;
+#if !SILVERLIGHT || WINDOWS_PHONE
+            long deltaTicks = utc.Ticks - Interlocked.Read(ref _lastUpdated);
+#else
+            long deltaTicks = utc.Ticks - Interlocked.CompareExchange(ref _lastUpdated, 0, 0);
+#endif
+            long ticksOffset = _ticksOffset;
+
+            if (deltaTicks > TimeSpan.TicksPerSecond || deltaTicks < -TimeSpan.TicksPerSecond)
+            {
+                _ticksOffset = ticksOffset = (DateTime.Now - utc).Ticks;
+                _lastUpdated = utc.Ticks;
+            }
+
+            long ticks = utc.Ticks + ticksOffset;
+            return new DateTime(ticks, DateTimeKind.Local);
+        }
+    }
+}


### PR DESCRIPTION
This TimeSource is close to the performance of TimeSource.AccurateUtc but returns local time

Here is benchmark results using [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet)
[Source code of benchmark](https://gist.github.com/Encamy/51a789bf00450aa117596ecd1e1a1fa3)

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17763.475 (1809/October2018Update/Redstone5)
Intel Core i5-3570 CPU 3.40GHz (Ivy Bridge), 1 CPU, 4 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3324.0
  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3324.0


```
|               Method |       Mean |     Error |    StdDev |
|--------------------- |-----------:|----------:|----------:|
|            FastLocal |   5.784 ns | 0.0340 ns | 0.0318 ns |
|              FastUtc |   5.246 ns | 0.0303 ns | 0.0284 ns |
|        AccurateLocal | 215.149 ns | 0.8370 ns | 0.7830 ns |
|          AccurateUtc | 147.001 ns | 0.7035 ns | 0.6581 ns |
| AccurateAndFastLocal | 152.786 ns | 0.7137 ns | 0.6676 ns |
