### PR TITLE
Decouple LogEventInfo from other classes (WIP)

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -225,11 +225,11 @@ namespace NLog.Config
         {
             get
             {
-                if (ReferenceEquals(LogEventInfo.DefaultMessageFormatter, LogEventInfo.StringFormatMessageFormatter))
+                if (ReferenceEquals(LogMessageTemplateFormatterAdapter.DefaultMessageFormatter, LogMessageTemplateFormatterAdapter.StringFormatMessageFormatter))
                 {
                     return false;
                 }
-                else if (ReferenceEquals(LogEventInfo.DefaultMessageFormatter, LogMessageTemplateFormatter.Default.MessageFormatter))
+                else if (ReferenceEquals(LogMessageTemplateFormatterAdapter.DefaultMessageFormatter, LogMessageTemplateFormatterAdapter.Default))
                 {
                     return true;
                 }
@@ -238,7 +238,7 @@ namespace NLog.Config
                     return null;
                 }
             }
-            set => LogEventInfo.SetDefaultMessageFormatter(value);
+            set => LogMessageTemplateFormatterAdapter.SetDefaultMessageFormatter(value);
         }
 
         /// <summary>

--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -204,7 +204,7 @@ namespace NLog.Config
         [Obsolete("Instead use LogFactory.ServiceRepository.ResolveInstance(typeof(IValueFormatter)). Marked obsolete on NLog 5.0")]
         public IValueFormatter ValueFormatter
         {
-            get => _serviceResolver.ResolveService<IValueFormatter>() ?? MessageTemplates.ValueFormatter.Instance;
+            get => _serviceResolver.ResolveService<IValueFormatter>();
             set => _serviceResolver.RegisterValueFormatter(value);
         }
 

--- a/src/NLog/Config/ServiceRepositoryExtensions.cs
+++ b/src/NLog/Config/ServiceRepositoryExtensions.cs
@@ -33,6 +33,7 @@
 
 using System;
 using JetBrains.Annotations;
+using NLog.MessageTemplates;
 using NLog.Targets;
 
 namespace NLog.Config
@@ -76,7 +77,7 @@ namespace NLog.Config
                 throw new ArgumentNullException(nameof(valueFormatter));
             }
 
-            serviceRepository.RegisterSingleton(valueFormatter);
+            serviceRepository.RegisterSingleton(valueFormatter); //todo not good? Parameter could be non static registered?
             return serviceRepository;
         }
 
@@ -105,7 +106,7 @@ namespace NLog.Config
         public static IServiceRepository RegisterDefaults(this IServiceRepository serviceRepository)
         {
             serviceRepository.RegisterJsonConverter(DefaultJsonSerializer.Instance);
-            serviceRepository.RegisterValueFormatter(new MessageTemplates.ValueFormatter(serviceRepository));
+          //todo  serviceRepository.RegisterType<IValueFormatter>(typeof(ValueFormatter));
             serviceRepository.RegisterPropertyTypeConverter(PropertyTypeConverter.Instance);
             return serviceRepository;
         }

--- a/src/NLog/Internal/Abstractions/ILogMessageFormatter.cs
+++ b/src/NLog/Internal/Abstractions/ILogMessageFormatter.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using NLog.MessageTemplates;
+
 namespace NLog.Internal
 {
     using System.Text;
@@ -44,8 +46,9 @@ namespace NLog.Internal
         /// Format the message and return
         /// </summary>
         /// <param name="logEvent">LogEvent with message to be formatted</param>
+        /// <param name="templateRenderer"></param>
         /// <returns>formatted message</returns>
-        string FormatMessage(LogEventInfo logEvent);
+        string FormatMessage(LogEventInfo logEvent, TemplateRenderer templateRenderer); 
 
         /// <summary>
         /// Has the logevent properties?
@@ -59,6 +62,7 @@ namespace NLog.Internal
         /// </summary>
         /// <param name="logEvent">LogEvent with message to be formatted</param>
         /// <param name="builder">The <see cref="StringBuilder"/> to append the formatted message.</param>
-        void AppendFormattedMessage(LogEventInfo logEvent, StringBuilder builder);
+        /// <param name="templateRenderer"></param>
+        void AppendFormattedMessage(LogEventInfo logEvent, StringBuilder builder, TemplateRenderer templateRenderer);
     }
 }

--- a/src/NLog/Internal/LogMessageTemplateFormatter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatter.cs
@@ -51,6 +51,8 @@ namespace NLog.Internal
         private readonly bool _forceTemplateRenderer;
         private readonly bool _singleTargetOnly;
 
+        private TemplateRenderer _templateRenderer; //todo
+
         /// <summary>
         /// New formatter
         /// </summary>
@@ -61,6 +63,7 @@ namespace NLog.Internal
             _forceTemplateRenderer = forceTemplateRenderer;
             _singleTargetOnly = singleTargetOnly;
             MessageFormatter = FormatMessage;
+
         }
 
         /// <summary>
@@ -87,7 +90,7 @@ namespace NLog.Internal
             return true;    // Parse message template and allocate PropertiesDictionary
         }
 
-        private bool HasParameters(LogEventInfo logEvent)
+        private static bool HasParameters(LogEventInfo logEvent)
         {
             //if message is empty, there no parameters
             //null check cheapest, so in-front
@@ -102,7 +105,7 @@ namespace NLog.Internal
             }
             else
             {
-                logEvent.Message.Render(logEvent.FormatProvider ?? CultureInfo.CurrentCulture, logEvent.Parameters, _forceTemplateRenderer, builder, out _);
+                _templateRenderer.Render(logEvent.Message, logEvent.FormatProvider ?? CultureInfo.CurrentCulture, logEvent.Parameters, _forceTemplateRenderer, builder, out _);
             }
         }
 
@@ -121,7 +124,7 @@ namespace NLog.Internal
 
         private void AppendToBuilder(LogEventInfo logEvent, StringBuilder builder)
         {
-            logEvent.Message.Render(logEvent.FormatProvider ?? CultureInfo.CurrentCulture, logEvent.Parameters, _forceTemplateRenderer, builder, out var messageTemplateParameterList);
+            _templateRenderer.Render(logEvent.Message, logEvent.FormatProvider ?? CultureInfo.CurrentCulture, logEvent.Parameters, _forceTemplateRenderer, builder, out var messageTemplateParameterList);
             logEvent.CreateOrUpdatePropertiesInternal(false, messageTemplateParameterList ?? ArrayHelper.Empty<MessageTemplateParameter>());
         }
     }

--- a/src/NLog/Internal/LogMessageTemplateFormatterAdapter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatterAdapter.cs
@@ -1,0 +1,123 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Linq;
+using System.Text;
+using NLog.Common;
+using NLog.MessageTemplates;
+
+namespace NLog.Internal
+{
+    class LogMessageTemplateFormatterAdapter //todo fix better name
+    {
+        private readonly TemplateRenderer _templateRenderer;
+        public static readonly ILogMessageFormatter DefaultAuto = new LogMessageTemplateFormatter(false, false);
+        public static readonly ILogMessageFormatter Default = new LogMessageTemplateFormatter(true, false);
+        public static readonly ILogMessageFormatter DefaultAutoSingleTarget = new LogMessageTemplateFormatter(false, true);
+        
+        internal static readonly ILogMessageFormatter StringFormatMessageFormatter = new StringFormatMessageFormatter();
+
+        internal static ILogMessageFormatter DefaultMessageFormatter { get; private set; } = DefaultAuto;
+
+
+        private ILogMessageFormatter _messageFormatter = DefaultMessageFormatter;
+
+        /// <summary>
+        /// Set the <see cref="DefaultMessageFormatter"/>
+        /// </summary>
+        /// <param name="mode">true = Always, false = Never, null = Auto Detect</param>
+        internal static void SetDefaultMessageFormatter(bool? mode)
+        {
+            if (mode == true)
+            {
+                InternalLogger.Info("Message Template Format always enabled");
+                DefaultMessageFormatter = Default;
+            }
+            else if (mode == false)
+            {
+                InternalLogger.Info("Message Template String Format always enabled");
+                DefaultMessageFormatter = StringFormatMessageFormatter;
+            }
+            else
+            {
+                //null = auto
+                InternalLogger.Info("Message Template Auto Format enabled");
+                DefaultMessageFormatter = DefaultAuto;
+            }
+        }
+
+
+        /// <inheritdoc />
+        public LogMessageTemplateFormatterAdapter(TemplateRenderer templateRenderer)
+        {
+            _templateRenderer = templateRenderer;
+        }
+
+        public void AppendFormattedMessage(LogEventInfo logEventInfo, StringBuilder builder)
+        {
+            var useAutoSingle = UseAutoSingle(logEventInfo);
+
+            if (useAutoSingle)
+            {
+                DefaultAutoSingleTarget.AppendFormattedMessage(logEventInfo, builder, _templateRenderer);
+            }
+            else
+            {
+                Default.AppendFormattedMessage(logEventInfo, builder, _templateRenderer);
+            }
+        }
+
+        private static bool UseAutoSingle(LogEventInfo logEventInfo)
+        {
+            bool useAutoSingle;
+            if (logEventInfo.HasFormattedMessage)
+                useAutoSingle = false;
+            else
+            {
+                var parameters = logEventInfo.Parameters;
+                if (parameters == null || parameters.Length == 0)
+                    useAutoSingle = false;
+                else
+                {
+                    if (logEventInfo.Message?.Length < 256 && ReferenceEquals(DefaultMessageFormatter, DefaultAuto))
+                        useAutoSingle = true;
+                    else
+                        useAutoSingle = false;
+                }
+            }
+
+            return useAutoSingle;
+        }
+    }
+}

--- a/src/NLog/Internal/StringFormatMessageFormatter.cs
+++ b/src/NLog/Internal/StringFormatMessageFormatter.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NLog.MessageTemplates;
+
+namespace NLog.Internal
+{
+    class StringFormatMessageFormatter : ILogMessageFormatter
+    {
+        #region Implementation of ILogMessageFormatter
+
+        /// <inheritdoc />
+        public string FormatMessage(LogEventInfo logEvent, TemplateRenderer templateRenderer)
+        {
+            if (logEvent.Parameters == null || logEvent.Parameters.Length == 0)
+            {
+                return logEvent.Message;
+            }
+            else
+            {
+                return string.Format(logEvent.FormatProvider ?? CultureInfo.CurrentCulture, logEvent.Message, logEvent.Parameters);
+            }
+        }
+
+        /// <inheritdoc />
+        public bool HasProperties(LogEventInfo logEvent)
+        {
+            return false; //todo
+        }
+
+        /// <inheritdoc />
+        public void AppendFormattedMessage(LogEventInfo logEvent, StringBuilder builder, TemplateRenderer templateRenderer)
+        {
+            builder.AppendFormat(logEvent.FormatProvider ?? CultureInfo.CurrentCulture, logEvent.Message, logEvent.Parameters);
+        }
+
+        #endregion
+    }
+}

--- a/src/NLog/Internal/Strings/StringBuilderExt.cs
+++ b/src/NLog/Internal/Strings/StringBuilderExt.cs
@@ -59,7 +59,7 @@ namespace NLog.Internal
             {
                 builder.Append(value);  // Avoid automatic quotes
             }
-            else if (format == MessageTemplates.ValueFormatter.FormatAsJson)
+            else if (format == MessageTemplates.ValueFormats.FormatAsJson)
             {
                 valueFormatter.FormatValue(value, null, CaptureType.Serialize, formatProvider, builder);
             }

--- a/src/NLog/LayoutRenderers/Contexts/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/EventPropertiesLayoutRenderer.cs
@@ -129,7 +129,7 @@ namespace NLog.LayoutRenderers
 
         private string GetStringValue(LogEventInfo logEvent)
         {
-            if (Format != MessageTemplates.ValueFormatter.FormatAsJson)
+            if (Format != MessageTemplates.ValueFormats.FormatAsJson)
             {
                 if (TryGetValue(logEvent, out var value))
                 {

--- a/src/NLog/LayoutRenderers/Contexts/GdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/GdcLayoutRenderer.cs
@@ -83,7 +83,7 @@ namespace NLog.LayoutRenderers
 
         private string GetStringValue(LogEventInfo logEvent)
         {
-            if (Format != MessageTemplates.ValueFormatter.FormatAsJson)
+            if (Format != MessageTemplates.ValueFormats.FormatAsJson)
             {
                 object value = GetValue();
                 string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, null));

--- a/src/NLog/LayoutRenderers/Contexts/MdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/MdcLayoutRenderer.cs
@@ -71,7 +71,7 @@ namespace NLog.LayoutRenderers
 
         private string GetStringValue(LogEventInfo logEvent)
         {
-            if (Format != MessageTemplates.ValueFormatter.FormatAsJson)
+            if (Format != MessageTemplates.ValueFormats.FormatAsJson)
             {
                 object value = GetValue();
                 string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, null));

--- a/src/NLog/LayoutRenderers/Contexts/MdlcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/MdlcLayoutRenderer.cs
@@ -73,7 +73,7 @@ namespace NLog.LayoutRenderers
 
         private string GetStringValue(LogEventInfo logEvent)
         {
-            if (Format != MessageTemplates.ValueFormatter.FormatAsJson)
+            if (Format != MessageTemplates.ValueFormats.FormatAsJson)
             {
                 object value = GetValue();
                 string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, null));

--- a/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
@@ -46,11 +46,14 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class MessageLayoutRenderer : LayoutRenderer, IStringValueRenderer
     {
+        private readonly ILogMessageFormatter _formatter;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageLayoutRenderer" /> class.
         /// </summary>
         public MessageLayoutRenderer()
         {
+            _formatter = Resolve<ILogMessageFormatter>(); //todo smart/lazy?
             ExceptionSeparator = EnvironmentHelper.NewLine;
         }
 
@@ -83,15 +86,7 @@ namespace NLog.LayoutRenderers
             }
             else if (!exceptionOnly)
             {
-                if (ReferenceEquals(logEvent.MessageFormatter, LogMessageTemplateFormatter.DefaultAutoSingleTarget.MessageFormatter))
-                {
-                    // Skip string-allocation of LogEventInfo.FormattedMessage, but just write directly to StringBuilder
-                    logEvent.AppendFormattedMessage(LogMessageTemplateFormatter.DefaultAutoSingleTarget, builder);
-                }
-                else
-                {
-                    builder.Append(logEvent.FormattedMessage);
-                }
+                logEvent.AppendFormattedMessage(_formatter, builder);
             }
 
             if (WithException && logEvent.Exception != null)

--- a/src/NLog/MessageTemplates/TemplateRenderer.cs
+++ b/src/NLog/MessageTemplates/TemplateRenderer.cs
@@ -177,7 +177,7 @@ namespace NLog.MessageTemplates
             }
             else
             {
-                ValueFormatter.Instance.FormatValue(value, holeFormat, captureType, formatProvider, sb);
+                ValueFormatter.GetInstance(null).FormatValue(value, holeFormat, captureType, formatProvider, sb);
             }
         }
 

--- a/src/NLog/MessageTemplates/TemplateRenderer.cs
+++ b/src/NLog/MessageTemplates/TemplateRenderer.cs
@@ -40,8 +40,16 @@ namespace NLog.MessageTemplates
     /// <summary>
     /// Render templates
     /// </summary>
-    internal static class TemplateRenderer
+    internal class TemplateRenderer
     {
+        private readonly IValueFormatter _valueFormatter;
+
+        /// <inheritdoc />
+        public TemplateRenderer(IValueFormatter valueFormatter)
+        {
+            _valueFormatter = valueFormatter;
+        }
+
         /// <summary>
         /// Render a template to a string.
         /// </summary>
@@ -51,7 +59,7 @@ namespace NLog.MessageTemplates
         /// <param name="forceTemplateRenderer">Do not fallback to StringBuilder.Format for positional templates.</param>
         /// <param name="sb">The String Builder destination.</param>
         /// <param name="messageTemplateParameters">Parameters for the holes.</param>
-        public static void Render(this string template, IFormatProvider formatProvider, object[] parameters, bool forceTemplateRenderer, StringBuilder sb, out IList<MessageTemplateParameter> messageTemplateParameters)
+        public void Render(string template, IFormatProvider formatProvider, object[] parameters, bool forceTemplateRenderer, StringBuilder sb, out IList<MessageTemplateParameter> messageTemplateParameters)
         {
             int pos = 0;
             int holeIndex = 0;
@@ -128,7 +136,7 @@ namespace NLog.MessageTemplates
         /// <param name="formatProvider">Culture.</param>
         /// <param name="parameters">Parameters for the holes.</param>
         /// <returns>Rendered template, never null.</returns>
-        public static void Render(this Template template, StringBuilder sb, IFormatProvider formatProvider, object[] parameters)
+        public void Render(Template template, StringBuilder sb, IFormatProvider formatProvider, object[] parameters)
         {
             int pos = 0;
             int holeIndex = 0;
@@ -158,12 +166,12 @@ namespace NLog.MessageTemplates
             }
         }
 
-        private static void RenderHole(StringBuilder sb, Hole hole, IFormatProvider formatProvider, object value, bool legacy = false)
+        private void RenderHole(StringBuilder sb, Hole hole, IFormatProvider formatProvider, object value, bool legacy = false)
         {
             RenderHole(sb, hole.CaptureType, hole.Format, formatProvider, value, legacy);
         }
 
-        public static void RenderHole(StringBuilder sb, CaptureType captureType, string holeFormat, IFormatProvider formatProvider, object value, bool legacy = false)
+        public void RenderHole(StringBuilder sb, CaptureType captureType, string holeFormat, IFormatProvider formatProvider, object value, bool legacy = false)
         {
             if (value == null)
             {
@@ -173,11 +181,11 @@ namespace NLog.MessageTemplates
 
             if (captureType == CaptureType.Normal && legacy)
             {
-                ValueFormatter.FormatToString(value, holeFormat, formatProvider, sb);
+                _valueFormatter.FormatToString(value, holeFormat, formatProvider, sb);
             }
             else
             {
-                ValueFormatter.GetInstance(null).FormatValue(value, holeFormat, captureType, formatProvider, sb);
+                _valueFormatter.FormatValue(value, holeFormat, captureType, formatProvider, sb);
             }
         }
 

--- a/src/NLog/MessageTemplates/ValueFormats.cs
+++ b/src/NLog/MessageTemplates/ValueFormats.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -32,34 +32,13 @@
 // 
 
 using System;
-using System.Text;
-using NLog.MessageTemplates;
+using System.Linq;
 
-namespace NLog
+namespace NLog.MessageTemplates
 {
-    /// <summary>
-    /// Render a message template property to a string
-    /// </summary>
-    public interface IValueFormatter
+    internal static class ValueFormats
     {
-        /// <summary>
-        /// Serialization of an object, e.g. JSON and append to <paramref name="builder"/>
-        /// </summary>
-        /// <param name="value">The object to serialize to string.</param>
-        /// <param name="format">Parameter Format</param>
-        /// <param name="captureType">Parameter CaptureType</param>
-        /// <param name="formatProvider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="builder">Output destination.</param>
-        /// <returns>Serialize succeeded (true/false)</returns>
-        bool FormatValue(object value, string format, CaptureType captureType, IFormatProvider formatProvider, StringBuilder builder);
-
-        /// <summary>
-        /// Convert a value to a string with format and append to <paramref name="builder"/>.
-        /// </summary>
-        /// <param name="value">The value to convert.</param>
-        /// <param name="format">Format sting for the value.</param>
-        /// <param name="formatProvider">Format provider for the value.</param>
-        /// <param name="builder">Append to this</param>
-        void FormatToString(object value, string format, IFormatProvider formatProvider, StringBuilder builder);
+        public const string FormatAsJson = "@";
+        public const string FormatAsString = "$";
     }
 }

--- a/src/NLog/MessageTemplates/ValueFormatter.cs
+++ b/src/NLog/MessageTemplates/ValueFormatter.cs
@@ -47,11 +47,7 @@ namespace NLog.MessageTemplates
     /// </summary>
     internal class ValueFormatter : IValueFormatter
     {
-        public static IValueFormatter Instance
-        {
-            get => _instance ?? (_instance = new ValueFormatter(null)); //todo fix
-            set => _instance = value ?? new ValueFormatter(null);
-        }
+        public static IValueFormatter GetInstance(object serviceRepository) => _instance ?? (_instance = new ValueFormatter(serviceRepository));
         private static IValueFormatter _instance;
         private static readonly IEqualityComparer<object> _referenceEqualsComparer = SingleItemOptimizedHashSet<object>.ReferenceEqualityComparer.Default;
 


### PR DESCRIPTION
@snakefoot I'm trying to get the DI working correctly for  IValueFormatter /IJsonConverter , that means, not hard dependencies. Currently this is broken, as `null` is passed and then ValueFormatter.Instance is used.

Unfortunately i'm now stuck. LogEventInfo is really complex coupled to a lot of classes, which isn't correct as IValueFormatter and IJsonConverter should be in the DI container.

This PR is a try, but failed. Any idea how to decouple this?