### PR TITLE
RetryingMultiProcessFileAppender - better init BufferSize 

### DIFF
--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -63,7 +63,8 @@ namespace NLog.Internal.FileAppenders
         /// <param name="count">The number of bytes.</param>
         public override void Write(byte[] bytes, int offset, int count)
         {
-            using (FileStream fileStream = CreateFileStream(false))
+            int overrideBufferSize = Math.Min((count / 4096 + 1) * 4096, CreateFileParameters.BufferSize);
+            using (FileStream fileStream = CreateFileStream(false, overrideBufferSize))
             {
                 fileStream.Write(bytes, offset, count);
             }


### PR DESCRIPTION
BufferSize should match byte-count

No need to allocate 30.000 bytes to write 100 bytes.