### PR TITLE
Fix VerificationException Operation could destabilize the runtime

### DIFF
--- a/src/NLog/Internal/AppendBuilderCreator.cs
+++ b/src/NLog/Internal/AppendBuilderCreator.cs
@@ -49,7 +49,7 @@ namespace NLog.Internal
         /// </summary>
         public StringBuilder Builder => _builder.Item;
 
-        private StringBuilderPool.ItemHolder _builder;
+        private StringBuilderPool.ItemHolder _builder;  // Not readonly to avoid struct-copy on Dispose(), and to avoid VerificationException when medium-trust AppDomain
 
         public AppendBuilderCreator(StringBuilder appendTarget, bool mustBeEmpty)
         {

--- a/src/NLog/Internal/AppendBuilderCreator.cs
+++ b/src/NLog/Internal/AppendBuilderCreator.cs
@@ -49,7 +49,7 @@ namespace NLog.Internal
         /// </summary>
         public StringBuilder Builder => _builder.Item;
 
-        private readonly StringBuilderPool.ItemHolder _builder;
+        private StringBuilderPool.ItemHolder _builder;
 
         public AppendBuilderCreator(StringBuilder appendTarget, bool mustBeEmpty)
         {

--- a/src/NLog/Internal/SortHelpers.cs
+++ b/src/NLog/Internal/SortHelpers.cs
@@ -173,7 +173,7 @@ namespace NLog.Internal
         /// <typeparam name="TValue">The type of the value.</typeparam>
         public struct ReadOnlySingleBucketDictionary<TKey, TValue> : IDictionary<TKey, TValue>
         {
-            KeyValuePair<TKey, TValue>? _singleBucket;
+            KeyValuePair<TKey, TValue>? _singleBucket;  // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
             readonly Dictionary<TKey, TValue> _multiBucket;
             readonly IEqualityComparer<TKey> _comparer;
             public IEqualityComparer<TKey> Comparer => _comparer;
@@ -262,7 +262,7 @@ namespace NLog.Internal
             public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>
             {
                 bool _singleBucketFirstRead;
-                KeyValuePair<TKey, TValue> _singleBucket;
+                KeyValuePair<TKey, TValue> _singleBucket;   // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
                 readonly IEnumerator<KeyValuePair<TKey, TValue>> _multiBuckets;
 
                 internal Enumerator(Dictionary<TKey, TValue> multiBucket)

--- a/src/NLog/Internal/SortHelpers.cs
+++ b/src/NLog/Internal/SortHelpers.cs
@@ -173,7 +173,7 @@ namespace NLog.Internal
         /// <typeparam name="TValue">The type of the value.</typeparam>
         public struct ReadOnlySingleBucketDictionary<TKey, TValue> : IDictionary<TKey, TValue>
         {
-            readonly KeyValuePair<TKey, TValue>? _singleBucket;
+            KeyValuePair<TKey, TValue>? _singleBucket;
             readonly Dictionary<TKey, TValue> _multiBucket;
             readonly IEqualityComparer<TKey> _comparer;
             public IEqualityComparer<TKey> Comparer => _comparer;
@@ -262,7 +262,7 @@ namespace NLog.Internal
             public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>
             {
                 bool _singleBucketFirstRead;
-                readonly KeyValuePair<TKey, TValue> _singleBucket;
+                KeyValuePair<TKey, TValue> _singleBucket;
                 readonly IEnumerator<KeyValuePair<TKey, TValue>> _multiBuckets;
 
                 internal Enumerator(Dictionary<TKey, TValue> multiBucket)

--- a/src/NLog/MessageTemplates/Literal.cs
+++ b/src/NLog/MessageTemplates/Literal.cs
@@ -40,9 +40,15 @@ namespace NLog.MessageTemplates
     {
         /// <summary>Number of characters from the original template to copy at the current position.</summary>
         /// <remarks>This can be 0 when the template starts with a hole or when there are multiple consecutive holes.</remarks>
-        public int Print;
+        public readonly int Print;
         /// <summary>Number of characters to skip in the original template at the current position.</summary>
         /// <remarks>0 is a special value that mean: 1 escaped char, no hole. It can also happen last when the template ends with a literal.</remarks>
-        public int Skip;
+        public readonly int Skip;
+
+        public Literal(int print, int skip)
+        {
+            Print = print;
+            Skip = skip;
+        }
     }
 }

--- a/src/NLog/MessageTemplates/LiteralHole.cs
+++ b/src/NLog/MessageTemplates/LiteralHole.cs
@@ -39,10 +39,10 @@ namespace NLog.MessageTemplates
     internal struct LiteralHole
     {
         /// <summary>Literal</summary>
-        public readonly Literal Literal;
+        public Literal Literal;
         /// <summary>Hole</summary>
         /// <remarks>Uninitialized when <see cref="MessageTemplates.Literal.Skip"/> = 0.</remarks>
-        public readonly Hole Hole;
+        public Hole Hole;
 
         public LiteralHole(Literal literal, Hole hole)
         {

--- a/src/NLog/MessageTemplates/LiteralHole.cs
+++ b/src/NLog/MessageTemplates/LiteralHole.cs
@@ -39,10 +39,10 @@ namespace NLog.MessageTemplates
     internal struct LiteralHole
     {
         /// <summary>Literal</summary>
-        public Literal Literal;
+        public Literal Literal; // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
         /// <summary>Hole</summary>
         /// <remarks>Uninitialized when <see cref="MessageTemplates.Literal.Skip"/> = 0.</remarks>
-        public Hole Hole;
+        public Hole Hole;       // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
 
         public LiteralHole(Literal literal, Hole hole)
         {

--- a/src/NLog/MessageTemplates/TemplateEnumerator.cs
+++ b/src/NLog/MessageTemplates/TemplateEnumerator.cs
@@ -134,7 +134,7 @@ namespace NLog.MessageTemplates
 
         private void AddLiteral()
         {
-            _current = new LiteralHole(new Literal { Print = _literalLength, Skip = Zero }, default(Hole));
+            _current = new LiteralHole(new Literal(_literalLength, Zero), default(Hole));
             _literalLength = 0;
         }
 
@@ -195,7 +195,7 @@ namespace NLog.MessageTemplates
             }
 
             int literalSkip = _position - start + (type == CaptureType.Normal ? 1 : 2);     // Account for skipped '{', '{$' or '{@'
-            _current = new LiteralHole(new Literal { Print = _literalLength, Skip = literalSkip }, new Hole(
+            _current = new LiteralHole(new Literal(_literalLength, literalSkip), new Hole(
                 name,
                 format,
                 type,

--- a/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
+++ b/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
@@ -169,7 +169,7 @@ namespace NLog.UnitTests.Internal
                     logger.Debug("aaa");
                     logger.Info("bbb");
                     logger.Warn("ccc");
-                    logger.Error("ddd");
+                    logger.Error("{d:l}", "ddd");
                     logger.Fatal("eee");
                 }
             }


### PR DESCRIPTION
That was triggered by copying readonly structs in medium trust AppDomain. Not sure why it would destabilize, but lets not get into details.

See also #3142 and #3138