### PR TITLE
JsonSerializer - Write DateTime directly to StringBuilder instead of allocating string 

### DIFF
--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -181,7 +181,7 @@ namespace NLog.Internal
                 int digitCount = CalculateDigitCount((uint)fraction);
                 if (max_digit_count > digitCount)
                     builder.Append('0', max_digit_count - digitCount);
-                AppendInvariant(builder, (uint)fraction);
+                ApppendValueWithDigitCount(builder, (uint)fraction, digitCount);
             }
             builder.Append('Z');
         }


### PR DESCRIPTION
Bonus fix for #3694. No need to calculated digit-count twice.