### PR TITLE
Add support for optional size threshold to archive log file on startup

### DIFF
--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -46,7 +46,7 @@ namespace NLog.Internal.FileAppenders
     /// <summary>
     /// Maintains a collection of file appenders usually associated with file targets.
     /// </summary>
-    internal sealed class FileAppenderCache : IDisposable
+    internal sealed class FileAppenderCache : IFileAppenderCache
     {
         private readonly BaseFileAppender[] _appenders;
         private Timer _autoClosingTimer;

--- a/src/NLog/Internal/FileAppenders/IFileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/IFileAppenderCache.cs
@@ -1,0 +1,120 @@
+// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+
+namespace NLog.Internal.FileAppenders
+{
+    internal interface IFileAppenderCache : IDisposable
+    {
+        /// <summary>
+        /// Gets the parameters which will be used for creating a file.
+        /// </summary>
+        ICreateFileParameters CreateFileParameters { get; }
+
+        /// <summary>
+        /// Gets the file appender factory used by all the appenders in this list.
+        /// </summary>
+        IFileAppenderFactory Factory { get; }
+
+        /// <summary>
+        /// Gets the number of appenders which the list can hold.
+        /// </summary>
+        int Size { get; }
+
+        /// <summary>
+        /// Subscribe to background monitoring of active file appenders
+        /// </summary>
+        event EventHandler CheckCloseAppenders;
+
+        /// <summary>
+        /// It allocates the first slot in the list when the file name does not already in the list and clean up any
+        /// unused slots.
+        /// </summary>
+        /// <param name="fileName">File name associated with a single appender.</param>
+        /// <returns>The allocated appender.</returns>
+        /// <exception cref="NullReferenceException">
+        /// Thrown when <see cref="M:AllocateAppender"/> is called on an <c>Empty</c><see cref="FileAppenderCache"/> instance.
+        /// </exception>
+        BaseFileAppender AllocateAppender(string fileName);
+
+        /// <summary>
+        /// Close all the allocated appenders. 
+        /// </summary>
+        void CloseAppenders(string reason);
+
+        /// <summary>
+        /// Close the allocated appenders initialized before the supplied time.
+        /// </summary>
+        /// <param name="expireTime">The time which prior the appenders considered expired</param>
+        void CloseAppenders(DateTime expireTime);
+
+        /// <summary>
+        /// Flush all the allocated appenders. 
+        /// </summary>
+        void FlushAppenders();
+
+        DateTime? GetFileCreationTimeSource(string filePath, DateTime? fallbackTimeSource = null);
+
+        /// <summary>
+        /// File Archive Logic uses the File-Creation-TimeStamp to detect if time to archive, and the File-LastWrite-Timestamp to name the archive-file.
+        /// </summary>
+        /// <remarks>
+        /// NLog always closes all relevant appenders during archive operation, so no need to lookup file-appender
+        /// </remarks>
+        DateTime? GetFileLastWriteTimeUtc(string filePath);
+
+        long? GetFileLength(string filePath);
+
+        /// <summary>
+        /// Closes the specified appender and removes it from the list. 
+        /// </summary>
+        /// <param name="filePath">File name of the appender to be closed.</param>
+        /// <returns>File Appender that matched the filePath (null if none found)</returns>
+        BaseFileAppender InvalidateAppender(string filePath);
+
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
+        
+        /// <summary>
+        /// The archive file path pattern that is used to detect when archiving occurs.
+        /// </summary>
+        string ArchiveFilePatternToWatch { get; set; }
+
+        /// <summary>
+        /// Invalidates appenders for all files that were archived.
+        /// </summary>
+        void InvalidateAppendersForArchivedFiles();
+
+#endif
+    }
+}

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -154,7 +154,7 @@ namespace NLog.Targets
         public FileTarget() : this(FileAppenderCache.Empty)
         {
         }
-        
+
         internal FileTarget(IFileAppenderCache fileAppenderCache)
         {
             ArchiveNumbering = ArchiveNumberingMode.Sequence;
@@ -2305,14 +2305,16 @@ namespace NLog.Targets
         /// <returns>Decision whether to archive or not.</returns>
         internal bool ShouldArchiveOldFileOnStartup(string fileName)
         {
-            if (_archiveOldFileOnStartup.HasValue)
+            if (_archiveOldFileOnStartup == false)
             {
-                return _archiveOldFileOnStartup.Value;
+                // explicitly disabled
+                return false;
             }
-            // No size threshold specified
+
+            // No size threshold specified, use archiveOldFileOnStartup flag
             if (ArchiveOldFileOnStartupAboveSize <= 0)
             {
-                return false;
+                return _archiveOldFileOnStartup == true;
             }
             // Check whether size threshold exceeded
             var length = _fileAppenderCache.GetFileLength(fileName);

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -2307,18 +2307,20 @@ namespace NLog.Targets
         {
             if (_archiveOldFileOnStartup == false)
             {
-                // explicitly disabled
+                // explicitly disabled and not the default
                 return false;
+            }
+            
+            var aboveSizeSet = ArchiveOldFileOnStartupAboveSize > 0;
+            if (aboveSizeSet)
+            {
+                // Check whether size threshold exceeded
+                var length = _fileAppenderCache.GetFileLength(fileName);
+                return length.HasValue && length.Value > ArchiveOldFileOnStartupAboveSize;
             }
 
             // No size threshold specified, use archiveOldFileOnStartup flag
-            if (ArchiveOldFileOnStartupAboveSize <= 0)
-            {
-                return _archiveOldFileOnStartup == true;
-            }
-            // Check whether size threshold exceeded
-            var length = _fileAppenderCache.GetFileLength(fileName);
-            return length.HasValue && length.Value > ArchiveOldFileOnStartupAboveSize;
+            return _archiveOldFileOnStartup == true;
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -789,7 +789,7 @@ namespace NLog.UnitTests.Targets
                 AssertFileContents(logFile, "Info aaa\n", Encoding.UTF8);
                 Assert.False(File.Exists(archiveTempName));
 
-               // Archive on startup with small threshold -> Must be archived
+                // Archive on startup with small threshold -> Must be archived
                 SimpleConfigurator.ConfigureForTargetLogging(CreateTestTarget(3));
                 logger.Info("ccc");
                 LogManager.Flush();
@@ -4120,11 +4120,13 @@ namespace NLog.UnitTests.Targets
         }
 
         [Theory]
-        [InlineData(true, 100, true)]
+        [InlineData(true, 100, true)] // archive, as size of file is 101
+        [InlineData(true, 101, false)] //equals is not above
+        [InlineData(true, 102, false)] // don;t archive, we didn't reach the aboveSize
         [InlineData(false, 100, false)]
         [InlineData(null, 0, false)]
-        [InlineData(null, 99, true)] 
-        [InlineData(null, 100, true)] 
+        [InlineData(null, 99, true)]
+        [InlineData(null, 100, true)]
         [InlineData(null, 101, false)]
         public void ShouldArchiveOldFileOnStartupTest(bool? archiveOldFileOnStartup, long archiveOldFileOnStartupAboveSize, bool expected)
         {
@@ -4145,7 +4147,7 @@ namespace NLog.UnitTests.Targets
 
             // Act
             var result = target.ShouldArchiveOldFileOnStartup(filePath);
-            
+
             // Assert
             Assert.Equal(expected, result);
         }

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -758,6 +758,59 @@ namespace NLog.UnitTests.Targets
             }
         }
 
+        [Fact]
+        public void ArchiveOldFileOnStartupAboveSize()
+        {
+            var logFile = Path.GetTempFileName();
+            var tempArchiveFolder = Path.Combine(Path.GetTempPath(), "Archive");
+            var archiveTempName = Path.Combine(tempArchiveFolder, "archive_size_threshold.txt");
+            FileTarget CreateTestTarget(bool doArchive, long threshold)
+            {
+                return new FileTarget
+                {
+                    FileName = SimpleLayout.Escape(logFile),
+                    LineEnding = LineEndingMode.LF,
+                    Layout = "${level} ${message}",
+                    ArchiveOldFileOnStartup = doArchive,
+                    ArchiveOldFileOnStartupAboveSize = threshold,
+                    ArchiveFileName = archiveTempName,
+                    ArchiveNumbering = ArchiveNumberingMode.Sequence,
+                    MaxArchiveFiles = 1
+                };
+            }
+            try
+            {
+                // No archive on startup (ignoring threshold)
+                SimpleConfigurator.ConfigureForTargetLogging(WrapFileTarget(CreateTestTarget(false, 1000)));
+                logger.Info("aaa");
+                LogManager.Flush();
+                AssertFileContents(logFile, "Info aaa\n", Encoding.UTF8);
+                Assert.False(File.Exists(archiveTempName));
+
+                // Archive on startup with huge threshold -> Must not be archived
+                SimpleConfigurator.ConfigureForTargetLogging(WrapFileTarget(CreateTestTarget(true, 10000)));
+                logger.Info("bbb");
+                LogManager.Flush();
+                AssertFileContents(logFile, "Info aaa\nInfo bbb\n", Encoding.UTF8);
+                Assert.False(File.Exists(archiveTempName));
+
+                // Archive on startup with small threshold -> Must be archived
+                SimpleConfigurator.ConfigureForTargetLogging(CreateTestTarget(true, 3));
+                logger.Info("ccc");
+                LogManager.Flush();
+                AssertFileContents(logFile, "Info ccc\n", Encoding.UTF8);
+                Assert.True(File.Exists(archiveTempName));
+                AssertFileContents(archiveTempName, "Info aaa\nInfo bbb\n", Encoding.UTF8);
+            }
+            finally
+            {
+                if (File.Exists(logFile))
+                    File.Delete(logFile);
+                if (Directory.Exists(tempArchiveFolder))
+                    Directory.Delete(tempArchiveFolder, true);
+            }
+        }
+
         public static IEnumerable<object[]> ReplaceFileContentsOnEachWriteTest_TestParameters
         {
             get


### PR DESCRIPTION
With that feature it's possible to archive the old file on startup when a certain size threshold is reached.

By enabling this you can ensure that the current application session is always in the same file but still have some kind of size based archival. Could also be comined with other archival options.