### PR TITLE
DatabaseTarget - Added support for Connection Properties (e.g. for Azure AD Access Token)

### DIFF
--- a/src/NLog/Internal/PropertySetter.cs
+++ b/src/NLog/Internal/PropertySetter.cs
@@ -37,18 +37,13 @@ namespace NLog.Internal
     using System.Reflection;
     using NLog.Common;
 
-    internal interface IPropertySetter
-    {
-        bool SetPropertyValue(object instance, object value);
-    }
-
-    internal class PropertySetter : IPropertySetter
+    internal class PropertySetter
     {
         private readonly Type _objectType;
         private readonly PropertyInfo _propertyInfo;
         private ReflectionHelpers.LateBoundMethod _propertySetter;
 
-        public static IPropertySetter GeneratePropertySetter(Type objectType, string propertyName)
+        public static PropertySetter CreatePropertySetter(Type objectType, string propertyName)
         {
             if (TryGetProperty(objectType, propertyName, out var propertyInfo))
             {
@@ -78,8 +73,9 @@ namespace NLog.Internal
             else
             {
                 // Generate compiled method if setter works without throwing exception
-                _propertyInfo.GetSetMethod().Invoke(instance, new[] { value });
-                _propertySetter = ReflectionHelpers.CreateLateBoundMethod(_propertyInfo.GetSetMethod());
+                var setterMethod = _propertyInfo.GetSetMethod();
+                setterMethod.Invoke(instance, new[] { value });
+                _propertySetter = ReflectionHelpers.CreateLateBoundMethod(setterMethod);
             }
 
             return true;

--- a/src/NLog/Internal/PropertySetter.cs
+++ b/src/NLog/Internal/PropertySetter.cs
@@ -1,0 +1,119 @@
+﻿// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal
+{
+    using System;
+    using System.Reflection;
+    using NLog.Common;
+
+    internal interface IPropertySetter
+    {
+        bool SetPropertyValue(object instance, object value);
+    }
+
+    internal class PropertySetter : IPropertySetter
+    {
+        private readonly Type _objectType;
+        private readonly PropertyInfo _propertyInfo;
+        private ReflectionHelpers.LateBoundMethod _propertySetter;
+
+        public static IPropertySetter GeneratePropertySetter(Type objectType, string propertyName)
+        {
+            if (TryGetProperty(objectType, propertyName, out var propertyInfo))
+            {
+                return new PropertySetter(objectType, propertyInfo);
+            }
+
+            return null;
+        }
+
+        private PropertySetter(Type objectType, PropertyInfo propertyInfo)
+        {
+            _objectType = objectType;
+            _propertyInfo = propertyInfo;
+        }
+
+        public bool SetPropertyValue(object instance, object value)
+        {
+            if (instance == null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            if (_propertySetter != null)
+            {
+                _propertySetter.Invoke(instance, new[] { value });
+            }
+            else
+            {
+                // Generate compiled method if setter works without throwing exception
+                _propertyInfo.GetSetMethod().Invoke(instance, new[] { value });
+                _propertySetter = ReflectionHelpers.CreateLateBoundMethod(_propertyInfo.GetSetMethod());
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Try get the property
+        /// </summary>
+        private static bool TryGetProperty(Type objectType, string propertyName, out PropertyInfo property)
+        {
+            if (objectType == null)
+            {
+                throw new ArgumentNullException(nameof(objectType));
+            }
+
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            property = objectType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (property == null)
+            {
+                InternalLogger.Warn("Cannot set {0} on type {1}, property not found", propertyName, objectType.FullName);
+                return false;
+            }
+
+            if (!property.CanWrite)
+            {
+                InternalLogger.Warn("Cannot set {0} on type {1}, property not settable", propertyName, objectType.FullName);
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/NLog/Targets/DatabaseObjectPropertyInfo.cs
+++ b/src/NLog/Targets/DatabaseObjectPropertyInfo.cs
@@ -44,34 +44,34 @@ namespace NLog.Targets
     using NLog.Layouts;
 
     /// <summary>
-    /// Information about database connection property + value
+    /// Information about object-property for the database-connection-object
     /// </summary>
     [NLogConfigurationItem]
-    public class DatabaseConnectionInfo
+    public class DatabaseObjectPropertyInfo
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DatabaseConnectionInfo"/> class.
+        /// Initializes a new instance of the <see cref="DatabaseObjectPropertyInfo"/> class.
         /// </summary>
-        public DatabaseConnectionInfo()
+        public DatabaseObjectPropertyInfo()
         {
         }
 
         /// <summary>
-        /// Gets or sets the property name for the database connection object (Not case-sensitive)
+        /// Gets or sets the name for the object-property
         /// </summary>
         /// <docgen category='Connection Options' order='10' />
         [RequiredParameter]
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets the value to assign on database connection object
+        /// Gets or sets the value to assign on the object-property
         /// </summary>
         /// <docgen category='Connection Options' order='10' />
         [RequiredParameter]
         public Layout Layout { get; set; }
 
         /// <summary>
-        /// Gets or sets the type of the database connection property
+        /// Gets or sets the type of the object-property
         /// </summary>
         /// <docgen category='Connection Options' order='10' />
         [DefaultValue(typeof(string))]

--- a/src/NLog/Targets/DatabaseParameterInfo.cs
+++ b/src/NLog/Targets/DatabaseParameterInfo.cs
@@ -121,7 +121,7 @@ namespace NLog.Targets
         private Type _parameterType;
 
         /// <summary>
-        /// Gets or sets convert format of the database parameter value .
+        /// Gets or sets convert format of the database parameter value.
         /// </summary>
         /// <docgen category='Parameter Options' order='8' />
         [DefaultValue(null)]

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -277,8 +277,8 @@ namespace NLog.Targets
         /// between NLog layout and a property on the DbConnection instance
         /// </summary>
         /// <docgen category='Connection Options' order='10' />
-        [ArrayParameter(typeof(DatabaseConnectionInfo), "connectionproperty")]
-        public IList<DatabaseConnectionInfo> ConnectionProperties { get; } = new List<DatabaseConnectionInfo>();
+        [ArrayParameter(typeof(DatabaseObjectPropertyInfo), "connectionproperty")]
+        public IList<DatabaseObjectPropertyInfo> ConnectionProperties { get; } = new List<DatabaseObjectPropertyInfo>();
 
         /// <summary>
         /// Configures isolated transaction batch writing. If supported by the database, then it will improve insert performance.
@@ -1081,7 +1081,7 @@ namespace NLog.Targets
             return RenderObjectValue(logEvent, parameterInfo.Name, parameterInfo.Layout, parameterInfo.ParameterType, parameterInfo.Format, parameterInfo.Culture);
         }
 
-        private object GetDatabaseConnectionValue(LogEventInfo logEvent, DatabaseConnectionInfo connectionInfo)
+        private object GetDatabaseConnectionValue(LogEventInfo logEvent, DatabaseObjectPropertyInfo connectionInfo)
         {
             return RenderObjectValue(logEvent, connectionInfo.Name, connectionInfo.Layout, connectionInfo.PropertyType, connectionInfo.Format, connectionInfo.Culture);
         }

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -1172,7 +1172,7 @@ Dispose()
                 DBProvider = typeof(MockDbConnection).AssemblyQualifiedName,
                 CommandText = "command1",
             };
-            databaseTarget.ConnectionProperties.Add(new DatabaseConnectionInfo() { Name = "AccessToken", Layout = accessToken });
+            databaseTarget.ConnectionProperties.Add(new DatabaseObjectPropertyInfo() { Name = "AccessToken", Layout = accessToken });
             databaseTarget.Initialize(new LoggingConfiguration());
 
             // Act
@@ -1196,7 +1196,7 @@ Dispose()
                 DBProvider = typeof(MockDbConnection).AssemblyQualifiedName,
                 CommandText = "command1",
             };
-            databaseTarget.ConnectionProperties.Add(new DatabaseConnectionInfo() { Name = "AccessToken", Layout = "abc", PropertyType = typeof(int) });
+            databaseTarget.ConnectionProperties.Add(new DatabaseObjectPropertyInfo() { Name = "AccessToken", Layout = "abc", PropertyType = typeof(int) });
             databaseTarget.Initialize(new LoggingConfiguration());
 
             // Act + Assert


### PR DESCRIPTION
Based on  #3825

fixes #3554

```xml
<target name="db"
        xsi:type="Database"
        commandType="StoredProcedure"
        commandText="[dbo].[NLog_AddEntry_p]"
        >
  <connectionProperty name="AccessToken" layout="${gdc:AccessToken}" propertyType="System.String" />
  <parameter name="@logged"         layout="${date}" />
  <parameter name="@level"          layout="${level}" />
  <parameter name="@message"        layout="${message}" />
  <parameter name="@logger"         layout="${logger}" />
</target>
```

For SqlConnection AccessToken then one needs a special LayoutRenderer that can call `AzureServiceTokenProvider` as AccessToken can have a limited lifetime.