### PR TITLE
WrapperLayoutRendererBuilderBase - Obsolete and no longer used

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/Encodings/JsonEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/Encodings/JsonEncodeLayoutRendererWrapper.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
-    public sealed class JsonEncodeLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    public sealed class JsonEncodeLayoutRendererWrapper : WrapperLayoutRendererBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonEncodeLayoutRendererWrapper" /> class.
@@ -96,9 +96,9 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        protected override string Transform(string text)
         {
+            throw new NotSupportedException();
         }
 
         private bool RequiresJsonEncode(StringBuilder target, int startPos = 0)

--- a/src/NLog/LayoutRenderers/Wrappers/Encodings/Rot13LayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/Encodings/Rot13LayoutRendererWrapper.cs
@@ -48,7 +48,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
-    public sealed class Rot13LayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    public sealed class Rot13LayoutRendererWrapper : WrapperLayoutRendererBase
     {
         /// <summary>
         /// Gets or sets the layout to be wrapped.
@@ -86,9 +86,9 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        protected override string Transform(string text)
         {
+            throw new NotSupportedException();
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/Wrappers/FileSystemNormalizeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/FileSystemNormalizeLayoutRendererWrapper.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
-    public sealed class FileSystemNormalizeLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    public sealed class FileSystemNormalizeLayoutRendererWrapper : WrapperLayoutRendererBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSystemNormalizeLayoutRendererWrapper" /> class.
@@ -75,9 +75,9 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        protected override string Transform(string text)
         {
+            throw new NotSupportedException();
         }
 
         private static void TransformFileSystemNormalize(StringBuilder builder, int startPos)

--- a/src/NLog/LayoutRenderers/Wrappers/String transformations/LowercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/String transformations/LowercaseLayoutRendererWrapper.cs
@@ -47,7 +47,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
-    public sealed class LowercaseLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    public sealed class LowercaseLayoutRendererWrapper : WrapperLayoutRendererBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LowercaseLayoutRendererWrapper" /> class.
@@ -83,9 +83,9 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        protected override string Transform(string text)
         {
+            throw new NotSupportedException();
         }
 
         private void TransformToLowerCase(StringBuilder target, int startPos)

--- a/src/NLog/LayoutRenderers/Wrappers/String transformations/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/String transformations/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -47,7 +47,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
-    public sealed class ReplaceNewLinesLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    public sealed class ReplaceNewLinesLayoutRendererWrapper : WrapperLayoutRendererBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ReplaceNewLinesLayoutRendererWrapper" /> class.
@@ -83,15 +83,15 @@ namespace NLog.LayoutRenderers.Wrappers
             }
         }
 
+        /// <inheritdoc/>
+        protected override string Transform(string text)
+        {
+            throw new NotSupportedException();
+        }
+
         private static bool HasUnixNewline(string str)
         {
             return str != null && str.IndexOf('\n') >= 0;
-        }
-
-        /// <inheritdoc/>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
-        protected override void TransformFormattedMesssage(StringBuilder target)
-        {
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/String transformations/TrimWhiteSpaceLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/String transformations/TrimWhiteSpaceLayoutRendererWrapper.cs
@@ -47,7 +47,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
-    public sealed class TrimWhiteSpaceLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    public sealed class TrimWhiteSpaceLayoutRendererWrapper : WrapperLayoutRendererBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TrimWhiteSpaceLayoutRendererWrapper" /> class.
@@ -76,9 +76,9 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        protected override string Transform(string text)
         {
+            throw new NotSupportedException();
         }
 
         private static void TransformTrimWhiteSpaces(StringBuilder builder, int startPos)

--- a/src/NLog/LayoutRenderers/Wrappers/String transformations/UppercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/String transformations/UppercaseLayoutRendererWrapper.cs
@@ -52,7 +52,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     [ThreadSafe]
-    public sealed class UppercaseLayoutRendererWrapper : WrapperLayoutRendererBuilderBase
+    public sealed class UppercaseLayoutRendererWrapper : WrapperLayoutRendererBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UppercaseLayoutRendererWrapper" /> class.
@@ -88,9 +88,9 @@ namespace NLog.LayoutRenderers.Wrappers
         }
 
         /// <inheritdoc/>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
-        protected override void TransformFormattedMesssage(StringBuilder target)
+        protected override string Transform(string text)
         {
+            throw new NotSupportedException();
         }
 
         private void TransformToUpperCase(StringBuilder target, int startPos)

--- a/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
@@ -47,7 +47,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AmbientProperty("WhenEmpty")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public sealed class WhenEmptyLayoutRendererWrapper : WrapperLayoutRendererBuilderBase, IRawValue, IStringValueRenderer
+    public sealed class WhenEmptyLayoutRendererWrapper : WrapperLayoutRendererBase, IRawValue, IStringValueRenderer
     {
         private bool _skipStringValueRenderer;
 
@@ -75,6 +75,12 @@ namespace NLog.LayoutRenderers.Wrappers
 
             // render WhenEmpty when the inner layout was empty
             WhenEmpty.RenderAppendBuilder(logEvent, builder);
+        }
+
+        /// <inheritdoc/>
+        protected override string Transform(string text)
+        {
+            throw new NotSupportedException();
         }
 
         string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent)
@@ -135,12 +141,6 @@ namespace NLog.LayoutRenderers.Wrappers
 
             // render WhenEmpty when the inner layout was empty
             return WhenEmpty.TryGetRawValue(logEvent, out value);
-        }
-
-        /// <inheritdoc/>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
-        protected override void TransformFormattedMesssage(StringBuilder target)
-        {
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
@@ -47,7 +47,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AmbientProperty("When")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public sealed class WhenLayoutRendererWrapper : WrapperLayoutRendererBuilderBase, IRawValue
+    public sealed class WhenLayoutRendererWrapper : WrapperLayoutRendererBase, IRawValue
     {
         /// <summary>
         /// Gets or sets the condition that must be met for the <see cref="WrapperLayoutRendererBase.Inner"/> layout to be printed.
@@ -84,15 +84,15 @@ namespace NLog.LayoutRenderers.Wrappers
             }
         }
 
+        /// <inheritdoc/>
+        protected override string Transform(string text)
+        {
+            throw new NotSupportedException();
+        }
+
         private bool ShouldRenderInner(LogEventInfo logEvent)
         {
             return When == null || true.Equals(When.Evaluate(logEvent));
-        }
-
-        /// <inheritdoc/>
-        [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
-        protected override void TransformFormattedMesssage(StringBuilder target)
-        {
         }
 
         /// <inheritdoc />

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
@@ -41,6 +41,7 @@ namespace NLog.LayoutRenderers.Wrappers
     /// 
     /// This expects the transformation to work on a <see cref="StringBuilder"/>
     /// </summary>
+    [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 5.0")]
     public abstract class WrapperLayoutRendererBuilderBase : WrapperLayoutRendererBase
     {
         /// <inheritdoc/>
@@ -91,7 +92,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <returns></returns>
         protected sealed override string Transform(string text)
         {
-            throw new NotSupportedException("Use TransformFormattedMesssage");
+            throw new NotSupportedException("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform()");
         }
 
         /// <summary>
@@ -101,7 +102,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <returns></returns>
         protected sealed override string RenderInner(LogEventInfo logEvent)
         {
-            throw new NotSupportedException("Use RenderFormattedMessage");
+            throw new NotSupportedException("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform()");
         }
     }
 }


### PR DESCRIPTION
Moving WrapperLayoutRendererBuilderBase one step closer to the edge of oblivion. The last remains of a failed optimization attempt, that should not be followed by anyone.