### PR TITLE
MessageTemplates - Changed Literal.Skip to be Int32 for long message templates

### DIFF
--- a/src/NLog/MessageTemplates/Literal.cs
+++ b/src/NLog/MessageTemplates/Literal.cs
@@ -43,6 +43,6 @@ namespace NLog.MessageTemplates
         public int Print;
         /// <summary>Number of characters to skip in the original template at the current position.</summary>
         /// <remarks>0 is a special value that mean: 1 escaped char, no hole. It can also happen last when the template ends with a literal.</remarks>
-        public short Skip;
+        public int Skip;
     }
 }

--- a/src/NLog/MessageTemplates/TemplateEnumerator.cs
+++ b/src/NLog/MessageTemplates/TemplateEnumerator.cs
@@ -140,7 +140,7 @@ namespace NLog.MessageTemplates
 
         private void ParseTextPart()
         {
-            _literalLength = (short)SkipUntil(TextDelimiters, required: false);
+            _literalLength = SkipUntil(TextDelimiters, required: false);
         }
 
         private void ParseOpenBracketPart()
@@ -195,7 +195,7 @@ namespace NLog.MessageTemplates
             }
 
             int literalSkip = _position - start + (type == CaptureType.Normal ? 1 : 2);     // Account for skipped '{', '{$' or '{@'
-            _current = new LiteralHole(new Literal { Print = _literalLength, Skip = (short)literalSkip }, new Hole(
+            _current = new LiteralHole(new Literal { Print = _literalLength, Skip = literalSkip }, new Hole(
                 name,
                 format,
                 type,


### PR DESCRIPTION
Support message templates longer than short.MaxValue. Resolves #4052

Think the `short`-logic was a memory optimization, but since modern CPUs really like 32 bit (or even better 64 bit numbers), then I actually think it is a de-optimization to use `short`.