### PR TITLE
BaseDirLayoutRenderer - Improve FixTempDir on Linux when TMPDIR is not set

### DIFF
--- a/src/NLog/Config/LoggingConfigurationFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationFileLoader.cs
@@ -444,9 +444,8 @@ namespace NLog.Config
             if (string.IsNullOrEmpty(processDirectory))
                 return false;
 
-            string tempFilePath = PathHelpers.TrimDirectorySeparators(appEnvironment.UserTempFilePath);
-            if (!string.IsNullOrEmpty(tempFilePath) && entryAssemblyLocation.StartsWith(tempFilePath, StringComparison.OrdinalIgnoreCase))
-                return true;   // Hack for .NET Core 3 - Single File Publish that unpacks Entry-Assembly into temp-folder, and process-directory is valid
+            if (PathHelpers.IsTempDir(entryAssemblyLocation, appEnvironment.UserTempFilePath))
+                return true;    // Hack for .NET Core 3 - Single File Publish that unpacks Entry-Assembly into temp-folder, and process-directory is valid
 
             return false;   // NetCore Application is not published and is possible being executed by dotnet-process
         }

--- a/src/NLog/Internal/PathHelpers.cs
+++ b/src/NLog/Internal/PathHelpers.cs
@@ -72,5 +72,24 @@ namespace NLog.Internal
         {
             return path?.TrimEnd(DirectorySeparatorChars) ?? string.Empty;
         }
+
+        public static bool IsTempDir(string directory, string tempDir)
+        {
+            tempDir = TrimDirectorySeparators(tempDir);
+            if (string.IsNullOrEmpty(directory) || string.IsNullOrEmpty(tempDir))
+                return false;
+
+            var fullpath = Path.GetFullPath(directory);
+            if (string.IsNullOrEmpty(fullpath))
+                return false;
+
+            if (fullpath.StartsWith(tempDir, System.StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (tempDir.StartsWith("/tmp") && directory.StartsWith("/var/tmp/"))
+                return true;    // Microsoft has made a funny joke on Linux. Path.GetTempPath() uses /tmp/ as fallback, but single-publish uses /var/tmp/ as first fallback
+
+            return false;
+        }
     }
 }

--- a/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
@@ -128,11 +128,11 @@ namespace NLog.LayoutRenderers
         {
             try
             {
-                var tempDir = PathHelpers.TrimDirectorySeparators(Path.GetTempPath());
-                if (!string.IsNullOrEmpty(tempDir) && Path.GetFullPath(baseDir).StartsWith(tempDir, StringComparison.OrdinalIgnoreCase))
+                var tempDir = Path.GetTempPath();
+                if (PathHelpers.IsTempDir(baseDir, tempDir))
                 {
                     var processDir = GetProcessDir();
-                    if (!string.IsNullOrEmpty(processDir) && !Path.GetFullPath(processDir).StartsWith(tempDir, StringComparison.OrdinalIgnoreCase))
+                    if (!string.IsNullOrEmpty(processDir) && !PathHelpers.IsTempDir(processDir, tempDir))
                     {
                         return processDir;
                     }

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -59,18 +59,9 @@ namespace NLog.UnitTests
         protected NLogTestBase()
         {
             //reset before every test
-            if (LogManager.Configuration != null)
-            {
-                //flush all events if needed.
-                LogManager.Configuration.Close();
-            }
+            LogManager.Configuration = null;    // Will close any existing config
+            LogManager.LogFactory.ResetCandidateConfigFilePath();
 
-            if (LogManager.LogFactory != null)
-            {
-                LogManager.LogFactory.ResetCandidateConfigFilePath();
-            }
-
-            LogManager.Configuration = null;
             InternalLogger.Reset();
             InternalLogger.LogLevel = LogLevel.Off;
             LogManager.ThrowExceptions = true;  // Ensure exceptions are thrown by default during unit-testing


### PR DESCRIPTION
See GetTempPath on Linux (Uses `/tmp/` as only fallback):

https://github.com/dotnet/coreclr/blob/6ba74dc2a7194f8d6c86c3aeab572a074ef645c8/src/mscorlib/shared/System/IO/Path.Unix.cs#L153

See single file publish on Linux (Uses `/var/tmp/` as first fallback):

https://github.com/dotnet/core-setup/blob/074c3bece80ca300e2f9d053b18748b6537d6f67/src/corehost/common/pal.unix.cpp#L306

Everything is great when TMPDIR is configured, but if not then fallback-paths doesn't match.

Resolves #3899