### PR TITLE
LongDateLayoutRenderer - Implement IRawValue-interface

### DIFF
--- a/src/NLog/LayoutRenderers/LongDateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LongDateLayoutRenderer.cs
@@ -35,7 +35,6 @@ namespace NLog.LayoutRenderers
 {
     using System;
     using System.ComponentModel;
-    using System.Diagnostics;
     using System.Text;
     using NLog.Config;
     using NLog.Internal;
@@ -46,7 +45,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("longdate")]
     [ThreadAgnostic]
     [ThreadSafe]
-    public class LongDateLayoutRenderer : LayoutRenderer
+    public class LongDateLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <summary>
         /// Gets or sets a value indicating whether to output UTC time instead of local time.
@@ -62,12 +61,8 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            DateTime dt = logEvent.TimeStamp;
-            if (UniversalTime)
-            {
-                dt = dt.ToUniversalTime();
-            }
-            
+            DateTime dt = GetValue(logEvent);
+
             //no culture according to specs
 
             builder.Append4DigitsZeroPadded(dt.Year);
@@ -83,6 +78,22 @@ namespace NLog.LayoutRenderers
             builder.Append2DigitsZeroPadded(dt.Second);
             builder.Append('.');
             builder.Append4DigitsZeroPadded((int)(dt.Ticks % 10000000) / 1000);
+        }
+
+        bool IRawValue.TryGetRawValue(LogEventInfo logEvent, out object value)
+        {
+            value = GetValue(logEvent);
+            return true;
+        }
+
+        private DateTime GetValue(LogEventInfo logEvent)
+        {
+            DateTime dt = logEvent.TimeStamp;
+            if (UniversalTime)
+            {
+                dt = dt.ToUniversalTime();
+            }
+            return dt;
         }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/LongDateTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/LongDateTests.cs
@@ -36,7 +36,9 @@ using NLog.Config;
 
 namespace NLog.UnitTests.LayoutRenderers
 {
+    using System;
     using NLog.LayoutRenderers;
+    using NLog.Layouts;
     using Xunit;
 
     public class LongDateTests : NLogTestBase
@@ -71,6 +73,25 @@ namespace NLog.UnitTests.LayoutRenderers
             
             var ei = new LogEventInfo(LogLevel.Info, "logger", "msg");
             Assert.Equal(ei.TimeStamp.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffff", CultureInfo.InvariantCulture), dt.Render(ei));
+        }
+
+
+        [Fact]
+        public void LongDateTryGetRawValue()
+        {
+            // Arrange
+            SimpleLayout l = "${longdate:UniversalTime=true}";
+            var timestamp = DateTime.Now;
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            logEventInfo.TimeStamp = timestamp;
+
+            // Act
+            var success = l.TryGetRawValue(logEventInfo, out var value);
+
+            // Assert
+            Assert.True(success, "success");
+            Assert.IsType<DateTime>(value);
+            Assert.Equal(timestamp.ToUniversalTime(), (DateTime)value);
         }
 
         [Fact]


### PR DESCRIPTION
Identical to `${date}` but less confusing for NLog-users.