### PR TITLE
NLog InternalLogger Setup: added AddLogSubscription and RemoveLogSubscription

### DIFF
--- a/src/NLog/SetupInternalLoggerBuilderExtensions.cs
+++ b/src/NLog/SetupInternalLoggerBuilderExtensions.cs
@@ -88,5 +88,23 @@ namespace NLog
             InternalLogger.LogWriter = writer;
             return setupBuilder;
         }
+
+        /// <summary>
+        /// Configures <see cref="InternalLogger.LogMessageReceived"/>
+        /// </summary>
+        public static ISetupInternalLoggerBuilder AddLogSubscription(this ISetupInternalLoggerBuilder setupBuilder, System.EventHandler<InternalLoggerMessageEventArgs> eventSubscriber)
+        {
+            InternalLogger.LogMessageReceived += eventSubscriber;
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Configures <see cref="InternalLogger.LogMessageReceived"/>
+        /// </summary>
+        public static ISetupInternalLoggerBuilder RemoveLogSubscription(this ISetupInternalLoggerBuilder setupBuilder, System.EventHandler<InternalLoggerMessageEventArgs> eventSubscriber)
+        {
+            InternalLogger.LogMessageReceived -= eventSubscriber;
+            return setupBuilder;
+        }
     }
 }

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -804,10 +804,14 @@ namespace NLog.UnitTests.Common
             {
                 // Arrange
                 var receivedArgs = new List<InternalLoggerMessageEventArgs>();
-                InternalLogger.LogMessageReceived += (sender, e) =>
+                var logFactory = new LogFactory();
+                logFactory.Setup().SetupInternalLogger(s =>
                 {
-                    receivedArgs.Add(e);
-                };
+                    EventHandler<InternalLoggerMessageEventArgs> eventHandler = (sender, e) => receivedArgs.Add(e);
+                    s.AddLogSubscription(eventHandler);
+                    s.RemoveLogSubscription(eventHandler);
+                    s.AddLogSubscription(eventHandler);
+                });
                 var exception = new Exception();
 
                 // Act


### PR DESCRIPTION
Fluent API for LogMessageReceived

```c#
                LogManager.Setup().SetupInternalLogger(s =>
                {
                    s.AddLogSubscription(eventHandler);
                });
```