### PR TITLE
Added ${object-path} / ${exception:objectpath=PropertyName}, for rendering a property of an object (e.g. an exception)

### DIFF
--- a/src/NLog/Internal/ObjectPropertyHelper.cs
+++ b/src/NLog/Internal/ObjectPropertyHelper.cs
@@ -1,0 +1,95 @@
+// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal
+{
+    /// <summary>
+    /// Helper for extracting propertyPath
+    /// </summary>
+    internal class ObjectPropertyHelper
+    {
+        private string[] _objectPropertyPath;
+        private ObjectReflectionCache _objectReflectionCache;
+        private ObjectReflectionCache ObjectReflectionCache => _objectReflectionCache ?? (_objectReflectionCache = new ObjectReflectionCache());
+
+        /// <summary>
+        /// Object Path to check
+        /// </summary>
+        public string ObjectPath
+        {
+            get => _objectPropertyPath?.Length > 0 ? string.Join(".", _objectPropertyPath) : null;
+            set => _objectPropertyPath = StringHelpers.IsNullOrWhiteSpace(value) ? null : value.SplitAndTrimTokens('.');
+        }
+
+        /// <summary>
+        /// Try get value from <paramref name="value"/>, using <see cref="ObjectPath"/>, and set into <paramref name="foundValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="foundValue"></param>
+        /// <returns></returns>
+        public bool TryGetObjectProperty(object value, out object foundValue)
+        {
+            foundValue = null;
+
+            if (_objectPropertyPath == null)
+            {
+                return false;
+            }
+
+            var objectReflectionCache = ObjectReflectionCache;
+            for (int i = 0; i < _objectPropertyPath.Length; ++i)
+            {
+                if (value == null)
+                {
+                    // Found null
+                    foundValue = null;
+                    return true;
+                }
+
+                var eventProperties = objectReflectionCache.LookupObjectProperties(value);
+                if (eventProperties.TryGetPropertyValue(_objectPropertyPath[i], out var propertyValue))
+                {
+                    value = propertyValue.Value;
+                }
+                else
+                {
+                    foundValue = null;
+                    return false; //Wrong, but done
+                }
+            }
+
+            foundValue = value;
+            return true;
+        }
+    }
+}

--- a/src/NLog/LayoutRenderers/Wrappers/ObjectPathRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ObjectPathRendererWrapper.cs
@@ -44,12 +44,15 @@ namespace NLog.LayoutRenderers.Wrappers
     /// <summary>
     /// Render a single property of a object
     /// </summary>
-    [LayoutRenderer("Object-path")]
-    [AmbientProperty("object-path")]
+    [LayoutRenderer("Object-Path")]
+    [AmbientProperty(nameof(ObjectPath))]
     [ThreadSafe]
+    [ThreadAgnostic]
     public class ObjectPathRendererWrapper : WrapperLayoutRendererBase, IRawValue
     {
         private readonly ObjectPropertyHelper _objectPropertyHelper = new ObjectPropertyHelper();
+
+        private SimpleLayout _innerAsSimple;
 
         /// <inheritdoc />
         public ObjectPathRendererWrapper()
@@ -58,23 +61,22 @@ namespace NLog.LayoutRenderers.Wrappers
             UpdateInner();
         }
 
-        private void ObjectPathRendererWrapper_InnerChanged(object sender, EventArgs e)
+        /// <summary>
+        /// Gets or sets the object-property-navigation-path for lookup of nested property
+        ///
+        /// Shortcut for <see cref="ObjectPath"/>
+        /// </summary>
+        public string Path
         {
-            UpdateInner();
+            get => ObjectPath;
+            set => ObjectPath = value;
         }
-
-        private void UpdateInner()
-        {
-            _innerAsSimple = Inner as SimpleLayout;
-        }
-
-        private SimpleLayout _innerAsSimple;
 
         /// <summary>
         /// Gets or sets the object-property-navigation-path for lookup of nested property
         /// </summary>
         /// <docgen category='Rendering Options' order='20' />
-        public string Path
+        public string ObjectPath
         {
             get => _objectPropertyHelper.ObjectPath;
             set => _objectPropertyHelper.ObjectPath = value;
@@ -136,5 +138,15 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         #endregion
+
+        private void ObjectPathRendererWrapper_InnerChanged(object sender, EventArgs e)
+        {
+            UpdateInner();
+        }
+
+        private void UpdateInner()
+        {
+            _innerAsSimple = Inner as SimpleLayout;
+        }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/ObjectPathRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ObjectPathRendererWrapper.cs
@@ -1,0 +1,140 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using NLog.Config;
+using NLog.Internal;
+using NLog.Layouts;
+
+namespace NLog.LayoutRenderers.Wrappers
+{
+    /// <summary>
+    /// Render a single property of a object
+    /// </summary>
+    [LayoutRenderer("Object-path")]
+    [AmbientProperty("object-path")]
+    [ThreadSafe]
+    public class ObjectPathRendererWrapper : WrapperLayoutRendererBase, IRawValue
+    {
+        private readonly ObjectPropertyHelper _objectPropertyHelper = new ObjectPropertyHelper();
+
+        /// <inheritdoc />
+        public ObjectPathRendererWrapper()
+        {
+            InnerChanged += ObjectPathRendererWrapper_InnerChanged;
+            UpdateInner();
+        }
+
+        private void ObjectPathRendererWrapper_InnerChanged(object sender, EventArgs e)
+        {
+            UpdateInner();
+        }
+
+        private void UpdateInner()
+        {
+            _innerAsSimple = Inner as SimpleLayout;
+        }
+
+        private SimpleLayout _innerAsSimple;
+
+        /// <summary>
+        /// Gets or sets the object-property-navigation-path for lookup of nested property
+        /// </summary>
+        /// <docgen category='Rendering Options' order='20' />
+        public string Path
+        {
+            get => _objectPropertyHelper.ObjectPath;
+            set => _objectPropertyHelper.ObjectPath = value;
+        }
+
+        /// <summary>
+        /// Format string for conversion from object to string.
+        /// </summary>
+        /// <docgen category='Rendering Options' order='50' />
+        public string Format { get; set; }
+
+        /// <summary>
+        /// Gets or sets the culture used for rendering. 
+        /// </summary>
+        /// <docgen category='Rendering Options' order='100' />
+        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+
+        #region Overrides of WrapperLayoutRendererBase
+
+        /// <inheritdoc />
+        protected override string Transform(string text)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc />
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
+        {
+            if (_innerAsSimple != null)
+            {
+                if (TryGetRawValue(logEvent, out object rawValue))
+                {
+                    var formatProvider = GetFormatProvider(logEvent, Culture);
+                    builder.AppendFormattedValue(rawValue, Format, formatProvider);
+                }
+            }
+            else
+            {
+                Inner?.RenderAppendBuilder(logEvent, builder);
+            }
+        }
+
+        #endregion
+
+        #region Implementation of IRawValue
+
+        /// <inheritdoc />
+        public bool TryGetRawValue(LogEventInfo logEvent, out object value)
+        {
+            if (_innerAsSimple != null &&
+                _innerAsSimple.TryGetRawValue(logEvent, out var rawValue) &&
+                _objectPropertyHelper.TryGetObjectProperty(rawValue, out value))
+            {
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        #endregion
+    }
+}

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBase.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System;
+
 namespace NLog.LayoutRenderers.Wrappers
 {
     using System.Text;
@@ -49,6 +51,8 @@ namespace NLog.LayoutRenderers.Wrappers
     /// </example>
     public abstract class WrapperLayoutRendererBase : LayoutRenderer
     {
+        private Layout _inner;
+
         /// <summary>
         /// Gets or sets the wrapped layout.
         /// 
@@ -56,7 +60,23 @@ namespace NLog.LayoutRenderers.Wrappers
         /// </summary>
         /// <docgen category='Transformation Options' order='10' />
         [DefaultParameter]
-        public Layout Inner { get; set; }
+        public Layout Inner
+        {
+            get => _inner;
+            set
+            {
+                var changed = !ReferenceEquals(_inner, value);
+                _inner = value;
+
+                if (changed)
+                    InnerChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Notify when <see cref="Inner"/> has been changed
+        /// </summary>
+        protected event EventHandler InnerChanged;
 
         /// <inheritdoc/>
         protected override void InitializeLayoutRenderer()

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBase.cs
@@ -76,7 +76,8 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <summary>
         /// Notify when <see cref="Inner"/> has been changed
         /// </summary>
-        protected event EventHandler InnerChanged;
+        /// <remarks>Change to private protected in C# 7.3</remarks>
+        internal event EventHandler InnerChanged;
 
         /// <inheritdoc/>
         protected override void InitializeLayoutRenderer()

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ObjectPathRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ObjectPathRendererWrapperTests.cs
@@ -1,0 +1,103 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using NLog.Layouts;
+using Xunit;
+
+namespace NLog.UnitTests.LayoutRenderers.Wrappers
+{
+    public class ObjectPathRendererWrapperTests
+    {
+        [Theory]
+        [InlineData("${object-path:${exception}:path=ParamName}")]
+        [InlineData("${exception:object-path=ParamName}")]
+        public void RenderPropertyOfException(string layout)
+        {
+            // Arrange
+            var logEvent1 = new LogEventInfo
+            {
+                Exception = new ArgumentException("ArgumentException with param name", "MyParam")
+            };
+            var logEvent = logEvent1;
+            Layout l = layout;
+
+            // Act
+            var result = l.Render(logEvent);
+
+            // Assert
+            Assert.Equal("MyParam", result);
+        }
+
+        [Theory]
+        [InlineData(null, "5000")]
+        [InlineData("N2", "5.000,00")]
+        public void RenderPropertyOfExceptionWithFormat(string format, string expected)
+        {
+            // Arrange
+            var logEvent = new LogEventInfo
+            {
+                Exception = new ExternalException("Exception with errorCode", 5000),
+            };
+            Layout l = "${object-path:${exception}:path=HResult:Culture=NL-nl:format=" + format + "}";
+
+            // Act
+            var result = l.Render(logEvent);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("HResult", 5000, true)]
+        [InlineData("hResult", null, false)] // path is case sensitive
+        public void RenderPropertyOfExceptionRawValue(string path, int? expectedInt, bool expectedResult)
+        {
+            // Arrange
+            var logEvent = new LogEventInfo
+            {
+                Exception = new ExternalException("Exception with errorCode", 5000),
+            };
+            Layout l = "${object-path:${exception}:path=" + path + "}";
+
+            // Act
+            var result = l.TryGetRawValue(logEvent, out var rawValue);
+
+            // Assert
+            Assert.Equal(expectedInt, rawValue);
+            Assert.Equal(expectedResult, result);
+        }
+    }
+}

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ObjectPathRendererWrapperTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ObjectPathRendererWrapperTests.cs
@@ -43,7 +43,7 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
     {
         [Theory]
         [InlineData("${object-path:${exception}:path=ParamName}")]
-        [InlineData("${exception:object-path=ParamName}")]
+        [InlineData("${exception:objectpath=ParamName}")]
         public void RenderPropertyOfException(string layout)
         {
             // Arrange


### PR DESCRIPTION
Examples:

```
${object-path:${exception}:path=PropertyName}
${exception:objectpath=PropertyName}
```