### PR TITLE
JsonSerializer - Write DateTime directly to StringBuilder instead of allocating string

### DIFF
--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -103,6 +103,12 @@ namespace NLog.Internal
                 return;
             }
 
+            int digitCount = CalculateDigitCount(value);
+            ApppendValueWithDigitCount(builder, value, digitCount);
+        }
+
+        private static int CalculateDigitCount(uint value)
+        {
             // Calculate length of integer when written out
             int length = 0;
             uint length_calc = value;
@@ -113,14 +119,18 @@ namespace NLog.Internal
                 length++;
             }
             while (length_calc > 0);
+            return length;
+        }
 
+        private static void ApppendValueWithDigitCount(StringBuilder builder, uint value, int digitCount)
+        {
             // Pad out space for writing.
-            builder.Append('0', length);
+            builder.Append('0', digitCount);
 
             int strpos = builder.Length;
 
             // We're writing backwards, one character at a time.
-            while (length > 0)
+            while (digitCount > 0)
             {
                 strpos--;
 
@@ -128,10 +138,53 @@ namespace NLog.Internal
                 builder[strpos] = charToInt[value % 10];
 
                 value /= 10;
-                length--;
+                digitCount--;
             }
         }
+
         private static readonly char[] charToInt = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+
+        /// <summary>
+        /// Convert DateTime into UTC and format to yyyy-MM-ddTHH:mm:ss.fffffffZ - ISO 6801 date (Round-Trip-Time)
+        /// </summary>
+        public static void AppendXmlDateTimeRoundTrip(this StringBuilder builder, DateTime dateTime)
+        {
+            if (dateTime.Kind == DateTimeKind.Unspecified)
+                dateTime = new DateTime(dateTime.Ticks, DateTimeKind.Utc);
+            else
+                dateTime = dateTime.ToUniversalTime();
+            builder.Append4DigitsZeroPadded(dateTime.Year);
+            builder.Append('-');
+            builder.Append2DigitsZeroPadded(dateTime.Month);
+            builder.Append('-');
+            builder.Append2DigitsZeroPadded(dateTime.Day);
+            builder.Append('T');
+            builder.Append2DigitsZeroPadded(dateTime.Hour);
+            builder.Append(':');
+            builder.Append2DigitsZeroPadded(dateTime.Minute);
+            builder.Append(':');
+            builder.Append2DigitsZeroPadded(dateTime.Second);
+            int fraction = (int)(dateTime.Ticks % 10000000);
+            if (fraction > 0)
+            {
+                builder.Append('.');
+
+                // Remove trailing zeros
+                int max_digit_count = 7;
+                while (fraction % 10 == 0)
+                {
+                    --max_digit_count;
+                    fraction /= 10;
+                }
+
+                // Append the remaining fraction
+                int digitCount = CalculateDigitCount((uint)fraction);
+                if (max_digit_count > digitCount)
+                    builder.Append('0', max_digit_count - digitCount);
+                AppendInvariant(builder, (uint)fraction);
+            }
+            builder.Append('Z');
+        }
 
         /// <summary>
         /// Clears the provider StringBuilder

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -465,21 +465,35 @@ namespace NLog.Targets
                     bool includeQuotes = forceToString || objTypeCode == TypeCode.Object || !SkipQuotes(value, objTypeCode);
                     SerializeWithFormatProvider(formattable, includeQuotes, destination, options, hasFormat);
                 }
-                else if (IsNumericTypeCode(objTypeCode, false))
+                else
                 {
-                    SerializeSimpleNumericValue(value, objTypeCode, destination, options, forceToString);
+                    SerializeSimpleTypeCodeValueNoEscape(value, objTypeCode, destination, options, forceToString);
+                }
+            }
+        }
+
+        private void SerializeSimpleTypeCodeValueNoEscape(IConvertible value, TypeCode objTypeCode, StringBuilder destination, JsonSerializeOptions options, bool forceToString)
+        {
+            if (IsNumericTypeCode(objTypeCode, false))
+            {
+                SerializeSimpleNumericValue(value, objTypeCode, destination, options, forceToString);
+            }
+            else if (objTypeCode == TypeCode.DateTime)
+            {
+                destination.Append('"');
+                destination.AppendXmlDateTimeRoundTrip(value.ToDateTime(CultureInfo.InvariantCulture));
+                destination.Append('"');
+            }
+            else
+            {
+                string str = XmlHelper.XmlConvertToString(value, objTypeCode);
+                if (!forceToString && str != null && SkipQuotes(value, objTypeCode))
+                {
+                    destination.Append(str);
                 }
                 else
                 {
-                    string str = XmlHelper.XmlConvertToString(value, objTypeCode);
-                    if (!forceToString && str != null && SkipQuotes(value, objTypeCode))
-                    {
-                        destination.Append(str);
-                    }
-                    else
-                    {
-                        QuoteValue(destination, str);
-                    }
+                    QuoteValue(destination, str);
                 }
             }
         }

--- a/tests/NLog.UnitTests/Internal/StringBuilderExtTests.cs
+++ b/tests/NLog.UnitTests/Internal/StringBuilderExtTests.cs
@@ -31,10 +31,11 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System;
+using System.Collections.Generic;
 using System.Text;
 using NLog.Internal;
 using Xunit;
-using Xunit.Extensions;
 
 namespace NLog.UnitTests.Internal
 {
@@ -73,6 +74,69 @@ namespace NLog.UnitTests.Internal
             sb.Length = 0;
             StringBuilderExt.AppendInvariant(sb, input);
             Assert.Equal(input.ToString(System.Globalization.CultureInfo.InvariantCulture), sb.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(TestAppendXsdDateTimeRoundTripCases))]
+        void TestAppendXmlDateTimeRoundTripUndefined(DateTime input)
+        {
+            StringBuilder sb = new StringBuilder();
+            StringBuilderExt.AppendXmlDateTimeRoundTrip(sb, input);
+            Assert.Equal(System.Xml.XmlConvert.ToString(input, System.Xml.XmlDateTimeSerializationMode.Utc), sb.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(TestAppendXsdDateTimeRoundTripCases))]
+        void TestAppendXmlDateTimeRoundTripLocal(DateTime input)
+        {
+            input = new DateTime(input.Ticks, DateTimeKind.Local);
+            StringBuilder sb = new StringBuilder();
+            StringBuilderExt.AppendXmlDateTimeRoundTrip(sb, input);
+            Assert.Equal(System.Xml.XmlConvert.ToString(input, System.Xml.XmlDateTimeSerializationMode.Utc), sb.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(TestAppendXsdDateTimeRoundTripCases))]
+        void TestAppendXmlDateTimeRoundTripUtc(DateTime input)
+        {
+            input = new DateTime(input.Ticks, DateTimeKind.Utc);
+            StringBuilder sb = new StringBuilder();
+            StringBuilderExt.AppendXmlDateTimeRoundTrip(sb, input);
+            Assert.Equal(System.Xml.XmlConvert.ToString(input, System.Xml.XmlDateTimeSerializationMode.Utc), sb.ToString());
+        }
+
+        public static IEnumerable<object[]> TestAppendXsdDateTimeRoundTripCases()
+        {
+            yield return new object[] { DateTime.MinValue };
+            yield return new object[] { DateTime.MaxValue };
+            yield return new object[] { new DateTime(123, 1, 2) };
+            yield return new object[] { new DateTime(1234, 10, 20) };
+            yield return new object[] { new DateTime(1970, 01, 01, 01, 01, 01) };
+            yield return new object[] { new DateTime(1970, 10, 10, 10, 10, 10) };
+            yield return new object[] { new DateTime(1970, 01, 01, 01, 01, 01, 1) };
+            yield return new object[] { new DateTime(1970, 10, 10, 10, 10, 10, 10) };
+            yield return new object[] { new DateTime(1970, 11, 11, 11, 11, 11, 11) };
+            yield return new object[] { new DateTime(1970, 10, 10, 10, 10, 10, 100) };
+            yield return new object[] { new DateTime(1970, 12, 12, 12, 12, 12, 110) };
+            yield return new object[] { new DateTime(1970, 10, 11, 12, 13, 14, 999) };
+            yield return new object[] { new DateTime(1970, 11, 12, 13, 14, 15).AddTicks(1) };
+            yield return new object[] { new DateTime(1970, 12, 13, 14, 15, 16).AddTicks(10) };
+            yield return new object[] { new DateTime(1970, 01, 02, 03, 04, 05).AddTicks(12) };
+            yield return new object[] { new DateTime(1970, 02, 03, 04, 05, 06).AddTicks(120) };
+            yield return new object[] { new DateTime(1970, 03, 04, 05, 06, 07).AddTicks(123) };
+            yield return new object[] { new DateTime(1970, 04, 05, 06, 07, 08).AddTicks(1230) };
+            yield return new object[] { new DateTime(1970, 05, 06, 07, 08, 09).AddTicks(1234) };
+            yield return new object[] { new DateTime(1970, 06, 07, 08, 09, 10).AddTicks(12340) };
+            yield return new object[] { new DateTime(1970, 07, 08, 09, 10, 11).AddTicks(12345) };
+            yield return new object[] { new DateTime(1970, 08, 09, 10, 11, 12).AddTicks(123450) };
+            yield return new object[] { new DateTime(1970, 09, 10, 11, 12, 13).AddTicks(123456) };
+            yield return new object[] { new DateTime(1970, 10, 15, 20, 25, 30).AddTicks(1234560) };
+            yield return new object[] { new DateTime(1970, 05, 10, 15, 20, 25).AddTicks(1234567) };
+            yield return new object[] { new DateTime(1970, 10, 30, 10, 30, 10).AddTicks(1000000) };
+            yield return new object[] { new DateTime(1970, 01, 02, 03, 04, 05).AddTicks(100000) };
+            yield return new object[] { new DateTime(1970, 10, 20, 20, 40, 50).AddTicks(10000) };
+            yield return new object[] { new DateTime(1970, 01, 01, 23, 59, 59).AddTicks(1000) };
+            yield return new object[] { new DateTime(1970, 12, 31, 23, 59, 59).AddTicks(100) };
         }
     }
 }


### PR DESCRIPTION
`System.Xml.XmlConvert.ToString(input, System.Xml.XmlDateTimeSerializationMode.Utc)` is a fixed format.

Reusing the same trick, that has been implemented for `${longdate}`-layout-renderer

In a performance test where creating logevent with below object and writing file:

```
    public class SomeData
    {
        public int MyProperty1 { get; set; } = 1;
        public double MyProperty2 { get; set; } = 1.4;
        public DateTime MyProperty3 { get; set; } = DateTime.Now;
        public bool MyProperty4 { get; set; } = true;
        public string MyProperty5 { get; set; } = "my value";
        public SomeData MyProperty6 { get; set; }
    }
```

Then writing object to file-target becomes 10 pct faster with this optimization, because most time is spent on DateTime-serialization (Now the only overhead is the conversion to UTC)