### PR TITLE
NLog.LogManager.Setup() - Introduced LoadConfiguration and friends for ISetupBuilder

### DIFF
--- a/src/NLog/Config/ISetupLoadConfigurationBuilder.cs
+++ b/src/NLog/Config/ISetupLoadConfigurationBuilder.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -33,34 +33,19 @@
 
 namespace NLog.Config
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <summary>
-    /// Interface for loading NLog <see cref="LoggingConfiguration"/>
+    /// Interface for fluent setup of LogFactory options
     /// </summary>
-    internal interface ILoggingConfigurationLoader : IDisposable
+    public interface ISetupLoadConfigurationBuilder
     {
         /// <summary>
-        /// Finds and loads the NLog configuration
+        /// LogFactory under configuration
         /// </summary>
-        /// <param name="logFactory">LogFactory that owns the NLog configuration</param>
-        /// <param name="filename">Name of NLog.config file (optional)</param>
-        /// <returns>NLog configuration (or null if none found)</returns>
-        LoggingConfiguration Load(LogFactory logFactory, string filename = null);
+        LogFactory LogFactory { get; }
 
         /// <summary>
-        /// Notifies when LoggingConfiguration has been successfully applied
+        /// LoggingConfiguration being built
         /// </summary>
-        /// <param name="logFactory">LogFactory that owns the NLog configuration</param>
-        /// <param name="config">NLog Config</param>
-        void Activated(LogFactory logFactory, LoggingConfiguration config);
-
-        /// <summary>
-        /// Get file paths (including filename) for the possible NLog config files. 
-        /// </summary>
-        /// <param name="filename">Name of NLog.config file (optional)</param>
-        /// <returns>The file paths to the possible config file</returns>
-        IEnumerable<string> GetDefaultCandidateConfigFilePaths(string filename = null);
+        LoggingConfiguration Configuration { get; set; }
     }
 }

--- a/src/NLog/Config/LoggingConfigurationWatchableFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationWatchableFileLoader.cs
@@ -54,15 +54,18 @@ namespace NLog.Config
         private bool _isDisposing;
         private LogFactory _logFactory;
 
-        public override LoggingConfiguration Load(LogFactory logFactory)
+        public override LoggingConfiguration Load(LogFactory logFactory, string filename = null)
         {
 #if !NETSTANDARD
-            var config = TryLoadFromAppConfig();
-            if (config != null)
-                return config;
+            if (string.IsNullOrEmpty(filename))
+            {
+                var config = TryLoadFromAppConfig();
+                if (config != null)
+                    return config;
+            }
 #endif
 
-            return base.Load(logFactory);
+            return base.Load(logFactory, filename);
         }
 
         public override void Activated(LogFactory logFactory, LoggingConfiguration config)

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -174,7 +174,6 @@ namespace NLog.Config
             Initialize(reader, fileName, ignoreErrors);
         }
 
-#if !SILVERLIGHT
         /// <summary>
         /// Initializes a new instance of the <see cref="XmlLoggingConfiguration" /> class.
         /// </summary>
@@ -196,13 +195,21 @@ namespace NLog.Config
         /// <summary>
         /// Parse XML string as NLog configuration
         /// </summary>
-        /// <param name="xml">NLog configuration</param>
-        /// <returns></returns>
+        /// <param name="xml">NLog configuration in XML to be parsed</param>
         public static XmlLoggingConfiguration CreateFromXmlString(string xml)
         {
-            return new XmlLoggingConfiguration(xml, string.Empty, LogManager.LogFactory);
+            return CreateFromXmlString(xml, LogManager.LogFactory);
         }
-#endif
+
+        /// <summary>
+        /// Parse XML string as NLog configuration
+        /// </summary>
+        /// <param name="xml">NLog configuration in XML to be parsed</param>
+        /// <param name="logFactory">NLog LogFactory</param>
+        public static XmlLoggingConfiguration CreateFromXmlString(string xml, LogFactory logFactory)
+        {
+            return new XmlLoggingConfiguration(xml, string.Empty, logFactory);
+        }
 
 #if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD
         /// <summary>
@@ -594,7 +601,6 @@ namespace NLog.Config
 
         private static string GetFileLookupKey([NotNull] string fileName)
         {
-
 #if SILVERLIGHT && !WINDOWS_PHONE
             // file names are relative to XAP
             return fileName;

--- a/src/NLog/Internal/SetupLoadConfigurationBuilder.cs
+++ b/src/NLog/Internal/SetupLoadConfigurationBuilder.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,36 +31,26 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.Config
+namespace NLog.Internal
 {
-    using System;
-    using System.Collections.Generic;
+    using NLog.Config;
 
-    /// <summary>
-    /// Interface for loading NLog <see cref="LoggingConfiguration"/>
-    /// </summary>
-    internal interface ILoggingConfigurationLoader : IDisposable
+    internal class SetupLoadConfigurationBuilder : ISetupLoadConfigurationBuilder
     {
-        /// <summary>
-        /// Finds and loads the NLog configuration
-        /// </summary>
-        /// <param name="logFactory">LogFactory that owns the NLog configuration</param>
-        /// <param name="filename">Name of NLog.config file (optional)</param>
-        /// <returns>NLog configuration (or null if none found)</returns>
-        LoggingConfiguration Load(LogFactory logFactory, string filename = null);
+        internal SetupLoadConfigurationBuilder(LogFactory logFactory, LoggingConfiguration configuration)
+        {
+            LogFactory = logFactory;
+            Configuration = configuration;
+        }
 
-        /// <summary>
-        /// Notifies when LoggingConfiguration has been successfully applied
-        /// </summary>
-        /// <param name="logFactory">LogFactory that owns the NLog configuration</param>
-        /// <param name="config">NLog Config</param>
-        void Activated(LogFactory logFactory, LoggingConfiguration config);
+        public LogFactory LogFactory { get; }
 
-        /// <summary>
-        /// Get file paths (including filename) for the possible NLog config files. 
-        /// </summary>
-        /// <param name="filename">Name of NLog.config file (optional)</param>
-        /// <returns>The file paths to the possible config file</returns>
-        IEnumerable<string> GetDefaultCandidateConfigFilePaths(string filename = null);
+        public LoggingConfiguration Configuration
+        {
+            get => _configuration ?? (_configuration = new LoggingConfiguration(LogFactory));
+            set => _configuration = value;
+        }
+
+        internal LoggingConfiguration _configuration;
     }
 }

--- a/src/NLog/SetupBuilderExtensions.cs
+++ b/src/NLog/SetupBuilderExtensions.cs
@@ -86,5 +86,55 @@ namespace NLog
             serializationBuilder(new SetupSerializationBuilder(setupBuilder.LogFactory));
             return setupBuilder;
         }
+
+        /// <summary>
+        /// Loads NLog config created by the method <paramref name="configBuilder"/>
+        /// </summary>
+        public static ISetupBuilder LoadConfiguration(this ISetupBuilder setupBuilder, Action<ISetupLoadConfigurationBuilder> configBuilder)
+        {
+            var config = setupBuilder.LogFactory._config;
+            var setupConfig = new SetupLoadConfigurationBuilder(setupBuilder.LogFactory, config);
+            configBuilder(setupConfig);
+            var newConfig = setupConfig._configuration;
+            bool configHasChanged = !ReferenceEquals(config, setupBuilder.LogFactory._config);
+
+            if (ReferenceEquals(newConfig, setupBuilder.LogFactory._config))
+            {
+                setupBuilder.LogFactory.ReconfigExistingLoggers();
+            }
+            else if (!configHasChanged || !ReferenceEquals(config, newConfig))
+            {
+                setupBuilder.LogFactory.Configuration = newConfig;
+            }
+
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Loads NLog config provided in <paramref name="loggingConfiguration"/>
+        /// </summary>
+        public static ISetupBuilder LoadConfiguration(this ISetupBuilder setupBuilder, LoggingConfiguration loggingConfiguration)
+        {
+            setupBuilder.LogFactory.Configuration = loggingConfiguration;
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Loads NLog config from filename <paramref name="configFile"/> if provided, else fallback to scanning for NLog.config
+        /// </summary>
+        public static ISetupBuilder LoadConfigurationFromFile(this ISetupBuilder setupBuilder, string configFile = null, bool optional = true)
+        {
+            setupBuilder.LogFactory.LoadConfiguration(configFile, optional);
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Loads NLog config from XML in <paramref name="configXml"/>
+        /// </summary>
+        public static ISetupBuilder LoadConfigurationFromXml(this ISetupBuilder setupBuilder, string configXml)
+        {
+            setupBuilder.LogFactory.Configuration = XmlLoggingConfiguration.CreateFromXmlString(configXml, setupBuilder.LogFactory);
+            return setupBuilder;
+        }
     }
 }

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -110,14 +110,15 @@ namespace NLog.UnitTests
         public void GetConfigFile_absolutePath_loads(string filename, string accepts, string expected, string baseDir)
         {
             // Arrange
-            var appEnvMock = new AppEnvironmentMock(f => f == accepts, f => null) { AppDomainBaseDirectory = baseDir };
+            var appEnvMock = new AppEnvironmentMock(f => f == accepts, f => System.Xml.XmlReader.Create(new StringReader(@"<nlog autoreload=""true""></nlog>"))) { AppDomainBaseDirectory = baseDir };
             var fileLoader = new LoggingConfigurationFileLoader(appEnvMock);
+            var logFactory = new LogFactory(fileLoader);
 
             // Act
-            var result = fileLoader.GetConfigFile(filename);
+            var result = fileLoader.Load(logFactory, filename);
 
             // Assert
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, result?.FileNamesToWatch.First());
         }
 
         public static IEnumerable<object[]> GetConfigFile_absolutePath_loads_testData()
@@ -127,7 +128,7 @@ namespace NLog.UnitTests
             var dirInBaseDir = $"{baseDir}dir1";
             yield return new object[] { $"{baseDir}configfile", $"{baseDir}configfile", $"{baseDir}configfile", dirInBaseDir };
             yield return new object[] { "nlog.config", $"{baseDir}dir1{d}nlog.config", $"{baseDir}dir1{d}nlog.config", dirInBaseDir }; //exists
-            yield return new object[] { "nlog.config", $"{baseDir}dir1{d}nlog2.config", "nlog.config", dirInBaseDir }; //not existing, fallback
+            yield return new object[] { "nlog.config", $"{baseDir}dir1{d}nlog2.config", null, dirInBaseDir }; //not existing, fallback
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -155,7 +155,7 @@ namespace NLog.UnitTests
                     var ex = Record.Exception(() => logFactory.LoadConfiguration(configFile));
 
                     // Assert
-                    Assert.IsType<IOException>(ex);
+                    Assert.IsType<FileNotFoundException>(ex);
                 }
 
                 // Assert


### PR DESCRIPTION
Very small dive into the idea of fluent-api for setup of NLog-LoggingConfiguration:

```c#
LogManager.Setup().LoadConfigurationFromFile();
```

```c#
LogManager.Setup().LoadConfigurationFromFile("NLog.config", optional: false);
```

```c#
LogManager.Setup().LoadConfigurationFromXml("<nlog></nlog>");
```

```c#
LogManager.Setup().LoadConfiguration(nlogConfig);
```

```c#
LogManager.Setup().LoadConfiguration(builder => 
  // Targets where to log to: File and Console
  var logfile = new NLog.Targets.FileTarget("logfile") { FileName = "file.txt" };
  var logconsole = new NLog.Targets.ConsoleTarget("logconsole");
            
  // Rules for mapping loggers to targets            
  builder.Configuration.AddRule(LogLevel.Info, LogLevel.Fatal, logconsole);
  builder.Configuration.AddRule(LogLevel.Debug, LogLevel.Fatal, logfile);
);
```

This will match the PRs here:

https://github.com/NLog/NLog.Extensions.Logging/pull/418
https://github.com/NLog/NLog.Web/pull/540

This allows one to setup a fallback configuration, if no `NLog.config` file was found:

```c#
LogManager.Setup().LoadConfigurationFromFile().LoadConfiguration(builder =>{
  var config = builder.LogFactory.Configuration;
  if (config != null)
        return;   // Config already assigned and loaded

  // Targets where to log to: File and Console
  var logconsole = new NLog.Targets.ConsoleTarget("logconsole");
            
  // Rules for mapping loggers to targets            
  builder.Configuration.AddRule(LogLevel.Info, LogLevel.Fatal, logconsole);
}));
```

Or one can so this (Resolves almost #1429, but without `autoReload=true` support)

```c#
LogManager.Setup().LoadConfigurationFromFile().LoadConfiguration(builder => {
   // Dynamically adds the console-target after having loaded from NLog.config
   var consoleTarget = new ColoredConsoleTarget("console");
   builder.Configuration.AddRule(LogLevel.Info, LogLevel.Fatal, consoleTarget);
}));
```

One can also setup support for loading NLog.config first in Process-Directory (Before NLog5 is released)

```c#
var processDir = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
LogManager.Setup().
   LoadConfigurationFromFile(Path.Combine(processDir, "NLog.config"), optional: true).
   LoadConfigurationFromFile();  // Skips loading of default NLog.config if config already loaded
```