### PR TITLE
Layout - Object scanning should only check class-attributes for LayoutRenderers

### DIFF
--- a/src/NLog/Conditions/ConditionExpression.cs
+++ b/src/NLog/Conditions/ConditionExpression.cs
@@ -31,20 +31,17 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using NLog.Common;
-
 namespace NLog.Conditions
 {
     using System;
-    using Config;
-    using Internal;
+    using NLog.Common;
+    using NLog.Config;
+    using NLog.Internal;
 
     /// <summary>
     /// Base class for representing nodes in condition expression trees.
     /// </summary>
     [NLogConfigurationItem]
-    [ThreadAgnostic]
-    [ThreadSafe]
     public abstract class ConditionExpression
     {
         /// <summary>

--- a/src/NLog/Layouts/CsvColumn.cs
+++ b/src/NLog/Layouts/CsvColumn.cs
@@ -39,8 +39,6 @@ namespace NLog.Layouts
     /// A column in the CSV.
     /// </summary>
     [NLogConfigurationItem]
-    [ThreadAgnostic]
-    [ThreadSafe]
     public class CsvColumn 
     {
         /// <summary>

--- a/src/NLog/Layouts/JsonAttribute.cs
+++ b/src/NLog/Layouts/JsonAttribute.cs
@@ -40,9 +40,6 @@ namespace NLog.Layouts
     /// JSON attribute.
     /// </summary>
     [NLogConfigurationItem]
-    [ThreadAgnostic]
-    [ThreadSafe]
-    [AppDomainFixedOutput]
     public class JsonAttribute
     {
         /// <summary>

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -336,7 +336,7 @@ namespace NLog.Layouts
 
         internal void PerformObjectScanning()
         {
-            var objectGraphScannerList = ObjectGraphScanner.FindReachableObjects<object>(true, this);
+            var objectGraphScannerList = ObjectGraphScanner.FindReachableObjects<IRenderable>(true, this);
             var objectGraphTypes = new HashSet<Type>(objectGraphScannerList.Select(o => o.GetType()));
             objectGraphTypes.Remove(typeof(SimpleLayout));
             objectGraphTypes.Remove(typeof(NLog.LayoutRenderers.LiteralLayoutRenderer));

--- a/src/NLog/Layouts/XmlAttribute.cs
+++ b/src/NLog/Layouts/XmlAttribute.cs
@@ -41,9 +41,6 @@ namespace NLog.Layouts
     /// XML attribute.
     /// </summary>
     [NLogConfigurationItem]
-    [AppDomainFixedOutput]
-    [ThreadAgnostic]
-    [ThreadSafe]
     public class XmlAttribute
     {
         /// <summary>

--- a/src/NLog/Layouts/XmlElement.cs
+++ b/src/NLog/Layouts/XmlElement.cs
@@ -40,9 +40,6 @@ namespace NLog.Layouts
     /// A XML Element
     /// </summary>
     [NLogConfigurationItem]
-    [AppDomainFixedOutput]
-    [ThreadAgnostic]
-    [ThreadSafe]
     public class XmlElement : XmlElementBase
     {
         private const string DefaultElementName = "item";

--- a/src/NLog/Targets/NLogViewerParameterInfo.cs
+++ b/src/NLog/Targets/NLogViewerParameterInfo.cs
@@ -33,16 +33,13 @@
 
 namespace NLog.Targets
 {
-    using Config;
-    using Layouts;
+    using NLog.Config;
+    using NLog.Layouts;
 
     /// <summary>
     /// Represents a parameter to a NLogViewer target.
     /// </summary>
     [NLogConfigurationItem]
-    [ThreadAgnostic]
-    [ThreadSafe]
-    [AppDomainFixedOutput]
     public class NLogViewerParameterInfo
     {
         /// <summary>

--- a/src/NLog/Targets/TargetPropertyWithContext.cs
+++ b/src/NLog/Targets/TargetPropertyWithContext.cs
@@ -42,7 +42,6 @@ namespace NLog.Targets
     /// Attribute details for <see cref="TargetWithContext"/> 
     /// </summary>
     [NLogConfigurationItem]
-    [ThreadAgnostic]
     public class TargetPropertyWithContext
     {
         /// <summary>


### PR DESCRIPTION
Only Layouts and LayoutRenderers are relevant. Should ignore NLogConfigurationItem-objects.

It is confusing for NLog users that they need to add additional special attributes to custom-classes marked with NLogConfigurationItem (When creating their own custom targets/layouts). If forgetting then NLog-Layout-engine will see everything as "unsafe".