### PR TITLE
ObjectReflectionCache - Skip reflection for Stream objects

### DIFF
--- a/src/NLog/Internal/ObjectReflectionCache.cs
+++ b/src/NLog/Internal/ObjectReflectionCache.cs
@@ -189,13 +189,16 @@ namespace NLog.Internal
                 return true;
 
             if (typeof(MemberInfo).IsAssignableFrom(objectType))
-                return true;
+                return true;    // Skip serializing all types in the application
 
             if (typeof(Assembly).IsAssignableFrom(objectType))
-                return true;
+                return true;    // Skip serializing all types in the application
 
             if (typeof(Module).IsAssignableFrom(objectType))
-                return true;
+                return true;    // Skip serializing all types in the application
+
+            if (typeof(System.IO.Stream).IsAssignableFrom(objectType))
+                return true;    // Skip serializing properties that often throws exceptions
 
             return false;
         }


### PR DESCRIPTION
Hard to serialize something useful from a Stream-object. Instead their properties often throw exceptions.