### PR TITLE
Supporting contruction of  XmlLoggingConfiguration from XmlReader

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -115,6 +115,18 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="XmlLoggingConfiguration" /> class.
+        /// </summary>
+        /// <param name="reader">XML reader to read from.</param>
+        /// <param name="ignoreErrors">Ignore any errors during configuration.</param>
+        /// <param name="logFactory">The <see cref="LogFactory" /> to which to apply any applicable configuration values.</param>
+        public XmlLoggingConfiguration(XmlReader reader, bool ignoreErrors, LogFactory logFactory)
+            : base(logFactory)
+        {
+            Initialize(reader, null, ignoreErrors);
+        }
+
+        /// <summary>
         /// Create XML reader for (xml config) file.
         /// </summary>
         /// <param name="fileName">filepath</param>

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -118,13 +118,8 @@ namespace NLog.Config
         /// Initializes a new instance of the <see cref="XmlLoggingConfiguration" /> class.
         /// </summary>
         /// <param name="reader">XML reader to read from.</param>
-        /// <param name="ignoreErrors">Ignore any errors during configuration.</param>
-        /// <param name="logFactory">The <see cref="LogFactory" /> to which to apply any applicable configuration values.</param>
-        public XmlLoggingConfiguration(XmlReader reader, bool ignoreErrors, LogFactory logFactory)
-            : base(logFactory)
-        {
-            Initialize(reader, null, ignoreErrors);
-        }
+        public XmlLoggingConfiguration(XmlReader reader)             
+            : this(reader, null) {  }
 
         /// <summary>
         /// Create XML reader for (xml config) file.


### PR DESCRIPTION
### Motivation

Every c-tor of `XmlLoggingConfiguration` accepts path. In other words, the `XmlLoggingConfiguration` only supports initialization from files. However, the XML configuration may reside in any place other than a file e.g. memory, network stream, a document data store etc.

### Solution
Introduce `public XmlLoggingConfiguration(XmlReader reader` constructor.