### PR TITLE
AsyncTargetWrapper and AsyncTaskTarget will enqueue when missing dependency

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -769,14 +769,14 @@ namespace NLog.Config
         {
             if (_missingServiceTypes)
             {
-                _missingServiceTypes = false;
+                bool missingServiceTypes = false;
 
                 var allTargets = AllTargets;
                 foreach (var target in allTargets)
                 {
                     if (target.InitializeException is NLogResolveException resolveException)
                     {
-                        _missingServiceTypes = true;
+                        missingServiceTypes = true;
 
                         if (typeof(IServiceProvider).IsAssignableFrom(serviceType) || IsMissingServiceType(resolveException, serviceType))
                         {
@@ -785,7 +785,9 @@ namespace NLog.Config
                     }
                 }
 
-                if (_missingServiceTypes)
+                _missingServiceTypes = missingServiceTypes;
+
+                if (missingServiceTypes)
                 {
                     InitializeAll();
                 }

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -301,7 +301,7 @@ namespace NLog.Targets
             {
                 lock (SyncRoot)
                 {
-                    logEvent.Continuation(CreateInitException());
+                    WriteFailedNotInitialized(logEvent, _initializeException);
                 }
                 return;
             }
@@ -364,7 +364,7 @@ namespace NLog.Targets
                 {
                     for (int i = 0; i < logEvents.Count; ++i)
                     {
-                        logEvents[i].Continuation(CreateInitException());
+                        WriteFailedNotInitialized(logEvents[i], _initializeException);
                     }
                 }
                 return;
@@ -407,6 +407,15 @@ namespace NLog.Targets
                     wrappedEvents[i].Continuation(exception);
                 }
             }
+        }
+
+        /// <summary>
+        /// LogEvent is written to target, but target failed to succesfully initialize
+        /// </summary>
+        protected virtual void WriteFailedNotInitialized(AsyncLogEventInfo logEvent, Exception initializeException)
+        {
+            var initializeFailedException = new NLogRuntimeException($"Target {this} failed to initialize.", initializeException);
+            logEvent.Continuation(initializeFailedException);
         }
 
         /// <summary>
@@ -664,11 +673,6 @@ namespace NLog.Targets
 
                 Write(logEvents);
             }
-        }
-
-        private Exception CreateInitException()
-        {
-            return new NLogRuntimeException($"Target {this} failed to initialize.", _initializeException);
         }
 
         /// <summary>


### PR DESCRIPTION
Further improvements to the lazy initialize behavior introduced with #4023