### PR TITLE
FileTarget - enable test ArchiveAboveSizeWithArchiveNumberingModeDate_maxfiles_o

### DIFF
--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -1075,7 +1075,7 @@ namespace NLog.UnitTests.Targets
             }
         }
 
-        [Fact(Skip = "this is not supported, because we cannot create multiple archive files with  ArchiveNumberingMode.Date (for one day)")]
+        [Fact]
         public void ArchiveAboveSizeWithArchiveNumberingModeDate_maxfiles_o()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), "ArchiveEveryCombinedWithArchiveAboveSize_" + Guid.NewGuid().ToString());


### PR DESCRIPTION
Now supported as merge into existing archive file works with NLog 4.5.7. See #1680 + #2776