### PR TITLE
Shutdown should not block on exceptions from targets

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -257,7 +257,10 @@ namespace NLog
                         if (!FlushAllTargetsSync(oldConfig, DefaultFlushTimeout, ThrowExceptions))
                         {
                             var manualResetEvent = new ManualResetEvent(false);
-                            AsyncHelpers.ForEachItemInParallel(new[] { oldConfig }, ex => manualResetEvent.Set(), (old, cont) => { old.Close(); cont(null); });
+                            AsyncHelpers.ForEachItemInParallel(new[] { oldConfig },
+                                ex => manualResetEvent.Set(),
+                                (old, cont) => { old.Close(); cont(null); }
+                            );
                             if (!manualResetEvent.WaitOne(DefaultFlushTimeout))
                             {
                                 InternalLogger.Info("Timeout closing old configuration.");

--- a/tests/NLog.UnitTests/LayoutRenderers/IdentityTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/IdentityTests.cs
@@ -162,9 +162,6 @@ namespace NLog.UnitTests.LayoutRenderers
 
 
                     Assert.Equal("auth:CustomAuth:SOMEDOMAIN\\SomeUser", rendered);
-
-
-
                 }
                 finally
                 {


### PR DESCRIPTION
LogFactory Shutdown performs async close of configuration, when timeout on flush

Trying to resolve #3958 