### PR TITLE
ObjectReflectionCache - Skip property-reflection for IFormattable

### DIFF
--- a/src/NLog/Internal/ObjectReflectionCache.cs
+++ b/src/NLog/Internal/ObjectReflectionCache.cs
@@ -177,10 +177,7 @@ namespace NLog.Internal
 
         private static bool ConvertToString(Type objectType)
         {
-            if (objectType == typeof(Guid))
-                return true;
-
-            if (objectType == typeof(TimeSpan))
+            if (typeof(IFormattable).IsAssignableFrom(objectType))
                 return true;
 
             if (typeof(Uri).IsAssignableFrom(objectType))


### PR DESCRIPTION
Avoid serializing JSON.NET `JValue`-properties when it contains a non-primitive object (Ex. like TimeSpan).