### PR TITLE
Rename Create methods on Layout - don't introduce obsoletes

### DIFF
--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -90,7 +90,7 @@ namespace NLog.Layouts
         /// <returns><see cref="SimpleLayout"/> object represented by the text.</returns>
         public static implicit operator Layout([Localizable(false)] string text)
         {
-            return CreateFromString(text);
+            return FromString(text, ConfigurationItemFactory.Default);
         }
 
         /// <summary>
@@ -98,7 +98,6 @@ namespace NLog.Layouts
         /// </summary>
         /// <param name="layoutText">The layout string.</param>
         /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>'
-        [Obsolete("Use Layout.CreateFromString. Obsolete from NLog 4.7")]
         public static Layout FromString(string layoutText)
         {
             return FromString(layoutText, ConfigurationItemFactory.Default);
@@ -110,7 +109,6 @@ namespace NLog.Layouts
         /// <param name="layoutText">The layout string.</param>
         /// <param name="configurationItemFactory">The NLog factories to use when resolving layout renderers.</param>
         /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
-        [Obsolete("Use Layout.CreateFromString. Obsolete from NLog 4.7")]
         public static Layout FromString(string layoutText, ConfigurationItemFactory configurationItemFactory)
         {
             return new SimpleLayout(layoutText, configurationItemFactory);
@@ -120,19 +118,9 @@ namespace NLog.Layouts
         /// Implicitly converts the specified string to a <see cref="SimpleLayout"/>.
         /// </summary>
         /// <param name="layoutText">The layout string.</param>
-        /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
-        public static Layout CreateFromString(string layoutText)
-        {
-            return new SimpleLayout(layoutText, ConfigurationItemFactory.Default);
-        }
-
-        /// <summary>
-        /// Implicitly converts the specified string to a <see cref="SimpleLayout"/>.
-        /// </summary>
-        /// <param name="layoutText">The layout string.</param>
         /// <param name="throwConfigExceptions">Whether <see cref="NLogConfigurationException"/> should be thrown on parse errors (false = replace unrecognized tokens with a space).</param>
         /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
-        public static Layout CreateFromString(string layoutText, bool throwConfigExceptions)
+        public static Layout FromString(string layoutText, bool throwConfigExceptions)
         {
             try
             {
@@ -152,12 +140,12 @@ namespace NLog.Layouts
         }
 
         /// <summary>
-        /// Implicits converts the specific lambda method into a <see cref="SimpleLayout"/>.
+        /// Create a <see cref="SimpleLayout"/> from a lambda method.
         /// </summary>
         /// <param name="layoutMethod">Method that renders the layout.</param>
         /// <param name="options">Tell if method is safe for concurrent threading.</param>
         /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
-        public static Layout CreateFromMethod(Func<LogEventInfo, object> layoutMethod, LayoutRenderOptions options = LayoutRenderOptions.None)
+        public static Layout FromMethod(Func<LogEventInfo, object> layoutMethod, LayoutRenderOptions options = LayoutRenderOptions.None)
         {
             if (layoutMethod == null)
                 throw new ArgumentNullException(nameof(layoutMethod));
@@ -167,11 +155,11 @@ namespace NLog.Layouts
 #else
             var name = $"{layoutMethod.Method?.DeclaringType?.ToString()}.{layoutMethod.Method?.Name}";
 #endif
-            var layoutRenderer = CreateFunLayoutRenderer(layoutMethod, options, name);
+            var layoutRenderer = CreateFuncLayoutRenderer(layoutMethod, options, name);
             return new SimpleLayout(new[] { layoutRenderer }, layoutRenderer.LayoutRendererName, ConfigurationItemFactory.Default);
         }
 
-        private static LayoutRenderers.FuncLayoutRenderer CreateFunLayoutRenderer(Func<LogEventInfo, object> layoutMethod, LayoutRenderOptions options, string name)
+        private static LayoutRenderers.FuncLayoutRenderer CreateFuncLayoutRenderer(Func<LogEventInfo, object> layoutMethod, LayoutRenderOptions options, string name)
         {
             if ((options & LayoutRenderOptions.ThreadAgnostic) == LayoutRenderOptions.ThreadAgnostic)
                 return new LayoutRenderers.FuncThreadAgnosticLayoutRenderer(name, (l, c) => layoutMethod(l));

--- a/src/NLog/Layouts/LayoutRenderOptions.cs
+++ b/src/NLog/Layouts/LayoutRenderOptions.cs
@@ -36,7 +36,7 @@ namespace NLog.Layouts
     using System;
 
     /// <summary>
-    /// Options available for <see cref="Layout.CreateFromMethod"/>
+    /// Options available for <see cref="Layout.FromMethod"/>
     /// </summary>
     [Flags]
     public enum LayoutRenderOptions

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -622,7 +622,7 @@ namespace NLog.UnitTests.Layouts
         void FuncLayoutRendererFluentMethod_ThreadSafe_Test()
         {
             // Arrange
-            var layout = Layout.CreateFromMethod(l => "42", LayoutRenderOptions.ThreadSafe);
+            var layout = Layout.FromMethod(l => "42", LayoutRenderOptions.ThreadSafe);
             // Act
             var result = layout.Render(LogEventInfo.CreateNullEvent());
             // Assert
@@ -635,7 +635,7 @@ namespace NLog.UnitTests.Layouts
         void FuncLayoutRendererFluentMethod_ThreadAgnostic_Test()
         {
             // Arrange
-            var layout = Layout.CreateFromMethod(l => "42", LayoutRenderOptions.ThreadAgnostic);
+            var layout = Layout.FromMethod(l => "42", LayoutRenderOptions.ThreadAgnostic);
             // Act
             var result = layout.Render(LogEventInfo.CreateNullEvent());
             // Assert
@@ -648,7 +648,7 @@ namespace NLog.UnitTests.Layouts
         void FuncLayoutRendererFluentMethod_ThreadUnsafe_Test()
         {
             // Arrange
-            var layout = Layout.CreateFromMethod(l => "42", LayoutRenderOptions.None);
+            var layout = Layout.FromMethod(l => "42", LayoutRenderOptions.None);
             // Act
             var result = layout.Render(LogEventInfo.CreateNullEvent());
             // Assert
@@ -661,7 +661,7 @@ namespace NLog.UnitTests.Layouts
         void FuncLayoutRendererFluentMethod_NullThrows_Test()
         {
             // Arrange
-            Assert.Throws<ArgumentNullException>(() => Layout.CreateFromMethod(null));
+            Assert.Throws<ArgumentNullException>(() => Layout.FromMethod(null));
         }
 
         [Fact]
@@ -696,13 +696,13 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         void SimpleLayout_CreateFromString_ThrowConfigExceptions()
         {
-            Assert.Throws<NLogConfigurationException>(() => Layout.CreateFromString("${evil}", true));
+            Assert.Throws<NLogConfigurationException>(() => Layout.FromString("${evil}", true));
         }
 
         [Fact]
         void SimpleLayout_CreateFromString_NoThrowConfigExceptions()
         {
-            Assert.NotNull(Layout.CreateFromString("${evil}", false));
+            Assert.NotNull(Layout.FromString("${evil}", false));
         }
 
         private class LayoutRendererWithListParam : LayoutRenderer


### PR DESCRIPTION
- Rename CreateFromString to FromString
- Rename CreateFromMethod to FromMethod
- Remove never released obsoletes