### PR TITLE
ObjectReflectionCache - Reduce initial memory allocation until needed

### DIFF
--- a/src/NLog/Internal/MruCache.cs
+++ b/src/NLog/Internal/MruCache.cs
@@ -51,7 +51,7 @@ namespace NLog.Internal
         public MruCache(int maxCapacity)
         {
             _maxCapacity = maxCapacity;
-            _dictionary = new Dictionary<TKey, MruCacheItem>(_maxCapacity);
+            _dictionary = new Dictionary<TKey, MruCacheItem>(_maxCapacity / 4);
             _currentVersion = 1;
         }
 

--- a/src/NLog/MessageTemplates/ValueFormatter.cs
+++ b/src/NLog/MessageTemplates/ValueFormatter.cs
@@ -63,7 +63,7 @@ namespace NLog.MessageTemplates
         private const int MaxValueLength = 512 * 1024;
         private const string LiteralFormatSymbol = "l";
 
-        private readonly MruCache<Enum, string> _enumCache = new MruCache<Enum, string>(1500);
+        private readonly MruCache<Enum, string> _enumCache = new MruCache<Enum, string>(2000);
 
         public const string FormatAsJson = "@";
         public const string FormatAsString = "$";

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -48,7 +48,7 @@ namespace NLog.Targets
 #pragma warning restore 618
     {
         private readonly ObjectReflectionCache _objectReflectionCache = new ObjectReflectionCache();
-        private readonly MruCache<Enum, string> _enumCache = new MruCache<Enum, string>(1500);
+        private readonly MruCache<Enum, string> _enumCache = new MruCache<Enum, string>(2000);
         private readonly JsonSerializeOptions _serializeOptions = new JsonSerializeOptions();
         private readonly JsonSerializeOptions _exceptionSerializeOptions = new JsonSerializeOptions() { SanitizeDictionaryKeys = true };
         private readonly IFormatProvider _defaultFormatProvider = CreateFormatProvider();


### PR DESCRIPTION
Skips allocation of 300 KByte upfront. When actually being used, then it will  use start-capacity of 75 KByte (Just below LargeObjectHeap-treshold) and allow doubling capacity 2 times (150 KByte -> 300 KByte).

Before the initial memory allocation was only done when making use of structured-logging. But with #3610 this was changed to always (NLog 4.7)