### PR TITLE
Azure AD Access Token support for DatabaseTarget

### DIFF
--- a/src/NLog.WindowsIdentity/NLog.WindowsIdentity.csproj
+++ b/src/NLog.WindowsIdentity/NLog.WindowsIdentity.csproj
@@ -54,7 +54,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -304,6 +304,10 @@ For all config options and platform support, check https://nlog-project.org/conf
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1" />
   </ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+		<PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+	</ItemGroup>
   
   <ItemGroup Condition=" '$(monobuild)' != '' ">
     <Reference Include="Mono.Posix" />

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -41,6 +41,7 @@ namespace NLog.UnitTests.Targets
 #endif
     using System.Data;
     using System.Data.Common;
+    using System.Data.SqlClient;
     using System.Globalization;
     using System.IO;
     using System.Linq;
@@ -49,7 +50,6 @@ namespace NLog.UnitTests.Targets
     using NLog.Targets;
     using Xunit;
     using Xunit.Extensions;
-    using System.Data.SqlClient;
 
 #if MONO 
     using Mono.Data.Sqlite;
@@ -1155,7 +1155,7 @@ Dispose()
             dt.CommandText = "Notimportant";
             dt.Initialize(null);
             Assert.Same(MockDbFactory.Instance, dt.ProviderFactory);
-            dt.OpenConnection("myConnectionString");
+            dt.OpenConnection("myConnectionString", null);
             Assert.Equal(1, MockDbConnection2.OpenCount);
             Assert.Equal("myConnectionString", MockDbConnection2.LastOpenConnectionString);
         }
@@ -1175,11 +1175,7 @@ Dispose()
                 };
 
                 dt.Initialize(null);
-#if !NETSTANDARD
                 Assert.Equal(typeof(SqlConnection), dt.ConnectionType);
-#else
-                Assert.NotNull(dt.ConnectionType);
-#endif
             }
         }
 


### PR DESCRIPTION
Provide support for setting an Azure AD Access Token when creating a SqlConnection
Add a package reference to System.Data.SqlClient for the netstandard2.0 target
Update the System.Security.Principal.Windows package version in support of adding the System.Data.SqlClient package