### PR TITLE
Added "Properties" property on Logger for reading and editing properties.

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -61,7 +61,7 @@ namespace NLog.Config
         /// <summary>
         /// Variables defined in xml or in API. name is case case insensitive. 
         /// </summary>
-        private readonly Dictionary<string, SimpleLayout> _variables = new Dictionary<string, SimpleLayout>(StringComparer.OrdinalIgnoreCase);
+        private readonly ThreadSafeDictionary<string, SimpleLayout> _variables = new ThreadSafeDictionary<string, SimpleLayout>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets the factory that will be configured
@@ -812,10 +812,7 @@ namespace NLog.Config
         /// <param name="masterVariables">Master variables dictionary</param>
         internal void CopyVariables(IDictionary<string, SimpleLayout> masterVariables)
         {
-            foreach (var variable in masterVariables)
-            {
-                Variables[variable.Key] = variable.Value;
-            }
+            _variables.CopyFrom(masterVariables);
         }
 
         /// <summary>

--- a/src/NLog/GlobalDiagnosticsContext.cs
+++ b/src/NLog/GlobalDiagnosticsContext.cs
@@ -43,6 +43,7 @@ namespace NLog
     /// </summary>
     public static class GlobalDiagnosticsContext
     {
+        private static readonly object _lockObject = new object();
         private static Dictionary<string, object> _dict = new Dictionary<string, object>();
         private static Dictionary<string, object> _dictReadOnly;  // Reset cache on change
 
@@ -63,7 +64,7 @@ namespace NLog
         /// <param name="value">Item value.</param>
         public static void Set(string item, object value)
         {
-            lock (_dict)
+            lock (_lockObject)
             {
                 bool requireCopyOnWrite = _dictReadOnly != null && !_dict.ContainsKey(item); // Overwiting existing value is ok (no resize)
                 GetWritableDict(requireCopyOnWrite)[item] = value;
@@ -129,7 +130,7 @@ namespace NLog
         /// <param name="item">Item name.</param>
         public static void Remove(string item)
         {
-            lock (_dict)
+            lock (_lockObject)
             {
                 bool requireCopyOnWrite = _dictReadOnly != null && _dict.ContainsKey(item);
                 GetWritableDict(requireCopyOnWrite).Remove(item);
@@ -141,7 +142,7 @@ namespace NLog
         /// </summary>
         public static void Clear()
         {
-            lock (_dict)
+            lock (_lockObject)
             {
                 bool requireCopyOnWrite = _dictReadOnly != null && _dict.Count > 0;
                 GetWritableDict(requireCopyOnWrite, true).Clear();
@@ -153,7 +154,7 @@ namespace NLog
             var readOnly = _dictReadOnly;
             if (readOnly == null)
             {
-                lock (_dict)
+                lock (_lockObject)
                 {
                     readOnly = _dictReadOnly = _dict;
                 }

--- a/src/NLog/Internal/ThreadSafeDictionary.cs
+++ b/src/NLog/Internal/ThreadSafeDictionary.cs
@@ -1,0 +1,233 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    internal class ThreadSafeDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private readonly object _lockObject = new object();
+        private readonly IEqualityComparer<TKey> _comparer;
+        private Dictionary<TKey, TValue> _dict;
+        private Dictionary<TKey, TValue> _dictReadOnly;  // Reset cache on change
+
+        public ThreadSafeDictionary()
+            :this(EqualityComparer<TKey>.Default)
+        {
+        }
+
+        public ThreadSafeDictionary(IEqualityComparer<TKey> comparer)
+        {
+            _comparer = comparer;
+            _dict = new Dictionary<TKey, TValue>(_comparer);
+        }
+
+        public ThreadSafeDictionary(ThreadSafeDictionary<TKey, TValue> source)
+        {
+            _comparer = source._comparer;
+            _dict = source.GetReadOnlyDict();
+            GetWritableDict();  // Clone
+        }
+
+        public TValue this[TKey key]
+        {
+            get { return GetReadOnlyDict()[key]; }
+            set
+            {
+                lock (_lockObject)
+                {
+                    GetWritableDict()[key] = value;
+                }
+            }
+        }
+
+        public ICollection<TKey> Keys => GetReadOnlyDict().Keys;
+
+        public ICollection<TValue> Values => GetReadOnlyDict().Values;
+
+        public int Count => GetReadOnlyDict().Count;
+
+        public bool IsReadOnly => false;
+
+        public void Add(TKey key, TValue value)
+        {
+            lock (_lockObject)
+            {
+                GetWritableDict().Add(key, value);
+            }
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            lock (_lockObject)
+            {
+                GetWritableDict().Add(item.Key, item.Value);
+            }
+        }
+
+        public void Clear()
+        {
+            lock (_lockObject)
+            {
+                GetWritableDict(true);
+            }
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return GetReadOnlyDict().Contains(item);
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return GetReadOnlyDict().ContainsKey(key);
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+           ((IDictionary<TKey,TValue>)GetReadOnlyDict()).CopyTo(array, arrayIndex);
+        }
+
+        public void CopyFrom(IDictionary<TKey, TValue> source)
+        {
+            if (!ReferenceEquals(this, source))
+            {
+                if (source?.Count > 0)
+                {
+                    lock (_lockObject)
+                    {
+                        var destDict = GetWritableDict();
+                        foreach (var item in source)
+                            destDict[item.Key] = item.Value;
+                    }
+                }
+            }
+        }
+
+        public bool Remove(TKey key)
+        {
+            lock (_lockObject)
+            {
+                return GetWritableDict().Remove(key);
+            }
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            lock (_lockObject)
+            {
+                return GetWritableDict().Remove(item);
+            }
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            return GetReadOnlyDict().TryGetValue(key, out value);
+        }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+        {
+            return GetReadOnlyDict().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetReadOnlyDict().GetEnumerator();
+        }
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(GetReadOnlyDict().GetEnumerator());
+        }
+
+        public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>
+        {
+            Dictionary<TKey, TValue>.Enumerator _enumerator;
+
+            public Enumerator(Dictionary<TKey, TValue>.Enumerator enumerator)
+            {
+                _enumerator = enumerator;
+            }
+
+            public KeyValuePair<TKey, TValue> Current => _enumerator.Current;
+
+            object IEnumerator.Current => _enumerator.Current;
+
+            public void Dispose()
+            {
+                _enumerator.Dispose();
+            }
+
+            public bool MoveNext()
+            {
+                return _enumerator.MoveNext();
+            }
+
+            void IEnumerator.Reset()
+            {
+                ((IEnumerator)_enumerator).Reset();
+            }
+        }
+
+        private Dictionary<TKey, TValue> GetReadOnlyDict()
+        {
+            var readOnly = _dictReadOnly;
+            if (readOnly == null)
+            {
+                lock (_lockObject)
+                {
+                    readOnly = _dictReadOnly = _dict;
+                }
+            }
+            return readOnly;
+        }
+
+        private IDictionary<TKey, TValue> GetWritableDict(bool clearDictionary = false)
+        {
+            var newDict = new Dictionary<TKey, TValue>(clearDictionary ? 0 : _dict.Count + 1, _comparer);
+            if (!clearDictionary)
+            {
+                // Less allocation with enumerator than Dictionary-constructor
+                foreach (var item in _dict)
+                    newDict[item.Key] = item.Value;
+            }
+            _dict = newDict;
+            _dictReadOnly = null;
+            return newDict;
+        }
+    }
+}

--- a/src/NLog/Internal/ThreadSafeDictionary.cs
+++ b/src/NLog/Internal/ThreadSafeDictionary.cs
@@ -65,7 +65,7 @@ namespace NLog.Internal
 
         public TValue this[TKey key]
         {
-            get { return GetReadOnlyDict()[key]; }
+            get => GetReadOnlyDict()[key];
             set
             {
                 lock (_lockObject)
@@ -124,16 +124,13 @@ namespace NLog.Internal
 
         public void CopyFrom(IDictionary<TKey, TValue> source)
         {
-            if (!ReferenceEquals(this, source))
+            if (!ReferenceEquals(this, source) && source?.Count > 0)
             {
-                if (source?.Count > 0)
+                lock (_lockObject)
                 {
-                    lock (_lockObject)
-                    {
-                        var destDict = GetWritableDict();
-                        foreach (var item in source)
-                            destDict[item.Key] = item.Value;
-                    }
+                    var destDict = GetWritableDict();
+                    foreach (var item in source)
+                        destDict[item.Key] = item.Value;
                 }
             }
         }

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -86,8 +86,8 @@ namespace NLog
         /// Collection of context properties for the Logger. The logger will append it for all log events
         /// </summary>
         /// <remarks>
-        /// It is recommended to only use <see cref="WithProperty(string, object)"/> for modifying context properties.
-        /// Because direct changes might give unexpected side-effects as multiple locations can share the same logger-object.
+        /// It is recommended to use <see cref="WithProperty(string, object)"/> for modifying context properties
+        /// when same named logger is used at multiple locations or shared by different thread contexts.
         /// </remarks>
         public IDictionary<string, object> Properties => _contextProperties ?? System.Threading.Interlocked.CompareExchange(ref _contextProperties, CreateContextPropertiesDictionary(null), null) ?? _contextProperties;
 
@@ -126,14 +126,21 @@ namespace NLog
         }
 
         /// <summary>
-        /// Updates the specified context property for the current logger. The logger will append it for all log events
+        /// Updates the specified context property for the current logger. The logger will append it for all log events.
+        ///
+        /// It could be rendered with ${event-properties:YOURNAME}
+        ///
+        /// With <see cref="Properties"/> property, all properties could be changed. 
         /// </summary>
         /// <remarks>
         /// Will affect all locations/contexts that makes use of the same named logger object.
         /// </remarks>
         /// <param name="propertyKey">Property Name</param>
         /// <param name="propertyValue">Property Value</param>
-        [Obsolete("Instead use the Properties-property to access or modify the active collection")]
+        /// <remarks>
+        /// It is recommended to use <see cref="WithProperty(string, object)"/> for modifying context properties
+        /// when same named logger is used at multiple locations or shared by different thread contexts.
+        /// </remarks>
         public void SetProperty(string propertyKey, object propertyValue)
         {
             if (string.IsNullOrEmpty(propertyKey))

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -50,7 +50,7 @@ namespace NLog
     {
         internal static readonly Type DefaultLoggerType = typeof(Logger);
         private Logger _contextLogger;
-        private Dictionary<string, object> _contextProperties;
+        private ThreadSafeDictionary<string, object> _contextProperties;
         private LoggerConfiguration _configuration;
         private volatile bool _isTraceEnabled;
         private volatile bool _isDebugEnabled;
@@ -83,6 +83,15 @@ namespace NLog
         public LogFactory Factory { get; private set; }
 
         /// <summary>
+        /// Collection of context properties for the Logger. The logger will append it for all log events
+        /// </summary>
+        /// <remarks>
+        /// It is recommended to only use <see cref="WithProperty(string, object)"/> for modifying context properties.
+        /// Because direct changes might give unexpected side-effects as multiple locations can share the same logger-object.
+        /// </remarks>
+        public IDictionary<string, object> Properties => _contextProperties ?? System.Threading.Interlocked.CompareExchange(ref _contextProperties, CreateContextPropertiesDictionary(null), null) ?? _contextProperties;
+
+        /// <summary>
         /// Gets a value indicating whether logging is enabled for the specified level.
         /// </summary>
         /// <param name="level">Log level to be checked.</param>
@@ -110,7 +119,8 @@ namespace NLog
 
             Logger newLogger = Factory.CreateNewLogger(GetType()) ?? new Logger();
             newLogger.Initialize(Name, _configuration, Factory);
-            newLogger._contextProperties = CopyOnWrite(propertyKey, propertyValue);
+            newLogger._contextProperties = CreateContextPropertiesDictionary(_contextProperties);
+            newLogger._contextProperties[propertyKey] = propertyValue;
             newLogger._contextLogger = _contextLogger;  // Use the LoggerConfiguration of the parent Logger
             return newLogger;
         }
@@ -123,21 +133,20 @@ namespace NLog
         /// </remarks>
         /// <param name="propertyKey">Property Name</param>
         /// <param name="propertyValue">Property Value</param>
+        [Obsolete("Instead use the Properties-property to access or modify the active collection")]
         public void SetProperty(string propertyKey, object propertyValue)
         {
             if (string.IsNullOrEmpty(propertyKey))
                 throw new ArgumentException(nameof(propertyKey));
 
-            _contextProperties = CopyOnWrite(propertyKey, propertyValue);
+            Properties[propertyKey] = propertyValue;
         }
 
-        private Dictionary<string, object> CopyOnWrite(string propertyKey, object propertyValue)
+        private static ThreadSafeDictionary<string, object> CreateContextPropertiesDictionary(ThreadSafeDictionary<string, object> contextProperties)
         {
-            var contextProperties = _contextProperties;
             contextProperties = contextProperties != null
-                ? new Dictionary<string, object>(contextProperties)
-                : new Dictionary<string, object>();
-            contextProperties[propertyKey] = propertyValue;
+                ? new ThreadSafeDictionary<string, object>(contextProperties)
+                : new ThreadSafeDictionary<string, object>();
             return contextProperties;
         }
 
@@ -246,10 +255,10 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [MessageTemplateFormatMethod("message")]
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
-        { 
+        {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, args); 
+                WriteToTargets(level, formatProvider, message, args);
             }
         }
 
@@ -258,8 +267,8 @@ namespace NLog
         /// </summary>
         /// <param name="level">The log level.</param>
         /// <param name="message">Log message.</param>
-        public void Log(LogLevel level, [Localizable(false)] string message) 
-        { 
+        public void Log(LogLevel level, [Localizable(false)] string message)
+        {
             if (IsEnabled(level))
             {
                 WriteToTargets(level, null, message);
@@ -273,8 +282,8 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing format items.</param>
         /// <param name="args">Arguments to format.</param>
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, [Localizable(false)] string message, params object[] args) 
-        { 
+        public void Log(LogLevel level, [Localizable(false)] string message, params object[] args)
+        {
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, args);
@@ -340,10 +349,10 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [MessageTemplateFormatMethod("message")]
         public void Log<TArgument>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument)
-        { 
+        {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -374,11 +383,11 @@ namespace NLog
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
         [MessageTemplateFormatMethod("message")]
-        public void Log<TArgument1, TArgument2>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2) 
-        { 
+        public void Log<TArgument1, TArgument2>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
+        {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument1, argument2 }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument1, argument2 });
             }
         }
 
@@ -393,7 +402,7 @@ namespace NLog
         /// <param name="argument2">The second argument to format.</param>
         [MessageTemplateFormatMethod("message")]
         public void Log<TArgument1, TArgument2>(LogLevel level, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
-        { 
+        {
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument1, argument2 });
@@ -413,11 +422,11 @@ namespace NLog
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
         [MessageTemplateFormatMethod("message")]
-        public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) 
-        { 
+        public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument1, argument2, argument3 }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument1, argument2, argument3 });
             }
         }
 
@@ -434,7 +443,7 @@ namespace NLog
         /// <param name="argument3">The third argument to format.</param>
         [MessageTemplateFormatMethod("message")]
         public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
-        { 
+        {
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument1, argument2, argument3 });


### PR DESCRIPTION
Logger - Properties added using WithProperty can now be inspected safely

Alternative implementation of #3424 to fix #3422 

Also resolves partly #2960 (Still doesn't resolve use of SimpleLayout that are not threadsafe). And there will now be a performance-hit if very aggressive about modifying NLog-variables, and have many of them.