### PR TITLE
LogFactory.ServiceRepository for better dependency injection support

### DIFF
--- a/src/NLog/Config/Factory.cs
+++ b/src/NLog/Config/Factory.cs
@@ -262,8 +262,8 @@ namespace NLog.Config
             FuncLayoutRenderer funcResult;
             if (_funcRenderers != null)
             {
-                var succesAsFunc = _funcRenderers.TryGetValue(itemName, out funcResult);
-                if (succesAsFunc)
+                var successAsFunc = _funcRenderers.TryGetValue(itemName, out funcResult);
+                if (successAsFunc)
                 {
                     result = funcResult;
                     return true;

--- a/src/NLog/Config/IServiceRepository.cs
+++ b/src/NLog/Config/IServiceRepository.cs
@@ -1,0 +1,55 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    using System;
+
+    /// <summary>
+    /// Interface to register available configuration objects type
+    /// </summary>
+    public interface IServiceRepository : IServiceResolver
+    {
+        /// <summary>
+        /// Register a type for NLog to use, along with how to resolve instance
+        /// </summary>
+        /// <param name="type">Type of object</param>
+        /// <param name="objectResolver">How to resolve instance of object</param>
+        void RegisterType(Type type, ConfigurationItemCreator objectResolver);
+
+        /// <summary>
+        /// Mapping of symbol name to actual <see cref="System.Type"/>
+        /// </summary>
+        ConfigurationItemFactory ConfigurationItemFactory { get; }
+    }
+}

--- a/src/NLog/Config/IServiceResolver.cs
+++ b/src/NLog/Config/IServiceResolver.cs
@@ -1,0 +1,53 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    using System;
+
+    /// <summary>
+    /// Interface to instantiate configuration objects.
+    /// </summary>
+    /// <remarks>
+    /// Create own custom implementation to perform dependency injection or custom initialization
+    /// </remarks>
+    public interface IServiceResolver
+    {
+        /// <summary>
+        /// Lookup instance of the configuration item (target, layout, layout renderer, etc.) given its type.
+        /// </summary>
+        /// <param name="itemType">Type of the item.</param>
+        /// <returns>Created object of the specified type.</returns>
+        object ResolveInstance(Type itemType);
+    }
+}

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -53,7 +53,7 @@ namespace NLog.Config
     /// </summary>
     public abstract class LoggingConfigurationParser : LoggingConfiguration
     {
-        private ConfigurationItemFactory _configurationItemFactory;
+        private readonly IServiceRepository _serviceRepository;
 
         /// <summary>
         /// Constructor
@@ -62,6 +62,7 @@ namespace NLog.Config
         protected LoggingConfigurationParser(LogFactory logFactory)
             : base(logFactory)
         {
+            _serviceRepository = logFactory.ServiceRepository;
         }
 
         /// <summary>
@@ -185,8 +186,7 @@ namespace NLog.Config
                 InternalLogger.LogLevel = LogLevel.Off; // Reduce overhead of the InternalLogger when not configured
             }
 
-            _configurationItemFactory = ConfigurationItemFactory.Default;
-            _configurationItemFactory.ParseMessageTemplates = parseMessageTemplates;
+            _serviceRepository.ConfigurationItemFactory.ParseMessageTemplates = parseMessageTemplates;
         }
 
         /// <summary>
@@ -387,7 +387,7 @@ namespace NLog.Config
         {
             try
             {
-                _configurationItemFactory.RegisterType(Type.GetType(type, true), itemNamePrefix);
+                _serviceRepository.ConfigurationItemFactory.RegisterType(Type.GetType(type, true), itemNamePrefix);
             }
             catch (Exception exception)
             {
@@ -407,7 +407,7 @@ namespace NLog.Config
             try
             {
                 Assembly asm = AssemblyHelpers.LoadFromPath(assemblyFile, baseDirectory);
-                _configurationItemFactory.RegisterItemsFromAssembly(asm, prefix);
+                _serviceRepository.ConfigurationItemFactory.RegisterItemsFromAssembly(asm, prefix);
             }
             catch (Exception exception)
             {
@@ -427,7 +427,7 @@ namespace NLog.Config
             try
             {
                 Assembly asm = AssemblyHelpers.LoadFromName(assemblyName);
-                _configurationItemFactory.RegisterItemsFromAssembly(asm, prefix);
+                _serviceRepository.ConfigurationItemFactory.RegisterItemsFromAssembly(asm, prefix);
             }
             catch (Exception exception)
             {
@@ -506,7 +506,7 @@ namespace NLog.Config
             if (!AssertNonEmptyValue(timeSourceType, "type", timeElement.Name, string.Empty))
                 return;
 
-            TimeSource newTimeSource = _configurationItemFactory.TimeSources.CreateInstance(timeSourceType);
+            TimeSource newTimeSource = _serviceRepository.ConfigurationItemFactory.TimeSources.CreateInstance(timeSourceType);
             ConfigureObjectFromAttributes(newTimeSource, timeElement, true);
 
             InternalLogger.Info("Selecting time source {0}", newTimeSource);
@@ -703,7 +703,7 @@ namespace NLog.Config
 
         private SimpleLayout ParseLevelLayout(string levelLayout)
         {
-            SimpleLayout simpleLayout = !StringHelpers.IsNullOrWhiteSpace(levelLayout) ? new SimpleLayout(levelLayout, _configurationItemFactory) : null;
+            SimpleLayout simpleLayout = !StringHelpers.IsNullOrWhiteSpace(levelLayout) ? new SimpleLayout(levelLayout, _serviceRepository.ConfigurationItemFactory) : null;
             simpleLayout?.Initialize(this);
             return simpleLayout;
         }
@@ -778,14 +778,14 @@ namespace NLog.Config
             if (defaultActionResult != null)
             {
                 PropertyHelper.SetPropertyFromString(rule, nameof(rule.DefaultFilterResult), defaultActionResult,
-                    _configurationItemFactory);
+                    _serviceRepository.ConfigurationItemFactory);
             }
 
             foreach (var filterElement in filtersElement.ValidChildren)
             {
                 string name = filterElement.Name;
 
-                Filter filter = _configurationItemFactory.Filters.CreateInstance(name);
+                Filter filter = _serviceRepository.ConfigurationItemFactory.Filters.CreateInstance(name);
                 ConfigureObjectFromAttributes(filter, filterElement, false);
                 rule.Filters.Add(filter);
             }
@@ -872,7 +872,7 @@ namespace NLog.Config
 
             try
             {
-                newTarget = _configurationItemFactory.Targets.CreateInstance(targetTypeName);
+                newTarget = _serviceRepository.ConfigurationItemFactory.Targets.CreateInstance(targetTypeName);
                 if (newTarget == null)
                     throw new NLogConfigurationException($"Factory returned null for target type: {targetTypeName}");
             }
@@ -1050,7 +1050,7 @@ namespace NLog.Config
                 try
                 {
                     PropertyHelper.SetPropertyFromString(targetObject, childName, ExpandSimpleVariables(childValue),
-                        _configurationItemFactory);
+                        _serviceRepository.ConfigurationItemFactory);
                 }
                 catch (Exception ex)
                 {
@@ -1119,7 +1119,7 @@ namespace NLog.Config
             object arrayItem = TryCreateLayoutInstance(element, elementType);
             // arrayItem is not a layout
             if (arrayItem == null)
-                arrayItem = FactoryHelper.CreateInstance(elementType);
+                arrayItem = _serviceRepository.ResolveInstance(elementType);
 
             ConfigureObjectFromAttributes(arrayItem, element, true);
             ConfigureObjectFromElement(arrayItem, element);
@@ -1157,12 +1157,12 @@ namespace NLog.Config
 
         private Layout TryCreateLayoutInstance(ValidatedConfigurationElement element, Type type)
         {
-            return TryCreateInstance(element, type, _configurationItemFactory.Layouts);
+            return TryCreateInstance(element, type, _serviceRepository.ConfigurationItemFactory.Layouts);
         }
 
         private Filter TryCreateFilterInstance(ValidatedConfigurationElement element, Type type)
         {
-            return TryCreateInstance(element, type, _configurationItemFactory.Filters);
+            return TryCreateInstance(element, type, _serviceRepository.ConfigurationItemFactory.Filters);
         }
 
         private T TryCreateInstance<T>(ValidatedConfigurationElement element, Type type, INamedItemFactory<T, Type> factory)

--- a/src/NLog/Config/MethodFactory.cs
+++ b/src/NLog/Config/MethodFactory.cs
@@ -36,8 +36,8 @@ namespace NLog.Config
     using System;
     using System.Collections.Generic;
     using System.Reflection;
-    using Common;
-    using Internal;
+    using NLog.Common;
+    using NLog.Internal;
 
     /// <summary>
     /// Factory for locating methods.
@@ -49,6 +49,12 @@ namespace NLog.Config
         where TMethodAttributeType : NameBaseAttribute
     {
         private readonly Dictionary<string, MethodInfo> _nameToMethodInfo = new Dictionary<string, MethodInfo>();
+        private readonly MethodFactory<TClassAttributeType, TMethodAttributeType> _globalDefaultFactory;
+
+        public MethodFactory(MethodFactory<TClassAttributeType, TMethodAttributeType> globalDefaultFactory)
+        {
+            _globalDefaultFactory = globalDefaultFactory;
+        }
 
         /// <summary>
         /// Gets a collection of all registered items in the factory.
@@ -83,8 +89,6 @@ namespace NLog.Config
                     {
                         throw;
                     }
-
-                    
                 }
             }
         }
@@ -135,7 +139,7 @@ namespace NLog.Config
         /// <returns>A value of <c>true</c> if the method was found, <c>false</c> otherwise.</returns>
         public bool TryCreateInstance(string itemName, out MethodInfo result)
         {
-            return _nameToMethodInfo.TryGetValue(itemName, out result);
+            return TryGetDefinition(itemName, out result);
         }
 
         /// <summary>
@@ -163,7 +167,12 @@ namespace NLog.Config
         /// <returns>A value of <c>true</c> if the method was found, <c>false</c> otherwise.</returns>
         public bool TryGetDefinition(string itemName, out MethodInfo result)
         {
-            return _nameToMethodInfo.TryGetValue(itemName, out result);
+            if (_nameToMethodInfo.TryGetValue(itemName, out result))
+            {
+                return true;
+            }
+
+            return _globalDefaultFactory?.TryGetDefinition(itemName, out result) ?? false;
         }
     }
 }

--- a/src/NLog/Config/PropertyTypeConverter.cs
+++ b/src/NLog/Config/PropertyTypeConverter.cs
@@ -38,8 +38,13 @@ namespace NLog.Config
     /// <summary>
     /// Default implementation of <see cref="IPropertyTypeConverter"/>
     /// </summary>
-    class PropertyTypeConverter : IPropertyTypeConverter
+    internal class PropertyTypeConverter : IPropertyTypeConverter
     {
+        /// <summary>
+        /// Singleton instance of the serializer.
+        /// </summary>
+        public static PropertyTypeConverter Instance { get; } = new PropertyTypeConverter();
+
         /// <inheritdoc/>
         public object Convert(object propertyValue, Type propertyType, string format, IFormatProvider formatProvider)
         {

--- a/src/NLog/Config/ServiceRepository.cs
+++ b/src/NLog/Config/ServiceRepository.cs
@@ -40,7 +40,7 @@ namespace NLog.Config
     using NLog.Targets;
 
     /// <summary>
-    /// Repository of intefaces used by NLog to allow override for dependency injection
+    /// Repository of interfaces used by NLog to allow override for dependency injection
     /// </summary>
     internal sealed class ServiceRepository : IServiceRepository
     {
@@ -61,26 +61,16 @@ namespace NLog.Config
             if (resetGlobalCache)
                 ConfigurationItemFactory.Default = null;    //build new global factory
 
-            RegisterSingleton(typeof(IJsonConverter), DefaultJsonSerializer.Instance);
-            RegisterSingleton(typeof(IValueFormatter), new MessageTemplates.ValueFormatter(this));
-            RegisterSingleton(typeof(IPropertyTypeConverter), NLog.Config.PropertyTypeConverter.Instance);
-            CreateInstance = new ConfigurationItemCreator(t => DefaultResolveInstance(t));
+            this.RegisterDefaults();
+            CreateInstance = DefaultResolveInstance;
             // Maybe also include active TimeSource ? Could also be done with LogFactory extension-methods
         }
 
         /// <summary>
-        /// Registers singleton-object as implementation of specific interface.
+        /// 
         /// </summary>
-        /// <remarks>
-        /// If the same single-object implements multiple interfaces then it must be registered for each interface
-        /// </remarks>
-        /// <param name="interfaceType">Type of interface</param>
-        /// <param name="singletonObject">Singleton object to use for override</param>
-        internal void RegisterSingleton(Type interfaceType, object singletonObject)
-        {
-            _serviceRepository[interfaceType] = (t) => singletonObject;
-        }
-
+        /// <param name="type"></param>
+        /// <param name="objectResolver"><c>null</c> will unregister the type</param>
         public void RegisterType(Type type, ConfigurationItemCreator objectResolver)
         {
             if (objectResolver == null)
@@ -96,10 +86,8 @@ namespace NLog.Config
             {
                 return createInstance(itemType);
             }
-            else
-            {
-                return DefaultResolveInstance(itemType);
-            }
+
+            return DefaultResolveInstance(itemType);
         }
 
         private object DefaultResolveInstance(Type itemType)

--- a/src/NLog/Config/ServiceRepository.cs
+++ b/src/NLog/Config/ServiceRepository.cs
@@ -1,0 +1,130 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using NLog.Internal;
+    using NLog.Targets;
+
+    /// <summary>
+    /// Repository of intefaces used by NLog to allow override for dependency injection
+    /// </summary>
+    internal sealed class ServiceRepository : IServiceRepository
+    {
+        private readonly Dictionary<Type, ConfigurationItemCreator> _serviceRepository = new Dictionary<Type, ConfigurationItemCreator>();
+        private ConfigurationItemFactory _localItemFactory;
+
+        public ConfigurationItemFactory ConfigurationItemFactory
+        {
+            get => _localItemFactory ?? (_localItemFactory = new ConfigurationItemFactory(this, ConfigurationItemFactory.Default, ArrayHelper.Empty<Assembly>()));
+            set => _localItemFactory = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceRepository"/> class.
+        /// </summary>
+        internal ServiceRepository(bool resetGlobalCache = false)
+        {
+            if (resetGlobalCache)
+                ConfigurationItemFactory.Default = null;    //build new global factory
+
+            RegisterSingleton(typeof(IJsonConverter), DefaultJsonSerializer.Instance);
+            RegisterSingleton(typeof(IValueFormatter), new MessageTemplates.ValueFormatter(this));
+            RegisterSingleton(typeof(IPropertyTypeConverter), NLog.Config.PropertyTypeConverter.Instance);
+            CreateInstance = new ConfigurationItemCreator(t => DefaultResolveInstance(t));
+            // Maybe also include active TimeSource ? Could also be done with LogFactory extension-methods
+        }
+
+        /// <summary>
+        /// Registers singleton-object as implementation of specific interface.
+        /// </summary>
+        /// <remarks>
+        /// If the same single-object implements multiple interfaces then it must be registered for each interface
+        /// </remarks>
+        /// <param name="interfaceType">Type of interface</param>
+        /// <param name="singletonObject">Singleton object to use for override</param>
+        internal void RegisterSingleton(Type interfaceType, object singletonObject)
+        {
+            _serviceRepository[interfaceType] = (t) => singletonObject;
+        }
+
+        public void RegisterType(Type type, ConfigurationItemCreator objectResolver)
+        {
+            if (objectResolver == null)
+                _serviceRepository.Remove(type);
+            else
+                _serviceRepository[type] = objectResolver;
+        }
+
+        public object ResolveInstance(Type itemType)
+        {
+            var createInstance = CreateInstance;
+            if (createInstance != null)
+            {
+                return createInstance(itemType);
+            }
+            else
+            {
+                return DefaultResolveInstance(itemType);
+            }
+        }
+
+        private object DefaultResolveInstance(Type itemType)
+        {
+            if (_serviceRepository.TryGetValue(itemType, out var objectResolver))
+            {
+                return objectResolver(itemType);
+            }
+
+            try
+            {
+                return Activator.CreateInstance(itemType);
+            }
+            catch (MissingMethodException exception)
+            {
+                throw new NLogConfigurationException($"Cannot access the constructor of type: {itemType.FullName}. Is the required permission granted?", exception);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the creator delegate used to instantiate configuration objects.
+        /// </summary>
+        /// <remarks>
+        /// By overriding this property, one can enable dependency injection or interception for created objects.
+        /// </remarks>
+        public ConfigurationItemCreator CreateInstance { get; set; }
+    }
+}

--- a/src/NLog/Config/ServiceRepositoryExtensions.cs
+++ b/src/NLog/Config/ServiceRepositoryExtensions.cs
@@ -75,7 +75,7 @@ namespace NLog.Config
         /// <param name="singleton">Singleton object to use for override</param>
         public static IServiceRepository RegisterSingleton<T>(this IServiceRepository serviceRepository, T singleton) where T : class
         {
-            serviceRepository.RegisterType(typeof(IValueFormatter), (t) => singleton);
+            serviceRepository.RegisterType(typeof(T), (t) => singleton);
             return serviceRepository;
         }
 

--- a/src/NLog/Config/ServiceRepositoryHelper.cs
+++ b/src/NLog/Config/ServiceRepositoryHelper.cs
@@ -1,0 +1,86 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    using NLog.Internal;
+
+    internal static class ServiceRepositoryHelper
+    {
+        public static IServiceResolver GetServiceResolver(this LoggingConfiguration loggingConfiguration)
+        {
+            return loggingConfiguration?.LogFactory?.ServiceRepository ?? LogManager.LogFactory.ServiceRepository;
+        }
+
+        public static T ResolveService<T>(this IServiceResolver serviceResolver) where T : class
+        {
+            return (serviceResolver ?? LogManager.LogFactory.ServiceRepository)?.ResolveInstance(typeof(T)) as T;
+        }
+
+        public static IJsonConverter ResolveJsonConverter(this IServiceResolver serviceResolver)
+        {
+            return serviceResolver?.ResolveService<IJsonConverter>() ?? Targets.DefaultJsonSerializer.Instance;
+        }
+
+        public static IPropertyTypeConverter ResolvePropertyTypeConverter(this IServiceResolver serviceResolver)
+        {
+            return serviceResolver?.ResolveService<IPropertyTypeConverter>() ?? PropertyTypeConverter.Instance;
+        }
+
+        public static IValueFormatter ResolveValueFormatter(this IServiceResolver serviceResolver)
+        {
+            return serviceResolver?.ResolveService<IValueFormatter>() ?? MessageTemplates.ValueFormatter.Instance;
+        }
+
+        public static IServiceRepository RegisterSingleton<T>(this IServiceRepository serviceRepository, T singleton) where T : class
+        {
+            serviceRepository.RegisterType(typeof(IValueFormatter), (t) => singleton);
+            return serviceRepository;
+        }
+
+        /// <summary>
+        /// Registers the string serializer to use with <see cref="LogEventInfo.MessageTemplateParameters"/>
+        /// </summary>
+        public static IServiceRepository RegisterValueFormatter(this IServiceRepository serviceRepository, IValueFormatter valueFormatter)
+        {
+            serviceRepository.RegisterSingleton(valueFormatter ?? MessageTemplates.ValueFormatter.Instance);
+            return serviceRepository;
+        }
+
+        public static IServiceRepository RegisterJsonConverter(this IServiceRepository serviceRepository, IJsonConverter jsonConverter)
+        {
+            serviceRepository.RegisterSingleton(jsonConverter ?? Targets.DefaultJsonSerializer.Instance);
+            return serviceRepository;
+        }
+    }
+}

--- a/src/NLog/Internal/Strings/StringBuilderExt.cs
+++ b/src/NLog/Internal/Strings/StringBuilderExt.cs
@@ -51,7 +51,8 @@ namespace NLog.Internal
         /// <param name="value">value to be appended</param>
         /// <param name="format">formatstring. If @, then serialize the value with the Default JsonConverter.</param>
         /// <param name="formatProvider">provider, for example culture</param>
-        public static void AppendFormattedValue(this StringBuilder builder, object value, string format, IFormatProvider formatProvider)
+        /// <param name="valueFormatter">NLog string.Format interface</param>
+        public static void AppendFormattedValue(this StringBuilder builder, object value, string format, IFormatProvider formatProvider, IValueFormatter valueFormatter)
         {
             string stringValue = value as string;
             if (stringValue != null && string.IsNullOrEmpty(format))
@@ -60,11 +61,11 @@ namespace NLog.Internal
             }
             else if (format == MessageTemplates.ValueFormatter.FormatAsJson)
             {
-                ValueFormatter.Instance.FormatValue(value, null, CaptureType.Serialize, formatProvider, builder);
+                valueFormatter.FormatValue(value, null, CaptureType.Serialize, formatProvider, builder);
             }
             else if (value != null)
             {
-                ValueFormatter.Instance.FormatValue(value, format, CaptureType.Normal, formatProvider, builder);
+                valueFormatter.FormatValue(value, format, CaptureType.Normal, formatProvider, builder);
             }
         }
 

--- a/src/NLog/LayoutRenderers/ApplicationEnvironment/ProcessInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ApplicationEnvironment/ProcessInfoLayoutRenderer.cs
@@ -53,6 +53,9 @@ namespace NLog.LayoutRenderers
         private Process _process;
         private ReflectionHelpers.LateBoundMethod _lateBoundPropertyGet;
 
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceResolver().ResolveValueFormatter());
+        private IValueFormatter _valueFormatter;
+
         /// <summary>
         /// Gets or sets the property to retrieve.
         /// </summary>
@@ -101,7 +104,7 @@ namespace NLog.LayoutRenderers
             if (value != null)
             {
                 var formatProvider = GetFormatProvider(logEvent);
-                builder.AppendFormattedValue(value, Format, formatProvider);
+                builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
             }
         }
 

--- a/src/NLog/LayoutRenderers/Contexts/AllEventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/AllEventPropertiesLayoutRenderer.cs
@@ -57,6 +57,9 @@ namespace NLog.LayoutRenderers
         private string _afterKey;
         private string _afterValue;
 
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceResolver().ResolveValueFormatter());
+        private IValueFormatter _valueFormatter;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AllEventPropertiesLayoutRenderer"/> class.
         /// </summary>
@@ -164,9 +167,9 @@ namespace NLog.LayoutRenderers
                     else
                     {
                         builder.Append(_beforeKey);
-                        builder.AppendFormattedValue(property.Key, null, formatProvider);
+                        builder.AppendFormattedValue(property.Key, null, formatProvider, ValueFormatter);
                         builder.Append(_afterKey);
-                        builder.AppendFormattedValue(property.Value, null, formatProvider);
+                        builder.AppendFormattedValue(property.Value, null, formatProvider, ValueFormatter);
                         builder.Append(_afterValue);
                     }
                 }

--- a/src/NLog/LayoutRenderers/Contexts/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/EventPropertiesLayoutRenderer.cs
@@ -52,6 +52,9 @@ namespace NLog.LayoutRenderers
     {
         private readonly ObjectPropertyHelper _objectPropertyHelper = new ObjectPropertyHelper();
 
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceResolver().ResolveValueFormatter());
+        private IValueFormatter _valueFormatter;
+
         /// <summary>
         /// Gets or sets the name of the item.
         /// </summary>
@@ -88,7 +91,7 @@ namespace NLog.LayoutRenderers
             if (TryGetValue(logEvent, out var value))
             {
                 var formatProvider = GetFormatProvider(logEvent, Culture);
-                builder.AppendFormattedValue(value, Format, formatProvider);
+                builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
             }
         }
 

--- a/src/NLog/LayoutRenderers/Contexts/GdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/GdcLayoutRenderer.cs
@@ -46,6 +46,9 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class GdcLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceResolver().ResolveValueFormatter());
+        private IValueFormatter _valueFormatter;
+
         /// <summary>
         /// Gets or sets the name of the item.
         /// </summary>
@@ -64,8 +67,11 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             object value = GetValue();
-            var formatProvider = GetFormatProvider(logEvent, null);
-            builder.AppendFormattedValue(value, Format, formatProvider);
+            if (value != null || !string.IsNullOrEmpty(Format))
+            {
+                var formatProvider = GetFormatProvider(logEvent, null);
+                builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/NLog/LayoutRenderers/Contexts/MdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/MdcLayoutRenderer.cs
@@ -44,6 +44,9 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class MdcLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceResolver().ResolveValueFormatter());
+        private IValueFormatter _valueFormatter;
+
         /// <summary>
         /// Gets or sets the name of the item.
         /// </summary>
@@ -63,7 +66,7 @@ namespace NLog.LayoutRenderers
         {
             var value = GetValue();
             var formatProvider = GetFormatProvider(logEvent, null);
-            builder.AppendFormattedValue(value, Format, formatProvider);
+            builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
         }
 
         /// <inheritdoc/>

--- a/src/NLog/LayoutRenderers/Contexts/MdlcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/MdlcLayoutRenderer.cs
@@ -46,6 +46,9 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class MdlcLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceResolver().ResolveValueFormatter());
+        private IValueFormatter _valueFormatter;
+
         /// <summary>
         /// Gets or sets the name of the item.
         /// </summary>
@@ -65,7 +68,7 @@ namespace NLog.LayoutRenderers
         {
             var value = GetValue();
             var formatProvider = GetFormatProvider(logEvent, null);
-            builder.AppendFormattedValue(value, Format, formatProvider);
+            builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
         }
         
         /// <inheritdoc/>

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -54,6 +54,9 @@ namespace NLog.LayoutRenderers
         private string _innerFormat = string.Empty;
         private readonly Dictionary<ExceptionRenderingFormat, Action<StringBuilder, Exception>> _renderingfunctions;
 
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceResolver().ResolveValueFormatter());
+        private IValueFormatter _valueFormatter;
+
         private static readonly Dictionary<string, ExceptionRenderingFormat> _formatsMapping = new Dictionary<string, ExceptionRenderingFormat>(StringComparer.OrdinalIgnoreCase)
                                                                                                     {
                                                                                                         {"MESSAGE",ExceptionRenderingFormat.Message},
@@ -421,7 +424,7 @@ namespace NLog.LayoutRenderers
         /// <param name="ex">The Exception whose properties should be appended.</param>
         protected virtual void AppendSerializeObject(StringBuilder sb, Exception ex)
         {
-            ConfigurationItemFactory.Default.ValueFormatter.FormatValue(ex, null, MessageTemplates.CaptureType.Serialize, null, sb);
+            ValueFormatter.FormatValue(ex, null, MessageTemplates.CaptureType.Serialize, null, sb);
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/Wrappers/ObjectPathRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ObjectPathRendererWrapper.cs
@@ -52,6 +52,9 @@ namespace NLog.LayoutRenderers.Wrappers
     {
         private readonly ObjectPropertyHelper _objectPropertyHelper = new ObjectPropertyHelper();
 
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceResolver().ResolveValueFormatter());
+        private IValueFormatter _valueFormatter;
+
         private SimpleLayout _innerAsSimple;
 
         /// <inheritdoc />
@@ -110,7 +113,7 @@ namespace NLog.LayoutRenderers.Wrappers
                 if (TryGetRawValue(logEvent, out object rawValue))
                 {
                     var formatProvider = GetFormatProvider(logEvent, Culture);
-                    builder.AppendFormattedValue(rawValue, Format, formatProvider);
+                    builder.AppendFormattedValue(rawValue, Format, formatProvider, ValueFormatter);
                 }
             }
             else

--- a/src/NLog/Layouts/JSON/JsonLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonLayout.cs
@@ -48,13 +48,13 @@ namespace NLog.Layouts
     {
         private LimitRecursionJsonConvert JsonConverter
         {
-            get => _jsonConverter ?? (_jsonConverter = new LimitRecursionJsonConvert(MaxRecursionLimit, ConfigurationItemFactory.Default.JsonConverter));
+            get => _jsonConverter ?? (_jsonConverter = new LimitRecursionJsonConvert(MaxRecursionLimit, LoggingConfiguration.GetServiceResolver().ResolveJsonConverter()));
             set => _jsonConverter = value;
         }
         private LimitRecursionJsonConvert _jsonConverter;
         private IValueFormatter ValueFormatter
         {
-            get => _valueFormatter ?? (_valueFormatter = ConfigurationItemFactory.Default.ValueFormatter);
+            get => _valueFormatter ?? (_valueFormatter = LoggingConfiguration.GetServiceResolver().ResolveValueFormatter());
             set => _valueFormatter = value;
         }
         private IValueFormatter _valueFormatter;

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -386,7 +386,7 @@ namespace NLog.Layouts
                     //check for performance
                     if (InternalLogger.IsWarnEnabled || InternalLogger.IsErrorEnabled)
                     {
-                        InternalLogger.Warn(exception, "Exception in '{0}.Append()'", _stringValueRenderer?.GetType().FullName);
+                        InternalLogger.Warn(exception, "Exception in '{0}.GetFormattedString()'", _stringValueRenderer?.GetType().FullName);
                     }
 
                     if (exception.MustBeRethrown())

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -257,6 +257,11 @@ namespace NLog
         }
 
         /// <summary>
+        /// Repository of intefaces used by NLog to allow override for dependency injection
+        /// </summary>
+        public IServiceRepository ServiceRepository { get; internal set; } = new ServiceRepository();
+
+        /// <summary>
         /// Gets or sets the global log level threshold. Log events below this threshold are not logged.
         /// </summary>
         public LogLevel GlobalThreshold
@@ -920,7 +925,7 @@ namespace NLog
             }
             else
             {
-                var instance = FactoryHelper.CreateInstance(customLoggerType);
+                var instance = ServiceRepository.ResolveInstance(customLoggerType);
                 var newLogger = instance as Logger;
                 if (newLogger == null)
                 {

--- a/src/NLog/MessageTemplates/ValueFormatter.cs
+++ b/src/NLog/MessageTemplates/ValueFormatter.cs
@@ -54,11 +54,11 @@ namespace NLog.MessageTemplates
         private static IValueFormatter _instance;
         private static readonly IEqualityComparer<object> _referenceEqualsComparer = SingleItemOptimizedHashSet<object>.ReferenceEqualityComparer.Default;
 
-        private readonly ServiceRepository _serviceRepository;
+        private readonly IServiceRepository _serviceRepository;
         private IJsonConverter JsonConverter => _jsonConverter ?? (_jsonConverter = _serviceRepository.ResolveJsonConverter());
         private IJsonConverter _jsonConverter;
 
-        internal ValueFormatter(ServiceRepository serviceRepository)
+        internal ValueFormatter(IServiceRepository serviceRepository)
         {
             _serviceRepository = serviceRepository;
         }

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -266,7 +266,7 @@ namespace NLog.Targets
 
         private IPropertyTypeConverter PropertyTypeConverter
         {
-            get => _propertyTypeConverter ?? (_propertyTypeConverter = ConfigurationItemFactory.Default.PropertyTypeConverter);
+            get => _propertyTypeConverter ?? (_propertyTypeConverter = LoggingConfiguration.GetServiceResolver().ResolvePropertyTypeConverter());
             set => _propertyTypeConverter = value;
         }
         private IPropertyTypeConverter _propertyTypeConverter;

--- a/src/NLog/Targets/MethodCallTargetBase.cs
+++ b/src/NLog/Targets/MethodCallTargetBase.cs
@@ -63,7 +63,7 @@ namespace NLog.Targets
 
         private IPropertyTypeConverter PropertyTypeConverter
         {
-            get => _propertyTypeConverter ?? (_propertyTypeConverter = ConfigurationItemFactory.Default.PropertyTypeConverter);
+            get => _propertyTypeConverter ?? (_propertyTypeConverter = LoggingConfiguration.GetServiceResolver().ResolvePropertyTypeConverter());
             set => _propertyTypeConverter = value;
         }
         private IPropertyTypeConverter _propertyTypeConverter;

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -112,7 +112,7 @@ namespace NLog.Targets
 
         private IPropertyTypeConverter PropertyTypeConverter
         {
-            get => _propertyTypeConverter ?? (_propertyTypeConverter = ConfigurationItemFactory.Default.PropertyTypeConverter);
+            get => _propertyTypeConverter ?? (_propertyTypeConverter = LoggingConfiguration.GetServiceResolver().ResolvePropertyTypeConverter());
             set => _propertyTypeConverter = value;
         }
         private IPropertyTypeConverter _propertyTypeConverter;

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -625,12 +625,12 @@ namespace NLog.Targets
 
         private class HttpPostJsonFormatter : HttpPostTextFormatterBase
         {
-            private IJsonConverter JsonConverter => _jsonConverter ?? (_jsonConverter = ConfigurationItemFactory.Default.JsonConverter);
-            private IJsonConverter _jsonConverter;
+            private readonly IJsonConverter _jsonConverter;
 
             public HttpPostJsonFormatter(WebServiceTarget target)
                 : base(target)
             {
+                _jsonConverter = target.LoggingConfiguration.GetServiceResolver().ResolveJsonConverter();
             }
 
             protected override string GetContentType(WebServiceTarget target)
@@ -656,7 +656,7 @@ namespace NLog.Targets
                         builder.Append('"');
                         builder.Append(parameter.Name);
                         builder.Append("\":");
-                        JsonConverter.SerializeObject(parameterValues[i], builder);
+                        _jsonConverter.SerializeObject(parameterValues[i], builder);
                         separator = ",";
                     }
                     builder.Append('}');

--- a/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
@@ -45,8 +45,8 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void ConfigurationItemFactoryDefaultTest()
         {
-            var cif = new ConfigurationItemFactory();
-            Assert.IsType<DebugTarget>(cif.CreateInstance(typeof(DebugTarget)));
+            var serviceRepository = new ServiceRepository();
+            Assert.IsType<DebugTarget>(serviceRepository.CreateInstance(typeof(DebugTarget)));
         }
 
         [Fact]
@@ -64,7 +64,9 @@ namespace NLog.UnitTests.Config
             var cif = new ConfigurationItemFactory();
             cif.RegisterType(typeof(DebugTarget), string.Empty);
             List<Type> resolvedTypes = new List<Type>();
-            cif.CreateInstance = t => { resolvedTypes.Add(t); return FactoryHelper.CreateInstance(t); };
+#pragma warning disable CS0618 // Type or member is obsolete
+            cif.CreateInstance = t => { resolvedTypes.Add(t); return Activator.CreateInstance(t); };
+#pragma warning restore CS0618 // Type or member is obsolete
             Target target = cif.Targets.CreateInstance("Debug");
             Assert.NotNull(target);
             Assert.Single(resolvedTypes);

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -66,7 +66,7 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void ExtensionTest1()
         {
-            ConfigurationItemFactory.Default = null; //build new factory next time
+            LogManager.LogFactory.ServiceRepository = new ServiceRepository(true);
 
             Assert.NotNull(typeof(FooLayout));
 
@@ -113,7 +113,7 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void ExtensionTest2()
         {
-            ConfigurationItemFactory.Default = null; //build new factory next time
+            LogManager.LogFactory.ServiceRepository = new ServiceRepository(true);
 
             var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
 <nlog throwExceptions='true'>
@@ -162,7 +162,7 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void ExtensionWithPrefixTest()
         {
-            ConfigurationItemFactory.Default = null; //build new factory next time
+            LogManager.LogFactory.ServiceRepository = new ServiceRepository(true);
 
             var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
 <nlog throwExceptions='true'>
@@ -209,7 +209,7 @@ namespace NLog.UnitTests.Config
         {
             Assert.NotNull(typeof(FooLayout));
 
-            ConfigurationItemFactory.Default = null; //build new factory next time
+            LogManager.LogFactory.ServiceRepository = new ServiceRepository(true);
 
             var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
 <nlog throwExceptions='true'>
@@ -259,7 +259,7 @@ namespace NLog.UnitTests.Config
         {
             Assert.NotNull(typeof(FooLayout));
 
-            ConfigurationItemFactory.Default = null; //build new factory next time
+            LogManager.LogFactory.ServiceRepository = new ServiceRepository(true);
 
             var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
 <nlog throwExceptions='true'>
@@ -419,7 +419,7 @@ namespace NLog.UnitTests.Config
             finally
             {
                 ConfigurationItemFactory.Default.Clear();
-                ConfigurationItemFactory.Default = null; //build new factory next time
+                LogManager.LogFactory.ServiceRepository = new ServiceRepository(true);
             }
         }
 
@@ -439,7 +439,7 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                ConfigurationItemFactory.Default = null; //build new factory next time
+                LogManager.LogFactory.ServiceRepository = new ServiceRepository(true);
                 ConfigurationItemFactory.AssemblyLoading += onAssemblyLoading;
 
                 using(new NoThrowNLogExceptions())
@@ -475,7 +475,7 @@ namespace NLog.UnitTests.Config
                 //cleanup
                 ConfigurationItemFactory.AssemblyLoading -= onAssemblyLoading;
                 ConfigurationItemFactory.Default.Clear();
-                ConfigurationItemFactory.Default = null; //build new factory next time
+                LogManager.LogFactory.ServiceRepository = new ServiceRepository(true);
             }
         }
 
@@ -488,8 +488,8 @@ namespace NLog.UnitTests.Config
                 var writer = new StringWriter();
                 InternalLogger.LogWriter = writer;
                 InternalLogger.LogLevel = LogLevel.Debug;
-                //reload ConfigurationItemFactory 
-                ConfigurationItemFactory.Default = null;
+                LogManager.LogFactory.ServiceRepository = new ServiceRepository(true);
+
                 var fact = ConfigurationItemFactory.Default;
 
                 //also throw exceptions 

--- a/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
@@ -1,0 +1,121 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.Config
+{
+    using System.IO;
+    using System.Text;
+    using System.Xml;
+    using NLog.Targets;
+    using Xunit;
+
+    public class ServiceRepositoryTests : NLogTestBase
+    {
+        [Fact]
+        public void SideBySideLogFactoryExternalInterfaceTest()
+        {
+            // Stage
+            LogFactory logFactory1 = new LogFactory();
+            logFactory1.ServiceRepository.RegisterType(typeof(IMyPrettyInterface), (t) => new MyPrettyImplementation() { Test = nameof(logFactory1) });
+
+            LogFactory logFactory2 = new LogFactory();
+            logFactory2.ServiceRepository.RegisterType(typeof(IMyPrettyInterface), (t) => new MyPrettyImplementation() { Test = nameof(logFactory2) });
+
+            // Act
+            var logFactory1service = logFactory1.ServiceRepository.ResolveInstance(typeof(IMyPrettyInterface));
+            var logFactory2service = logFactory2.ServiceRepository.ResolveInstance(typeof(IMyPrettyInterface));
+
+            // Assert
+            Assert.Equal(nameof(logFactory1), logFactory1service.ToString());
+            Assert.Equal(nameof(logFactory2), logFactory2service.ToString());
+        }
+
+        [Fact]
+        public void SideBySideLogFactoryInternalInterfaceTest()
+        {
+            // Stage
+            LogFactory logFactory1 = new LogFactory();
+            InitializeLogFactoryJsonConverter(logFactory1, nameof(logFactory1), out Logger logger1, out DebugTarget target1);
+
+            LogFactory logFactory2 = new LogFactory();
+            InitializeLogFactoryJsonConverter(logFactory2, nameof(logFactory2), out Logger logger2, out DebugTarget target2);
+
+            // Act
+            logger1.Info("Hello {user}", "Kenny");
+            logger2.Info("Hello {user}", "Kenny");
+
+            // Assert
+            Assert.Equal("Kenny" + "_" + nameof(logFactory1), target1.LastMessage);
+            Assert.Equal("Kenny" + "_" + nameof(logFactory2), target2.LastMessage);
+        }
+
+        private static void InitializeLogFactoryJsonConverter(LogFactory logFactory, string jsonOutput, out Logger logger, out DebugTarget target)
+        {
+            logFactory.ServiceRepository.RegisterType(typeof(IJsonConverter), (t) => new MySimpleJsonConverter() { Test = jsonOutput });
+            using (var stringReader = new StringReader(@"<nlog><targets><target type='debug' name='test' layout='${event-properties:user:format=@}'/></targets><rules><logger name='*' minLevel='Debug' writeTo='test'/></rules></nlog>"))
+            {
+                using (var reader = XmlReader.Create(stringReader))
+                {
+                    logFactory.Configuration = new NLog.Config.XmlLoggingConfiguration(reader, null, logFactory);
+                }
+            }
+            logger = logFactory.GetLogger(nameof(logFactory));
+            target = logFactory.Configuration.FindTargetByName("test") as DebugTarget;
+        }
+
+        interface IMyPrettyInterface
+        {
+            string Test { get; }
+        }
+
+        class MyPrettyImplementation : IMyPrettyInterface
+        {
+            public string Test { get; set; }
+            public override string ToString()
+            {
+                return Test;
+            }
+        }
+
+        class MySimpleJsonConverter : IJsonConverter
+        {
+            public string Test { get; set; }
+
+            public bool SerializeObject(object value, StringBuilder builder)
+            {
+                builder.Append(string.Concat(value.ToString(), "_", Test));
+                return true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #3362 by allowing two LogFactory-object to have their own individual dependency-injection without being restricted by ConfigurationItemFactory.Default. 

There are still some static variables that remains, which requires more work. This PR is mostly about naming and design.

This can also be used to replace the static variables for registering HttpContext in NLog.Web and IConfiguration in ConfigSetting-LayoutRenderer.

My goal is to make ConfigurationItemFactory into an internal-class, so no longer accessible by others.

This pullrequest replaces #3128. Please ignore this PullRequest until #3431 has been merged.