### PR TITLE
Added support for StackTraceUsage With CallSite only (e.g. Caller Information attributes) + Improve CLScomplaint

### DIFF
--- a/src/NLog/Config/StackTraceUsage.cs
+++ b/src/NLog/Config/StackTraceUsage.cs
@@ -42,35 +42,36 @@ namespace NLog.Config
     public enum StackTraceUsage
     {
         /// <summary>
-        /// Stack trace should not be captured.
+        /// No Stack trace needs to be captured.
         /// </summary>
         None = 0,
 
         /// <summary>
-        /// Stack trace should be captured
+        /// Stack trace should be captured. This option won't add the filenames and linenumbers
         /// </summary>
         WithStackTrace = 1,
 
 #if !SILVERLIGHT
         /// <summary>
-        /// Source-level information should be capture (source-filename + linenumber)
+        /// Capture also filenames and linenumbers
         /// </summary>
         WithFileNameAndLineNumber = 2,
 #endif
 
         /// <summary>
-        /// Stack trace should only be captured if callsite details are missing
+        /// Capture the location of the call
         /// </summary>
         WithCallSite = 4,
 
         /// <summary>
-        /// Stack trace should be captured without source-level information.
+        /// Stack trace should be captured. This option won't add the filenames and linenumbers.
         /// </summary>
+        [Obsolete("Replace with `WithStackTrace`. Will be removed in NLog 6")]
         WithoutSource = WithStackTrace,
 
 #if !SILVERLIGHT
         /// <summary>
-        /// Stack trace should be captured including source-level information such as line numbers.
+        /// Stack trace should be captured including filenames and linenumbers.
         /// </summary>
         WithSource = WithStackTrace | WithFileNameAndLineNumber,
 

--- a/src/NLog/Config/StackTraceUsage.cs
+++ b/src/NLog/Config/StackTraceUsage.cs
@@ -55,7 +55,7 @@ namespace NLog.Config
         /// <summary>
         /// Source-level information should be capture (source-filename + linenumber)
         /// </summary>
-        WithSourceCode = 2,
+        WithFileNameAndLineNumber = 2,
 #endif
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace NLog.Config
         /// <summary>
         /// Stack trace should be captured including source-level information such as line numbers.
         /// </summary>
-        WithSource = WithStackTrace | WithSourceCode,
+        WithSource = WithStackTrace | WithFileNameAndLineNumber,
 
         /// <summary>
         /// Capture maximum amount of the stack trace information supported on the platform.

--- a/src/NLog/Config/StackTraceUsage.cs
+++ b/src/NLog/Config/StackTraceUsage.cs
@@ -33,36 +33,56 @@
 
 namespace NLog.Config
 {
+    using System;
+
     /// <summary>
     /// Value indicating how stack trace should be captured when processing the log event.
     /// </summary>
+    [Flags]
     public enum StackTraceUsage
     {
         /// <summary>
         /// Stack trace should not be captured.
         /// </summary>
-        None = 0, 
+        None = 0,
+
+        /// <summary>
+        /// Stack trace should be captured
+        /// </summary>
+        WithStackTrace = 1,
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// Source-level information should be capture (source-filename + linenumber)
+        /// </summary>
+        WithSourceCode = 2,
+#endif
+
+        /// <summary>
+        /// Stack trace should only be captured if callsite details are missing
+        /// </summary>
+        WithCallSite = 4,
 
         /// <summary>
         /// Stack trace should be captured without source-level information.
         /// </summary>
-        WithoutSource = 1,
+        WithoutSource = WithStackTrace,
 
 #if !SILVERLIGHT
         /// <summary>
         /// Stack trace should be captured including source-level information such as line numbers.
         /// </summary>
-        WithSource = 2,
+        WithSource = WithStackTrace | WithSourceCode,
 
         /// <summary>
         /// Capture maximum amount of the stack trace information supported on the platform.
         /// </summary>
-        Max = 2,
+        Max = WithSource,
 #else
         /// <summary>
         /// Capture maximum amount of the stack trace information supported on the platform.
         /// </summary>
-        Max = 1,
+        Max = WithoutSource,
 #endif
     }
 }

--- a/src/NLog/Fluent/Log.cs
+++ b/src/NLog/Fluent/Log.cs
@@ -30,9 +30,11 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
+
 using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using NLog.Internal;
 
 namespace NLog.Fluent
 {
@@ -54,7 +56,7 @@ namespace NLog.Fluent
         {
             return Create(logLevel, callerFilePath);
         }
-        
+
         /// <summary>
         /// Starts building a log event at the <c>Trace</c> level.
         /// </summary>
@@ -117,13 +119,9 @@ namespace NLog.Fluent
 
         private static LogBuilder Create(LogLevel logLevel, string callerFilePath)
         {
-            string name = Path.GetFileNameWithoutExtension(callerFilePath ?? string.Empty);
-            var logger = string.IsNullOrWhiteSpace(name) ? _logger : LogManager.GetLogger(name);
-
+            string name = !StringHelpers.IsNullOrWhiteSpace(callerFilePath) ? Path.GetFileNameWithoutExtension(callerFilePath) : null;
+            var logger = StringHelpers.IsNullOrWhiteSpace(name) ? _logger : LogManager.GetLogger(name);
             var builder = new LogBuilder(logger, logLevel);
-            if (callerFilePath != null)
-                builder.Property("CallerFilePath", callerFilePath);
-
             return builder;
         }
     }

--- a/src/NLog/Fluent/LogBuilder.cs
+++ b/src/NLog/Fluent/LogBuilder.cs
@@ -285,19 +285,11 @@ namespace NLog.Fluent
         /// <param name="callerMemberName">The method or property name of the caller to the method. This is set at by the compiler.</param>
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is set at by the compiler.</param>
         /// <param name="callerLineNumber">The line number in the source file at which the method is called. This is set at by the compiler.</param>
+#if NET4_5
         public void Write(
-#if NET4_5
-            [CallerMemberName]
-#endif
-            string callerMemberName = null,
-#if NET4_5
-            [CallerFilePath]
-#endif
-            string callerFilePath = null,
-#if NET4_5
-            [CallerLineNumber]
-#endif
-            int callerLineNumber = 0)
+            [CallerMemberName]string callerMemberName = null,
+            [CallerFilePath]string callerFilePath = null,
+            [CallerLineNumber]int callerLineNumber = 0)
         {
             if (!_logger.IsEnabled(_logEvent.Level))
                 return;
@@ -306,7 +298,16 @@ namespace NLog.Fluent
 
             _logger.Log(_logEvent);
         }
-        
+#else
+        public void Write(
+            string callerMemberName = null,
+            string callerFilePath = null,
+            int callerLineNumber = 0)
+        {
+            _logger.Log(_logEvent);
+        }
+#endif
+
         /// <summary>
         /// Writes the log event to the underlying logger if the condition delegate is true.
         /// </summary>
@@ -314,20 +315,12 @@ namespace NLog.Fluent
         /// <param name="callerMemberName">The method or property name of the caller to the method. This is set at by the compiler.</param>
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is set at by the compiler.</param>
         /// <param name="callerLineNumber">The line number in the source file at which the method is called. This is set at by the compiler.</param>
+#if NET4_5
         public void WriteIf(
             Func<bool> condition,
-#if NET4_5
-            [CallerMemberName]
-#endif
-            string callerMemberName = null,
-#if NET4_5
-            [CallerFilePath]
-#endif
-            string callerFilePath = null,
-#if NET4_5
-            [CallerLineNumber]
-#endif
-            int callerLineNumber = 0)
+            [CallerMemberName]string callerMemberName = null,
+            [CallerFilePath]string callerFilePath = null,
+            [CallerLineNumber]int callerLineNumber = 0)
         {
             if (condition == null || !condition() || !_logger.IsEnabled(_logEvent.Level))
                 return;
@@ -336,6 +329,19 @@ namespace NLog.Fluent
 
             _logger.Log(_logEvent);
         }
+#else
+        public void WriteIf(
+            Func<bool> condition,
+            string callerMemberName = null,
+            string callerFilePath = null,
+            int callerLineNumber = 0)
+        {
+            if (condition == null || !condition() || !_logger.IsEnabled(_logEvent.Level))
+                return;
+
+            _logger.Log(_logEvent);
+        }
+#endif
 
         /// <summary>
         /// Writes the log event to the underlying logger if the condition is true.
@@ -344,20 +350,12 @@ namespace NLog.Fluent
         /// <param name="callerMemberName">The method or property name of the caller to the method. This is set at by the compiler.</param>
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is set at by the compiler.</param>
         /// <param name="callerLineNumber">The line number in the source file at which the method is called. This is set at by the compiler.</param>
+#if NET4_5
         public void WriteIf(
             bool condition,
-#if NET4_5
-            [CallerMemberName]
-#endif
-            string callerMemberName = null,
-#if NET4_5
-            [CallerFilePath]
-#endif
-            string callerFilePath = null,
-#if NET4_5
-            [CallerLineNumber]
-#endif
-            int callerLineNumber = 0)
+            [CallerMemberName]string callerMemberName = null,
+            [CallerFilePath]string callerFilePath = null,
+            [CallerLineNumber]int callerLineNumber = 0)
         {
             if (!condition || !_logger.IsEnabled(_logEvent.Level))
                 return;
@@ -366,6 +364,19 @@ namespace NLog.Fluent
 
             _logger.Log(_logEvent);
         }
+#else
+        public void WriteIf(
+            bool condition,
+            string callerMemberName = null,
+            string callerFilePath = null,
+            int callerLineNumber = 0)
+        {
+            if (!condition || !_logger.IsEnabled(_logEvent.Level))
+                return;
+
+            _logger.Log(_logEvent);
+        }
+#endif
 
         private void SetCallerInfo(string callerMemberName, string callerFilePath, int callerLineNumber)
         {

--- a/src/NLog/Fluent/LogBuilder.cs
+++ b/src/NLog/Fluent/LogBuilder.cs
@@ -279,7 +279,6 @@ namespace NLog.Fluent
             return this;
         }
 
-#if NET4_5
         /// <summary>
         /// Writes the log event to the underlying logger.
         /// </summary>
@@ -287,36 +286,27 @@ namespace NLog.Fluent
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is set at by the compiler.</param>
         /// <param name="callerLineNumber">The line number in the source file at which the method is called. This is set at by the compiler.</param>
         public void Write(
-            [CallerMemberName]string callerMemberName = null,
-            [CallerFilePath]string callerFilePath = null,
-            [CallerLineNumber]int callerLineNumber = 0)
+#if NET4_5
+            [CallerMemberName]
+#endif
+            string callerMemberName = null,
+#if NET4_5
+            [CallerFilePath]
+#endif
+            string callerFilePath = null,
+#if NET4_5
+            [CallerLineNumber]
+#endif
+            int callerLineNumber = 0)
         {
             if (!_logger.IsEnabled(_logEvent.Level))
                 return;
 
-            // TODO NLog ver. 5 - Remove these properties
-            if (callerMemberName != null)
-                Property("CallerMemberName", callerMemberName);
-            if (callerFilePath != null)
-                Property("CallerFilePath", callerFilePath);
-            if (callerLineNumber != 0)
-                Property("CallerLineNumber", callerLineNumber);
-
-            _logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+            SetCallerInfo(callerMemberName, callerFilePath, callerLineNumber);
 
             _logger.Log(_logEvent);
         }
-#else
-        /// <summary>
-        /// Writes the log event to the underlying logger.
-        /// </summary>
-        public void Write()
-        {
-            _logger.Log(_logEvent);
-        }
-#endif
-
-#if NET4_5
+        
         /// <summary>
         /// Writes the log event to the underlying logger if the condition delegate is true.
         /// </summary>
@@ -326,39 +316,27 @@ namespace NLog.Fluent
         /// <param name="callerLineNumber">The line number in the source file at which the method is called. This is set at by the compiler.</param>
         public void WriteIf(
             Func<bool> condition,
-            [CallerMemberName]string callerMemberName = null,
-            [CallerFilePath]string callerFilePath = null,
-            [CallerLineNumber]int callerLineNumber = 0)
-        {
-            if (condition == null || !condition() || !_logger.IsEnabled(_logEvent.Level))
-                return;
-
-            if (callerMemberName != null)
-                Property("CallerMemberName", callerMemberName);
-            if (callerFilePath != null)
-                Property("CallerFilePath", callerFilePath);
-            if (callerLineNumber != 0)
-                Property("CallerLineNumber", callerLineNumber);
-
-            _logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
-
-            _logger.Log(_logEvent);
-        }
-#else
-        /// <summary>
-        /// Writes the log event to the underlying logger.
-        /// </summary>
-        /// <param name="condition">If condition is true, write log event; otherwise ignore event.</param>
-        public void WriteIf(Func<bool> condition)
-        {
-            if (condition == null || !condition() || !_logger.IsEnabled(_logEvent.Level))
-                return;
-
-            _logger.Log(_logEvent);
-        }
-#endif
-
 #if NET4_5
+            [CallerMemberName]
+#endif
+            string callerMemberName = null,
+#if NET4_5
+            [CallerFilePath]
+#endif
+            string callerFilePath = null,
+#if NET4_5
+            [CallerLineNumber]
+#endif
+            int callerLineNumber = 0)
+        {
+            if (condition == null || !condition() || !_logger.IsEnabled(_logEvent.Level))
+                return;
+
+            SetCallerInfo(callerMemberName, callerFilePath, callerLineNumber);
+
+            _logger.Log(_logEvent);
+        }
+
         /// <summary>
         /// Writes the log event to the underlying logger if the condition is true.
         /// </summary>
@@ -367,14 +345,31 @@ namespace NLog.Fluent
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is set at by the compiler.</param>
         /// <param name="callerLineNumber">The line number in the source file at which the method is called. This is set at by the compiler.</param>
         public void WriteIf(
-            bool condition, 
-            [CallerMemberName]string callerMemberName = null, 
-            [CallerFilePath]string callerFilePath = null, 
-            [CallerLineNumber]int callerLineNumber = 0)
+            bool condition,
+#if NET4_5
+            [CallerMemberName]
+#endif
+            string callerMemberName = null,
+#if NET4_5
+            [CallerFilePath]
+#endif
+            string callerFilePath = null,
+#if NET4_5
+            [CallerLineNumber]
+#endif
+            int callerLineNumber = 0)
         {
             if (!condition || !_logger.IsEnabled(_logEvent.Level))
                 return;
 
+            SetCallerInfo(callerMemberName, callerFilePath, callerLineNumber);
+
+            _logger.Log(_logEvent);
+        }
+
+        private void SetCallerInfo(string callerMemberName, string callerFilePath, int callerLineNumber)
+        {
+            // TODO NLog ver. 5 - Remove these properties
             if (callerMemberName != null)
                 Property("CallerMemberName", callerMemberName);
             if (callerFilePath != null)
@@ -382,23 +377,8 @@ namespace NLog.Fluent
             if (callerLineNumber != 0)
                 Property("CallerLineNumber", callerLineNumber);
 
-            _logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
-
-            _logger.Log(_logEvent);
+            if (callerMemberName != null || callerFilePath != null || callerLineNumber != 0)
+                _logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
         }
-#else
-        /// <summary>
-        /// Writes the log event to the underlying logger.
-        /// </summary>
-        /// <param name="condition">If condition is true, write log event; otherwise ignore event.</param>
-        public void WriteIf(bool condition)
-        {
-            if (!condition || !_logger.IsEnabled(_logEvent.Level))
-                return;
-
-            _logger.Log(_logEvent);
-        }
-#endif
-
     }
 }

--- a/src/NLog/Fluent/LogBuilder.cs
+++ b/src/NLog/Fluent/LogBuilder.cs
@@ -378,18 +378,18 @@ namespace NLog.Fluent
         }
 #endif
 
-        private void SetCallerInfo(string callerMemberName, string callerFilePath, int callerLineNumber)
+        private void SetCallerInfo(string callerMethodName, string callerFilePath, int callerLineNumber)
         {
             // TODO NLog ver. 5 - Remove these properties
-            if (callerMemberName != null)
-                Property("CallerMemberName", callerMemberName);
+            if (callerMethodName != null)
+                Property("CallerMemberName", callerMethodName);
             if (callerFilePath != null)
                 Property("CallerFilePath", callerFilePath);
             if (callerLineNumber != 0)
                 Property("CallerLineNumber", callerLineNumber);
 
-            if (callerMemberName != null || callerFilePath != null || callerLineNumber != 0)
-                _logEvent.SetCallerInfo(null, callerMemberName, callerFilePath, callerLineNumber);
+            if (callerMethodName != null || callerFilePath != null || callerLineNumber != 0)
+                _logEvent.SetCallerInfo(null, callerMethodName, callerFilePath, callerLineNumber);
         }
     }
 }

--- a/src/NLog/Internal/CallSiteInformation.cs
+++ b/src/NLog/Internal/CallSiteInformation.cs
@@ -56,13 +56,13 @@ namespace NLog.Internal
         /// Sets the details retrieved from the Caller Information Attributes
         /// </summary>
         /// <param name="callerClassName"></param>
-        /// <param name="callerMemberName"></param>
+        /// <param name="callerMethodName"></param>
         /// <param name="callerFilePath"></param>
         /// <param name="callerLineNumber"></param>
-        public void SetCallerInfo(string callerClassName, string callerMemberName, string callerFilePath, int callerLineNumber)
+        public void SetCallerInfo(string callerClassName, string callerMethodName, string callerFilePath, int callerLineNumber)
         {
             CallerClassName = callerClassName;
-            CallerMemberName = callerMemberName;
+            CallerMethodName = callerMethodName;
             CallerFilePath = callerFilePath;
             CallerLineNumber = callerLineNumber;
         }
@@ -121,10 +121,10 @@ namespace NLog.Internal
             return StackTraceUsageUtils.GetStackFrameMethodClassName(method, includeNameSpace, cleanAsyncMoveNext, cleanAnonymousDelegates) ?? string.Empty;
         }
 
-        public string GetCallerMemberName(MethodBase method, bool includeMethodInfo, bool cleanAsyncMoveNext, bool cleanAnonymousDelegates)
+        public string GetCallerMethodName(MethodBase method, bool includeMethodInfo, bool cleanAsyncMoveNext, bool cleanAnonymousDelegates)
         {
-            if (!string.IsNullOrEmpty(CallerMemberName))
-                return CallerMemberName;
+            if (!string.IsNullOrEmpty(CallerMethodName))
+                return CallerMethodName;
 
             method = method ?? GetCallerStackFrameMethod(0);
             if (method == null)
@@ -158,7 +158,7 @@ namespace NLog.Internal
         }
 
         public string CallerClassName { get; internal set; }
-        public string CallerMemberName { get; private set; }
+        public string CallerMethodName { get; private set; }
         public string CallerFilePath { get; private set; }
         public int? CallerLineNumber { get; private set; }
     }

--- a/src/NLog/Internal/CallSiteInformation.cs
+++ b/src/NLog/Internal/CallSiteInformation.cs
@@ -157,7 +157,7 @@ namespace NLog.Internal
             return frame?.GetFileLineNumber() ?? 0;
         }
 
-        public string CallerClassName { get; private set; }
+        public string CallerClassName { get; internal set; }
         public string CallerMemberName { get; private set; }
         public string CallerFilePath { get; private set; }
         public int? CallerLineNumber { get; private set; }

--- a/src/NLog/Internal/StackTraceUsageUtils.cs
+++ b/src/NLog/Internal/StackTraceUsageUtils.cs
@@ -52,7 +52,7 @@ namespace NLog.Internal
         {
 #if !SILVERLIGHT
             if (includeFileName)
-                return skipFrames == 0 ? (StackTraceUsage.WithCallSite | StackTraceUsage.WithSourceCode) : StackTraceUsage.WithSource;
+                return skipFrames == 0 ? (StackTraceUsage.WithCallSite | StackTraceUsage.WithFileNameAndLineNumber) : StackTraceUsage.WithSource;
             else
 #endif
                 return skipFrames == 0 ? StackTraceUsage.WithCallSite : StackTraceUsage.WithoutSource;

--- a/src/NLog/Internal/StackTraceUsageUtils.cs
+++ b/src/NLog/Internal/StackTraceUsageUtils.cs
@@ -48,9 +48,14 @@ namespace NLog.Internal
         private static readonly Assembly mscorlibAssembly = typeof(string).GetAssembly();
         private static readonly Assembly systemAssembly = typeof(Debug).GetAssembly();
 
-        internal static StackTraceUsage Max(StackTraceUsage u1, StackTraceUsage u2)
+        public static StackTraceUsage GetStackTraceUsage(bool includeFileName, int skipFrames)
         {
-            return (StackTraceUsage)Math.Max((int)u1, (int)u2);
+#if !SILVERLIGHT
+            if (includeFileName)
+                return skipFrames == 0 ? (StackTraceUsage.WithCallSite | StackTraceUsage.WithSourceCode) : StackTraceUsage.WithSource;
+            else
+#endif
+                return skipFrames == 0 ? StackTraceUsage.WithCallSite : StackTraceUsage.WithoutSource;
         }
 
         public static int GetFrameCount(this StackTrace strackTrace)

--- a/src/NLog/Internal/StackTraceUsageUtils.cs
+++ b/src/NLog/Internal/StackTraceUsageUtils.cs
@@ -55,7 +55,7 @@ namespace NLog.Internal
                 return skipFrames == 0 ? (StackTraceUsage.WithCallSite | StackTraceUsage.WithFileNameAndLineNumber) : StackTraceUsage.WithSource;
             else
 #endif
-                return skipFrames == 0 ? StackTraceUsage.WithCallSite : StackTraceUsage.WithoutSource;
+                return skipFrames == 0 ? StackTraceUsage.WithCallSite : StackTraceUsage.WithStackTrace;
         }
 
         public static int GetFrameCount(this StackTrace strackTrace)

--- a/src/NLog/Internal/TargetWithFilterChain.cs
+++ b/src/NLog/Internal/TargetWithFilterChain.cs
@@ -114,6 +114,20 @@ namespace NLog.Internal
             return true;
         }
 
+        internal bool MustCaptureStackTrace(StackTraceUsage stackTraceUsage, LogEventInfo logEvent)
+        {
+            if (logEvent.HasStackTrace)
+                return false;
+
+            if ((stackTraceUsage & (StackTraceUsage.WithCallSite | StackTraceUsage.WithStackTrace)) != StackTraceUsage.WithCallSite)
+                return true;
+
+            if (string.IsNullOrEmpty(logEvent.CallSiteInformation?.CallerMethodName) && string.IsNullOrEmpty(logEvent.CallSiteInformation?.CallerFilePath))
+                return true;   // We don't have enough CallSiteInformation
+
+            return false;
+        }
+
         internal bool TryRememberCallSiteClassName(LogEventInfo logEvent)
         {
             if (string.IsNullOrEmpty(logEvent.CallSiteInformation?.CallerFilePath))

--- a/src/NLog/Internal/TargetWithFilterChain.cs
+++ b/src/NLog/Internal/TargetWithFilterChain.cs
@@ -33,10 +33,11 @@
 
 namespace NLog.Internal
 {
+    using System;
     using System.Collections.Generic;
-    using Config;
-    using Filters;
-    using Targets;
+    using NLog.Config;
+    using NLog.Filters;
+    using NLog.Targets;
 
     /// <summary>
     /// Represents target with a chain of filters which determine
@@ -49,6 +50,106 @@ namespace NLog.Internal
         /// cached result as calculating is expensive.
         /// </summary>
         private StackTraceUsage? _stackTraceUsage;
+
+        private MruCache<CallSiteKey, string> _callSiteClassNameCache;
+
+        struct CallSiteKey : IEquatable<CallSiteKey>
+        {
+            public CallSiteKey(string methodName, string fileSourceName, int fileSourceLineNumber)
+            {
+                MethodName = methodName ?? string.Empty;
+                FileSourceName = fileSourceName ?? string.Empty;
+                FileSourceLineNumber = fileSourceLineNumber;
+            }
+
+            public readonly string MethodName;
+            public readonly string FileSourceName;
+            public readonly int FileSourceLineNumber;
+
+            /// <summary>
+            /// Serves as a hash function for a particular type.
+            /// </summary>
+            /// <returns>
+            /// A hash code for the current <see cref="T:System.Object"/>.
+            /// </returns>
+            public override int GetHashCode()
+            {
+                return MethodName.GetHashCode() ^ FileSourceName.GetHashCode() ^ FileSourceLineNumber;
+            }
+
+            /// <summary>
+            /// Determines if two objects are equal in value.
+            /// </summary>
+            /// <param name="obj">Other object to compare to.</param>
+            /// <returns>True if objects are equal, false otherwise.</returns>
+            public override bool Equals(object obj)
+            {
+                return obj is CallSiteKey key && Equals(key);
+            }
+
+            /// <summary>
+            /// Determines if two objects of the same type are equal in value.
+            /// </summary>
+            /// <param name="other">Other object to compare to.</param>
+            /// <returns>True if objects are equal, false otherwise.</returns>
+            public bool Equals(CallSiteKey other)
+            {
+                return FileSourceLineNumber == other.FileSourceLineNumber
+                    && string.Equals(FileSourceName, other.FileSourceName, StringComparison.Ordinal)
+                    && string.Equals(MethodName, other.MethodName, StringComparison.Ordinal);
+            }
+        }
+
+        internal bool TryCallSiteClassNameOptimization(StackTraceUsage stackTraceUsage, LogEventInfo logEvent)
+        {
+            if ((stackTraceUsage & (StackTraceUsage.WithCallSite | StackTraceUsage.WithStackTrace)) != StackTraceUsage.WithCallSite)
+                return false;
+
+            if (string.IsNullOrEmpty(logEvent.CallSiteInformation?.CallerFilePath))
+                return false;
+
+            if (logEvent.HasStackTrace)
+                return false;
+
+            return true;
+        }
+
+        internal bool TryRememberCallSiteClassName(LogEventInfo logEvent)
+        {
+            if (string.IsNullOrEmpty(logEvent.CallSiteInformation?.CallerFilePath))
+                return false;
+
+            string className = logEvent.CallSiteInformation.GetCallerClassName(null, true, true, true);
+            if (string.IsNullOrEmpty(className))
+                return false;
+
+            if (_callSiteClassNameCache == null)
+                return false;
+
+            string internClassName = logEvent.LoggerName == className ?
+                logEvent.LoggerName :
+#if !NETSTANDARD1_0
+                string.Intern(className);   // Single string-reference for all logging-locations for the same class
+#else
+                className;
+#endif
+            CallSiteKey callSiteKey = new CallSiteKey(logEvent.CallerMemberName, logEvent.CallerFilePath, logEvent.CallerLineNumber);
+            return _callSiteClassNameCache.TryAddValue(callSiteKey, internClassName);
+        }
+
+        internal bool TryLookupCallSiteClassName(LogEventInfo logEvent, out string callSiteClassName)
+        {
+            callSiteClassName = logEvent.CallSiteInformation?.CallerClassName;
+            if (!string.IsNullOrEmpty(callSiteClassName))
+                return true;
+
+            if (_callSiteClassNameCache == null)
+            {
+                System.Threading.Interlocked.CompareExchange(ref _callSiteClassNameCache, new MruCache<CallSiteKey, string>(1000), null);
+            }
+            CallSiteKey callSiteKey = new CallSiteKey(logEvent.CallerMemberName, logEvent.CallerFilePath, logEvent.CallerLineNumber);
+            return _callSiteClassNameCache.TryGetValue(callSiteKey, out callSiteClassName);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TargetWithFilterChain" /> class.
@@ -108,11 +209,10 @@ namespace NLog.Internal
             }
 
             //recurse into chain if not max
-            if (NextInChain != null && stackTraceUsage != StackTraceUsage.Max)
+            if (NextInChain != null && (stackTraceUsage & StackTraceUsage.Max) != StackTraceUsage.Max)
             {
                 var stackTraceUsageForChain = NextInChain.PrecalculateStackTraceUsage();
-                if (stackTraceUsageForChain > stackTraceUsage)
-                    stackTraceUsage = stackTraceUsageForChain;
+                stackTraceUsage |= stackTraceUsageForChain;
             }
 
             _stackTraceUsage = stackTraceUsage;

--- a/src/NLog/LayoutRenderers/CallSite and stacktraces/CallSiteFileNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSite and stacktraces/CallSiteFileNameLayoutRenderer.cs
@@ -65,7 +65,7 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsage.WithSource;
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsageUtils.GetStackTraceUsage(true, SkipFrames);
 
         /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)

--- a/src/NLog/LayoutRenderers/CallSite and stacktraces/CallSiteLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSite and stacktraces/CallSiteLayoutRenderer.cs
@@ -124,20 +124,13 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage
-        {
-            get
-            {
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsageUtils.GetStackTraceUsage(
 #if !SILVERLIGHT
-                if (FileName)
-                {
-                    return StackTraceUsage.Max;
-                }
+            FileName,
+#else
+            false,
 #endif
-
-                return StackTraceUsage.WithoutSource;
-            }
-        }
+            SkipFrames);
 
         /// <summary>
         /// Renders the call site and appends it to the specified <see cref="StringBuilder" />.

--- a/src/NLog/LayoutRenderers/CallSite and stacktraces/CallSiteLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSite and stacktraces/CallSiteLayoutRenderer.cs
@@ -153,7 +153,7 @@ namespace NLog.LayoutRenderers
                     }
                     if (MethodName)
                     {
-                        string methodName = logEvent.CallSiteInformation.GetCallerMemberName(method, false, CleanNamesOfAsyncContinuations, CleanNamesOfAnonymousDelegates);
+                        string methodName = logEvent.CallSiteInformation.GetCallerMethodName(method, false, CleanNamesOfAsyncContinuations, CleanNamesOfAnonymousDelegates);
                         if (string.IsNullOrEmpty(methodName))
                             methodName = "<no method>";
 

--- a/src/NLog/LayoutRenderers/CallSite and stacktraces/CallSiteLineNumberLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSite and stacktraces/CallSiteLineNumberLayoutRenderer.cs
@@ -54,11 +54,11 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(0)]
         public int SkipFrames { get; set; }
-        
+
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsage.WithSource;
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsageUtils.GetStackTraceUsage(true, SkipFrames);
 
         /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)

--- a/src/NLog/LayoutRenderers/CallSite and stacktraces/StackTraceLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSite and stacktraces/StackTraceLayoutRenderer.cs
@@ -89,7 +89,7 @@ namespace NLog.LayoutRenderers
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
         /// <value></value>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage => (Format == StackTraceFormat.Raw) ? StackTraceUsage.Max : StackTraceUsage.WithoutSource;
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => (Format == StackTraceFormat.Raw) ? StackTraceUsage.Max : StackTraceUsage.WithStackTrace;
 
         /// <summary>
         /// Renders the call site and appends it to the specified <see cref="StringBuilder" />.

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -229,23 +229,7 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage
-        {
-            get
-            {
-                if (IncludeSourceInfo)
-                {
-                    return StackTraceUsage.Max;
-                }
-
-                if (IncludeCallSite)
-                {
-                    return StackTraceUsage.WithoutSource;
-                }
-
-                return StackTraceUsage.None;
-            }
-        }
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => (IncludeCallSite || IncludeSourceInfo) ? StackTraceUsageUtils.GetStackTraceUsage(IncludeSourceInfo, 0) : StackTraceUsage.None;
 
         internal IList<NLogViewerParameterInfo> Parameters { get; set; }
 

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -401,7 +401,7 @@ namespace NLog.LayoutRenderers
         {
             MethodBase methodBase = logEvent.CallSiteInformation.GetCallerStackFrameMethod(0);
             string callerClassName = logEvent.CallSiteInformation.GetCallerClassName(methodBase, true, true, true);
-            string callerMemberName = logEvent.CallSiteInformation.GetCallerMemberName(methodBase, true, true, true);
+            string callerMethodName = logEvent.CallSiteInformation.GetCallerMethodName(methodBase, true, true, true);
 
             xtw.WriteStartElement("log4j", "locationInfo", dummyNamespace);
             if (!string.IsNullOrEmpty(callerClassName))
@@ -409,7 +409,7 @@ namespace NLog.LayoutRenderers
                 xtw.WriteAttributeSafeString("class", callerClassName);
             }
 
-            xtw.WriteAttributeSafeString("method", callerMemberName);
+            xtw.WriteAttributeSafeString("method", callerMethodName);
 #if !SILVERLIGHT
             if (IncludeSourceInfo)
             {

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -204,7 +204,7 @@ namespace NLog
         /// <summary>
         /// Gets the callsite member function name
         /// </summary>
-        public string CallerMemberName => CallSiteInformation?.GetCallerMemberName(null, false, true, true);
+        public string CallerMemberName => CallSiteInformation?.GetCallerMethodName(null, false, true, true);
 
         /// <summary>
         /// Gets the callsite source file path

--- a/src/NLog/LogFactory-T.cs
+++ b/src/NLog/LogFactory-T.cs
@@ -50,7 +50,7 @@ namespace NLog
         /// <returns>An instance of <typeparamref name="T"/>.</returns>
         public new T GetLogger(string name)
         {
-            return (T)GetLogger(name, typeof(T));
+            return GetLogger<T>(name);
         }
 
         /// <summary>

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -224,7 +224,6 @@ namespace NLog
         /// Creates a logger that discards all log messages.
         /// </summary>
         /// <returns>Null logger which discards all log messages.</returns>
-        [CLSCompliant(false)]
         public static Logger CreateNullLogger()
         {
             return factory.CreateNullLogger();
@@ -235,7 +234,6 @@ namespace NLog
         /// </summary>
         /// <param name="name">Name of the logger.</param>
         /// <returns>The logger reference. Multiple calls to <c>GetLogger</c> with the same argument aren't guaranteed to return the same logger reference.</returns>
-        [CLSCompliant(false)]
         public static Logger GetLogger(string name)
         {
             return factory.GetLogger(name);
@@ -248,7 +246,6 @@ namespace NLog
         /// <param name="loggerType">The logger class. The class must inherit from <see cref="Logger" />.</param>
         /// <returns>The logger of type <paramref name="loggerType"/>. Multiple calls to <c>GetLogger</c> with the same argument aren't guaranteed to return the same logger reference.</returns>
         /// <remarks>The generic way for this method is <see cref="NLog.LogFactory{loggerType}.GetLogger(string)"/></remarks>
-        [CLSCompliant(false)]
         public static Logger GetLogger(string name, Type loggerType)
         {
             return factory.GetLogger(name, loggerType);

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -67,7 +67,7 @@ namespace NLog
 #if SILVERLIGHT
                     var stackTrace = new StackTrace();
 #else
-                    bool includeSource = (stu & StackTraceUsage.WithSourceCode) != 0;
+                    bool includeSource = (stu & StackTraceUsage.WithFileNameAndLineNumber) != 0;
 #if NETSTANDARD1_5
                     var stackTrace = (StackTrace)Activator.CreateInstance(typeof(StackTrace), new object[] { includeSource });
 #else

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -55,19 +55,35 @@ namespace NLog
         {
 #if !NETSTANDARD1_0 || NETSTANDARD1_5
             StackTraceUsage stu = targetsForLevel.GetStackTraceUsage();
-            if (stu != StackTraceUsage.None && !logEvent.HasStackTrace)
+            if (stu != StackTraceUsage.None)
             {
-#if NETSTANDARD1_5
-                var stackTrace = (StackTrace)Activator.CreateInstance(typeof(StackTrace), new object[] { stu == StackTraceUsage.WithSource });
-#elif !SILVERLIGHT
-                var stackTrace = new StackTrace(StackTraceSkipMethods, stu == StackTraceUsage.WithSource);
+                bool attemptCallSiteOptimization = targetsForLevel.TryCallSiteClassNameOptimization(stu, logEvent);
+                if (attemptCallSiteOptimization && targetsForLevel.TryLookupCallSiteClassName(logEvent, out string callSiteClassName))
+                {
+                    logEvent.CallSiteInformation.CallerClassName = callSiteClassName;
+                }
+                else if (!logEvent.HasStackTrace)
+                {
+#if SILVERLIGHT
+                    var stackTrace = new StackTrace();
 #else
-                var stackTrace = new StackTrace();
+                    bool includeSource = (stu & StackTraceUsage.WithSourceCode) != 0;
+#if NETSTANDARD1_5
+                    var stackTrace = (StackTrace)Activator.CreateInstance(typeof(StackTrace), new object[] { includeSource });
+#else
+                    var stackTrace = new StackTrace(StackTraceSkipMethods, includeSource);
 #endif
-                var stackFrames = stackTrace.GetFrames();
-                int? firstUserFrame = FindCallingMethodOnStackTrace(stackFrames, loggerType);
-                int? firstLegacyUserFrame = firstUserFrame.HasValue ? SkipToUserStackFrameLegacy(stackFrames, firstUserFrame.Value) : (int?)null;
-                logEvent.GetCallSiteInformationInternal().SetStackTrace(stackTrace, firstUserFrame ?? 0, firstLegacyUserFrame);
+#endif
+                    var stackFrames = stackTrace.GetFrames();
+                    int? firstUserFrame = FindCallingMethodOnStackTrace(stackFrames, loggerType);
+                    int? firstLegacyUserFrame = firstUserFrame.HasValue ? SkipToUserStackFrameLegacy(stackFrames, firstUserFrame.Value) : (int?)null;
+                    logEvent.GetCallSiteInformationInternal().SetStackTrace(stackTrace, firstUserFrame ?? 0, firstLegacyUserFrame);
+
+                    if (attemptCallSiteOptimization)
+                    {
+                        targetsForLevel.TryRememberCallSiteClassName(logEvent);
+                    }
+                }
             }
 #endif
 

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -62,7 +62,7 @@ namespace NLog
                 {
                     logEvent.CallSiteInformation.CallerClassName = callSiteClassName;
                 }
-                else if (!logEvent.HasStackTrace)
+                else if (attemptCallSiteOptimization || targetsForLevel.MustCaptureStackTrace(stu, logEvent))
                 {
 #if SILVERLIGHT
                     var stackTrace = new StackTrace();

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -521,9 +521,9 @@ namespace NLog.Targets
             {
                 _allLayoutsAreThreadSafe = _allLayouts.All(layout => layout.ThreadSafe);
             }
-            StackTraceUsage = _allLayouts.DefaultIfEmpty().Max(layout => layout?.StackTraceUsage ?? StackTraceUsage.None);
-            if (this is IUsesStackTrace usesStackTrace && usesStackTrace.StackTraceUsage > StackTraceUsage)
-                StackTraceUsage = usesStackTrace.StackTraceUsage;
+            StackTraceUsage = _allLayouts.DefaultIfEmpty().Aggregate(StackTraceUsage.None, (seed,layout) => seed | (layout?.StackTraceUsage ?? StackTraceUsage.None));
+            if (this is IUsesStackTrace usesStackTrace)
+                StackTraceUsage |= usesStackTrace.StackTraceUsage;
             _scannedForLayouts = true;
         }
 

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -521,7 +521,13 @@ namespace NLog.Targets
             {
                 _allLayoutsAreThreadSafe = _allLayouts.All(layout => layout.ThreadSafe);
             }
-            StackTraceUsage = _allLayouts.DefaultIfEmpty().Aggregate(StackTraceUsage.None, (seed,layout) => seed | (layout?.StackTraceUsage ?? StackTraceUsage.None));
+
+            StackTraceUsage result = StackTraceUsage.None;
+            foreach (var layout in _allLayouts.DefaultIfEmpty())
+            {
+                result |= layout?.StackTraceUsage ?? StackTraceUsage.None;
+            }
+            StackTraceUsage = result;
             if (this is IUsesStackTrace usesStackTrace)
                 StackTraceUsage |= usesStackTrace.StackTraceUsage;
             _scannedForLayouts = true;

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -705,7 +705,7 @@ namespace NLog.Targets
 
                     if (IncludeCallSite)
                     {
-                        return StackTraceUsage.WithoutSource;
+                        return StackTraceUsage.WithCallSite;
                     }
                     return StackTraceUsage.None;
                 }

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSite and stacktraces/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSite and stacktraces/CallSiteTests.cs
@@ -1272,7 +1272,7 @@ namespace NLog.UnitTests.LayoutRenderers
         [InlineData(true)]
         public void CallsiteTargetUsesStackTraceTest(bool includeStackTraceUsage)
         {
-            var target = new MyTarget() { StackTraceUsage = includeStackTraceUsage ? StackTraceUsage.WithoutSource : StackTraceUsage.None };
+            var target = new MyTarget() { StackTraceUsage = includeStackTraceUsage ? StackTraceUsage.WithStackTrace : StackTraceUsage.None };
             SimpleConfigurator.ConfigureForTargetLogging(target);
             var logger = LogManager.GetLogger(nameof(CallsiteTargetUsesStackTraceTest));
             string t = null;
@@ -1282,6 +1282,25 @@ namespace NLog.UnitTests.LayoutRenderers
                 Assert.NotNull(target.LastEvent.StackTrace);
             else
                 Assert.Null(target.LastEvent.StackTrace);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void CallsiteTargetSkipsStackTraceTest(bool includeLogEventCallSite)
+        {
+            var target = new MyTarget() { StackTraceUsage = StackTraceUsage.WithCallSite };
+            SimpleConfigurator.ConfigureForTargetLogging(target);
+            var logger = LogManager.GetLogger(nameof(CallsiteTargetUsesStackTraceTest));
+            var logEvent = LogEventInfo.Create(LogLevel.Info, logger.Name, "Hello");
+            if (includeLogEventCallSite)
+                logEvent.SetCallerInfo(nameof(CallSiteTests), nameof(CallsiteTargetSkipsStackTraceTest), string.Empty, 0);
+            logger.Log(logEvent);
+            Assert.NotNull(target.LastEvent);
+            if (includeLogEventCallSite)
+                Assert.Null(target.LastEvent.StackTrace);
+            else
+                Assert.NotNull(target.LastEvent.StackTrace);
         }
 
         public class MyTarget : TargetWithLayout, IUsesStackTrace


### PR DESCRIPTION
Extracted the callsite optimization from #2527, but excluded the special LoggerCallSite. And changed `enum StackTraceUsage` into a Flags-enum.

This allows NLog to make optimal use of caller-member-attributes to provide Callsite-information. Just need to figure out how to make a nice way to provide the info besides the fluent LogBuilder-interface.

Resolves partly #532 when using LogBuilder and resolves #2059 