### PR TITLE
LogBuilder - Removed Caller-properties since they are available with ${callsite}

### DIFF
--- a/src/NLog/Fluent/LogBuilder.cs
+++ b/src/NLog/Fluent/LogBuilder.cs
@@ -380,14 +380,6 @@ namespace NLog.Fluent
 
         private void SetCallerInfo(string callerMethodName, string callerFilePath, int callerLineNumber)
         {
-            // TODO NLog ver. 5 - Remove these properties
-            if (callerMethodName != null)
-                Property("CallerMemberName", callerMethodName);
-            if (callerFilePath != null)
-                Property("CallerFilePath", callerFilePath);
-            if (callerLineNumber != 0)
-                Property("CallerLineNumber", callerLineNumber);
-
             if (callerMethodName != null || callerFilePath != null || callerLineNumber != 0)
                 _logEvent.SetCallerInfo(null, callerMethodName, callerFilePath, callerLineNumber);
         }

--- a/src/NLog/LayoutRenderers/Contexts/AllEventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/AllEventPropertiesLayoutRenderer.cs
@@ -62,11 +62,7 @@ namespace NLog.LayoutRenderers
             Separator = ", ";
             Format = "[key]=[value]";
             Exclude = new HashSet<string>(
-#if NET4_5
-                CallerInformationAttributeNames,
-#else
                 ArrayHelper.Empty<string>(),
-#endif
                 StringComparer.OrdinalIgnoreCase);
         }
 
@@ -92,42 +88,6 @@ namespace NLog.LayoutRenderers
         public HashSet<string> Exclude { get; set; }
 #else
         public ISet<string> Exclude { get; set; }
-#endif
-
-#if NET4_5
-        /// <summary>
-        /// Also render the caller information attributes? (<see cref="System.Runtime.CompilerServices.CallerMemberNameAttribute"/>,
-        /// <see cref="System.Runtime.CompilerServices.CallerFilePathAttribute"/>, <see cref="System.Runtime.CompilerServices.CallerLineNumberAttribute"/>). 
-        /// 
-        /// See https://msdn.microsoft.com/en-us/library/hh534540.aspx
-        /// </summary>
-        /// <docgen category='Rendering Options' order='10' />
-        [Obsolete("Instead use the Exclude-property. Marked obsolete on NLog 4.6.8")]
-        [DefaultValue(false)]
-        public bool IncludeCallerInformation
-        {
-            get => Exclude?.Contains(CallerInformationAttributeNames[0]) != true;
-            set
-            {
-                if (!value)
-                {
-                    if (Exclude == null)
-                    {
-                        Exclude = new HashSet<string>(CallerInformationAttributeNames, StringComparer.OrdinalIgnoreCase);
-                    }
-                    else
-                    {
-                        foreach (var item in CallerInformationAttributeNames)
-                            Exclude.Add(item);
-                    }
-                }
-                else if (Exclude?.Count > 0)
-                {
-                    foreach (var item in CallerInformationAttributeNames)
-                        Exclude.Remove(item);
-                }
-            }
-        }
 #endif
 
         /// <summary>
@@ -215,13 +175,6 @@ namespace NLog.LayoutRenderers
         private bool CheckForExclude(LogEventInfo logEvent)
         {
             bool checkForExclude = Exclude?.Count > 0;
-#if NET45
-            if (checkForExclude)
-            {
-                // Skip Exclude check when only to exclude CallSiteInformation, and there is none
-                checkForExclude = !(logEvent.CallSiteInformation == null && Exclude.Count == CallerInformationAttributeNames.Length && Exclude.Contains(CallerInformationAttributeNames[0]));
-            }
-#endif
             return checkForExclude && logEvent.HasProperties;
         }
 
@@ -234,19 +187,5 @@ namespace NLog.LayoutRenderers
 
             return value == null;
         }
-
-#if NET4_5
-        /// <summary>
-        /// The names of caller information attributes.
-        /// <see cref="System.Runtime.CompilerServices.CallerMemberNameAttribute"/>, <see cref="System.Runtime.CompilerServices.CallerFilePathAttribute"/>, <see cref="System.Runtime.CompilerServices.CallerLineNumberAttribute"/>). 
-        /// https://msdn.microsoft.com/en-us/library/hh534540.aspx
-        /// TODO NLog ver. 5 - Remove these properties
-        /// </summary>
-        private static string[] CallerInformationAttributeNames = {
-            "CallerMemberName",
-            "CallerFilePath",
-            "CallerLineNumber",
-        };
-#endif
     }
 }

--- a/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
+++ b/tests/NLog.UnitTests/Fluent/LogBuilderTests.cs
@@ -572,11 +572,6 @@ namespace NLog.UnitTests.Fluent
 
             Assert.NotNull(_lastLogEventInfo.Properties);
 
-            // TODO NLog ver. 5 - Remove these properties
-            _lastLogEventInfo.Properties.Remove("CallerMemberName");
-            _lastLogEventInfo.Properties.Remove("CallerLineNumber");
-            _lastLogEventInfo.Properties.Remove("CallerFilePath");
-
             Assert.Equal(expected.Properties, _lastLogEventInfo.Properties);
             Assert.Equal(expected.LoggerName, _lastLogEventInfo.LoggerName);
             Assert.Equal(expected.Level, _lastLogEventInfo.Level);

--- a/tests/NLog.UnitTests/LayoutRenderers/Contexts/AllEventPropertiesTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Contexts/AllEventPropertiesTests.cs
@@ -146,7 +146,7 @@ namespace NLog.UnitTests.Layouts
                     <targets>
                         <target type='Debug'
                                 name='m'
-                                layout='${all-event-properties:IncludeCallerInformation=true}'
+                                layout='${all-event-properties}${callsite}'
                                 />
                     </targets>
                     <rules>
@@ -164,44 +164,9 @@ namespace NLog.UnitTests.Layouts
                 .Property("a", "not b")
                 .Write();
 
-            AssertDebugLastMessageContains("m", "CallerMemberName=");
-            AssertDebugLastMessageContains("m", "CallerFilePath=");
-            AssertDebugLastMessageContains("m", "CallerLineNumber=");
+            AssertDebugLastMessageContains("m", nameof(AllEventWithFluent_with_callerInformation));
+            AssertDebugLastMessageContains("m", nameof(AllEventPropertiesTests));
         }
-
-#if NET4_5
-        [Fact]
-        [Obsolete("Instead use the Exclude-property. Marked obsolete on NLog 4.6.8")]
-        public void IncludeCallerInformationEnableTest()
-        {
-            // Arrange
-            var renderer = new AllEventPropertiesLayoutRenderer();
-            Assert.False(renderer.IncludeCallerInformation);
-            Assert.Equal(3, renderer.Exclude.Count);
-
-            // Act
-            renderer.IncludeCallerInformation = true;
-
-            // Assert
-            Assert.Empty(renderer.Exclude);
-        }
-
-        [Fact]
-        [Obsolete("Instead use the Exclude-property. Marked obsolete on NLog 4.6.8")]
-        public void IncludeCallerInformationDisableTest()
-        {
-            // Arrange
-            var renderer = new AllEventPropertiesLayoutRenderer() { IncludeCallerInformation = true };
-            renderer.Exclude.Add("Test");
-            Assert.Single(renderer.Exclude);
-
-            // Act
-            renderer.IncludeCallerInformation = false;
-
-            // Assert
-            Assert.Equal(4, renderer.Exclude.Count);
-        }
-#endif
 
         [Theory]
         [InlineData(null, "a=1, hello=world, 17=100, notempty=0")]


### PR DESCRIPTION
Resolves #775 and resolves #2501

Also removes `IncludeCallerInformation`-property from `${all-event-properties}`, since it has no meaning.

Follow up to the work started with #3431. Still need to figure out a nice way to capture caller-member-variables when not using LogBuilder.  Maybe it should just be LogBuilder as a struct that performs no allocation, when LogLevel not active. Moving LogBuilder out of NLog.Fluent. See also #3433