### PR TITLE
Added null terminator line ending mode

### DIFF
--- a/src/NLog/Targets/LineEndingMode.cs
+++ b/src/NLog/Targets/LineEndingMode.cs
@@ -72,6 +72,12 @@ namespace NLog.Targets
         public static readonly LineEndingMode LF = new LineEndingMode("LF", "\n");
 
         /// <summary>
+        /// Insert null terminator (ASCII 0) after each line.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "Type is immutable")]
+        public static readonly LineEndingMode Null = new LineEndingMode("Null", "\0");
+
+        /// <summary>
         /// Do not insert any line ending.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "Type is immutable")]
@@ -122,6 +128,7 @@ namespace NLog.Targets
             if (name.Equals(LF.Name, StringComparison.OrdinalIgnoreCase)) return LF;
             if (name.Equals(CR.Name, StringComparison.OrdinalIgnoreCase)) return CR;
             if (name.Equals(Default.Name, StringComparison.OrdinalIgnoreCase)) return Default;
+            if (name.Equals(Null.Name, StringComparison.OrdinalIgnoreCase)) return Null;
             if (name.Equals(None.Name, StringComparison.OrdinalIgnoreCase)) return None;
 
 #if !SILVERLIGHT

--- a/tests/NLog.UnitTests/Targets/LineEndingModeTests.cs
+++ b/tests/NLog.UnitTests/Targets/LineEndingModeTests.cs
@@ -47,22 +47,27 @@ namespace NLog.UnitTests.Targets
             LineEndingMode modeNone = LineEndingMode.None;
             LineEndingMode modeLF = LineEndingMode.LF;
             LineEndingMode modeCRLF = LineEndingMode.CRLF;
+            LineEndingMode modeNull = LineEndingMode.Null;
 
             Assert.True(LineEndingMode.Default == modeDefault);
             Assert.True(LineEndingMode.None == modeNone);
             Assert.True(LineEndingMode.LF == modeLF);
+            Assert.True(LineEndingMode.Null == modeNull);
             Assert.False(LineEndingMode.Default == modeNone);
             Assert.False(LineEndingMode.None == modeLF);
             Assert.False(LineEndingMode.None == modeCRLF);
+            Assert.False(LineEndingMode.None == modeNull);
             Assert.False(LineEndingMode.None == (object)new { });
             Assert.False(LineEndingMode.None == null);
 
             Assert.True(LineEndingMode.Default.Equals(modeDefault));
             Assert.True(LineEndingMode.None.Equals(modeNone));
             Assert.True(LineEndingMode.LF.Equals(modeLF));
+            Assert.True(LineEndingMode.Null.Equals(modeNull));
             Assert.False(LineEndingMode.Default.Equals(modeNone));
             Assert.False(LineEndingMode.None.Equals(modeLF));
             Assert.False(LineEndingMode.None.Equals(modeCRLF));
+            Assert.False(LineEndingMode.None.Equals(modeNull));
             Assert.False(LineEndingMode.None.Equals(new { }));
             Assert.False(LineEndingMode.None.Equals(null));
 
@@ -86,14 +91,17 @@ namespace NLog.UnitTests.Targets
             LineEndingMode modeNone = LineEndingMode.None;
             LineEndingMode modeLF = LineEndingMode.LF;
             LineEndingMode modeCRLF = LineEndingMode.CRLF;
+            LineEndingMode modeNull = LineEndingMode.Null;
 
             Assert.True(LineEndingMode.Default != modeNone);
             Assert.True(LineEndingMode.None != modeLF);
             Assert.True(LineEndingMode.None != modeCRLF);
+            Assert.True(LineEndingMode.None != modeNull);
             Assert.False(LineEndingMode.Default != modeDefault);
             Assert.False(LineEndingMode.None != modeNone);
             Assert.False(LineEndingMode.LF != modeLF);
             Assert.False(LineEndingMode.CRLF != modeCRLF);
+            Assert.False(LineEndingMode.Null != modeNull);
 
             Assert.True(null != LineEndingMode.LF);
             Assert.True(null != modeLF);
@@ -103,6 +111,10 @@ namespace NLog.UnitTests.Targets
             Assert.True(null != modeCRLF);
             Assert.True(LineEndingMode.CRLF != null);
             Assert.True(modeCRLF != null);
+            Assert.True(null != LineEndingMode.Null);
+            Assert.True(null != modeNull);
+            Assert.True(LineEndingMode.Null != null);
+            Assert.True(modeNull != null);
 
             // Handle running tests on different operating systems
             if (modeCRLF.NewLineCharacters == Environment.NewLine)
@@ -139,6 +151,7 @@ namespace NLog.UnitTests.Targets
             Assert.Equal("CRLF", LineEndingMode.CRLF.ToString());
             Assert.Equal("CR", LineEndingMode.CR.ToString());
             Assert.Equal("LF", LineEndingMode.LF.ToString());
+            Assert.Equal("Null", LineEndingMode.Null.ToString());
         }
     }
 }


### PR DESCRIPTION
Currently there are only 4 options for target line ending mode, CRLF|LF|CR|None.
This pull request adds null terminator line ending mode to target "lineEnding" attribute in configuration.
https://github.com/NLog/NLog/wiki/Network-target