### PR TITLE
DatabaseTarget: Added IsolationLevel option - activates transactions for batch writes

### DIFF
--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
@@ -177,7 +177,7 @@ namespace NLog.UnitTests.Targets.Wrappers
 #if NET4_5
                 if (!IsAppVeyor())  // Skip timing test when running within OpenCover.Console.exe
 #endif
-                    Assert.InRange(elapsedMilliseconds, 0, 950);
+                    Assert.InRange(elapsedMilliseconds, 0, 975);
 
                 targetWrapper.Flush(flushHandler);
                 for (int i = 0; i < 2000 && flushCounter != 2; ++i)


### PR DESCRIPTION
Alternative version of #3150

Improve performance with help from transactions. DbCommands will not be committed individually but will be committed as a single transaction-chunk. This will reduce the number of requests sent to the database-instance, so less network-latency overhead.

There is one downside. When a single LogEvent in a batch has problems, then it will also cause all other LogEvents in the same batch to fail..