### PR TITLE
Support for ${ProcessDir} in internalLogFile when parsing nlog.config

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -245,6 +245,10 @@ namespace NLog.Config
                     internalLogFile = internalLogFile.Replace(baseDirToken, LogFactory.CurrentAppDomain.BaseDirectory + System.IO.Path.DirectorySeparatorChar.ToString());
                 if (ContainsSubStringIgnoreCase(internalLogFile, "${tempdir}", out string tempDirToken))
                     internalLogFile = internalLogFile.Replace(tempDirToken, System.IO.Path.GetTempPath() + System.IO.Path.DirectorySeparatorChar.ToString());
+#if !NETSTANDARD1_3
+                if (ContainsSubStringIgnoreCase(internalLogFile, "${processdir}", out string processDirToken))
+                    internalLogFile = internalLogFile.Replace(processDirToken, System.IO.Path.GetDirectoryName(ProcessIDHelper.Instance.CurrentProcessFilePath) + System.IO.Path.DirectorySeparatorChar.ToString());
+#endif
                 if (internalLogFile.IndexOf("%", StringComparison.OrdinalIgnoreCase) >= 0)
                     internalLogFile = Environment.ExpandEnvironmentVariables(internalLogFile);
 #endif

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -106,6 +106,15 @@ namespace NLog.UnitTests.Config
                 Assert.Contains(System.IO.Path.GetTempPath(), InternalLogger.LogFile);
             }
 
+#if !NETSTANDARD1_3
+            using (new InternalLoggerScope(true))
+            {
+                var xml = "<nlog internalLogFile='${ProcessDir}test.txt'></nlog>";
+                var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+                Assert.Contains(Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess()?.MainModule?.FileName), InternalLogger.LogFile);
+            }
+#endif
+
             using (new InternalLoggerScope(true))
             {
                 var userName = Environment.GetEnvironmentVariable("USERNAME") ?? string.Empty;


### PR DESCRIPTION
Improve support for single file publish where Process-Executable-Directory `${processdir}` is the valid location (Not `${basedir}`)