### PR TITLE
SplitGroupTarget - Target write failure should not skip remaining targets

### DIFF
--- a/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
@@ -36,8 +36,7 @@ namespace NLog.Targets.Wrappers
     using System;
     using System.Collections.Generic;
     using System.Threading;
-    using Common;
-    using Internal;
+    using NLog.Common;
 
     /// <summary>
     /// Writes log events to all targets.
@@ -94,7 +93,22 @@ namespace NLog.Targets.Wrappers
         /// <param name="logEvent">The log event.</param>
         protected override void Write(AsyncLogEventInfo logEvent)
         {
-            AsyncHelpers.ForEachItemSequentially(Targets, logEvent.Continuation, (t, cont) => t.WriteAsyncLogEvent(logEvent.LogEvent.WithContinuation(cont)));
+            if (Targets.Count == 0)
+            {
+                logEvent.Continuation(null);
+            }
+            else
+            {
+                if (Targets.Count > 1)
+                {
+                    logEvent = logEvent.LogEvent.WithContinuation(CreateCountedContinuation(logEvent.Continuation, Targets.Count));
+                }
+
+                for (int i = 0; i < Targets.Count; ++i)
+                {
+                    Targets[i].WriteAsyncLogEvent(logEvent);
+                }
+            }
         }
 
         /// <summary>
@@ -121,36 +135,48 @@ namespace NLog.Targets.Wrappers
         {
             InternalLogger.Trace("SplitGroup(Name={0}): Writing {1} events", Name, logEvents.Count);
 
-            for (int i = 0; i < logEvents.Count; ++i)
+            if (logEvents.Count == 1)
             {
-                AsyncLogEventInfo ev = logEvents[i];
-                logEvents[i] = new AsyncLogEventInfo(ev.LogEvent, CountedWrap(ev.Continuation, Targets.Count));
+                Write(logEvents[0]);    // Skip array allocation for each destination target
             }
-
-            for (int i = 0; i < Targets.Count; ++i)
+            else if (Targets.Count == 0 || logEvents.Count == 0)
             {
-                InternalLogger.Trace("SplitGroup(Name={0}): Sending {1} events to {2}", Name, logEvents.Count, Targets[i]);
-
-                var targetLogEvents = logEvents;
-                if (i < Targets.Count - 1)
+                for (int i = 0; i < logEvents.Count; ++i)
                 {
-                    // OptimizeBufferReuse = true, will change the input-array (so we make clones here)
-                    AsyncLogEventInfo[] cloneLogEvents = new AsyncLogEventInfo[logEvents.Count];
-                    logEvents.CopyTo(cloneLogEvents, 0);
-                    targetLogEvents = cloneLogEvents;
+                    logEvents[i].Continuation(null);
+                }
+            }
+            else
+            {
+                if (Targets.Count > 1)
+                {
+                    for (int i = 0; i < logEvents.Count; ++i)
+                    {
+                        AsyncLogEventInfo ev = logEvents[i];
+                        logEvents[i] = ev.LogEvent.WithContinuation(CreateCountedContinuation(ev.Continuation, Targets.Count));
+                    }
                 }
 
-                Targets[i].WriteAsyncLogEvents(targetLogEvents);
+                for (int i = 0; i < Targets.Count; ++i)
+                {
+                    InternalLogger.Trace("SplitGroup(Name={0}): Sending {1} events to {2}", Name, logEvents.Count, Targets[i]);
+
+                    var targetLogEvents = logEvents;
+                    if (i < Targets.Count - 1)
+                    {
+                        // OptimizeBufferReuse = true, will change the input-array (so we make clones here)
+                        AsyncLogEventInfo[] cloneLogEvents = new AsyncLogEventInfo[logEvents.Count];
+                        logEvents.CopyTo(cloneLogEvents, 0);
+                        targetLogEvents = cloneLogEvents;
+                    }
+
+                    Targets[i].WriteAsyncLogEvents(targetLogEvents);
+                }
             }
         }
 
-        private static AsyncContinuation CountedWrap(AsyncContinuation originalContinuation, int counter)
+        private static AsyncContinuation CreateCountedContinuation(AsyncContinuation originalContinuation, int targetCounter)
         {
-            if (counter == 1)
-            {
-                return originalContinuation;
-            }
-
             var exceptions = new List<Exception>();
 
             AsyncContinuation wrapper =
@@ -164,17 +190,17 @@ namespace NLog.Targets.Wrappers
                         }
                     }
 
-                    int c = Interlocked.Decrement(ref counter);
+                    int pendingTargets = Interlocked.Decrement(ref targetCounter);
 
-                    if (c == 0)
+                    if (pendingTargets == 0)
                     {
                         var combinedException = AsyncHelpers.GetCombinedException(exceptions);
-                        InternalLogger.Trace("Combined exception: {0}", combinedException);
+                        InternalLogger.Trace("SplitGroup: Combined exception: {0}", combinedException);
                         originalContinuation(combinedException);
                     }
                     else
                     {
-                        InternalLogger.Trace("{0} remaining.", c);
+                        InternalLogger.Trace("SplitGroup: {0} remaining.", pendingTargets);
                     }
                 };
 

--- a/tests/NLog.UnitTests/Targets/Wrappers/SplitGroupTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/SplitGroupTargetTests.cs
@@ -31,12 +31,11 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.Linq;
-
 namespace NLog.UnitTests.Targets.Wrappers
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using NLog.Common;
     using NLog.Targets;
@@ -46,109 +45,74 @@ namespace NLog.UnitTests.Targets.Wrappers
     public class SplitGroupTargetTests : NLogTestBase
     {
         [Fact]
-        public void SplitGroupSyncTest1()
+        public void NoTargets_SplitGroupTarget_IsWorking()
         {
-            SplitGroupSyncTest1inner(false);
+            SplitGroupTarget_Exercise(new MyTarget[] { });
         }
 
         [Fact]
-        public void SplitGroupSyncTest1_allEventsAtOnce()
+        public void SingleTarget_SplitGroupTarget_IsWorking()
         {
-            SplitGroupSyncTest1inner(true);
+            SplitGroupTarget_Exercise(new []{ new MyTarget() });
         }
 
-        private static void SplitGroupSyncTest1inner(bool allEventsAtOnce)
+        [Fact]
+        public void MultipleTargets_SplitGroupTarget_IsWorking()
         {
-            var myTarget1 = new MyTarget();
-            var myTarget2 = new MyTarget();
-            var myTarget3 = new MyTarget();
+            SplitGroupTarget_Exercise(new[] { new MyTarget(), new MyTarget(), new MyTarget() });
+        }
 
-            var wrapper = new SplitGroupTarget()
+        [Fact]
+        public void FirstTargetFails_SplitGroupTarget_WritesToAll()
+        {
+            using (new NoThrowNLogExceptions())
             {
-                Targets = { myTarget1, myTarget2, myTarget3 },
-            };
+                int logEventFailCount = 2;
+                var failingTarget = new MyTarget() { FailCounter = logEventFailCount };
+                SplitGroupTarget_Exercise(new[] { failingTarget, new MyTarget(), new MyTarget() }, logEventFailCount);
+            }
+        }
 
-            myTarget1.Initialize(null);
-            myTarget2.Initialize(null);
-            myTarget3.Initialize(null);
+        [Fact]
+        public void AsyncOutOfOrder_SplitGroupTarget_IsWorking()
+        {
+            var targets = Enumerable.Range(0, 3).Select(i => new AsyncTargetWrapper(i.ToString(), new MyTarget()) { TimeToSleepBetweenBatches = i * 10 }).ToArray();
+            targets.ToList().ForEach(t => t.WrappedTarget.Initialize(null));
+            Func<Target, MyTarget> lookupTarget = t => (MyTarget)((AsyncTargetWrapper)t).WrappedTarget;
+            SplitGroupTarget_Exercise(targets, 0, lookupTarget);
+        }
+
+        private static void SplitGroupTarget_Exercise(Target[] targets, int logEventFailCount = 0, Func<Target, MyTarget> lookupTarget = null)
+        {
+            // Arrange
+            var wrapper = new SplitGroupTarget(targets);
+            foreach (var target in targets)
+                target.Initialize(null);
             wrapper.Initialize(null);
-
             List<Exception> exceptions = new List<Exception>();
+            var flushComplete = new ManualResetEvent(false);
+            lookupTarget = lookupTarget ?? new Func<Target, MyTarget>(t => (MyTarget)t);
+            const int LogEventBatchSize = 2;
+            const int LogEventWriteCount = LogEventBatchSize + 2;
 
-            var inputEvents = new List<LogEventInfo>();
-            for (int i = 0; i < 10; ++i)
+            // Act
+            wrapper.WriteAsyncLogEvent(LogEventInfo.Create(LogLevel.Info, "", null, 1).WithContinuation(exceptions.Add));
+            wrapper.WriteAsyncLogEvents(new[] { LogEventInfo.Create(LogLevel.Info, "", null, 2).WithContinuation(exceptions.Add) });
+            wrapper.WriteAsyncLogEvents(Enumerable.Range(3, LogEventBatchSize).Select(i => LogEventInfo.Create(LogLevel.Info, "", null, i).WithContinuation(exceptions.Add)).ToArray());
+            wrapper.Flush(ex => { exceptions.Add(ex); flushComplete.Set(); });
+            flushComplete.WaitOne(5000);
+
+            // Assert
+            Assert.Equal(LogEventWriteCount + 1, exceptions.Count); // +1 because of flush
+            Assert.Equal(LogEventWriteCount + 1 - logEventFailCount, exceptions.Count(ex => ex == null));
+            foreach (var target in targets)
             {
-                inputEvents.Add(LogEventInfo.CreateNullEvent());
+                var myTarget = lookupTarget(target);
+                Assert.Equal(LogEventWriteCount, myTarget.WrittenEvents.Count);
+                Assert.Equal(1, myTarget.FlushCount);
+                Assert.Equal(myTarget.WrittenEvents, myTarget.WrittenEvents.OrderBy(l => l.FormattedMessage).ToList());
             }
-
-            int remaining = inputEvents.Count;
-            var allDone = new ManualResetEvent(false);
-
-            // no exceptions
-
-            AsyncContinuation asyncContinuation = ex =>
-            {
-                lock (exceptions)
-                {
-                    exceptions.Add(ex);
-                    if (Interlocked.Decrement(ref remaining) == 0)
-                    {
-                        allDone.Set();
-                    }
-                }
-                      ;
-            };
-
-            if (allEventsAtOnce)
-            {
-                wrapper.WriteAsyncLogEvents(inputEvents.Select(ev => ev.WithContinuation(asyncContinuation)).ToArray());
-            }
-            else
-            {
-                for (int i = 0; i < inputEvents.Count; ++i)
-                {
-                    wrapper.WriteAsyncLogEvent(inputEvents[i].WithContinuation(asyncContinuation));
-                }
-            }
-
-            allDone.WaitOne();
-
-            Assert.Equal(inputEvents.Count, exceptions.Count);
-            foreach (var e in exceptions)
-            {
-                Assert.Null(e);
-            }
-
-            Assert.Equal(inputEvents.Count, myTarget1.WriteCount);
-            Assert.Equal(inputEvents.Count, myTarget2.WriteCount);
-            Assert.Equal(inputEvents.Count, myTarget3.WriteCount);
-
-            for (int i = 0; i < inputEvents.Count; ++i)
-            {
-                Assert.Same(inputEvents[i], myTarget1.WrittenEvents[i]);
-                Assert.Same(inputEvents[i], myTarget2.WrittenEvents[i]);
-                Assert.Same(inputEvents[i], myTarget3.WrittenEvents[i]);
-            }
-
-            Exception flushException = null;
-            var flushHit = new ManualResetEvent(false);
-            wrapper.Flush(ex =>
-            {
-                flushException = ex;
-                flushHit.Set();
-            });
-
-            flushHit.WaitOne();
-            if (flushException != null)
-            {
-                Assert.True(false, flushException.ToString());
-            }
-
-            Assert.Equal(1, myTarget1.FlushCount);
-            Assert.Equal(1, myTarget2.FlushCount);
-            Assert.Equal(1, myTarget3.FlushCount);
         }
-
 
         [Fact]
         public void SplitGroupToStringTest()
@@ -163,88 +127,6 @@ namespace NLog.UnitTests.Targets.Wrappers
             };
 
             Assert.Equal("SplitGroup Target[(unnamed)](MyTarget, File Target[file1], Console Target[Console2])", wrapper.ToString());
-        }
-
-        [Fact]
-        public void SplitGroupSyncTest2()
-        {
-            var wrapper = new SplitGroupTarget()
-            {
-                // no targets
-            };
-
-            wrapper.Initialize(null);
-
-            List<Exception> exceptions = new List<Exception>();
-
-            // no exceptions
-            for (int i = 0; i < 10; ++i)
-            {
-                wrapper.WriteAsyncLogEvent(LogEventInfo.CreateNullEvent().WithContinuation(exceptions.Add));
-            }
-
-            Assert.Equal(10, exceptions.Count);
-            foreach (var e in exceptions)
-            {
-                Assert.Null(e);
-            }
-
-            Exception flushException = new Exception("Flush not hit synchronously.");
-            wrapper.Flush(ex => flushException = ex);
-
-            if (flushException != null)
-            {
-                Assert.True(false, flushException.ToString());
-            }
-        }
-
-        public class MyAsyncTarget : Target
-        {
-            public int FlushCount { get; private set; }
-            public int WriteCount { get; private set; }
-
-            public MyAsyncTarget() : base()
-            {
-            }
-
-            public MyAsyncTarget(string name) : this()
-            {
-                Name = name;
-            }
-
-            protected override void Write(LogEventInfo logEvent)
-            {
-                throw new NotSupportedException();
-            }
-
-            protected override void Write(AsyncLogEventInfo logEvent)
-            {
-                Assert.True(FlushCount <= WriteCount);
-                WriteCount++;
-                ThreadPool.QueueUserWorkItem(
-                    s =>
-                        {
-                            if (ThrowExceptions)
-                            {
-                                logEvent.Continuation(new InvalidOperationException("Some problem!"));
-                                logEvent.Continuation(new InvalidOperationException("Some problem!"));
-                            }
-                            else
-                            {
-                                logEvent.Continuation(null);
-                                logEvent.Continuation(null);
-                            }
-                        });
-            }
-
-            protected override void FlushAsync(AsyncContinuation asyncContinuation)
-            {
-                FlushCount++;
-                ThreadPool.QueueUserWorkItem(
-                    s => asyncContinuation(null));
-            }
-
-            public bool ThrowExceptions { get; set; }
         }
 
         public class MyTarget : Target
@@ -262,12 +144,12 @@ namespace NLog.UnitTests.Targets.Wrappers
             public int FlushCount { get; set; }
             public int WriteCount { get; set; }
             public int FailCounter { get; set; }
-            public List<LogEventInfo> WrittenEvents { get; private set; }
+            public List<LogEventInfo> WrittenEvents { get; }
 
             protected override void Write(LogEventInfo logEvent)
             {
                 Assert.True(FlushCount <= WriteCount);
-                lock (this)
+                lock (WrittenEvents)
                 {
                     WriteCount++;
                     WrittenEvents.Add(logEvent);
@@ -276,7 +158,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 if (FailCounter > 0)
                 {
                     FailCounter--;
-                    throw new InvalidOperationException("Some failure.");
+                    throw new ApplicationException("Some failure.");
                 }
             }
 


### PR DESCRIPTION
The following bugs has been fixed:
- Writing a single LogEvent will not skip remaining targets, if first target fails with exception (Funny observation is that if writing a batch of LogEvents then it behaved correctly)
- Writing a batch of LogEvents without any configured targets should still ensure to call async continuation (Funny observation is that if writing a single LogEvent then it behaved correctly).

Have updated unit-tests to verify that both scenarios are working for single LogEvent and batch of LogEvents.

Have added minor optimization when writing batch with only a single LogEvent, then it skips array-allocation for each target destination.

Could consider marking `AsyncHelpers.ForEachItemSequentially` as obsolete, since no longer used.