### PR TITLE
MappedDiagnosticsLogicalContext - SetScoped with IReadOnlyList for Xamarin

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -586,7 +586,7 @@ namespace NLog.Config
             }
 #endif
 
-#if NET4_5 || NETSTANDARD
+#if !SILVERLIGHT && !NET3_5 && !NET4_0
             _layoutRenderers.RegisterNamedType("configsetting", "NLog.Extensions.Logging.ConfigSettingLayoutRenderer, NLog.Extensions.Logging");
 #endif
         }

--- a/src/NLog/Internal/ReflectionHelpers.cs
+++ b/src/NLog/Internal/ReflectionHelpers.cs
@@ -349,7 +349,7 @@ namespace NLog.Internal
 
         public static object GetPropertyValue(this PropertyInfo p, object instance)
         {
-#if NET45
+#if NET4_5
             return p.GetValue(instance);
 #else
             return p.GetGetMethod().Invoke(instance, null);

--- a/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AllEventPropertiesLayoutRenderer.cs
@@ -216,7 +216,7 @@ namespace NLog.LayoutRenderers
         private bool CheckForExclude(LogEventInfo logEvent)
         {
             bool checkForExclude = Exclude?.Count > 0;
-#if NET45
+#if NET4_5
             if (checkForExclude)
             {
                 // Skip Exclude check when only to exclude CallSiteInformation, and there is none

--- a/src/NLog/MappedDiagnosticsLogicalContext.cs
+++ b/src/NLog/MappedDiagnosticsLogicalContext.cs
@@ -38,7 +38,7 @@ namespace NLog
     using System;
     using System.Collections.Generic;
     using System.Threading;
-    using Internal;
+    using NLog.Internal;
 
     /// <summary>
     /// Async version of Mapped Diagnostics Context - a logical context structure that keeps a dictionary
@@ -54,7 +54,7 @@ namespace NLog
         private sealed class ItemRemover : IDisposable
         {
             private readonly string _item1;
-#if NET4_5
+#if !NET3_5 && !NET4_0
             // Optimized for HostingLogScope with 3 properties
             private readonly string _item2;
             private readonly string _item3;
@@ -70,7 +70,7 @@ namespace NLog
                 _wasEmpty = wasEmpty;
             }
 
-#if NET4_5
+#if !NET3_5 && !NET4_0
             public ItemRemover(IReadOnlyList<KeyValuePair<string,object>> items, bool wasEmpty)
             {
                 int itemCount = items.Count;
@@ -110,7 +110,7 @@ namespace NLog
 
                     var dictionary = GetLogicalThreadDictionary(true);
                     dictionary.Remove(_item1);
-#if NET4_5
+#if !NET3_5 && !NET4_0
                     if (_item2 != null)
                     {
                         dictionary.Remove(_item2);
@@ -131,7 +131,7 @@ namespace NLog
 
             private bool RemoveScopeWillClearContext()
             {
-#if NET4_5
+#if !NET3_5 && !NET4_0
                 if (_itemArray == null)
                 {
                     var immutableDict = GetLogicalThreadDictionary(false);
@@ -268,7 +268,7 @@ namespace NLog
             return new ItemRemover(item, wasEmpty);
         }
 
-#if NET4_5
+#if !NET3_5 && !NET4_0
         /// <summary>
         /// Updates the current logical context with multiple items in single operation
         /// </summary>


### PR DESCRIPTION
Curious if a workaround can be made for: https://github.com/NLog/NLog.Extensions.Logging/issues/415

For some "strange" reason then even if using NetCore / NetStandard on Xamarin, then it insists on using the Xamarin-builds instead of the NetStandard-build (But only when using the linker)