### PR TITLE
AutoFlushTargetWrapper - Added FlushOnConditionOnly property

### DIFF
--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -187,7 +187,14 @@ namespace NLog.Targets.Wrappers
                 _flushTimer = null;
                 if (currentTimer.WaitForDispose(TimeSpan.FromSeconds(1)))
                 {
-                    WriteEventsInBuffer("Closing Target");
+                    if (OverflowAction == BufferingTargetWrapperOverflowAction.Discard)
+                    {
+                        _buffer.GetEventsAndClear();
+                    }
+                    else
+                    {
+                        WriteEventsInBuffer("Closing Target");
+                    }
                 }
             }
 

--- a/tests/NLog.UnitTests/Targets/Wrappers/AutoFlushTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AutoFlushTargetWrapperTests.cs
@@ -269,7 +269,37 @@ namespace NLog.UnitTests.Targets.Wrappers
             autoFlushOnLevelWrapper.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Fatal, "*", "test").WithContinuation(continuation));
             Assert.Equal(2, testTarget.WriteCount);
             Assert.Equal(1, testTarget.FlushCount);
-            autoFlushOnLevelWrapper.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Trace, "*", "Please FlushThis").WithContinuation(continuation));
+            autoFlushOnLevelWrapper.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Trace, "*", "Please do not FlushThis").WithContinuation(continuation));
+            Assert.Equal(2, testTarget.WriteCount);
+            Assert.Equal(1, testTarget.FlushCount);
+            autoFlushOnLevelWrapper.Flush(continuation);
+            Assert.Equal(3, testTarget.WriteCount);
+            Assert.Equal(2, testTarget.FlushCount);
+        }
+
+        [Fact]
+        public void IgnoreExplicitAutoFlushWrapperTest()
+        {
+            var testTarget = new MyTarget();
+            var bufferingTargetWrapper = new BufferingTargetWrapper(testTarget, 100);
+            var autoFlushOnLevelWrapper = new AutoFlushTargetWrapper(bufferingTargetWrapper);
+            autoFlushOnLevelWrapper.Condition = "level > LogLevel.Info";
+            autoFlushOnLevelWrapper.FlushOnConditionOnly = true;
+            testTarget.Initialize(null);
+            bufferingTargetWrapper.Initialize(null);
+            autoFlushOnLevelWrapper.Initialize(null);
+
+            AsyncContinuation continuation = ex => { };
+            autoFlushOnLevelWrapper.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Trace, "*", "test").WithContinuation(continuation));
+            Assert.Equal(0, testTarget.WriteCount);
+            Assert.Equal(0, testTarget.FlushCount);
+            autoFlushOnLevelWrapper.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Fatal, "*", "test").WithContinuation(continuation));
+            Assert.Equal(2, testTarget.WriteCount);
+            Assert.Equal(1, testTarget.FlushCount);
+            autoFlushOnLevelWrapper.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Trace, "*", "Please do not FlushThis").WithContinuation(continuation));
+            Assert.Equal(2, testTarget.WriteCount);
+            Assert.Equal(1, testTarget.FlushCount);
+            autoFlushOnLevelWrapper.Flush(continuation);
             Assert.Equal(2, testTarget.WriteCount);
             Assert.Equal(1, testTarget.FlushCount);
         }

--- a/tests/NLog.UnitTests/Targets/Wrappers/BufferingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/BufferingTargetWrapperTests.cs
@@ -582,6 +582,14 @@ namespace NLog.UnitTests.Targets.Wrappers
             Assert.Equal(bufferSize, myTarget.WriteCount);
             Assert.Equal(1, myTarget.BufferedWriteCount);
             Assert.Equal(bufferSize, myTarget.BufferedTotalEvents);
+
+            // Make sure that events are discarded when closing target (config-reload + shutdown)
+            targetWrapper.WriteAsyncLogEvent(new LogEventInfo().WithContinuation(createAsyncContinuation(totalEvents)));
+            targetWrapper.Close();
+            Assert.Equal(bufferSize, hitCount);
+            Assert.Equal(bufferSize, myTarget.WriteCount);
+            Assert.Equal(1, myTarget.BufferedWriteCount);
+            Assert.Equal(bufferSize, myTarget.BufferedTotalEvents);
         }
 
         private static void InitializeTargets(params Target[] targets)


### PR DESCRIPTION
Skips flush on reload-config and application-shutdown. Resolve #3512 

To be used in combination with BufferingWrapper and `overflowAction=Discard`