### PR TITLE
More robust GetCurrentClassLogger when we get lambda_method

### DIFF
--- a/src/NLog/Internal/StackTraceUsageUtils.cs
+++ b/src/NLog/Internal/StackTraceUsageUtils.cs
@@ -184,7 +184,7 @@ namespace NLog.Internal
 #if !NETSTANDARD1_0
         /// <summary>
         /// Gets the fully qualified name of the class invoking the calling method, including the 
-        /// namespace but not the assembly.    
+        /// namespace but not the assembly.
         /// </summary>
         /// <param name="stackFrame">StackFrame from the calling method</param>
         /// <returns>Fully qualified class name</returns>
@@ -199,6 +199,8 @@ namespace NLog.Internal
                 var stackTrace = new StackTrace(false);
 #endif
                 className = GetClassFullName(stackTrace);
+                if (string.IsNullOrEmpty(className))
+                    className = stackFrame.GetMethod()?.Name ?? string.Empty;
             }
             return className;
         }
@@ -259,10 +261,17 @@ namespace NLog.Internal
             var method = stackFrame.GetMethod();
             if (method != null && LookupAssemblyFromStackFrame(stackFrame) != null)
             {
-                string className = GetStackFrameMethodClassName(method, true, true, true) ?? method.Name;
-                if (!string.IsNullOrEmpty(className) && !className.StartsWith("System.", StringComparison.Ordinal))
+                string className = GetStackFrameMethodClassName(method, true, true, true);
+                if (!string.IsNullOrEmpty(className))
                 {
-                    return className;
+                    if (!className.StartsWith("System.", StringComparison.Ordinal))
+                        return className;
+                }
+                else
+                {
+                    className = method.Name ?? string.Empty;
+                    if (className != "lambda_method" && className != "MoveNext")
+                        return className;
                 }
             }
 

--- a/tests/NLog.UnitTests/GetLoggerTests.cs
+++ b/tests/NLog.UnitTests/GetLoggerTests.cs
@@ -46,6 +46,14 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        public void GetCurrentClassLoggerLambdaTest()
+        {
+            System.Linq.Expressions.Expression<Func<ILogger>> sum = () => LogManager.GetCurrentClassLogger();
+            ILogger logger = sum.Compile().Invoke();
+            Assert.Equal("NLog.UnitTests.GetLoggerTests", logger.Name);
+        }
+
+        [Fact]
         public void TypedGetLoggerTest()
         {
             LogFactory lf = new LogFactory();


### PR DESCRIPTION
GetCurrentClassLogger with fallback to StackTrace when lambda_method

When first StackFrame is lambda_method, then scan entire StackTrace. See also #3630

Note merge to master