### PR TITLE
LogEventInfo - PropertiesDictionary should not clone internal generated param list

### DIFF
--- a/src/NLog/Internal/PropertiesDictionary.cs
+++ b/src/NLog/Internal/PropertiesDictionary.cs
@@ -88,12 +88,9 @@ namespace NLog.Internal
         /// <param name="parameterList">Message-template-parameters</param>
         public PropertiesDictionary(IList<MessageTemplateParameter> parameterList = null)
         {
-            if (parameterList != null && parameterList.Count > 0)
+            if (parameterList?.Count > 0)
             {
-                var messageProperties = new MessageTemplateParameter[parameterList.Count];
-                for (int i = 0; i < parameterList.Count; ++i)
-                    messageProperties[i] = parameterList[i];
-                MessageProperties = messageProperties;
+                MessageProperties = parameterList;
             }
         }
 

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -108,9 +108,12 @@ namespace NLog
         public LogEventInfo(LogLevel level, string loggerName, [Localizable(false)] string message, IList<MessageTemplateParameter> messageTemplateParameters)
             : this(level, loggerName, null, message, null, null)
         {
-            if (messageTemplateParameters != null && messageTemplateParameters.Count > 0)
+            if (messageTemplateParameters?.Count > 0)
             {
-                _properties = new PropertiesDictionary(messageTemplateParameters);
+                var messageProperties = new MessageTemplateParameter[messageTemplateParameters.Count];
+                for (int i = 0; i < messageTemplateParameters.Count; ++i)
+                    messageProperties[i] = messageTemplateParameters[i];
+                _properties = new PropertiesDictionary(messageProperties);
             }
         }
 


### PR DESCRIPTION
Should only protect itself from message-parameter-lists received as input-parameter (Ex. from NLog.Extensions.Logging)

The message-parameter-list received from NLog own internal parser is safe to store directly.