### PR TITLE
DatabaseTarget - DbType enum parsing should not be case-sensitive

### DIFF
--- a/src/NLog/Common/ConversionHelpers.cs
+++ b/src/NLog/Common/ConversionHelpers.cs
@@ -42,7 +42,7 @@ namespace NLog.Common
     public static class ConversionHelpers
     {
         /// <summary>
-        /// Converts input string value into <see cref="System.Enum"/>
+        /// Converts input string value into <see cref="System.Enum"/>. Parsing is case-insensitive.
         /// </summary>
         /// <param name="inputValue">Input value</param>
         /// <param name="resultValue">Output value</param>
@@ -62,19 +62,6 @@ namespace NLog.Common
                 return false;
             }
             return true;
-        }
-
-        /// <summary>
-        /// Converts the string representation of the name or numeric value of one or more enumerated constants to an equivalent enumerated object. A parameter specifies whether the operation is case-sensitive. The return value indicates whether the conversion succeeded.
-        /// </summary>
-        /// <typeparam name="TEnum">The enumeration type to which to convert value.</typeparam>
-        /// <param name="value">The string representation of the enumeration name or underlying value to convert.</param>
-        /// <param name="result">When this method returns, result contains an object of type TEnum whose value is represented by value if the parse operation succeeds. If the parse operation fails, result contains the default value of the underlying type of TEnum. Note that this value need not be a member of the TEnum enumeration. This parameter is passed uninitialized.</param>
-        /// <returns><c>true</c> if the value parameter was converted successfully; otherwise, <c>false</c>.</returns>
-        /// <remarks>Wrapper because Enum.TryParse is not present in .net 3.5</remarks>
-        internal static bool TryParse<TEnum>(string value, out TEnum result) where TEnum : struct
-        {
-            return TryParse(value, false, out result);
         }
 
         /// <summary>

--- a/src/NLog/Targets/DatabaseParameterInfo.cs
+++ b/src/NLog/Targets/DatabaseParameterInfo.cs
@@ -184,7 +184,8 @@ namespace NLog.Targets
                     }
                     else
                     {
-                        if (ConversionHelpers.TryParse(dbTypeNames[dbTypeNames.Length - 1], out DbType dbType))
+                        dbTypeName = dbTypeNames[dbTypeNames.Length - 1];
+                        if (!string.IsNullOrEmpty(dbTypeName) && ConversionHelpers.TryParseEnum(dbTypeName, out DbType dbType))
                         {
                             _dbTypeValue = dbType;
                             ParameterType = TryLookupParameterType(dbType);
@@ -305,7 +306,7 @@ namespace NLog.Targets
                 bool IEnumTypeConverter.TryParseEnum(string value, out Enum enumValue)
                 {
                     TEnum enumValueT;
-                    if (ConversionHelpers.TryParse(value, out enumValueT))
+                    if (!string.IsNullOrEmpty(value) && ConversionHelpers.TryParseEnum(value, out enumValueT))
                     {
                         enumValue = enumValueT as Enum;
                         return enumValue != null;

--- a/tests/NLog.UnitTests/Internal/EnumHelpersTests.cs
+++ b/tests/NLog.UnitTests/Internal/EnumHelpersTests.cs
@@ -31,125 +31,46 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using NLog.Common;
-using Xunit;
-
 namespace NLog.UnitTests.Internal
 {
+    using System;
+    using NLog.Common;
+    using Xunit;
+
     public class EnumHelpersTests : NLogTestBase
     {
-
         enum TestEnum
         {
             Foo,
             bar,
-
         }
-
-        #region tryparse - no ignorecase parameter
-
-        [Fact]
-        public void EnumParse1()
-        {
-            TestEnumParseCaseSentisive("Foo", TestEnum.Foo, true);
-        }
-        [Fact]
-        public void EnumParse2()
-        {
-            TestEnumParseCaseSentisive("foo", TestEnum.Foo, false);
-        }
-
-        [Fact]
-        public void EnumParseDefault()
-        {
-            TestEnumParseCaseSentisive("BAR", TestEnum.Foo, false);
-        }
-        [Fact]
-        public void EnumParseDefault2()
-        {
-            TestEnumParseCaseSentisive("x", TestEnum.Foo, false);
-        }
-        [Fact]
-        public void EnumParseBar()
-        {
-            TestEnumParseCaseSentisive("bar", TestEnum.bar, true);
-        }
-        [Fact]
-        public void EnumParseBar2()
-        {
-            TestEnumParseCaseSentisive(" bar ", TestEnum.bar, true);
-        }
-
-        [Fact]
-        public void EnumParseBar3()
-        {
-            TestEnumParseCaseSentisive(" \r\nbar ", TestEnum.bar, true);
-        }
-
-
-        [Fact]
-        public void EnumParse_null()
-        {
-            TestEnumParseCaseSentisive(null, TestEnum.Foo, false);
-        }
-
-        [Fact]
-        public void EnumParse_emptystring()
-        {
-            TestEnumParseCaseSentisive(string.Empty, TestEnum.Foo, false);
-        }
-
-        [Fact]
-        public void EnumParse_whitespace()
-        {
-            TestEnumParseCaseSentisive("   ", TestEnum.Foo, false);
-        }
-
-        [Fact]
-        public void EnumParse_ArgumentException()
-        {
-            double result;
-            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParse("not enum", out result));
-        }
-
-        [Fact]
-        public void EnumParse_null_ArgumentException()
-        {
-            //even with null, first ArgumentException
-            double result;
-            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParse(null, out result));
-        }
-
-        #endregion
 
         #region tryparse - ignorecase parameter: false
-
-
-
 
         [Fact]
         public void EnumParse1_ignoreCaseFalse()
         {
             TestEnumParseCaseIgnoreCaseParam("Foo", false, TestEnum.Foo, true);
         }
+
         [Fact]
         public void EnumParse2_ignoreCaseFalse()
         {
             TestEnumParseCaseIgnoreCaseParam("foo", false, TestEnum.Foo, false);
         }
+
         [Fact]
         public void EnumParseDefault_ignoreCaseFalse()
         {
             TestEnumParseCaseIgnoreCaseParam("BAR", false, TestEnum.Foo, false);
         }
+
         [Fact]
         public void EnumParseDefault2_ignoreCaseFalse()
         {
             TestEnumParseCaseIgnoreCaseParam("x", false, TestEnum.Foo, false);
         }
+
         [Fact]
         public void EnumParseBar_ignoreCaseFalse()
         {
@@ -193,6 +114,7 @@ namespace NLog.UnitTests.Internal
             double result;
             Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParse("not enum", false, out result));
         }
+
         [Fact]
         public void EnumParse_null_ArgumentException_ignoreCaseFalse()
         {
@@ -210,21 +132,25 @@ namespace NLog.UnitTests.Internal
         {
             TestEnumParseCaseIgnoreCaseParam("Foo", true, TestEnum.Foo, true);
         }
+
         [Fact]
         public void EnumParse2_ignoreCaseTrue()
         {
             TestEnumParseCaseIgnoreCaseParam("foo", true, TestEnum.Foo, true);
         }
+
         [Fact]
         public void EnumParseDefault_ignoreCaseTrue()
         {
             TestEnumParseCaseIgnoreCaseParam("BAR", true, TestEnum.bar, true);
         }
+
         [Fact]
         public void EnumParseDefault2_ignoreCaseTrue()
         {
             TestEnumParseCaseIgnoreCaseParam("x", true, TestEnum.Foo, false);
         }
+
         [Fact]
         public void EnumParseBar_ignoreCaseTrue()
         {
@@ -242,7 +168,6 @@ namespace NLog.UnitTests.Internal
         {
             TestEnumParseCaseIgnoreCaseParam(" \r\nbar ", true, TestEnum.bar, true);
         }
-
 
         [Fact]
         public void EnumParse_null_ignoreCaseTrue()
@@ -280,17 +205,6 @@ namespace NLog.UnitTests.Internal
         #endregion
 
         #region helpers
-
-
-        private static void TestEnumParseCaseSentisive(string value, TestEnum expected, bool expectedReturn)
-        {
-            TestEnum result;
-
-            var returnResult = ConversionHelpers.TryParse(value, out result);
-
-            Assert.Equal(expected, result);
-            Assert.Equal(expectedReturn, returnResult);
-        }
 
         private static void TestEnumParseCaseIgnoreCaseParam(string value, bool ignoreCase, TestEnum expected, bool expectedReturn)
         {

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -768,7 +768,7 @@ Dispose()
                         <ConnectionString>FooBar</ConnectionString>
                         <CommandText>INSERT INTO FooBar VALUES(@message,@level,@date)</CommandText>
                         <parameter name='@message' layout='${message}'/>
-                        <parameter name='@level' dbType='MockDbType.Int32' layout='${level:format=Ordinal}'/>
+                        <parameter name='@level' dbType=' MockDbType.int32  ' layout='${level:format=Ordinal}'/>
                         <parameter name='@date' dbType='MockDbType.DateTime' format='yyyy-MM-dd HH:mm:ss.fff' layout='${date:format=yyyy-MM-dd HH\:mm\:ss.fff}'/>
                     </target>
                 </targets>

--- a/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
@@ -236,8 +236,8 @@ namespace NLog.UnitTests.Targets
         [InlineData(5, EventLogEntryType.Error, "AtErrorLevel_WhenNLogLevelIsFatal", null)]
         [InlineData(3, EventLogEntryType.SuccessAudit, "AtSuccessAuditLevel_WhenEntryTypeLayoutSpecifiedAsSuccessAudit", "SuccessAudit")]
         [InlineData(3, EventLogEntryType.SuccessAudit, "AtSuccessAuditLevel_WhenEntryTypeLayoutSpecifiedAsSuccessAudit_Uppercase", "SUCCESSAUDIT")]
-        [InlineData(1, EventLogEntryType.FailureAudit, "AtFailureAuditLevel_WhenEntryTypeLayoutSpecifiedAsFailureAudit", "FailureAudit")]
-        [InlineData(1, EventLogEntryType.Error, "AtErrorLevel_WhenEntryTypeLayoutSpecifiedAsError", "error")]
+        [InlineData(1, EventLogEntryType.FailureAudit, "AtFailureAuditLevel_WhenEntryTypeLayoutSpecifiedAsFailureAudit_Space", "FailureAudit ")]
+        [InlineData(1, EventLogEntryType.Error, "AtErrorLevel_WhenEntryTypeLayoutSpecifiedAsErrorLowerCase", "error")]
         [InlineData(3, EventLogEntryType.Warning, "AtSpecifiedNLogLevel_WhenWrongEntryTypeLayoutSupplied", "fallback to auto determined")]
         public void TruncatedMessagesShouldBeWrittenAtCorrenpondingNLogLevel(int logLevelOrdinal, EventLogEntryType expectedEventLogEntryType, string expectedMessage, string layoutString)
         {


### PR DESCRIPTION
Resolves #3695

Cannot figure out why it was ignoreCase=false by default, but have now removed the unused `TryParse`, and instead changed to the public `TryParseEnum`-method that works as intended.
