### PR TITLE
Added .NET Framework 4.6 as first-class citizen

### DIFF
--- a/src/NLog/Abstractions/ISuppress.cs
+++ b/src/NLog/Abstractions/ISuppress.cs
@@ -34,7 +34,7 @@
 namespace NLog
 {
     using System;
-#if NET4_5
+#if NET4_5 || NET4_6
     using System.Threading.Tasks;
 #endif
 
@@ -68,7 +68,7 @@ namespace NLog
         /// <returns>Result returned by the provided function or fallback value in case of exception.</returns>
         T Swallow<T>(Func<T> func, T fallback);
 
-#if NET4_5
+#if NET4_5 || NET4_6
         /// <summary>
         /// Logs an exception is logged at <c>Error</c> level if the provided task does not run to completion.
         /// </summary>

--- a/src/NLog/Config/AdvancedAttribute.cs
+++ b/src/NLog/Config/AdvancedAttribute.cs
@@ -40,7 +40,7 @@ namespace NLog.Config
     /// default in generated documentation.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
-#if NET4_0 || NET4_5 && !NETSTANDARD1_0
+#if NET4_0 || (NET4_5 || NET4_6) && !NETSTANDARD1_0
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 #endif
     public sealed class AdvancedAttribute : Attribute

--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -566,7 +566,7 @@ namespace NLog.Config
         private void RegisterExternalItems()
         {
 
-#if NET4_5 || NETSTANDARD
+#if NET4_5 || NET4_6 || NETSTANDARD
             _layoutRenderers.RegisterNamedType("configsetting", "NLog.Extensions.Logging.ConfigSettingLayoutRenderer, NLog.Extensions.Logging");
 #endif
         }

--- a/src/NLog/Contexts/MappedDiagnosticsLogicalContext.cs
+++ b/src/NLog/Contexts/MappedDiagnosticsLogicalContext.cs
@@ -54,7 +54,7 @@ namespace NLog
         private sealed class ItemRemover : IDisposable
         {
             private readonly string _item1;
-#if NET4_5
+#if NET4_5 || NET4_6
             // Optimized for HostingLogScope with 3 properties
             private readonly string _item2;
             private readonly string _item3;
@@ -70,7 +70,7 @@ namespace NLog
                 _wasEmpty = wasEmpty;
             }
 
-#if NET4_5
+#if NET4_5 || NET4_6
             public ItemRemover(IReadOnlyList<KeyValuePair<string,object>> items, bool wasEmpty)
             {
                 int itemCount = items.Count;
@@ -110,7 +110,7 @@ namespace NLog
 
                     var dictionary = GetLogicalThreadDictionary(true);
                     dictionary.Remove(_item1);
-#if NET4_5
+#if NET4_5 || NET4_6
                     if (_item2 != null)
                     {
                         dictionary.Remove(_item2);
@@ -131,7 +131,7 @@ namespace NLog
 
             private bool RemoveScopeWillClearContext()
             {
-#if NET4_5
+#if NET4_5 || NET4_6
                 if (_itemArray == null)
                 {
                     var immutableDict = GetLogicalThreadDictionary(false);
@@ -268,7 +268,7 @@ namespace NLog
             return new ItemRemover(item, wasEmpty);
         }
 
-#if NET4_5
+#if NET4_5 || NET4_6
         /// <summary>
         /// Updates the current logical context with multiple items in single operation
         /// </summary>

--- a/src/NLog/Fluent/Log.cs
+++ b/src/NLog/Fluent/Log.cs
@@ -38,7 +38,7 @@ using NLog.Internal;
 
 namespace NLog.Fluent
 {
-#if NET4_5
+#if NET4_5 || NET4_6
     /// <summary>
     /// A global logging class using caller info to find the logger.
     /// </summary>

--- a/src/NLog/Fluent/LogBuilder.cs
+++ b/src/NLog/Fluent/LogBuilder.cs
@@ -285,7 +285,7 @@ namespace NLog.Fluent
         /// <param name="callerMemberName">The method or property name of the caller to the method. This is set at by the compiler.</param>
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is set at by the compiler.</param>
         /// <param name="callerLineNumber">The line number in the source file at which the method is called. This is set at by the compiler.</param>
-#if NET4_5
+#if NET4_5 || NET4_6
         public void Write(
             [CallerMemberName]string callerMemberName = null,
             [CallerFilePath]string callerFilePath = null,
@@ -315,7 +315,7 @@ namespace NLog.Fluent
         /// <param name="callerMemberName">The method or property name of the caller to the method. This is set at by the compiler.</param>
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is set at by the compiler.</param>
         /// <param name="callerLineNumber">The line number in the source file at which the method is called. This is set at by the compiler.</param>
-#if NET4_5
+#if NET4_5 || NET4_6
         public void WriteIf(
             Func<bool> condition,
             [CallerMemberName]string callerMemberName = null,
@@ -350,7 +350,7 @@ namespace NLog.Fluent
         /// <param name="callerMemberName">The method or property name of the caller to the method. This is set at by the compiler.</param>
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is set at by the compiler.</param>
         /// <param name="callerLineNumber">The line number in the source file at which the method is called. This is set at by the compiler.</param>
-#if NET4_5
+#if NET4_5 || NET4_6
         public void WriteIf(
             bool condition,
             [CallerMemberName]string callerMemberName = null,

--- a/src/NLog/Internal/Strings/StringHelpers.cs
+++ b/src/NLog/Internal/Strings/StringHelpers.cs
@@ -157,7 +157,7 @@ namespace NLog.Internal
         /// <paramref name="values" /> is <see langword="null" />. </exception>
         internal static string Join(string separator, IEnumerable<string> values)
         {
-#if NETSTANDARD || NET4_5 || NET4_0
+#if NETSTANDARD || NET4_5 || NET4_6 || NET4_0
             return string.Join(separator, values);
 #else
             return string.Join(separator, values.ToArray());

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -420,7 +420,7 @@ namespace NLog.LayoutRenderers
         /// <param name="ex">The Exception whose HResult should be appended.</param>
         protected virtual void AppendHResult(StringBuilder sb, Exception ex)
         {
-#if NET4_5
+#if NET4_5 || NET4_6
             const int S_OK = 0;     // Carries no information, so skip
             const int S_FALSE = 1;  // Carries no information, so skip
             if (ex.HResult != S_OK && ex.HResult != S_FALSE)

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -36,7 +36,7 @@ namespace NLog
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
-#if NET4_5
+#if NET4_5 || NET4_6
     using System.Threading.Tasks;
 #endif
     using JetBrains.Annotations;
@@ -499,7 +499,7 @@ namespace NLog
             }
         }
 
-#if NET4_5
+#if NET4_5 || NET4_6
         /// <summary>
         /// Logs an exception is logged at <c>Error</c> level if the provided task does not run to completion.
         /// </summary>

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -164,7 +164,7 @@ namespace NLog
         /// <param name="firstUserStackFrame">Starting point for skipping async MoveNext-frames</param>
         internal static int SkipToUserStackFrameLegacy(StackFrame[] stackFrames, int firstUserStackFrame)
         {
-#if NET4_5
+#if NET4_5 || NET4_6
             for (int i = firstUserStackFrame; i < stackFrames.Length; ++i)
             {
                 var stackFrame = stackFrames[i];

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net45;net40-client;net35;netstandard1.3;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net46;net45;net40-client;net35;netstandard1.3;netstandard1.5;netstandard2.0</TargetFrameworks>
 
     <Title>NLog for .NET Framework and .NET Standard</Title>
     <Company>NLog</Company>
@@ -92,7 +92,14 @@ For all config options and platform support, check https://nlog-project.org/conf
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'netstandard2.0' ">true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Title>NLog for .NET Framework 4.6</Title>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <DebugType Condition=" '$(Configuration)' == 'Debug' ">Full</DebugType>
+    <DefineConstants>$(DefineConstants);NET4_6;DYNAMIC_OBJECT</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
@@ -203,7 +210,7 @@ For all config options and platform support, check https://nlog-project.org/conf
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />

--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -174,7 +174,7 @@ namespace NLog.Targets
                 ForceLockingQueue = true;   // ConcurrentQueue does not perform well if constantly hitting QueueLimit
             }
 
-#if NET4_5 || NET4_0
+#if NET4_5 || NET4_6 || NET4_0
             if (_forceLockingQueue.HasValue && _forceLockingQueue.Value != (_requestQueue is AsyncRequestQueue))
             {
                 _requestQueue = ForceLockingQueue ? (AsyncRequestQueueBase)new AsyncRequestQueue(QueueLimit, OverflowAction) : new ConcurrentRequestQueue(QueueLimit, OverflowAction);

--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -241,7 +241,7 @@ namespace NLog.Targets
                 ConsoleTargetHelper.SetConsoleOutputEncoding(_encoding, true, _pauseLogging);
 #endif
 
-#if NET4_5
+#if NET4_5 || NET4_6
             if (DetectOutputRedirected)
             {
                 try

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -189,7 +189,7 @@ namespace NLog.Targets
             OptimizeBufferReuse = GetType() == typeof(FileTarget);    // Class not sealed, reduce breaking changes
         }
 
-#if NET4_5
+#if NET4_5 || NET4_6
         static FileTarget()
         {
             FileCompressor = new ZipArchiveFileCompressor();

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -284,7 +284,7 @@ namespace NLog.Targets.Wrappers
                 ForceLockingQueue = true;   // ConcurrentQueue does not perform well if constantly hitting QueueLimit
             }
 
-#if NET4_5 || NET4_0
+#if NET4_5 || NET4_6 || NET4_0
             if (_forceLockingQueue.HasValue && _forceLockingQueue.Value != (_requestQueue is AsyncRequestQueue))
             {
                 _requestQueue = ForceLockingQueue ? (AsyncRequestQueueBase)new AsyncRequestQueue(QueueLimit, OverflowAction) : new ConcurrentRequestQueue(QueueLimit, OverflowAction);

--- a/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
+++ b/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if NET4_5 || NET4_0
+#if NET4_5 || NET4_6 || NET4_0
 
 namespace NLog.Targets.Wrappers
 {

--- a/src/NLog/Targets/ZipArchiveFileCompressor.cs
+++ b/src/NLog/Targets/ZipArchiveFileCompressor.cs
@@ -33,7 +33,7 @@
 
 namespace NLog.Targets
 {
-#if NET4_5
+#if NET4_5 || NET4_6
 using System.IO;
 using System.IO.Compression;
 

--- a/tests/ManuallyLoadedExtension/ManuallyLoadedExtension.csproj
+++ b/tests/ManuallyLoadedExtension/ManuallyLoadedExtension.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/NLog.UnitTests/NLog.UnitTests.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net46;net452;netcoreapp2.0</TargetFrameworks>
 
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -18,10 +18,10 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
 
-    <DebugType Condition=" '$(TargetFramework)' == 'net452' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == 'net452' or '$(TargetFramework)' == 'net46' ">Full</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' AND '$(TestTargetFramework)' == '' ">
+  <PropertyGroup Condition=" ('$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'net46') AND '$(TestTargetFramework)' == '' ">
     <DefineConstants>$(DefineConstants);NET4_5;DYNAMIC_OBJECT</DefineConstants>
   </PropertyGroup>
 
@@ -41,7 +41,7 @@
     <DefineConstants>$(DefineConstants);MONO</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU' OR '$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|AnyCPU'">
     <NoWarn>1701;1702;1705</NoWarn>
   </PropertyGroup>
 
@@ -65,7 +65,7 @@
     </ProjectReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -86,11 +86,11 @@
     <PackageReference Include="DotNetZip.Reduced" Version="1.9.1.8" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' AND '$(TestTargetFramework)' == '' ">
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'net46') AND '$(TestTargetFramework)' == '' ">
     <ProjectReference Include="..\..\src\NLog.MSMQ\NLog.MSMQ.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' AND '$(TestTargetFramework)' != '' ">
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'net46') AND '$(TestTargetFramework)' != '' ">
     <Reference Include="NLog">
       <HintPath>..\..\src\NLog\bin\$(Configuration)\$(TestTargetFramework)\NLog.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
Fixes #3817 - added .NET Framework 4.6 (net46) Target Framework to switch from CallContext to AsyncLocal for contexts

Note that locally there are a few unit tests failing locally. I didn't think to run them before making my changes, so I'll try to circle back around to see if they were already broken locally, but this is the majority of the work either way.

For 4.5, 4.6, and .NET Standard 2.0 the following tests are broken locally:
```
NLog.UnitTests.LoggerTests.MixedStructuredEventsConfigTest(parseMessageTemplates: null, param1: "0", param2: "@Client")
NLog.UnitTests.LoggerTests.MixedStructuredEventsConfigTest(parseMessageTemplates: null, param1: "1", param2: "@Client")
```

For 4.5 and 4.6 the following test is also broken locally:
```
NLog.UnitTests.Internal.AppDomainPartialTrustTests.MediumTrustWithExternalClass
```