### PR TITLE
AsyncTargetWrapper - Eject writers on close incase timer thread is blocked

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
+++ b/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
@@ -177,6 +177,12 @@ namespace NLog.Targets.Wrappers
             lock (_logEventInfoQueue)
             {
                 _logEventInfoQueue.Clear();
+
+                if (OnOverflow == AsyncTargetWrapperOverflowAction.Block)
+                {
+                    // Try to eject any threads, that are blocked in the RequestQueue
+                    System.Threading.Monitor.PulseAll(_logEventInfoQueue);
+                }
             }
         }
     }

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -308,6 +308,7 @@ namespace NLog.Targets.Wrappers
         protected override void CloseTarget()
         {
             StopLazyWriterThread();
+            
             if (Monitor.TryEnter(_writeLockObject, 500))
             {
                 try
@@ -319,6 +320,12 @@ namespace NLog.Targets.Wrappers
                     Monitor.Exit(_writeLockObject);
                 }
             }
+
+            if (OverflowAction == AsyncTargetWrapperOverflowAction.Block)
+            {
+                _requestQueue.Clear();  // Try to eject any threads, that are blocked in the RequestQueue
+            }
+
             base.CloseTarget();
         }
 

--- a/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
+++ b/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
@@ -234,6 +234,15 @@ namespace NLog.Targets.Wrappers
             while (!_logEventInfoQueue.IsEmpty)
                 _logEventInfoQueue.TryDequeue(out var _);
             Interlocked.Exchange(ref _count, 0);
+
+            if (OnOverflow == AsyncTargetWrapperOverflowAction.Block)
+            {
+                // Try to eject any threads, that are blocked in the RequestQueue
+                lock (_logEventInfoQueue)
+                {
+                    Monitor.PulseAll(_logEventInfoQueue);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Trying to resolve the following issue:

- 10 Threads attacks the async-console-target. Async-background-writer falls behind because console is slow. OverflowAction block causes 10 threads to get stuck waiting for async-background-writer to catch up.
- NLog Configuration is reloaded. AsyncWrapper is closed (and stops async-background-writer), but never releases any of the threads being stuck inside waiting for queue. New async-console-target is created.
- 10 new threads attacks the new async-console-target. Story repeats itself until having 1100 threads stuck inside old async-console-target-objects.

See also #3621

Note merge to master