### PR TITLE
DatabaseTarget - Added support for DbCommand Properties

### DIFF
--- a/src/NLog/Targets/DatabaseObjectPropertyInfo.cs
+++ b/src/NLog/Targets/DatabaseObjectPropertyInfo.cs
@@ -91,9 +91,9 @@ namespace NLog.Targets
         [DefaultValue(null)]
         public CultureInfo Culture { get; set; }
 
-        internal bool SetPropertyValue(IDbConnection dbConnection, object propertyValue)
+        internal bool SetPropertyValue(object dbObject, object propertyValue)
         {
-            var dbConnectionType = dbConnection.GetType();
+            var dbConnectionType = dbObject.GetType();
             var propertySetterCache = _propertySetter;
             if (!propertySetterCache.Equals(Name, dbConnectionType))
             {
@@ -102,7 +102,7 @@ namespace NLog.Targets
                 _propertySetter = propertySetterCache;
             }
 
-            return propertySetterCache.PropertySetter?.SetPropertyValue(dbConnection, propertyValue) ?? false;
+            return propertySetterCache.PropertySetter?.SetPropertyValue(dbObject, propertyValue) ?? false;
         }
 
         private struct PropertySetterCacheItem


### PR DESCRIPTION
Reusing the logic from DbConnection to also apply properties for DbCommand:

```xml
<target name="db"
        xsi:type="Database"
        commandType="StoredProcedure"
        commandText="[dbo].[NLog_AddEntry_p]"
        >
  <commandProperty name="CommandTimeout" layout="${gdc:DefaultCommandTimeout}" propertyType="System.Int32" />
  <parameter name="@logged"         layout="${date}" />
  <parameter name="@level"          layout="${level}" />
  <parameter name="@message"        layout="${message}" />
  <parameter name="@logger"         layout="${logger}" />
</target>
```

See also #3829