### PR TITLE
InternalLogger - Added Target context to LogMessageReceived event

### DIFF
--- a/src/NLog/Common/IInternalLoggerContext.cs
+++ b/src/NLog/Common/IInternalLoggerContext.cs
@@ -31,52 +31,16 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-using JetBrains.Annotations;
-
 namespace NLog.Common
 {
     /// <summary>
-    /// Written to the internal logger
+    /// Enables <see cref="InternalLogger"/> to extract extra context details for <see cref="InternalLogger.LogMessageReceived"/>
     /// </summary>
-    public sealed class InternalLoggerMessageEventArgs : EventArgs
+    internal interface IInternalLoggerContext
     {
         /// <summary>
-        /// The rendered message
+        /// Name of context
         /// </summary>
-        public string Message { get; }
-
-        /// <summary>
-        /// The loglevel
-        /// </summary>
-        public LogLevel Level { get; }
-
-        /// <summary>
-        /// Optional, the exception
-        /// </summary>
-        [CanBeNull]
-        public Exception Exception { get; }
-
-        /// <summary>
-        /// Optional, the context-type. Ex. Target-Type
-        /// </summary>
-        [CanBeNull]
-        public Type ContextType { get; }
-
-        /// <summary>
-        /// Optional, the context-name. Ex. Target-Name
-        /// </summary>
-        [CanBeNull]
-        public string ContextName { get; }
-
-        /// <inheritdoc />
-        internal InternalLoggerMessageEventArgs(string message, LogLevel level, [CanBeNull] Exception exception, [CanBeNull] Type contextType, [CanBeNull] string contextName)
-        {
-            Message = message;
-            Level = level;
-            Exception = exception;
-            ContextType = contextType;
-            ContextName = contextName;
-        }
+        string Name { get; }
     }
 }

--- a/src/NLog/Common/InternalLogger-generated.cs
+++ b/src/NLog/Common/InternalLogger-generated.cs
@@ -36,39 +36,39 @@ namespace NLog.Common
     using JetBrains.Annotations;
     using System;
     using System.ComponentModel;
+    using NLog.Targets;
 	
     public static partial class InternalLogger
     {
-        
-         /// <summary>
+        /// <summary>
         /// Gets a value indicating whether internal log includes Trace messages.
         /// </summary>
-        public static bool IsTraceEnabled => LogLevel.Trace >= LogLevel;
+        public static bool IsTraceEnabled => IsLogLevelEnabled(LogLevel.Trace);
 
         /// <summary>
         /// Gets a value indicating whether internal log includes Debug messages.
         /// </summary>
-        public static bool IsDebugEnabled => LogLevel.Debug >= LogLevel;
+        public static bool IsDebugEnabled => IsLogLevelEnabled(LogLevel.Debug);
 
         /// <summary>
         /// Gets a value indicating whether internal log includes Info messages.
         /// </summary>
-        public static bool IsInfoEnabled => LogLevel.Info >= LogLevel;
+        public static bool IsInfoEnabled => IsLogLevelEnabled(LogLevel.Info);
 
         /// <summary>
         /// Gets a value indicating whether internal log includes Warn messages.
         /// </summary>
-        public static bool IsWarnEnabled => LogLevel.Warn >= LogLevel;
+        public static bool IsWarnEnabled => IsLogLevelEnabled(LogLevel.Warn);
 
         /// <summary>
         /// Gets a value indicating whether internal log includes Error messages.
         /// </summary>
-        public static bool IsErrorEnabled => LogLevel.Error >= LogLevel;
+        public static bool IsErrorEnabled => IsLogLevelEnabled(LogLevel.Error);
 
         /// <summary>
         /// Gets a value indicating whether internal log includes Fatal messages.
         /// </summary>
-        public static bool IsFatalEnabled => LogLevel.Fatal >= LogLevel;
+        public static bool IsFatalEnabled => IsLogLevelEnabled(LogLevel.Fatal);
 
 
         /// <summary>
@@ -91,17 +91,17 @@ namespace NLog.Common
             Write(null, LogLevel.Trace, message, null);
         }
 
-		/// <summary>
+        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Trace level. 
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Trace.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Trace.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
         public static void Trace([Localizable(false)] Func<string> messageFunc)
         {
-			if (IsTraceEnabled)
-				Write(null, LogLevel.Trace, messageFunc(), null);
+            if (IsTraceEnabled)
+                Write(null, LogLevel.Trace, messageFunc(), null);
         }
-	
+
         /// <summary>
         /// Logs the specified message with an <see cref="Exception"/> at the Trace level.
         /// </summary>
@@ -112,6 +112,28 @@ namespace NLog.Common
         public static void Trace(Exception ex, [Localizable(false)] string message, params object[] args)
         {
             Write(ex, LogLevel.Trace, message, args);
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Trace level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void Trace(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.Trace, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Trace level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Trace.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void Trace(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (IsTraceEnabled)
+                Write(ex, LogLevel.Trace, messageFunc(), null);
         }
 
         /// <summary>
@@ -160,28 +182,6 @@ namespace NLog.Common
         }
 
         /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Trace level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void Trace(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.Trace, message, null);
-        }	        
-		
-		/// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Trace level.
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Trace.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Trace(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-			if (IsTraceEnabled)
-				Write(ex, LogLevel.Trace, messageFunc(), null);
-        }	
-
-        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Debug level.
         /// </summary>
         /// <param name="message">Message which may include positional parameters.</param>
@@ -201,17 +201,17 @@ namespace NLog.Common
             Write(null, LogLevel.Debug, message, null);
         }
 
-		/// <summary>
+        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Debug level. 
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Debug.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Debug.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
         public static void Debug([Localizable(false)] Func<string> messageFunc)
         {
-			if (IsDebugEnabled)
-				Write(null, LogLevel.Debug, messageFunc(), null);
+            if (IsDebugEnabled)
+                Write(null, LogLevel.Debug, messageFunc(), null);
         }
-	
+
         /// <summary>
         /// Logs the specified message with an <see cref="Exception"/> at the Debug level.
         /// </summary>
@@ -222,6 +222,28 @@ namespace NLog.Common
         public static void Debug(Exception ex, [Localizable(false)] string message, params object[] args)
         {
             Write(ex, LogLevel.Debug, message, args);
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Debug level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void Debug(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.Debug, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Debug level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Debug.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void Debug(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (IsDebugEnabled)
+                Write(ex, LogLevel.Debug, messageFunc(), null);
         }
 
         /// <summary>
@@ -270,28 +292,6 @@ namespace NLog.Common
         }
 
         /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Debug level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void Debug(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.Debug, message, null);
-        }	        
-		
-		/// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Debug level.
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Debug.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Debug(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-			if (IsDebugEnabled)
-				Write(ex, LogLevel.Debug, messageFunc(), null);
-        }	
-
-        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Info level.
         /// </summary>
         /// <param name="message">Message which may include positional parameters.</param>
@@ -311,17 +311,17 @@ namespace NLog.Common
             Write(null, LogLevel.Info, message, null);
         }
 
-		/// <summary>
+        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Info level. 
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Info.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Info.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
         public static void Info([Localizable(false)] Func<string> messageFunc)
         {
-			if (IsInfoEnabled)
-				Write(null, LogLevel.Info, messageFunc(), null);
+            if (IsInfoEnabled)
+                Write(null, LogLevel.Info, messageFunc(), null);
         }
-	
+
         /// <summary>
         /// Logs the specified message with an <see cref="Exception"/> at the Info level.
         /// </summary>
@@ -332,6 +332,28 @@ namespace NLog.Common
         public static void Info(Exception ex, [Localizable(false)] string message, params object[] args)
         {
             Write(ex, LogLevel.Info, message, args);
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Info level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void Info(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.Info, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Info level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Info.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void Info(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (IsInfoEnabled)
+                Write(ex, LogLevel.Info, messageFunc(), null);
         }
 
         /// <summary>
@@ -380,28 +402,6 @@ namespace NLog.Common
         }
 
         /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Info level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void Info(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.Info, message, null);
-        }	        
-		
-		/// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Info level.
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Info.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Info(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-			if (IsInfoEnabled)
-				Write(ex, LogLevel.Info, messageFunc(), null);
-        }	
-
-        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Warn level.
         /// </summary>
         /// <param name="message">Message which may include positional parameters.</param>
@@ -421,17 +421,17 @@ namespace NLog.Common
             Write(null, LogLevel.Warn, message, null);
         }
 
-		/// <summary>
+        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Warn level. 
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Warn.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Warn.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
         public static void Warn([Localizable(false)] Func<string> messageFunc)
         {
-			if (IsWarnEnabled)
-				Write(null, LogLevel.Warn, messageFunc(), null);
+            if (IsWarnEnabled)
+                Write(null, LogLevel.Warn, messageFunc(), null);
         }
-	
+
         /// <summary>
         /// Logs the specified message with an <see cref="Exception"/> at the Warn level.
         /// </summary>
@@ -442,6 +442,28 @@ namespace NLog.Common
         public static void Warn(Exception ex, [Localizable(false)] string message, params object[] args)
         {
             Write(ex, LogLevel.Warn, message, args);
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Warn level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void Warn(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.Warn, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Warn level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Warn.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void Warn(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (IsWarnEnabled)
+                Write(ex, LogLevel.Warn, messageFunc(), null);
         }
 
         /// <summary>
@@ -490,28 +512,6 @@ namespace NLog.Common
         }
 
         /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Warn level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void Warn(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.Warn, message, null);
-        }	        
-		
-		/// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Warn level.
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Warn.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Warn(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-			if (IsWarnEnabled)
-				Write(ex, LogLevel.Warn, messageFunc(), null);
-        }	
-
-        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Error level.
         /// </summary>
         /// <param name="message">Message which may include positional parameters.</param>
@@ -531,17 +531,17 @@ namespace NLog.Common
             Write(null, LogLevel.Error, message, null);
         }
 
-		/// <summary>
+        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Error level. 
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Error.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Error.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
         public static void Error([Localizable(false)] Func<string> messageFunc)
         {
-			if (IsErrorEnabled)
-				Write(null, LogLevel.Error, messageFunc(), null);
+            if (IsErrorEnabled)
+                Write(null, LogLevel.Error, messageFunc(), null);
         }
-	
+
         /// <summary>
         /// Logs the specified message with an <see cref="Exception"/> at the Error level.
         /// </summary>
@@ -552,6 +552,28 @@ namespace NLog.Common
         public static void Error(Exception ex, [Localizable(false)] string message, params object[] args)
         {
             Write(ex, LogLevel.Error, message, args);
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Error level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void Error(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.Error, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Error level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Error.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void Error(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (IsErrorEnabled)
+                Write(ex, LogLevel.Error, messageFunc(), null);
         }
 
         /// <summary>
@@ -600,28 +622,6 @@ namespace NLog.Common
         }
 
         /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Error level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void Error(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.Error, message, null);
-        }	        
-		
-		/// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Error level.
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Error.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Error(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-			if (IsErrorEnabled)
-				Write(ex, LogLevel.Error, messageFunc(), null);
-        }	
-
-        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Fatal level.
         /// </summary>
         /// <param name="message">Message which may include positional parameters.</param>
@@ -641,17 +641,17 @@ namespace NLog.Common
             Write(null, LogLevel.Fatal, message, null);
         }
 
-		/// <summary>
+        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Fatal level. 
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Fatal.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Fatal.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
         public static void Fatal([Localizable(false)] Func<string> messageFunc)
         {
-			if (IsFatalEnabled)
-				Write(null, LogLevel.Fatal, messageFunc(), null);
+            if (IsFatalEnabled)
+                Write(null, LogLevel.Fatal, messageFunc(), null);
         }
-	
+
         /// <summary>
         /// Logs the specified message with an <see cref="Exception"/> at the Fatal level.
         /// </summary>
@@ -662,6 +662,28 @@ namespace NLog.Common
         public static void Fatal(Exception ex, [Localizable(false)] string message, params object[] args)
         {
             Write(ex, LogLevel.Fatal, message, args);
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Fatal level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void Fatal(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.Fatal, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Fatal level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Fatal.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void Fatal(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (IsFatalEnabled)
+                Write(ex, LogLevel.Fatal, messageFunc(), null);
         }
 
         /// <summary>
@@ -708,28 +730,6 @@ namespace NLog.Common
             if (IsFatalEnabled)
                 Log(null, LogLevel.Fatal, message, arg0, arg1, arg2);
         }
-
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Fatal level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void Fatal(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.Fatal, message, null);
-        }	        
-		
-		/// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Fatal level.
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Fatal.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Fatal(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-			if (IsFatalEnabled)
-				Write(ex, LogLevel.Fatal, messageFunc(), null);
-        }	
      
     }
 }

--- a/src/NLog/Common/InternalLogger-generated.cs
+++ b/src/NLog/Common/InternalLogger-generated.cs
@@ -36,7 +36,6 @@ namespace NLog.Common
     using JetBrains.Annotations;
     using System;
     using System.ComponentModel;
-    using NLog.Targets;
 	
     public static partial class InternalLogger
     {
@@ -115,28 +114,6 @@ namespace NLog.Common
         }
 
         /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Trace level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void Trace(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.Trace, message, null);
-        }
-		
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Trace level.
-        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Trace.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Trace(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-            if (IsTraceEnabled)
-                Write(ex, LogLevel.Trace, messageFunc(), null);
-        }
-
-        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Trace level.
         /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
@@ -182,6 +159,28 @@ namespace NLog.Common
         }
 
         /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Trace level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void Trace(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.Trace, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Trace level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Trace.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void Trace(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (IsTraceEnabled)
+                Write(ex, LogLevel.Trace, messageFunc(), null);
+        }
+
+        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Debug level.
         /// </summary>
         /// <param name="message">Message which may include positional parameters.</param>
@@ -222,28 +221,6 @@ namespace NLog.Common
         public static void Debug(Exception ex, [Localizable(false)] string message, params object[] args)
         {
             Write(ex, LogLevel.Debug, message, args);
-        }
-
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Debug level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void Debug(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.Debug, message, null);
-        }
-		
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Debug level.
-        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Debug.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Debug(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-            if (IsDebugEnabled)
-                Write(ex, LogLevel.Debug, messageFunc(), null);
         }
 
         /// <summary>
@@ -292,6 +269,28 @@ namespace NLog.Common
         }
 
         /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Debug level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void Debug(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.Debug, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Debug level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Debug.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void Debug(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (IsDebugEnabled)
+                Write(ex, LogLevel.Debug, messageFunc(), null);
+        }
+
+        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Info level.
         /// </summary>
         /// <param name="message">Message which may include positional parameters.</param>
@@ -332,28 +331,6 @@ namespace NLog.Common
         public static void Info(Exception ex, [Localizable(false)] string message, params object[] args)
         {
             Write(ex, LogLevel.Info, message, args);
-        }
-
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Info level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void Info(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.Info, message, null);
-        }
-		
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Info level.
-        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Info.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Info(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-            if (IsInfoEnabled)
-                Write(ex, LogLevel.Info, messageFunc(), null);
         }
 
         /// <summary>
@@ -402,6 +379,28 @@ namespace NLog.Common
         }
 
         /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Info level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void Info(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.Info, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Info level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Info.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void Info(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (IsInfoEnabled)
+                Write(ex, LogLevel.Info, messageFunc(), null);
+        }
+
+        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Warn level.
         /// </summary>
         /// <param name="message">Message which may include positional parameters.</param>
@@ -442,28 +441,6 @@ namespace NLog.Common
         public static void Warn(Exception ex, [Localizable(false)] string message, params object[] args)
         {
             Write(ex, LogLevel.Warn, message, args);
-        }
-
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Warn level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void Warn(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.Warn, message, null);
-        }
-		
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Warn level.
-        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Warn.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Warn(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-            if (IsWarnEnabled)
-                Write(ex, LogLevel.Warn, messageFunc(), null);
         }
 
         /// <summary>
@@ -512,6 +489,28 @@ namespace NLog.Common
         }
 
         /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Warn level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void Warn(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.Warn, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Warn level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Warn.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void Warn(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (IsWarnEnabled)
+                Write(ex, LogLevel.Warn, messageFunc(), null);
+        }
+
+        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Error level.
         /// </summary>
         /// <param name="message">Message which may include positional parameters.</param>
@@ -552,28 +551,6 @@ namespace NLog.Common
         public static void Error(Exception ex, [Localizable(false)] string message, params object[] args)
         {
             Write(ex, LogLevel.Error, message, args);
-        }
-
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Error level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void Error(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.Error, message, null);
-        }
-		
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Error level.
-        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Error.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Error(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-            if (IsErrorEnabled)
-                Write(ex, LogLevel.Error, messageFunc(), null);
         }
 
         /// <summary>
@@ -622,6 +599,28 @@ namespace NLog.Common
         }
 
         /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Error level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void Error(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.Error, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Error level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Error.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void Error(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (IsErrorEnabled)
+                Write(ex, LogLevel.Error, messageFunc(), null);
+        }
+
+        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Fatal level.
         /// </summary>
         /// <param name="message">Message which may include positional parameters.</param>
@@ -662,28 +661,6 @@ namespace NLog.Common
         public static void Fatal(Exception ex, [Localizable(false)] string message, params object[] args)
         {
             Write(ex, LogLevel.Fatal, message, args);
-        }
-
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Fatal level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void Fatal(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.Fatal, message, null);
-        }
-		
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the Fatal level.
-        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Fatal.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Fatal(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-            if (IsFatalEnabled)
-                Write(ex, LogLevel.Fatal, messageFunc(), null);
         }
 
         /// <summary>
@@ -729,6 +706,28 @@ namespace NLog.Common
         {
             if (IsFatalEnabled)
                 Log(null, LogLevel.Fatal, message, arg0, arg1, arg2);
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Fatal level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void Fatal(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.Fatal, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Fatal level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Fatal.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void Fatal(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (IsFatalEnabled)
+                Write(ex, LogLevel.Fatal, messageFunc(), null);
         }
      
     }

--- a/src/NLog/Common/InternalLogger-generated.tt
+++ b/src/NLog/Common/InternalLogger-generated.tt
@@ -36,11 +36,11 @@ namespace NLog.Common
     using JetBrains.Annotations;
     using System;
     using System.ComponentModel;
+    using NLog.Targets;
 	
     public static partial class InternalLogger
     {
-        
- <#
+<#
     var levels = new string[]{"Trace", "Debug", "Info", "Warn", "Error", "Fatal"};
 
     foreach(var level in levels)
@@ -49,11 +49,11 @@ namespace NLog.Common
         /// <summary>
         /// Gets a value indicating whether internal log includes <#=level#> messages.
         /// </summary>
-        public static bool Is<#=level#>Enabled => LogLevel.<#=level#> >= LogLevel;
+        public static bool Is<#=level#>Enabled => IsLogLevelEnabled(LogLevel.<#=level#>);
 
 <#
     }
-	   foreach(var level in levels)
+    foreach(var level in levels)
     { 
 #>
 
@@ -77,17 +77,17 @@ namespace NLog.Common
             Write(null, LogLevel.<#=level#>, message, null);
         }
 
-		/// <summary>
+        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the <#=level#> level. 
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  <#=level#>.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  <#=level#>.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
         public static void <#=level#>([Localizable(false)] Func<string> messageFunc)
         {
-			if (Is<#=level#>Enabled)
-				Write(null, LogLevel.<#=level#>, messageFunc(), null);
+            if (Is<#=level#>Enabled)
+                Write(null, LogLevel.<#=level#>, messageFunc(), null);
         }
-	
+
         /// <summary>
         /// Logs the specified message with an <see cref="Exception"/> at the <#=level#> level.
         /// </summary>
@@ -98,6 +98,28 @@ namespace NLog.Common
         public static void <#=level#>(Exception ex, [Localizable(false)] string message, params object[] args)
         {
             Write(ex, LogLevel.<#=level#>, message, args);
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the <#=level#> level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void <#=level#>(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.<#=level#>, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the <#=level#> level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  <#=level#>.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void <#=level#>(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (Is<#=level#>Enabled)
+                Write(ex, LogLevel.<#=level#>, messageFunc(), null);
         }
 
         /// <summary>
@@ -144,30 +166,8 @@ namespace NLog.Common
             if (Is<#=level#>Enabled)
                 Log(null, LogLevel.<#=level#>, message, arg0, arg1, arg2);
         }
-
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the <#=level#> level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void <#=level#>(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.<#=level#>, message, null);
-        }	        
-		
-		/// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the <#=level#> level.
-		/// <paramref name="messageFunc"/> will be only called when logging is enabled for level  <#=level#>.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void <#=level#>(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-			if (Is<#=level#>Enabled)
-				Write(ex, LogLevel.<#=level#>, messageFunc(), null);
-        }	
 <#
 	}
- #>     
+#>     
     }
 }

--- a/src/NLog/Common/InternalLogger-generated.tt
+++ b/src/NLog/Common/InternalLogger-generated.tt
@@ -36,7 +36,6 @@ namespace NLog.Common
     using JetBrains.Annotations;
     using System;
     using System.ComponentModel;
-    using NLog.Targets;
 	
     public static partial class InternalLogger
     {
@@ -101,28 +100,6 @@ namespace NLog.Common
         }
 
         /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the <#=level#> level.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="message">Log message.</param>
-        public static void <#=level#>(Exception ex, [Localizable(false)] string message)
-        {
-            Write(ex, LogLevel.<#=level#>, message, null);
-        }
-		
-        /// <summary>
-        /// Logs the specified message with an <see cref="Exception"/> at the <#=level#> level.
-        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  <#=level#>.
-        /// </summary>
-        /// <param name="ex">Exception to be logged.</param>
-        /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void <#=level#>(Exception ex, [Localizable(false)] Func<string> messageFunc)
-        {
-            if (Is<#=level#>Enabled)
-                Write(ex, LogLevel.<#=level#>, messageFunc(), null);
-        }
-
-        /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Trace level.
         /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
@@ -165,6 +142,28 @@ namespace NLog.Common
         {
             if (Is<#=level#>Enabled)
                 Log(null, LogLevel.<#=level#>, message, arg0, arg1, arg2);
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the <#=level#> level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Log message.</param>
+        public static void <#=level#>(Exception ex, [Localizable(false)] string message)
+        {
+            Write(ex, LogLevel.<#=level#>, message, null);
+        }
+		
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the <#=level#> level.
+        /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  <#=level#>.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="messageFunc">Function that returns the log message.</param>
+        public static void <#=level#>(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        {
+            if (Is<#=level#>Enabled)
+                Write(ex, LogLevel.<#=level#>, messageFunc(), null);
         }
 <#
 	}

--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -338,17 +338,23 @@ namespace NLog.Common
 
             if (IncludeTimestamp)
             {
-                if (ex != null)
-                    return $"{TimeSource.Current.Time.ToString(timeStampFormat, CultureInfo.InvariantCulture)}{fieldSeparator}{level.ToString()}{fieldSeparator}{fullMessage}{fieldSeparator}Exception: {ex.ToString()}";
-                else
-                    return $"{TimeSource.Current.Time.ToString(timeStampFormat, CultureInfo.InvariantCulture)}{fieldSeparator}{level.ToString()}{fieldSeparator}{fullMessage}";
+                return string.Concat(
+                    TimeSource.Current.Time.ToString(timeStampFormat, CultureInfo.InvariantCulture),
+                    fieldSeparator,
+                    level.ToString(),
+                    fieldSeparator,
+                    fullMessage,
+                    ex != null ? " Exception: " : "",
+                    ex?.ToString() ?? "");
             }
             else
             {
-                if (ex != null)
-                    return $"{level.ToString()}{fieldSeparator}{fullMessage}{fieldSeparator}Exception: {ex.ToString()}";
-                else
-                    return $"{level.ToString()}{fieldSeparator}{fullMessage}";
+                return string.Concat(
+                    level.ToString(),
+                    fieldSeparator,
+                    fullMessage,
+                    ex != null ? " Exception: " : "",
+                    ex?.ToString() ?? "");
             }
         }
 

--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -276,8 +276,8 @@ namespace NLog.Common
 
                 if (hasEventListeners)
                 {
-                    var targetContext = args?.Length > 0 ? args[0] as IInternalLoggerContext : null;
-                    LogMessageReceived?.Invoke(null, new InternalLoggerMessageEventArgs(fullMessage, level, ex, targetContext?.GetType(), targetContext?.Name));
+                    var loggerContext = args?.Length > 0 ? args[0] as IInternalLoggerContext : null;
+                    LogMessageReceived?.Invoke(null, new InternalLoggerMessageEventArgs(fullMessage, level, ex, loggerContext?.GetType(), loggerContext?.Name));
 
                     ex?.MarkAsLoggedToInternalLogger();
                 }

--- a/src/NLog/Common/InternalLoggerMessageEventArgs.cs
+++ b/src/NLog/Common/InternalLoggerMessageEventArgs.cs
@@ -37,7 +37,7 @@ using JetBrains.Annotations;
 namespace NLog.Common
 {
     /// <summary>
-    /// Written to the internal logger
+    /// A message has been written to the internal logger
     /// </summary>
     public sealed class InternalLoggerMessageEventArgs : EventArgs
     {
@@ -47,24 +47,26 @@ namespace NLog.Common
         public string Message { get; }
 
         /// <summary>
-        /// The loglevel
+        /// The log level
         /// </summary>
         public LogLevel Level { get; }
 
         /// <summary>
-        /// Optional, the exception
+        /// The exception. Could be null.
         /// </summary>
         [CanBeNull]
         public Exception Exception { get; }
 
         /// <summary>
-        /// Optional, the context-type. Ex. Target-Type
+        /// The type that triggered this internal log event, for example the FileTarget. 
+        /// This property is not always populated. 
         /// </summary>
         [CanBeNull]
         public Type ContextType { get; }
 
         /// <summary>
-        /// Optional, the context-name. Ex. Target-Name
+        /// The context name that triggered this internal log event, for example the name of the Target. 
+        /// This property is not always populated. 
         /// </summary>
         [CanBeNull]
         public string ContextName { get; }

--- a/src/NLog/Common/InternalLoggerMessageEventArgs.cs
+++ b/src/NLog/Common/InternalLoggerMessageEventArgs.cs
@@ -62,23 +62,23 @@ namespace NLog.Common
         /// This property is not always populated. 
         /// </summary>
         [CanBeNull]
-        public Type ContextType { get; }
+        public Type SenderType { get; }
 
         /// <summary>
         /// The context name that triggered this internal log event, for example the name of the Target. 
         /// This property is not always populated. 
         /// </summary>
         [CanBeNull]
-        public string ContextName { get; }
+        public string SenderName { get; }
 
         /// <inheritdoc />
-        internal InternalLoggerMessageEventArgs(string message, LogLevel level, [CanBeNull] Exception exception, [CanBeNull] Type contextType, [CanBeNull] string contextName)
+        internal InternalLoggerMessageEventArgs(string message, LogLevel level, [CanBeNull] Exception exception, [CanBeNull] Type senderType, [CanBeNull] string senderName)
         {
             Message = message;
             Level = level;
             Exception = exception;
-            ContextType = contextType;
-            ContextName = contextName;
+            SenderType = senderType;
+            SenderName = senderName;
         }
     }
 }

--- a/src/NLog/Internal/ExceptionHelper.cs
+++ b/src/NLog/Internal/ExceptionHelper.cs
@@ -36,7 +36,6 @@ namespace NLog.Internal
     using System;
     using System.Threading;
     using NLog.Common;
-    using NLog.Targets;
 
     /// <summary>
     /// Helper class for dealing with exceptions.

--- a/src/NLog/Internal/ExceptionHelper.cs
+++ b/src/NLog/Internal/ExceptionHelper.cs
@@ -78,9 +78,9 @@ namespace NLog.Internal
         /// Advised to log first the error to the <see cref="InternalLogger"/> before calling this method.
         /// </summary>
         /// <param name="exception">The exception to check.</param>
-        /// <param name="targetContext">Target context of the exception.</param>
+        /// <param name="loggerContext">Target context of the exception.</param>
         /// <returns><c>true</c>if the <paramref name="exception"/> must be rethrown, <c>false</c> otherwise.</returns>
-        public static bool MustBeRethrown(this Exception exception, IInternalLoggerContext targetContext = null)
+        public static bool MustBeRethrown(this Exception exception, IInternalLoggerContext loggerContext = null)
         {
             if (exception.MustBeRethrownImmediately())
             {
@@ -94,8 +94,8 @@ namespace NLog.Internal
             if (!exception.IsLoggedToInternalLogger())
             {
                 var level = isConfigError ? LogLevel.Warn : LogLevel.Error;
-                if (targetContext != null)
-                    InternalLogger.Log(exception, level, "{0}: Error has been raised.", targetContext);
+                if (loggerContext != null)
+                    InternalLogger.Log(exception, level, "{0}: Error has been raised.", loggerContext);
                 else
                     InternalLogger.Log(exception, level, "Error has been raised.");
             }

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -36,7 +36,6 @@ namespace NLog.Targets
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
     using NLog.Common;
     using NLog.Config;
     using NLog.Internal;
@@ -46,7 +45,7 @@ namespace NLog.Targets
     /// Represents logging target.
     /// </summary>
     [NLogConfigurationItem]
-    public abstract class Target : ISupportsInitialize, IDisposable
+    public abstract class Target : ISupportsInitialize, IInternalLoggerContext, IDisposable
     {
         private List<Layout> _allLayouts;
         
@@ -172,7 +171,7 @@ namespace NLog.Targets
                 }
                 catch (Exception exception)
                 {
-                    if (exception.MustBeRethrown())
+                    if (exception.MustBeRethrown(this))
                     {
                         throw;
                     }
@@ -311,7 +310,7 @@ namespace NLog.Targets
             }
             catch (Exception ex)
             {
-                if (ex.MustBeRethrown())
+                if (ex.MustBeRethrown(this))
                     throw;
 
                 wrappedLogEvent.Continuation(ex);
@@ -393,7 +392,7 @@ namespace NLog.Targets
             }
             catch (Exception exception)
             {
-                if (exception.MustBeRethrown())
+                if (exception.MustBeRethrown(this))
                 {
                     throw;
                 }
@@ -436,7 +435,7 @@ namespace NLog.Targets
 
                         _initializeException = exception;
 
-                        if (exception.MustBeRethrown())
+                        if (exception.MustBeRethrown(this))
                         {
                             throw;
                         }
@@ -476,7 +475,7 @@ namespace NLog.Targets
                     {
                         InternalLogger.Error(exception, "{0}: Error closing target", this);
 
-                        if (exception.MustBeRethrown())
+                        if (exception.MustBeRethrown(this))
                         {
                             throw;
                         }
@@ -566,7 +565,7 @@ namespace NLog.Targets
             }
             catch (Exception exception)
             {
-                if (exception.MustBeRethrown())
+                if (exception.MustBeRethrown(this))
                 {
                     throw;
                 }
@@ -666,8 +665,7 @@ namespace NLog.Targets
                     return;
                 }
 
-                AsyncLogEventInfo[] logEventsArray = OptimizeBufferReuse ? null : logEvents as AsyncLogEventInfo[];
-                if (!OptimizeBufferReuse && logEventsArray != null)
+                if (!OptimizeBufferReuse && logEvents is AsyncLogEventInfo[] logEventsArray)
                 {
                     // Backwards compatibility
 #pragma warning disable 612, 618

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -823,7 +823,33 @@ namespace NLog.UnitTests.Common
         }
 
         [Fact]
-        public void TestReceivedLogEventExceptionContextTest()
+        public void TestReceivedLogEventThrowingTest()
+        {
+            using (var loggerScope = new InternalLoggerScope())
+            {
+                // Arrange
+                var receivedArgs = new List<InternalLoggerMessageEventArgs>();
+                InternalLogger.LogMessageReceived += (sender, e) =>
+                {
+                    receivedArgs.Add(e);
+                    throw new ApplicationException("I'm a bad programmer");
+                };
+                var exception = new Exception();
+
+                // Act
+                InternalLogger.Info(exception, "Hello {0}", "it's me!");
+
+                // Assert
+                Assert.Single(receivedArgs);
+                var logEventArgs = receivedArgs.Single();
+                Assert.Equal(LogLevel.Info, logEventArgs.Level);
+                Assert.Equal(exception, logEventArgs.Exception);
+                Assert.Equal("Hello it's me!", logEventArgs.Message);
+            }
+        }
+
+        [Fact]
+        public void TestReceivedLogEventContextTest()
         {
             using (var loggerScope = new InternalLoggerScope())
             {

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -870,7 +870,7 @@ namespace NLog.UnitTests.Common
                 var logEventArgs = receivedArgs.Single();
                 Assert.Equal(LogLevel.Error, logEventArgs.Level);
                 Assert.Equal(exception, logEventArgs.Exception);
-                Assert.Equal(targetContext.GetType(), logEventArgs.ContextType);
+                Assert.Equal(targetContext.GetType(), logEventArgs.SenderType);
             }
         }
 

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -552,20 +552,29 @@ namespace NLog.UnitTests
 
             public void Dispose()
             {
+                var logFile = InternalLogger.LogFile;
+
                 InternalLogger.Reset();
+                LogManager.GlobalThreshold = globalThreshold;
+                LogManager.ThrowExceptions = throwExceptions;
+                LogManager.ThrowConfigExceptions = throwConfigExceptions;
 
                 if (ConsoleOutputWriter != null)
                     Console.SetOut(oldConsoleOutputWriter);
                 if (ConsoleErrorWriter != null)
                     Console.SetError(oldConsoleErrorWriter);
 
-                if (File.Exists(InternalLogger.LogFile))
-                    File.Delete(InternalLogger.LogFile);
+                if (!string.IsNullOrEmpty(InternalLogger.LogFile))
+                {
+                    if (File.Exists(InternalLogger.LogFile))
+                        File.Delete(InternalLogger.LogFile);
+                }
 
-                //restore logmanager
-                LogManager.GlobalThreshold = globalThreshold;
-                LogManager.ThrowExceptions = throwExceptions;
-                LogManager.ThrowConfigExceptions = throwConfigExceptions;
+                if (!string.IsNullOrEmpty(logFile) && logFile != InternalLogger.LogFile)
+                {
+                    if (File.Exists(logFile))
+                        File.Delete(logFile);
+                }
             }
         }
 


### PR DESCRIPTION
Make it possible to provide target-context-details for the InternalLogger InternalLoggerMessageEventArgs

Completing the first step started with #3796 so InternalLoggerMessageEventArgs can actually provide the intended details in the initial version. Fixes #2710, first steps for #3350 and #1193

Note merge to master. 