### PR TITLE
DatabaseTarget - Added AllowDbNull for easier support for nullable pa…

### DIFF
--- a/src/NLog/Targets/DatabaseParameterInfo.cs
+++ b/src/NLog/Targets/DatabaseParameterInfo.cs
@@ -134,6 +134,13 @@ namespace NLog.Targets
         [DefaultValue(null)]
         public CultureInfo Culture { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether empty value should translate into DbNull. Requires database column to allow NULL values.
+        /// </summary>
+        /// <docgen category='Parameter Options' order='8' />
+        [DefaultValue(false)]
+        public bool AllowDbNull { get; set; }
+
         internal bool SetDbType(IDbDataParameter dbParameter)
         {
             if (!string.IsNullOrEmpty(DbType))

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -607,18 +607,23 @@ Dispose()
         [InlineData("${event-properties:almostAsIntProp}", DbType.Int32, 124)]
         [InlineData("${event-properties:almostAsIntProp}", DbType.Int64, (long)124)]
         [InlineData("${event-properties:almostAsIntProp}", DbType.AnsiString, " 124 ")]
+        [InlineData("${event-properties:emptyprop}", DbType.AnsiString, "")]
+        [InlineData("${event-properties:emptyprop}", DbType.AnsiString, "", true)]
         [InlineData("${event-properties:NullRawValue}", DbType.AnsiString, "")]
-        [InlineData("${event-properties:NullawValue}", DbType.Int32, 0)]
+        [InlineData("${event-properties:NullRawValue}", DbType.Int32, 0)]
         [InlineData("${event-properties:NullRawValue}", DbType.AnsiString, null, true)]
         [InlineData("${event-properties:NullRawValue}", DbType.Int32, null, true)]
+        [InlineData("${event-properties:NullRawValue}", DbType.Guid, null, true)]
         [InlineData("", DbType.AnsiString, null, true)]
         [InlineData("", DbType.Int32, null, true)]
+        [InlineData("", DbType.Guid, null, true)]
         public void GetParameterValueTest(string layout, DbType dbtype, object expected, bool allowDbNull = false, bool convertToDecimal = false)
         {
             // Arrange
             var logEventInfo = new LogEventInfo(LogLevel.Debug, "logger1", "message 2");
             logEventInfo.Properties["intprop"] = 123;
             logEventInfo.Properties["boolprop"] = true;
+            logEventInfo.Properties["emptyprop"] = "";
             logEventInfo.Properties["almostAsIntProp"] = " 124 ";
             logEventInfo.Properties["dateprop"] = new DateTime(2018, 12, 30, 13, 34, 56);
 
@@ -647,7 +652,7 @@ Dispose()
 
         [Theory]
         [MemberData(nameof(ConvertFromStringTestCases))]
-        public void GetParameterValueFromStringTest(string value, DbType dbType, object expected, string format = null, CultureInfo cultureInfo = null)
+        public void GetParameterValueFromStringTest(string value, DbType dbType, object expected, string format = null, CultureInfo cultureInfo = null, bool? allowDbNull = null)
         {
 
             var culture = System.Threading.Thread.CurrentThread.CurrentCulture;
@@ -662,6 +667,7 @@ Dispose()
                     Format = format,
                     DbType = dbType.ToString(),
                     Culture = cultureInfo,
+                    AllowDbNull = allowDbNull ?? false,
                 };
                 databaseParameterInfo.SetDbType(new MockDbConnection().CreateCommand().CreateParameter());
 
@@ -711,7 +717,10 @@ Dispose()
             yield return new object[] { "${db-null}", DbType.DateTime, DBNull.Value };
             yield return new object[] { "${event-properties:userid}", DbType.Int32, 0 };
             yield return new object[] { "${date:universalTime=true:format=yyyy-MM:norawvalue=true}", DbType.DateTime, DateTime.SpecifyKind(DateTime.UtcNow.Date.AddDays(-DateTime.UtcNow.Day + 1), DateTimeKind.Unspecified) };
-            yield return new object[] { "${shortdate:universalTime=true}", DbType.DateTime, DateTime.UtcNow.Date };
+            yield return new object[] { "${shortdate:universalTime=true}", DbType.DateTime, DateTime.UtcNow.Date, null, null, true };
+            yield return new object[] { "${shortdate:universalTime=true}", DbType.DateTime, DateTime.UtcNow.Date, null, null, false };
+            yield return new object[] { "${shortdate:universalTime=true}", DbType.String, DateTime.UtcNow.Date.ToString("yyyy-MM-dd"), null, null, true };
+            yield return new object[] { "${shortdate:universalTime=true}", DbType.String, DateTime.UtcNow.Date.ToString("yyyy-MM-dd"), null, null, false };
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -591,7 +591,7 @@ Dispose()
         [InlineData("${counter}", DbType.Int32, 1)]
         [InlineData("${counter}", DbType.Int64, (long)1)]
         [InlineData("${counter:norawvalue=true}", DbType.Int16, (short)1)] //fallback
-        [InlineData("${counter}", DbType.VarNumeric, 1, true)]
+        [InlineData("${counter}", DbType.VarNumeric, 1, false, true)]
         [InlineData("${counter}", DbType.AnsiString, "1")]
         [InlineData("${level}", DbType.AnsiString, "Debug")]
         [InlineData("${level}", DbType.Int32, 1)]
@@ -607,7 +607,13 @@ Dispose()
         [InlineData("${event-properties:almostAsIntProp}", DbType.Int32, 124)]
         [InlineData("${event-properties:almostAsIntProp}", DbType.Int64, (long)124)]
         [InlineData("${event-properties:almostAsIntProp}", DbType.AnsiString, " 124 ")]
-        public void GetParameterValueTest(string layout, DbType dbtype, object expected, bool convertToDecimal = false)
+        [InlineData("${event-properties:NullRawValue}", DbType.AnsiString, "")]
+        [InlineData("${event-properties:NullawValue}", DbType.Int32, 0)]
+        [InlineData("${event-properties:NullRawValue}", DbType.AnsiString, null, true)]
+        [InlineData("${event-properties:NullRawValue}", DbType.Int32, null, true)]
+        [InlineData("", DbType.AnsiString, null, true)]
+        [InlineData("", DbType.Int32, null, true)]
+        public void GetParameterValueTest(string layout, DbType dbtype, object expected, bool allowDbNull = false, bool convertToDecimal = false)
         {
             // Arrange
             var logEventInfo = new LogEventInfo(LogLevel.Debug, "logger1", "message 2");
@@ -622,6 +628,7 @@ Dispose()
                 DbType = dbtype.ToString(),
                 Layout = layout,
                 Name = parameterName,
+                AllowDbNull = allowDbNull,
             };
             databaseParameterInfo.SetDbType(new MockDbConnection().CreateCommand().CreateParameter());
 
@@ -635,7 +642,7 @@ Dispose()
                 expected = (decimal)(int)expected;
             }
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected ?? DBNull.Value, result);
         }
 
         [Theory]


### PR DESCRIPTION
Instead of doing this:

`<parameter name="@exception" layout="${exception:format=tostring:whenEmpty=${db-null}}" parameterType="System.Object" 
/>`
`<parameter name="@correlationid" layout="${activityid:whenEmpty=${db-null}}" dbType="DbType.Guid" parameterType="System.Object" />`

Then one can do this:

`<parameter name="@exception" layout="${exception:format=tostring}" allowDbNull="true" />`
`<parameter name="@exception" layout="${activityid}" dbType="DbType.Guid" allowDbNull="true" />`

Trying to resolve #4070 