### PR TITLE
MessageTemplateParameters - Improve validation of parameters when isPositional

### DIFF
--- a/src/NLog/MessageTemplates/MessageTemplateParameters.cs
+++ b/src/NLog/MessageTemplates/MessageTemplateParameters.cs
@@ -125,11 +125,11 @@ namespace NLog.MessageTemplates
                         var hole = templateEnumerator.Current.Hole;
                         if (hole.Index != -1 && isPositional)
                         {
-                            holeIndex++;
+                            holeIndex = GetMaxHoleIndex(holeIndex, hole.Index);
                             var value = GetHoleValueSafe(parameters, hole.Index, ref isValidTemplate);
                             templateParameters.Add(new MessageTemplateParameter(hole.Name, value, hole.Format, hole.CaptureType));
                         }
-                        else 
+                        else
                         {
                             if (isPositional)
                             {
@@ -151,9 +151,19 @@ namespace NLog.MessageTemplates
                     }
                 }
 
-                if (templateParameters.Count != parameters.Length)
+                if (isPositional)
                 {
-                    isValidTemplate = false;
+                    if (templateParameters.Count < parameters.Length || holeIndex != parameters.Length)
+                    {
+                        isValidTemplate = false;
+                    }
+                }
+                else
+                {
+                    if (templateParameters.Count != parameters.Length)
+                    {
+                        isValidTemplate = false;
+                    }
                 }
 
                 return templateParameters;
@@ -164,6 +174,18 @@ namespace NLog.MessageTemplates
                 InternalLogger.Warn(ex, "Error when parsing a message.");
                 return templateParameters;
             }
+        }
+
+        private static short GetMaxHoleIndex(short maxHoleIndex, short holeIndex)
+        {
+            if (maxHoleIndex == 0)
+                maxHoleIndex++;
+            if (maxHoleIndex <= holeIndex)
+            {
+                maxHoleIndex = holeIndex;
+                maxHoleIndex++;
+            }
+            return maxHoleIndex;
         }
 
         private static object GetHoleValueSafe(object[] parameters, short holeIndex, ref bool isValidTemplate)
@@ -177,4 +199,3 @@ namespace NLog.MessageTemplates
         }
     }
 }
-

--- a/tests/NLog.UnitTests/MessageTemplates/MessageTemplateParametersTests.cs
+++ b/tests/NLog.UnitTests/MessageTemplates/MessageTemplateParametersTests.cs
@@ -118,6 +118,46 @@ namespace NLog.UnitTests.MessageTemplates
             Assert.Equal(names, resultNames);
         }
 
+        [Theory]
+        [InlineData("", 0, true)] //empty OK
+        [InlineData("  ", 0, true)] //empty OK
+        [InlineData("", 1, false)]
+        [InlineData("{0}", 1, true)]
+        [InlineData("{A}", 1, true)]
+        //[InlineData("{A}", 0, false)]
+        [InlineData("{A}", 2, false)]
+        [InlineData("{ 0}", 1, true)]
+        //[InlineData("{0} {1}", 0, false)]
+        [InlineData("{0} {1}", 1, false)]
+        [InlineData("{0} {1}", 2, true)]
+        //[InlineData("{0} {A}", 0, false)]
+        [InlineData("{0} {A}", 1, false)]
+        [InlineData("{0} {A}", 2, true)]
+        //[InlineData("{A} {1}", 0, false)]
+        [InlineData("{A} {1}", 1, false)]
+        [InlineData("{A} {1}", 2, true)]
+        //[InlineData("{A} {B}", 0, false)]
+        [InlineData("{A} {B}", 1, false)]
+        [InlineData("{A} {B}", 2, true)]
+        //[InlineData("{0} {0}", 0, false)]
+        [InlineData("{0} {0}", 1, true)]
+        [InlineData("{0} {0}", 2, false)]
+        //[InlineData("{A} {A}", 0, false)]
+        [InlineData("{A} {A}", 1, false)]
+        [InlineData("{A} {A}", 2, true)] //overwrite
+        public void IsValidTemplateTest(string input, int parameterCount, bool expected)
+        {
+            // Arrange
+            var parameters = CreateParameters(parameterCount);
+
+            // Act
+            var messageTemplateParameters = new MessageTemplateParameters(input, parameters);
+
+            // Assert
+            Assert.Equal(expected, messageTemplateParameters.IsValidTemplate);
+        }
+
+
         private static object[] CreateParameters(int count)
         {
             var parameters = new List<object>(count);


### PR DESCRIPTION
Fixes these test-cases. See also: #3286

`[InlineData("{0} {0}", 1, true)]`
`[InlineData("{0} {0}", 2, false)]`

Notice merge to master-branch.