### PR TITLE
LoggingConfiguration with support for automatic target re-initialize

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -187,7 +187,7 @@ namespace NLog.Config
         [Obsolete("Instead use LogFactory.ServiceRepository.ResolveInstance(typeof(IJsonConverter)). Marked obsolete on NLog 5.0")]
         public IJsonConverter JsonConverter
         {
-            get => _serviceRepository.ResolveService<IJsonConverter>();
+            get => _serviceRepository.GetService<IJsonConverter>();
             set => _serviceRepository.RegisterJsonConverter(value);
         }
 
@@ -197,7 +197,7 @@ namespace NLog.Config
         [Obsolete("Instead use LogFactory.ServiceRepository.ResolveInstance(typeof(IValueFormatter)). Marked obsolete on NLog 5.0")]
         public IValueFormatter ValueFormatter
         {
-            get => _serviceRepository.ResolveService<IValueFormatter>();
+            get => _serviceRepository.GetService<IValueFormatter>();
             set => _serviceRepository.RegisterValueFormatter(value);
         }
 
@@ -207,7 +207,7 @@ namespace NLog.Config
         [Obsolete("Instead use LogFactory.ServiceRepository.ResolveInstance(typeof(IPropertyTypeConverter)). Marked obsolete on NLog 5.0")]
         public IPropertyTypeConverter PropertyTypeConverter
         {
-            get => _serviceRepository.ResolveService<IPropertyTypeConverter>();
+            get => _serviceRepository.GetService<IPropertyTypeConverter>();
             set => _serviceRepository.RegisterPropertyTypeConverter(value);
         }
        
@@ -223,7 +223,7 @@ namespace NLog.Config
         {
             get
             {
-                var messageFormatter = _serviceRepository.ResolveService<ILogMessageFormatter>();
+                var messageFormatter = _serviceRepository.GetService<ILogMessageFormatter>();
                 if (ReferenceEquals(messageFormatter, LogMessageStringFormatter.Default))
                 {
                     return false;

--- a/src/NLog/Config/ServiceRepositoryInternal.cs
+++ b/src/NLog/Config/ServiceRepositoryInternal.cs
@@ -111,6 +111,9 @@ namespace NLog.Config
 
             if (objectResolver == null && compiledConstructor == null)
             {
+                if (itemType.IsAbstract())
+                    throw new NLogResolveException("Instance of class must be registered", itemType);
+
                 // Do not hold lock while resolving types to avoid deadlock on initialization of type static members
                 var newCompiledConstructor = CreateCompiledConstructor(itemType);
 

--- a/src/NLog/Internal/LogMessageTemplateFormatter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatter.cs
@@ -46,7 +46,7 @@ namespace NLog.Internal
         private static readonly StringBuilderPool _builderPool = new StringBuilderPool(Environment.ProcessorCount * 2);
         private readonly IServiceProvider _serviceProvider;
 
-        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = _serviceProvider.ResolveService<IValueFormatter>());
+        private IValueFormatter ValueFormatter => _valueFormatter ?? (_valueFormatter = _serviceProvider.GetService<IValueFormatter>());
         private IValueFormatter _valueFormatter;
 
         /// <summary>

--- a/src/NLog/Internal/Reflection/ObjectReflectionCache.cs
+++ b/src/NLog/Internal/Reflection/ObjectReflectionCache.cs
@@ -51,7 +51,7 @@ namespace NLog.Internal
     {
         private readonly MruCache<Type, ObjectPropertyInfos> _objectTypeCache = new MruCache<Type, ObjectPropertyInfos>(10000);
         private readonly IServiceProvider _serviceProvider;
-        private IObjectTypeTransformer ObjectTypeTransformation => _objectTypeTransformation ?? (_objectTypeTransformation = _serviceProvider?.ResolveService<IObjectTypeTransformer>() ?? this);
+        private IObjectTypeTransformer ObjectTypeTransformation => _objectTypeTransformation ?? (_objectTypeTransformation = _serviceProvider?.GetService<IObjectTypeTransformer>() ?? this);
         private IObjectTypeTransformer _objectTypeTransformation;
 
         public ObjectReflectionCache(IServiceProvider serviceProvider)

--- a/src/NLog/LayoutRenderers/Contexts/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/EventPropertiesLayoutRenderer.cs
@@ -50,7 +50,7 @@ namespace NLog.LayoutRenderers
     [MutableUnsafe]
     public class EventPropertiesLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {
-        private ObjectReflectionCache ObjectReflectionCache => _objectReflectionCache ?? (_objectReflectionCache = new ObjectReflectionCache(LoggingConfiguration.GetServiceResolver()));
+        private ObjectReflectionCache ObjectReflectionCache => _objectReflectionCache ?? (_objectReflectionCache = new ObjectReflectionCache(LoggingConfiguration.GetServiceProvider()));
         private ObjectReflectionCache _objectReflectionCache;
         private ObjectPropertyPath _objectPropertyPath;
 

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -84,7 +84,7 @@ namespace NLog.LayoutRenderers
             "TargetSite",// Not available on NETSTANDARD1_0
         }, StringComparer.Ordinal);
 
-        private ObjectReflectionCache ObjectReflectionCache => _objectReflectionCache ?? (_objectReflectionCache = new ObjectReflectionCache(LoggingConfiguration.GetServiceResolver()));
+        private ObjectReflectionCache ObjectReflectionCache => _objectReflectionCache ?? (_objectReflectionCache = new ObjectReflectionCache(LoggingConfiguration.GetServiceProvider()));
         private ObjectReflectionCache _objectReflectionCache;
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -291,7 +291,7 @@ namespace NLog.LayoutRenderers
         /// <returns></returns>
         protected T Resolve<T>() where T : class
         {
-            return LoggingConfiguration.GetServiceResolver().ResolveService<T>();
+            return LoggingConfiguration.GetServiceProvider().ResolveService<T>(_isInitialized);
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -235,11 +235,6 @@ namespace NLog.LayoutRenderers
 
         internal IList<NLogViewerParameterInfo> Parameters { get; set; }
 
-        internal void AppendToStringBuilder(StringBuilder sb, LogEventInfo logEvent)
-        {
-            Append(sb, logEvent);
-        }
-
         /// <summary>
         /// Renders the XML logging event and appends it to the specified <see cref="StringBuilder" />.
         /// </summary>

--- a/src/NLog/LayoutRenderers/Wrappers/ObjectPathRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ObjectPathRendererWrapper.cs
@@ -48,7 +48,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [ThreadAgnostic]
     public sealed class ObjectPathRendererWrapper : WrapperLayoutRendererBase, IRawValue
     {
-        private ObjectReflectionCache ObjectReflectionCache => _objectReflectionCache ?? (_objectReflectionCache = new ObjectReflectionCache(LoggingConfiguration.GetServiceResolver()));
+        private ObjectReflectionCache ObjectReflectionCache => _objectReflectionCache ?? (_objectReflectionCache = new ObjectReflectionCache(LoggingConfiguration.GetServiceProvider()));
         private ObjectReflectionCache _objectReflectionCache;
         private ObjectPropertyPath _objectPropertyPath;
 

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -467,7 +467,7 @@ namespace NLog.Layouts
         /// <remarks>Avoid calling this while handling a LogEvent, since random deadlocks can occur</remarks>
         protected T ResolveService<T>() where T : class
         {
-            return LoggingConfiguration.GetServiceResolver().ResolveService<T>();
+            return LoggingConfiguration.GetServiceProvider().ResolveService<T>(IsInitialized);
         }
     }
 }

--- a/src/NLog/Layouts/XML/XmlElementBase.cs
+++ b/src/NLog/Layouts/XML/XmlElementBase.cs
@@ -199,7 +199,7 @@ namespace NLog.Layouts
         /// <docgen category='LogEvent Properties XML Options' order='10' />
         public int MaxRecursionLimit { get; set; } = 1;
 
-        private ObjectReflectionCache ObjectReflectionCache => _objectReflectionCache ?? (_objectReflectionCache = new ObjectReflectionCache(LoggingConfiguration.GetServiceResolver()));
+        private ObjectReflectionCache ObjectReflectionCache => _objectReflectionCache ?? (_objectReflectionCache = new ObjectReflectionCache(LoggingConfiguration.GetServiceProvider()));
         private ObjectReflectionCache _objectReflectionCache;
         private static readonly IEqualityComparer<object> _referenceEqualsComparer = SingleItemOptimizedHashSet<object>.ReferenceEqualityComparer.Default;
         private const int MaxXmlLength = 512 * 1024;

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -330,7 +330,7 @@ namespace NLog
 
         private void RefreshMessageFormatter()
         {
-            var messageFormatter = _serviceRepository.ResolveService<ILogMessageFormatter>();
+            var messageFormatter = _serviceRepository.GetService<ILogMessageFormatter>();
             ActiveMessageFormatter = messageFormatter.FormatMessage;
             if (messageFormatter is LogMessageTemplateFormatter templateFormatter)
             {

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -322,6 +322,8 @@ namespace NLog
 
         private void ServiceRepository_TypeRegistered(object sender, RepositoryUpdateEventArgs e)
         {
+            _config?.CheckForMissingServiceTypes(e.Type);
+
             if (e.Type == typeof(ILogMessageFormatter))
             {
                 RefreshMessageFormatter();

--- a/src/NLog/MessageTemplates/ValueFormatter.cs
+++ b/src/NLog/MessageTemplates/ValueFormatter.cs
@@ -50,7 +50,7 @@ namespace NLog.MessageTemplates
         private static readonly IEqualityComparer<object> _referenceEqualsComparer = SingleItemOptimizedHashSet<object>.ReferenceEqualityComparer.Default;
         private readonly MruCache<Enum, string> _enumCache = new MruCache<Enum, string>(1500);
         private readonly IServiceProvider _serviceProvider;
-        private IJsonConverter JsonConverter => _jsonConverter ?? (_jsonConverter = _serviceProvider.ResolveService<IJsonConverter>());
+        private IJsonConverter JsonConverter => _jsonConverter ?? (_jsonConverter = _serviceProvider.GetService<IJsonConverter>());
         private IJsonConverter _jsonConverter;
 
         public ValueFormatter([NotNull] IServiceProvider serviceProvider)

--- a/src/NLog/SetupSerializationBuilderExtensions.cs
+++ b/src/NLog/SetupSerializationBuilderExtensions.cs
@@ -68,7 +68,7 @@ namespace NLog
             if (transformer == null)
                 throw new ArgumentNullException(nameof(transformer));
 
-            var original = setupBuilder.LogFactory.ServiceRepository.ResolveService<IObjectTypeTransformer>();
+            var original = setupBuilder.LogFactory.ServiceRepository.GetService<IObjectTypeTransformer>();
             setupBuilder.LogFactory.ServiceRepository.RegisterObjectTypeTransformer(new ObjectTypeTransformation<T>(transformer, original));
             return setupBuilder;
         }
@@ -83,7 +83,7 @@ namespace NLog
             if (transformer == null)
                 throw new ArgumentNullException(nameof(transformer));
 
-            var original = setupBuilder.LogFactory.ServiceRepository.ResolveService<IObjectTypeTransformer>();
+            var original = setupBuilder.LogFactory.ServiceRepository.GetService<IObjectTypeTransformer>();
             setupBuilder.LogFactory.ServiceRepository.RegisterObjectTypeTransformer(new ObjectTypeTransformation(objectType, transformer, original));
             return setupBuilder;
         }

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -765,7 +765,7 @@ namespace NLog.Targets
         /// <remarks>Avoid calling this while handling a LogEvent, since random deadlocks can occur.</remarks>
         protected T ResolveService<T>() where T : class
         {
-            return LoggingConfiguration.GetServiceResolver().ResolveService<T>();
+            return LoggingConfiguration.GetServiceProvider().ResolveService<T>(IsInitialized);
         }
 
         /// <summary>

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -61,6 +61,8 @@ namespace NLog.Targets
         /// </summary>
         internal StackTraceUsage StackTraceUsage { get; private set; }
 
+        internal Exception InitializeException => _initializeException;
+
         /// <summary>
         /// Gets or sets the name of the target.
         /// </summary>
@@ -433,15 +435,30 @@ namespace NLog.Targets
                             FindAllLayouts();
                         }
                     }
-                    catch (Exception exception)
+                    catch (NLogResolveException exception)
                     {
-                        InternalLogger.Error(exception, "{0}: Error initializing target", this);
-
+                        // Target is now in disabled state, and cannot be used for writing LogEvents
                         _initializeException = exception;
-
+                        InternalLogger.Error(exception, "{0}: Error initializing target", this);
                         if (ExceptionMustBeRethrown(exception))
                         {
                             throw;
+                        }
+                    }
+                    catch (Exception exception)
+                    {
+                        // Target is now in disabled state, and cannot be used for writing LogEvents
+                        _initializeException = exception;
+                        InternalLogger.Error(exception, "{0}: Error initializing target", this);
+                        if (ExceptionMustBeRethrown(exception))
+                        {
+                            throw;
+                        }
+
+                        var logFactory = LoggingConfiguration?.LogFactory ?? LogManager.LogFactory;
+                        if ((logFactory.ThrowConfigExceptions ?? logFactory.ThrowExceptions))
+                        {
+                            throw new NLogConfigurationException($"Error during initialization of target {this}", exception);
                         }
                     }
                     finally

--- a/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
@@ -31,13 +31,13 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-using JetBrains.Annotations;
-using NLog.Config;
 
 namespace NLog.UnitTests.Config
 {
+    using System;
     using System.Text;
+    using JetBrains.Annotations;
+    using NLog.Config;
     using NLog.Targets;
     using Xunit;
 
@@ -129,6 +129,50 @@ namespace NLog.UnitTests.Config
 
             // Act & Assert
             AssertCycleException<TargetWithIndirectCycleInjection>(logFactory);
+        }
+
+        [Fact]
+        public void HandleDelayedInjectDependenciesFailure()
+        {
+            using (new NoThrowNLogExceptions())
+            {
+                // Arrange
+                var logFactory = new LogFactory();
+                logFactory.ThrowConfigExceptions = true;
+                var logConfig = new LoggingConfiguration(logFactory);
+                var logTarget = new TargetWithMissingDependency() { Name = "NeedDependency" };
+                logConfig.AddRuleForAllLevels(logTarget);
+
+                // Act
+                logFactory.Configuration = logConfig;
+                logFactory.GetLogger("Test").Info("Test");
+
+                // Assert
+                Assert.Null(logTarget.LastLogEvent);
+            }
+        }
+
+        [Fact]
+        public void HandleDelayedInjectDependenciesSuccess()
+        {
+            using (new NoThrowNLogExceptions())
+            {
+                // Arrange
+                var logFactory = new LogFactory();
+                logFactory.ThrowConfigExceptions = true;
+                var logConfig = new LoggingConfiguration(logFactory);
+                var logTarget = new TargetWithMissingDependency() { Name = "NeedDependency" };
+                logConfig.AddRuleForAllLevels(logTarget);
+
+                // Act
+                logFactory.Configuration = logConfig;
+                logFactory.GetLogger("Test").Info("Test");
+                logFactory.ServiceRepository.RegisterSingleton<IMisingDependencyClass>(new MisingDependencyClass());
+                logFactory.GetLogger("Test").Info("Test Again");
+
+                // Assert
+                Assert.NotNull(logTarget.LastLogEvent);
+            }
         }
 
         [Fact]
@@ -250,6 +294,23 @@ namespace NLog.UnitTests.Config
                 JsonConverter = jsonConverter;
             }
         }
+
+        private class TargetWithMissingDependency : Target
+        {
+            public LogEventInfo LastLogEvent { get; private set; }
+
+            protected override void InitializeTarget()
+            {
+                var wantedDependency = ResolveService<IMisingDependencyClass>();
+                base.InitializeTarget();
+            }
+
+            protected override void Write(LogEventInfo logEvent)
+            {
+                LastLogEvent = logEvent;
+            }
+        }
+
         private interface IMisingDependencyClass
         {
 


### PR DESCRIPTION
Allow loading target from `NLog.config` that fails on InitializeTarget because of missing service-dependency. Without exploding in your face even with `ThrowConfigExceptions=true`.

When the missing service-dependency arrives in the ServiceRepostory, then it will automatically retry initialize of the target.

This should handle the case with Microsoft ApplicationInsight-Target where `TelemetryConfiguration.Active` is obsolete, and should now be acquired through dependency-injection.