### PR TITLE
ObjectReflectionCache - Skip reflection for Module objects

### DIFF
--- a/src/NLog/Internal/ObjectReflectionCache.cs
+++ b/src/NLog/Internal/ObjectReflectionCache.cs
@@ -195,6 +195,9 @@ namespace NLog.Internal
             if (typeof(Assembly).IsAssignableFrom(objectType))
                 return true;
 
+            if (typeof(Module).IsAssignableFrom(objectType))
+                return true;
+
             return false;
         }
 


### PR DESCRIPTION
They are "dangerous" like Assembly and MethodInfo