### PR TITLE
LogFactory.Setup with fluent registration of condition methods

### DIFF
--- a/src/NLog/Conditions/ConditionMethodExpression.cs
+++ b/src/NLog/Conditions/ConditionMethodExpression.cs
@@ -39,34 +39,40 @@ namespace NLog.Conditions
     using System.Reflection;
     using System.Text;
     using NLog.Common;
+    using NLog.Internal;
 
     /// <summary>
     /// Condition method invocation expression (represented by <b>method(p1,p2,p3)</b> syntax).
     /// </summary>
 	internal sealed class ConditionMethodExpression : ConditionExpression
     {
-        private readonly bool _acceptsLogEvent;
         private readonly string _conditionMethodName;
+        private readonly bool _acceptsLogEvent;
+        private readonly ConditionExpression[] _methodParameters;
+        private readonly ReflectionHelpers.LateBoundMethod _lateBoundMethod;
+        private readonly object[] _lateBoundMethodDefaultParameters;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConditionMethodExpression" /> class.
         /// </summary>
         /// <param name="conditionMethodName">Name of the condition method.</param>
         /// <param name="methodInfo"><see cref="MethodInfo"/> of the condition method.</param>
+        /// <param name="lateBoundMethod">Precompiled delegate of the condition method.</param>
         /// <param name="methodParameters">The method parameters.</param>
-        public ConditionMethodExpression(string conditionMethodName, MethodInfo methodInfo, IEnumerable<ConditionExpression> methodParameters)
+        public ConditionMethodExpression(string conditionMethodName, MethodInfo methodInfo, ReflectionHelpers.LateBoundMethod lateBoundMethod, IEnumerable<ConditionExpression> methodParameters)
         {
             MethodInfo = methodInfo;
+            _lateBoundMethod = lateBoundMethod;
             _conditionMethodName = conditionMethodName;
-            MethodParameters = new List<ConditionExpression>(methodParameters).AsReadOnly();
-
+            _methodParameters = new List<ConditionExpression>(methodParameters).ToArray();
             ParameterInfo[] formalParameters = MethodInfo.GetParameters();
             if (formalParameters.Length > 0 && formalParameters[0].ParameterType == typeof(LogEventInfo))
             {
                 _acceptsLogEvent = true;
             }
+            _lateBoundMethodDefaultParameters = CreateMethodDefaultParameters(formalParameters, _methodParameters, _acceptsLogEvent ? 1 : 0);
 
-            int actualParameterCount = MethodParameters.Count;
+            int actualParameterCount = _methodParameters.Length;
             if (_acceptsLogEvent)
             {
                 actualParameterCount++;
@@ -101,26 +107,27 @@ namespace NLog.Conditions
                 InternalLogger.Error(message);
                 throw new ConditionParseException(message);
             }
-
-            CreateBoundMethod(formalParameters);
         }
 
-        private void CreateBoundMethod(ParameterInfo[] formalParameters)
+        /// <summary>
+        /// Gets the method info.
+        /// </summary>
+        public MethodInfo MethodInfo { get; }
+
+        private static object[] CreateMethodDefaultParameters(ParameterInfo[] formalParameters, ConditionExpression[] methodParameters, int parameterOffset)
         {
-            _lateBoundMethod = Internal.ReflectionHelpers.CreateLateBoundMethod(MethodInfo);
-            if (formalParameters.Length > MethodParameters.Count)
+            var defaultParameterCount = formalParameters.Length - methodParameters.Length - parameterOffset;
+            if (defaultParameterCount <= 0)
+                return ArrayHelper.Empty<object>();
+
+            var extraDefaultParameters = new object[defaultParameterCount];
+            for (int i = methodParameters.Length + parameterOffset; i < formalParameters.Length; ++i)
             {
-                _lateBoundMethodDefaultParameters = new object[formalParameters.Length - MethodParameters.Count];
-                for (int i = MethodParameters.Count; i < formalParameters.Length; ++i)
-                {
-                    ParameterInfo param = formalParameters[i];
-                    _lateBoundMethodDefaultParameters[i - MethodParameters.Count] = param.DefaultValue;
-                }
+                ParameterInfo param = formalParameters[i];
+                extraDefaultParameters[i - methodParameters.Length + parameterOffset] = param.DefaultValue;
             }
-            else
-            {
-                _lateBoundMethodDefaultParameters = null;
-            }
+
+            return extraDefaultParameters;
         }
 
         private static void CountParmameters(ParameterInfo[] formalParameters, out int requiredParametersCount, out int optionalParametersCount)
@@ -138,19 +145,6 @@ namespace NLog.Conditions
         }
 
         /// <summary>
-        /// Gets the method info.
-        /// </summary>
-        public MethodInfo MethodInfo { get; private set; }
-        private Internal.ReflectionHelpers.LateBoundMethod _lateBoundMethod;
-        private object[] _lateBoundMethodDefaultParameters;
-
-        /// <summary>
-        /// Gets the method parameters.
-        /// </summary>
-        /// <value>The method parameters.</value>
-        public IList<ConditionExpression> MethodParameters { get; private set; }
-
-        /// <summary>
         /// Returns a string representation of the expression.
         /// </summary>
         /// <returns>
@@ -164,11 +158,8 @@ namespace NLog.Conditions
 
             string separator = string.Empty;
 
-            //Memory profiling pointed out that using a foreach-loop was allocating
-            //an Enumerator. Switching to a for-loop avoids the memory allocation.
-            for (int i = 0; i < MethodParameters.Count; i++)
+            foreach (var expr in _methodParameters)
             {
-                ConditionExpression expr = MethodParameters[i];
                 sb.Append(separator);
                 sb.Append(expr);
                 separator = ", ";
@@ -192,27 +183,26 @@ namespace NLog.Conditions
         private object[] GenerateCallParameters(LogEventInfo context)
         {
             int parameterOffset = _acceptsLogEvent ? 1 : 0;
-            int parameterDefaults = _lateBoundMethodDefaultParameters?.Length ?? 0;
-            int callParametersCount = MethodParameters.Count + parameterOffset + parameterDefaults;
+            int callParametersCount = _methodParameters.Length + parameterOffset + _lateBoundMethodDefaultParameters.Length;
             if (callParametersCount == 0)
-                return NLog.Internal.ArrayHelper.Empty<object>();
+                return ArrayHelper.Empty<object>();
 
             var callParameters = new object[callParametersCount];
-
-            //Memory profiling pointed out that using a foreach-loop was allocating
-            //an Enumerator. Switching to a for-loop avoids the memory allocation.
-            for (int i = 0; i < MethodParameters.Count; i++)
-            {
-                ConditionExpression ce = MethodParameters[i];
-                callParameters[i + parameterOffset] = ce.Evaluate(context);
-            }
 
             if (_acceptsLogEvent)
             {
                 callParameters[0] = context;
             }
 
-            if (_lateBoundMethodDefaultParameters != null)
+            //Memory profiling pointed out that using a foreach-loop was allocating
+            //an Enumerator. Switching to a for-loop avoids the memory allocation.
+            for (int i = 0; i < _methodParameters.Length; i++)
+            {
+                ConditionExpression ce = _methodParameters[i];
+                callParameters[i + parameterOffset] = ce.Evaluate(context);
+            }
+
+            if (_lateBoundMethodDefaultParameters.Length > 0)
             {
                 for (int i = _lateBoundMethodDefaultParameters.Length - 1; i >= 0; --i)
                 {

--- a/src/NLog/Conditions/ConditionParser.cs
+++ b/src/NLog/Conditions/ConditionParser.cs
@@ -134,7 +134,8 @@ namespace NLog.Conditions
             try
             {
                 var methodInfo = _configurationItemFactory.ConditionMethods.CreateInstance(functionName);
-                return new ConditionMethodExpression(functionName, methodInfo, par);
+                var methodDelegate = _configurationItemFactory.ConditionMethodDelegates.CreateInstance(functionName);
+                return new ConditionMethodExpression(functionName, methodInfo, methodDelegate, par);
             }
             catch (Exception exception)
             {

--- a/src/NLog/Config/Factory.cs
+++ b/src/NLog/Config/Factory.cs
@@ -80,7 +80,6 @@ namespace NLog.Config
                     {
                         throw;
                     }
-
                 }
             }
         }
@@ -243,7 +242,6 @@ namespace NLog.Config
             _funcRenderers[name] = renderer;
         }
 
-
         /// <summary>
         /// Tries to create an item instance.
         /// </summary>
@@ -268,6 +266,5 @@ namespace NLog.Config
 
             return success;
         }
-
     }
 }

--- a/src/NLog/Config/MethodFactory.cs
+++ b/src/NLog/Config/MethodFactory.cs
@@ -36,33 +36,30 @@ namespace NLog.Config
     using System;
     using System.Collections.Generic;
     using System.Reflection;
-    using Common;
-    using Internal;
+    using NLog.Common;
+    using NLog.Internal;
 
     /// <summary>
     /// Factory for locating methods.
     /// </summary>
-    /// <typeparam name="TClassAttributeType">The type of the class marker attribute.</typeparam>
-    /// <typeparam name="TMethodAttributeType">The type of the method marker attribute.</typeparam>
-    internal class MethodFactory<TClassAttributeType, TMethodAttributeType> : INamedItemFactory<MethodInfo, MethodInfo>, IFactory
-        where TClassAttributeType : Attribute
-        where TMethodAttributeType : NameBaseAttribute
+    internal class MethodFactory : INamedItemFactory<MethodInfo, MethodInfo>, INamedItemFactory<ReflectionHelpers.LateBoundMethod, MethodInfo>, IFactory
     {
         private readonly Dictionary<string, MethodInfo> _nameToMethodInfo = new Dictionary<string, MethodInfo>();
+        private readonly Dictionary<string, ReflectionHelpers.LateBoundMethod> _nameToLateBoundMethod = new Dictionary<string, ReflectionHelpers.LateBoundMethod>();
+        private readonly Func<Type, IList<KeyValuePair<string, MethodInfo>>> _methodExtractor;
 
         /// <summary>
-        /// Gets a collection of all registered items in the factory.
+        /// Initializes a new instance of the <see cref="MethodFactory"/> class.
         /// </summary>
-        /// <returns>
-        /// Sequence of key/value pairs where each key represents the name
-        /// of the item and value is the <see cref="MethodInfo"/> of
-        /// the item.
-        /// </returns>
-        public IDictionary<string, MethodInfo> AllRegisteredItems => _nameToMethodInfo;
+        /// <param name="methodExtractor">Helper method to extract relevant methods from type</param>
+        public MethodFactory(Func<Type, IList<KeyValuePair<string, MethodInfo>>> methodExtractor)
+        {
+            _methodExtractor = methodExtractor;
+        }
 
         /// <summary>
-        /// Scans the assembly for classes marked with <typeparamref name="TClassAttributeType"/>
-        /// and methods marked with <typeparamref name="TMethodAttributeType"/> and adds them 
+        /// Scans the assembly for classes marked with expected class <see cref="Attribute"/>
+        /// and methods marked with expected <see cref="NameBaseAttribute"/> and adds them 
         /// to the factory.
         /// </summary>
         /// <param name="types">The types to scan.</param>
@@ -73,7 +70,10 @@ namespace NLog.Config
             {
                 try
                 {
-                    RegisterType(t, prefix);
+                    if (t.IsClass() || t.IsAbstract())
+                    {
+                        RegisterType(t, prefix);
+                    }
                 }
                 catch (Exception exception)
                 {
@@ -83,8 +83,6 @@ namespace NLog.Config
                     {
                         throw;
                     }
-
-                    
                 }
             }
         }
@@ -96,17 +94,41 @@ namespace NLog.Config
         /// <param name="itemNamePrefix">The item name prefix.</param>
         public void RegisterType(Type type, string itemNamePrefix)
         {
-            if (type.IsDefined(typeof(TClassAttributeType), false))
+            var extractedMethods = _methodExtractor(type);
+            if (extractedMethods?.Count > 0)
             {
-                foreach (MethodInfo mi in type.GetMethods())
+                for (int i = 0; i < extractedMethods.Count; ++i)
                 {
-                    var methodAttributes = (TMethodAttributeType[])mi.GetCustomAttributes(typeof(TMethodAttributeType), false);
-                    foreach (TMethodAttributeType attr in methodAttributes)
-                    {
-                        RegisterDefinition(itemNamePrefix + attr.Name, mi);
-                    }
+                    RegisterDefinition(itemNamePrefix + extractedMethods[i].Key, extractedMethods[i].Value);
                 }
             }
+        }
+
+        /// <summary>
+        /// Scans a type for relevant methods with their symbolic names
+        /// </summary>
+        /// <typeparam name="TClassAttributeType">Include types that are marked with this attribute</typeparam>
+        /// <typeparam name="TMethodAttributeType">Include methods that are marked with this attribute</typeparam>
+        /// <param name="type">Class Type to scan</param>
+        /// <returns>Collection of methods with their symbolic names</returns>
+        public static IList<KeyValuePair<string, MethodInfo>> ExtractClassMethods<TClassAttributeType, TMethodAttributeType>(Type type) 
+            where TClassAttributeType : Attribute
+            where TMethodAttributeType : NameBaseAttribute
+        {
+            if (!type.IsDefined(typeof(TClassAttributeType), false))
+                return ArrayHelper.Empty<KeyValuePair<string, MethodInfo>>();
+
+            var conditionMethods = new List<KeyValuePair<string, MethodInfo>>();
+            foreach (MethodInfo mi in type.GetMethods())
+            {
+                var methodAttributes = (TMethodAttributeType[])mi.GetCustomAttributes(typeof(TMethodAttributeType), false);
+                foreach (var attr in methodAttributes)
+                {
+                    conditionMethods.Add(new KeyValuePair<string, MethodInfo>(attr.Name, mi));
+                }
+            }
+
+            return conditionMethods;
         }
 
         /// <summary>
@@ -115,6 +137,8 @@ namespace NLog.Config
         public void Clear()
         {
             _nameToMethodInfo.Clear();
+            lock (_nameToLateBoundMethod)
+                _nameToLateBoundMethod.Clear();
         }
 
         /// <summary>
@@ -125,6 +149,21 @@ namespace NLog.Config
         public void RegisterDefinition(string itemName, MethodInfo itemDefinition)
         {
             _nameToMethodInfo[itemName] = itemDefinition;
+            lock (_nameToLateBoundMethod)
+                _nameToLateBoundMethod.Remove(itemName);
+        }
+
+        /// <summary>
+        /// Registers the definition of a single method.
+        /// </summary>
+        /// <param name="itemName">The method name.</param>
+        /// <param name="itemDefinition">The method info.</param>
+        /// <param name="lateBoundMethod">The precompiled method delegate.</param>
+        internal void RegisterDefinition(string itemName, MethodInfo itemDefinition, ReflectionHelpers.LateBoundMethod lateBoundMethod)
+        {
+            _nameToMethodInfo[itemName] = itemDefinition;
+            lock (_nameToLateBoundMethod)
+                _nameToLateBoundMethod[itemName] = lateBoundMethod;
         }
 
         /// <summary>
@@ -139,15 +178,55 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Tries to retrieve method-delegate by name.
+        /// </summary>
+        /// <param name="itemName">The method name.</param>
+        /// <param name="result">The result.</param>
+        /// <returns>A value of <c>true</c> if the method was found, <c>false</c> otherwise.</returns>
+        public bool TryCreateInstance(string itemName, out ReflectionHelpers.LateBoundMethod result)
+        {
+            lock (_nameToLateBoundMethod)
+            {
+                if (_nameToLateBoundMethod.TryGetValue(itemName, out result))
+                {
+                    return true;
+                }
+            }
+
+            if (_nameToMethodInfo.TryGetValue(itemName, out var methodInfo))
+            {
+                result = ReflectionHelpers.CreateLateBoundMethod(methodInfo);
+                lock (_nameToLateBoundMethod)
+                    _nameToLateBoundMethod[itemName] = result;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Retrieves method by name.
         /// </summary>
         /// <param name="itemName">Method name.</param>
         /// <returns>MethodInfo object.</returns>
-        public MethodInfo CreateInstance(string itemName)
+        MethodInfo INamedItemFactory<MethodInfo, MethodInfo>.CreateInstance(string itemName)
         {
-            MethodInfo result;
+            if (TryCreateInstance(itemName, out MethodInfo result))
+            {
+                return result;
+            }
 
-            if (TryCreateInstance(itemName, out result))
+            throw new NLogConfigurationException($"Unknown function: '{itemName}'");
+        }
+
+        /// <summary>
+        /// Retrieves method by name.
+        /// </summary>
+        /// <param name="itemName">Method name.</param>
+        /// <returns>Method delegate object.</returns>
+        public ReflectionHelpers.LateBoundMethod CreateInstance(string itemName)
+        {
+            if (TryCreateInstance(itemName, out ReflectionHelpers.LateBoundMethod result))
             {
                 return result;
             }

--- a/src/NLog/Internal/NetStandardHelpers.cs
+++ b/src/NLog/Internal/NetStandardHelpers.cs
@@ -36,7 +36,6 @@
 namespace NLog.Internal
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
     using System.Reflection;
@@ -74,8 +73,7 @@ namespace NLog.Internal
             if (modifiers != null)
                 throw new ArgumentException("Not supported", nameof(modifiers));
 
-            var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Static);
-            foreach (MethodInfo method in methods)
+            foreach (MethodInfo method in type.GetMethods(bindingAttr))
             {
                 if (method.Name != name)
                     continue;

--- a/src/NLog/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog/SetupExtensionsBuilderExtensions.cs
@@ -79,7 +79,6 @@ namespace NLog
         /// <summary>
         /// Register a custom Target.
         /// </summary>
-        /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <typeparam name="T"> Type of the Target.</typeparam>
         /// <param name="name"> Name of the Target.</param>
@@ -92,7 +91,6 @@ namespace NLog
         /// <summary>
         /// Register a custom Target.
         /// </summary>
-        /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="targetType"> Type of the Target.</param>
         /// <param name="name"> Name of the Target.</param>
@@ -105,7 +103,6 @@ namespace NLog
         /// <summary>
         /// Register a custom layout renderer.
         /// </summary>
-        /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <typeparam name="T"> Type of the layout renderer.</typeparam>
         /// <param name="name"> Name of the layout renderer - without ${}.</param>
@@ -119,7 +116,6 @@ namespace NLog
         /// <summary>
         /// Register a custom layout renderer.
         /// </summary>
-        /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="layoutRendererType"> Type of the layout renderer.</param>
         /// <param name="name"> Name of the layout renderer - without ${}.</param>
@@ -152,5 +148,58 @@ namespace NLog
             ConfigurationItemFactory.Default.GetLayoutRenderers().RegisterFuncLayout(name, layoutRenderer);
             return setupBuilder;
         }
+
+        /// <summary>
+        /// Register a custom condition method, that can use in condition filters
+        /// </summary>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
+        /// <param name="name">Name of the condition filter method</param>
+        /// <param name="conditionMethod">MethodInfo extracted by reflection - typeof(MyClass).GetMethod("MyFunc", BindingFlags.Static).</param>
+        public static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, MethodInfo conditionMethod)
+        {
+            if (conditionMethod == null)
+                throw new ArgumentNullException(nameof(conditionMethod));
+            if (!conditionMethod.IsStatic)
+                throw new ArgumentException($"{conditionMethod.Name} must be static", nameof(conditionMethod));
+
+            ConfigurationItemFactory.Default.ConditionMethods.RegisterDefinition(name, conditionMethod);
+            return setupBuilder;
+        }
+
+#if !NETSTANDARD1_0
+        private static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, MethodInfo conditionMethod, ReflectionHelpers.LateBoundMethod lateBoundMethod)
+        {
+            ConfigurationItemFactory.Default.ConditionMethodDelegates.RegisterDefinition(name, conditionMethod, lateBoundMethod);
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Register a custom condition method, that can use in condition filters
+        /// </summary>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
+        /// <param name="name">Name of the condition filter method</param>
+        /// <param name="conditionMethod">Lambda method.</param>
+        public static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, Func<LogEventInfo, object> conditionMethod)
+        {
+            if (conditionMethod == null)
+                throw new ArgumentNullException(nameof(conditionMethod));
+            ReflectionHelpers.LateBoundMethod lateBound = (target, args) => conditionMethod((LogEventInfo)args[0]);
+            return RegisterConditionMethod(setupBuilder, name, conditionMethod.Method, lateBound);
+        }
+
+        /// <summary>
+        /// Register a custom condition method, that can use in condition filters
+        /// </summary>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
+        /// <param name="name">Name of the condition filter method</param>
+        /// <param name="conditionMethod">Lambda method.</param>
+        public static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, Func<object> conditionMethod)
+        {
+            if (conditionMethod == null)
+                throw new ArgumentNullException(nameof(conditionMethod));
+            ReflectionHelpers.LateBoundMethod lateBound = (target, args) => conditionMethod();
+            return RegisterConditionMethod(setupBuilder, name, conditionMethod.Method, lateBound);
+        }
+#endif
     }
 }


### PR DESCRIPTION
Trying to resolve #1934
```c#
LogManager.Setup().SetupExtensions(s => 
   s.RegisterConditionMethod("hasParameters", evt => evt.Parameters?.Length > 0)
);
```

And ofcourse the usual suspect:
```c#
LogManager.Setup().SetupExtensions(s =>
   s.RegisterConditionMethod("has-diag-category", typeof(NLogConditionMethods).GetMethod("HasDiagnosticCategory", BindingFlags.Static))
);
```

Also optimized the MethodFactory to only scan classes and abstract-classes for static-methods. Skipping value-types and interfaces.