### PR TITLE
LoggingConfigurationParser - Moved attribute validation from Xml-Config

### DIFF
--- a/src/NLog/Config/ILoggingConfigurationElement.cs
+++ b/src/NLog/Config/ILoggingConfigurationElement.cs
@@ -52,10 +52,5 @@ namespace NLog.Config
         /// Child config sections
         /// </summary>
         IEnumerable<ILoggingConfigurationElement> Children { get; }
-
-        /// <summary>
-        /// Gets the value of the element.
-        /// </summary>
-        string Value { get; }
     }
 }

--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -31,13 +31,13 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.Linq;
-
 namespace NLog.Config
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Xml;
+    using NLog.Internal;
 
     /// <summary>
     /// Represents simple XML element with case-insensitive attribute semantics.
@@ -47,40 +47,20 @@ namespace NLog.Config
         /// <summary>
         /// Initializes a new instance of the <see cref="NLogXmlElement"/> class.
         /// </summary>
-        /// <param name="inputUri">The input URI.</param>
-        public NLogXmlElement(string inputUri)
-            : this()
-        {
-            using (var reader = XmlReader.Create(inputUri))
-            {
-                reader.MoveToContent();
-                Parse(reader, true);
-            }
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NLogXmlElement"/> class.
-        /// </summary>
         /// <param name="reader">The reader to initialize element from.</param>
         public NLogXmlElement(XmlReader reader)
-            : this(reader, false)
+            : this(reader, true)
         {
         }
 
-        private NLogXmlElement(XmlReader reader, bool nestedElement)
-            : this()
+        private NLogXmlElement(XmlReader reader, bool topElement)
         {
-            Parse(reader, nestedElement);
-        }
+            if (topElement)
+                reader.MoveToContent();
 
-        /// <summary>
-        /// Prevents a default instance of the <see cref="NLogXmlElement"/> class from being created.
-        /// </summary>
-        private NLogXmlElement()
-        {
-            AttributeValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            Children = new List<NLogXmlElement>();
-            _parsingErrors = new List<string>();
+            Parse(reader, topElement, out var attributes, out var children);
+            AttributeValues = attributes ?? ArrayHelper.Empty<KeyValuePair<string, string>>();
+            Children = children ?? ArrayHelper.Empty<NLogXmlElement>();
         }
 
         /// <summary>
@@ -91,7 +71,7 @@ namespace NLog.Config
         /// <summary>
         /// Gets the dictionary of attribute values.
         /// </summary>
-        public Dictionary<string, string> AttributeValues { get; }
+        public IList<KeyValuePair<string,string>> AttributeValues { get; }
 
         /// <summary>
         /// Gets the collection of child elements.
@@ -144,11 +124,6 @@ namespace NLog.Config
         }
 
         /// <summary>
-        /// Last error occured during configuration read
-        /// </summary>
-        private readonly List<string> _parsingErrors;
-
-        /// <summary>
         /// Returns children elements with the specified element name.
         /// </summary>
         /// <param name="elementName">Name of the element.</param>
@@ -185,30 +160,13 @@ namespace NLog.Config
             throw new InvalidOperationException("Assertion failed. Expected element name '" + string.Join("|", allowedNames) + "', actual: '" + LocalName + "'.");
         }
 
-        /// <summary>
-        /// Returns all parsing errors from current and all child elements.
-        /// </summary>
-        public IEnumerable<string> GetParsingErrors()
+        private void Parse(XmlReader reader, bool topElement, out IList<KeyValuePair<string,string>> attributes, out IList<NLogXmlElement> children)
         {
-            foreach (var parsingError in _parsingErrors)
-            {
-                yield return parsingError;
-            }
-
-            foreach (var childElement in Children)
-            {
-                foreach (var parsingError in childElement.GetParsingErrors())
-                {
-                    yield return parsingError;
-                }
-            }
-        }
-
-        private void Parse(XmlReader reader, bool nestedElement)
-        {
-            ParseAttributes(reader, nestedElement);
+            ParseAttributes(reader, topElement, out attributes);
 
             LocalName = reader.LocalName;
+
+            children = null;
 
             if (!reader.IsEmptyElement)
             {
@@ -227,32 +185,27 @@ namespace NLog.Config
 
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        Children.Add(new NLogXmlElement(reader, true));
+                        children = children ?? new List<NLogXmlElement>();
+                        children.Add(new NLogXmlElement(reader, false));
                     }
                 }
             }
         }
 
-        private void ParseAttributes(XmlReader reader, bool nestedElement)
+        private void ParseAttributes(XmlReader reader, bool topElement, out IList<KeyValuePair<string, string>> attributes)
         {
+            attributes = null;
             if (reader.MoveToFirstAttribute())
             {
                 do
                 {
-                    if (!nestedElement && IsSpecialXmlAttribute(reader))
+                    if (topElement && IsSpecialXmlAttribute(reader))
                     {
                         continue;
                     }
 
-                    if (!AttributeValues.ContainsKey(reader.LocalName))
-                    {
-                        AttributeValues.Add(reader.LocalName, reader.Value);
-                    }
-                    else
-                    {
-                        string message = $"Duplicate attribute detected. Attribute name: [{reader.LocalName}]. Duplicate value:[{reader.Value}], Current value:[{AttributeValues[reader.LocalName]}]";
-                        _parsingErrors.Add(message);
-                    }
+                    attributes = attributes ?? new List<KeyValuePair<string, string>>();
+                    attributes.Add(new KeyValuePair<string, string>(reader.LocalName, reader.Value));
                 }
                 while (reader.MoveToNextAttribute());
                 reader.MoveToElement();

--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -95,7 +95,7 @@ namespace NLog.Config
                     if (SingleValueElement(child))
                     {
                         // Values assigned using nested node-elements. Maybe in combination with attributes
-                        return Children.Where(item => SingleValueElement(item)).Select(item => new KeyValuePair<string, string>(item.Name, item.Value)).Concat(AttributeValues);
+                        return AttributeValues.Concat(Children.Where(item => SingleValueElement(item)).Select(item => new KeyValuePair<string, string>(item.Name, item.Value)));
                     }
                 }
                 return AttributeValues;

--- a/src/NLog/Internal/Strings/StringHelpers.cs
+++ b/src/NLog/Internal/Strings/StringHelpers.cs
@@ -32,6 +32,7 @@
 // 
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
@@ -146,6 +147,21 @@ namespace NLog.Internal
             }
             return sb.ToString();
 
+        }
+
+        /// <summary>Concatenates all the elements of a string array, using the specified separator between each element. </summary>
+        /// <param name="separator">The string to use as a separator. <paramref name="separator" /> is included in the returned string only if <paramref name="values" /> has more than one element.</param>
+        /// <param name="values">An collection that contains the elements to concatenate. </param>
+        /// <returns>A string that consists of the elements in <paramref name="values" /> delimited by the <paramref name="separator" /> string. If <paramref name="values" /> is an empty array, the method returns <see cref="F:System.String.Empty" />.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        /// <paramref name="values" /> is <see langword="null" />. </exception>
+        internal static string Join(string separator, IEnumerable<string> values)
+        {
+#if NETSTANDARD || NET4_5 || NET4_0
+            return string.Join(separator, values);
+#else
+            return string.Join(separator, values.ToArray());
+#endif
         }
     }
 }

--- a/tests/NLog.UnitTests/Config/DuplicateConfigurationAttributeTests.cs
+++ b/tests/NLog.UnitTests/Config/DuplicateConfigurationAttributeTests.cs
@@ -86,8 +86,8 @@ namespace NLog.UnitTests.Config
                 }
             }, LogLevel.Error);
 
-            Assert.True(internalLog.Contains("Duplicate attribute detected. Attribute name: [minLevel]. Duplicate value:[trace], Current value:[info]"), internalLog);
-            Assert.True(internalLog.Contains("Duplicate attribute detected. Attribute name: [Substring]. Duplicate value:[msg1], Current value:[msg]"), internalLog);
+            Assert.True(internalLog.Contains("Skipping Duplicate value for 'logger'. PropertyName=minLevel. Skips Value=trace. Existing Value=info"), internalLog);
+            Assert.True(internalLog.Contains("Skipping Duplicate value for 'whencontains'. PropertyName=Substring. Skips Value=msg1. Existing Value=msg"), internalLog);
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -137,7 +137,6 @@ namespace NLog.UnitTests.Config
             Assert.False(rule.IsLoggingEnabledForLevel(LogLevel.Warn));
             Assert.False(rule.IsLoggingEnabledForLevel(LogLevel.Error));
             Assert.False(rule.IsLoggingEnabledForLevel(LogLevel.Fatal));
-
         }
 
         [Fact]
@@ -162,17 +161,19 @@ namespace NLog.UnitTests.Config
         {
             var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
 <nlog throwExceptions='true'>
-    <variable name='prefix'  >[[</variable>
-    <variable name='suffix'>]]</variable>
-
+    <variable name='prefix'><layout><![CDATA[
+newline
+]]></layout></variable>
+    <variable name='suffix'><layout>]]</layout></variable>
 </nlog>");
 
             var nullEvent = LogEventInfo.CreateNullEvent();
 
             // Act & Assert
-            Assert.Equal("[[", configuration.Variables["prefix"].Render(nullEvent));
+            Assert.Equal("\nnewline\n", configuration.Variables["prefix"].Render(nullEvent).Replace("\r", ""));
             Assert.Equal("]]", configuration.Variables["suffix"].Render(nullEvent));
         }
+
         [Fact]
         public void Xml_configuration_with_innerLayouts_returns_defined_variables()
         {

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -219,15 +219,17 @@ newline
         [Fact]
         public void Xml_configuration_variableWithInnerAndAttribute_attributeHasPrecedence()
         {
-            var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
-<nlog throwExceptions='true'>
+            using (new NoThrowNLogExceptions())
+            {
+                var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+<nlog>
     <variable name='var1' value='1'><value>2</value></variable>
 </nlog>");
+                var nullEvent = LogEventInfo.CreateNullEvent();
 
-            var nullEvent = LogEventInfo.CreateNullEvent();
-
-            // Act & Assert
-            Assert.Equal("1", configuration.Variables["var1"].Render(nullEvent));
+                // Act & Assert
+                Assert.Equal("1", configuration.Variables["var1"].Render(nullEvent));
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Improves the validation for `appsettings-json` 

Removing `Value` from `ILoggingConfigurationElement`. Unless full support for checking the Value in all locations where possible (And not just for variables). And also avoid too much diversion from XML and JSON-config (Suddenly supporting unnamed-properties).

Instead one can do this, where one assigns the `value`-property (and allow `<layout>` as alias):
```xml
<variable name="mailBodyLayout">
<layout>
<![CDATA[${onexception:inner=${exceptionMailBodyLayout}:whenempty=${standardMailBodyLayout}}

---
${application-name} v${application-version}

Server: ${machinename}
Date: ${longdate}
${when:when=length('${iis-site-name}') > 0:inner=${iisApplicationInformation}}
Base Directory: ${basedir}
Identity: ${windows-identity}
Process Time: ${processtime}]]>
</layout>
</variable>
```