### PR TITLE
WebServiceTarget - Debug mode should not die because of System.Net.WebException

### DIFF
--- a/src/NLog/Internal/ExceptionHelper.cs
+++ b/src/NLog/Internal/ExceptionHelper.cs
@@ -144,6 +144,10 @@ namespace NLog.Internal
             {
                 return true;
             }
+            if (exception is System.Net.WebException)
+            {
+                return false;   // Not a real InvalidOperationException
+            }
             if (exception is InvalidOperationException)
             {
                 return true;    // Ex. Collection was modified

--- a/src/NLog/Internal/NetworkSenders/HttpNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/HttpNetworkSender.cs
@@ -103,9 +103,9 @@ namespace NLog.Internal.NetworkSenders
                     }
                     catch (Exception ex)
                     {
-                        if (ex.MustBeRethrown())
+                        if (ex.MustBeRethrownImmediately())
                         {
-                            throw;
+                            throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                         }
 
                         base.EndRequest(_ => asyncContinuation(ex), null);    // pendingException = null to keep sender alive


### PR DESCRIPTION
Trying to fix error:

https://ci.appveyor.com/project/nlog/nlog/builds/30470785