### PR TITLE
Added Layout.CreateFromMethod to allow custom layoutrenders using Config API

### DIFF
--- a/src/NLog/Conditions/ConditionParser.cs
+++ b/src/NLog/Conditions/ConditionParser.cs
@@ -177,7 +177,7 @@ namespace NLog.Conditions
 
             if (_tokenizer.TokenType == ConditionTokenType.String)
             {
-                ConditionExpression e = new ConditionLayoutExpression(Layout.FromString(_tokenizer.StringTokenValue, _configurationItemFactory));
+                ConditionExpression e = new ConditionLayoutExpression(new SimpleLayout(_tokenizer.StringTokenValue, _configurationItemFactory));
                 _tokenizer.GetNextToken();
                 return e;
             }

--- a/src/NLog/LayoutRenderers/FuncThreadSafeLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/FuncThreadSafeLayoutRenderer.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -34,67 +34,22 @@
 namespace NLog.LayoutRenderers
 {
     using System;
-    using System.Text;
     using NLog.Config;
-    using NLog.Internal;
 
     /// <summary>
     /// A layout renderer which could have different behavior per instance by using a <see cref="Func{TResult}"/>.
     /// </summary>
-    public class FuncLayoutRenderer : LayoutRenderer, IStringValueRenderer
+    [ThreadSafe]
+    class FuncThreadSafeLayoutRenderer : FuncLayoutRenderer
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FuncLayoutRenderer"/> class.
+        /// Initializes a new instance of the <see cref="FuncThreadSafeLayoutRenderer"/> class.
         /// </summary>
         /// <param name="layoutRendererName">Name without ${}.</param>
         /// <param name="renderMethod">Method that renders the layout.</param>
-        public FuncLayoutRenderer(string layoutRendererName, Func<LogEventInfo, LoggingConfiguration, object> renderMethod)
+        public FuncThreadSafeLayoutRenderer(string layoutRendererName, Func<LogEventInfo, LoggingConfiguration, object> renderMethod)
+            : base(layoutRendererName, renderMethod)
         {
-            RenderMethod = renderMethod ?? throw new ArgumentNullException(nameof(renderMethod));
-            LayoutRendererName = layoutRendererName;
-        }
-
-        /// <summary>
-        /// Name used in config without ${}. E.g. "test" could be used as "${test}".
-        /// </summary>
-        public string LayoutRendererName { get; set; }
-
-        /// <summary>
-        /// Method that renders the layout. 
-        /// </summary>
-        public Func<LogEventInfo, LoggingConfiguration, object> RenderMethod { get; }
-
-        /// <summary>
-        /// Format string for conversion from object to string.
-        /// </summary>
-        /// <docgen category='Rendering Options' order='50' />
-        public string Format { get; set; }
-
-        /// <inheritdoc />
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
-        {
-            var value = GetValue(logEvent);
-            var formatProvider = GetFormatProvider(logEvent, null);
-            builder.AppendFormattedValue(value, Format, formatProvider);
-        }
-
-        /// <inheritdoc/>
-        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);
-
-        private string GetStringValue(LogEventInfo logEvent)
-        {
-            if (Format != MessageTemplates.ValueFormatter.FormatAsJson)
-            {
-                object value = GetValue(logEvent);
-                string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, null));
-                return stringValue;
-            }
-            return null;
-        }
-
-        private object GetValue(LogEventInfo logEvent)
-        {
-            return RenderMethod.Invoke(logEvent, LoggingConfiguration);
         }
     }
 }

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -130,9 +130,9 @@ namespace NLog.Layouts
         /// Implicits converts the specific lambda method into a <see cref="SimpleLayout"/>.
         /// </summary>
         /// <param name="layoutMethod">Method that renders the layout.</param>
-        /// <param name="threadSafe">Tell if method is safe for concurrent threading.</param>
+        /// <param name="options">Tell if method is safe for concurrent threading.</param>
         /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
-        public static Layout CreateFromMethod(Func<LogEventInfo, object> layoutMethod, bool threadSafe = false)
+        public static Layout CreateFromMethod(Func<LogEventInfo, object> layoutMethod, LayoutRenderOptions options = LayoutRenderOptions.None)
         {
             if (layoutMethod == null)
                 throw new ArgumentNullException(nameof(layoutMethod));
@@ -142,7 +142,7 @@ namespace NLog.Layouts
 #else
             var name = $"{layoutMethod.Method?.DeclaringType?.ToString()}.{layoutMethod.Method?.Name}";
 #endif
-            var layoutRenderer = threadSafe ?
+            var layoutRenderer = ((options & LayoutRenderOptions.ThreadSafe) != 0) ?
                 new LayoutRenderers.FuncThreadSafeLayoutRenderer(name, (l, c) => layoutMethod(l)) :
                 new LayoutRenderers.FuncLayoutRenderer(name, (l, c) => layoutMethod(l));
             return new SimpleLayout(new[] { layoutRenderer }, layoutRenderer.LayoutRendererName, ConfigurationItemFactory.Default);

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -90,14 +90,15 @@ namespace NLog.Layouts
         /// <returns><see cref="SimpleLayout"/> object represented by the text.</returns>
         public static implicit operator Layout([Localizable(false)] string text)
         {
-            return FromString(text);
+            return CreateFromString(text);
         }
 
         /// <summary>
         /// Implicitly converts the specified string to a <see cref="SimpleLayout"/>.
         /// </summary>
         /// <param name="layoutText">The layout string.</param>
-        /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
+        /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>'
+        [Obsolete("Use Layout.CreateFromString. Obsolete from NLog 4.7")]
         public static Layout FromString(string layoutText)
         {
             return FromString(layoutText, ConfigurationItemFactory.Default);
@@ -109,9 +110,20 @@ namespace NLog.Layouts
         /// <param name="layoutText">The layout string.</param>
         /// <param name="configurationItemFactory">The NLog factories to use when resolving layout renderers.</param>
         /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
+        [Obsolete("Use Layout.CreateFromString. Obsolete from NLog 4.7")]
         public static Layout FromString(string layoutText, ConfigurationItemFactory configurationItemFactory)
         {
             return new SimpleLayout(layoutText, configurationItemFactory);
+        }
+
+        /// <summary>
+        /// Implicitly converts the specified string to a <see cref="SimpleLayout"/>.
+        /// </summary>
+        /// <param name="layoutText">The layout string.</param>
+        /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
+        public static Layout CreateFromString(string layoutText)
+        {
+            return new SimpleLayout(layoutText, ConfigurationItemFactory.Default);
         }
 
         /// <summary>
@@ -120,7 +132,7 @@ namespace NLog.Layouts
         /// <param name="layoutMethod">Method that renders the layout.</param>
         /// <param name="threadSafe">Tell if method is safe for concurrent threading.</param>
         /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
-        public static Layout FromLayoutMethod(Func<LogEventInfo, object> layoutMethod, bool threadSafe = false)
+        public static Layout CreateFromMethod(Func<LogEventInfo, object> layoutMethod, bool threadSafe = false)
         {
             if (layoutMethod == null)
                 throw new ArgumentNullException(nameof(layoutMethod));

--- a/src/NLog/Layouts/LayoutRenderOptions.cs
+++ b/src/NLog/Layouts/LayoutRenderOptions.cs
@@ -1,0 +1,53 @@
+﻿// 
+// Copyright (c) 2004-2019 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Layouts
+{
+    using System;
+
+    /// <summary>
+    /// Options available for <see cref="Layout.CreateFromMethod"/>
+    /// </summary>
+    [Flags]
+    public enum LayoutRenderOptions
+    {
+        /// <summary>
+        /// Default options
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Layout renderer method can handle concurrent threads
+        /// </summary>
+        ThreadSafe = 1,
+    }
+}

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -76,7 +76,7 @@ namespace NLog.UnitTests
         void FuncLayoutRendererFluentMethod_ThreadSafe_Test()
         {
             // Arrange
-            var layout = Layout.FromLayoutMethod(l => "42", threadSafe: true);
+            var layout = Layout.CreateFromMethod(l => "42", threadSafe: true);
             // Act
             var result = layout.Render(LogEventInfo.CreateNullEvent());
             // Assert
@@ -88,7 +88,7 @@ namespace NLog.UnitTests
         void FuncLayoutRendererFluentMethod_ThreadUnsafe_Test()
         {
             // Arrange
-            var layout = Layout.FromLayoutMethod(l => "42", threadSafe: false);
+            var layout = Layout.CreateFromMethod(l => "42", threadSafe: false);
             // Act
             var result = layout.Render(LogEventInfo.CreateNullEvent());
             // Assert
@@ -100,7 +100,7 @@ namespace NLog.UnitTests
         void FuncLayoutRendererFluentMethod_NullThrows_Test()
         {
             // Arrange
-            Assert.Throws<ArgumentNullException>(() => Layout.FromLayoutMethod(null, threadSafe: true));
+            Assert.Throws<ArgumentNullException>(() => Layout.CreateFromMethod(null, threadSafe: true));
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -76,7 +76,7 @@ namespace NLog.UnitTests
         void FuncLayoutRendererFluentMethod_ThreadSafe_Test()
         {
             // Arrange
-            var layout = Layout.CreateFromMethod(l => "42", threadSafe: true);
+            var layout = Layout.CreateFromMethod(l => "42", LayoutRenderOptions.ThreadSafe);
             // Act
             var result = layout.Render(LogEventInfo.CreateNullEvent());
             // Assert
@@ -88,7 +88,7 @@ namespace NLog.UnitTests
         void FuncLayoutRendererFluentMethod_ThreadUnsafe_Test()
         {
             // Arrange
-            var layout = Layout.CreateFromMethod(l => "42", threadSafe: false);
+            var layout = Layout.CreateFromMethod(l => "42", LayoutRenderOptions.None);
             // Act
             var result = layout.Render(LogEventInfo.CreateNullEvent());
             // Assert
@@ -100,7 +100,7 @@ namespace NLog.UnitTests
         void FuncLayoutRendererFluentMethod_NullThrows_Test()
         {
             // Arrange
-            Assert.Throws<ArgumentNullException>(() => Layout.CreateFromMethod(null, threadSafe: true));
+            Assert.Throws<ArgumentNullException>(() => Layout.CreateFromMethod(null));
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -73,15 +73,46 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        void FuncLayoutRendererFluentMethod_ThreadSafe_Test()
+        {
+            // Arrange
+            var layout = Layout.FromLayoutMethod(l => "42", threadSafe: true);
+            // Act
+            var result = layout.Render(LogEventInfo.CreateNullEvent());
+            // Assert
+            Assert.Equal("42", result);
+            Assert.True(layout.ThreadSafe);
+        }
+
+        [Fact]
+        void FuncLayoutRendererFluentMethod_ThreadUnsafe_Test()
+        {
+            // Arrange
+            var layout = Layout.FromLayoutMethod(l => "42", threadSafe: false);
+            // Act
+            var result = layout.Render(LogEventInfo.CreateNullEvent());
+            // Assert
+            Assert.Equal("42", result);
+            Assert.False(layout.ThreadSafe);
+        }
+
+        [Fact]
+        void FuncLayoutRendererFluentMethod_NullThrows_Test()
+        {
+            // Arrange
+            Assert.Throws<ArgumentNullException>(() => Layout.FromLayoutMethod(null, threadSafe: true));
+        }
+
+        [Fact]
         void FuncLayoutRendererRegisterTest1WithXML()
         {
-            LayoutRenderer.Register("the-answer", (info) => "42");
+            LayoutRenderer.Register("the-answer", (info) => 42);
 
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
 <nlog throwExceptions='true'>
             
                 <targets>
-                    <target name='debug' type='Debug' layout= '${the-answer}' /></targets>
+                    <target name='debug' type='Debug' layout= 'TheAnswer=${the-answer:Format=D3}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>
@@ -89,7 +120,7 @@ namespace NLog.UnitTests
 
             var logger = LogManager.GetCurrentClassLogger();
             logger.Debug("test1");
-            AssertDebugLastMessage("debug", "42");
+            AssertDebugLastMessage("debug", "TheAnswer=042");
         }
 
         [Fact]


### PR DESCRIPTION
Another building block to make it easier to use the Config API

- Added Layout.CreateFromString and marked Layout.FromString as obsolete
- Added Format-property to FuncLayoutRenderer 
- Added IStringValueRenderer-support to FuncLayoutRenderer