### PR TITLE
ColoredConsoleTarget - Fix bug in handling of newlines without word-highlight

### DIFF
--- a/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
@@ -43,6 +43,14 @@ namespace NLog.UnitTests.Targets
 
     public class ColoredConsoleTargetTests : NLogTestBase
     {
+        [Fact]
+        public void RowHighLightNewLineTest()
+        {
+            var target = new ColoredConsoleTarget { Layout = "${logger} ${message}" };
+            AssertOutput(target, "Before\a\nAfter\a",
+    new string[] { "Before", "After" });
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]


### PR DESCRIPTION
Resolves #3917

Bug was introduced with #3018, because Ansi-coloring required extra handling for newlines.