### PR TITLE
LoggingConfiguration - Moved CheckUnusedTargets to InitializeAll 

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -502,6 +502,7 @@ namespace NLog.Config
             InternalLogger.Info("Selecting time source {0}", newTimeSource);
             TimeSource.Current = newTimeSource;
         }
+
         [ContractAnnotation("value:notnull => true")]
         private static bool AssertNotNullValue(string value, string propertyName, string elementName, string sectionName)
         {
@@ -510,6 +511,7 @@ namespace NLog.Config
 
             return AssertNonEmptyValue(string.Empty, propertyName, elementName, sectionName);
         }
+
         [ContractAnnotation("value:null => false")]
         private static bool AssertNonEmptyValue(string value, string propertyName, string elementName, string sectionName)
         {
@@ -1338,10 +1340,9 @@ namespace NLog.Config
         {
             return string.IsNullOrEmpty(target.Name) ? target.GetType().Name : target.Name;
         }
-
     }
 
-    static class ILoggingConfigurationSectionExtensions
+    internal static class ILoggingConfigurationSectionExtensions
     {
         public static bool MatchesName(this ILoggingConfigurationElement section, string expectedName)
         {

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -335,7 +335,6 @@ namespace NLog.Config
                 }
                 InitializeSucceeded = true;
                 CheckParsingErrors(content);
-                base.CheckUnusedTargets();
             }
             catch (Exception exception)
             {

--- a/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
@@ -453,7 +453,6 @@ namespace NLog.UnitTests.Config
             var logger = LogManager.GetLogger("logger1");
             logger.Warn("test 1");
             AssertDebugLastMessage("d1", "");
-
         }
 
         [Fact]
@@ -491,7 +490,7 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                XmlLoggingConfiguration.CreateFromXmlString("<nlog internalLogFile='" + tempFileName + @"' internalLogLevel='Warn'>
+                var config = XmlLoggingConfiguration.CreateFromXmlString("<nlog internalLogFile='" + tempFileName + @"' internalLogLevel='Warn'>
                     <targets>
                         <target name='d1' type='Debug' />
                         <target name='d2' type='Debug' />
@@ -505,6 +504,9 @@ namespace NLog.UnitTests.Config
                            <logger name='*' level='Debug' writeTo='d1,d2,d3' />
                     </rules>
                 </nlog>");
+
+                var logFactory = new LogFactory();
+                logFactory.Configuration = config;
 
                 AssertFileContains(tempFileName, "Unused target detected. Add a rule for this target to the configuration. TargetName: d4", Encoding.UTF8);
 
@@ -527,11 +529,11 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                XmlLoggingConfiguration.CreateFromXmlString("<nlog internalLogFile='" + tempFileName + @"' internalLogLevel='Warn'>
+                var config = XmlLoggingConfiguration.CreateFromXmlString("<nlog internalLogFile='" + tempFileName + @"' internalLogLevel='Warn'>
                     <extensions>
                         <add assembly='NLog.UnitTests'/> 
                     </extensions>
-                    <targets>
+                    <targets async='true'>
                         <target name='d1' type='Debug' />
                         <target name='d2' type='MockWrapper'>
                             <target name='d3' type='Debug' />
@@ -546,6 +548,8 @@ namespace NLog.UnitTests.Config
                     </rules>
                 </nlog>");
 
+                var logFactory = new LogFactory();
+                logFactory.Configuration = config;
 
                 AssertFileNotContains(tempFileName, "Unused target detected. Add a rule for this target to the configuration. TargetName: d2", Encoding.UTF8);
 


### PR DESCRIPTION
To allow use of _configItems. Skip CheckUnusedTargets-checking when warnings disabled.

This also activates validation for NLog.Extension.Logging when loading NLog-config from appsettings.json