### PR TITLE
Skip need for Activator.CreateInstance in DbTypeSetter + fix Enum.TryParse for whitespace

### DIFF
--- a/src/NLog/Common/ConversionHelpers.cs
+++ b/src/NLog/Common/ConversionHelpers.cs
@@ -44,15 +44,15 @@ namespace NLog.Common
         /// <summary>
         /// Converts input string value into <see cref="System.Enum"/>. Parsing is case-insensitive.
         /// </summary>
-        /// <param name="value">Input value</param>
-        /// <param name="result">Output value</param>
+        /// <param name="inputValue">Input value</param>
+        /// <param name="resultValue">Output value</param>
         /// <param name="defaultValue">Default value</param>
         /// <returns>Returns <paramref name="defaultValue"/> if the input value could not be parsed</returns>
-        public static bool TryParseEnum<TEnum>(string value, out TEnum result, TEnum defaultValue = default(TEnum)) where TEnum : struct
+        public static bool TryParseEnum<TEnum>(string inputValue, out TEnum resultValue, TEnum defaultValue = default(TEnum)) where TEnum : struct
         {
-            if (!TryParseEnum(value, true, out result))
+            if (!TryParseEnum(inputValue, true, out resultValue))
             {
-                result = defaultValue;
+                resultValue = defaultValue;
                 return false;
             }
             return true;
@@ -61,20 +61,20 @@ namespace NLog.Common
         /// <summary>
         /// Converts input string value into <see cref="System.Enum"/>. Parsing is case-insensitive.
         /// </summary>
-        /// <param name="value">Input value</param>
+        /// <param name="inputValue">Input value</param>
         /// <param name="enumType">The type of the enum</param>
-        /// <param name="result">Output value. Null if parse failed</param>
-        internal static bool TryParseEnum(string value, Type enumType, out object result)
+        /// <param name="resultValue">Output value. Null if parse failed</param>
+        internal static bool TryParseEnum(string inputValue, Type enumType, out object resultValue)
         {
             // Note: .NET Standard 2.1 added a public Enum.TryParse(Type)
             try
             {
-                result = Enum.Parse(enumType, value, true);
+                resultValue = Enum.Parse(enumType, inputValue, true);
                 return true;
             }
             catch (ArgumentException)
             {
-                result = null;
+                resultValue = null;
                 return false;
             }
         }
@@ -83,17 +83,17 @@ namespace NLog.Common
         /// Converts the string representation of the name or numeric value of one or more enumerated constants to an equivalent enumerated object. A parameter specifies whether the operation is case-sensitive. The return value indicates whether the conversion succeeded.
         /// </summary>
         /// <typeparam name="TEnum">The enumeration type to which to convert value.</typeparam>
-        /// <param name="value">The string representation of the enumeration name or underlying value to convert.</param>
+        /// <param name="inputValue">The string representation of the enumeration name or underlying value to convert.</param>
         /// <param name="ignoreCase"><c>true</c> to ignore case; <c>false</c> to consider case.</param>
-        /// <param name="result">When this method returns, result contains an object of type TEnum whose value is represented by value if the parse operation succeeds. If the parse operation fails, result contains the default value of the underlying type of TEnum. Note that this value need not be a member of the TEnum enumeration. This parameter is passed uninitialized.</param>
+        /// <param name="resultValue">When this method returns, result contains an object of type TEnum whose value is represented by value if the parse operation succeeds. If the parse operation fails, result contains the default value of the underlying type of TEnum. Note that this value need not be a member of the TEnum enumeration. This parameter is passed uninitialized.</param>
         /// <returns><c>true</c> if the value parameter was converted successfully; otherwise, <c>false</c>.</returns>
         /// <remarks>Wrapper because Enum.TryParse is not present in .net 3.5</remarks>
-        internal static bool TryParseEnum<TEnum>(string value, bool ignoreCase, out TEnum result) where TEnum : struct
+        internal static bool TryParseEnum<TEnum>(string inputValue, bool ignoreCase, out TEnum resultValue) where TEnum : struct
         {
 #if NET3_5
-            return TryParseEnum_net3(value, ignoreCase, out result);
+            return TryParseEnum_net3(inputValue, ignoreCase, out resultValue);
 #else
-            return Enum.TryParse(value, ignoreCase, out result);
+            return Enum.TryParse(inputValue, ignoreCase, out resultValue);
 #endif
         }
 

--- a/src/NLog/Common/ConversionHelpers.cs
+++ b/src/NLog/Common/ConversionHelpers.cs
@@ -64,6 +64,21 @@ namespace NLog.Common
             return true;
         }
 
+        internal static bool TryParseEnum(string value, Type enumType, out object result)
+        {
+            // Note: .NET Standard 2.1 added a public Enum.TryParse(Type)
+            try
+            {
+                result = Enum.Parse(enumType, value, true);
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                result = null;
+                return false;
+            }
+        }
+
         /// <summary>
         /// Converts the string representation of the name or numeric value of one or more enumerated constants to an equivalent enumerated object. A parameter specifies whether the operation is case-sensitive. The return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/NLog/Common/ConversionHelpers.cs
+++ b/src/NLog/Common/ConversionHelpers.cs
@@ -50,12 +50,6 @@ namespace NLog.Common
         /// <returns>Returns <paramref name="defaultValue"/> if the input value could not be parsed</returns>
         public static bool TryParseEnum<TEnum>(string value, out TEnum result, TEnum defaultValue = default(TEnum)) where TEnum : struct
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                result = defaultValue;
-                return true;
-            }
-
             if (!TryParseEnum(value, true, out result))
             {
                 result = defaultValue;

--- a/src/NLog/Common/ConversionHelpers.cs
+++ b/src/NLog/Common/ConversionHelpers.cs
@@ -47,7 +47,7 @@ namespace NLog.Common
         /// <param name="inputValue">Input value</param>
         /// <param name="resultValue">Output value</param>
         /// <param name="defaultValue">Default value</param>
-        /// <returns>Returns <paramref name="defaultValue"/> if the input value could not be parsed</returns>
+        /// <returns>Returns false if the input value could not be parsed</returns>
         public static bool TryParseEnum<TEnum>(string inputValue, out TEnum resultValue, TEnum defaultValue = default(TEnum)) where TEnum : struct
         {
             if (!TryParseEnum(inputValue, true, out resultValue))
@@ -66,6 +66,11 @@ namespace NLog.Common
         /// <param name="resultValue">Output value. Null if parse failed</param>
         internal static bool TryParseEnum(string inputValue, Type enumType, out object resultValue)
         {
+            if (StringHelpers.IsNullOrWhiteSpace(inputValue))
+            {
+                resultValue = null;
+                return false;
+            }
             // Note: .NET Standard 2.1 added a public Enum.TryParse(Type)
             try
             {
@@ -90,6 +95,12 @@ namespace NLog.Common
         /// <remarks>Wrapper because Enum.TryParse is not present in .net 3.5</remarks>
         internal static bool TryParseEnum<TEnum>(string inputValue, bool ignoreCase, out TEnum resultValue) where TEnum : struct
         {
+            if (StringHelpers.IsNullOrWhiteSpace(inputValue))
+            {
+                resultValue = default(TEnum);
+                return false;
+            }
+
 #if NET3_5
             return TryParseEnum_net3(inputValue, ignoreCase, out resultValue);
 #else

--- a/src/NLog/Common/ConversionHelpers.cs
+++ b/src/NLog/Common/ConversionHelpers.cs
@@ -44,26 +44,32 @@ namespace NLog.Common
         /// <summary>
         /// Converts input string value into <see cref="System.Enum"/>. Parsing is case-insensitive.
         /// </summary>
-        /// <param name="inputValue">Input value</param>
-        /// <param name="resultValue">Output value</param>
+        /// <param name="value">Input value</param>
+        /// <param name="result">Output value</param>
         /// <param name="defaultValue">Default value</param>
-        /// <returns>Returns failure if the input value could not be parsed</returns>
-        public static bool TryParseEnum<TEnum>(string inputValue, out TEnum resultValue, TEnum defaultValue = default(TEnum)) where TEnum : struct
+        /// <returns>Returns <paramref name="defaultValue"/> if the input value could not be parsed</returns>
+        public static bool TryParseEnum<TEnum>(string value, out TEnum result, TEnum defaultValue = default(TEnum)) where TEnum : struct
         {
-            if (string.IsNullOrEmpty(inputValue))
+            if (string.IsNullOrEmpty(value))
             {
-                resultValue = defaultValue;
+                result = defaultValue;
                 return true;
             }
 
-            if (!TryParse(inputValue, true, out resultValue))
+            if (!TryParseEnum(value, true, out result))
             {
-                resultValue = defaultValue;
+                result = defaultValue;
                 return false;
             }
             return true;
         }
 
+        /// <summary>
+        /// Converts input string value into <see cref="System.Enum"/>. Parsing is case-insensitive.
+        /// </summary>
+        /// <param name="value">Input value</param>
+        /// <param name="enumType">The type of the enum</param>
+        /// <param name="result">Output value. Null if parse failed</param>
         internal static bool TryParseEnum(string value, Type enumType, out object result)
         {
             // Note: .NET Standard 2.1 added a public Enum.TryParse(Type)
@@ -88,7 +94,7 @@ namespace NLog.Common
         /// <param name="result">When this method returns, result contains an object of type TEnum whose value is represented by value if the parse operation succeeds. If the parse operation fails, result contains the default value of the underlying type of TEnum. Note that this value need not be a member of the TEnum enumeration. This parameter is passed uninitialized.</param>
         /// <returns><c>true</c> if the value parameter was converted successfully; otherwise, <c>false</c>.</returns>
         /// <remarks>Wrapper because Enum.TryParse is not present in .net 3.5</remarks>
-        internal static bool TryParse<TEnum>(string value, bool ignoreCase, out TEnum result) where TEnum : struct
+        internal static bool TryParseEnum<TEnum>(string value, bool ignoreCase, out TEnum result) where TEnum : struct
         {
 #if NET3_5
             return TryParseEnum_net3(value, ignoreCase, out result);

--- a/src/NLog/Targets/DatabaseParameterInfo.cs
+++ b/src/NLog/Targets/DatabaseParameterInfo.cs
@@ -173,8 +173,7 @@ namespace NLog.Targets
                         PropertyInfo propInfo = dbParameterType.GetProperty(dbTypeNames[0], BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
                         if (propInfo != null)
                         {
-                            var enumConverter = (IEnumTypeConverter)Activator.CreateInstance(typeof(EnumTypeConverter<>).MakeGenericType(propInfo.PropertyType));
-                            if (enumConverter.TryParseEnum(dbTypeNames[1], out Enum enumType))
+                            if (TryParseEnum(dbTypeNames[1], propInfo.PropertyType, out Enum enumType))
                             {
                                 _dbTypeSetter = propInfo;
                                 _dbTypeValue = enumType;
@@ -296,24 +295,15 @@ namespace NLog.Targets
                 return false;
             }
 
-            interface IEnumTypeConverter
+            private static bool TryParseEnum(string value, Type enumType, out Enum enumValue)
             {
-                bool TryParseEnum(string value, out Enum enumValue);
-            }
-
-            class EnumTypeConverter<TEnum> : IEnumTypeConverter where TEnum : struct
-            {
-                bool IEnumTypeConverter.TryParseEnum(string value, out Enum enumValue)
+                if (!string.IsNullOrEmpty(value) && ConversionHelpers.TryParseEnum(value, enumType, out var enumValueT))
                 {
-                    TEnum enumValueT;
-                    if (!string.IsNullOrEmpty(value) && ConversionHelpers.TryParseEnum(value, out enumValueT))
-                    {
-                        enumValue = enumValueT as Enum;
-                        return enumValue != null;
-                    }
-                    enumValue = null;
-                    return false;
+                    enumValue = enumValueT as Enum;
+                    return enumValue != null;
                 }
+                enumValue = null;
+                return false;
             }
         }
     }

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -650,7 +650,7 @@ namespace NLog.Targets
             if (Priority != null)
             {
                 var renderedPriority = Priority.Render(lastEvent);
-                if (ConversionHelpers.TryParseEnum(renderedPriority, out MailPriority mailPriority))
+                if (!string.IsNullOrEmpty(renderedPriority) && ConversionHelpers.TryParseEnum(renderedPriority, out MailPriority mailPriority))
                 {
                     msg.Priority = mailPriority;
                 }

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -170,7 +170,7 @@ namespace NLog.Targets
             get
             {
 #if !__ANDROID__ && !__IOS__ && !NETSTANDARD
-                
+
                 // In contrary to other settings, System.Net.Mail.SmtpClient doesn't read the 'From' attribute from the system.net/mailSettings/smtp section in the config file.
                 // Thus, when UseSystemNetMailSettings is enabled we have to read the configuration section of system.net/mailSettings/smtp to initialize the 'From' address.
                 // It will do so only if the 'From' attribute in system.net/mailSettings/smtp is not empty.
@@ -650,7 +650,12 @@ namespace NLog.Targets
             if (Priority != null)
             {
                 var renderedPriority = Priority.Render(lastEvent);
-                if (!string.IsNullOrEmpty(renderedPriority) && ConversionHelpers.TryParseEnum(renderedPriority, out MailPriority mailPriority))
+
+                if (string.IsNullOrEmpty(renderedPriority))
+                {
+                    msg.Priority = MailPriority.Normal;
+                }
+                else if (ConversionHelpers.TryParseEnum(renderedPriority, out MailPriority mailPriority))
                 {
                     msg.Priority = mailPriority;
                 }

--- a/tests/NLog.UnitTests/Internal/ConversionHelpersTests.cs
+++ b/tests/NLog.UnitTests/Internal/ConversionHelpersTests.cs
@@ -215,19 +215,25 @@ namespace NLog.UnitTests.Internal
                 Assert.Equal(expectedReturn, returnResult);
             }
 
-
             // if true, test also other TryParseEnum
             if (ignoreCase)
             {
                 {
-                    var returnResult = ConversionHelpers.TryParseEnum(value, typeof(TestEnum), out var result);
+                    var returnResult = ConversionHelpers.TryParseEnum<TestEnum>(value, out var result);
                     Assert.Equal(expected, result);
                     Assert.Equal(expectedReturn, returnResult);
                 }
                 {
-                    var returnResult = ConversionHelpers.TryParseEnum<TestEnum>(value, out var result);
-                    Assert.Equal(expected, result);
+                    var returnResult = ConversionHelpers.TryParseEnum(value, typeof(TestEnum), out var result);
                     Assert.Equal(expectedReturn, returnResult);
+                    if (expectedReturn)
+                    {
+                        Assert.Equal(expected, result);
+                    }
+                    else
+                    {
+                        Assert.Null(result);
+                    }
                 }
             }
         }

--- a/tests/NLog.UnitTests/Internal/ConversionHelpersTests.cs
+++ b/tests/NLog.UnitTests/Internal/ConversionHelpersTests.cs
@@ -208,12 +208,28 @@ namespace NLog.UnitTests.Internal
 
         private static void TestEnumParseCaseIgnoreCaseParam(string value, bool ignoreCase, TestEnum expected, bool expectedReturn)
         {
-            TestEnum result;
+            {
+                var returnResult = ConversionHelpers.TryParseEnum(value, ignoreCase, out TestEnum result);
 
-            var returnResult = ConversionHelpers.TryParseEnum(value, ignoreCase, out result);
+                Assert.Equal(expected, result);
+                Assert.Equal(expectedReturn, returnResult);
+            }
 
-            Assert.Equal(expected, result);
-            Assert.Equal(expectedReturn, returnResult);
+
+            // if true, test also other TryParseEnum
+            if (ignoreCase)
+            {
+                {
+                    var returnResult = ConversionHelpers.TryParseEnum(value, typeof(TestEnum), out var result);
+                    Assert.Equal(expected, result);
+                    Assert.Equal(expectedReturn, returnResult);
+                }
+                {
+                    var returnResult = ConversionHelpers.TryParseEnum<TestEnum>(value, out var result);
+                    Assert.Equal(expected, result);
+                    Assert.Equal(expectedReturn, returnResult);
+                }
+            }
         }
 
         #endregion

--- a/tests/NLog.UnitTests/Internal/ConversionHelpersTests.cs
+++ b/tests/NLog.UnitTests/Internal/ConversionHelpersTests.cs
@@ -109,18 +109,9 @@ namespace NLog.UnitTests.Internal
         }
 
         [Fact]
-        public void EnumParse_ArgumentException_ignoreCaseFalse()
+        public void EnumParse_wrongInput_ignoreCaseFalse()
         {
-            double result;
-            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParseEnum("not enum", false, out result));
-        }
-
-        [Fact]
-        public void EnumParse_null_ArgumentException_ignoreCaseFalse()
-        {
-            //even with null, first ArgumentException
-            double result;
-            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParseEnum(null, false, out result));
+            TestEnumParseCaseIgnoreCaseParam("not enum", false, TestEnum.Foo, false);
         }
 
         #endregion
@@ -192,14 +183,6 @@ namespace NLog.UnitTests.Internal
         {
             double result;
             Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParseEnum("not enum", true, out result));
-        }
-
-        [Fact]
-        public void EnumParse_null_ArgumentException_ignoreCaseTrue()
-        {
-            //even with null, first ArgumentException
-            double result;
-            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParseEnum(null, true, out result));
         }
 
         #endregion

--- a/tests/NLog.UnitTests/Internal/ConversionHelpersTests.cs
+++ b/tests/NLog.UnitTests/Internal/ConversionHelpersTests.cs
@@ -37,7 +37,7 @@ namespace NLog.UnitTests.Internal
     using NLog.Common;
     using Xunit;
 
-    public class EnumHelpersTests : NLogTestBase
+    public class ConversionHelpersTests : NLogTestBase
     {
         enum TestEnum
         {

--- a/tests/NLog.UnitTests/Internal/EnumHelpersTests.cs
+++ b/tests/NLog.UnitTests/Internal/EnumHelpersTests.cs
@@ -112,7 +112,7 @@ namespace NLog.UnitTests.Internal
         public void EnumParse_ArgumentException_ignoreCaseFalse()
         {
             double result;
-            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParse("not enum", false, out result));
+            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParseEnum("not enum", false, out result));
         }
 
         [Fact]
@@ -120,7 +120,7 @@ namespace NLog.UnitTests.Internal
         {
             //even with null, first ArgumentException
             double result;
-            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParse(null, false, out result));
+            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParseEnum(null, false, out result));
         }
 
         #endregion
@@ -191,7 +191,7 @@ namespace NLog.UnitTests.Internal
         public void EnumParse_ArgumentException_ignoreCaseTrue()
         {
             double result;
-            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParse("not enum", true, out result));
+            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParseEnum("not enum", true, out result));
         }
 
         [Fact]
@@ -199,7 +199,7 @@ namespace NLog.UnitTests.Internal
         {
             //even with null, first ArgumentException
             double result;
-            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParse(null, true, out result));
+            Assert.Throws<ArgumentException>(() => ConversionHelpers.TryParseEnum(null, true, out result));
         }
 
         #endregion
@@ -210,7 +210,7 @@ namespace NLog.UnitTests.Internal
         {
             TestEnum result;
 
-            var returnResult = ConversionHelpers.TryParse(value, ignoreCase, out result);
+            var returnResult = ConversionHelpers.TryParseEnum(value, ignoreCase, out result);
 
             Assert.Equal(expected, result);
             Assert.Equal(expectedReturn, returnResult);


### PR DESCRIPTION
And removal of some code complexity in DbTypeSetter  with interfaces, explicit interface impl and MakeGeneric. 