### PR TITLE
InternalLogger - Include FilePath when logging config is being initialized

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -602,5 +602,11 @@ namespace NLog.Config
             return Path.GetFullPath(fileName);
 #endif
         }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{base.ToString()}, FilePath={_originalFileName}";
+        }
     }
 }


### PR DESCRIPTION
Instead of writing:

> Found 28 configuration items

Then it will write:

> Validating config: TargetNames=f, c, ConfigItems=28, FilePath=C:\WindowsService\GasStationService\Nlog.config