### PR TITLE
LoggingConfiguration - ValidateConfig should only throw when enabled

### DIFF
--- a/src/NLog/Common/AsyncHelpers.cs
+++ b/src/NLog/Common/AsyncHelpers.cs
@@ -230,9 +230,10 @@ namespace NLog.Common
                 T itemCopy = item;
                 StartAsyncTask(new AsyncHelpersTask(s =>
                 {
+                    var preventMultipleCalls = PreventMultipleCalls(continuation);
                     try
                     {
-                        action(itemCopy, PreventMultipleCalls(continuation));
+                        action(itemCopy, preventMultipleCalls);
                     }
                     catch (Exception ex)
                     {
@@ -241,6 +242,8 @@ namespace NLog.Common
                         {
                             throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                         }
+
+                        preventMultipleCalls.Invoke(ex);
                     }
                 }), null);
             }

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -743,7 +743,18 @@ namespace NLog.Config
 
             foreach (object o in _configItems)
             {
-                PropertyHelper.CheckRequiredParameters(o);
+                try
+                {
+                    if (o is ISupportsInitialize)
+                        continue;   // Target + Layout + LayoutRenderer validate on Initialize()
+
+                    PropertyHelper.CheckRequiredParameters(o);
+                }
+                catch (Exception ex)
+                {
+                    if (ex.MustBeRethrown())
+                        throw;
+                }
             }
         }
 
@@ -776,7 +787,7 @@ namespace NLog.Config
                 }
                 catch (Exception exception)
                 {
-                    if (exception.MustBeRethrown())
+                    if (exception.MustBeRethrown(initialize as IInternalLoggerContext))
                     {
                         throw;
                     }

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -133,6 +133,7 @@ namespace NLog.LayoutRenderers
             if (!_isInitialized)
             {
                 _isInitialized = true;
+                PropertyHelper.CheckRequiredParameters(this);
                 InitializeLayoutRenderer();
             }
         }

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -321,8 +321,11 @@ namespace NLog.Layouts
             if (!IsInitialized)
             {
                 LoggingConfiguration = configuration;
+
                 IsInitialized = true;
                 _scannedForObjects = false;
+
+                PropertyHelper.CheckRequiredParameters(this);
 
                 InitializeLayout();
 

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -419,11 +419,10 @@ namespace NLog.Targets
 
                 if (!IsInitialized)
                 {
-                    if (configuration == null)
-                        PropertyHelper.CheckRequiredParameters(this);
-
                     try
                     {
+                        PropertyHelper.CheckRequiredParameters(this);
+
                         InitializeTarget();
                         _initializeException = null;
                         if (!_scannedForLayouts)

--- a/src/NLog/Targets/Wrappers/WrapperTargetBase.cs
+++ b/src/NLog/Targets/Wrappers/WrapperTargetBase.cs
@@ -64,7 +64,10 @@ namespace NLog.Targets.Wrappers
         /// <param name="asyncContinuation">The asynchronous continuation.</param>
         protected override void FlushAsync(AsyncContinuation asyncContinuation)
         {
-            WrappedTarget.Flush(asyncContinuation);
+            if (WrappedTarget != null)
+                WrappedTarget.Flush(asyncContinuation);
+            else
+                asyncContinuation(null);
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Config/TargetConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/TargetConfigurationTests.cs
@@ -496,7 +496,29 @@ namespace NLog.UnitTests.Config
 
             LogManager.Configuration = configuration;
             LogManager.GetLogger("TestLogger").Info("DefaultFileTargetParametersTests.DontThrowExceptionWhenArchiveEverySetByDefaultParameters is true");
+        }
 
+        [Fact]
+        public void DontThrowExceptionsWhenMissingRequiredParameters()
+        {
+            using (new NoThrowNLogExceptions())
+            {
+                var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+<nlog>
+    <targets>
+        <target type='bufferingwrapper' name='mytarget'>
+            <target type='unknowntargettype' name='badtarget' />
+        </target>
+    </targets>
+    <rules>
+        <logger name='*' writeTo='mytarget'/>
+    </rules>
+</nlog> ");
+
+                LogManager.Configuration = configuration;
+                LogManager.GetLogger(nameof(DontThrowExceptionsWhenMissingRequiredParameters)).Info("Test");
+                LogManager.Configuration = null;
+            }
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/LayoutRenderers/EnvironmentTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/EnvironmentTests.cs
@@ -70,8 +70,11 @@ namespace NLog.UnitTests.LayoutRenderers
         [Fact]
         public void Environment_empty()
         {
-            AssertLayoutRendererOutput("${environment}", "");
-            AssertLayoutRendererOutput("${environment:noDefault}", "");
+            using (new NoThrowNLogExceptions())
+            {
+                AssertLayoutRendererOutput("${environment}", "");
+                AssertLayoutRendererOutput("${environment:noDefault}", "");
+            }
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenTests.cs
@@ -101,19 +101,21 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
         [Fact]
         public void WhenElseCase_empty_when()
         {
-            //else cannot be invoked ambiently. First param is inner
-            SimpleLayout l = @"${when:good:else=better}";
+            using (new NoThrowNLogExceptions())
+            {
+                //else cannot be invoked ambiently. First param is inner
+                SimpleLayout l = @"${when:good:else=better}";
 
-            {
-                var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
-                Assert.Equal("good", l.Render(le));
-            }
-            {
-                var le = LogEventInfo.Create(LogLevel.Info, "logger1", "message");
-                Assert.Equal("good", l.Render(le));
+                {
+                    var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+                    Assert.Equal("good", l.Render(le));
+                }
+                {
+                    var le = LogEventInfo.Create(LogLevel.Info, "logger1", "message");
+                    Assert.Equal("good", l.Render(le));
+                }
             }
         }
-
 
         [Fact]
         public void WhenElseCase_noIf()

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -31,25 +31,22 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Security;
 
 namespace NLog.UnitTests
 {
     using System;
-    using NLog.Common;
-    using System.IO;
-    using System.Text;
+    using System.Collections.Generic;
     using System.Globalization;
-    using NLog.Layouts;
+    using System.Linq;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Runtime.CompilerServices;
+    using System.Text;
+    using NLog.Common;
     using NLog.Config;
+    using NLog.Layouts;
     using NLog.Targets;
     using Xunit;
-    using System.Xml.Linq;
-    using System.Xml;
-    using System.IO.Compression;
 #if (NET3_5 || NET4_0 || NET4_5) && !NETSTANDARD
     using Ionic.Zip;
 #endif
@@ -59,6 +56,7 @@ namespace NLog.UnitTests
         protected NLogTestBase()
         {
             //reset before every test
+            LogManager.ThrowExceptions = false; // Ignore any errors triggered by closing existing config
             LogManager.Configuration = null;    // Will close any existing config
             LogManager.LogFactory.ResetCandidateConfigFilePath();
 


### PR DESCRIPTION
Trying to resolve #4099

For some reason then NLog has always thrown exceptions on missing / invalid required-parameters. Independent of throwException or throwConfigException.

I think NLog should continue even if having loaded invalid config (Logging should not break the host application).

Have adjusted the validation logic so it is expected that objects that implements `ISupportsInitialize` will implicit call `CheckRequiredParameters`. This ensures that Target-objects will become disabled and not call `InitializeTarget` (Just like now).

This has the side-effect that Layouts and LayoutRenderers will now also call `CheckRequiredParameters` when created and used outside the context of the `LoggingConfiguration`. Think this is an improvement.