### PR TITLE
FileTarget - New current file should write start header after archive of previous file

### DIFF
--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -1382,7 +1382,8 @@ namespace NLog.UnitTests.Targets
                     KeepFileOpen = keepFileOpen,
                     NetworkWrites = networkWrites,
                     ForceManaged = forceManaged,
-                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites
+                    ForceMutexConcurrentWrites = forceMutexConcurrentWrites,
+                    Header = "header",
                 });
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
@@ -1435,6 +1436,9 @@ namespace NLog.UnitTests.Targets
                 var files = Directory.GetFiles(archiveFolder);
                 //the amount of archived files may not exceed the set 'MaxArchiveFiles'
                 Assert.Equal(maxArchiveFiles, files.Length);
+
+                foreach (var file in files)
+                    AssertFileContentsStartsWith(file, "header", Encoding.UTF8);
 
                 SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
                 //writing one line on a new day will trigger the cleanup of old archived files
@@ -3210,7 +3214,6 @@ namespace NLog.UnitTests.Targets
                 NLog.Common.InternalLogger.Reset();
             }
         }
-
 
         [Fact]
         public void Dont_throw_Exception_when_archiving_is_enabled_with_async()


### PR DESCRIPTION
Trying to resolve  #4105. Bug was introduced with #1993