### PR TITLE
Logger should not crash when platform cannot capture StackTrace

### DIFF
--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -117,7 +117,7 @@ namespace NLog
                 if (factory.ThrowExceptions || ex.MustBeRethrownImmediately())
                     throw;
 
-                InternalLogger.Error(ex, "Failed to capture CallSite for Logger {0}. Platform might not support ${callsite}", logEvent.LoggerName);
+                InternalLogger.Error(ex, "Failed to capture CallSite for Logger {0}. Platform might not support ${{callsite}}", logEvent.LoggerName);
             }
         }
 

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -31,6 +31,10 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+#if !NETSTANDARD1_0 || NETSTANDARD1_5
+#define CaptureCallSiteInfo
+#endif
+
 namespace NLog
 {
     using System;
@@ -53,7 +57,7 @@ namespace NLog
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", Justification = "Using 'NLog' in message.")]
         internal static void Write([NotNull] Type loggerType, [NotNull] TargetWithFilterChain targetsForLevel, LogEventInfo logEvent, LogFactory factory)
         {
-#if !NETSTANDARD1_0 || NETSTANDARD1_5
+#if CaptureCallSiteInfo
             StackTraceUsage stu = targetsForLevel.GetStackTraceUsage();
             if (stu != StackTraceUsage.None && !logEvent.HasStackTrace)
             {
@@ -96,6 +100,7 @@ namespace NLog
             }
         }
 
+#if CaptureCallSiteInfo
         private static void CaptureCallSiteInfo(LogFactory factory, Type loggerType, LogEventInfo logEvent, StackTraceUsage stackTraceUsage)
         {
             try
@@ -120,6 +125,7 @@ namespace NLog
                 InternalLogger.Error(ex, "Failed to capture CallSite for Logger {0}. Platform might not support ${{callsite}}", logEvent.LoggerName);
             }
         }
+#endif
 
         /// <summary>
         ///  Finds first user stack frame in a stack trace
@@ -247,7 +253,7 @@ namespace NLog
         /// <returns>The result of the filter.</returns>
         private static FilterResult GetFilterResult(IList<Filter> filterChain, LogEventInfo logEvent, FilterResult defaultFilterResult)
         {
-            FilterResult result = defaultFilterResult; 
+            FilterResult result = defaultFilterResult;
 
             if (filterChain == null || filterChain.Count == 0)
                 return result;


### PR DESCRIPTION
Minor refactoring and adding of exception-handler. See also https://github.com/KoalaBear84/OpenDirectoryDownloader/issues/19

Note merge to master (And NLog 4.7)