### PR TITLE
FilteringTargetWrapper: Add support for batch writing + PostFilteringTargetWrapper: performance optimizations

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -1021,6 +1021,11 @@ namespace NLog.Config
                 return;
             }
 
+            if (SetFilterFromElement(o, propInfo, element))
+            {
+                return;
+            }
+
             SetItemFromElement(o, propInfo, element);
         }
 
@@ -1093,6 +1098,30 @@ namespace NLog.Config
                 return null;
 
             return _configurationItemFactory.Layouts.CreateInstance(ExpandSimpleVariables(layoutTypeName));
+        }
+
+        private bool SetFilterFromElement(object o, PropertyInfo propInfo, ILoggingConfigurationElement layoutElement)
+        {
+            // Check if it is a Filter
+            if (!typeof(Filter).IsAssignableFrom(propInfo.PropertyType))
+                return false;
+
+            // Check if the 'type' attribute has been specified
+            string filterTypeName = GetConfigItemTypeAttribute(layoutElement);
+            if (filterTypeName == null)
+                return false;
+
+            Filter filter = _configurationItemFactory.Filters.CreateInstance(ExpandSimpleVariables(filterTypeName));
+            // and is a Filter and 'type' attribute has been specified
+            if (filter != null)
+            {
+                ConfigureObjectFromAttributes(filter, layoutElement, true);
+                ConfigureObjectFromElement(filter, layoutElement);
+                propInfo.SetValue(o, filter, null);
+                return true;
+            }
+
+            return false;
         }
 
         private void SetItemFromElement(object o, PropertyInfo propInfo, ILoggingConfigurationElement element)

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -1070,15 +1070,15 @@ namespace NLog.Config
             return arrayItem;
         }
 
-        private bool SetLayoutFromElement(object o, PropertyInfo propInfo, ILoggingConfigurationElement layoutElement)
+        private bool SetLayoutFromElement(object o, PropertyInfo propInfo, ILoggingConfigurationElement element)
         {
-            Layout layout = TryCreateLayoutInstance(layoutElement, propInfo.PropertyType);
+            var layout = TryCreateLayoutInstance(element, propInfo.PropertyType);
 
             // and is a Layout and 'type' attribute has been specified
             if (layout != null)
             {
-                ConfigureObjectFromAttributes(layout, layoutElement, true);
-                ConfigureObjectFromElement(layout, layoutElement);
+                ConfigureObjectFromAttributes(layout, element, true);
+                ConfigureObjectFromElement(layout, element);
                 propInfo.SetValue(o, layout, null);
                 return true;
             }

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -1083,33 +1083,12 @@ namespace NLog.Config
 
             return false;
         }
-
-        private Layout TryCreateLayoutInstance(ILoggingConfigurationElement element, Type type)
-        {
-            // Check if it is a Layout
-            if (!IsAssignableFrom<Layout>(type))
-                return null;
-
-            // Check if the 'type' attribute has been specified
-            string layoutTypeName = GetConfigItemTypeAttribute(element);
-            if (layoutTypeName == null)
-                return null;
-
-            return _configurationItemFactory.Layouts.CreateInstance(ExpandSimpleVariables(layoutTypeName));
-        }
-
+        
         private bool SetFilterFromElement(object o, PropertyInfo propInfo, ILoggingConfigurationElement element)
         {
-            // Check if it is a Filter
-            if (!IsAssignableFrom<Filter>(propInfo.PropertyType))
-                return false;
+            var type = propInfo.PropertyType;
 
-            // Check if the 'type' attribute has been specified
-            string filterTypeName = GetConfigItemTypeAttribute(element);
-            if (filterTypeName == null)
-                return false;
-
-            Filter filter = _configurationItemFactory.Filters.CreateInstance(ExpandSimpleVariables(filterTypeName));
+            Filter filter = TryCreateFilterInstance(element, type);
             // and is a Filter and 'type' attribute has been specified
             if (filter != null)
             {
@@ -1118,6 +1097,31 @@ namespace NLog.Config
             }
 
             return false;
+        }
+
+        private Layout TryCreateLayoutInstance(ILoggingConfigurationElement element, Type type)
+        {
+            return TryCreateInstance(element, type, _configurationItemFactory.Layouts);
+        } 
+        
+        private Filter TryCreateFilterInstance(ILoggingConfigurationElement element, Type type)
+        {
+            return TryCreateInstance(element, type, _configurationItemFactory.Filters);
+        }
+
+        private T TryCreateInstance<T>(ILoggingConfigurationElement element, Type type, INamedItemFactory<T, Type> factory)
+            where T : class
+        {
+            // Check if correct type
+            if (!IsAssignableFrom<T>(type))
+                return null;
+
+            // Check if the 'type' attribute has been specified
+            string layoutTypeName = GetConfigItemTypeAttribute(element);
+            if (layoutTypeName == null)
+                return null;
+
+            return factory.CreateInstance(ExpandSimpleVariables(layoutTypeName));
         }
 
         private static bool IsAssignableFrom<T>(Type type)

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -1077,9 +1077,7 @@ namespace NLog.Config
             // and is a Layout and 'type' attribute has been specified
             if (layout != null)
             {
-                ConfigureObjectFromAttributes(layout, element, true);
-                ConfigureObjectFromElement(layout, element);
-                propInfo.SetValue(o, layout, null);
+                SetItemOnProperty(o, propInfo, element, layout);
                 return true;
             }
 
@@ -1089,7 +1087,7 @@ namespace NLog.Config
         private Layout TryCreateLayoutInstance(ILoggingConfigurationElement element, Type type)
         {
             // Check if it is a Layout
-            if (!typeof(Layout).IsAssignableFrom(type))
+            if (!IsAssignableFrom<Layout>(type))
                 return null;
 
             // Check if the 'type' attribute has been specified
@@ -1100,14 +1098,14 @@ namespace NLog.Config
             return _configurationItemFactory.Layouts.CreateInstance(ExpandSimpleVariables(layoutTypeName));
         }
 
-        private bool SetFilterFromElement(object o, PropertyInfo propInfo, ILoggingConfigurationElement layoutElement)
+        private bool SetFilterFromElement(object o, PropertyInfo propInfo, ILoggingConfigurationElement element)
         {
             // Check if it is a Filter
-            if (!typeof(Filter).IsAssignableFrom(propInfo.PropertyType))
+            if (!IsAssignableFrom<Filter>(propInfo.PropertyType))
                 return false;
 
             // Check if the 'type' attribute has been specified
-            string filterTypeName = GetConfigItemTypeAttribute(layoutElement);
+            string filterTypeName = GetConfigItemTypeAttribute(element);
             if (filterTypeName == null)
                 return false;
 
@@ -1115,13 +1113,23 @@ namespace NLog.Config
             // and is a Filter and 'type' attribute has been specified
             if (filter != null)
             {
-                ConfigureObjectFromAttributes(filter, layoutElement, true);
-                ConfigureObjectFromElement(filter, layoutElement);
-                propInfo.SetValue(o, filter, null);
+                SetItemOnProperty(o, propInfo, element, filter);
                 return true;
             }
 
             return false;
+        }
+
+        private static bool IsAssignableFrom<T>(Type type)
+        {
+            return typeof(T).IsAssignableFrom(type);
+        }
+
+        private void SetItemOnProperty(object o, PropertyInfo propInfo, ILoggingConfigurationElement element, object properyValue)
+        {
+            ConfigureObjectFromAttributes(properyValue, element, true);
+            ConfigureObjectFromElement(properyValue, element);
+            propInfo.SetValue(o, properyValue, null);
         }
 
         private void SetItemFromElement(object o, PropertyInfo propInfo, ILoggingConfigurationElement element)
@@ -1252,7 +1260,7 @@ namespace NLog.Config
 
             return attributeValue.Substring(p + 1);
         }
-       
+
         private static string GetName(Target target)
         {
             return string.IsNullOrEmpty(target.Name) ? target.GetType().Name : target.Name;

--- a/src/NLog/Filters/ConditionBasedFilter.cs
+++ b/src/NLog/Filters/ConditionBasedFilter.cs
@@ -55,6 +55,8 @@ namespace NLog.Filters
         [RequiredParameter]
         public ConditionExpression Condition { get; set; }
 
+        internal FilterResult DefaultFilterResult { get; set; } = FilterResult.Neutral;
+
         /// <summary>
         /// Checks whether log event should be logged or not.
         /// </summary>
@@ -72,7 +74,7 @@ namespace NLog.Filters
                 return Action;
             }
 
-            return FilterResult.Neutral;
+            return DefaultFilterResult;
         }
     }
 }

--- a/src/NLog/Internal/ArrayHelper.cs
+++ b/src/NLog/Internal/ArrayHelper.cs
@@ -31,34 +31,19 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-using System.Collections.Generic;
-using JetBrains.Annotations;
-
 namespace NLog.Internal
 {
-    internal static class CollectionExtensions
+    internal static class ArrayHelper
     {
-        /// <summary>
-        /// Create a partial list with the items from the parameter <paramref name="items"/>
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="items">items to include into the returning list.</param>
-        /// <param name="untilIndex">until index, not included.</param>
-        /// <returns>New list</returns>
-        /// <remarks>IList as input for performance reasons.</remarks>
-        public static IList<T> CreatePartialList<T>([NotNull] this IList<T> items, int untilIndex)
+        private static class EmptyArray<T>
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException(nameof(items));
-            }
-
-            IList<T> list = new List<T>();
-            for (var i = 0; i < untilIndex && i < items.Count; ++i)
-                list.Add(items[i]);
-            return list;
+            internal static readonly T[] Instance = new T[0];
         }
 
+        internal static T[] Empty<T>()
+        {
+            // TODO Use Array.Empty<T> in NET 4.6 when we are ready
+            return EmptyArray<T>.Instance;
+        }
     }
 }

--- a/src/NLog/Internal/CollectionExtensions.cs
+++ b/src/NLog/Internal/CollectionExtensions.cs
@@ -39,7 +39,12 @@ namespace NLog.Internal
 {
     internal static class CollectionExtensions
     {
-        public static IList<TItem> FilterList<TItem,TState>([NotNull] this IList<TItem> items, TState state, Func<TItem, TState, bool> filter)
+        /// <summary>
+        /// Memory optimized filtering
+        /// </summary>
+        /// <remarks>Passing state too avoid delegate capture and memory-allocations.</remarks>
+        [NotNull]
+        public static IList<TItem> Filter<TItem, TState>([NotNull] this IList<TItem> items, TState state, Func<TItem, TState, bool> filter)
         {
             var hasIgnoredLogEvents = false;
             IList<TItem> filterLogEvents = null;

--- a/src/NLog/Internal/CollectionExtensions.cs
+++ b/src/NLog/Internal/CollectionExtensions.cs
@@ -31,19 +31,34 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
 namespace NLog.Internal
 {
-    internal static class ArrayHelper
+    internal static class CollectionExtensions
     {
-        private static class EmptyArray<T>
+        /// <summary>
+        /// Create a partial list with the items from the parameter <paramref name="items"/>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="items">items to include into the returning list.</param>
+        /// <param name="untilIndex">until index, not included.</param>
+        /// <returns>New list</returns>
+        /// <remarks>IList as input for performance reasons.</remarks>
+        public static IList<T> CreatePartialList<T>([NotNull] this IList<T> items, int untilIndex)
         {
-            internal static readonly T[] Instance = new T[0];
+            if (items == null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            IList<T> list = new List<T>();
+            for (var i = 0; i < untilIndex && i < items.Count; ++i)
+                list.Add(items[i]);
+            return list;
         }
 
-        internal static T[] Empty<T>()
-        {
-            // TODO Use Array.Empty<T> in NET 4.6 when we are ready
-            return EmptyArray<T>.Instance;
-        }
     }
 }

--- a/src/NLog/Internal/CollectionExtensions.cs
+++ b/src/NLog/Internal/CollectionExtensions.cs
@@ -31,34 +31,19 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-using System.Collections.Generic;
-using JetBrains.Annotations;
-
 namespace NLog.Internal
 {
-    internal static class CollectionExtensions
+    internal static class ArrayHelper
     {
-        /// <summary>
-        /// Create a partial list with the items from the parameter <paramref name="items"/>
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="items">items to include into the returning list.</param>
-        /// <param name="untilIndex">until index, not included.</param>
-        /// <returns>New list</returns>
-        /// <remarks>IList as input for performance reasons.</remarks>
-        public static IList<T> CreatePartialList<T>([NotNull] this IList<T> items, int untilIndex)
+        private static class EmptyArray<T>
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException(nameof(items));
-            }
-
-            IList<T> list = new List<T>();
-            for (var i = 0; i < untilIndex && i < items.Count; ++i)
-                list.Add(items[i]);
-            return list;
+            internal static readonly T[] Instance = new T[0];
         }
 
+        internal static T[] Empty<T>()
+        {
+            // TODO Use Array.Empty<T> in NET 4.6 when we are ready
+            return EmptyArray<T>.Instance;
+        }
     }
 }

--- a/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
@@ -38,6 +38,7 @@ namespace NLog.Targets.Wrappers
     using NLog.Conditions;
     using NLog.Config;
     using NLog.Filters;
+    using NLog.Internal;
 
     /// <summary>
     /// Filters log entries based on a condition.
@@ -164,7 +165,7 @@ namespace NLog.Targets.Wrappers
                 {
                     if (!hasIgnoredLogEvents && i > 0)
                     {
-                        filterLogEvents = CreateAsyncLogEventList(logEvents, i);
+                        filterLogEvents = logEvents.CreatePartialList(i);
                     }
                     hasIgnoredLogEvents = true;
                     logEvent.Continuation(null);
@@ -177,14 +178,6 @@ namespace NLog.Targets.Wrappers
                 WrappedTarget.WriteAsyncLogEvents(filterLogEvents);
             else if (filterLogEvent.LogEvent != null)
                 WrappedTarget.WriteAsyncLogEvent(filterLogEvent);
-        }
-
-        private static IList<AsyncLogEventInfo> CreateAsyncLogEventList(IList<AsyncLogEventInfo> logEvents, int untilIndex)
-        {
-            IList<AsyncLogEventInfo> list = new List<AsyncLogEventInfo>();
-            for (var i = 0; i < untilIndex; ++i)
-                list.Add(logEvents[i]);
-            return list;
         }
 
         private static bool ShouldLogEvent(LogEventInfo logEvent, Filter filter)

--- a/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
@@ -164,9 +164,7 @@ namespace NLog.Targets.Wrappers
                 {
                     if (!hasIgnoredLogEvents && i > 0)
                     {
-                        filterLogEvents = new List<AsyncLogEventInfo>();
-                        for (var j = 0; j < i; ++j)
-                            filterLogEvents.Add(logEvents[j]);
+                        filterLogEvents = CreateAsyncLogEventList(logEvents, i);
                     }
                     hasIgnoredLogEvents = true;
                     logEvent.Continuation(null);
@@ -179,6 +177,14 @@ namespace NLog.Targets.Wrappers
                 WrappedTarget.WriteAsyncLogEvents(filterLogEvents);
             else if (filterLogEvent.LogEvent != null)
                 WrappedTarget.WriteAsyncLogEvent(filterLogEvent);
+        }
+
+        private static IList<AsyncLogEventInfo> CreateAsyncLogEventList(IList<AsyncLogEventInfo> logEvents, int untilIndex)
+        {
+            IList<AsyncLogEventInfo> list = new List<AsyncLogEventInfo>();
+            for (var i = 0; i < untilIndex; ++i)
+                list.Add(logEvents[i]);
+            return list;
         }
 
         private static bool ShouldLogEvent(LogEventInfo logEvent, Filter filter)

--- a/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
@@ -138,7 +138,7 @@ namespace NLog.Targets.Wrappers
         /// <inheritdoc/>
         protected override void Write(IList<AsyncLogEventInfo> logEvents)
         {
-            var filterLogEvents = logEvents.FilterList(Filter, ShouldLogEvent);
+            var filterLogEvents = logEvents.Filter(Filter, ShouldLogEvent);
             WrappedTarget.WriteAsyncLogEvents(filterLogEvents);
         }
 

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -202,7 +202,7 @@ namespace NLog.Targets.Wrappers
                 {
                     if (!hasIgnoredLogEvents && i > 0)
                     {
-                        resultBuffer = CreateAsyncLogEventList(logEvents, i);
+                        resultBuffer = logEvents.CreatePartialList(i);
                     }
                     hasIgnoredLogEvents = true;
                     // anything not passed down will be notified about successful completion
@@ -211,14 +211,6 @@ namespace NLog.Targets.Wrappers
             }
 
             return resultBuffer ?? (hasIgnoredLogEvents ? ArrayHelper.Empty<AsyncLogEventInfo>() : logEvents);
-        }
-
-        private static IList<AsyncLogEventInfo> CreateAsyncLogEventList(IList<AsyncLogEventInfo> logEvents, int untilIndex)
-        {
-            IList<AsyncLogEventInfo> list = new List<AsyncLogEventInfo>();
-            for (var i = 0; i < untilIndex; ++i)
-                list.Add(logEvents[i]);
-            return list;
         }
 
         /// <summary>

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -202,9 +202,7 @@ namespace NLog.Targets.Wrappers
                 {
                     if (!hasIgnoredLogEvents && i > 0)
                     {
-                        resultBuffer = new List<AsyncLogEventInfo>();
-                        for (int j = 0; j < i; ++j)
-                            resultBuffer.Add(logEvents[j]);
+                        resultBuffer = CreateAsyncLogEventList(logEvents, i);
                     }
                     hasIgnoredLogEvents = true;
                     // anything not passed down will be notified about successful completion
@@ -213,6 +211,14 @@ namespace NLog.Targets.Wrappers
             }
 
             return resultBuffer ?? (hasIgnoredLogEvents ? ArrayHelper.Empty<AsyncLogEventInfo>() : logEvents);
+        }
+
+        private static IList<AsyncLogEventInfo> CreateAsyncLogEventList(IList<AsyncLogEventInfo> logEvents, int untilIndex)
+        {
+            IList<AsyncLogEventInfo> list = new List<AsyncLogEventInfo>();
+            for (var i = 0; i < untilIndex; ++i)
+                list.Add(logEvents[i]);
+            return list;
         }
 
         /// <summary>

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -187,7 +187,8 @@ namespace NLog.Targets.Wrappers
             IList<AsyncLogEventInfo> resultBuffer = null;
             for (int i = 0; i < logEvents.Count; ++i)
             {
-                object v = resultFilter.Evaluate(logEvents[i].LogEvent);
+                var logEvent = logEvents[i];
+                object v = resultFilter.Evaluate(logEvent.LogEvent);
                 if (boxedTrue.Equals(v))
                 {
                     if (hasIgnoredLogEvents && resultBuffer == null)
@@ -195,8 +196,7 @@ namespace NLog.Targets.Wrappers
                         resultBuffer = new List<AsyncLogEventInfo>();
                     }
 
-                    if (resultBuffer != null)
-                        resultBuffer.Add(logEvents[i]);
+                    resultBuffer?.Add(logEvent);
                 }
                 else
                 {
@@ -208,7 +208,7 @@ namespace NLog.Targets.Wrappers
                     }
                     hasIgnoredLogEvents = true;
                     // anything not passed down will be notified about successful completion
-                    logEvents[i].Continuation(null);
+                    logEvent.Continuation(null);
                 }
             }
 

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -165,7 +165,7 @@ namespace NLog.Targets.Wrappers
             else
             {
                 InternalLogger.Trace("PostFilteringWrapper(Name={0}): Filter to apply: {1}", Name, resultFilter);
-                var resultBuffer = logEvents.FilterList(resultFilter, ApplyFilter);
+                var resultBuffer = logEvents.Filter(resultFilter, ApplyFilter);
                 InternalLogger.Trace("PostFilteringWrapper(Name={0}): After filtering: {1} events.", Name, resultBuffer.Count);
                 if (resultBuffer.Count > 0)
                 {

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -35,10 +35,10 @@ namespace NLog.Targets.Wrappers
 {
     using System;
     using System.Collections.Generic;
-    using Common;
-    using Conditions;
-    using Config;
-    using Internal;
+    using NLog.Common;
+    using NLog.Conditions;
+    using NLog.Config;
+    using NLog.Internal;
 
     /// <summary>
     /// Filters buffered log entries based on a set of conditions that are evaluated on a group of events.
@@ -75,18 +75,17 @@ namespace NLog.Targets.Wrappers
         /// <summary>
         /// Initializes a new instance of the <see cref="PostFilteringTargetWrapper" /> class.
         /// </summary>
-        public PostFilteringTargetWrapper() : this(null)
+        public PostFilteringTargetWrapper()
+            : this(null)
         {
-            Rules = new List<FilteringRule>();
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PostFilteringTargetWrapper" /> class.
         /// </summary>
         public PostFilteringTargetWrapper(Target wrappedTarget)
+            : this(null, wrappedTarget)
         {
-            Rules = new List<FilteringRule>();
-            WrappedTarget = wrappedTarget;
         }
 
         /// <summary>
@@ -95,9 +94,10 @@ namespace NLog.Targets.Wrappers
         /// <param name="name">Name of the target.</param>
         /// <param name="wrappedTarget">The wrapped target.</param>
         public PostFilteringTargetWrapper(string name, Target wrappedTarget)
-            : this(wrappedTarget)
         {
             Name = name;
+            WrappedTarget = wrappedTarget;
+            Rules = new List<FilteringRule>();
         }
 
         /// <summary>
@@ -114,6 +114,23 @@ namespace NLog.Targets.Wrappers
         /// <docgen category='Filtering Rules' order='10' />
         [ArrayParameter(typeof(FilteringRule), "when")]
         public IList<FilteringRule> Rules { get; private set; }
+
+        /// <inheritdoc/>
+        protected override void InitializeTarget()
+        {
+            base.InitializeTarget();
+
+            if (!OptimizeBufferReuse && WrappedTarget != null && WrappedTarget.OptimizeBufferReuse)
+            {
+                OptimizeBufferReuse = GetType() == typeof(PostFilteringTargetWrapper); // Class not sealed, reduce breaking changes
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void Write(AsyncLogEventInfo logEvent)
+        {
+            Write((IList<AsyncLogEventInfo>)new[] { logEvent });  // Single LogEvent should also work
+        }
 
         /// <summary>
         /// NOTE! Obsolete, instead override Write(IList{AsyncLogEventInfo} logEvents)
@@ -138,12 +155,9 @@ namespace NLog.Targets.Wrappers
         /// <param name="logEvents">Array of log events to be post-filtered.</param>
         protected override void Write(IList<AsyncLogEventInfo> logEvents)
         {
-
-
             InternalLogger.Trace("PostFilteringWrapper(Name={0}): Running on {1} events", Name, logEvents.Count);
 
             var resultFilter = EvaluateAllRules(logEvents) ?? DefaultFilter;
-
             if (resultFilter == null)
             {
                 WrappedTarget.WriteAsyncLogEvents(logEvents);
@@ -151,9 +165,7 @@ namespace NLog.Targets.Wrappers
             else
             {
                 InternalLogger.Trace("PostFilteringWrapper(Name={0}): Filter to apply: {1}", Name, resultFilter);
-
                 var resultBuffer = ApplyFilter(logEvents, resultFilter);
-
                 InternalLogger.Trace("PostFilteringWrapper(Name={0}): After filtering: {1} events.", Name, resultBuffer.Count);
                 if (resultBuffer.Count > 0)
                 {
@@ -169,25 +181,38 @@ namespace NLog.Targets.Wrappers
         /// <param name="logEvents"></param>
         /// <param name="resultFilter"></param>
         /// <returns></returns>
-        private static List<AsyncLogEventInfo> ApplyFilter(IList<AsyncLogEventInfo> logEvents, ConditionExpression resultFilter)
+        private static IList<AsyncLogEventInfo> ApplyFilter(IList<AsyncLogEventInfo> logEvents, ConditionExpression resultFilter)
         {
-            var resultBuffer = new List<AsyncLogEventInfo>();
-
+            bool hasIgnoredLogEvents = false;
+            IList<AsyncLogEventInfo> resultBuffer = null;
             for (int i = 0; i < logEvents.Count; ++i)
             {
                 object v = resultFilter.Evaluate(logEvents[i].LogEvent);
                 if (boxedTrue.Equals(v))
                 {
-                    resultBuffer.Add(logEvents[i]);
+                    if (hasIgnoredLogEvents && resultBuffer == null)
+                    {
+                        resultBuffer = new List<AsyncLogEventInfo>();
+                    }
+
+                    if (resultBuffer != null)
+                        resultBuffer.Add(logEvents[i]);
                 }
                 else
                 {
+                    if (!hasIgnoredLogEvents && i > 0)
+                    {
+                        resultBuffer = new List<AsyncLogEventInfo>();
+                        for (int j = 0; j < i; ++j)
+                            resultBuffer.Add(logEvents[j]);
+                    }
+                    hasIgnoredLogEvents = true;
                     // anything not passed down will be notified about successful completion
                     logEvents[i].Continuation(null);
                 }
             }
 
-            return resultBuffer;
+            return resultBuffer ?? (hasIgnoredLogEvents ? ArrayHelper.Empty<AsyncLogEventInfo>() : logEvents);
         }
 
         /// <summary>
@@ -197,30 +222,24 @@ namespace NLog.Targets.Wrappers
         /// <returns></returns>
         private ConditionExpression EvaluateAllRules(IList<AsyncLogEventInfo> logEvents)
         {
-            ConditionExpression resultFilter = null;
-            
+            if (Rules.Count == 0)
+                return null;
+
             for (int i = 0; i < logEvents.Count; ++i)
             {
-                foreach (FilteringRule rule in Rules)
+                for (int j = 0; j < Rules.Count; ++j)
                 {
+                    var rule = Rules[j];
                     object v = rule.Exists.Evaluate(logEvents[i].LogEvent);
-
                     if (boxedTrue.Equals(v))
                     {
                         InternalLogger.Trace("PostFilteringWrapper(Name={0}): Rule matched: {1}", Name, rule.Exists);
-
-                        resultFilter = rule.Filter;
-                        break;
+                        return rule.Filter;
                     }
-                }
-
-                if (resultFilter != null)
-                {
-                    break;
                 }
             }
 
-            return resultFilter;
+            return null;
         }
     }
 }

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -84,8 +84,6 @@ namespace NLog.UnitTests.Targets
                       
                         var args = new List<object> { fileTarget };
 
-                
-
                         //default ctor
                         var defaultConstructedTarget = (WrapperTargetBase)Activator.CreateInstance(targetType);
                         defaultConstructedTarget.Name = name;
@@ -94,7 +92,7 @@ namespace NLog.UnitTests.Targets
                         //specials cases
                         if (targetType == typeof(FilteringTargetWrapper))
                         {
-                            var cond = new ConditionLoggerNameExpression();
+                            ConditionLoggerNameExpression cond = null;
                             args.Add(cond);
                             var target = (FilteringTargetWrapper) defaultConstructedTarget;
                             target.Condition = cond;

--- a/tests/NLog.UnitTests/Targets/Wrappers/PostFilteringTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/PostFilteringTargetWrapperTests.cs
@@ -204,6 +204,26 @@ namespace NLog.UnitTests.Targets.Wrappers
         }
 
         [Fact]
+        public void PostFilteringTargetWrapperOnlyDefaultFilter()
+        {
+            var target = new MyTarget() { OptimizeBufferReuse = true };
+            var wrapper = new PostFilteringTargetWrapper()
+            {
+                WrappedTarget = target,
+                DefaultFilter = "level >= LogLevel.Info",   // by default log info and above
+            };
+
+            wrapper.Initialize(null);
+            target.Initialize(null);
+
+            var exceptions = new List<Exception>();
+            wrapper.WriteAsyncLogEvent(new LogEventInfo(LogLevel.Info, "Logger1", "Hello").WithContinuation(exceptions.Add));
+            Assert.Single(target.Events);
+            wrapper.WriteAsyncLogEvent(new LogEventInfo(LogLevel.Debug, "Logger1", "Hello").WithContinuation(exceptions.Add));
+            Assert.Single(target.Events);
+        }
+
+        [Fact]
         public void PostFilteringTargetWrapperNoFiltersDefined()
         {
             var target = new MyTarget();

--- a/tools/MakeNLogXSD/XsdFileGenerator.cs
+++ b/tools/MakeNLogXSD/XsdFileGenerator.cs
@@ -312,6 +312,9 @@ namespace MakeNLogXSD
                 case "Layout":
                     return attribute ? "SimpleLayoutAttribute" : "Layout";
 
+                case "NLog.Filters.Filter":
+                    return "Filter";
+
                 case "Condition":
                     return "Condition";
 


### PR DESCRIPTION
And allow use of WhenRepeated as Filter:

```xml
      <target name="default" xsi:type="FilteringWrapper">
        <filter xsi:type="whenRepeated" layout="${message}" timeoutSeconds="30" action="Ignore" />
        <target name="console" xsi:type="Console" />
      </target>
```

Also made some optimizations to `PostFilteringTargetWrapper` so it also supports OptimizeBufferReuse = true.

And also "fixed" `PostFilteringTargetWrapper` so it also works when writing a single LogEvent, without using BufferingWrapper or AsyncWrapper (More intuitive and user-friendly)