### PR TITLE
ConcurrentRequestQueue - Consumer should always pulse waiting producers

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
+++ b/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
@@ -106,7 +106,7 @@ namespace NLog.Targets.Wrappers
                                 InternalLogger.Trace("Entered critical section.");
                             }
 
-                            InternalLogger.Trace("Limit ok.");
+                            InternalLogger.Trace("Async queue limit ok.");
                             break;
                     }
                 }


### PR DESCRIPTION
See also #3621

Note merge to master