### PR TITLE
FileTarget - Skip delegate capture in GetFileCreationTimeSource

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -304,7 +304,7 @@ namespace NLog.Internal.FileAppenders
             FileInfo fileInfo = new FileInfo(FileName);
             if (fileInfo.Exists)
             {
-                CreationTimeUtc = fileInfo.LookupValidFileCreationTimeUtc().Value;
+                CreationTimeUtc = fileInfo.LookupValidFileCreationTimeUtc();
             }
             else
             {

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -432,7 +432,7 @@ namespace NLog.Internal.FileAppenders
             {
                 try
                 {
-                    result = FileInfoHelper.LookupValidFileCreationTimeUtc(appender, (f) => f.GetFileCreationTimeUtc(), f => fallbackTimeSource);
+                    result = appender.GetFileCreationTimeUtc();
                     if (result.HasValue)
                     {
                         // Check if cached value is still valid, and update if not (Will automatically update CreationTimeSource)
@@ -455,7 +455,7 @@ namespace NLog.Internal.FileAppenders
             var fileInfo = new FileInfo(filePath);
             if (fileInfo.Exists)
             {
-                result = fileInfo.LookupValidFileCreationTimeUtc(fallbackTimeSource).Value;
+                result = fileInfo.LookupValidFileCreationTimeUtc(fallbackTimeSource);
                 return Time.TimeSource.Current.FromSystemTime(result.Value);
             }
 

--- a/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/RetryingMultiProcessFileAppender.cs
@@ -96,7 +96,7 @@ namespace NLog.Internal.FileAppenders
             FileInfo fileInfo = new FileInfo(FileName);
             if (fileInfo.Exists)
             {
-                return fileInfo.GetCreationTimeUtc();
+                return fileInfo.LookupValidFileCreationTimeUtc();
             }
             return null;
         }

--- a/src/NLog/Internal/FileInfoExt.cs
+++ b/src/NLog/Internal/FileInfoExt.cs
@@ -55,15 +55,15 @@ namespace NLog.Internal
 #endif
         }
 
-        public static DateTime? LookupValidFileCreationTimeUtc(this FileInfo fileInfo)
+        public static DateTime LookupValidFileCreationTimeUtc(this FileInfo fileInfo)
         {
-            return FileInfoHelper.LookupValidFileCreationTimeUtc(fileInfo, (f) => f.GetCreationTimeUtc(), (f) => f.GetLastWriteTimeUtc());
+            return FileInfoHelper.LookupValidFileCreationTimeUtc(fileInfo, (f) => f.GetCreationTimeUtc(), (f) => f.GetLastWriteTimeUtc()).Value;
         }
 
-        public static DateTime? LookupValidFileCreationTimeUtc(this FileInfo fileInfo, DateTime? fallbackTime)
+        public static DateTime LookupValidFileCreationTimeUtc(this FileInfo fileInfo, DateTime? fallbackTime)
         {
             if (fallbackTime > DateTime.MinValue)
-                return FileInfoHelper.LookupValidFileCreationTimeUtc(fileInfo, (f) => f.GetCreationTimeUtc(), (f) => fallbackTime.Value, (f) => f.GetLastWriteTimeUtc());
+                return FileInfoHelper.LookupValidFileCreationTimeUtc(fileInfo, (f) => f.GetCreationTimeUtc(), (f) => fallbackTime.Value, (f) => f.GetLastWriteTimeUtc()).Value;
             else
                 return LookupValidFileCreationTimeUtc(fileInfo);
         }

--- a/src/NLog/Targets/FileArchiveModes/FileArchiveModeDynamicSequence.cs
+++ b/src/NLog/Targets/FileArchiveModes/FileArchiveModeDynamicSequence.cs
@@ -235,7 +235,7 @@ namespace NLog.Targets.FileArchiveModes
 
             int sequenceNumber = ExtractArchiveNumberFromFileName(archiveFile.FullName);
             InternalLogger.Trace("FileTarget: extracted sequenceNumber: {0} from file '{1}'", sequenceNumber, archiveFile.FullName);
-            var creationTimeUtc = archiveFile.LookupValidFileCreationTimeUtc().Value;
+            var creationTimeUtc = archiveFile.LookupValidFileCreationTimeUtc();
             return new DateAndSequenceArchive(archiveFile.FullName, creationTimeUtc, string.Empty, sequenceNumber > 0 ? sequenceNumber : 0);
         }
 


### PR DESCRIPTION
Skip unnecessary allocation for every logevent when using `archiveEvery="Day"`

Fallback only necessary when appender has been closed (Because NLog caches the creation-time on the appender).