### PR TITLE
Faster reflection of NLog configuration items by skipping Type.IsDefined 

### DIFF
--- a/src/NLog/Config/Factory.cs
+++ b/src/NLog/Config/Factory.cs
@@ -31,14 +31,14 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using NLog.LayoutRenderers;
-
 namespace NLog.Config
 {
     using System;
     using System.Collections.Generic;
-    using Common;
-    using Internal;
+    using System.Reflection;
+    using NLog.Common;
+    using NLog.Internal;
+    using NLog.LayoutRenderers;
 
     /// <summary>
     /// Factory for class-based items.
@@ -92,12 +92,15 @@ namespace NLog.Config
         /// <param name="itemNamePrefix">The item name prefix.</param>
         public void RegisterType(Type type, string itemNamePrefix)
         {
-            IEnumerable<TAttributeType> attributes = type.GetCustomAttributes<TAttributeType>(false);
-            if (attributes != null)
+            if (typeof(TBaseType).IsAssignableFrom(type))
             {
-                foreach (TAttributeType attr in attributes)
+                IEnumerable<TAttributeType> attributes = type.GetCustomAttributes<TAttributeType>(false);
+                if (attributes != null)
                 {
-                    RegisterDefinition(itemNamePrefix + attr.Name, type);
+                    foreach (TAttributeType attr in attributes)
+                    {
+                        RegisterDefinition(itemNamePrefix + attr.Name, type);
+                    }
                 }
             }
         }

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -282,13 +282,16 @@ namespace NLog.Layouts
         internal void PerformObjectScanning()
         {
             var objectGraphScannerList = ObjectGraphScanner.FindReachableObjects<object>(true, this);
+            var objectGraphTypes = new HashSet<Type>(objectGraphScannerList.Select(o => o.GetType()));
+            objectGraphTypes.Remove(typeof(SimpleLayout));
+            objectGraphTypes.Remove(typeof(NLog.LayoutRenderers.LiteralLayoutRenderer));
 
             // determine whether the layout is thread-agnostic
             // layout is thread agnostic if it is thread-agnostic and 
             // all its nested objects are thread-agnostic.
-            ThreadAgnostic = objectGraphScannerList.All(item => item.GetType().IsDefined(typeof(ThreadAgnosticAttribute), true));
-            ThreadSafe = objectGraphScannerList.All(item => item.GetType().IsDefined(typeof(ThreadSafeAttribute), true));
-            MutableUnsafe = objectGraphScannerList.Any(item => item.GetType().IsDefined(typeof(MutableUnsafeAttribute), true));
+            ThreadAgnostic = objectGraphTypes.All(t => t.IsDefined(typeof(ThreadAgnosticAttribute), true));
+            ThreadSafe = objectGraphTypes.All(t => t.IsDefined(typeof(ThreadSafeAttribute), true));
+            MutableUnsafe = objectGraphTypes.Any(t => t.IsDefined(typeof(MutableUnsafeAttribute), true));
 
             // determine the max StackTraceUsage, to decide if Logger needs to capture callsite
             StackTraceUsage = StackTraceUsage.None;    // In case this Layout should implement IUsesStackTrace


### PR DESCRIPTION
Can load 100 NLog-configs within 3 secs (before 6 secs):

Test application:

```c#
        static void Main(string[] args)
        {
            for (int i = 0; i < 100; ++i)
            {
                NLog.Config.ConfigurationItemFactory.Default = null;
                NLog.LogManager.Configuration = null;
                var logger = NLog.LogManager.GetLogger(i.ToString());
                logger.Fatal("Testing");
            }
        }
```

Still not super duper fast, but still an improvement.

Note merge to master branch.