### PR TITLE
LogFactory - Fix deadlock issue with AutoReload

### DIFF
--- a/src/NLog/Internal/MultiFileWatcher.cs
+++ b/src/NLog/Internal/MultiFileWatcher.cs
@@ -135,6 +135,8 @@ namespace NLog.Internal
                 return;
             }
 
+            var fileFilter = Path.GetFileName(fileName);
+
             lock (_watcherMap)
             {
                 if (_watcherMap.ContainsKey(fileName))
@@ -147,7 +149,7 @@ namespace NLog.Internal
                     watcher = new FileSystemWatcher
                     {
                         Path = directory,
-                        Filter = Path.GetFileName(fileName),
+                        Filter = fileFilter,
                         NotifyFilter = NotifyFilters
                     };
 


### PR DESCRIPTION
Should not acquire LogFactory.SyncRoot in ConfigFileChanged when triggering reloadtimer. Resolves #3757

The deadlock happens inside the FileSystemWatcher-object. Where the Dispose-method takes a lock(this). And CompletionStatusChanged also takes lock(this).

This give the following callstacks:

    FileWatcher-CompletionStatusChanged (lock this) and starts the ReloadTimer (lock LogFactory.SyncRoot).
    ReloadConfigOnTimer (lock LogFactory.SyncRoot) and disposes the ReloadTimer + FileWatcher (lock this).

Because not in same order, then it becomes deadlock. 

Now with this PR it becomes this lock-pattern:

    FileWatcher-CompletionStatusChanged (lock this) and notifies the ReloadTimer (lock lockobject)
    ReloadConfigOnTimer (lock lockobject) and disposes the ReloadTimer.
    ReloadConfigOnTimer (lock LogFactory.SyncRoot) and disposes the FileWatcher (lock this).