### PR TITLE
ObjectReflectionCache extended to allow override of object reflection

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -31,15 +31,14 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.IO;
-using System.Linq;
-using NLog.Common;
-
 namespace NLog.Config
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
     using System.Reflection;
+    using NLog.Common;
     using NLog.Conditions;
     using NLog.Filters;
     using NLog.Internal;
@@ -67,6 +66,7 @@ namespace NLog.Config
         private readonly Factory<TimeSource, TimeSourceAttribute> _timeSources;
 
         private IJsonConverter _jsonSerializer = DefaultJsonSerializer.Instance;
+        private IObjectTypeTransformer _objectTypeTransformer = ObjectReflectionCache.Instance;
 
         /// <summary>
         /// Called before the assembly will be loaded.
@@ -191,6 +191,15 @@ namespace NLog.Config
         {
             get => MessageTemplates.ValueFormatter.Instance;
             set => MessageTemplates.ValueFormatter.Instance = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the custom object-type transformation for use in <see cref="JsonLayout"/>, <see cref="XmlLayout"/> or <see cref="NLog.LayoutRenderers.Wrappers.ObjectPathRendererWrapper"/>
+        /// </summary>
+        internal IObjectTypeTransformer ObjectTypeTransformer
+        {
+            get => _objectTypeTransformer;
+            set => _objectTypeTransformer = value ?? ObjectReflectionCache.Instance;
         }
 
         /// <summary>

--- a/src/NLog/Config/ISetupSerializationBuilder.cs
+++ b/src/NLog/Config/ISetupSerializationBuilder.cs
@@ -31,42 +31,16 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog
+namespace NLog.Config
 {
-    using System;
-    using NLog.Config;
-    using NLog.Internal;
-
     /// <summary>
-    /// Extension methods to setup LogFactory options
+    /// Interface for fluent setup of LogFactory options for logevent serialization
     /// </summary>
-    public static class SetupBuilderExtensions
+    public interface ISetupSerializationBuilder
     {
         /// <summary>
-        /// Configures loading of NLog extensions for Targets and LayoutRenderers
+        /// LogFactory under configuration
         /// </summary>
-        public static ISetupBuilder SetupExtensions(this ISetupBuilder setupBuilder, Action<ISetupExtensionsBuilder> extensionsBuilder)
-        {
-            extensionsBuilder(new SetupExtensionsBuilder(setupBuilder.LogFactory));
-            return setupBuilder;
-        }
-
-        /// <summary>
-        /// Configures the output of NLog <see cref="Common.InternalLogger"/> for diagnostics / troubleshooting
-        /// </summary>
-        public static ISetupBuilder SetupInternalLogger(this ISetupBuilder setupBuilder, Action<ISetupInternalLoggerBuilder> internalLoggerBuilder)
-        {
-            internalLoggerBuilder(new SetupInternalLoggerBuilder(setupBuilder.LogFactory));
-            return setupBuilder;
-        }
-
-        /// <summary>
-        /// Configures serialization and transformation of LogEvents
-        /// </summary>
-        public static ISetupBuilder SetupSerialization(this ISetupBuilder setupBuilder, Action<ISetupSerializationBuilder> serializationBuilder)
-        {
-            serializationBuilder(new SetupSerializationBuilder(setupBuilder.LogFactory));
-            return setupBuilder;
-        }
+        LogFactory LogFactory { get; }
     }
 }

--- a/src/NLog/IObjectTypeTransformer.cs
+++ b/src/NLog/IObjectTypeTransformer.cs
@@ -33,40 +33,17 @@
 
 namespace NLog
 {
-    using System;
-    using NLog.Config;
-    using NLog.Internal;
-
     /// <summary>
-    /// Extension methods to setup LogFactory options
+    /// Interface for handling object transformation
     /// </summary>
-    public static class SetupBuilderExtensions
+    internal interface IObjectTypeTransformer
     {
         /// <summary>
-        /// Configures loading of NLog extensions for Targets and LayoutRenderers
+        /// Takes a dangerous (or massive) object and converts into a safe (or reduced) object
         /// </summary>
-        public static ISetupBuilder SetupExtensions(this ISetupBuilder setupBuilder, Action<ISetupExtensionsBuilder> extensionsBuilder)
-        {
-            extensionsBuilder(new SetupExtensionsBuilder(setupBuilder.LogFactory));
-            return setupBuilder;
-        }
-
-        /// <summary>
-        /// Configures the output of NLog <see cref="Common.InternalLogger"/> for diagnostics / troubleshooting
-        /// </summary>
-        public static ISetupBuilder SetupInternalLogger(this ISetupBuilder setupBuilder, Action<ISetupInternalLoggerBuilder> internalLoggerBuilder)
-        {
-            internalLoggerBuilder(new SetupInternalLoggerBuilder(setupBuilder.LogFactory));
-            return setupBuilder;
-        }
-
-        /// <summary>
-        /// Configures serialization and transformation of LogEvents
-        /// </summary>
-        public static ISetupBuilder SetupSerialization(this ISetupBuilder setupBuilder, Action<ISetupSerializationBuilder> serializationBuilder)
-        {
-            serializationBuilder(new SetupSerializationBuilder(setupBuilder.LogFactory));
-            return setupBuilder;
-        }
+        /// <returns>
+        /// Null if unknown object, or object cannot be handled
+        /// </returns>
+        object TryTransformObject(object obj);
     }
 }

--- a/src/NLog/Internal/SetupSerializationBuilder.cs
+++ b/src/NLog/Internal/SetupSerializationBuilder.cs
@@ -31,42 +31,17 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog
+namespace NLog.Internal
 {
-    using System;
     using NLog.Config;
-    using NLog.Internal;
 
-    /// <summary>
-    /// Extension methods to setup LogFactory options
-    /// </summary>
-    public static class SetupBuilderExtensions
+    internal class SetupSerializationBuilder : ISetupSerializationBuilder
     {
-        /// <summary>
-        /// Configures loading of NLog extensions for Targets and LayoutRenderers
-        /// </summary>
-        public static ISetupBuilder SetupExtensions(this ISetupBuilder setupBuilder, Action<ISetupExtensionsBuilder> extensionsBuilder)
+        internal SetupSerializationBuilder(LogFactory logFactory)
         {
-            extensionsBuilder(new SetupExtensionsBuilder(setupBuilder.LogFactory));
-            return setupBuilder;
+            LogFactory = logFactory;
         }
 
-        /// <summary>
-        /// Configures the output of NLog <see cref="Common.InternalLogger"/> for diagnostics / troubleshooting
-        /// </summary>
-        public static ISetupBuilder SetupInternalLogger(this ISetupBuilder setupBuilder, Action<ISetupInternalLoggerBuilder> internalLoggerBuilder)
-        {
-            internalLoggerBuilder(new SetupInternalLoggerBuilder(setupBuilder.LogFactory));
-            return setupBuilder;
-        }
-
-        /// <summary>
-        /// Configures serialization and transformation of LogEvents
-        /// </summary>
-        public static ISetupBuilder SetupSerialization(this ISetupBuilder setupBuilder, Action<ISetupSerializationBuilder> serializationBuilder)
-        {
-            serializationBuilder(new SetupSerializationBuilder(setupBuilder.LogFactory));
-            return setupBuilder;
-        }
+        public LogFactory LogFactory { get; }
     }
 }

--- a/src/NLog/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog/SetupExtensionsBuilderExtensions.cs
@@ -51,106 +51,106 @@ namespace NLog
         /// <remarks>
         /// Enabled by default, and gives a huge performance hit during startup. Recommended to disable this when running in the cloud.
         /// </remarks>
-        public static ISetupExtensionsBuilder AutoLoadAssemblies(this ISetupExtensionsBuilder extensionsBuilder, bool enable)
+        public static ISetupExtensionsBuilder AutoLoadAssemblies(this ISetupExtensionsBuilder setupBuilder, bool enable)
         {
             ConfigurationItemFactory.Default = enable ? null : new ConfigurationItemFactory(typeof(SetupBuilderExtensions).GetAssembly());
-            return extensionsBuilder;
+            return setupBuilder;
         }
 
         /// <summary>
         /// Registers NLog extensions from the assembly.
         /// </summary>
-        public static ISetupExtensionsBuilder RegisterAssembly(this ISetupExtensionsBuilder extensionsBuilder, Assembly assembly)
+        public static ISetupExtensionsBuilder RegisterAssembly(this ISetupExtensionsBuilder setupBuilder, Assembly assembly)
         {
             ConfigurationItemFactory.Default.RegisterItemsFromAssembly(assembly);
-            return extensionsBuilder;
+            return setupBuilder;
         }
 
         /// <summary>
         /// Registers NLog extensions from the assembly type name
         /// </summary>
-        public static ISetupExtensionsBuilder RegisterAssembly(this ISetupExtensionsBuilder extensionsBuilder, string assemblyName)
+        public static ISetupExtensionsBuilder RegisterAssembly(this ISetupExtensionsBuilder setupBuilder, string assemblyName)
         {
             Assembly assembly = AssemblyHelpers.LoadFromName(assemblyName);
             ConfigurationItemFactory.Default.RegisterItemsFromAssembly(assembly);
-            return extensionsBuilder;
+            return setupBuilder;
         }
 
         /// <summary>
         /// Register a custom Target.
         /// </summary>
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
-        /// <param name="extensionsBuilder">Fluent interface parameter.</param>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <typeparam name="T"> Type of the Target.</typeparam>
         /// <param name="name"> Name of the Target.</param>
-        public static ISetupExtensionsBuilder RegisterTarget<T>(this ISetupExtensionsBuilder extensionsBuilder, string name) where T : Target
+        public static ISetupExtensionsBuilder RegisterTarget<T>(this ISetupExtensionsBuilder setupBuilder, string name) where T : Target
         {
             var layoutRendererType = typeof(T);
-            return RegisterTarget(extensionsBuilder, name, layoutRendererType);
+            return RegisterTarget(setupBuilder, name, layoutRendererType);
         }
 
         /// <summary>
         /// Register a custom Target.
         /// </summary>
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
-        /// <param name="extensionsBuilder">Fluent interface parameter.</param>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="targetType"> Type of the Target.</param>
         /// <param name="name"> Name of the Target.</param>
-        public static ISetupExtensionsBuilder RegisterTarget(this ISetupExtensionsBuilder extensionsBuilder, string name, Type targetType)
+        public static ISetupExtensionsBuilder RegisterTarget(this ISetupExtensionsBuilder setupBuilder, string name, Type targetType)
         {
             ConfigurationItemFactory.Default.Targets.RegisterDefinition(name, targetType);
-            return extensionsBuilder;
+            return setupBuilder;
         }
 
         /// <summary>
         /// Register a custom layout renderer.
         /// </summary>
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
-        /// <param name="extensionsBuilder">Fluent interface parameter.</param>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <typeparam name="T"> Type of the layout renderer.</typeparam>
         /// <param name="name"> Name of the layout renderer - without ${}.</param>
-        public static ISetupExtensionsBuilder RegisterLayoutRenderer<T>(this ISetupExtensionsBuilder extensionsBuilder, string name)
+        public static ISetupExtensionsBuilder RegisterLayoutRenderer<T>(this ISetupExtensionsBuilder setupBuilder, string name)
             where T : LayoutRenderer
         {
             var layoutRendererType = typeof(T);
-            return RegisterLayoutRenderer(extensionsBuilder, name, layoutRendererType);
+            return RegisterLayoutRenderer(setupBuilder, name, layoutRendererType);
         }
 
         /// <summary>
         /// Register a custom layout renderer.
         /// </summary>
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
-        /// <param name="extensionsBuilder">Fluent interface parameter.</param>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="layoutRendererType"> Type of the layout renderer.</param>
         /// <param name="name"> Name of the layout renderer - without ${}.</param>
-        public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder extensionsBuilder, string name, Type layoutRendererType)
+        public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder setupBuilder, string name, Type layoutRendererType)
         {
             ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition(name, layoutRendererType);
-            return extensionsBuilder;
+            return setupBuilder;
         }
 
         /// <summary>
         /// Register a custom layout renderer with a callback function <paramref name="layoutMethod"/>. The callback receives the logEvent.
         /// </summary>
-        /// <param name="extensionsBuilder">Fluent interface parameter.</param>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="name">Name of the layout renderer - without ${}.</param>
         /// <param name="layoutMethod">Callback that returns the value for the layout renderer.</param>
-        public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder extensionsBuilder, string name, Func<LogEventInfo, object> layoutMethod)
+        public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder setupBuilder, string name, Func<LogEventInfo, object> layoutMethod)
         {
-            return RegisterLayoutRenderer(extensionsBuilder, name, (info, configuration) => layoutMethod(info));
+            return RegisterLayoutRenderer(setupBuilder, name, (info, configuration) => layoutMethod(info));
         }
 
         /// <summary>
         /// Register a custom layout renderer with a callback function <paramref name="layoutMethod"/>. The callback receives the logEvent and the current configuration.
         /// </summary>
-        /// <param name="extensionsBuilder">Fluent interface parameter.</param>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="name">Name of the layout renderer - without ${}.</param>
         /// <param name="layoutMethod">Callback that returns the value for the layout renderer.</param>
-        public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder extensionsBuilder, string name, Func<LogEventInfo, LoggingConfiguration, object> layoutMethod)
+        public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder setupBuilder, string name, Func<LogEventInfo, LoggingConfiguration, object> layoutMethod)
         {
             var layoutRenderer = new FuncLayoutRenderer(name, layoutMethod);
             ConfigurationItemFactory.Default.GetLayoutRenderers().RegisterFuncLayout(name, layoutRenderer);
-            return extensionsBuilder;
+            return setupBuilder;
         }
     }
 }

--- a/src/NLog/SetupSerializationBuilderExtensions.cs
+++ b/src/NLog/SetupSerializationBuilderExtensions.cs
@@ -1,0 +1,139 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog
+{
+    using System;
+    using System.Reflection;
+    using NLog.Common;
+    using NLog.Config;
+
+    /// <summary>
+    /// Extension methods to setup NLog extensions, so they are known when loading NLog LoggingConfiguration
+    /// </summary>
+    public static class SetupSerializationBuilderExtensions
+    {
+        /// <summary>
+        /// Overrides the active <see cref="IJsonConverter"/> with a new custom implementation
+        /// </summary>
+        public static ISetupSerializationBuilder RegisterJsonConverter(this ISetupSerializationBuilder setupBuilder, IJsonConverter jsonConverter)
+        {
+            ConfigurationItemFactory.Default.JsonConverter = jsonConverter ?? NLog.Targets.DefaultJsonSerializer.Instance;
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Overrides the active <see cref="IValueFormatter"/> with a new custom implementation
+        /// </summary>
+        public static ISetupSerializationBuilder RegisterValueFormatter(this ISetupSerializationBuilder setupBuilder, IValueFormatter valueFormatter)
+        {
+            ConfigurationItemFactory.Default.ValueFormatter = valueFormatter ?? NLog.MessageTemplates.ValueFormatter.Instance;
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Registers object Type transformation from dangerous (massive) object to safe (reduced) object
+        /// </summary>
+        public static ISetupSerializationBuilder RegisterObjectTransformation<T>(this ISetupSerializationBuilder setupBuilder, Func<T, object> transformer)
+        {
+            if (transformer == null)
+                throw new ArgumentNullException(nameof(transformer));
+
+            var original = ConfigurationItemFactory.Default.ObjectTypeTransformer;
+            ConfigurationItemFactory.Default.ObjectTypeTransformer = new ObjectTypeTransformation<T>(transformer, original);
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Registers object Type transformation from dangerous (massive) object to safe (reduced) object
+        /// </summary>
+        public static ISetupSerializationBuilder RegisterObjectTransformation(this ISetupSerializationBuilder setupBuilder, Type objectType, Func<object, object> transformer)
+        {
+            if (objectType == null)
+                throw new ArgumentNullException(nameof(objectType));
+            if (transformer == null)
+                throw new ArgumentNullException(nameof(transformer));
+
+            var original = ConfigurationItemFactory.Default.ObjectTypeTransformer;
+            ConfigurationItemFactory.Default.ObjectTypeTransformer = new ObjectTypeTransformation(objectType, transformer, original);
+            return setupBuilder;
+        }
+
+        private class ObjectTypeTransformation<T> : IObjectTypeTransformer
+        {
+            private readonly IObjectTypeTransformer _original;
+            private readonly Func<T, object> _transformer;
+
+            public ObjectTypeTransformation(Func<T, object> transformer, IObjectTypeTransformer original)
+            {
+                _original = original;
+                _transformer = transformer;
+            }
+
+            public object TryTransformObject(object obj)
+            {
+                if (obj is T rawObject)
+                {
+                    var wantedObject = _transformer(rawObject);
+                    if (wantedObject != null)
+                        return wantedObject;
+                }
+                return _original?.TryTransformObject(obj);
+            }
+        }
+
+        private class ObjectTypeTransformation : IObjectTypeTransformer
+        {
+            private readonly IObjectTypeTransformer _original;
+            private readonly Func<object, object> _transformer;
+            private readonly Type _objectType;
+
+            public ObjectTypeTransformation(Type objecType, Func<object, object> transformer, IObjectTypeTransformer original)
+            {
+                _original = original;
+                _transformer = transformer;
+                _objectType = objecType;
+            }
+
+            public object TryTransformObject(object obj)
+            {
+                if (_objectType.IsAssignableFrom(obj.GetType()))
+                {
+                    return _transformer(obj);
+                }
+
+                return _original?.TryTransformObject(obj);
+            }
+        }
+    }
+}

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -55,14 +55,12 @@ namespace NLog.Targets
 
         private const int MaxJsonLength = 512 * 1024;
 
-        private static readonly DefaultJsonSerializer instance = new DefaultJsonSerializer();
-
         private static readonly IEqualityComparer<object> _referenceEqualsComparer = SingleItemOptimizedHashSet<object>.ReferenceEqualityComparer.Default;
 
         /// <summary>
         /// Singleton instance of the serializer.
         /// </summary>
-        public static DefaultJsonSerializer Instance => instance;
+        public static DefaultJsonSerializer Instance { get; } = new DefaultJsonSerializer();
 
         static DefaultJsonSerializer()
         {
@@ -71,7 +69,7 @@ namespace NLog.Targets
         /// <summary>
         /// Private. Use <see cref="Instance"/>
         /// </summary>
-        private DefaultJsonSerializer()
+        internal DefaultJsonSerializer()
         { }
 
         /// <summary>
@@ -429,10 +427,10 @@ namespace NLog.Targets
                 var objectPropertyList = _objectReflectionCache.LookupObjectProperties(value);
                 if (!objectPropertyList.ConvertToString)
                 {
-                    if (ReferenceEquals(options, instance._serializeOptions) && value is Exception)
+                    if (ReferenceEquals(options, Instance._serializeOptions) && value is Exception)
                     {
                         // Exceptions are seldom under control, and can include random Data-Dictionary-keys, so we sanitize by default
-                        options = instance._exceptionSerializeOptions;
+                        options = Instance._exceptionSerializeOptions;
                     }
 
                     using (new SingleItemOptimizedHashSet<object>.SingleItemScopedInsert(value, ref objectsInPath, false, _referenceEqualsComparer))

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerClassTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerClassTests.cs
@@ -1,0 +1,131 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System.Text;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.UnitTests.Targets
+{
+    /// <summary>
+    ///     Test via <see cref="IJsonConverter" /> path
+    /// </summary>
+    public class DefaultJsonSerializerClassTests : NLogTestBase
+    {
+        private static readonly object _testSyncObject = new object();
+
+        private interface IExcludedInterface
+        {
+        }
+
+        private class ExcludedClass : IExcludedInterface
+        {
+            public string ExcludedString { get; set; }
+            public override string ToString()
+            {
+                return "Skipped"; 
+            }
+        }
+
+        private class IncludedClass
+        {
+            public string IncludedString { get; set; }
+        }
+
+        private class ContainerClass
+        {
+            public string S { get; set; }
+            public ExcludedClass Excluded { get; set; }
+            public IncludedClass Included { get; set; }
+        }
+
+        private static ContainerClass BuildSampleObject()
+        {
+            var testObject = new ContainerClass
+            {
+                S = "sample",
+                Excluded = new ExcludedClass { ExcludedString = "shouldn't be serialized" },
+                Included = new IncludedClass { IncludedString = "serialized" }
+            };
+            return testObject;
+        }
+
+        [Fact]
+        public void IExcludedInterfaceSerializer_RegistersSerializeAsToString_InvokesToString()
+        {
+            try
+            {
+                var testObject = BuildSampleObject();
+
+                var sb = new StringBuilder();
+                var options = new JsonSerializeOptions();
+
+                LogManager.Setup().SetupSerialization(s => s.RegisterObjectTransformation<IExcludedInterface>(o => o.ToString()));
+
+                var jsonSerializer = new DefaultJsonSerializer();
+                jsonSerializer.SerializeObject(testObject, sb, options);
+                const string expectedValue =
+                    @"{""S"":""sample"", ""Excluded"":""Skipped"", ""Included"":{""IncludedString"":""serialized""}}";
+                Assert.Equal(expectedValue, sb.ToString());
+            }
+            finally
+            {
+                NLog.Config.ConfigurationItemFactory.Default.ObjectTypeTransformer = null;
+            }
+        }
+
+        [Fact]
+        public void ExcludedClassSerializer_RegistersSerializeAsToString_InvokesToString()
+        {
+            try
+            {
+                var testObject = BuildSampleObject();
+
+                var sb = new StringBuilder();
+                var options = new JsonSerializeOptions();
+
+                LogManager.Setup().SetupSerialization(s => s.RegisterObjectTransformation(typeof(ExcludedClass), o => o.ToString()));
+
+                var jsonSerializer = new DefaultJsonSerializer();
+                jsonSerializer.SerializeObject(testObject, sb, options);
+                const string expectedValue =
+                    @"{""S"":""sample"", ""Excluded"":""Skipped"", ""Included"":{""IncludedString"":""serialized""}}";
+                Assert.Equal(expectedValue, sb.ToString());
+            }
+            finally
+            {
+                NLog.Config.ConfigurationItemFactory.Default.ObjectTypeTransformer = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Alternative solution for #3588

Introduces the new interface:

```c#
    public interface IObjectTypeTransformer
    {
        /// <summary>
        /// Takes a dangerous (or massive) object and converts into a safe (or reduced) object
        /// </summary>
        /// <returns>
        /// Null if unknown object, or object cannot be handled
        /// </returns>
        object TryTransformObject(object obj);
    }
```

Then one can do this: (NLog 4.7+)

```c#
NLog.LogManager.Setup().SetupSerialization(s => 
   s.RegisterObjectTransformation<IExcludedInterface>(o => o.ToString()));
```

Note merge to master-branch.