### PR TITLE
LocalIpAddressLayoutRenderer - IsDnsEligible and PrefixOrigin fails on Linux

### DIFF
--- a/src/NLog/LayoutRenderers/LocalIpAddressLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LocalIpAddressLayoutRenderer.cs
@@ -163,12 +163,6 @@ namespace NLog.LayoutRenderers
             if (currentScore == 0)
                 return 0;
 
-            if (!networkAddress.IsDnsEligible)
-                currentScore += 1;
-
-            if (networkAddress.PrefixOrigin == PrefixOrigin.Dhcp)
-                currentScore += 1;
-
             var gatewayAddresses = ipProperties.GatewayAddresses;
             if (gatewayAddresses?.Count > 0)
             {
@@ -177,6 +171,19 @@ namespace NLog.LayoutRenderers
                     if (!IsLoopbackAddressValue(gateway.Address))
                     {
                         currentScore += 3;
+                        break;
+                    }
+                }
+            }
+
+            var dnsAddresses = ipProperties.DnsAddresses;
+            if (dnsAddresses?.Count > 0)
+            {
+                foreach (var dns in dnsAddresses)
+                {
+                    if (!IsLoopbackAddressValue(dns))
+                    {
+                        currentScore += 1;
                         break;
                     }
                 }

--- a/tests/NLog.UnitTests/LayoutRenderers/LocalIpAddressLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/LocalIpAddressLayoutRendererTests.cs
@@ -55,12 +55,6 @@ namespace NLog.UnitTests.LayoutRenderers
         [Fact]
         public void LocalIpAddress_CurrentMachine_NotEmpty()
         {
-            if (IsTravis())
-            {
-                Console.WriteLine("[SKIP] NetworkIpAddressLayoutRendererTests.LocalIpAddress_CurrentMachine_NotEmpty because we are running in Travis");
-                return;
-            }
-
             var ipAddressRenderer = new LocalIpAddressLayoutRenderer();
             var result = ipAddressRenderer.Render(LogEventInfo.CreateNullEvent());
             Assert.NotEmpty(result);


### PR DESCRIPTION
Throws PlatformNotSupportedException. Trying to resolve #4010

https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixUnicastIPAddressInformation.cs#L23

https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixUnicastIPAddressInformation.cs#L40

