### PR TITLE
FileTarget - Skip checking file-length on every file write, when using ArchiveEvery

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -944,7 +944,7 @@ namespace NLog.Targets
 
         private bool IsArchivingEnabled => ArchiveAboveSize > ArchiveAboveSizeDisabled || ArchiveEvery != FileArchivePeriod.None;
 
-        private bool IsSimpleKeepFileOpen => KeepFileOpen && !NetworkWrites && !ReplaceFileContentsOnEachWrite && !ConcurrentWrites;
+        private bool IsSimpleKeepFileOpen => KeepFileOpen && !ConcurrentWrites && !NetworkWrites && !ReplaceFileContentsOnEachWrite;
 
         private bool EnableFileDeleteSimpleMonitor => EnableFileDelete && !PlatformDetector.IsWin32 && IsSimpleKeepFileOpen;
 
@@ -1822,9 +1822,9 @@ namespace NLog.Targets
                         {
                             mutexFileAppender.ArchiveMutex.WaitOne();
                         }
-                        else
+                        else if (!IsSimpleKeepFileOpen)
                         {
-                            InternalLogger.Info("FileTarget(Name={0}): Archive mutex not available: {1}", Name, archiveFile);
+                            InternalLogger.Debug("FileTarget(Name={0}): Archive mutex not available: {1}", Name, archiveFile);
                         }
                     }
                     catch (AbandonedMutexException)

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1947,6 +1947,8 @@ namespace NLog.Targets
             var fileLength = _fileAppenderCache.GetFileLength(previousFileName);
             if (!fileLength.HasValue)
             {
+                _initializedFiles.Remove(previousFileName);
+
                 if (!string.IsNullOrEmpty(_previousLogFileName) && previousFileName != _previousLogFileName)
                 {
                     upcomingWriteSize = 0;
@@ -2000,6 +2002,8 @@ namespace NLog.Targets
             DateTime? creationTimeSource = TryGetArchiveFileCreationTimeSource(fileName, previousLogEventTimestamp);
             if (!creationTimeSource.HasValue)
             {
+                _initializedFiles.Remove(fileName);
+
                 if (!string.IsNullOrEmpty(_previousLogFileName) && fileName != _previousLogFileName)
                 {
                     return GetArchiveFileNameBasedOnTime(_previousLogFileName, logEvent, previousLogEventTimestamp);
@@ -2034,14 +2038,6 @@ namespace NLog.Targets
             var creationTimeSource = _fileAppenderCache.GetFileCreationTimeSource(fileName, fallbackTimeSourceLinux);
             if (!creationTimeSource.HasValue)
                 return null;
-
-            var fileLength = _fileAppenderCache.GetFileLength(fileName);   // Verifies file-handle by checking FileStream.Length
-            if (!fileLength.HasValue)
-            {
-                InternalLogger.Debug("FileTarget(Name={0}): Cannot get length of file {1} with creation date {2}.", Name, fileName, creationTimeSource.Value);
-                _initializedFiles.Remove(fileName);
-                return null;
-            }
 
             if (previousLogEventTimestamp != DateTime.MinValue && previousLogEventTimestamp < creationTimeSource)
             {

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1776,31 +1776,13 @@ namespace NLog.Targets
                 archiveFile = GetArchiveFileName(fileName, ev, upcomingWriteSize, previousLogEventTimestamp);
                 if (!string.IsNullOrEmpty(archiveFile))
                 {
-                    InternalLogger.Trace("FileTarget(Name={0}): Archive attempt for file '{1}'", Name, archiveFile);
-                    archivedAppender = _fileAppenderCache.InvalidateAppender(fileName);
-                    if (fileName != archiveFile)
-                    {
-                        var fileAppender = _fileAppenderCache.InvalidateAppender(archiveFile);
-                        archivedAppender = archivedAppender ?? fileAppender;
-                    }
-
-                    if (!string.IsNullOrEmpty(_previousLogFileName) && _previousLogFileName != archiveFile && _previousLogFileName != fileName)
-                    {
-                        var fileAppender = _fileAppenderCache.InvalidateAppender(_previousLogFileName);
-                        archivedAppender = archivedAppender ?? fileAppender;
-                    }
+                    archivedAppender = TryCloseFileAppenderBeforeArchive(fileName, archiveFile);
+                }
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
-                    // Closes all file handles if any archive operation has been detected by file-watcher
-                    _fileAppenderCache.InvalidateAppendersForArchivedFiles();
+                // Closes all file handles if any archive operation has been detected by file-watcher
+                _fileAppenderCache.InvalidateAppendersForArchivedFiles();
 #endif
-                }
-                else
-                {
-#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD1_3
-                    _fileAppenderCache.InvalidateAppendersForArchivedFiles();
-#endif
-                }
             }
             catch (Exception exception)
             {
@@ -1811,72 +1793,104 @@ namespace NLog.Targets
                 }
             }
 
-            if (!string.IsNullOrEmpty(archiveFile))
+            if (string.IsNullOrEmpty(archiveFile))
+                return false;
+
+            try
             {
+#if SupportsMutex
                 try
                 {
-#if SupportsMutex
-                    try
+                    if (archivedAppender is BaseMutexFileAppender mutexFileAppender && mutexFileAppender.ArchiveMutex != null)
                     {
-                        if (archivedAppender is BaseMutexFileAppender mutexFileAppender && mutexFileAppender.ArchiveMutex != null)
-                        {
-                            mutexFileAppender.ArchiveMutex.WaitOne();
-                        }
-                        else if (!IsSimpleKeepFileOpen)
-                        {
-                            InternalLogger.Debug("FileTarget(Name={0}): Archive mutex not available: {1}", Name, archiveFile);
-                        }
+                        mutexFileAppender.ArchiveMutex.WaitOne();
                     }
-                    catch (AbandonedMutexException)
+                    else if (!IsSimpleKeepFileOpen)
                     {
-                        // ignore the exception, another process was killed without properly releasing the mutex
-                        // the mutex has been acquired, so proceed to writing
-                        // See: https://msdn.microsoft.com/en-us/library/system.threading.abandonedmutexexception.aspx
+                        InternalLogger.Debug("FileTarget(Name={0}): Archive mutex not available: {1}", Name, archiveFile);
                     }
+                }
+                catch (AbandonedMutexException)
+                {
+                    // ignore the exception, another process was killed without properly releasing the mutex
+                    // the mutex has been acquired, so proceed to writing
+                    // See: https://msdn.microsoft.com/en-us/library/system.threading.abandonedmutexexception.aspx
+                }
 #endif
 
-                    // Check again if archive is needed. We could have been raced by another process
-                    var validatedArchiveFile = GetArchiveFileName(fileName, ev, upcomingWriteSize, previousLogEventTimestamp);
-                    if (string.IsNullOrEmpty(validatedArchiveFile))
-                    {
-                        InternalLogger.Trace("FileTarget(Name={0}): Archive already performed for file '{1}'", Name, archiveFile);
-                        if (archiveFile != fileName)
-                            _initializedFiles.Remove(fileName);
-                        _initializedFiles.Remove(archiveFile);
-                    }
-                    else
-                    {
-                        archiveFile = validatedArchiveFile;
-                        DoAutoArchive(archiveFile, ev, previousLogEventTimestamp, initializedNewFile);
-                        _initializedFiles.Remove(archiveFile);
-                    }
-
-                    if (_previousLogFileName == archiveFile)
-                    {
-                        _previousLogFileName = null;
-                        _previousLogEventTimestamp = null;
-                    }
-                    return true;
-                }
-                catch (Exception exception)
-                {
-                    InternalLogger.Warn(exception, "FileTarget(Name={0}): Failed to archive file '{1}'.", Name, archiveFile);
-                    if (exception.MustBeRethrown())
-                    {
-                        throw;
-                    }
-                }
-                finally
-                {
+                return TryArchiveFileAfterCloseFileAppender(fileName, archiveFile, ev, upcomingWriteSize, previousLogEventTimestamp, initializedNewFile);
+            }
+            finally
+            {
 #if SupportsMutex
-                    if (archivedAppender is BaseMutexFileAppender mutexFileAppender)
-                        mutexFileAppender.ArchiveMutex?.ReleaseMutex();
+                if (archivedAppender is BaseMutexFileAppender mutexFileAppender)
+                    mutexFileAppender.ArchiveMutex?.ReleaseMutex();
 #endif
-                    archivedAppender?.Dispose();    // Dispose of Archive Mutex
-                }
+                archivedAppender?.Dispose();    // Dispose of Archive Mutex
+            }
+        }
+
+        /// <summary>
+        /// Closes any active file-appenders that matches the input filenames.
+        /// File-appender is requested to invalidate/close its filehandle, but keeping its archive-mutex alive
+        /// </summary>
+        private BaseFileAppender TryCloseFileAppenderBeforeArchive(string fileName, string archiveFile)
+        {
+            InternalLogger.Trace("FileTarget(Name={0}): Archive attempt for file '{1}'", Name, archiveFile);
+            BaseFileAppender archivedAppender = _fileAppenderCache.InvalidateAppender(fileName);
+            if (fileName != archiveFile)
+            {
+                var fileAppender = _fileAppenderCache.InvalidateAppender(archiveFile);
+                archivedAppender = archivedAppender ?? fileAppender;
             }
 
-            return false;
+            if (!string.IsNullOrEmpty(_previousLogFileName) && _previousLogFileName != archiveFile && _previousLogFileName != fileName)
+            {
+                var fileAppender = _fileAppenderCache.InvalidateAppender(_previousLogFileName);
+                archivedAppender = archivedAppender ?? fileAppender;
+            }
+
+            return archivedAppender;
+        }
+
+        private bool TryArchiveFileAfterCloseFileAppender(string fileName, string archiveFile, LogEventInfo ev, int upcomingWriteSize, DateTime previousLogEventTimestamp, bool initializedNewFile)
+        {
+            try
+            {
+                // Check again if archive is needed. We could have been raced by another process
+                var validatedArchiveFile = GetArchiveFileName(fileName, ev, upcomingWriteSize, previousLogEventTimestamp);
+                if (string.IsNullOrEmpty(validatedArchiveFile))
+                {
+                    InternalLogger.Trace("FileTarget(Name={0}): Archive already performed for file '{1}'", Name, archiveFile);
+                    if (archiveFile != fileName)
+                        _initializedFiles.Remove(fileName);
+                    _initializedFiles.Remove(archiveFile);
+                }
+                else
+                {
+                    archiveFile = validatedArchiveFile;
+                    DoAutoArchive(archiveFile, ev, previousLogEventTimestamp, initializedNewFile);
+                    _initializedFiles.Remove(archiveFile);
+                }
+
+                if (_previousLogFileName == archiveFile)
+                {
+                    _previousLogFileName = null;
+                    _previousLogEventTimestamp = null;
+                }
+
+                return true;    // Archive operation has been executed, by this application (or a concurrent one)
+            }
+            catch (Exception exception)
+            {
+                InternalLogger.Warn(exception, "FileTarget(Name={0}): Failed to archive file '{1}'.", Name, archiveFile);
+                if (exception.MustBeRethrown())
+                {
+                    throw;
+                }
+
+                return false;
+            }
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -69,7 +69,7 @@ namespace NLog.UnitTests
             logger.Factory.Flush(ex => { timeoutException = ex; manualResetEvent.Set(); }, TimeSpan.FromMilliseconds(1));
 
             // Assert
-            Assert.True(manualResetEvent.WaitOne(1000));
+            Assert.True(manualResetEvent.WaitOne(5000));
             Assert.NotNull(timeoutException);
         }
 


### PR DESCRIPTION
Fixes performance regression introduced with #3691 when only using `ArchiveEvery` without specifying `ArchiveAboveSize`. The performance hit most is for this setup:

- KeepFileOpen=true and ConcurrentWrites=true

The performance hit comes from doing a probe of file-length for every write to file-stream. The probe was introduced to ensure the file was still valid (not archived by other process). But since the archive-operation is already performing double-check (One with filestream open, Second with filestream closed). Then there is no need to perform triple check.

Also removed  InternalLogger noise when using file-appender without mutex-support. Ex. KeepFileOpen=true and ConcurrentWrites=false.