### PR TITLE
FileTarget - improvements when ConcurrentWrites=false + Extra test MessageTemplate.Render

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
@@ -71,7 +71,7 @@ namespace NLog.Internal.FileAppenders
         protected BaseMutexFileAppender(string fileName, ICreateFileParameters createParameters)
             : base(fileName, createParameters)
         {
-            if (createParameters.IsArchivingEnabled)
+            if (createParameters.IsArchivingEnabled && createParameters.ConcurrentWrites)
             {
                 if (PlatformDetector.SupportsSharableMutex)
                 {

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -134,7 +134,7 @@ namespace NLog.Targets
         /// </summary>
         private string _previousLogFileName;
 
-        private bool? _concurrentWrites;
+        private bool _concurrentWrites;
         private bool _keepFileOpen;
         private bool _cleanupFileName;
         private FilePathKind _fileNameKind;
@@ -437,14 +437,7 @@ namespace NLog.Targets
         [DefaultValue(true)]
         public bool ConcurrentWrites
         {
-            get
-            {
-#if SupportsMutex
-                return _concurrentWrites ?? PlatformDetector.SupportsSharableMutex;
-#else
-                return _concurrentWrites ?? false;  // Better user experience for mobile platforms
-#endif
-            }
+            get => _concurrentWrites;
             set
             {
                 if (_concurrentWrites != value)
@@ -1370,7 +1363,7 @@ namespace NLog.Targets
                 if (!EnableFileDelete && KeepFileOpen)
                     throw;  // No need to retry when file delete has been disabled
 
-                if (!PlatformDetector.SupportsSharableMutex)
+                if (ConcurrentWrites && !PlatformDetector.SupportsSharableMutex)
                     throw;  // No need to retry when not having a real archive mutex to protect us
 
                 // It is possible to move a file while other processes has open file-handles.

--- a/tests/NLog.UnitTests/MessageTemplates/RendererTests.cs
+++ b/tests/NLog.UnitTests/MessageTemplates/RendererTests.cs
@@ -77,6 +77,7 @@ namespace NLog.UnitTests.MessageTemplates
         [InlineData("Always use the correct {enum:D}", new object[] { NLog.Config.ExceptionRenderingFormat.Method }, "Always use the correct 4")]
         [InlineData("hello {0,-10}", new object[] { null }, "hello NULL      ")]
         [InlineData("hello {0,10}", new object[] { null }, "hello       NULL")]
+        [InlineData("Status [0x{status:X8}]", new object[] { 16 }, "Status [0x00000010]")]
         public void RenderTest(string input, object[] args, string expected)
         {
             var culture = CultureInfo.InvariantCulture;


### PR DESCRIPTION
- Skips creation of archive mutex when ConcurrentWrites=false
- Skips call to PlatformDetector.SupportsSharableMutex when ConcurrentWrites=false

This is for NLog 4.6.6 No breaking changes. Just better compatibility when explicit specifying `ConcurrentWrites=false`