### PR TITLE
${Exception} - Added Format options: HResult and Properties

### DIFF
--- a/src/NLog/Config/ExceptionRenderingFormat.cs
+++ b/src/NLog/Config/ExceptionRenderingFormat.cs
@@ -75,8 +75,12 @@ namespace NLog.Config
         /// </summary>
         Source = 8,
         /// <summary>
+        /// Appends the <see cref="System.Exception.HResult"/> from the application or the object that caused the error.
+        /// </summary>
+        HResult = 9,
+        /// <summary>
         /// Appends any additional properties that specific type of Exception might have.
         /// </summary>
-        Properties = 9,
+        Properties = 10,
     }
 }

--- a/src/NLog/Config/ExceptionRenderingFormat.cs
+++ b/src/NLog/Config/ExceptionRenderingFormat.cs
@@ -74,5 +74,9 @@ namespace NLog.Config
         /// Appends the <see cref="System.Exception.Source"/> from the application or the object that caused the error.
         /// </summary>
         Source = 8,
+        /// <summary>
+        /// Appends any additional properties that specific type of Exception might have.
+        /// </summary>
+        Properties = 9,
     }
 }

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -68,16 +68,30 @@ namespace NLog.LayoutRenderers
                                                                                                         {"STACKTRACE", ExceptionRenderingFormat.StackTrace},
                                                                                                         {"DATA",ExceptionRenderingFormat.Data},
                                                                                                         {"@",ExceptionRenderingFormat.Serialize},
+                                                                                                        {"HRESULT",ExceptionRenderingFormat.HResult},
                                                                                                         {"PROPERTIES",ExceptionRenderingFormat.Properties},
                                                                                                     };
 
         private static readonly HashSet<string> ExcludeDefaultProperties = new HashSet<string>(new[] {
             "Type",
             nameof(Exception.Data),
+#if !SILVERLIGHT
             nameof(Exception.HelpLink),
+#else
+            "HelpLink",
+#endif
+#if NET45
+            nameof(Exception.HResult),
+#else
+            "HResult",
+#endif
             nameof(Exception.InnerException),
             nameof(Exception.Message),
+#if !SILVERLIGHT
             nameof(Exception.Source),
+#else
+            "Source",
+#endif            
             nameof(Exception.StackTrace),
 #if SILVERLIGHT || NETSTANDARD1_0
             "TargetSite",
@@ -111,6 +125,7 @@ namespace NLog.LayoutRenderers
                                                                                                         {ExceptionRenderingFormat.StackTrace, AppendStackTrace},
                                                                                                         {ExceptionRenderingFormat.Data, AppendData},
                                                                                                         {ExceptionRenderingFormat.Serialize, AppendSerializeObject},
+                                                                                                        {ExceptionRenderingFormat.HResult, AppendHResult},
                                                                                                         {ExceptionRenderingFormat.Properties, AppendProperties},
                                                                                                     };
         }
@@ -401,6 +416,21 @@ namespace NLog.LayoutRenderers
         {
 #if !SILVERLIGHT
             sb.Append(ex.Source);
+#endif
+        }
+
+        /// <summary>
+        /// Appends the HResult of an Exception to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="ex">The Exception whose HResult should be appended.</param>
+        protected virtual void AppendHResult(StringBuilder sb, Exception ex)
+        {
+#if NET45
+            if (ex.HResult != 0 && ex.HResult != 1)
+            {
+                sb.AppendFormat("0x{0:X8}", ex.HResult);
+            }
 #endif
         }
 

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -311,7 +311,7 @@ namespace NLog.LayoutRenderers
             AppendException(currentException, InnerFormats ?? Formats, builder);
         }
 
-        private void AppendException(Exception currentException, IEnumerable<ExceptionRenderingFormat> renderFormats, StringBuilder builder)
+        private void AppendException(Exception currentException, List<ExceptionRenderingFormat> renderFormats, StringBuilder builder)
         {
             int orgLength = builder.Length;
             foreach (ExceptionRenderingFormat renderingFormat in renderFormats)

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -645,6 +645,24 @@ namespace NLog.UnitTests.LayoutRenderers
             Assert.Contains("Test Inner 1", lastMessage);
         }
 
+        [Fact]
+        public void CustomExceptionProperties_Layout_Test()
+        {
+            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog>
+                <targets>
+                    <target name='debug1' type='Debug' layout='${exception:format=Properties}' />
+                </targets>
+                <rules>
+                    <logger minlevel='Info' writeTo='debug1' />
+                </rules>
+            </nlog>");
+
+            var ex = new CustomArgumentException("Goodbye World", "Nuke");
+            logger.Fatal(ex, "msg");
+            AssertDebugLastMessage("debug1", $"{nameof(CustomArgumentException.ParamName)}: Nuke");
+        }
+
         private class ExceptionWithBrokenMessagePropertyException : NLogConfigurationException
         {
             public override string Message => throw new Exception("Exception from Message property");

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -44,6 +44,8 @@ namespace NLog.UnitTests.LayoutRenderers
 
     public class ExceptionTests : NLogTestBase
     {
+        const int E_FAIL = 80004005;
+
         private ILogger logger = LogManager.GetLogger("NLog.UnitTests.LayoutRenderer.ExceptionTests");
         private const string ExceptionDataFormat = "{0}: {1}";
 
@@ -63,9 +65,10 @@ namespace NLog.UnitTests.LayoutRenderers
                     <target name='debug8' type='Debug' layout='${exception:format=message,shorttype:separator=*}' />
                     <target name='debug9' type='Debug' layout='${exception:format=data}' />
                     <target name='debug10' type='Debug' layout='${exception:format=source}' />
+                    <target name='debug11' type='Debug' layout='${exception:format=hresult}' />
                 </targets>
                 <rules>
-                    <logger minlevel='Info' writeTo='debug1,debug2,debug3,debug4,debug5,debug6,debug7,debug8,debug9,debug10' />
+                    <logger minlevel='Info' writeTo='debug1,debug2,debug3,debug4,debug5,debug6,debug7,debug8,debug9,debug10,debug11' />
                 </rules>
             </nlog>");
 
@@ -86,6 +89,9 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug6", exceptionMessage);
             AssertDebugLastMessage("debug9", string.Format(ExceptionDataFormat, exceptionDataKey, exceptionDataValue));
             AssertDebugLastMessage("debug10", GetType().ToString());
+#if NET45
+            AssertDebugLastMessage("debug11", $"0x{E_FAIL:X8}");
+#endif
 
             // each version of the framework produces slightly different information for MethodInfo, so we just 
             // make sure it's not empty
@@ -111,9 +117,10 @@ namespace NLog.UnitTests.LayoutRenderers
                     <target name='debug8' type='Debug' layout='${exception:format=message,shorttype:separator=*}' />
                     <target name='debug9' type='Debug' layout='${exception:format=data}' />
                     <target name='debug10' type='Debug' layout='${exception:format=source}' />
+                    <target name='debug11' type='Debug' layout='${exception:format=hresult}' />
                 </targets>
                 <rules>
-                    <logger minlevel='Info' writeTo='debug1,debug2,debug3,debug4,debug5,debug6,debug7,debug8,debug9,debug10' />
+                    <logger minlevel='Info' writeTo='debug1,debug2,debug3,debug4,debug5,debug6,debug7,debug8,debug9,debug10,debug11' />
                 </rules>
             </nlog>");
 
@@ -131,6 +138,9 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug6", exceptionMessage);
             AssertDebugLastMessage("debug9", string.Format(ExceptionDataFormat, exceptionDataKey, exceptionDataValue));
             AssertDebugLastMessage("debug10", GetType().ToString());
+#if NET45
+            AssertDebugLastMessage("debug11", $"0x{E_FAIL:X8}");
+#endif
 
             // each version of the framework produces slightly different information for MethodInfo, so we just 
             // make sure it's not empty
@@ -159,9 +169,10 @@ namespace NLog.UnitTests.LayoutRenderers
                     <target name='debug8' type='Debug' layout='${exception:format=message,shorttype:separator=*}' />
                     <target name='debug9' type='Debug' layout='${exception:format=data}' />
                     <target name='debug10' type='Debug' layout='${exception:format=source}' />
+                    <target name='debug11' type='Debug' layout='${exception:format=hresult}' />
                 </targets>
                 <rules>
-                    <logger minlevel='Info' writeTo='debug1,debug2,debug3,debug4,debug5,debug6,debug7,debug8,debug9,debug10' />
+                    <logger minlevel='Info' writeTo='debug1,debug2,debug3,debug4,debug5,debug6,debug7,debug8,debug9,debug10,debug11' />
                 </rules>
             </nlog>");
 
@@ -179,6 +190,9 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug6", exceptionMessage);
             AssertDebugLastMessage("debug9", string.Format(ExceptionDataFormat, exceptionDataKey, exceptionDataValue));
             AssertDebugLastMessage("debug10", GetType().ToString());
+#if NET45
+            AssertDebugLastMessage("debug11", $"0x{E_FAIL:X8}");
+#endif
 
             // each version of the framework produces slightly different information for MethodInfo, so we just 
             // make sure it's not empty
@@ -205,9 +219,10 @@ namespace NLog.UnitTests.LayoutRenderers
                     <target name='debug8' type='Debug' layout='${exception:format=message,shorttype:separator=*}' />
                     <target name='debug9' type='Debug' layout='${exception:format=data}' />
                     <target name='debug10' type='Debug' layout='${exception:format=source}' />
+                    <target name='debug11' type='Debug' layout='${exception:format=hresult}' />
                 </targets>
                 <rules>
-                    <logger minlevel='Info' writeTo='debug1,debug2,debug3,debug4,debug5,debug6,debug7,debug8,debug9,debug10' />
+                    <logger minlevel='Info' writeTo='debug1,debug2,debug3,debug4,debug5,debug6,debug7,debug8,debug9,debug10,debug11' />
                 </rules>
             </nlog>");
 
@@ -230,6 +245,9 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug8", "Test exception*" + typeof(CustomArgumentException).Name);
             AssertDebugLastMessage("debug9", string.Format(ExceptionDataFormat, exceptionDataKey, exceptionDataValue));
             AssertDebugLastMessage("debug10", "");
+#if NET45
+            AssertDebugLastMessage("debug11", $"0x{E_FAIL:X8}");
+#endif
         }
 
         [Fact]
@@ -248,9 +266,10 @@ namespace NLog.UnitTests.LayoutRenderers
                     <target name='debug8' type='Debug' layout='${exception:format=message,shorttype:separator=*}' />
                     <target name='debug9' type='Debug' layout='${exception:format=data}' />
                     <target name='debug10' type='Debug' layout='${exception:format=source}' />
+                    <target name='debug11' type='Debug' layout='${exception:format=hresult}' />
                 </targets>
                 <rules>
-                    <logger minlevel='Info' writeTo='debug1,debug2,debug3,debug4,debug5,debug6,debug7,debug8,debug9,debug10' />
+                    <logger minlevel='Info' writeTo='debug1,debug2,debug3,debug4,debug5,debug6,debug7,debug8,debug9,debug10,debug11' />
                 </rules>
             </nlog>");
 
@@ -270,6 +289,9 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug8", "Test exception*" + typeof(CustomArgumentException).Name);
             AssertDebugLastMessage("debug9", string.Format(ExceptionDataFormat, exceptionDataKey, exceptionDataValue));
             AssertDebugLastMessage("debug10", "");
+#if NET45
+            AssertDebugLastMessage("debug11", $"0x{E_FAIL:X8}");
+#endif
         }
 
         [Fact]
@@ -755,6 +777,7 @@ namespace NLog.UnitTests.LayoutRenderers
             {
                 ParamName = paramName;
                 StrangeProperty = "Strange World";
+                HResult = E_FAIL;
             }
 
             public string ParamName { get; }


### PR DESCRIPTION
Trying to resolve #3519 together with #3610

```c#
NLog.LogManager.LogFactory.RegisterObjectTransformation<System.Net.WebException>(ex =>new {
    Type = ex.GetType().ToString(),
    Message = ex.Message,
    StackTrace = ex.StackTrace,
    Source = ex.Source,
    InnerException = ex.InnerException,
    Status = ex.Status,
    Response = ex.Response.ToString(),  // Call your custom method to render stream as string
});
```

Then you can do this in NLog.config:

```xml
${exception:format=Properties}
```

Then it will output `Status` and `Response`  like they were entries in the Exception.Data-dictionary.

Alternative one could just setup a conversion of the type `System.Net.WebResponse` so it becomes a string. Then any object logged by NLog that contains a `System.Net.WebResponse` will automatically output its string-value.