### PR TITLE
JsonLayout - EscapeForwardSlash should be nullable

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
@@ -74,8 +74,13 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <summary>
         /// Should forward slashes be escaped? If true, / will be converted to \/ 
         /// </summary>
-        [DefaultValue(true)] // todo NLog 5, default to false
-        public bool EscapeForwardSlash { get; set; } = true;
+        [DefaultValue(true)] // TODO NLog 5 change to nullable (with default fallback to false)
+        public bool EscapeForwardSlash
+        {
+            get => EscapeForwardSlashInternal ?? true;
+            set => EscapeForwardSlashInternal = value;
+        }
+        internal bool? EscapeForwardSlashInternal;
 
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)

--- a/src/NLog/Layouts/JsonAttribute.cs
+++ b/src/NLog/Layouts/JsonAttribute.cs
@@ -31,10 +31,9 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.ComponentModel;
-
 namespace NLog.Layouts
 {
+    using System.ComponentModel;
     using NLog.Config;
 
     /// <summary>
@@ -113,7 +112,7 @@ namespace NLog.Layouts
         /// <summary>
         /// Should forward slashes be escaped? If true, / will be converted to \/ 
         /// </summary>
-        [DefaultValue(true)] // todo NLog 5, default to false
+        [DefaultValue(true)] // TODO NLog 5 change to nullable (with default fallback to false)
         public bool EscapeForwardSlash 
         {
             get => LayoutWrapper.EscapeForwardSlash;

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -35,6 +35,7 @@ namespace NLog.Layouts
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Text;
     using NLog.Config;
 
@@ -101,52 +102,58 @@ namespace NLog.Layouts
         /// <summary>
         /// Gets the array of attributes' configurations.
         /// </summary>
-        /// <docgen category='JSON Options' order='10' />
+        /// <docgen category='JSON Output' order='10' />
         [ArrayParameter(typeof(JsonAttribute), "attribute")]
         public IList<JsonAttribute> Attributes { get; private set; }
 
         /// <summary>
         /// Gets or sets the option to suppress the extra spaces in the output json
         /// </summary>
-        /// <docgen category='JSON Options' order='10' />
+        /// <docgen category='JSON Formating' order='10' />
+        [DefaultValue(false)]
         public bool SuppressSpaces { get; set; }
 
         /// <summary>
         /// Gets or sets the option to render the empty object value {}
         /// </summary>
-        /// <docgen category='JSON Options' order='10' />
+        /// <docgen category='JSON Formating' order='10' />
+        [DefaultValue(true)]
         public bool RenderEmptyObject { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="GlobalDiagnosticsContext"/> dictionary.
         /// </summary>
-        /// <docgen category='JSON Options' order='10' />
+        /// <docgen category='JSON Output' order='10' />
+        [DefaultValue(false)]
         public bool IncludeGdc { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsContext"/> dictionary.
         /// </summary>
-        /// <docgen category='JSON Options' order='10' />
+        /// <docgen category='JSON Output' order='10' />
+        [DefaultValue(false)]
         public bool IncludeMdc { get; set; }
 
 #if !SILVERLIGHT
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
-        /// <docgen category='JSON Options' order='10' />
+        /// <docgen category='JSON Output' order='10' />
+        [DefaultValue(false)]
         public bool IncludeMdlc { get; set; }
 #endif
 
         /// <summary>
         /// Gets or sets the option to include all properties from the log event (as JSON)
         /// </summary>
-        /// <docgen category='JSON Options' order='10' />
+        /// <docgen category='JSON Output' order='10' />
+        [DefaultValue(false)]
         public bool IncludeAllProperties { get; set; }
 
         /// <summary>
         /// List of property names to exclude when <see cref="IncludeAllProperties"/> is true
         /// </summary>
-        /// <docgen category='JSON Options' order='10' />
+        /// <docgen category='JSON Output' order='10' />
 #if NET3_5
         public HashSet<string> ExcludeProperties { get; set; }
 #else
@@ -156,13 +163,21 @@ namespace NLog.Layouts
         /// <summary>
         /// How far should the JSON serializer follow object references before backing off
         /// </summary>
-        /// <docgen category='JSON Options' order='10' />
+        /// <docgen category='JSON Output' order='10' />
+        [DefaultValue(0)]
         public int MaxRecursionLimit { get; set; }
 
         /// <summary>
         /// Should forward slashes be escaped? If true, / will be converted to \/ 
         /// </summary>
-        public bool EscapeForwardSlash { get; set; } = true; // todo NLog 5, default to false
+        /// <docgen category='JSON Formating' order='10' />
+        [DefaultValue(true)]    // TODO NLog 5 change to nullable (with default fallback to false)
+        public bool EscapeForwardSlash
+        {
+            get => _escapeForwardSlashInternal ?? true;
+            set => _escapeForwardSlashInternal = value;
+        }
+        private bool? _escapeForwardSlashInternal;
 
         /// <summary>
         /// Initializes the layout.
@@ -183,6 +198,17 @@ namespace NLog.Layouts
             if (IncludeAllProperties)
             {
                 MutableUnsafe = true;
+            }
+
+            if (_escapeForwardSlashInternal.HasValue && Attributes?.Count > 0)
+            {
+                foreach (var attribute in Attributes)
+                {
+                    if (!attribute.LayoutWrapper.EscapeForwardSlashInternal.HasValue)
+                    {
+                        attribute.LayoutWrapper.EscapeForwardSlashInternal = _escapeForwardSlashInternal.Value;
+                    }
+                }
             }
         }
 

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -751,6 +751,33 @@ namespace NLog.UnitTests.Layouts
             AssertDebugLastMessage("debug", "{ \"DoubleNaN\": \"NaN\", \"DoubleInfPositive\": \"Infinity\", \"DoubleInfNegative\": \"-Infinity\", \"FloatNaN\": \"NaN\", \"FloatInfPositive\": \"Infinity\", \"FloatInfNegative\": \"-Infinity\" }");
         }
 
+        [Fact]
+        public void EscapeForwardSlashDefaultTest()
+        {
+            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog throwExceptions='true'>
+            <targets>
+                <target name='debug' type='Debug'  >
+                  <layout type='JsonLayout' escapeForwardSlash='false'>
+                    <attribute name='myurl1' layout='${event-properties:myurl}' />
+                    <attribute name='myurl2' layout='${event-properties:myurl}' escapeForwardSlash='true' />
+                  </layout>
+                </target>
+            </targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+
+            var logEventInfo1 = new LogEventInfo();
+            logEventInfo1.Properties.Add("myurl", "http://hello.world.com/");
+            logger.Debug(logEventInfo1);
+
+            AssertDebugLastMessage("debug", "{ \"myurl1\": \"http://hello.world.com/\", \"myurl2\": \"http:\\/\\/hello.world.com\\/\" }");
+        }
+
         private static LogEventInfo CreateLogEventWithExcluded()
         {
             var logEventInfo = new LogEventInfo


### PR DESCRIPTION
Trying to resolve  #3741. But it will only apply to direct sub-attributes.

If a nested attribute embeds a JsonLayout using encode="false", then it will not inherit the configuration from the top-JsonLayout (There is no guaranteed of the order of initializing NLog Layouts)