### PR TITLE
${message} renders Exception.GetType + Exception.Message when single exception parameter

### DIFF
--- a/src/NLog/Internal/ExceptionMessageFormatProvider.cs
+++ b/src/NLog/Internal/ExceptionMessageFormatProvider.cs
@@ -1,0 +1,62 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal
+{
+    using System;
+
+    /// <summary>
+    /// FormatProvider that renders an exception-object as $"{ex.GetType()}: {ex.Message}"
+    /// </summary>
+    internal class ExceptionMessageFormatProvider : IFormatProvider, ICustomFormatter
+    {
+        internal static readonly ExceptionMessageFormatProvider Instance = new ExceptionMessageFormatProvider();
+
+        string ICustomFormatter.Format(string format, object arg, IFormatProvider formatProvider)
+        {
+            if (arg is Exception exception)
+            {
+                return $"{exception.GetType().ToString()}: {exception.Message}";
+            }
+            else
+            {
+                return string.Format("{0}", arg);
+            }
+        }
+
+        object IFormatProvider.GetFormat(Type formatType)
+        {
+            return (formatType == typeof(ICustomFormatter)) ? this : null;
+        }
+    }
+}

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -446,6 +446,7 @@ namespace NLog
                 logEvent.FormatProvider = formatProvider ?? logEvent.FormatProvider;
                 return logEvent;
             }
+            formatProvider = formatProvider ?? (exception != null ? ExceptionMessageFormatProvider.Instance : null);
             return new LogEventInfo(logLevel, loggerName, formatProvider, "{0}", new[] { message }, exception);
         }
 

--- a/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/MessageTests.cs
@@ -219,5 +219,31 @@ namespace NLog.UnitTests.LayoutRenderers
             logger.Debug(ex);
             AssertDebugLastMessage("debug", ex.ToString());
         }
+
+        [Fact]
+        public void SingleParameterException_OutputsSingleStackTrace()
+        {
+            // Arrange
+            var logFactory = new LogFactory();
+            var logConfig = new LoggingConfiguration(logFactory);
+            var logTarget = new NLog.Targets.DebugTarget("debug") { Layout = "${message}|${exception}" };
+            logConfig.AddRuleForAllLevels(logTarget);
+            logFactory.Configuration = logConfig;
+            var logger = logFactory.GetLogger("SingleParameterException");
+
+            // Act
+            try
+            {
+                logger.Info("Hello");
+                throw new ArgumentException("Holy Moly");
+            }
+            catch (Exception ex)
+            {
+                logger.Fatal(ex);
+            }
+
+            // Assert
+            Assert.StartsWith("System.ArgumentException: Holy Moly|System.ArgumentException", logTarget.LastMessage);
+        }
     }
 }


### PR DESCRIPTION
Instead of rendering Exception.ToString(). This PR resolves #1034 and resolves #1291 

Users that perform the following logging-operation will no longer get full stacktrace in `${message}`:

`logger.Error(ex);`

Users will still be able to get full stacktrace with `${message:withException=true}` or `${exception}`.

This PR will not affect users that perform the following logger-operation (Maintains the illusion of `string.Format`):

`logger.Error("{0}", ex);`

The new custom formatting is implemented with a special IFormatProvider, that is used when single-parameter-exception. This means `LogEventInfo.FormattedMessage` will also be affected (Will match the output of `${message}`)