### PR TITLE
FileTarget: set writing BOM initial to true for UTF-16 and UTF-32

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -450,7 +450,6 @@ namespace NLog.Targets
 
         private bool? _writeBom;
 
-
         /// <summary>
         /// Gets or sets a value indicating whether to write BOM (byte order mark) in created files.
         ///
@@ -2422,10 +2421,15 @@ namespace NLog.Targets
         private static bool InitialValueBom(Encoding encoding)
         {
             // Initial of true for UTF 16 and UTF 32
-            return encoding.CodePage == 1200 // UTF-16
-                   || encoding.CodePage == 1201 // UTF16-BE
-                   || encoding.CodePage == 12000 // UTF-32
-                   || encoding.CodePage == 12001; // UTF-32BE
+            const int utf16 = 1200;
+            const int utf16Be = 1201;
+            const int utf32 = 12000;
+            const int urf32Be = 12001;
+
+            return encoding.CodePage == utf16
+                   || encoding.CodePage == utf16Be
+                   || encoding.CodePage == utf32
+                   || encoding.CodePage == urf32Be;
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using NSubstitute.Core;
+
 namespace NLog.UnitTests.Targets
 {
     using System;
@@ -3924,6 +3926,25 @@ namespace NLog.UnitTests.Targets
         protected override Target WrapFileTarget(FileTarget target)
         {
             return target;
+        }
+
+        [Theory]
+        [InlineData("UTF-16", true)]
+        [InlineData("UTF-16BE", true)]
+        [InlineData("UTF-32", true)]
+        [InlineData("UTF-32BE", true)]
+        [InlineData("UTF-7", false)]
+        [InlineData("UTF-8", false)]
+        [InlineData("ASCII", false)]
+        public void TestInitialBomValue(string encodingName, bool expected)
+        {
+            var fileTarget = new FileTarget();
+
+            // Act
+            fileTarget.Encoding = Encoding.GetEncoding(encodingName);
+
+            // Assert
+            Assert.Equal(expected, fileTarget.WriteBom);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/NLog/NLog/issues/2533