### PR TITLE
Async / buffering wrapper: Improve performance when blocking

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
+++ b/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
@@ -94,8 +94,8 @@ namespace NLog.Targets.Wrappers
 
                         case AsyncTargetWrapperOverflowAction.Grow:
                             InternalLogger.Debug("The overflow action is Grow, adding element anyway");
-                            RequestLimit *= 2;
                             OnLogEventQueueGrows(RequestCount + 1);
+                            RequestLimit *= 2;
                             break;
 
                         case AsyncTargetWrapperOverflowAction.Block:

--- a/tests/NLog.UnitTests/Targets/Wrappers/ConcurrentRequestQueueTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/ConcurrentRequestQueueTests.cs
@@ -45,7 +45,8 @@ namespace NLog.UnitTests.Targets.Wrappers
         {
             const int RequestsLimit = 2;
             const int EventsCount = 5;
-            const int ExpectedCountOfGrovingTimes = EventsCount - RequestsLimit;
+            const int ExpectedCountOfGrovingTimes = 2;
+            const int ExpectedFinalSize = 8;
             int grovingItemsCount = 0;
 
             ConcurrentRequestQueue requestQueue = new ConcurrentRequestQueue(RequestsLimit, AsyncTargetWrapperOverflowAction.Grow);
@@ -58,6 +59,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             }
 
             Assert.Equal(ExpectedCountOfGrovingTimes, grovingItemsCount);
+            Assert.Equal(ExpectedFinalSize, requestQueue.RequestLimit);
         }
 
         [Fact]


### PR DESCRIPTION
ConcurrentRequestQueue - Improved DequeueBatch performance when blocking

Avoid activating throttle logic, when timer-thread is able to keep up. The throttle logic also affects the timer-thread, so only perform throttle-logic when timer-thread is falling behind.

And unit test for deadlock issue