### PR TITLE
BufferingWrapper should use AsyncRequestQueue instead of LogEventInfo…

### DIFF
--- a/src/NLog.Wcf/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog.Wcf/Targets/LogReceiverWebServiceTarget.cs
@@ -53,7 +53,9 @@ namespace NLog.Targets
     [Target("LogReceiverService")]
     public class LogReceiverWebServiceTarget : Target
     {
+        #pragma warning disable CS0618 // Type or member is obsolete
         private readonly LogEventInfoBuffer buffer = new LogEventInfoBuffer(10000, false, 10000);
+        #pragma warning restore CS0618 // Type or member is obsolete
         private bool inCall;
 
         /// <summary>

--- a/src/NLog/Common/LogEventInfoBuffer.cs
+++ b/src/NLog/Common/LogEventInfoBuffer.cs
@@ -38,6 +38,7 @@ namespace NLog.Common
     /// <summary>
     /// A cyclic buffer of <see cref="LogEventInfo"/> object.
     /// </summary>
+    [Obsolete("Use AsyncRequestQueue instead")]
     public class LogEventInfoBuffer
     {
         private readonly object _lockObject = new object();

--- a/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
+++ b/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
@@ -128,7 +128,7 @@ namespace NLog.Targets.Wrappers
 
             lock (_logEventInfoQueue)
             {
-                if (_logEventInfoQueue.Count < count)
+                if (count == -1 ||_logEventInfoQueue.Count < count)
                     count = _logEventInfoQueue.Count;
 
                 if (count == 0)


### PR DESCRIPTION
- Marked LogEventInfoBuffer as obsolete
- BufferingWrapper is using now AsyncRequestQueue instead of LogEventInfoBuffer
- Fixed bug in AsyncRequestQueue DequeueBatch method - count summery documented that passing -1 will result in taking everything from buffer when in reality it's caused aritmetic exception

fix #4054