### PR TITLE
Capture CallSite ClassName only when WithCallSiteClassName enabled

### DIFF
--- a/src/NLog/Config/StackTraceUsage.cs
+++ b/src/NLog/Config/StackTraceUsage.cs
@@ -64,6 +64,11 @@ namespace NLog.Config
         WithCallSite = 4,
 
         /// <summary>
+        /// Capture the class name for location of the call
+        /// </summary>
+        WithCallSiteClassName = 8,
+
+        /// <summary>
         /// Stack trace should be captured. This option won't add the filenames and linenumbers.
         /// </summary>
         [Obsolete("Replace with `WithStackTrace`. Will be removed in NLog 6")]
@@ -83,7 +88,7 @@ namespace NLog.Config
         /// <summary>
         /// Capture maximum amount of the stack trace information supported on the platform.
         /// </summary>
-        Max = WithoutSource,
+        Max = WithStackTrace,
 #endif
     }
 }

--- a/src/NLog/Internal/StackTraceUsageUtils.cs
+++ b/src/NLog/Internal/StackTraceUsageUtils.cs
@@ -48,14 +48,26 @@ namespace NLog.Internal
         private static readonly Assembly mscorlibAssembly = typeof(string).GetAssembly();
         private static readonly Assembly systemAssembly = typeof(Debug).GetAssembly();
 
-        public static StackTraceUsage GetStackTraceUsage(bool includeFileName, int skipFrames)
+        public static StackTraceUsage GetStackTraceUsage(bool includeFileName, int skipFrames, bool captureStackTrace)
         {
+            if (!captureStackTrace)
+            {
+                return StackTraceUsage.None;
+            }
+
+            if (skipFrames != 0)
+            {
+                return includeFileName ? StackTraceUsage.Max : StackTraceUsage.WithStackTrace;
+            }
+
 #if !SILVERLIGHT
             if (includeFileName)
-                return skipFrames == 0 ? (StackTraceUsage.WithCallSite | StackTraceUsage.WithFileNameAndLineNumber) : StackTraceUsage.WithSource;
-            else
+            {
+                return StackTraceUsage.WithCallSite | StackTraceUsage.WithFileNameAndLineNumber;
+            }
 #endif
-                return skipFrames == 0 ? StackTraceUsage.WithCallSite : StackTraceUsage.WithStackTrace;
+
+            return StackTraceUsage.WithCallSite;
         }
 
         public static int GetFrameCount(this StackTrace strackTrace)

--- a/src/NLog/Internal/TargetWithFilterChain.cs
+++ b/src/NLog/Internal/TargetWithFilterChain.cs
@@ -102,7 +102,7 @@ namespace NLog.Internal
 
         internal bool TryCallSiteClassNameOptimization(StackTraceUsage stackTraceUsage, LogEventInfo logEvent)
         {
-            if ((stackTraceUsage & (StackTraceUsage.WithCallSite | StackTraceUsage.WithStackTrace)) != StackTraceUsage.WithCallSite)
+            if ((stackTraceUsage & (StackTraceUsage.WithCallSiteClassName | StackTraceUsage.WithStackTrace)) != StackTraceUsage.WithCallSiteClassName)
                 return false;
 
             if (string.IsNullOrEmpty(logEvent.CallSiteInformation?.CallerFilePath))
@@ -119,11 +119,11 @@ namespace NLog.Internal
             if (logEvent.HasStackTrace)
                 return false;
 
-            if ((stackTraceUsage & (StackTraceUsage.WithCallSite | StackTraceUsage.WithStackTrace)) != StackTraceUsage.WithCallSite)
+            if ((stackTraceUsage & StackTraceUsage.WithStackTrace) != StackTraceUsage.None)
                 return true;
 
-            if (string.IsNullOrEmpty(logEvent.CallSiteInformation?.CallerMethodName) && string.IsNullOrEmpty(logEvent.CallSiteInformation?.CallerFilePath))
-                return true;   // We don't have enough CallSiteInformation
+            if ((stackTraceUsage & StackTraceUsage.WithCallSite) != StackTraceUsage.None && string.IsNullOrEmpty(logEvent.CallSiteInformation?.CallerMethodName) && string.IsNullOrEmpty(logEvent.CallSiteInformation?.CallerFilePath))
+                return true;    // We don't have enough CallSiteInformation
 
             return false;
         }

--- a/src/NLog/LayoutRenderers/CallSite/CallSiteFileNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSite/CallSiteFileNameLayoutRenderer.cs
@@ -71,7 +71,7 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage => CaptureStackTrace ? StackTraceUsageUtils.GetStackTraceUsage(true, SkipFrames) : StackTraceUsage.None;
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsageUtils.GetStackTraceUsage(true, SkipFrames, CaptureStackTrace);
 
         /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)

--- a/src/NLog/LayoutRenderers/CallSite/CallSiteLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSite/CallSiteLayoutRenderer.cs
@@ -134,18 +134,14 @@ namespace NLog.LayoutRenderers
         {
             get
             {
-                if (!CaptureStackTrace)
-                {
-                    return StackTraceUsage.None;
-                }
-
                 return StackTraceUsageUtils.GetStackTraceUsage(
 #if !SILVERLIGHT
                     FileName,
 #else
                     false,
 #endif
-                    SkipFrames);
+                    SkipFrames,
+                    CaptureStackTrace) | ((ClassName || IncludeNamespace) ? StackTraceUsage.WithCallSiteClassName : StackTraceUsage.None);
             }
         }
 

--- a/src/NLog/LayoutRenderers/CallSite/CallSiteLineNumberLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSite/CallSiteLineNumberLayoutRenderer.cs
@@ -64,7 +64,7 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage => CaptureStackTrace ? StackTraceUsageUtils.GetStackTraceUsage(true, SkipFrames) : StackTraceUsage.None;
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => StackTraceUsageUtils.GetStackTraceUsage(true, SkipFrames, CaptureStackTrace);
 
         /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -237,7 +237,7 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Gets the level of stack trace information required by the implementing class.
         /// </summary>
-        StackTraceUsage IUsesStackTrace.StackTraceUsage => (IncludeCallSite || IncludeSourceInfo) ? StackTraceUsageUtils.GetStackTraceUsage(IncludeSourceInfo, 0) : StackTraceUsage.None;
+        StackTraceUsage IUsesStackTrace.StackTraceUsage => (IncludeCallSite || IncludeSourceInfo) ? (StackTraceUsageUtils.GetStackTraceUsage(IncludeSourceInfo, 0, true) | StackTraceUsage.WithCallSiteClassName) : StackTraceUsage.None;
 
         internal IList<NLogViewerParameterInfo> Parameters { get; set; }
 

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -696,16 +696,12 @@ namespace NLog.Targets
                 {
                     if (IncludeCallSiteStackTrace)
                     {
-#if !SILVERLIGHT
-                        return StackTraceUsage.WithSource;
-#else
                         return StackTraceUsage.Max;
-#endif
                     }
 
                     if (IncludeCallSite)
                     {
-                        return StackTraceUsage.WithCallSite;
+                        return StackTraceUsage.WithCallSite | StackTraceUsage.WithCallSiteClassName;
                     }
                     return StackTraceUsage.None;
                 }


### PR DESCRIPTION
Extends #3431 to also support #3915 (CaptureStackTrace=false).

Making it possible to capture class-name for CallSite using CallerMember-Attributes alone, but only when available.

Minor optimization so it only attempts to capture class-name for CallSite, when explicitly requested (Similar to only capturing source-filename and source-linenumber for stacktrace).