### PR TITLE
LoggingRule.SetLoggingLevels() fixed IndexOutOfRangeException when using LogLevel.Off

### DIFF
--- a/src/NLog/Config/LoggingRuleLevelFilter.cs
+++ b/src/NLog/Config/LoggingRuleLevelFilter.cs
@@ -62,7 +62,7 @@ namespace NLog.Config
 
         public LoggingRuleLevelFilter SetLoggingLevels(LogLevel minLevel, LogLevel maxLevel, bool enable)
         {
-            for (int i = minLevel.Ordinal; i <= maxLevel.Ordinal; ++i)
+            for (int i = minLevel.Ordinal; i <= Math.Min(maxLevel.Ordinal, LogLevels.Length - 1); ++i)
                 LogLevels[i] = enable;
             return this;
         }

--- a/tests/NLog.UnitTests/Config/ConfigApiTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigApiTests.cs
@@ -290,6 +290,17 @@ namespace NLog.UnitTests.Config
             Assert.Equal(rule.Levels, new[] { LogLevel.Warn, LogLevel.Error, LogLevel.Fatal });
         }
 
+
+        [Fact]
+        public void LogRuleSetLoggingLevels_off()
+        {
+            var rule = new LoggingRule();
+            rule.EnableLoggingForLevels(LogLevel.MinLevel, LogLevel.MaxLevel);
+
+            rule.SetLoggingLevels(LogLevel.Off, LogLevel.Off);
+            Assert.Equal(rule.Levels, new LogLevel[0]);
+        }
+
         [Fact]
         public void LogRuleDisableLoggingLevels()
         {


### PR DESCRIPTION
Bug introduced with #3184

Note merge to master.