### PR TITLE
Single file publish with ${basedir=fixTempDir=true} and prioritize process-dir for auto-loading exe.nlog

### DIFF
--- a/src/NLog/Internal/Fakeables/AppEnvironmentWrapper.cs
+++ b/src/NLog/Internal/Fakeables/AppEnvironmentWrapper.cs
@@ -50,6 +50,7 @@ namespace NLog.Internal.Fakeables
         public string EntryAssemblyLocation => AssemblyHelpers.GetAssemblyFileLocation(System.Reflection.Assembly.GetEntryAssembly());
         /// <inheritdoc />
         public string EntryAssemblyFileName => Path.GetFileName(System.Reflection.Assembly.GetEntryAssembly().Location ?? string.Empty);
+        public string UserTempFilePath => Path.GetTempPath();
 #endif
         /// <inheritdoc />
         public IEnumerable<string> PrivateBinPath => LogFactory.CurrentAppDomain.PrivateBinPath;

--- a/src/NLog/Internal/Fakeables/IAppEnvironment.cs
+++ b/src/NLog/Internal/Fakeables/IAppEnvironment.cs
@@ -46,6 +46,7 @@ namespace NLog.Internal.Fakeables
         string CurrentProcessFilePath { get; }
         string EntryAssemblyLocation { get; }
         string EntryAssemblyFileName { get; }
+        string UserTempFilePath { get; }
 #endif
         IEnumerable<string> PrivateBinPath { get; }
     }

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -192,7 +192,6 @@ namespace NLog.UnitTests
         public void LoadConfigFile_NetCoreUnpublished_UseEntryDirectory()
         {
             // Arrange
-            var d = Path.DirectorySeparatorChar;
             var tmpDir = Path.GetTempPath();
             var appEnvMock = new AppEnvironmentMock(f => true, f => null)
             {
@@ -213,14 +212,13 @@ namespace NLog.UnitTests
             var result = fileLoader.GetDefaultCandidateConfigFilePaths().ToList();
 
             // Assert base-directory + entry-directory + nlog-assembly-directory
-            AssertResult(tmpDir, "EntryDir", "Entry", result);
+            AssertResult(tmpDir, "EntryDir", "EntryDir", "Entry", result);
         }
 
         [Fact]
         public void LoadConfigFile_NetCorePublished_UseProcessDirectory()
         {
             // Arrange
-            var d = Path.DirectorySeparatorChar;
             var tmpDir = Path.GetTempPath();
             var appEnvMock = new AppEnvironmentMock(f => true, f => null)
             {
@@ -241,10 +239,38 @@ namespace NLog.UnitTests
             var result = fileLoader.GetDefaultCandidateConfigFilePaths().ToList();
 
             // Assert base-directory + process-directory + nlog-assembly-directory
-            AssertResult(tmpDir, "ProcessDir", "Process", result);
+            AssertResult(tmpDir, "ProcessDir", "ProcessDir", "Process", result);
         }
 
-        private static void AssertResult(string tmpDir, string appDir, string appName, List<string> result)
+        [Fact]
+        public void LoadConfigFile_NetCoreSingleFilePublish_IgnoreTempDirectory()
+        {
+            // Arrange
+            var tmpDir = Path.GetTempPath();
+            var appEnvMock = new AppEnvironmentMock(f => true, f => null)
+            {
+                AppDomainBaseDirectory = Path.Combine(tmpDir, "BaseDir"),
+#if NETSTANDARD
+                AppDomainConfigurationFile = string.Empty,                  // NetCore style
+#else
+                AppDomainConfigurationFile = Path.Combine(tmpDir, "ProcessDir", "Process.exe.config"),
+#endif
+                CurrentProcessFilePath = Path.Combine(tmpDir, "ProcessDir", "Process.exe"),    // NetCore published exe
+                EntryAssemblyLocation = Path.Combine(tmpDir, "TempProcessDir"),
+                UserTempFilePath = Path.Combine(tmpDir, "TempProcessDir"),
+                EntryAssemblyFileName = "Entry.dll"
+            };
+
+            var fileLoader = new LoggingConfigurationFileLoader(appEnvMock);
+
+            // Act
+            var result = fileLoader.GetDefaultCandidateConfigFilePaths().ToList();
+
+            // Assert base-directory + process-directory + nlog-assembly-directory
+            AssertResult(tmpDir, "TempProcessDir", "ProcessDir", "Process", result);
+        }
+
+        private static void AssertResult(string tmpDir, string appDir, string processDir, string appName, List<string> result)
         {
             if (NLog.Internal.PlatformDetector.IsWin32)
             {
@@ -256,7 +282,7 @@ namespace NLog.UnitTests
             }
             Assert.Equal(Path.Combine(tmpDir, "BaseDir", "NLog.config"), result.First(), StringComparer.OrdinalIgnoreCase);
             Assert.Contains(Path.Combine(tmpDir, appDir, "NLog.config"), result, StringComparer.OrdinalIgnoreCase);
-            Assert.Contains(Path.Combine(tmpDir, appDir, appName + ".exe.nlog"), result, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(Path.Combine(tmpDir, processDir, appName + ".exe.nlog"), result, StringComparer.OrdinalIgnoreCase);
 #if NETSTANDARD
             Assert.Contains(Path.Combine(tmpDir, appDir, "Entry.dll.nlog"), result, StringComparer.OrdinalIgnoreCase);
 #endif

--- a/tests/NLog.UnitTests/Mocks/AppEnvironmentMock.cs
+++ b/tests/NLog.UnitTests/Mocks/AppEnvironmentMock.cs
@@ -59,6 +59,8 @@ namespace NLog.UnitTests.Mocks
 
         public string EntryAssemblyFileName { get; set; } = string.Empty;
 
+        public string UserTempFilePath { get; set; } = string.Empty;
+
         public IEnumerable<string> PrivateBinPath { get; set; } = NLog.Internal.ArrayHelper.Empty<string>();
 
         public bool FileExists(string path)


### PR DESCRIPTION
Patch for #3517 ( .NET Core 3 Single File Publish unpacks into temp-directory, and AppDomain-BaseDirectory points to temp-directory, but process-filepath is still correct)

`${basedir:fixtempdir=true}`

This PR also changes exe-file-nlog-config auto-loading, so it prioritizes the process-directory, when the Entry-Assembly-Directory is a sub-folder to the Temp-path. Normally the Entry-Assembly-Directory is better when executing with context of dotnet-process (But NOT for NetCore3 single file publish).

Note merge to master