### PR TITLE
Set properties of ProcessStartInfo correctly

### DIFF
--- a/tests/NLog.UnitTests/ProcessRunner.cs
+++ b/tests/NLog.UnitTests/ProcessRunner.cs
@@ -126,11 +126,9 @@ class C1
             proc.StartInfo.FileName = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Runner.exe");
 #endif
             proc.StartInfo.UseShellExecute = false;
-            proc.StartInfo.WindowStyle = ProcessWindowStyle.Normal;
-            proc.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
             proc.StartInfo.CreateNoWindow = true;
             // Hint:
-            // In case we wanna redirect stdout we should drain the redirected pipe continously.
+            // In case we wanna redirect stdout we should drain the redirected pipe continuously.
             // Otherwise Runner.exe's console buffer is full rather fast, leading to a lock within Console.Write(Line).
             proc.Start();
             return proc;


### PR DESCRIPTION
According the ProcessStartInfo.UseShellExecute property [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.useshellexecute?view=netcore-3.1#remarks) 
Setting this property to false enables you to redirect input, output, and error streams.
**If you set the WindowStyle to ProcessWindowStyle.Hidden, UseShellExecute must be set to true.**

I think you would like to set UseShellExecute  to false to enable the redirect function. So, I removed code about set the [ProcessStartInfo.WindowStyle](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.createnowindow?view=netcore-3.1) property.