### PR TITLE
Mark Condition Expressions as ThreadSafe. Improves concurrency

### DIFF
--- a/src/NLog/Conditions/ConditionExpression.cs
+++ b/src/NLog/Conditions/ConditionExpression.cs
@@ -44,6 +44,7 @@ namespace NLog.Conditions
     /// </summary>
     [NLogConfigurationItem]
     [ThreadAgnostic]
+    [ThreadSafe]
     public abstract class ConditionExpression
     {
         /// <summary>


### PR DESCRIPTION
Ex. For when-conditions:

`SimpleLayout l = @"${when:when=level<=LogLevel.Info:inner=Good:else=Bad}";`