### PR TITLE
CaptureStackTrace=false to disable implicit callsite capture

### DIFF
--- a/src/NLog/Internal/CallSiteInformation.cs
+++ b/src/NLog/Internal/CallSiteInformation.cs
@@ -44,12 +44,23 @@ namespace NLog.Internal
         /// </summary>
         /// <param name="stackTrace">The stack trace.</param>
         /// <param name="userStackFrame">Index of the first user stack frame within the stack trace.</param>
-        /// <param name="userStackFrameLegacy">Index of the first user stack frame within the stack trace.</param>
-        public void SetStackTrace(StackTrace stackTrace, int userStackFrame, int? userStackFrameLegacy)
+        /// <param name="loggerType">Type of the logger or logger wrapper. This is still Logger if it's a subclass of Logger.</param>
+        public void SetStackTrace(StackTrace stackTrace, int? userStackFrame = null, Type loggerType = null)
         {
             StackTrace = stackTrace;
-            UserStackFrameNumber = userStackFrame;
-            UserStackFrameNumberLegacy = userStackFrameLegacy != userStackFrame ? userStackFrameLegacy : null;
+            if (!userStackFrame.HasValue && stackTrace != null)
+            {
+                var stackFrames = stackTrace.GetFrames();
+                var firstUserFrame = loggerType != null ? FindCallingMethodOnStackTrace(stackFrames, loggerType) : 0;
+                var firstLegacyUserFrame = firstUserFrame.HasValue ? SkipToUserStackFrameLegacy(stackFrames, firstUserFrame.Value) : firstUserFrame;
+                UserStackFrameNumber = firstUserFrame ?? 0;
+                UserStackFrameNumberLegacy = firstLegacyUserFrame != firstUserFrame ? firstLegacyUserFrame : null;
+            }
+            else
+            {
+                UserStackFrameNumber = userStackFrame ?? 0;
+                UserStackFrameNumberLegacy = null;
+            }
         }
 
         /// <summary>
@@ -161,5 +172,96 @@ namespace NLog.Internal
         public string CallerMemberName { get; private set; }
         public string CallerFilePath { get; private set; }
         public int? CallerLineNumber { get; private set; }
+
+        /// <summary>
+        ///  Finds first user stack frame in a stack trace
+        /// </summary>
+        /// <param name="stackFrames">The stack trace of the logging method invocation</param>
+        /// <param name="loggerType">Type of the logger or logger wrapper. This is still Logger if it's a subclass of Logger.</param>
+        /// <returns>Index of the first user stack frame or 0 if all stack frames are non-user</returns>
+        private static int? FindCallingMethodOnStackTrace(StackFrame[] stackFrames, Type loggerType)
+        {
+            if (stackFrames == null || stackFrames.Length == 0)
+                return null;
+
+            int? firstStackFrameAfterLogger = null;
+            int? firstUserStackFrame = null;
+            for (int i = 0; i < stackFrames.Length; ++i)
+            {
+                var stackFrame = stackFrames[i];
+                if (SkipAssembly(stackFrame))
+                    continue;
+
+                if (!firstUserStackFrame.HasValue)
+                    firstUserStackFrame = i;
+
+                if (IsLoggerType(stackFrame, loggerType))
+                {
+                    firstStackFrameAfterLogger = null;
+                    continue;
+                }
+
+                if (!firstStackFrameAfterLogger.HasValue)
+                    firstStackFrameAfterLogger = i;
+            }
+
+            return firstStackFrameAfterLogger ?? firstUserStackFrame;
+        }
+
+        /// <summary>
+        /// This is only done for legacy reason, as the correct method-name and line-number should be extracted from the MoveNext-StackFrame
+        /// </summary>
+        /// <param name="stackFrames">The stack trace of the logging method invocation</param>
+        /// <param name="firstUserStackFrame">Starting point for skipping async MoveNext-frames</param>
+        private static int SkipToUserStackFrameLegacy(StackFrame[] stackFrames, int firstUserStackFrame)
+        {
+#if NET4_5
+            for (int i = firstUserStackFrame; i < stackFrames.Length; ++i)
+            {
+                var stackFrame = stackFrames[i];
+                if (SkipAssembly(stackFrame))
+                    continue;
+
+                if (stackFrame.GetMethod()?.Name == "MoveNext" && stackFrames.Length > i)
+                {
+                    var nextStackFrame = stackFrames[i + 1];
+                    var declaringType = nextStackFrame.GetMethod()?.DeclaringType;
+                    if (declaringType?.Namespace == "System.Runtime.CompilerServices" || declaringType == typeof(System.Threading.ExecutionContext))
+                    {
+                        //async, search further
+                        continue;
+                    }
+                }
+
+                return i;
+            }
+#endif
+            return firstUserStackFrame;
+        }
+
+        /// <summary>
+        /// Assembly to skip?
+        /// </summary>
+        /// <param name="frame">Find assembly via this frame. </param>
+        /// <returns><c>true</c>, we should skip.</returns>
+        private static bool SkipAssembly(StackFrame frame)
+        {
+            var assembly = StackTraceUsageUtils.LookupAssemblyFromStackFrame(frame);
+            return assembly == null || LogManager.IsHiddenAssembly(assembly);
+        }
+
+        /// <summary>
+        /// Is this the type of the logger?
+        /// </summary>
+        /// <param name="frame">get type of this logger in this frame.</param>
+        /// <param name="loggerType">Type of the logger.</param>
+        /// <returns></returns>
+        private static bool IsLoggerType(StackFrame frame, Type loggerType)
+        {
+            var method = frame.GetMethod();
+            Type declaringType = method?.DeclaringType;
+            var isLoggerType = declaringType != null && (loggerType == declaringType || declaringType.IsSubclassOf(loggerType) || loggerType.IsAssignableFrom(declaringType));
+            return isLoggerType;
+        }
     }
 }

--- a/src/NLog/LayoutRenderers/CallSiteFileNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteFileNameLayoutRenderer.cs
@@ -61,11 +61,17 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(0)]
         public int SkipFrames { get; set; }
-        
+
+        /// <summary>
+        /// Logger should capture StackTrace, if it was not provided manually
+        /// </summary>
+        [DefaultValue(true)]
+        public bool CaptureStackTrace { get; set; } = true;
+
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsage.WithSource;
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => CaptureStackTrace ? StackTraceUsage.WithSource : StackTraceUsage.None;
 
         /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)

--- a/src/NLog/LayoutRenderers/CallSiteLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteLayoutRenderer.cs
@@ -123,12 +123,23 @@ namespace NLog.LayoutRenderers
 #endif
 
         /// <summary>
+        /// Logger should capture StackTrace, if it was not provided manually
+        /// </summary>
+        [DefaultValue(true)]
+        public bool CaptureStackTrace { get; set; } = true;
+
+        /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
         StackTraceUsage IUsesStackTrace.StackTraceUsage
         {
             get
             {
+                if (!CaptureStackTrace)
+                {
+                    return StackTraceUsage.None;
+                }
+
 #if !SILVERLIGHT
                 if (FileName)
                 {

--- a/src/NLog/LayoutRenderers/CallSiteLineNumberLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteLineNumberLayoutRenderer.cs
@@ -54,11 +54,17 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(0)]
         public int SkipFrames { get; set; }
-        
+
+        /// <summary>
+        /// Logger should capture StackTrace, if it was not provided manually
+        /// </summary>
+        [DefaultValue(true)]
+        public bool CaptureStackTrace { get; set; } = true;
+
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsage.WithSource;
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => CaptureStackTrace ? StackTraceUsage.WithSource : StackTraceUsage.None;
 
         /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)

--- a/src/NLog/LayoutRenderers/StackTraceLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/StackTraceLayoutRenderer.cs
@@ -86,10 +86,28 @@ namespace NLog.LayoutRenderers
         public string Separator { get; set; }
 
         /// <summary>
+        /// Logger should capture StackTrace, if it was not provided manually
+        /// </summary>
+        [DefaultValue(true)]
+        public bool CaptureStackTrace { get; set; } = true;
+
+        /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
         /// <value></value>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage => (Format == StackTraceFormat.Raw) ? StackTraceUsage.Max : StackTraceUsage.WithoutSource;
+        StackTraceUsage IUsesStackTrace.StackTraceUsage
+        {
+            get
+            {
+                if (!CaptureStackTrace)
+                    return StackTraceUsage.None;
+
+                if (Format == StackTraceFormat.Raw)
+                    return StackTraceUsage.Max;
+
+                return StackTraceUsage.WithoutSource;
+            }
+        }
 
         /// <summary>
         /// Renders the call site and appends it to the specified <see cref="StringBuilder" />.

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -545,10 +545,10 @@ namespace NLog
         /// Sets the stack trace for the event info.
         /// </summary>
         /// <param name="stackTrace">The stack trace.</param>
-        /// <param name="userStackFrame">Index of the first user stack frame within the stack trace.</param>
+        /// <param name="userStackFrame">Index of the first user stack frame within the stack trace (Negative means NLog should skip stackframes from System-assemblies).</param>
         public void SetStackTrace(StackTrace stackTrace, int userStackFrame)
         {
-            GetCallSiteInformationInternal().SetStackTrace(stackTrace, userStackFrame, null);
+            GetCallSiteInformationInternal().SetStackTrace(stackTrace, userStackFrame >= 0 ? userStackFrame : (int?)null);
         }
 
         /// <summary>

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -40,7 +40,6 @@ namespace NLog
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Reflection;
     using JetBrains.Annotations;
     using NLog.Common;
     using NLog.Config;
@@ -112,10 +111,8 @@ namespace NLog
 #else
                 var stackTrace = new StackTrace();
 #endif
-                var stackFrames = stackTrace.GetFrames();
-                int? firstUserFrame = FindCallingMethodOnStackTrace(stackFrames, loggerType);
-                int? firstLegacyUserFrame = firstUserFrame.HasValue ? SkipToUserStackFrameLegacy(stackFrames, firstUserFrame.Value) : (int?)null;
-                logEvent.GetCallSiteInformationInternal().SetStackTrace(stackTrace, firstUserFrame ?? 0, firstLegacyUserFrame);
+
+                logEvent.GetCallSiteInformationInternal().SetStackTrace(stackTrace, null, loggerType);
             }
             catch (Exception ex)
             {
@@ -126,97 +123,6 @@ namespace NLog
             }
         }
 #endif
-
-        /// <summary>
-        ///  Finds first user stack frame in a stack trace
-        /// </summary>
-        /// <param name="stackFrames">The stack trace of the logging method invocation</param>
-        /// <param name="loggerType">Type of the logger or logger wrapper. This is still Logger if it's a subclass of Logger.</param>
-        /// <returns>Index of the first user stack frame or 0 if all stack frames are non-user</returns>
-        internal static int? FindCallingMethodOnStackTrace(StackFrame[] stackFrames, [NotNull] Type loggerType)
-        {
-            if (stackFrames == null || stackFrames.Length == 0)
-                return null;
-
-            int? firstStackFrameAfterLogger = null;
-            int? firstUserStackFrame = null;
-            for (int i = 0; i < stackFrames.Length; ++i)
-            {
-                var stackFrame = stackFrames[i];
-                if (SkipAssembly(stackFrame))
-                    continue;
-
-                if (!firstUserStackFrame.HasValue)
-                    firstUserStackFrame = i;
-
-                if (IsLoggerType(stackFrame, loggerType))
-                {
-                    firstStackFrameAfterLogger = null;
-                    continue;
-                }
-
-                if (!firstStackFrameAfterLogger.HasValue)
-                    firstStackFrameAfterLogger = i;
-            }
-
-            return firstStackFrameAfterLogger ?? firstUserStackFrame;
-        }
-
-        /// <summary>
-        /// This is only done for legacy reason, as the correct method-name and line-number should be extracted from the MoveNext-StackFrame
-        /// </summary>
-        /// <param name="stackFrames">The stack trace of the logging method invocation</param>
-        /// <param name="firstUserStackFrame">Starting point for skipping async MoveNext-frames</param>
-        internal static int SkipToUserStackFrameLegacy(StackFrame[] stackFrames, int firstUserStackFrame)
-        {
-#if NET4_5
-            for (int i = firstUserStackFrame; i < stackFrames.Length; ++i)
-            {
-                var stackFrame = stackFrames[i];
-                if (SkipAssembly(stackFrame))
-                    continue;
-
-                if (stackFrame.GetMethod()?.Name == "MoveNext" && stackFrames.Length > i)
-                {
-                    var nextStackFrame = stackFrames[i + 1];
-                    var declaringType = nextStackFrame.GetMethod()?.DeclaringType;
-                    if (declaringType?.Namespace == "System.Runtime.CompilerServices" || declaringType == typeof(System.Threading.ExecutionContext))
-                    {
-                        //async, search further
-                        continue;
-                    }
-                }
-
-                return i;
-            }
-#endif
-            return firstUserStackFrame;
-        }
-
-        /// <summary>
-        /// Assembly to skip?
-        /// </summary>
-        /// <param name="frame">Find assembly via this frame. </param>
-        /// <returns><c>true</c>, we should skip.</returns>
-        private static bool SkipAssembly(StackFrame frame)
-        {
-            var assembly = StackTraceUsageUtils.LookupAssemblyFromStackFrame(frame);
-            return assembly == null || LogManager.IsHiddenAssembly(assembly);
-        }
-
-        /// <summary>
-        /// Is this the type of the logger?
-        /// </summary>
-        /// <param name="frame">get type of this logger in this frame.</param>
-        /// <param name="loggerType">Type of the logger.</param>
-        /// <returns></returns>
-        private static bool IsLoggerType(StackFrame frame, Type loggerType)
-        {
-            var method = frame.GetMethod();
-            Type declaringType = method?.DeclaringType;
-            var isLoggerType = declaringType != null && (loggerType == declaringType || declaringType.IsSubclassOf(loggerType) || loggerType.IsAssignableFrom(declaringType));
-            return isLoggerType;
-        }
 
         private static bool WriteToTargetWithFilterChain(Targets.Target target, FilterResult result, LogEventInfo logEvent, AsyncContinuation onException)
         {

--- a/tests/NLog.UnitTests/LayoutRenderers/StackTraceRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/StackTraceRendererTests.cs
@@ -56,6 +56,38 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
+        public void RenderStackTraceNoCaptureStackTrace()
+        {
+            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${message} ${stacktrace:captureStackTrace=false}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            RenderMe("I am:");
+            AssertDebugLastMessage("debug", "I am: ");
+        }
+
+        [Fact]
+        public void RenderStackTraceNoCaptureStackTraceWithStackTrace()
+        {
+            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${message} ${stacktrace:captureStackTrace=false}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            var logEvent = new LogEventInfo(LogLevel.Info, null, "I am:");
+            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true), 0);
+            LogManager.GetCurrentClassLogger().Log(logEvent);
+            AssertDebugLastMessageContains("debug", $" => {nameof(StackTraceRendererTests)}.{nameof(RenderStackTraceNoCaptureStackTraceWithStackTrace)}");
+        }
+
+        [Fact]
         public void RenderStackTrace_topframes()
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"


### PR DESCRIPTION
Added CaptureStackTrace-property to the following layoutrenderers:
- StackTraceLayoutRenderer
- CallSiteLayoutRenderer
- CallSiteFileNameLayoutRenderer
- CallSiteLineNumberLayoutRenderer

Resolves #3914 