### PR TITLE
${substring}: length should not be mandatory

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
@@ -74,7 +74,6 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <value>Index</value>
         /// <docgen category='Transformation Options' order='10' />
         [DefaultValue(null)]
-        [RequiredParameter]
         public int? Length { get; set; }
 
 


### PR DESCRIPTION
fixes https://github.com/NLog/NLog/issues/3632