### PR TITLE
ConcurrentRequestQueue - DequeueBatch should handle that input list is non-empty

### DIFF
--- a/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
+++ b/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
@@ -212,6 +212,7 @@ namespace NLog.Targets.Wrappers
                 }
                 else
                 {
+                    count = i;
                     break;
                 }
             }
@@ -220,7 +221,7 @@ namespace NLog.Targets.Wrappers
             {
                 lock (_logEventInfoQueue)
                 {
-                    Interlocked.Add(ref _count, -result.Count);
+                    Interlocked.Add(ref _count, -count);
                     Monitor.PulseAll(_logEventInfoQueue);
                 }
             }


### PR DESCRIPTION
Not really a bug, but just a very minor improvement of internal collection.

Note merge to master.