### PR TITLE
Added Layout.CreateFromString with throwConfigExceptions parameter

### DIFF
--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -127,6 +127,31 @@ namespace NLog.Layouts
         }
 
         /// <summary>
+        /// Implicitly converts the specified string to a <see cref="SimpleLayout"/>.
+        /// </summary>
+        /// <param name="layoutText">The layout string.</param>
+        /// <param name="throwConfigExceptions">Whether <see cref="NLogConfigurationException"/> should be thrown on parse errors (false = replace unrecognized tokens with a space).</param>
+        /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
+        public static Layout CreateFromString(string layoutText, bool throwConfigExceptions)
+        {
+            try
+            {
+                return new SimpleLayout(layoutText, ConfigurationItemFactory.Default, throwConfigExceptions);
+            }
+            catch (NLogConfigurationException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                if (!throwConfigExceptions || ex.MustBeRethrownImmediately())
+                    throw;
+
+                throw new NLogConfigurationException($"Invalid Layout: {layoutText}", ex);
+            }
+        }
+
+        /// <summary>
         /// Implicits converts the specific lambda method into a <see cref="SimpleLayout"/>.
         /// </summary>
         /// <param name="layoutMethod">Method that renders the layout.</param>

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -50,7 +50,7 @@ namespace NLog.Layouts
     /// </summary>
     internal static class LayoutParser
     {
-        internal static LayoutRenderer[] CompileLayout(ConfigurationItemFactory configurationItemFactory, SimpleStringReader sr, bool isNested, out string text)
+        internal static LayoutRenderer[] CompileLayout(ConfigurationItemFactory configurationItemFactory, SimpleStringReader sr, bool? throwConfigExceptions, bool isNested, out string text)
         {
             var result = new List<LayoutRenderer>();
             var literalBuf = new StringBuilder();
@@ -101,7 +101,7 @@ namespace NLog.Layouts
                     //stash already found layout-renderer.
                     AddLiteral(literalBuf, result);
 
-                    LayoutRenderer newLayoutRenderer = ParseLayoutRenderer(configurationItemFactory, sr);
+                    LayoutRenderer newLayoutRenderer = ParseLayoutRenderer(configurationItemFactory, sr, throwConfigExceptions);
                     if (CanBeConvertedToLiteral(newLayoutRenderer))
                     {
                         newLayoutRenderer = ConvertToLiteral(newLayoutRenderer);
@@ -335,13 +335,13 @@ namespace NLog.Layouts
             return (char)code;
         }
 
-        private static LayoutRenderer ParseLayoutRenderer(ConfigurationItemFactory configurationItemFactory, SimpleStringReader stringReader)
+        private static LayoutRenderer ParseLayoutRenderer(ConfigurationItemFactory configurationItemFactory, SimpleStringReader stringReader, bool? throwConfigExceptions)
         {
             int ch = stringReader.Read();
             Debug.Assert(ch == '{', "'{' expected in layout specification");
 
             string name = ParseLayoutRendererName(stringReader);
-            var layoutRenderer = GetLayoutRenderer(configurationItemFactory, name);
+            var layoutRenderer = GetLayoutRenderer(configurationItemFactory, name, throwConfigExceptions);
 
             var wrappers = new Dictionary<Type, LayoutRenderer>();
             var orderedWrappers = new List<LayoutRenderer>();
@@ -392,7 +392,7 @@ namespace NLog.Layouts
                         {
                             var nestedLayout = new SimpleLayout();
                             string txt;
-                            LayoutRenderer[] renderers = CompileLayout(configurationItemFactory, stringReader, true, out txt);
+                            LayoutRenderer[] renderers = CompileLayout(configurationItemFactory, stringReader, throwConfigExceptions, true, out txt);
 
                             nestedLayout.SetRenderers(renderers, txt);
                             propertyInfo.SetValue(parameterTarget, nestedLayout, null);
@@ -422,7 +422,7 @@ namespace NLog.Layouts
             return layoutRenderer;
         }
 
-        private static LayoutRenderer GetLayoutRenderer(ConfigurationItemFactory configurationItemFactory, string name)
+        private static LayoutRenderer GetLayoutRenderer(ConfigurationItemFactory configurationItemFactory, string name, bool? throwConfigExceptions)
         {
             LayoutRenderer layoutRenderer;
             try
@@ -431,9 +431,9 @@ namespace NLog.Layouts
             }
             catch (Exception ex)
             {
-                if (LogManager.ThrowConfigExceptions ?? LogManager.ThrowExceptions)
+                if (throwConfigExceptions ?? LogManager.ThrowConfigExceptions ?? LogManager.ThrowExceptions)
                 {
-                    throw;
+                    throw;  // TODO NLog 5.0 throw NLogConfigurationException. Maybe also include entire input layout-string (if not too long)
                 }
                 InternalLogger.Error(ex, "Error parsing layout {0} will be ignored.", name);
                 // replace with empty values

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -83,14 +83,26 @@ namespace NLog.Layouts
         /// <param name="txt">The layout string to parse.</param>
         /// <param name="configurationItemFactory">The NLog factories to use when creating references to layout renderers.</param>
         public SimpleLayout(string txt, ConfigurationItemFactory configurationItemFactory)
+            :this(txt, configurationItemFactory, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SimpleLayout"/> class.
+        /// </summary>
+        /// <param name="txt">The layout string to parse.</param>
+        /// <param name="configurationItemFactory">The NLog factories to use when creating references to layout renderers.</param>
+        /// <param name="throwConfigExceptions">Whether <see cref="NLogConfigurationException"/> should be thrown on parse errors.</param>
+        internal SimpleLayout(string txt, ConfigurationItemFactory configurationItemFactory, bool? throwConfigExceptions)
         {
             _configurationItemFactory = configurationItemFactory;
-            Text = txt;
+            SetLayoutText(txt, throwConfigExceptions);
         }
 
         internal SimpleLayout(LayoutRenderer[] renderers, string text, ConfigurationItemFactory configurationItemFactory)
         {
             _configurationItemFactory = configurationItemFactory;
+            OriginalText = text;
             SetRenderers(renderers, text);
         }
 
@@ -106,29 +118,31 @@ namespace NLog.Layouts
         public string Text
         {
             get => _layoutText;
+            set => SetLayoutText(value);
+        }
 
-            set
+        private void SetLayoutText(string value, bool? throwConfigExceptions = null)
+        {
+            OriginalText = value;
+
+            LayoutRenderer[] renderers;
+            string txt;
+            if (value == null)
             {
-                OriginalText = value;
-
-                LayoutRenderer[] renderers;
-                string txt;
-                if (value == null)
-                {
-                    renderers = ArrayHelper.Empty<LayoutRenderer>();
-                    txt = string.Empty;
-                }
-                else
-                {
-                    renderers = LayoutParser.CompileLayout(
-                       _configurationItemFactory,
-                       new SimpleStringReader(value),
-                       false,
-                       out txt);
-                }
-
-                SetRenderers(renderers, txt);
+                renderers = ArrayHelper.Empty<LayoutRenderer>();
+                txt = string.Empty;
             }
+            else
+            {
+                renderers = LayoutParser.CompileLayout(
+                   _configurationItemFactory,
+                    new SimpleStringReader(value),
+                    throwConfigExceptions,
+                    false,
+                    out txt);
+            }
+
+            SetRenderers(renderers, txt);
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -43,11 +43,9 @@ namespace NLog.UnitTests
     using Microsoft.CSharp;
     using Xunit;
     using NLog.Config;
-    using NLog.Layouts;
-    using NLog.LayoutRenderers;
     using NLog.UnitTests.Mocks;
 
-    public class ConfigFileLocatorTests : NLogTestBase, IDisposable
+    public sealed class ConfigFileLocatorTests : NLogTestBase, IDisposable
     {
         private readonly string _tempDirectory;
 
@@ -61,91 +59,6 @@ namespace NLog.UnitTests
         {
             if (Directory.Exists(_tempDirectory))
                 Directory.Delete(_tempDirectory, true);
-        }
-
-        [Fact]
-        void FuncLayoutRendererRegisterTest1()
-        {
-            LayoutRenderer.Register("the-answer", (info) => "42");
-            Layout l = "${the-answer}";
-            var result = l.Render(LogEventInfo.CreateNullEvent());
-            Assert.Equal("42", result);
-        }
-
-        [Fact]
-        void FuncLayoutRendererFluentMethod_ThreadSafe_Test()
-        {
-            // Arrange
-            var layout = Layout.CreateFromMethod(l => "42", LayoutRenderOptions.ThreadSafe);
-            // Act
-            var result = layout.Render(LogEventInfo.CreateNullEvent());
-            // Assert
-            Assert.Equal("42", result);
-            Assert.True(layout.ThreadSafe);
-            Assert.False(layout.ThreadAgnostic);
-        }
-
-        [Fact]
-        void FuncLayoutRendererFluentMethod_ThreadAgnostic_Test()
-        {
-            // Arrange
-            var layout = Layout.CreateFromMethod(l => "42", LayoutRenderOptions.ThreadAgnostic);
-            // Act
-            var result = layout.Render(LogEventInfo.CreateNullEvent());
-            // Assert
-            Assert.Equal("42", result);
-            Assert.True(layout.ThreadSafe);
-            Assert.True(layout.ThreadAgnostic);
-        }
-
-        [Fact]
-        void FuncLayoutRendererFluentMethod_ThreadUnsafe_Test()
-        {
-            // Arrange
-            var layout = Layout.CreateFromMethod(l => "42", LayoutRenderOptions.None);
-            // Act
-            var result = layout.Render(LogEventInfo.CreateNullEvent());
-            // Assert
-            Assert.Equal("42", result);
-            Assert.False(layout.ThreadSafe);
-            Assert.False(layout.ThreadAgnostic);
-        }
-
-        [Fact]
-        void FuncLayoutRendererFluentMethod_NullThrows_Test()
-        {
-            // Arrange
-            Assert.Throws<ArgumentNullException>(() => Layout.CreateFromMethod(null));
-        }
-
-        [Fact]
-        void FuncLayoutRendererRegisterTest1WithXML()
-        {
-            LayoutRenderer.Register("the-answer", (info) => 42);
-
-            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
-<nlog throwExceptions='true'>
-            
-                <targets>
-                    <target name='debug' type='Debug' layout= 'TheAnswer=${the-answer:Format=D3}' /></targets>
-                <rules>
-                    <logger name='*' minlevel='Debug' writeTo='debug' />
-                </rules>
-            </nlog>");
-
-            var logger = LogManager.GetCurrentClassLogger();
-            logger.Debug("test1");
-            AssertDebugLastMessage("debug", "TheAnswer=042");
-        }
-
-        [Fact]
-        void FuncLayoutRendererRegisterTest2()
-        {
-            LayoutRenderer.Register("message-length", (info) => info.Message.Length);
-            Layout l = "${message-length}";
-            var result = l.Render(LogEventInfo.Create(LogLevel.Error, "logger-adhoc", "1234567890"));
-            Assert.Equal("10", result);
-
         }
 
         [Fact]


### PR DESCRIPTION
Trying to prevent cases where people globally enabled LogManager.ThrowExceptions to perform Layout-validation. See also:

https://github.com/elmahio/elmah.io.nlog/commit/f26377ec38c1c77de73e82e917d0b21e866027f3

And moved FuncLayoutRenderer-tests to SimpleLayoutParserTests.

Could also be convinced to rename it to TryCreateFromString. But then I'm not allowed to throw exception with reason why (and where) it failed.

