### PR TITLE
Fixes bug in ExceptionLayoutRenderer where separator is excluded

### DIFF
--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -297,23 +297,20 @@ namespace NLog.LayoutRenderers
 
         private void AppendException(Exception currentException, List<ExceptionRenderingFormat> renderFormats, StringBuilder builder)
         {
-            int orgLength = builder.Length;
+            int currentLength = builder.Length;
             foreach (ExceptionRenderingFormat renderingFormat in renderFormats)
             {
-                if (orgLength != builder.Length)
-                {
-                    orgLength = builder.Length;
-                    builder.Append(Separator);
-                }
-
                 int beforeRenderLength = builder.Length;
                 var currentRenderFunction = _renderingfunctions[renderingFormat];
                 currentRenderFunction(builder, currentException);
-                if (builder.Length == beforeRenderLength && builder.Length != orgLength)
+                if (builder.Length != beforeRenderLength)
                 {
-                    builder.Length = orgLength;
+                    currentLength = builder.Length;
+                    builder.Append(Separator);
                 }
             }
+
+            builder.Length = currentLength;
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -994,6 +994,37 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
+        public void ExceptionWithSeparatorForExistingBetweenRender()
+        {
+            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog>
+                <targets>                                        
+                    <target name='debug1' type='Debug' layout='${exception:format=tostring,data,type:separator=\r\nXXX}' />
+                </targets>
+                <rules>
+                    <logger minlevel='Info' writeTo='debug1' />
+                </rules>
+            </nlog>");
+
+            const string exceptionMessage = "message for exception";
+            const string exceptionDataKey1 = "testkey1";
+            const string exceptionDataValue1 = "testvalue1";
+
+            Exception ex = GetExceptionWithoutStackTrace(exceptionMessage);
+            ex.Data.Add(exceptionDataKey1, exceptionDataValue1);
+
+            logger.Error(ex);
+
+            AssertDebugLastMessage(
+                "debug1",
+                string.Format(ExceptionDataFormat, ex.GetType().FullName, exceptionMessage) +
+                "\r\nXXX" +
+                string.Format(ExceptionDataFormat, exceptionDataKey1, exceptionDataValue1) +
+                "\r\nXXX" +
+                ex.GetType().FullName);
+        }
+
+        [Fact]
         public void ExceptionWithoutSeparatorForNoRender()
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
@@ -1013,6 +1044,33 @@ namespace NLog.UnitTests.LayoutRenderers
             logger.Error(ex);
 
             AssertDebugLastMessage("debug1", string.Format(ExceptionDataFormat, ex.GetType().FullName, exceptionMessage));
+        }
+
+
+        [Fact]
+        public void ExceptionWithoutSeparatorForNoBetweenRender()
+        {
+            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog>
+                <targets>
+                    <target name='debug1' type='Debug' layout='${exception:format=tostring,data,type:separator=\r\nXXX}' />
+                </targets>
+                <rules>
+                    <logger minlevel='Info' writeTo='debug1' />
+                </rules>
+            </nlog>");
+
+            const string exceptionMessage = "message for exception";
+
+            Exception ex = GetExceptionWithoutStackTrace(exceptionMessage);
+
+            logger.Error(ex);
+
+            AssertDebugLastMessage(
+                "debug1",
+                string.Format(ExceptionDataFormat, ex.GetType().FullName, exceptionMessage) +
+                "\r\nXXX" +
+                ex.GetType().FullName);
         }
     }
 


### PR DESCRIPTION
Fixes a bug in `ExceptionLayoutRenderer` where the separator is excluded between rendering formats when text is empty.

For example, in a case where the layout is: `exception:format=tostring,data,type:separator=\r\nXXX` but the middle renderer is empty (e.g: `data`) the current code produces no separator between the `tostring` and `type` text.

This pull request fixes this and adds relevant unit tests.

Note, test `ExceptionWithSeparatorForExistingBetweenRender` passes with the existing code, `ExceptionWithoutSeparatorForNoBetweenRender` does not. Both tests pass with the update.