### PR TITLE
(WIP) Adding exclusion list for object serialization.

### DIFF
--- a/src/NLog/Internal/Reflection/ObjectReflectionCache.cs
+++ b/src/NLog/Internal/Reflection/ObjectReflectionCache.cs
@@ -175,7 +175,6 @@ namespace NLog.Internal
             return propertyInfos;
         }
 
-        internal static List<Func<Type, bool>> SerializationExclusionList { get; } = new List<Func<Type, bool>>();
         private static bool ConvertSimpleToString(Type objectType)
         {
             if (typeof(IFormattable).IsAssignableFrom(objectType))
@@ -189,12 +188,6 @@ namespace NLog.Internal
 
             if (typeof(Assembly).IsAssignableFrom(objectType))
                 return true;
-
-            foreach (var exclusionFunc in SerializationExclusionList)
-            {
-                if (exclusionFunc(objectType))
-                    return true;
-            }
 
             return false;
         }

--- a/src/NLog/Internal/Reflection/ObjectReflectionCache.cs
+++ b/src/NLog/Internal/Reflection/ObjectReflectionCache.cs
@@ -175,6 +175,7 @@ namespace NLog.Internal
             return propertyInfos;
         }
 
+        internal static List<Func<Type, bool>> SerializationExclusionList { get; } = new List<Func<Type, bool>>();
         private static bool ConvertSimpleToString(Type objectType)
         {
             if (typeof(IFormattable).IsAssignableFrom(objectType))
@@ -188,6 +189,12 @@ namespace NLog.Internal
 
             if (typeof(Assembly).IsAssignableFrom(objectType))
                 return true;
+
+            foreach (var exclusionFunc in SerializationExclusionList)
+            {
+                if (exclusionFunc(objectType))
+                    return true;
+            }
 
             return false;
         }

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -35,6 +35,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Reflection;
 using System.Text;
 using NLog.Internal;
 
@@ -424,6 +425,11 @@ namespace NLog.Targets
         {
             if (depth < options.MaxRecursionLimit)
             {
+                if (options.SerializationInterceptor != null && options.SerializationInterceptor.GetCustomSerializedValue(value.GetType(), value, out var replacement))
+                {
+                    return SerializeObject(replacement, destination, options, objectsInPath, depth);
+                }
+
                 var objectPropertyList = _objectReflectionCache.LookupObjectProperties(value);
                 if (!objectPropertyList.ConvertToString)
                 {

--- a/src/NLog/Targets/JsonSerializeOptions.cs
+++ b/src/NLog/Targets/JsonSerializeOptions.cs
@@ -33,6 +33,8 @@
 
 using System;
 using System.ComponentModel;
+using System.Reflection;
+using NLog.Targets.SerializationInterceptors;
 
 namespace NLog.Targets
 {
@@ -88,16 +90,25 @@ namespace NLog.Targets
         {
             QuoteKeys = true;
             MaxRecursionLimit = 10;
+
+            SerializeAsToString<Assembly>();
+            SerializeAsToString<MemberInfo>();
+            SerializeAsToString<Uri>();
+            SerializeAsToString<IFormattable>();
         }
 
-        /// <summary>Registers a type<see cref="T:System.Type" /> to be excluded from serialization.</summary>
-        public static void RegisterSerializationExclusion(Type t) => NLog.Internal.ObjectReflectionCache.SerializationExclusionList.Add(x => x == t);
-        /// <summary>Registers a type<see cref="T:System.Type" /> to be excluded from serialization.</summary>
-        public static void RegisterSerializationExclusion<T>() => NLog.Internal.ObjectReflectionCache.SerializationExclusionList.Add(x => x == typeof(T));
-        /// <summary>Registers a custom evaluation function to determine if a given type should be serialized.  If the func returns true, the object's ToString() will be invoked.  If false, the object will be serialized.</summary>
-        public static void RegisterSerializationExclusion(Func<Type, bool> func) => NLog.Internal.ObjectReflectionCache.SerializationExclusionList.Add(func);
-        /// <summary>Resets the list for custom serialization.</summary>
-        public static void ResetSerializationExclusions() => NLog.Internal.ObjectReflectionCache.SerializationExclusionList.Clear();
+        /// <summary>
+        /// The interceptor to be called during the serialization process.
+        /// </summary>
+        internal ISerializationInterceptor SerializationInterceptor { get; private set; } = null;
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        public void SerializeAsToString<T>()
+        {
+            SerializationInterceptor = new ToStringSerializationInterceptor(SerializationInterceptor, typeof(T));
+        }
     }
 }

--- a/src/NLog/Targets/JsonSerializeOptions.cs
+++ b/src/NLog/Targets/JsonSerializeOptions.cs
@@ -89,5 +89,15 @@ namespace NLog.Targets
             QuoteKeys = true;
             MaxRecursionLimit = 10;
         }
+
+        /// <summary>Registers a type<see cref="T:System.Type" /> to be excluded from serialization.</summary>
+        public static void RegisterSerializationExclusion(Type t) => NLog.Internal.ObjectReflectionCache.SerializationExclusionList.Add(x => x == t);
+        /// <summary>Registers a type<see cref="T:System.Type" /> to be excluded from serialization.</summary>
+        public static void RegisterSerializationExclusion<T>() => NLog.Internal.ObjectReflectionCache.SerializationExclusionList.Add(x => x == typeof(T));
+        /// <summary>Registers a custom evaluation function to determine if a given type should be serialized.  If the func returns true, the object's ToString() will be invoked.  If false, the object will be serialized.</summary>
+        public static void RegisterSerializationExclusion(Func<Type, bool> func) => NLog.Internal.ObjectReflectionCache.SerializationExclusionList.Add(func);
+        /// <summary>Resets the list for custom serialization.</summary>
+        public static void ResetSerializationExclusions() => NLog.Internal.ObjectReflectionCache.SerializationExclusionList.Clear();
+
     }
 }

--- a/src/NLog/Targets/SerializationInterceptors/Extensions.cs
+++ b/src/NLog/Targets/SerializationInterceptors/Extensions.cs
@@ -1,0 +1,38 @@
+// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+
+namespace NLog.Targets.SerializationInterceptors
+{
+}

--- a/src/NLog/Targets/SerializationInterceptors/ISerializationInterceptor.cs
+++ b/src/NLog/Targets/SerializationInterceptors/ISerializationInterceptor.cs
@@ -1,0 +1,53 @@
+// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+
+namespace NLog.Targets.SerializationInterceptors
+{
+    /// <summary>
+    /// An interface that can intercept objects during serialization.
+    /// </summary>
+    public interface ISerializationInterceptor
+    {
+        /// <summary>
+        /// The interception method.
+        /// </summary>
+        /// <param name="type">The type of the value being serialized.</param>
+        /// <param name="value">The object being serialized.</param>
+        /// <param name="replacementValue">An out parameter, the modified value to be serialized after interception.</param>
+        /// <returns></returns>
+        bool GetCustomSerializedValue(Type type, object value, out object replacementValue);
+    }
+
+}

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerClassTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerClassTests.cs
@@ -1,0 +1,117 @@
+// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System.Text;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.UnitTests.Targets
+{
+    /// <summary>
+    ///     Test via <see cref="IJsonConverter" /> path
+    /// </summary>
+    public class DefaultJsonSerializerClassTests : NLogTestBase
+    {
+        private static readonly object _testSyncObject = new object();
+
+        private class ExcludedClass
+        {
+            public string ExcludedString { get; set; }
+        }
+
+        private class IncludedClass
+        {
+            public string IncludedString { get; set; }
+        }
+
+        private class ContainerClass
+        {
+            public string S { get; set; }
+            public ExcludedClass Excluded { get; set; }
+            public IncludedClass Included { get; set; }
+        }
+
+        private static ContainerClass BuildSampleObject()
+        {
+            var testObject = new ContainerClass
+            {
+                S = "sample",
+                Excluded = new ExcludedClass {ExcludedString = "shouldn't be serialized"},
+                Included = new IncludedClass {IncludedString = "serialized"}
+            };
+            return testObject;
+        }
+
+        [Fact]
+        public void ExcludedClassSerializer_RegisterSerializationExclusionByFunc_DoesNotSerializeForTrue()
+        {
+            var testObject = BuildSampleObject();
+
+            var sb = new StringBuilder();
+            JsonSerializeOptions.ResetSerializationExclusions();
+            JsonSerializeOptions.RegisterSerializationExclusion(t => t.Name == nameof(ExcludedClass));
+            DefaultJsonSerializer.Instance.SerializeObject(testObject, sb);
+            const string expectedValue =
+                @"{""S"":""sample"", ""Excluded"":""NLog.UnitTests.Targets.DefaultJsonSerializerClassTests+ExcludedClass"", ""Included"":{""IncludedString"":""serialized""}}";
+            Assert.Equal(expectedValue, sb.ToString());
+        }
+
+        [Fact]
+        public void ExcludedClassSerializer_RegisterSerializationExclusionByGeneric_DoesNotSerializeType()
+        {
+            var testObject = BuildSampleObject();
+
+            var sb = new StringBuilder();
+            JsonSerializeOptions.ResetSerializationExclusions();
+            JsonSerializeOptions.RegisterSerializationExclusion<ExcludedClass>();
+            DefaultJsonSerializer.Instance.SerializeObject(testObject, sb);
+            const string expectedValue =
+                @"{""S"":""sample"", ""Excluded"":""NLog.UnitTests.Targets.DefaultJsonSerializerClassTests+ExcludedClass"", ""Included"":{""IncludedString"":""serialized""}}";
+            Assert.Equal(expectedValue, sb.ToString());
+        }
+
+        [Fact]
+        public void ExcludedClassSerializer_RegisterSerializationExclusionByType_DoesNotSerializeType()
+        {
+            var testObject = BuildSampleObject();
+
+            var sb = new StringBuilder();
+            JsonSerializeOptions.ResetSerializationExclusions();
+            JsonSerializeOptions.RegisterSerializationExclusion(typeof(ExcludedClass));
+            DefaultJsonSerializer.Instance.SerializeObject(testObject, sb);
+            const string expectedValue =
+                @"{""S"":""sample"", ""Excluded"":""NLog.UnitTests.Targets.DefaultJsonSerializerClassTests+ExcludedClass"", ""Included"":{""IncludedString"":""serialized""}}";
+            Assert.Equal(expectedValue, sb.ToString());
+        }
+    }
+}


### PR DESCRIPTION
This is an PR with an attempt to implement the suggestion raised in #3588.  

Based on the suggestion in the Issue, I implemented a mechanism in the `ObjectReflectionCache` for excluding types based on a type argument, a generic type, or a function to evaluate based on other mechanisms (Namespace, Assembly, etc)

To provide an initial solution, I just added some static methods at the end of the `JsonSerializationOptions` class.  I don't think they belong there, but I could not find a better class and I assumed that making the `ObjectReflectionCache` public would be a bad idea.  If there's no other options, a singleton class might be a long term option.  A singleton with some testing seams may also help address 'To Do' item no. 2 below.

## To Do
- [x] Find permanent home for the configuration methods.
- [x] There is the potential of some concurrency issues in the unit tests due to the static configuration.
- [ ] Address any changes raised in the pull request.