### PR TITLE
Added new() contraint on LogFactory<T> and to GetLogger<T> / GetCurrentClassLogger<T>

### DIFF
--- a/src/NLog/LogFactory-T.cs
+++ b/src/NLog/LogFactory-T.cs
@@ -42,7 +42,7 @@ namespace NLog
     /// <remarks>Use this only when a custom Logger type is defined.</remarks>
     /// <typeparam name="T">The type of the logger to be returned. Must inherit from <see cref="Logger"/>.</typeparam>
     public class LogFactory<T> : LogFactory 
-        where T : Logger
+        where T : Logger, new()
     {
         /// <summary>
         /// Gets the logger with type <typeparamref name="T"/>.

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -455,7 +455,7 @@ namespace NLog
         /// <remarks>This is a slow-running method. 
         /// Make sure you're not doing this in a loop.</remarks>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public T GetCurrentClassLogger<T>() where T : Logger
+        public T GetCurrentClassLogger<T>() where T : Logger, new()
         {
 #if NETSTANDARD1_0
             var className = StackTraceUsageUtils.GetClassFullName();
@@ -509,7 +509,7 @@ namespace NLog
         /// <typeparam name="T">Type of the logger</typeparam>
         /// <returns>The logger reference with type <typeparamref name="T"/>. Multiple calls to <c>GetLogger</c> with the same argument 
         /// are not guaranteed to return the same logger reference.</returns>
-        public T GetLogger<T>(string name) where T : Logger
+        public T GetLogger<T>(string name) where T : Logger, new()
         {
             return (T)GetLoggerThreadSafe(name, typeof(T));
         }

--- a/tests/NLog.UnitTests/GetLoggerTests.cs
+++ b/tests/NLog.UnitTests/GetLoggerTests.cs
@@ -63,12 +63,10 @@ namespace NLog.UnitTests
             MyLogger l1 = (MyLogger)lf.GetLogger("AAA", typeof(MyLogger));
             MyLogger l2 = lf.GetLogger<MyLogger>("AAA");
             ILogger l3 = lf.GetLogger("AAA", typeof(Logger));
-            ILogger l4 = lf.GetLogger<Logger>("AAA");
             ILogger l5 = lf.GetLogger("AAA");
             ILogger l6 = lf.GetLogger("AAA");
 
             Assert.Same(l1, l2);
-            Assert.Same(l3, l4);
             Assert.Same(l5, l6);
             Assert.Same(l3, l5);
 
@@ -86,12 +84,11 @@ namespace NLog.UnitTests
             MyLogger l1 = (MyLogger)lf.GetCurrentClassLogger(typeof(MyLogger));
             MyLogger l2 = lf.GetCurrentClassLogger<MyLogger>();
             ILogger l3 = lf.GetCurrentClassLogger(typeof(Logger));
-            ILogger l4 = lf.GetCurrentClassLogger<Logger>();
+     
             ILogger l5 = lf.GetCurrentClassLogger();
             ILogger l6 = lf.GetCurrentClassLogger();
 
             Assert.Same(l1, l2);
-            Assert.Same(l3, l4);
             Assert.Same(l5, l6);
             Assert.Same(l3, l5);
 


### PR DESCRIPTION

For custom loggers, there is the runtime requirement that it has an default constructor. This is now also visible in the typing

Fixes #3989, Fixes #962