### PR TITLE
LogFactory Shutdown is public so it can be used from NLogLoggerProvider

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -998,7 +998,10 @@ namespace NLog
             }
         }
 
-        internal void Shutdown()
+        /// <summary>
+        /// Dispose all targets, and shutdown logging.
+        /// </summary>
+        public void Shutdown()
         {
             InternalLogger.Info("Shutdown() called. Logger closing...");
             if (!_isDisposing && _configLoaded)


### PR DESCRIPTION
Allows this TODO to be fixed:

https://github.com/NLog/NLog.Extensions.Logging/blob/3c64a51328ace81efa2a6a0696926a29a53a7261/src/NLog.Extensions.Logging/Logging/NLogLoggerProvider.cs#L87

And also make NLog work better with isolated LogFactory-instances.