### PR TITLE
Console target thread safe and support for batch writing

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -415,10 +415,7 @@ namespace NLog.Common
                 return;
             }
 
-            lock (LockObject)
-            {
-                Console.WriteLine(message);
-            }
+            NLog.Targets.ConsoleTargetHelper.WriteLineThreadSafe(Console.Out, message);
         }
 #endif
 
@@ -438,10 +435,7 @@ namespace NLog.Common
                 return;
             }
 
-            lock (LockObject)
-            {
-                Console.Error.WriteLine(message);
-            }
+            NLog.Targets.ConsoleTargetHelper.WriteLineThreadSafe(Console.Error, message);
         }
 #endif
 

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -155,7 +155,7 @@ namespace NLog.Internal
         /// <param name="transformBuffer">Helper char-buffer to minimize memory allocations</param>
         public static void CopyToStream(this StringBuilder builder, MemoryStream ms, Encoding encoding, char[] transformBuffer)
         {
-#if !SILVERLIGHT
+#if !SILVERLIGHT || WINDOWS_PHONE
             if (transformBuffer != null)
             {
                 int charCount;
@@ -183,6 +183,15 @@ namespace NLog.Internal
             }
         }
 
+        public static void CopyToBuffer(this StringBuilder builder, char[] destination, int destinationIndex)
+        {
+#if !SILVERLIGHT || WINDOWS_PHONE
+            builder.CopyTo(0, destination, destinationIndex, builder.Length);
+#else
+            builder.ToString().CopyTo(0, destination, destinationIndex, builder.Length);
+#endif
+        }
+
         /// <summary>
         /// Copies the contents of the StringBuilder to the destination StringBuilder
         /// </summary>
@@ -207,7 +216,7 @@ namespace NLog.Internal
                 }
                 else
                 {
-#if !SILVERLIGHT
+#if !SILVERLIGHT || WINDOWS_PHONE
                     // Reuse single char-buffer allocation for large StringBuilders
                     char[] buffer = new char[256];
                     for (int i = 0; i < sourceLength; i += buffer.Length)

--- a/src/NLog/Targets/ColoredConsoleAnsiPrinter.cs
+++ b/src/NLog/Targets/ColoredConsoleAnsiPrinter.cs
@@ -51,14 +51,14 @@ namespace NLog.Targets
             return new StringWriter(reusableBuilder ?? new StringBuilder(50), consoleStream.FormatProvider);
         }
 
-        public void ReleaseTextWriter(TextWriter consoleWriter, TextWriter consoleStream, ConsoleColor? oldForegroundColor, ConsoleColor? oldBackgroundColor)
+        public void ReleaseTextWriter(TextWriter consoleWriter, TextWriter consoleStream, ConsoleColor? oldForegroundColor, ConsoleColor? oldBackgroundColor, bool flush)
         {
             // Flushes the in-memory console-writer to the actual console-stream
             var builder = (consoleWriter as StringWriter)?.GetStringBuilder();
             if (builder != null)
             {
                 builder.Append(TerminalDefaultColorEscapeCode);
-                consoleStream.WriteLine(builder.ToString());
+                ConsoleTargetHelper.WriteLineThreadSafe(consoleStream, builder.ToString(), flush);
             }
         }
 

--- a/src/NLog/Targets/ColoredConsoleSystemPrinter.cs
+++ b/src/NLog/Targets/ColoredConsoleSystemPrinter.cs
@@ -51,9 +51,11 @@ namespace NLog.Targets
             return consoleStream;
         }
 
-        public void ReleaseTextWriter(TextWriter consoleWriter, TextWriter consoleStream, ConsoleColor? oldForegroundColor, ConsoleColor? oldBackgroundColor)
+        public void ReleaseTextWriter(TextWriter consoleWriter, TextWriter consoleStream, ConsoleColor? oldForegroundColor, ConsoleColor? oldBackgroundColor, bool flush)
         {
             ResetDefaultColors(consoleWriter, oldForegroundColor, oldBackgroundColor);
+            if (flush)
+                consoleWriter.Flush();
         }
 
         public ConsoleColor? ChangeForegroundColor(TextWriter consoleWriter, ConsoleColor? foregroundColor)
@@ -96,7 +98,7 @@ namespace NLog.Targets
 
         public void WriteLine(TextWriter consoleWriter, string text)
         {
-            consoleWriter.WriteLine(text);
+            consoleWriter.WriteLine(text);  // Cannot be threadsafe, since colors are incrementally updated
         }
 
         public IList<ConsoleRowHighlightingRule> DefaultConsoleRowHighlightingRules { get; } = new List<ConsoleRowHighlightingRule>()

--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -379,16 +379,13 @@ namespace NLog.Targets
             var consoleStream = GetOutput();
             if (ReferenceEquals(colorMessage, message) && !newForegroundColor.HasValue && !newBackgroundColor.HasValue)
             {
-                consoleStream.WriteLine(message);
+                ConsoleTargetHelper.WriteLineThreadSafe(consoleStream, message, AutoFlush);
             }
             else
             {
                 bool wordHighlighting = !ReferenceEquals(colorMessage, message) || message?.IndexOf('\n') >= 0;
                 WriteToOutputWithPrinter(consoleStream, colorMessage, newForegroundColor, newBackgroundColor, wordHighlighting);
             }
-
-            if (AutoFlush)
-                consoleStream.Flush();
         }
 
         private void WriteToOutputWithPrinter(TextWriter consoleStream, string colorMessage, ConsoleColor? newForegroundColor, ConsoleColor? newBackgroundColor,  bool wordHighlighting)
@@ -430,7 +427,7 @@ namespace NLog.Targets
                 }
                 finally
                 {
-                    _consolePrinter.ReleaseTextWriter(consoleWriter, consoleStream, oldForegroundColor, oldBackgroundColor);
+                    _consolePrinter.ReleaseTextWriter(consoleWriter, consoleStream, oldForegroundColor, oldBackgroundColor, AutoFlush);
                 }
             }
         }

--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -342,19 +342,12 @@ namespace NLog.Targets
             {
                 WriteToOutputWithColor(logEvent, message);
             }
-            catch (IndexOutOfRangeException ex)
+            catch (Exception ex) when (ex is OverflowException || ex is IndexOutOfRangeException || ex is ArgumentOutOfRangeException)
             {
                 // This is a bug and will therefore stop the logging. For docs, see the PauseLogging property.
                 _pauseLogging = true;
-                InternalLogger.Warn(ex, "An IndexOutOfRangeException has been thrown and this is probably due to a race condition." +
-                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets");
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                // This is a bug and will therefore stop the logging. For docs, see the PauseLogging property.
-                _pauseLogging = true;
-                InternalLogger.Warn(ex, "An ArgumentOutOfRangeException has been thrown and this is probably due to a race condition." +
-                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets");
+                InternalLogger.Warn(ex, "ColoredConsole(Name={0}): {1} has been thrown and this is probably due to a race condition." +
+                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets", Name, ex.GetType());
             }
         }
 

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -170,7 +170,7 @@ namespace NLog.Targets
                 _pauseLogging = !ConsoleTargetHelper.IsConsoleAvailable(out reason);
                 if (_pauseLogging)
                 {
-                    InternalLogger.Info("Console has been detected as turned off. Disable DetectConsoleAvailable to skip detection. Reason: {0}", reason);
+                    InternalLogger.Info("Console(Name={0}): Console has been detected as turned off. Disable DetectConsoleAvailable to skip detection. Reason: {1}", Name, reason);
                 }
             }
 
@@ -349,19 +349,12 @@ namespace NLog.Targets
             {
                 ConsoleTargetHelper.WriteLineThreadSafe(output, message, AutoFlush);
             }
-            catch (IndexOutOfRangeException ex)
+            catch (Exception ex) when (ex is OverflowException || ex is IndexOutOfRangeException || ex is ArgumentOutOfRangeException)
             {
                 //this is a bug and therefor stopping logging. For docs, see PauseLogging property
                 _pauseLogging = true;
-                InternalLogger.Warn(ex, "An IndexOutOfRangeException has been thrown and this is probably due to a race condition." +
-                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets");
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                //this is a bug and therefor stopping logging. For docs, see PauseLogging property
-                _pauseLogging = true;
-                InternalLogger.Warn(ex, "An ArgumentOutOfRangeException has been thrown and this is probably due to a race condition." +
-                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets");
+                InternalLogger.Warn(ex, "Console(Name={0}): {1} has been thrown and this is probably due to a race condition." +
+                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets", Name, ex.GetType());
             }
         }
 
@@ -371,19 +364,12 @@ namespace NLog.Targets
             {
                 ConsoleTargetHelper.WriteBufferThreadSafe(output, buffer, length, AutoFlush);
             }
-            catch (IndexOutOfRangeException ex)
+            catch (Exception ex) when (ex is OverflowException || ex is IndexOutOfRangeException || ex is ArgumentOutOfRangeException)
             {
                 //this is a bug and therefor stopping logging. For docs, see PauseLogging property
                 _pauseLogging = true;
-                InternalLogger.Warn(ex, "An IndexOutOfRangeException has been thrown and this is probably due to a race condition." +
-                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets");
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                //this is a bug and therefor stopping logging. For docs, see PauseLogging property
-                _pauseLogging = true;
-                InternalLogger.Warn(ex, "An ArgumentOutOfRangeException has been thrown and this is probably due to a race condition." +
-                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets");
+                InternalLogger.Warn(ex, "Console(Name={0}): {1} has been thrown and this is probably due to a race condition." +
+                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets", Name, ex.GetType());
             }
         }
 

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -248,9 +248,7 @@ namespace NLog.Targets
 
             try
             {
-                output.WriteLine(textLine);
-                if (AutoFlush)
-                    output.Flush();
+                ConsoleTargetHelper.WriteLineThreadSafe(output, textLine, AutoFlush);
             }
             catch (IndexOutOfRangeException ex)
             {

--- a/src/NLog/Targets/ConsoleTargetHelper.cs
+++ b/src/NLog/Targets/ConsoleTargetHelper.cs
@@ -40,6 +40,8 @@ namespace NLog.Targets
 {
     internal static class ConsoleTargetHelper
     {
+        private static readonly object _lockObject = new object();
+
         public static bool IsConsoleAvailable(out string reason)
         {
             reason = string.Empty;
@@ -108,6 +110,16 @@ namespace NLog.Targets
             }
 #endif
             return false;       // No console available
+        }
+
+        public static void WriteLineThreadSafe(TextWriter console, string message, bool flush = false)
+        {
+            lock (_lockObject)
+            {
+                console.WriteLine(message);
+                if (flush)
+                    console.Flush();
+            }
         }
     }
 }

--- a/src/NLog/Targets/ConsoleTargetHelper.cs
+++ b/src/NLog/Targets/ConsoleTargetHelper.cs
@@ -121,5 +121,15 @@ namespace NLog.Targets
                     console.Flush();
             }
         }
+
+        public static void WriteBufferThreadSafe(TextWriter console, char[] buffer, int length, bool flush = false)
+        {
+            lock (_lockObject)
+            {
+                console.Write(buffer, 0, length);
+                if (flush)
+                    console.Flush();
+            }
+        }
     }
 }

--- a/src/NLog/Targets/IColoredConsolePrinter.cs
+++ b/src/NLog/Targets/IColoredConsolePrinter.cs
@@ -60,7 +60,8 @@ namespace NLog.Targets
         /// <param name="consoleStream">Active console stream</param>
         /// <param name="oldForegroundColor">Original foreground color for console (If changed)</param>
         /// <param name="oldBackgroundColor">Original background color for console (If changed)</param>
-        void ReleaseTextWriter(TextWriter consoleWriter, TextWriter consoleStream, ConsoleColor? oldForegroundColor, ConsoleColor? oldBackgroundColor);
+        /// <param name="flush">Flush TextWriter</param>
+        void ReleaseTextWriter(TextWriter consoleWriter, TextWriter consoleStream, ConsoleColor? oldForegroundColor, ConsoleColor? oldBackgroundColor, bool flush);
 
         /// <summary>
         /// Changes foreground color for the Colored TextWriter

--- a/tests/NLog.UnitTests/Targets/ConsoleTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ConsoleTargetTests.cs
@@ -45,13 +45,25 @@ namespace NLog.UnitTests.Targets
     public class ConsoleTargetTests : NLogTestBase
     {
         [Fact]
-        public void ConsoleOutTest()
+        public void ConsoleOutWriteLineTest()
+        {
+            ConsoleOutTest(false);
+        }
+
+        [Fact]
+        public void ConsoleOutWriteBufferTest()
+        {
+            ConsoleOutTest(true);
+        }
+
+        private void ConsoleOutTest(bool writeBuffer)
         {
             var target = new ConsoleTarget()
             {
                 Header = "-- header --",
                 Layout = "${logger} ${message}",
                 Footer = "-- footer --",
+                WriteBuffer = writeBuffer,
             };
 
             var consoleOutWriter = new StringWriter();


### PR DESCRIPTION
Trying to improve the console-target for the use-case presented at #3621

Will help against thread-safety-issues in the following cases:
- Having multiple console-targets in the same nlog-config
- Having multiple logfactory-instance each with their own console-target
- Enabled InternalLogger Console Output together with console-target

The batch writing support (Enabled with WriteBuffer=true) will also help console applications running in the cloud as azure-functions, where the container captures the console output.