### PR TITLE
Added LogFactory.ConfigurationLoading for better reload event

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -68,6 +68,8 @@ namespace NLog.Config
         /// </summary>
         public LogFactory LogFactory { get; }
 
+        internal bool IsConfigActivated { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggingConfiguration" /> class.
         /// </summary>

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -68,6 +68,9 @@ namespace NLog.Config
         /// </summary>
         public LogFactory LogFactory { get; }
 
+        /// <summary>
+        /// Is this configuration activated (so assigned at least once to a logFactory in the past)
+        /// </summary>
         internal bool IsConfigurationActivated { get; set; }
 
         /// <summary>

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -68,7 +68,7 @@ namespace NLog.Config
         /// </summary>
         public LogFactory LogFactory { get; }
 
-        internal bool IsConfigActivated { get; set; }
+        internal bool IsConfigurationActivated { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggingConfiguration" /> class.

--- a/src/NLog/Config/LoggingConfigurationLoadingEventArgs.cs
+++ b/src/NLog/Config/LoggingConfigurationLoadingEventArgs.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -36,50 +36,34 @@ namespace NLog.Config
     using System;
 
     /// <summary>
-    /// Arguments for <see cref="LogFactory.ConfigurationChanged"/> events.
+    /// Arguments for <see cref="LogFactory.ConfigurationLoading"/> events.
     /// </summary>
-    public class LoggingConfigurationChangedEventArgs : EventArgs
+    public class LoggingConfigurationLoadingEventArgs : EventArgs
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="LoggingConfigurationChangedEventArgs" /> class.
+        /// Initializes a new instance of the <see cref="LoggingConfigurationLoadingEventArgs" /> class.
         /// </summary>
-        /// <param name="activatedConfiguration">The new configuration.</param>
-        /// <param name="deactivatedConfiguration">The old configuration.</param>
-        public LoggingConfigurationChangedEventArgs(LoggingConfiguration activatedConfiguration, LoggingConfiguration deactivatedConfiguration)
+        /// <param name="activatingConfiguration">The new configuration.</param>
+        /// <param name="deactivatingConfiguration">The old configuration.</param>
+        public LoggingConfigurationLoadingEventArgs(LoggingConfiguration activatingConfiguration, LoggingConfiguration deactivatingConfiguration)
         {
-            ActivatedConfiguration = activatedConfiguration;
-            DeactivatedConfiguration = deactivatedConfiguration;
+            ActivatingConfiguration = activatingConfiguration;
+            DeactivatingConfiguration = deactivatingConfiguration;
         }
 
         /// <summary>
         /// Gets the old configuration.
         /// </summary>
-        /// <value>The old configuration.</value>
-        public LoggingConfiguration DeactivatedConfiguration { get; private set; }
+        public LoggingConfiguration DeactivatingConfiguration { get; private set; }
 
         /// <summary>
         /// Gets the new configuration.
         /// </summary>
-        /// <value>The new configuration.</value>
-        public LoggingConfiguration ActivatedConfiguration { get; private set; }
+        public LoggingConfiguration ActivatingConfiguration { get; private set; }
 
         /// <summary>
-        /// The <see cref="ActivatedConfiguration"/> has been loaded for the first time
+        /// The <see cref="ActivatingConfiguration"/> is being loaded for the first time
         /// </summary>
         public bool IsNewConfiguration { get; internal set; }
-
-        /// <summary>
-        /// Gets the new configuration
-        /// </summary>
-        /// <value>The new configuration.</value>
-        [Obsolete("This option will be removed in NLog 5. Marked obsolete on NLog 4.5")]
-        public LoggingConfiguration OldConfiguration => ActivatedConfiguration;
-
-        /// <summary>
-        /// Gets the old configuration
-        /// </summary>
-        /// <value>The old configuration.</value>
-        [Obsolete("This option will be removed in NLog 5. Marked obsolete on NLog 4.5")]
-        public LoggingConfiguration NewConfiguration => DeactivatedConfiguration;
     }
 }

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -264,7 +264,7 @@ namespace NLog
                         oldConfig.Close();
                     }
 
-                    var isNewConfiguration = value?.IsConfigActivated == false;
+                    var isNewConfiguration = value?.IsConfigurationActivated == false;
 
                     _config = value;
                     if (_config == null)
@@ -276,7 +276,7 @@ namespace NLog
                     {
                         try
                         {
-                            _config.IsConfigActivated = true;
+                            _config.IsConfigurationActivated = true;
                             OnConfigurationLoading(new LoggingConfigurationLoadingEventArgs(value, oldConfig) { IsNewConfiguration = isNewConfiguration });
                             _configLoader.Activated(this, _config);
                             _config.Dump();

--- a/src/NLog/SetupBuilderExtensions.cs
+++ b/src/NLog/SetupBuilderExtensions.cs
@@ -105,7 +105,7 @@ namespace NLog
             else if (!configHasChanged || !ReferenceEquals(config, newConfig))
             {
                 if (newConfig != null)
-                    newConfig.IsConfigActivated = true;  // Prepare for applyOnReload, that triggers on IsNewConfiguration = true
+                    newConfig.IsConfigurationActivated = true;  // Prepare for applyOnReload, that triggers on IsNewConfiguration = true
                 setupBuilder.LogFactory.Configuration = newConfig;
             }
 

--- a/src/NLog/SetupBuilderExtensions.cs
+++ b/src/NLog/SetupBuilderExtensions.cs
@@ -104,6 +104,8 @@ namespace NLog
             }
             else if (!configHasChanged || !ReferenceEquals(config, newConfig))
             {
+                if (newConfig != null)
+                    newConfig.IsConfigActivated = true;  // Prepare for applyOnReload, that triggers on IsNewConfiguration = true
                 setupBuilder.LogFactory.Configuration = newConfig;
             }
 

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -238,7 +238,12 @@ namespace NLog.UnitTests
                 logFactory.Configuration = config;  // Will throw unless ConfigurationChanging is working
 
                 var logger = logFactory.GetCurrentClassLogger();
-                Assert.Throws<System.Reflection.TargetInvocationException>(() => logger.Info("Hello World"));
+                // Act
+                var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() => logger.Info("Hello World"));
+
+                // Assert
+                var innerEx = Assert.IsType<TestException>(ex.InnerException);
+                Assert.Equal("Best day ever", innerEx.Message);
             }
             finally
             {
@@ -246,10 +251,18 @@ namespace NLog.UnitTests
             }
         }
 
+        private class TestException : Exception
+        {
+            /// <inheritdoc />
+            public TestException(string message) : base(message)
+            {
+            }
+        }
+
 #pragma warning disable xUnit1013 //we need public methods here
         public static void MyCustomMethod()
         {
-            throw new System.Reflection.TargetInvocationException("Best day ever", null);
+            throw new TestException("Best day ever");
         }
 #pragma warning restore xUnit1013 // Public method should be marked as test
 


### PR DESCRIPTION
Allow #3929 to use `ConfigurationLoading` (Because `ConfigurationReloaded` only works for xml-config. And `ConfigurationReloaded` happens AFTER target initialization):

```c#
            if (applyOnReload)
            {
                setupBuilder.LogFactory.ConfigurationLoading += (sender, e) =>
                {
                    if (e.IsNewConfiguration)
                    {
                         setupBuilder.Configuration = e.ActivatedConfiguration;
                         setupBuilder.LoadConfiguration(false, configBuilder);
                    }
```

This will make it also work for MEL-NLogLoggingConfiguration.

Maybe mark `ConfigurationReloaded` as obsolete in NLog 5.0? (Since that event-handler only works for xml-config)