### PR TITLE
LogLevel - Added support for TypeConverter

### DIFF
--- a/src/NLog/Attributes/LogLevelTypeConverter.cs
+++ b/src/NLog/Attributes/LogLevelTypeConverter.cs
@@ -1,0 +1,91 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Attributes
+{
+    using System;
+    using System.ComponentModel;
+    using System.Globalization;
+
+    /// <summary>
+    /// Support <see cref="NLog.LogLevel"/> implementation of <see cref="IConvertible"/>
+    /// </summary>
+    public class LogLevelTypeConverter : TypeConverter
+    {
+        /// <inheritdoc/>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || IsNumericType(sourceType) || base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value?.GetType() == typeof(string))
+                return LogLevel.FromString(value.ToString());
+            else if (IsNumericType(value?.GetType()))
+                return LogLevel.FromOrdinal(Convert.ToInt32(value));
+            else 
+                return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <inheritdoc/>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(string) || IsNumericType(destinationType) || base.CanConvertTo(context, destinationType);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (value is LogLevel logLevel)
+            {
+                if (destinationType == typeof(string))
+                    return logLevel.ToString();
+                else if (IsNumericType(destinationType))
+                    return Convert.ChangeType(logLevel.Ordinal, destinationType, culture);
+            }
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        private static bool IsNumericType(Type sourceType)
+        {
+            return sourceType == typeof(int) ||
+                sourceType == typeof(uint) ||
+                sourceType == typeof(long) ||
+                sourceType == typeof(ulong) ||
+                sourceType == typeof(short) ||
+                sourceType == typeof(ushort);
+        }
+    }
+}

--- a/src/NLog/Internal/ObjectReflectionCache.cs
+++ b/src/NLog/Internal/ObjectReflectionCache.cs
@@ -99,7 +99,7 @@ namespace NLog.Internal
         private static ObjectPropertyInfos BuildObjectPropertyInfos(object value, Type objectType)
         {
             ObjectPropertyInfos propertyInfos;
-            if (ConvertToString(objectType))
+            if (ConvertSimpleToString(objectType))
             {
                 propertyInfos = ObjectPropertyInfos.SimpleToString;
             }
@@ -125,7 +125,7 @@ namespace NLog.Internal
             return propertyInfos;
         }
 
-        private static bool ConvertToString(Type objectType)
+        private static bool ConvertSimpleToString(Type objectType)
         {
             if (objectType == typeof(Guid))
                 return true;

--- a/src/NLog/LogLevel.cs
+++ b/src/NLog/LogLevel.cs
@@ -35,11 +35,12 @@ namespace NLog
 {
     using System;
     using System.Collections.Generic;
-    using NLog.Internal;
+    using System.ComponentModel;
 
     /// <summary>
     /// Defines available log levels.
     /// </summary>
+    [TypeConverter(typeof(Attributes.LogLevelTypeConverter))]
     public sealed class LogLevel : IComparable, IEquatable<LogLevel>, IConvertible
     {
         /// <summary>
@@ -464,7 +465,10 @@ namespace NLog
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)
         {
-            return Convert.ChangeType(_ordinal, conversionType, provider);
+            if (conversionType == typeof(string))
+                return Name;
+            else
+                return Convert.ChangeType(_ordinal, conversionType, provider);
         }
 
         ushort IConvertible.ToUInt16(IFormatProvider provider)

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -293,6 +293,7 @@ For all config options and platform support, check https://nlog-project.org/conf
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.1.0" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.1.0" />
     <PackageReference Include="System.Data.Common" Version="4.1.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.0.1" />
     <PackageReference Include="System.Net.NameResolution" Version="4.0.0" />

--- a/tests/NLog.UnitTests/LayoutRenderers/LogLevelTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/LogLevelTests.cs
@@ -132,16 +132,24 @@ namespace NLog.UnitTests.LayoutRenderers
         [Theory]
         [InlineData(typeof(int), 2)]
         [InlineData(typeof(uint), (uint)2)]
+        [InlineData(typeof(string), "Info")]
         public void LogLevelConvertTest(Type type, object expected)
         {
             // Arrange
-            var logLevel = LogLevel.Info;
-
+            IConvertible logLevel = LogLevel.Info;
+            var logConverter = System.ComponentModel.TypeDescriptor.GetConverter(typeof(LogLevel));
+                
             // Act
-            var result = Convert.ChangeType(logLevel, type);
+            var changeTypeResult = Convert.ChangeType(logLevel, type);
+            var changeToResult = logLevel.ToType(type, System.Globalization.CultureInfo.CurrentCulture);
+            var convertToResult = logConverter.CanConvertTo(type) ? logConverter.ConvertTo(logLevel, type) : null;
+            var convertFromResult = logConverter.CanConvertFrom(expected.GetType()) ? logConverter.ConvertFrom(expected) : null;
 
             // Assert
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, changeTypeResult);
+            Assert.Equal(expected, changeToResult);
+            Assert.Equal(expected, convertToResult);
+            Assert.Equal(logLevel, convertFromResult);
         }
     }
 }


### PR DESCRIPTION
Also fixes bug where LogLevel always converts to ordinal. Even when asked for string.

See also: https://www.hanselman.com/blog/TypeConvertersTheresNotEnoughTypeDescripterGetConverterInTheWorld.aspx

Sadly enough it doesn't fully solve this issue:

https://stackoverflow.com/questions/56454590/im-having-problems-deserializing-enumerations

Because Json.Net doesn't make use of TypeConverter when class implements `IConvertible`. Guess there is a price of implementing `IConvertible`-interface for custom objects. One could consider creating a PullRequest for Json.Net to improve support for TypeConverter for classes that implements `IConvertible`. (Probably not a an easy task for an outsider, since by design: https://github.com/JamesNK/Newtonsoft.Json/issues/676 )

https://github.com/JamesNK/Newtonsoft.Json/blob/4ab34b0461fb595805d092a46a58f35f66c84d6a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs#L981 (See comment saying by design)

Alternative one could remove IConvertible-interface from LogLevel-class and only use TypeConverter-attribute.

Alternative one could change IConvertible-interface to return TypeCode.String for LogLevel. But it will probably have even more side-effects.

Alternative one could change LogLevel into an enum, instead of having it as class.