### PR TITLE
Added ${OnHasProperties} -  for easier custom output

### DIFF
--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -233,13 +233,7 @@ namespace NLog.LayoutRenderers
         /// </remarks>
         protected CultureInfo GetCulture(LogEventInfo logEvent, CultureInfo layoutCulture = null)
         {
-            var culture = logEvent.FormatProvider as CultureInfo ?? layoutCulture;
-
-            if (culture == null && LoggingConfiguration != null)
-            {
-                culture =  LoggingConfiguration.DefaultCultureInfo;
-            }
-            return culture;
+            return logEvent.FormatProvider as CultureInfo ?? layoutCulture ?? LoggingConfiguration?.DefaultCultureInfo;
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/Wrappers/OnHasPropertiesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/OnHasPropertiesLayoutRendererWrapper.cs
@@ -39,6 +39,9 @@ namespace NLog.LayoutRenderers.Wrappers
     /// <summary>
     /// Outputs alternative layout when the inner layout produces empty result.
     /// </summary>
+    /// <example>
+    /// ${onhasproperties:, Properties\: ${all-event-properties}}
+    /// </example>
     [LayoutRenderer("onhasproperties")]
     [ThreadAgnostic]
     [ThreadSafe]

--- a/src/NLog/LayoutRenderers/Wrappers/OnHasPropertiesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/OnHasPropertiesLayoutRendererWrapper.cs
@@ -1,0 +1,62 @@
+﻿// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.LayoutRenderers.Wrappers
+{
+    using System.Text;
+    using NLog.Config;
+
+    /// <summary>
+    /// Outputs alternative layout when the inner layout produces empty result.
+    /// </summary>
+    [LayoutRenderer("onhasproperties")]
+    [ThreadAgnostic]
+    [ThreadSafe]
+    public sealed class OnHasPropertiesLayoutRendererWrapper : WrapperLayoutRendererBase
+    {
+        /// <inheritdoc/>
+        protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
+        {
+            if (logEvent.HasProperties)
+            {
+                Inner.RenderAppendBuilder(logEvent, builder);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override string Transform(string text)
+        {
+            return text;
+        }
+    }
+}

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -379,12 +379,12 @@ namespace NLog
             return _properties;
         }
 
-        internal bool HasMessageTemplateParameters
+        private bool HasMessageTemplateParameters
         {
             get
             {
                 // Have not yet parsed/rendered the FormattedMessage, so check with ILogMessageFormatter
-                if (_formattedMessage == null)
+                if (_formattedMessage == null && _parameters?.Length > 0)
                 {
                     var logMessageFormatter = _messageFormatter?.Target as ILogMessageFormatter;
                     return logMessageFormatter?.HasProperties(this) ?? false;

--- a/src/NLog/MessageTemplates/MessageTemplateParameters.cs
+++ b/src/NLog/MessageTemplates/MessageTemplateParameters.cs
@@ -37,13 +37,14 @@ namespace NLog.MessageTemplates
     using System.Collections;
     using System.Collections.Generic;
     using NLog.Common;
+    using NLog.Internal;
 
     /// <summary>
     /// Parameters extracted from parsing <see cref="LogEventInfo.Message"/> as MessageTemplate
     /// </summary>
     public sealed class MessageTemplateParameters : IEnumerable<MessageTemplateParameter>
     {
-        internal static readonly MessageTemplateParameters Empty = new MessageTemplateParameters(string.Empty, NLog.Internal.ArrayHelper.Empty<object>());
+        internal static readonly MessageTemplateParameters Empty = new MessageTemplateParameters(string.Empty, ArrayHelper.Empty<object>());
 
         private readonly IList<MessageTemplateParameter> _parameters;
 
@@ -79,10 +80,10 @@ namespace NLog.MessageTemplates
         /// <param name="parameters">All <see cref="LogEventInfo.Parameters"/></param>
         internal MessageTemplateParameters(string message, object[] parameters)
         {
-            var hasParameters = parameters != null && parameters.Length > 0;
+            var hasParameters = parameters?.Length > 0;
             bool isPositional = hasParameters;
             bool isValidTemplate = !hasParameters;
-            _parameters = hasParameters ? ParseMessageTemplate(message, parameters, out isPositional, out isValidTemplate) : Internal.ArrayHelper.Empty<MessageTemplateParameter>();
+            _parameters = hasParameters ? ParseMessageTemplate(message, parameters, out isPositional, out isValidTemplate) : ArrayHelper.Empty<MessageTemplateParameter>();
             IsPositional = isPositional;
             IsValidTemplate = isValidTemplate;
         }
@@ -92,7 +93,7 @@ namespace NLog.MessageTemplates
         /// </summary>
         internal MessageTemplateParameters(IList<MessageTemplateParameter> templateParameters, string message, object[] parameters)
         {
-            _parameters = templateParameters ?? Internal.ArrayHelper.Empty<MessageTemplateParameter>();
+            _parameters = templateParameters ?? ArrayHelper.Empty<MessageTemplateParameter>();
             if (parameters != null && _parameters.Count != parameters.Length)
             {
                 IsValidTemplate = false;
@@ -102,11 +103,6 @@ namespace NLog.MessageTemplates
         /// <summary>
         /// Create MessageTemplateParameter from <paramref name="parameters"/>
         /// </summary>
-        /// <param name="template"></param>
-        /// <param name="parameters"></param>
-        /// <param name="isPositional"></param>
-        /// <param name="isValidTemplate"></param>
-        /// <returns></returns>
         private static IList<MessageTemplateParameter> ParseMessageTemplate(string template, object[] parameters, out bool isPositional, out bool isValidTemplate)
         {
             isPositional = true;

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/OnHasPropertiesTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/OnHasPropertiesTests.cs
@@ -1,0 +1,70 @@
+﻿// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.LayoutRenderers.Wrappers
+{
+    using NLog.Layouts;
+    using Xunit;
+
+    public class OnHasPropertiesTests : NLogTestBase
+    {
+        [Fact]
+        public void OnHasPropertiesValid()
+        {
+            // Arrange
+            SimpleLayout l = @"${message:raw=true}${onhasproperties:, Properties\: ${all-event-properties}}";
+            var logevent = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+            logevent.Properties["Foo"] = "Bar";
+
+            // Act
+            var result = l.Render(logevent);
+
+            // Assert
+            Assert.Equal("message, Properties: Foo=Bar", result);
+        }
+
+        [Fact]
+        public void OnHasPropertiesEmpty()
+        {
+            // Arrange
+            SimpleLayout l = @"${message:raw=true}${onhasproperties: Properties\:${all-event-properties}}";
+            var logevent = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+
+            // Act
+            var result = l.Render(logevent);
+
+            // Assert
+            Assert.Equal("message", result);
+        }
+    }
+}


### PR DESCRIPTION
Can do this (Inspired by [OnException](https://github.com/nlog/NLog/wiki/OnException-Layout-Renderer)):

> `${onhasproperties:, Properties\: ${all-event-properties}}`

Instead of this (performance hit from double rendering):

> `${when:when=length('${all-event-properties}')>0:inner=, Properties\: ${all-event-properties}}`

I guess when #3830 has been merged, then one could also create a static condition-method called `HasProperties(LogEventInfo)`.

Note merge to master