### PR TITLE
ObjectGraphScanner - Avoid holding list.SyncRoot lock while scanning

### DIFF
--- a/src/NLog/Internal/ObjectGraphScanner.cs
+++ b/src/NLog/Internal/ObjectGraphScanner.cs
@@ -134,15 +134,15 @@ namespace NLog.Internal
                     }
                     else
                     {
+                        List<object> elements = new List<object>(list.Count);
                         lock (list.SyncRoot)
                         {
-                            List<object> elements = new List<object>(list.Count);
                             for (int i = 0; i < list.Count; i++)
                             {
                                 elements.Add(list[i]);
                             }
-                            ScanPropertiesList(aggressiveSearch, result, elements, level + 1, visitedObjects);
                         }
+                        ScanPropertiesList(aggressiveSearch, result, elements, level + 1, visitedObjects);
                     }
                 }
             }


### PR DESCRIPTION
Fixing regression from #3618 (Not super important, but just easier for the eye)

Note merge to master