### PR TITLE
Serialization: improved support for custom expando objects

### DIFF
--- a/src/NLog/Internal/ObjectReflectionCache.cs
+++ b/src/NLog/Internal/ObjectReflectionCache.cs
@@ -53,6 +53,34 @@ namespace NLog.Internal
 
         public ObjectPropertyList LookupObjectProperties(object value)
         {
+            if (TryLookupExpandoObject(value, out var propertyValues))
+            {
+                return propertyValues;
+            }
+
+            var objectType = value.GetType();
+            var propertyInfos = BuildObjectPropertyInfos(value, objectType);
+            _objectTypeCache.TryAddValue(objectType, propertyInfos);
+            return new ObjectPropertyList(value, propertyInfos.Properties, propertyInfos.FastLookup);
+        }
+
+        public bool TryLookupExpandoObject(object value, out ObjectPropertyList objectPropertyList)
+        {
+            if (value is IDictionary<string, object> expando)
+            {
+                objectPropertyList = new ObjectPropertyList(expando);
+                return true;
+            }
+
+#if DYNAMIC_OBJECT
+            if (value is DynamicObject d)
+            {
+                var dictionary = DynamicObjectToDict(d);
+                objectPropertyList = new ObjectPropertyList(dictionary);
+                return true;
+            }
+#endif
+
             Type objectType = value.GetType();
             if (_objectTypeCache.TryGetValue(objectType, out var propertyInfos))
             {
@@ -62,7 +90,8 @@ namespace NLog.Internal
                     propertyInfos = new ObjectPropertyInfos(propertyInfos.Properties, fastLookup);
                     _objectTypeCache.TryAddValue(objectType, propertyInfos);
                 }
-                return new ObjectPropertyList(value, propertyInfos.Properties, propertyInfos.FastLookup);
+                objectPropertyList = new ObjectPropertyList(value, propertyInfos.Properties, propertyInfos.FastLookup);
+                return true;
             }
 
             if (_objectTypeOverride.Count > 0)
@@ -74,26 +103,47 @@ namespace NLog.Internal
                     {
                         var objectProperties = objectReflection.Invoke(value);
                         if (objectProperties?.Count > 0)
-                            return new ObjectPropertyList(objectProperties);
+                        {
+                            objectPropertyList = new ObjectPropertyList(objectProperties);
+                            return true;
+                        }
 
                         // object.ToString() since no properties
                         propertyInfos = ObjectPropertyInfos.SimpleToString;
-                        return new ObjectPropertyList(value, propertyInfos.Properties, propertyInfos.FastLookup);
+                        objectPropertyList = new ObjectPropertyList(value, propertyInfos.Properties, propertyInfos.FastLookup);
+                        return true;
                     }
                 }
             }
 
-#if DYNAMIC_OBJECT
-            if (value is DynamicObject d)
+            if (TryExtractExpandoObject(objectType, out propertyInfos))
             {
-                var dictionary = DynamicObjectToDict(d);
-                return new ObjectPropertyList(dictionary);
+                _objectTypeCache.TryAddValue(objectType, propertyInfos);
+                objectPropertyList = new ObjectPropertyList(value, propertyInfos.Properties, propertyInfos.FastLookup);
+                return true;
             }
-#endif
 
-            propertyInfos = BuildObjectPropertyInfos(value, objectType);
-            _objectTypeCache.TryAddValue(objectType, propertyInfos);
-            return new ObjectPropertyList(value, propertyInfos.Properties, propertyInfos.FastLookup);
+            objectPropertyList = default(ObjectPropertyList);
+            return false;
+        }
+
+        private static bool TryExtractExpandoObject(Type objectType, out ObjectPropertyInfos propertyInfos)
+        {
+            foreach (var interfaceType in objectType.GetInterfaces())
+            {
+                if (interfaceType.IsGenericType() && interfaceType.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+                {
+                    if (interfaceType.GetGenericArguments()[0] == typeof(string))
+                    {
+                        var dictionaryEnumerator = (IDictionaryEnumerator)Activator.CreateInstance(typeof(DictionaryEnumerator<,>).MakeGenericType(interfaceType.GetGenericArguments()));
+                        propertyInfos = new ObjectPropertyInfos(null, new[] { new FastPropertyLookup(string.Empty, TypeCode.Object, (o, p) => dictionaryEnumerator.GetEnumerator(o)) });
+                        return true;
+                    }
+                }
+            }
+
+            propertyInfos = default(ObjectPropertyInfos);
+            return false;
         }
 
         private static ObjectPropertyInfos BuildObjectPropertyInfos(object value, Type objectType)
@@ -207,6 +257,7 @@ namespace NLog.Internal
         public struct ObjectPropertyList : IEnumerable<ObjectPropertyList.PropertyValue>
         {
             internal static readonly StringComparer NameComparer = StringComparer.Ordinal;
+            private static readonly FastPropertyLookup[] CreateIDictionaryEnumerator = new[] { new FastPropertyLookup(string.Empty, TypeCode.Object, (o, p) => ((IDictionary<string, object>)o).GetEnumerator()) };
             private readonly object _object;
             private readonly PropertyInfo[] _properties;
             private readonly FastPropertyLookup[] _fastLookup;
@@ -215,19 +266,7 @@ namespace NLog.Internal
             {
                 public readonly string Name;
                 public readonly object Value;
-                public TypeCode TypeCode
-                {
-                    get
-                    {
-                        if (_typecode == TypeCode.Object)
-                        {
-                            return Convert.GetTypeCode(Value);
-                        }
-
-                        return Value == null ? TypeCode.Empty : _typecode;
-                    }
-                }
-
+                public TypeCode TypeCode => Value == null ? TypeCode.Empty : _typecode;
                 private readonly TypeCode _typecode;
 
                 public PropertyValue(string name, object value, TypeCode typeCode)
@@ -252,7 +291,7 @@ namespace NLog.Internal
                 }
             }
 
-            public int Count => _fastLookup?.Length ?? _properties?.Length ?? (_object as ICollection)?.Count ?? (_object as ICollection<KeyValuePair<string, object>>)?.Count ?? 0;
+            public bool ConvertToString => _properties?.Length == 0;
 
             internal ObjectPropertyList(object value, PropertyInfo[] properties, FastPropertyLookup[] fastLookup)
             {
@@ -265,38 +304,85 @@ namespace NLog.Internal
             {
                 _object = value;    // Expando objects
                 _properties = null;
-                _fastLookup = null;
+                _fastLookup = CreateIDictionaryEnumerator;
             }
 
             public bool TryGetPropertyValue(string name, out PropertyValue propertyValue)
             {
-                if (_fastLookup != null)
+                if (_properties != null)
                 {
-                    int nameHashCode = NameComparer.GetHashCode(name);
-                    foreach (var fastProperty in _fastLookup)
+                    if (_fastLookup != null)
                     {
-                        if (fastProperty.NameHashCode==nameHashCode && NameComparer.Equals(fastProperty.Name, name))
-                        {
-                            propertyValue = new PropertyValue(_object, fastProperty);
-                            return true;
-                        }
+                        return TryFastLookupPropertyValue(name, out propertyValue);
+                    }
+                    else
+                    {
+                        return TrySlowLookupPropertyValue(name, out propertyValue);
                     }
                 }
-                else if (_properties != null)
+                else if (_object is IDictionary<string, object> expandoObject)
                 {
-                    foreach (var propInfo in _properties)
+                    if (expandoObject.TryGetValue(name, out var objectValue))
                     {
-                        if (NameComparer.Equals(propInfo.Name, name))
-                        {
-                            propertyValue = new PropertyValue(_object, propInfo);
-                            return true;
-                        }
+                        propertyValue = new PropertyValue(name, objectValue, TypeCode.Object);
+                        return true;
+                    }
+                    propertyValue = default(PropertyValue);
+                    return false;
+                }
+                else
+                {
+                    return TryListLookupPropertyValue(name, out propertyValue);
+                }
+            }
+
+            /// <summary>
+            /// Scans properties for name (Skips string-compare and value-lookup until finding match)
+            /// </summary>
+            private bool TryFastLookupPropertyValue(string name, out PropertyValue propertyValue)
+            {
+                int nameHashCode = NameComparer.GetHashCode(name);
+                foreach (var fastProperty in _fastLookup)
+                {
+                    if (fastProperty.NameHashCode == nameHashCode && NameComparer.Equals(fastProperty.Name, name))
+                    {
+                        propertyValue = new PropertyValue(_object, fastProperty);
+                        return true;
                     }
                 }
-                else if (_object is IDictionary<string, object> expandoObject && expandoObject.TryGetValue(name, out var objectValue))
+                propertyValue = default(PropertyValue);
+                return false;
+            }
+
+            /// <summary>
+            /// Scans properties for name (Skips property value lookup until finding match)
+            /// </summary>
+            private bool TrySlowLookupPropertyValue(string name, out PropertyValue propertyValue)
+            {
+                foreach (var propInfo in _properties)
                 {
-                    propertyValue = new PropertyValue(name, objectValue, TypeCode.Object);
-                    return true;
+                    if (NameComparer.Equals(propInfo.Name, name))
+                    {
+                        propertyValue = new PropertyValue(_object, propInfo);
+                        return true;
+                    }
+                }
+                propertyValue = default(PropertyValue);
+                return false;
+            }
+
+            /// <summary>
+            /// Scans properties for name
+            /// </summary>
+            private bool TryListLookupPropertyValue(string name, out PropertyValue propertyValue)
+            {
+                foreach (var item in this)
+                {
+                    if (NameComparer.Equals(item.Name, name))
+                    {
+                        propertyValue = item;
+                        return true;
+                    }
                 }
                 propertyValue = default(PropertyValue);
                 return false;
@@ -312,7 +398,7 @@ namespace NLog.Internal
                 if (_properties != null)
                     return new Enumerator(_object, _properties, _fastLookup);
                 else
-                    return new Enumerator((_object as IDictionary<string, object>).GetEnumerator());
+                    return new Enumerator((IEnumerator<KeyValuePair<string, object>>)_fastLookup[0].ValueLookup(_object, null));
             }
 
             IEnumerator<PropertyValue> IEnumerable<PropertyValue>.GetEnumerator() => GetEnumerator();
@@ -459,5 +545,30 @@ namespace NLog.Internal
             }
         }
 #endif
+
+        private interface IDictionaryEnumerator
+        {
+            IEnumerator<KeyValuePair<string,object>> GetEnumerator(object value);
+        }
+
+        private static readonly IDictionary<string, object> EmptyDictionary = new NLog.Internal.SortHelpers.ReadOnlySingleBucketDictionary<string, object>();
+
+        internal sealed class DictionaryEnumerator<TKey, TValue> : IDictionaryEnumerator
+        {
+            public IEnumerator<KeyValuePair<string, object>> GetEnumerator(object value)
+            {
+                if (value is IDictionary<TKey, TValue> dictionary)
+                {
+                    return YieldEnumerator(dictionary);
+                }
+                return EmptyDictionary.GetEnumerator();
+            }
+
+            private IEnumerator<KeyValuePair<string, object>> YieldEnumerator(IDictionary<TKey,TValue> dictionary)
+            {
+                foreach (var item in dictionary)
+                    yield return new KeyValuePair<string, object>(item.Key.ToString(), item.Value);
+            }
+        }
     }
 }

--- a/src/NLog/Internal/PropertiesDictionary.cs
+++ b/src/NLog/Internal/PropertiesDictionary.cs
@@ -466,15 +466,7 @@ namespace NLog.Internal
                     }
                     if (_eventEnumeratorCreated)
                     {
-                        string parameterName;
-                        try
-                        {
-                            parameterName = XmlHelper.XmlConvertToString(_eventEnumerator.Current.Key ?? string.Empty);
-                        }
-                        catch
-                        {
-                            parameterName = "";
-                        }
+                        string parameterName = XmlHelper.XmlConvertToString(_eventEnumerator.Current.Key ?? string.Empty) ?? string.Empty;
                         return new MessageTemplateParameter(parameterName, _eventEnumerator.Current.Value.Value, null, CaptureType.Unknown);
                     }
                     throw new InvalidOperationException();

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -32,6 +32,7 @@
 // 
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using NLog.MessageTemplates;
@@ -333,28 +334,28 @@ namespace NLog.Internal
         /// <summary>
         /// Apend a int type (byte, int) as string
         /// </summary>
-        internal static void AppendIntegerAsString(this StringBuilder sb, object value, TypeCode objTypeCode)
+        internal static void AppendIntegerAsString(this StringBuilder sb, IConvertible value, TypeCode objTypeCode)
         {
             switch (objTypeCode)
             {
-                case TypeCode.Byte: sb.AppendInvariant((byte)value); break;
-                case TypeCode.SByte: sb.AppendInvariant((sbyte)value); break;
-                case TypeCode.Int16: sb.AppendInvariant((short)value); break;
-                case TypeCode.Int32: sb.AppendInvariant((int)value); break;
+                case TypeCode.Byte: sb.AppendInvariant(value.ToByte(CultureInfo.InvariantCulture)); break;
+                case TypeCode.SByte: sb.AppendInvariant(value.ToSByte(CultureInfo.InvariantCulture)); break;
+                case TypeCode.Int16: sb.AppendInvariant(value.ToInt16(CultureInfo.InvariantCulture)); break;
+                case TypeCode.Int32: sb.AppendInvariant(value.ToInt32(CultureInfo.InvariantCulture)); break;
                 case TypeCode.Int64:
                     {
-                        long int64 = (long)value;
+                        long int64 = value.ToInt64(CultureInfo.InvariantCulture);
                         if (int64 < int.MaxValue && int64 > int.MinValue)
                             sb.AppendInvariant((int)int64);
                         else
                             sb.Append(int64);
                     }
                     break;
-                case TypeCode.UInt16: sb.AppendInvariant((ushort)value); break;
-                case TypeCode.UInt32: sb.AppendInvariant((uint)value); break;
+                case TypeCode.UInt16: sb.AppendInvariant(value.ToUInt16(CultureInfo.InvariantCulture)); break;
+                case TypeCode.UInt32: sb.AppendInvariant(value.ToUInt32(CultureInfo.InvariantCulture)); break;
                 case TypeCode.UInt64:
                     {
-                        ulong uint64 = (ulong)value;
+                        ulong uint64 = value.ToUInt64(CultureInfo.InvariantCulture);
                         if (uint64 < uint.MaxValue)
                             sb.AppendInvariant((uint)uint64);
                         else

--- a/tests/NLog.UnitTests/Internal/ExpandoTestDictionary.cs
+++ b/tests/NLog.UnitTests/Internal/ExpandoTestDictionary.cs
@@ -1,0 +1,112 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.Internal
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Special Expando-Object that has custom object-value (Similar to JObject)
+    /// </summary>
+    internal class ExpandoTestDictionary : IDictionary<string, IConvertible>
+    {
+        private readonly Dictionary<string, IConvertible> _properties = new Dictionary<string, IConvertible>();
+
+        public IConvertible this[string key] { get => ((IDictionary<string, IConvertible>)_properties)[key]; set => ((IDictionary<string, IConvertible>)_properties)[key] = value; }
+
+        public ICollection<string> Keys => ((IDictionary<string, IConvertible>)_properties).Keys;
+
+        public ICollection<IConvertible> Values => ((IDictionary<string, IConvertible>)_properties).Values;
+
+        public int Count => ((IDictionary<string, IConvertible>)_properties).Count;
+
+        public bool IsReadOnly => ((IDictionary<string, IConvertible>)_properties).IsReadOnly;
+
+        public void Add(string key, IConvertible value)
+        {
+            ((IDictionary<string, IConvertible>)_properties).Add(key, value);
+        }
+
+        public void Add(KeyValuePair<string, IConvertible> item)
+        {
+            ((IDictionary<string, IConvertible>)_properties).Add(item);
+        }
+
+        public void Clear()
+        {
+            ((IDictionary<string, IConvertible>)_properties).Clear();
+        }
+
+        public bool Contains(KeyValuePair<string, IConvertible> item)
+        {
+            return ((IDictionary<string, IConvertible>)_properties).Contains(item);
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return ((IDictionary<string, IConvertible>)_properties).ContainsKey(key);
+        }
+
+        public void CopyTo(KeyValuePair<string, IConvertible>[] array, int arrayIndex)
+        {
+            ((IDictionary<string, IConvertible>)_properties).CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<KeyValuePair<string, IConvertible>> GetEnumerator()
+        {
+            return ((IDictionary<string, IConvertible>)_properties).GetEnumerator();
+        }
+
+        public bool Remove(string key)
+        {
+            return ((IDictionary<string, IConvertible>)_properties).Remove(key);
+        }
+
+        public bool Remove(KeyValuePair<string, IConvertible> item)
+        {
+            return ((IDictionary<string, IConvertible>)_properties).Remove(item);
+        }
+
+        public bool TryGetValue(string key, out IConvertible value)
+        {
+            return ((IDictionary<string, IConvertible>)_properties).TryGetValue(key, out value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IDictionary<string, IConvertible>)_properties).GetEnumerator();
+        }
+    }
+}

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
@@ -273,6 +273,16 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void SerializeExpandoDict_Test()
+        {
+            IDictionary<string, IConvertible> dictionary = new Internal.ExpandoTestDictionary();
+            dictionary.Add("key 2", 1.3m);
+            dictionary.Add("level", LogLevel.Info);
+            var actual = SerializeObject(dictionary);
+            Assert.Equal("{\"key 2\":1.3, \"level\":{\"Name\":\"Info\", \"Ordinal\":2}}", actual);
+        }
+
+        [Fact]
         public void SerializeIntegerKeyDict_Test()
         {
             var dictionary = new Dictionary<int, string>();


### PR DESCRIPTION
- Enables serialization of Newtonsoft JObject (Custom expando object that implements IDictionary-interface)
- Correct handling of custom objects implementing IConvertible (Avoids invalid-cast-exception)

See also: https://stackoverflow.com/questions/56118768/jobject-jtoken-doesnt-log-on-nlog
