### PR TITLE
ScopeContext to replace MDLC and NDLC

### DIFF
--- a/src/NLog/Abstractions/IIncludeContext.cs
+++ b/src/NLog/Abstractions/IIncludeContext.cs
@@ -54,18 +54,18 @@ namespace NLog
         /// Gets or sets the option to include all properties from the log events
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        bool IncludeAllProperties { get; set; }
+        bool IncludeEventProperties { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
+        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> properties-dictionary.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        bool IncludeMdlc { get; set; }
+        bool IncludeScopeProperties { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsLogicalContext"/> stack.
+        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> operation-state-stack.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        bool IncludeNdlc { get; set; }
+        bool IncludeScopeOperationStates { get; set; }
     }
 }

--- a/src/NLog/Abstractions/IIncludeContext.cs
+++ b/src/NLog/Abstractions/IIncludeContext.cs
@@ -57,13 +57,13 @@ namespace NLog
         bool IncludeEventProperties { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> properties-dictionary.
+        /// Gets or sets whether to include the contents of the <see cref="ScopeContext"/> properties-dictionary.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
         bool IncludeScopeProperties { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> operation-state-stack.
+        /// Gets or sets whether to include the contents of the <see cref="ScopeContext"/> operation-call-stack.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
         bool IncludeScopeOperationStates { get; set; }

--- a/src/NLog/Contexts/MappedDiagnosticsLogicalContext.cs
+++ b/src/NLog/Contexts/MappedDiagnosticsLogicalContext.cs
@@ -35,7 +35,6 @@ namespace NLog
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading;
     using NLog.Internal;
 
     /// <summary>
@@ -49,143 +48,6 @@ namespace NLog
     /// </remarks>
     public static class MappedDiagnosticsLogicalContext
     {
-        private sealed class ItemRemover : IDisposable
-        {
-            private readonly string _item1;
-#if !NET3_5 && !NET4_0
-            // Optimized for HostingLogScope with 3 properties
-            private readonly string _item2;
-            private readonly string _item3;
-            private readonly string[] _itemArray;
-#endif
-            //boolean as int to allow the use of Interlocked.Exchange
-            private int _disposed;
-            private readonly bool _wasEmpty;
-
-            public ItemRemover(string item, bool wasEmpty)
-            {
-                _item1 = item;
-                _wasEmpty = wasEmpty;
-            }
-
-#if !NET3_5 && !NET4_0
-            public ItemRemover(IReadOnlyList<KeyValuePair<string,object>> items, bool wasEmpty)
-            {
-                int itemCount = items.Count;
-                if (itemCount > 2)
-                {
-                    _item1 = items[0].Key;
-                    _item2 = items[1].Key;
-                    _item3 = items[2].Key;
-                    for (int i = 3; i < itemCount; ++i)
-                    {
-                        _itemArray = _itemArray ?? new string[itemCount - 3];
-                        _itemArray[i - 3] = items[i].Key;
-                    }
-                }
-                else if (itemCount > 1)
-                {
-                    _item1 = items[0].Key;
-                    _item2 = items[1].Key;
-                }
-                else
-                {
-                    _item1 = items[0].Key;
-                }
-                _wasEmpty = wasEmpty;
-            }
-#endif
-
-            public void Dispose()
-            {
-                if (Interlocked.Exchange(ref _disposed, 1) == 0)
-                {
-                    if (_wasEmpty && RemoveScopeWillClearContext())
-                    {
-                        Clear(true);
-                        return;
-                    }
-
-                    var dictionary = GetLogicalThreadDictionary(true);
-                    dictionary.Remove(_item1);
-#if !NET3_5 && !NET4_0
-                    if (_item2 != null)
-                    {
-                        dictionary.Remove(_item2);
-                        if (_item3 != null)
-                            dictionary.Remove(_item3);
-                        if (_itemArray != null)
-                        {
-                            for (int i = 0; i < _itemArray.Length; ++i)
-                            {
-                                if (_itemArray[i] != null)
-                                    dictionary.Remove(_itemArray[i]);
-                            }
-                        }
-                    }
-#endif
-                }
-            }
-
-            private bool RemoveScopeWillClearContext()
-            {
-#if !NET3_5 && !NET4_0
-                if (_itemArray == null)
-                {
-                    var immutableDict = GetLogicalThreadDictionary(false);
-                    if ((immutableDict.Count == 1 && ReferenceEquals(_item2, null) && immutableDict.ContainsKey(_item1))
-                      || (immutableDict.Count == 2 && !ReferenceEquals(_item2, null) && ReferenceEquals(_item3, null) && immutableDict.ContainsKey(_item1) && immutableDict.ContainsKey(_item2) && !_item1.Equals(_item2))
-                      || (immutableDict.Count == 3 && !ReferenceEquals(_item3, null) && immutableDict.ContainsKey(_item1) && immutableDict.ContainsKey(_item2) && immutableDict.ContainsKey(_item3) && !_item1.Equals(_item2) && !_item1.Equals(_item3) && !_item2.Equals(_item3))
-                      )
-                    {
-                        return true;
-                    }
-                }
-#else
-                var immutableDict = GetLogicalThreadDictionary(false);
-                if (immutableDict.Count == 1 && immutableDict.ContainsKey(_item1))
-                {
-                    return true;
-                }
-#endif
-                return false;
-            }
-
-            public override string ToString()
-            {
-                return _item1?.ToString() ?? base.ToString();
-            }
-        }
-
-        /// <summary>
-        /// Simulate ImmutableDictionary behavior (which is not yet part of all .NET frameworks).
-        /// In future the real ImmutableDictionary could be used here to minimize memory usage and copying time.
-        /// </summary>
-        /// <param name="clone">Must be true for any subsequent dictionary modification operation</param>
-        /// <param name="initialCapacity">Prepare dictionary for additional inserts</param>
-        /// <returns></returns>
-        private static IDictionary<string, object> GetLogicalThreadDictionary(bool clone = false, int initialCapacity = 0)
-        {
-            var dictionary = GetThreadLocal();
-            if (dictionary == null)
-            {
-                if (!clone)
-                    return EmptyDefaultDictionary;
-
-                dictionary = new Dictionary<string, object>(initialCapacity);
-                SetThreadLocal(dictionary);
-            }
-            else if (clone)
-            {
-                var newDictionary = new Dictionary<string, object>(dictionary.Count + initialCapacity);
-                foreach (var keyValue in dictionary)
-                    newDictionary[keyValue.Key] = keyValue.Value;
-                SetThreadLocal(newDictionary);
-                return newDictionary;
-            }
-            return dictionary;
-        }
-
         /// <summary>
         /// Gets the current logical context named item, as <see cref="string"/>.
         /// </summary>
@@ -216,18 +78,10 @@ namespace NLog
         /// <returns>The value of <paramref name="item"/>, if defined; otherwise <c>null</c>.</returns>
         public static object GetObject(string item)
         {
-            if (!GetLogicalThreadDictionary().TryGetValue(item, out var value))
+            if (ScopeContext.TryLookupProperty(item, out var value))
+                return value;
+            else
                 return null;
-
-#if NET4_6 || NETSTANDARD
-            return value;
-#else
-            if (value is ObjectHandleSerializer objectHandle)
-            {
-                return objectHandle.Unwrap();
-            }
-            return value;
-#endif
         }
 
         /// <summary>
@@ -260,10 +114,7 @@ namespace NLog
         /// <returns>>An <see cref="IDisposable"/> that can be used to remove the item from the current logical context.</returns>
         public static IDisposable SetScoped<T>(string item, T value)
         {
-            var logicalContext = GetLogicalThreadDictionary(true, 1);
-            bool wasEmpty = logicalContext.Count == 0;
-            SetItemValue(item, value, logicalContext);
-            return new ItemRemover(item, wasEmpty);
+            return ScopeContext.PushProperty(item, value);
         }
 
 #if !NET3_5 && !NET4_0
@@ -272,20 +123,9 @@ namespace NLog
         /// </summary>
         /// <param name="items">.</param>
         /// <returns>>An <see cref="IDisposable"/> that can be used to remove the item from the current logical context (null if no items).</returns>
-        public static IDisposable SetScoped(IReadOnlyList<KeyValuePair<string,object>> items)
+        public static IDisposable SetScoped(IReadOnlyList<KeyValuePair<string, object>> items)
         {
-            if (items?.Count > 0)
-            {
-                var logicalContext = GetLogicalThreadDictionary(true, items.Count);
-                bool wasEmpty = logicalContext.Count == 0;
-                for (int i = 0; i < items.Count; ++i)
-                {
-                    SetItemValue(items[i].Key, items[i].Value, logicalContext);
-                }
-                return new ItemRemover(items, wasEmpty);
-            }
-
-            return null;
+            return ScopeContext.PushProperties(items);
         }
 #endif
         /// <summary>
@@ -315,19 +155,13 @@ namespace NLog
         /// <param name="value">Item value.</param>
         public static void Set<T>(string item, T value)
         {
-            var logicalContext = GetLogicalThreadDictionary(true, 1);
-            SetItemValue(item, value, logicalContext);
-        }
-
-        private static void SetItemValue<T>(string item, T value, IDictionary<string, object> logicalContext)
-        {
-#if NET4_6 || NETSTANDARD
-            logicalContext[item] = value;
+#if !NET35 && !NET40 && !NET45
+            ScopeContext.SetMappedContextLegacy(item, value);
 #else
-            if (typeof(T).IsValueType || Convert.GetTypeCode(value) != TypeCode.Object)
-                logicalContext[item] = value;
-            else
-                logicalContext[item] = new ObjectHandleSerializer(value);
+            var oldContext = GetThreadLocal();
+            var newContext = CloneDictionary(oldContext, 1);
+            SetItemValue(item, value, newContext);
+            SetThreadLocal(newContext);
 #endif
         }
 
@@ -337,7 +171,11 @@ namespace NLog
         /// <returns>A collection of the names of all items in current logical context.</returns>
         public static ICollection<string> GetNames()
         {
-            return GetLogicalThreadDictionary().Keys;
+#if !NET35 && !NET40 && !NET45
+            return new List<string>(System.Linq.Enumerable.Select(ScopeContext.GetAllProperties(), i => i.Key));
+#else
+            return GetThreadLocal()?.Keys ?? (ICollection<string>)ArrayHelper.Empty<string>();
+#endif
         }
 
         /// <summary>
@@ -347,7 +185,11 @@ namespace NLog
         /// <returns>A boolean indicating whether the specified <paramref name="item"/> exists in current logical context.</returns>
         public static bool Contains(string item)
         {
-            return GetLogicalThreadDictionary().ContainsKey(item);
+#if !NET35 && !NET40 && !NET45
+            return ScopeContext.TryLookupProperty(item, out var _);
+#else
+            return GetThreadLocal()?.ContainsKey(item) == true;
+#endif
         }
 
         /// <summary>
@@ -356,7 +198,17 @@ namespace NLog
         /// <param name="item">Item name.</param>
         public static void Remove(string item)
         {
-            GetLogicalThreadDictionary(true).Remove(item);
+#if !NET35 && !NET40 && !NET45
+            ScopeContext.RemoveMappedContextLegacy(item);
+#else
+            var oldContext = GetThreadLocal();
+            if (oldContext?.ContainsKey(item)==true)
+            {
+                var newContext = CloneDictionary(oldContext, 0);
+                newContext.Remove(item);
+                SetThreadLocal(newContext);
+            }
+#endif
         }
 
         /// <summary>
@@ -373,43 +225,149 @@ namespace NLog
         /// <param name="free">Free the full slot.</param>
         public static void Clear(bool free)
         {
-            if (free)
+#if !NET35 && !NET40 && !NET45
+            ScopeContext.ClearMappedContextLegacy();
+#else
+            ClearDictionary();
+#endif
+        }
+
+#if NET35 || NET40 || NET45
+
+#if !NET35 && !NET40
+        internal static IDisposable PushProperties(IReadOnlyList<KeyValuePair<string, object>> properties)
+        {
+            if (properties?.Count > 0)
             {
-                SetThreadLocal(null);
+                var oldContext = GetThreadLocal();
+                var newContext = CloneDictionary(oldContext, properties.Count);
+                for (int i = 0; i < properties.Count; ++i)
+                    SetItemValue(properties[i].Key, properties[i].Value, newContext);
+                SetThreadLocal(newContext);
+                return new MappedScope(oldContext);
             }
-            else
+            return null;
+        }
+#endif
+
+        internal static IDisposable PushProperty<T>(string propertyName, T propertyValue)
+        {
+            var oldContext = GetThreadLocal();
+            var newContext = CloneDictionary(oldContext, 1);
+            SetItemValue(propertyName, propertyValue, newContext);
+            SetThreadLocal(newContext);
+            return new MappedScope(oldContext);
+        }
+
+        internal static bool TryLookupProperty(string propertyName, out object value)
+        {
+            var oldContext = GetThreadLocal();
+            if (oldContext != null && oldContext.TryGetValue(propertyName, out value))
             {
-                GetLogicalThreadDictionary(true).Clear();
+                if (value is ObjectHandleSerializer objectHandle)
+                    value = objectHandle.Unwrap();
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        internal static void ClearDictionary()
+        {
+            SetThreadLocal(null);
+        }
+
+        internal static IEnumerable<KeyValuePair<string, object>> GetAllProperties()
+        {
+            var context = GetThreadLocal();
+            if (context?.Count > 0)
+            {
+                foreach (var item in context)
+                {
+                    if (item.Value is ObjectHandleSerializer)
+                    {
+                        return GetAllPropertiesUnwrapped(context);
+                    }
+                }
+                return context;
+            }
+            return ArrayHelper.Empty<KeyValuePair<string, object>>();
+        }
+
+        private static IEnumerable<KeyValuePair<string, object>> GetAllPropertiesUnwrapped(Dictionary<string, object> properties)
+        {
+            foreach (var item in properties)
+            {
+                if (item.Value is ObjectHandleSerializer objectHandle)
+                {
+                    yield return new KeyValuePair<string, object>(item.Key, objectHandle.Unwrap());
+                }
+                else
+                {
+                    yield return item;
+                }
+            }
+        }
+
+        private static Dictionary<string, object> CloneDictionary(Dictionary<string, object> oldContext, int initialCapacity = 0)
+        {
+            if (oldContext?.Count > 0)
+            {
+                var dictionary = new Dictionary<string, object>(oldContext.Count + initialCapacity, DefaultComparer);
+                foreach (var keyValue in oldContext)
+                    dictionary[keyValue.Key] = keyValue.Value;
+                return dictionary;
+            }
+            
+            return new Dictionary<string, object>(initialCapacity, DefaultComparer);
+        }
+
+        private static void SetItemValue<T>(string item, T value, IDictionary<string, object> logicalContext)
+        {
+            object objectValue = value;
+            if (Convert.GetTypeCode(objectValue) != TypeCode.Object)
+                logicalContext[item] = objectValue;
+            else
+                logicalContext[item] = new ObjectHandleSerializer(objectValue);
+        }
+
+        private sealed class MappedScope : IDisposable
+        {
+            private readonly Dictionary<string, object> _oldContext;
+            private bool _diposed;
+
+            public MappedScope(Dictionary<string, object> oldContext)
+            {
+                _oldContext = oldContext;
+            }
+
+            public void Dispose()
+            {
+                if (!_diposed)
+                {
+                    SetThreadLocal(_oldContext);
+                    _diposed = true;
+                }
             }
         }
 
         private static void SetThreadLocal(Dictionary<string, object> newValue)
         {
-#if NET4_6 || NETSTANDARD
-            AsyncLocalDictionary.Value = newValue;
-#else
             if (newValue == null)
                 System.Runtime.Remoting.Messaging.CallContext.FreeNamedDataSlot(LogicalThreadDictionaryKey);
             else
                 System.Runtime.Remoting.Messaging.CallContext.LogicalSetData(LogicalThreadDictionaryKey, newValue);
-#endif
         }
 
         private static Dictionary<string, object> GetThreadLocal()
         {
-#if NET4_6 || NETSTANDARD
-            return AsyncLocalDictionary.Value;
-#else
             return System.Runtime.Remoting.Messaging.CallContext.LogicalGetData(LogicalThreadDictionaryKey) as Dictionary<string, object>;
-#endif
         }
 
-#if NET4_6 || NETSTANDARD
-        private static readonly System.Threading.AsyncLocal<Dictionary<string, object>> AsyncLocalDictionary = new System.Threading.AsyncLocal<Dictionary<string, object>>();
-#else
         private const string LogicalThreadDictionaryKey = "NLog.AsyncableMappedDiagnosticsContext";
-#endif
 
-        private static readonly IDictionary<string, object> EmptyDefaultDictionary = new SortHelpers.ReadOnlySingleBucketDictionary<string, object>();
+        private static IEqualityComparer<string> DefaultComparer = StringComparer.OrdinalIgnoreCase;
+#endif
     }
 }

--- a/src/NLog/Contexts/MappedDiagnosticsLogicalContext.cs
+++ b/src/NLog/Contexts/MappedDiagnosticsLogicalContext.cs
@@ -228,7 +228,7 @@ namespace NLog
 #if !NET35 && !NET40 && !NET45
             ScopeContext.ClearMappedContextLegacy();
 #else
-            ClearDictionary();
+            ClearMappedContext();
 #endif
         }
 
@@ -273,7 +273,7 @@ namespace NLog
             return false;
         }
 
-        internal static void ClearDictionary()
+        internal static void ClearMappedContext()
         {
             SetThreadLocal(null);
         }

--- a/src/NLog/Contexts/MappedDiagnosticsLogicalContext.cs
+++ b/src/NLog/Contexts/MappedDiagnosticsLogicalContext.cs
@@ -244,7 +244,7 @@ namespace NLog
                 for (int i = 0; i < properties.Count; ++i)
                     SetItemValue(properties[i].Key, properties[i].Value, newContext);
                 SetThreadLocal(newContext);
-                return new MappedScope(oldContext);
+                return new ScopeContextProperties(oldContext);
             }
             return null;
         }
@@ -256,7 +256,7 @@ namespace NLog
             var newContext = CloneDictionary(oldContext, 1);
             SetItemValue(propertyName, propertyValue, newContext);
             SetThreadLocal(newContext);
-            return new MappedScope(oldContext);
+            return new ScopeContextProperties(oldContext);
         }
 
         internal static bool TryLookupProperty(string propertyName, out object value)
@@ -332,12 +332,12 @@ namespace NLog
                 logicalContext[item] = new ObjectHandleSerializer(objectValue);
         }
 
-        private sealed class MappedScope : IDisposable
+        private sealed class ScopeContextProperties : IDisposable
         {
             private readonly Dictionary<string, object> _oldContext;
             private bool _diposed;
 
-            public MappedScope(Dictionary<string, object> oldContext)
+            public ScopeContextProperties(Dictionary<string, object> oldContext)
             {
                 _oldContext = oldContext;
             }

--- a/src/NLog/Contexts/NestedDiagnosticsLogicalContext.cs
+++ b/src/NLog/Contexts/NestedDiagnosticsLogicalContext.cs
@@ -35,6 +35,7 @@
 namespace NLog
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using NLog.Internal;
 
@@ -51,10 +52,7 @@ namespace NLog
         /// <returns>An instance of the object that implements IDisposable that returns the stack to the previous level when IDisposable.Dispose() is called. To be used with C# using() statement.</returns>
         public static IDisposable Push<T>(T value)
         {
-            var parent = GetThreadLocal();
-            var current = NestedContext<T>.CreateNestedContext(parent, value);
-            SetThreadLocal(current);
-            return current;
+            return ScopeContext.PushOperationState(value);
         }
 
         /// <summary>
@@ -94,10 +92,23 @@ namespace NLog
         /// <returns>The object from the top of the NDLC stack, if defined; otherwise <c>null</c>.</returns>
         public static object PopObject()
         {
-            var current = GetThreadLocal();
-            if (current != null)
-                SetThreadLocal(current.Parent);
-            return current?.Value;
+#if !NET35 && !NET40 && !NET45
+            return ScopeContext.PopNestedContextLegacy();
+#else
+            var currentContext = GetThreadLocal();
+            if (currentContext?.Count > 0)
+            {
+                var objectValue = currentContext.First.Value;
+                if (objectValue is ObjectHandleSerializer objectHandle)
+                    objectValue = objectHandle.Unwrap();
+                var newContext = currentContext.Count > 1 ? new LinkedList<object>(currentContext) : null;
+                if (newContext != null)
+                    newContext.RemoveFirst();
+                SetThreadLocal(newContext);
+                return objectValue;
+            }
+            return null;
+#endif
         }
 
         /// <summary>
@@ -106,40 +117,7 @@ namespace NLog
         /// <returns>The object from the top of the NDLC stack, if defined; otherwise <c>null</c>.</returns>
         public static object PeekObject()
         {
-            return PeekContext(false)?.Value;
-        }
-
-        /// <summary>
-        /// Peeks the current scope, and returns its start time
-        /// </summary>
-        /// <returns>Scope Creation Time</returns>
-        internal static DateTime PeekTopScopeBeginTime()
-        {
-            return new DateTime(PeekContext(false)?.CreatedTimeUtcTicks ?? DateTime.MinValue.Ticks, DateTimeKind.Utc);
-        }
-
-        /// <summary>
-        /// Peeks the first scope, and returns its start time
-        /// </summary>
-        /// <returns>Scope Creation Time</returns>
-        internal static DateTime PeekBottomScopeBeginTime()
-        {
-            return new DateTime(PeekContext(true)?.CreatedTimeUtcTicks ?? DateTime.MinValue.Ticks, DateTimeKind.Utc);
-        }
-
-        private static INestedContext PeekContext(bool bottomScope)
-        {
-            var current = GetThreadLocal();
-            if (current != null)
-            {
-                if (bottomScope)
-                {
-                    while (current.Parent != null)
-                        current = current.Parent;
-                }
-                return current;
-            }
-            return null;
+            return ScopeContext.PeekOperationState();
         }
 
         /// <summary>
@@ -147,7 +125,11 @@ namespace NLog
         /// </summary>
         public static void Clear()
         {
-            SetThreadLocal(null);
+#if !NET35 && !NET40 && !NET45
+            ScopeContext.ClearNestedContextLegacy();
+#else
+            ClearStack();
+#endif
         }
 
         /// <summary>
@@ -175,20 +157,100 @@ namespace NLog
         /// <returns>Array of objects on the stack.</returns>
         public static object[] GetAllObjects()
         {
-            var currentContext = GetThreadLocal();
-            if (currentContext == null)
-                return ArrayHelper.Empty<object>();
-
-            int index = 0;
-            object[] messages = new object[currentContext.FrameLevel];
-            while (currentContext != null)
-            {
-                messages[index++] = currentContext.Value;
-                currentContext = currentContext.Parent;
-            }
-            return messages;
+            return ScopeContext.GetAllOperationStates();
         }
 
+#if NET35 || NET40 || NET45
+
+        internal static IDisposable PushOperationState<T>(T value)
+        {
+            var oldContext = GetThreadLocal();
+            var newContext = oldContext?.Count > 0 ? new LinkedList<object>(oldContext) : new LinkedList<object>();
+            object objectValue = value;
+            if (Convert.GetTypeCode(objectValue) == TypeCode.Object)
+                objectValue = new ObjectHandleSerializer(objectValue);
+            newContext.AddFirst(objectValue);
+            SetThreadLocal(newContext);
+            return new NestedScope(oldContext, objectValue);
+        }
+
+        internal static object PeekOperationState()
+        {
+            var currentContext = GetThreadLocal();
+            var objectValue = currentContext?.Count > 0 ? currentContext.First.Value : null;
+            if (objectValue is ObjectHandleSerializer objectHandle)
+                objectValue = objectHandle.Unwrap();
+            return objectValue;
+        }
+
+        internal static object[] GetAllOperationStates()
+        {
+            var currentContext = GetThreadLocal();
+            if (currentContext?.Count > 0)
+            {
+                int index = 0;
+                object[] messages = new object[currentContext.Count];
+                foreach (var node in currentContext)
+                {
+                    if (node is ObjectHandleSerializer objectHandle)
+                        messages[index++] = objectHandle.Unwrap();
+                    else
+                        messages[index++] = node;
+                }
+                return messages;
+            }
+            return ArrayHelper.Empty<object>();
+        }
+
+        internal static void ClearStack()
+        {
+            SetThreadLocal(null);
+        }
+
+        private sealed class NestedScope : IDisposable
+        {
+            private readonly LinkedList<object> _oldContext;
+            private readonly object _value;
+            private bool _diposed;
+
+            public NestedScope(LinkedList<object> oldContext, object value)
+            {
+                _oldContext = oldContext;
+                _value = value;
+            }
+
+            public void Dispose()
+            {
+                if (!_diposed)
+                {
+                    SetThreadLocal(_oldContext);
+                    _diposed = true;
+                }
+            }
+
+            public override string ToString()
+            {
+                return _value?.ToString() ?? "null";
+            }
+        }
+
+        private static void SetThreadLocal(LinkedList<object> nestedContext)
+        {
+            if (nestedContext == null)
+                System.Runtime.Remoting.Messaging.CallContext.FreeNamedDataSlot(NestedDiagnosticsContextKey);
+            else
+                System.Runtime.Remoting.Messaging.CallContext.LogicalSetData(NestedDiagnosticsContextKey, nestedContext);
+        }
+
+        private static LinkedList<object> GetThreadLocal()
+        {
+            return System.Runtime.Remoting.Messaging.CallContext.LogicalGetData(NestedDiagnosticsContextKey) as LinkedList<object>;
+        }
+
+        private const string NestedDiagnosticsContextKey = "NLog.NestedDiagnosticsLogicalContext";
+#endif
+
+        [Obsolete("Required to be compatible with legacy NLog versions, when using remoting. Marked obsolete on NLog 5.0")]
         interface INestedContext : IDisposable
         {
             INestedContext Parent { get; }
@@ -200,7 +262,8 @@ namespace NLog
 #if !NETSTANDARD1_0
         [Serializable]
 #endif
-        class NestedContext<T> : INestedContext
+        [Obsolete("Required to be compatible with legacy NLog versions, when using remoting. Marked obsolete on NLog 5.0")]
+        sealed class NestedContext<T> : INestedContext
         {
             public INestedContext Parent { get; }
             public T Value { get; }
@@ -208,32 +271,18 @@ namespace NLog
             public int FrameLevel { get; }
             private int _disposed;
 
-            public static INestedContext CreateNestedContext(INestedContext parent, T value)
-            {
-#if NET4_6 || NETSTANDARD
-                return new NestedContext<T>(parent, value);
-#else
-                if (typeof(T).IsValueType || Convert.GetTypeCode(value) != TypeCode.Object)
-                    return new NestedContext<T>(parent, value);
-                else
-                    return new NestedContext<ObjectHandleSerializer>(parent, new ObjectHandleSerializer(value));
-#endif
-            }
-
             object INestedContext.Value
             {
                 get
                 {
-#if NET4_6 || NETSTANDARD
-                    return Value;
-#else
                     object value = Value;
+#if NET35 || NET40 || NET45
                     if (value is ObjectHandleSerializer objectHandle)
                     {
                         return objectHandle.Unwrap();
                     }
-                    return value;
 #endif
+                    return value;
                 }
             }
 
@@ -259,32 +308,5 @@ namespace NLog
                 return value?.ToString() ?? "null";
             }
         }
-
-        private static void SetThreadLocal(INestedContext newValue)
-        {
-#if NET4_6 || NETSTANDARD
-            AsyncNestedDiagnosticsContext.Value = newValue;
-#else
-            if (newValue == null)
-                System.Runtime.Remoting.Messaging.CallContext.FreeNamedDataSlot(NestedDiagnosticsContextKey);
-            else
-                System.Runtime.Remoting.Messaging.CallContext.LogicalSetData(NestedDiagnosticsContextKey, newValue);
-#endif
-        }
-
-        private static INestedContext GetThreadLocal()
-        {
-#if NET4_6 || NETSTANDARD
-            return AsyncNestedDiagnosticsContext.Value;
-#else
-            return System.Runtime.Remoting.Messaging.CallContext.LogicalGetData(NestedDiagnosticsContextKey) as INestedContext;
-#endif
-        }
-
-#if NET4_6 || NETSTANDARD
-        private static readonly System.Threading.AsyncLocal<INestedContext> AsyncNestedDiagnosticsContext = new System.Threading.AsyncLocal<INestedContext>();
-#else
-        private const string NestedDiagnosticsContextKey = "NLog.AsyncableNestedDiagnosticsContext";
-#endif
     }
 }

--- a/src/NLog/Contexts/NestedDiagnosticsLogicalContext.cs
+++ b/src/NLog/Contexts/NestedDiagnosticsLogicalContext.cs
@@ -171,7 +171,7 @@ namespace NLog
                 objectValue = new ObjectHandleSerializer(objectValue);
             newContext.AddFirst(objectValue);
             SetThreadLocal(newContext);
-            return new NestedScope(oldContext, objectValue);
+            return new ScopeContextOperationState(oldContext, objectValue);
         }
 
         internal static object PeekOperationState()
@@ -207,16 +207,16 @@ namespace NLog
             SetThreadLocal(null);
         }
 
-        private sealed class NestedScope : IDisposable
+        private sealed class ScopeContextOperationState : IDisposable
         {
             private readonly LinkedList<object> _oldContext;
-            private readonly object _value;
+            private readonly object _operationState;
             private bool _diposed;
 
-            public NestedScope(LinkedList<object> oldContext, object value)
+            public ScopeContextOperationState(LinkedList<object> oldContext, object operationState)
             {
                 _oldContext = oldContext;
-                _value = value;
+                _operationState = operationState;
             }
 
             public void Dispose()
@@ -230,7 +230,7 @@ namespace NLog
 
             public override string ToString()
             {
-                return _value?.ToString() ?? "null";
+                return _operationState?.ToString() ?? "null";
             }
         }
 

--- a/src/NLog/Contexts/NestedDiagnosticsLogicalContext.cs
+++ b/src/NLog/Contexts/NestedDiagnosticsLogicalContext.cs
@@ -128,7 +128,7 @@ namespace NLog
 #if !NET35 && !NET40 && !NET45
             ScopeContext.ClearNestedContextLegacy();
 #else
-            ClearStack();
+            ClearNestedContext();
 #endif
         }
 
@@ -202,7 +202,7 @@ namespace NLog
             return ArrayHelper.Empty<object>();
         }
 
-        internal static void ClearStack()
+        internal static void ClearNestedContext()
         {
             SetThreadLocal(null);
         }

--- a/src/NLog/Contexts/ScopeContext.cs
+++ b/src/NLog/Contexts/ScopeContext.cs
@@ -1,0 +1,994 @@
+﻿// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Collections.Generic;
+using NLog.Internal;
+
+namespace NLog
+{
+    /// <summary>
+    /// <see cref="ScopeContext"/> allows one to store state in the thread execution context. All LogEvents created
+    /// within a scope can include the scope state when wanted. The logical operation scope state supports both
+    /// scope-properties and scope-operation-states.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ScopeContext"/> unifies <see cref="MappedDiagnosticsLogicalContext"/> (MDLC) and <see cref="NestedDiagnosticsLogicalContext"/> (NDLC).
+    /// 
+    /// .NetCore (and .Net46) uses AsyncLocal for handling the thread execution context. Older .NetFramework uses System.Runtime.Remoting.CallContext
+    /// </remarks>
+    public static class ScopeContext
+    {
+#if !NET35 && !NET40
+        /// <summary>
+        /// Creates logical operation scope that includes provided properties and stack-value
+        /// </summary>
+        /// <param name="operationState">Value to added to the scope operation stack</param>
+        /// <param name="properties">Properties being added to the scope dictionray</param>
+        /// <returns>A disposable object that ends the logical operation scope on dispose.</returns>
+        /// <remarks>Scope dictionary keys are case-insensitive</remarks>
+        public static IDisposable PushOperationProperties(object operationState, IReadOnlyList<KeyValuePair<string, object>> properties)
+        {
+#if !NET45
+            var parent = GetThreadLocal();
+            IScopeContext current = null;
+            if (properties?.Count > 0)
+                current = new ScopeContextProperties(parent, properties, operationState);
+            else 
+                current = new ScopeContextOperationState<object>(parent, operationState);
+            SetThreadLocal(current);
+            return current;
+#else
+            if (properties?.Count > 0)
+            {
+                var mldcScope = MappedDiagnosticsLogicalContext.PushProperties(properties);
+                var ndlcScope = NestedDiagnosticsLogicalContext.PushOperationState(operationState);
+                return new ScopeProperties(ndlcScope, mldcScope);
+            }
+            else
+            {
+                return NestedDiagnosticsLogicalContext.PushOperationState(operationState);
+            }
+#endif
+        }
+#endif
+
+#if !NET35 && !NET40
+        /// <summary>
+        /// Creates logical operation scope that includes provided properties
+        /// </summary>
+        /// <param name="properties">Properties being added to the scope dictionray</param>
+        /// <returns>A disposable object that ends the logical operation scope on dispose.</returns>
+        /// <remarks>Scope dictionary keys are case-insensitive</remarks>
+        public static IDisposable PushProperties(IReadOnlyList<KeyValuePair<string, object>> properties)
+        {
+#if !NET45
+            var parent = GetThreadLocal();
+            var current = new ScopeContextProperties(parent, properties, null);
+            SetThreadLocal(current);
+            return current;
+#else
+            return MappedDiagnosticsLogicalContext.PushProperties(properties);
+#endif
+        }
+#endif
+
+        /// <summary>
+        /// Creates logical operation scope that includes provided property
+        /// </summary>
+        /// <param name="key">Name of property</param>
+        /// <param name="value">Value of property</param>
+        /// <returns>A disposable object that ends the logical operation scope on dispose.</returns>
+        /// <remarks>Scope dictionary keys are case-insensitive</remarks>
+        public static IDisposable PushProperty<T>(string key, T value)
+        {
+#if !NET35 && !NET40 && !NET45
+            // Skips casting to check for properties
+            var parent = GetThreadLocal();
+            var current = new ScopeContextProperty<T>(parent, key, value);
+            SetThreadLocal(current);
+            return current;
+#else
+            return MappedDiagnosticsLogicalContext.PushProperty(key, value);
+#endif
+        }
+
+        /// <summary>
+        /// Creates logical operation scope that includes provided state-value
+        /// </summary>
+        /// <param name="operationState">Value to added to the scope operation stack</param>
+        /// <returns>A disposable object that ends the logical operation scope on dispose.</returns>
+        public static IDisposable PushOperationState<T>(T operationState)
+        {
+#if !NET35 && !NET40 && !NET45
+            // Skips casting to check for properties
+            var parent = GetThreadLocal();
+            var current = new ScopeContextOperationState<T>(parent, operationState);
+            SetThreadLocal(current);
+            return current;
+#else
+            return NestedDiagnosticsLogicalContext.PushOperationState(operationState);
+#endif
+        }
+
+        /// <summary>
+        /// Clears all logical operation scopes
+        /// </summary>
+        public static void Clear()
+        {
+#if !NET35 && !NET40 && !NET45
+            SetThreadLocal(null);
+#else
+            MappedDiagnosticsLogicalContext.ClearDictionary();
+            NestedDiagnosticsLogicalContext.ClearStack();
+#endif
+        }
+
+        /// <summary>
+        /// Retrieves all properties stored within the logical operation scopes
+        /// </summary>
+        /// <returns>Collection of all properties</returns>
+        public static IEnumerable<KeyValuePair<string, object>> GetAllProperties()
+        {
+#if !NET35 && !NET40 && !NET45
+            var contextState = GetThreadLocal();
+            return contextState?.CaptureScopeProperties(0, out var _) ?? ArrayHelper.Empty<KeyValuePair<string, object>>();
+#else
+            return MappedDiagnosticsLogicalContext.GetAllProperties();
+#endif
+        }
+
+        /// <summary>
+        /// Lookup property key within the logical operation scopes
+        /// </summary>
+        /// <param name="key">Name of property</param>
+        /// <param name="value">When this method returns, contains the value associated with the specified key</param>
+        /// <returns>Returns true when value is found with the specified key</returns>
+        /// <remarks>Scope dictionary keys are case-insensitive</remarks>
+        public static bool TryLookupProperty(string key, out object value)
+        {
+#if !NET35 && !NET40 && !NET45
+            var contextState = GetThreadLocal();
+            if (contextState != null)
+            {
+                var mappedContext = contextState?.CaptureScopeProperties(0, out var _);
+                if (mappedContext != null)
+                {
+                    if (mappedContext is IDictionary<string, object> dictionary)
+                    {
+                        return dictionary.TryGetValue(key, out value);
+                    }
+                    else
+                    {
+                        return TryFindPropertyValue(mappedContext, key, out value);
+                    }
+                }
+            }
+            value = null;
+            return false;
+#else
+            return MappedDiagnosticsLogicalContext.TryLookupProperty(key, out value);
+#endif
+        }
+
+        /// <summary>
+        /// Retrieves all operation states stored within the current logical operation scope
+        /// </summary>
+        /// <returns>Array of operation state objects.</returns>
+        public static object[] GetAllOperationStates()
+        {
+#if !NET35 && !NET40 && !NET45
+            var parent = GetThreadLocal();
+            return parent?.CaptureScopeOperationStates(0, out var _) ?? ArrayHelper.Empty<object>();
+#else
+            return NestedDiagnosticsLogicalContext.GetAllOperationStates();
+#endif
+        }
+
+        /// <summary>
+        /// Peeks the top value on the stack of operation states within the current logical operation scope
+        /// </summary>
+        /// <returns>Value from the top of the stack.</returns>
+        public static object PeekOperationState()
+        {
+#if !NET35 && !NET40 && !NET45
+            var parent = GetThreadLocal();
+            while (parent != null)
+            {
+                var nestedContext = parent.OperationState;
+                if (nestedContext != null)
+                    return nestedContext;
+
+                parent = parent.Parent;
+            }
+            return null;
+#else
+            return NestedDiagnosticsLogicalContext.PeekOperationState();
+#endif
+        }
+
+        /// <summary>
+        /// Peeks the inner operation scope, and returns its running duration
+        /// </summary>
+        /// <returns>Scope Duration Time</returns>
+        internal static TimeSpan? PeekInnerOperationDuration()
+        {
+#if !NET35 && !NET40 && !NET45
+            var stopwatchNow = GetScopeOperationTimestamp(); // Early timestamp to reduce chance of measuring NLog time
+            var parent = GetThreadLocal();
+            while (parent != null)
+            {
+                var scopeTimestamp = parent.OperationTimestamp;
+                if (scopeTimestamp != 0)
+                {
+                    return GetScopeOperationDuration(scopeTimestamp, stopwatchNow);
+                }
+
+                parent = parent.Parent;
+            }
+            return null;
+#else
+            return default(TimeSpan?);  // Delay timing only supported when using AsyncLocal. CallContext is very sensitive.
+#endif
+        }
+
+        /// <summary>
+        /// Peeks the outer operation scope, and returns its running duration
+        /// </summary>
+        /// <returns>Scope Duration Time</returns>
+        internal static TimeSpan? PeekOuterOperationDuration()
+        {
+#if !NET35 && !NET40 && !NET45
+            var stopwatchNow = GetScopeOperationTimestamp(); // Early timestamp to reduce chance of measuring NLog time
+            var parent = GetThreadLocal();
+            var scopeTimestamp = 0L;
+            while (parent != null)
+            {
+                if (parent.OperationTimestamp != 0)
+                    scopeTimestamp = parent.OperationTimestamp;
+                parent = parent.Parent;
+            }
+
+            if (scopeTimestamp != 0L)
+            {
+                return GetScopeOperationDuration(scopeTimestamp, stopwatchNow);
+            }
+
+            return null;
+#else
+            return default(TimeSpan?);  // Delay timing only supported when using AsyncLocal. CallContext is very sensitive.
+#endif
+        }
+
+#if !NET35 && !NET40 && !NET45
+        internal static void SetMappedContextLegacy<T>(string key, T value)
+        {
+            if (TryLookupProperty(key, out var existingValue))
+            {
+                if (existingValue is IConvertible left
+                 && value is IConvertible right
+                 && left.GetTypeCode() == right.GetTypeCode()
+                 && value.Equals(existingValue))
+                    return; // No update is needed
+
+                // Replace with new legacy-scope, the legacy-scope can be discarded when previous parent scope is restored
+                var contextState = GetThreadLocal();
+                CaptureLegacyContext(contextState, out var scopeDictionary, out var scopeOperationStates, out var scopeOperationTimestamp);
+                scopeDictionary[key] = value;
+
+                var legacyScope = new LegacyScopeContext(scopeDictionary, scopeOperationStates, scopeOperationTimestamp);
+                SetThreadLocal(legacyScope);
+            }
+            else
+            {
+                PushProperty(key, value);
+            }
+        }
+
+        internal static void RemoveMappedContextLegacy(string key)
+        {
+            if (TryLookupProperty(key, out var _))
+            {
+                // Replace with new legacy-scope, the legacy-scope can be discarded when previous parent scope is restored
+                var contextState = GetThreadLocal();
+                CaptureLegacyContext(contextState, out var scopeDictionary, out var scopeOperationStates, out var scopeOperationTimestamp);
+                scopeDictionary.Remove(key);
+
+                var legacyScope = new LegacyScopeContext(scopeDictionary, scopeOperationStates, scopeOperationTimestamp);
+                SetThreadLocal(legacyScope);
+            }
+        }
+
+        internal static object PopNestedContextLegacy()
+        {
+            var contextState = GetThreadLocal();
+            if (contextState != null)
+            {
+                if ((contextState.Parent == null && contextState is LegacyScopeContext) || contextState.OperationState == null)
+                {
+                    var scopeOperationStates = contextState?.CaptureScopeOperationStates(0, out var _) ?? ArrayHelper.Empty<object>();
+                    if (scopeOperationStates.Length == 0)
+                        return null;    // Nothing to pop, just leave scope alone
+
+                    // Replace with new legacy-scope, the legacy-scope can be discarded when previous parent scope is restored
+                    var stackTopValue = scopeOperationStates[0];
+                    var scopeProperties = contextState?.CaptureScopeProperties(0, out var _) ?? ArrayHelper.Empty<KeyValuePair<string, object>>();
+                    if (scopeOperationStates.Length == 1)
+                    {
+                        scopeOperationStates = ArrayHelper.Empty<object>();
+                    }
+                    else
+                    {
+                        var newScope = new object[scopeOperationStates.Length - 1];
+                        for (int i = 0; i < newScope.Length; ++i)
+                            newScope[i] = scopeOperationStates[i + 1];
+                        scopeOperationStates = newScope;
+                    }
+
+                    var legacyScope = new LegacyScopeContext(scopeProperties, scopeOperationStates, scopeOperationStates.Length > 0 ? GetScopeOperationTimestamp() : 0L);
+                    SetThreadLocal(legacyScope);
+                    return stackTopValue;
+                }
+                else
+                {
+                    SetThreadLocal(contextState.Parent);
+                    return contextState?.OperationState;
+                }
+            }
+
+            return null;
+        }
+
+        internal static void ClearMappedContextLegacy()
+        {
+            var contextState = GetThreadLocal();
+            if (contextState != null)
+            {
+                CaptureLegacyContext(contextState, out var scopeDictionary, out var scopeOperationStates, out var scopeOperationTimestamp);
+                if (scopeOperationStates?.Length > 0)
+                {
+                    if (scopeDictionary?.Count > 0)
+                    {
+                        var legacyScope = new LegacyScopeContext(null, scopeOperationStates, scopeOperationTimestamp);
+                        SetThreadLocal(legacyScope);
+                    }
+                }
+                else
+                {
+                    SetThreadLocal(null);
+                }
+            }
+        }
+
+        internal static void ClearNestedContextLegacy()
+        {
+            var contextState = GetThreadLocal();
+            if (contextState != null)
+            {
+                CaptureLegacyContext(contextState, out var scopeDictionary, out var scopeOperationStates, out var scopeOperationTimestamp);
+                if (scopeDictionary?.Count > 0)
+                {
+                    if (scopeOperationStates?.Length > 0)
+                    {
+                        var legacyScope = new LegacyScopeContext(scopeDictionary, ArrayHelper.Empty<object>(), scopeOperationTimestamp);
+                        SetThreadLocal(legacyScope);
+                    }
+                }
+                else
+                {
+                    SetThreadLocal(null);
+                }
+            }
+        }
+
+        private static bool TryFindPropertyValue(IEnumerable<KeyValuePair<string, object>> scopeProperties, string key, out object value)
+        {
+            if (scopeProperties is IReadOnlyList<KeyValuePair<string, object>> mappedList)
+            {
+                for (int i = 0; i < mappedList.Count; ++i)
+                {
+                    var item = mappedList[i];
+                    if (DefaultComparer.Equals(item.Key, key))
+                    {
+                        value = item.Value;
+                        return true;
+                    }
+                }
+            }
+            else
+            {
+                foreach (var item in scopeProperties)
+                {
+                    if (DefaultComparer.Equals(item.Key, key))
+                    {
+                        value = item.Value;
+                        return true;
+                    }
+                }
+            }
+
+            value = null;
+            return false;
+        }
+
+        private static void CaptureLegacyContext(IScopeContext contextState, out Dictionary<string, object> scopeDictionary, out object[] scopeOperationStates, out long scopeOperationTimestamp)
+        {
+            scopeOperationStates = contextState?.CaptureScopeOperationStates(0, out var _) ?? ArrayHelper.Empty<object>();
+            scopeDictionary = null;
+            var scopeProperties = contextState?.CaptureScopeProperties(0, out scopeDictionary) ?? ArrayHelper.Empty<KeyValuePair<string, object>>();
+            if (scopeDictionary == null)
+            {
+                scopeDictionary = new Dictionary<string, object>(DefaultComparer);
+                foreach (var scopeProperty in scopeProperties)
+                    scopeDictionary[scopeProperty.Key] = scopeProperty.Value;
+            }
+
+            scopeOperationTimestamp = 0L;
+            if (scopeOperationStates?.Length > 0)
+            {
+                var parent = contextState;
+                while (parent != null)
+                {
+                    if (parent.OperationTimestamp != 0L)
+                        scopeOperationTimestamp = parent.OperationTimestamp;
+                    parent = parent.Parent;
+                }
+
+                if (scopeOperationTimestamp == 0L)
+                    scopeOperationTimestamp = GetScopeOperationTimestamp();
+            }
+        }
+
+        private static long GetScopeOperationTimestamp()
+        {
+            if (System.Diagnostics.Stopwatch.IsHighResolution)
+                return System.Diagnostics.Stopwatch.GetTimestamp();
+            else
+                return System.Environment.TickCount;
+        }
+
+        private static TimeSpan GetScopeOperationDuration(long scopeTimestamp, long currentTimestamp)
+        {
+            if (System.Diagnostics.Stopwatch.IsHighResolution)
+                return TimeSpan.FromTicks((currentTimestamp - scopeTimestamp) * TimeSpan.TicksPerSecond / System.Diagnostics.Stopwatch.Frequency);
+            else
+                return TimeSpan.FromMilliseconds((int)currentTimestamp - (int)scopeTimestamp);
+        }
+
+        private static Dictionary<string, object> CloneParentContextDictionary(IEnumerable<KeyValuePair<string, object>> parentContext, int accumulatedCount)
+        {
+            if (parentContext is IReadOnlyList<KeyValuePair<string, object>> parentContextList)
+            {
+                var scopeProperties = new Dictionary<string, object>(parentContextList.Count + accumulatedCount, DefaultComparer);
+                for (int i = 0; i < parentContextList.Count; ++i)
+                {
+                    var item = parentContextList[i];
+                    scopeProperties[item.Key] = item.Value;
+                }
+                return scopeProperties;
+            }
+            else if (parentContext is Dictionary<string, object> parentContextDictionary)
+            {
+                var scopeProperties = new Dictionary<string, object>(parentContextDictionary.Count + accumulatedCount, DefaultComparer);
+                foreach (var item in parentContextDictionary)
+                {
+                    scopeProperties[item.Key] = item.Value;
+                }
+                return scopeProperties;
+            }
+            else
+            {
+                var scopeProperties = new Dictionary<string, object>(1 + accumulatedCount, DefaultComparer);
+                foreach (var item in parentContext)
+                {
+                    scopeProperties[item.Key] = item.Value;
+                }
+                return scopeProperties;
+            }
+        }
+
+        interface IScopeContext : IDisposable
+        {
+            IScopeContext Parent { get; }
+            object OperationState { get; }
+            long OperationTimestamp { get; }
+            IEnumerable<KeyValuePair<string, object>> CaptureScopeProperties(int accumulatedCount, out Dictionary<string, object> scopeProperties);
+            object[] CaptureScopeOperationStates(int accumulatedCount, out object[] scopeOperationStates);
+        }
+
+        private sealed class ScopeContextOperationState<T> : IScopeContext
+        {
+            private readonly T _value;
+            private bool _disposed;
+
+            public ScopeContextOperationState(IScopeContext parent, T state)
+            {
+                Parent = parent;
+                OperationTimestamp = GetScopeOperationTimestamp();
+                _value = state;
+            }
+
+            public IScopeContext Parent { get; }
+
+            object IScopeContext.OperationState => _value;
+
+            public long OperationTimestamp { get; }
+
+            object[] IScopeContext.CaptureScopeOperationStates(int accumulatedCount, out object[] scopeOperationStates)
+            {
+                scopeOperationStates = null;
+                Parent?.CaptureScopeOperationStates(accumulatedCount + 1, out scopeOperationStates);
+                if (scopeOperationStates == null)
+                    scopeOperationStates = new object[accumulatedCount + 1];
+                scopeOperationStates[accumulatedCount] = _value;
+                return scopeOperationStates;
+            }
+
+            IEnumerable<KeyValuePair<string, object>> IScopeContext.CaptureScopeProperties(int accumulatedCount, out Dictionary<string, object> scopeProperties)
+            {
+                scopeProperties = null;
+                return Parent?.CaptureScopeProperties(accumulatedCount, out scopeProperties) ?? scopeProperties;
+            }
+
+            public override string ToString()
+            {
+                return Parent?.ToString() ?? "null";
+            }
+
+            public void Dispose()
+            {
+                if (!_disposed)
+                {
+                    SetThreadLocal(Parent);
+                    _disposed = true;
+                }
+            }
+        }
+
+        private sealed class ScopeContextProperty<T> : IScopeContext
+        {
+            public IScopeContext Parent { get; }
+            long IScopeContext.OperationTimestamp => 0;
+            object IScopeContext.OperationState => null;
+            public string Name { get; }
+            public T Value { get; }
+            private IReadOnlyCollection<KeyValuePair<string, object>> _scopeDictionary;
+            private bool _disposed;
+
+            public ScopeContextProperty(IScopeContext parent, string name, T value)
+            {
+                Parent = parent;
+                Name = name;
+                Value = value;
+            }
+
+            object[] IScopeContext.CaptureScopeOperationStates(int accumulatedCount, out object[] scopeOperationStates)
+            {
+                scopeOperationStates = null;
+                return Parent?.CaptureScopeOperationStates(accumulatedCount, out scopeOperationStates) ?? ArrayHelper.Empty<object>();
+            }
+
+            IEnumerable<KeyValuePair<string, object>> IScopeContext.CaptureScopeProperties(int accumulatedCount, out Dictionary<string, object> scopeProperties)
+            {
+                scopeProperties = null;
+                if (_scopeDictionary != null)
+                {
+                    return _scopeDictionary;
+                }
+                else
+                {
+                    var parentContext = Parent?.CaptureScopeProperties(accumulatedCount + 1, out scopeProperties);
+                    if (scopeProperties == null)
+                    {
+                        if (parentContext == null)
+                        {
+                            // No more parent-context, build scope-property-collection starting from this scope
+                            if (accumulatedCount == 0)
+                                return _scopeDictionary = new[] { new KeyValuePair<string, object>(Name, Value) };
+                            else
+                                scopeProperties = new Dictionary<string, object>(accumulatedCount + 1, DefaultComparer);
+                        }
+                        else
+                        {
+                            // Build scope-property-collection from parent-context
+                            scopeProperties = CloneParentContextDictionary(parentContext, accumulatedCount + 1);
+                        }
+                    }
+
+                    scopeProperties[Name] = Value;
+                    if (accumulatedCount == 0)
+                        _scopeDictionary = scopeProperties; // Immutable since no more scope-properties
+                    return scopeProperties;
+                }
+            }
+
+            public override string ToString()
+            {
+                return $"{Name}={Value?.ToString() ?? "null"}";
+            }
+
+            public void Dispose()
+            {
+                if (!_disposed)
+                {
+                    SetThreadLocal(Parent);
+                    _disposed = true;
+                }
+            }
+        }
+
+        private sealed class ScopeContextProperties : IScopeContext
+        {
+            public IScopeContext Parent { get; }
+            public long OperationTimestamp { get; }
+            public object OperationState { get; }
+            public IReadOnlyList<KeyValuePair<string, object>> ScopeProperties { get; }
+            private IReadOnlyCollection<KeyValuePair<string, object>> _scopeDictionary;
+            private bool _disposed;
+
+            public ScopeContextProperties(IScopeContext parent, IReadOnlyList<KeyValuePair<string, object>> scopeProperties, object scopeOperationState)
+            {
+                Parent = parent;
+                ScopeProperties = scopeProperties;
+                OperationState = scopeOperationState;
+                OperationTimestamp = scopeOperationState != null ? GetScopeOperationTimestamp() : 0;
+            }
+
+            object[] IScopeContext.CaptureScopeOperationStates(int accumulatedCount, out object[] scopeOperationStates)
+            {
+                scopeOperationStates = null;
+                int extraCount = (OperationState != null ? 1 : 0);
+                Parent?.CaptureScopeOperationStates(accumulatedCount + extraCount, out scopeOperationStates);
+                if (extraCount > 0)
+                {
+                    if (scopeOperationStates == null)
+                        scopeOperationStates = new object[accumulatedCount + extraCount];
+                    scopeOperationStates[accumulatedCount] = OperationState;
+                }
+                return scopeOperationStates;
+            }
+
+            IEnumerable<KeyValuePair<string, object>> IScopeContext.CaptureScopeProperties(int accumulatedCount, out Dictionary<string, object> scopeProperties)
+            {
+                scopeProperties = null;
+                if (_scopeDictionary != null)
+                {
+                    return _scopeDictionary;
+                }
+                else
+                {
+                    var parentContext = Parent?.CaptureScopeProperties(accumulatedCount + ScopeProperties.Count, out scopeProperties);
+                    if (scopeProperties == null)
+                    {
+                        if (parentContext == null)
+                        {
+                            // No more parent-context, build scope-property-collection starting from this scope
+                            if (accumulatedCount == 0)
+                                return _scopeDictionary = EnsureCollectionWithUniqueKeys();
+                            else
+                                scopeProperties = new Dictionary<string, object>(accumulatedCount + ScopeProperties.Count, DefaultComparer);
+                        }
+                        else
+                        {
+                            // Build scope-property-collection from parent-context
+                            scopeProperties = CloneParentContextDictionary(parentContext, accumulatedCount + ScopeProperties.Count);
+                        }
+                    }
+
+                    AppendScopeProperties(scopeProperties);
+                    if (accumulatedCount == 0)
+                        _scopeDictionary = scopeProperties; // Immutable since no more scope-properties
+                    return scopeProperties;
+                }
+            }
+
+            private IReadOnlyCollection<KeyValuePair<string, object>> EnsureCollectionWithUniqueKeys()
+            {
+                if (ScopeProperties.Count > 10)
+                {
+                    var mappedContext = new Dictionary<string, object>(ScopeProperties.Count, DefaultComparer);
+                    AppendScopeProperties(mappedContext);
+                    return mappedContext;
+                }
+
+                for (int i = 0; i < ScopeProperties.Count - 1; ++i)
+                {
+                    var left = ScopeProperties[i];
+                    for (int j = i + 1; j < ScopeProperties.Count; ++j)
+                    {
+                        var right = ScopeProperties[j];
+                        if (DefaultComparer.Equals(left.Key, right.Key))
+                        {
+                            var mappedContext = new Dictionary<string, object>(ScopeProperties.Count, DefaultComparer);
+                            AppendScopeProperties(mappedContext);
+                            return mappedContext;
+                        }
+                    }
+                }
+
+                return ScopeProperties;
+            }
+
+            private void AppendScopeProperties(Dictionary<string, object> mappedContext)
+            {
+                for (int i = 0; i < ScopeProperties.Count; ++i)
+                {
+                    var item = ScopeProperties[i];
+                    mappedContext[item.Key] = item.Value;
+                }
+            }
+
+            public override string ToString()
+            {
+                return OperationState?.ToString() ?? base.ToString();
+            }
+
+            public void Dispose()
+            {
+                if (!_disposed)
+                {
+                    SetThreadLocal(Parent);
+                    _disposed = true;
+                }
+            }
+        }
+
+        private sealed class LegacyScopeContext : IScopeContext
+        {
+            public IScopeContext Parent => null;    // Always top parent
+            public object[] NestedContext { get; }
+            public IEnumerable<KeyValuePair<string, object>> MappedContext { get; }
+            public long OperationTimestamp { get; }
+            private bool _disposed;
+
+            public LegacyScopeContext(IEnumerable<KeyValuePair<string, object>> mappedContext, object[] nestedContext, long scopeOperationTimestamp)
+            {
+                MappedContext = mappedContext;
+                NestedContext = nestedContext;
+                OperationTimestamp = scopeOperationTimestamp;
+            }
+
+            object IScopeContext.OperationState => NestedContext?.Length > 0 ? NestedContext[0] : null;
+
+            object[] IScopeContext.CaptureScopeOperationStates(int accumulatedCount, out object[] scopeOperationStates)
+            {
+                scopeOperationStates = null;
+                int extraCount = NestedContext?.Length ?? 0;
+                Parent?.CaptureScopeOperationStates(accumulatedCount + extraCount, out scopeOperationStates);
+                if (extraCount > 0)
+                {
+                    if (scopeOperationStates == null)
+                    {
+                        if (accumulatedCount == 0)
+                            return NestedContext;
+                        else
+                            scopeOperationStates = new object[accumulatedCount + extraCount];
+                    }
+
+                    for (int i = 0; i < extraCount; ++i)
+                        scopeOperationStates[accumulatedCount + i] = NestedContext[i];
+                }
+                return scopeOperationStates;
+            }
+
+            IEnumerable<KeyValuePair<string, object>> IScopeContext.CaptureScopeProperties(int accumulatedCount, out Dictionary<string, object> scopeProperties)
+            {
+                scopeProperties = null;
+                return MappedContext;
+            }
+
+            public override string ToString()
+            {
+                return NestedContext?.ToString() ?? base.ToString();
+            }
+
+            public void Dispose()
+            {
+                if (!_disposed)
+                {
+                    SetThreadLocal(Parent);
+                    _disposed = true;
+                }
+            }
+        }
+
+        private static void SetThreadLocal(IScopeContext newValue)
+        {
+            AsyncNestedDiagnosticsContext.Value = newValue;
+        }
+
+        private static IScopeContext GetThreadLocal()
+        {
+            return AsyncNestedDiagnosticsContext.Value;
+        }
+
+        private static IEqualityComparer<string> DefaultComparer = StringComparer.OrdinalIgnoreCase;                
+
+        private static readonly System.Threading.AsyncLocal<IScopeContext> AsyncNestedDiagnosticsContext = new System.Threading.AsyncLocal<IScopeContext>();
+#endif
+
+#if NET45
+        private sealed class ScopeProperties : IDisposable
+        {
+            private readonly IDisposable _mldcScope;
+            private readonly IDisposable _ndlcScope;
+
+            public ScopeProperties(IDisposable ndlcScope, IDisposable mldcScope)
+            {
+                _ndlcScope = ndlcScope;
+                _mldcScope = mldcScope;
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    _mldcScope?.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    NLog.Common.InternalLogger.Debug(ex, "Exception in BeginScope dispose MappedDiagnosticsLogicalContext");
+                }
+
+                try
+                {
+                    _ndlcScope?.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    NLog.Common.InternalLogger.Debug(ex, "Exception in BeginScope dispose NestedDiagnosticsLogicalContext");
+                }
+            }
+        }
+#endif
+
+        internal struct ScopePropertiesEnumerator : IEnumerator<KeyValuePair<string, object>>
+        {
+            readonly IEnumerator<KeyValuePair<string, object>> _scopeEnumerator;
+#if !NET35 && !NET40
+            readonly IReadOnlyList<KeyValuePair<string, object>> _scopeList;
+            int _scopeIndex;
+#endif
+            Dictionary<string, object>.Enumerator _dicationaryEnumerator;
+
+            public ScopePropertiesEnumerator(IEnumerable<KeyValuePair<string, object>> scopeProperties)
+            {
+                if (scopeProperties is Dictionary<string, object> scopeDictionary)
+                {
+                    _scopeEnumerator = null;
+#if !NET35 && !NET40
+                    _scopeList = null;
+                    _scopeIndex = 0;
+#endif
+                    _dicationaryEnumerator = scopeDictionary.GetEnumerator();
+                }
+#if !NET35 && !NET40
+                else if (scopeProperties is IReadOnlyList<KeyValuePair<string, object>> scopeList)
+                {
+                    _scopeEnumerator = null;
+                    _scopeList = scopeList;
+                    _scopeIndex = -1;
+                    _dicationaryEnumerator = default(Dictionary<string, object>.Enumerator);
+                }
+#endif
+                else
+                {
+                    _scopeEnumerator = scopeProperties.GetEnumerator();
+#if !NET35 && !NET40
+                    _scopeList = null;
+                    _scopeIndex = 0;
+#endif
+                    _dicationaryEnumerator = default(Dictionary<string, object>.Enumerator);
+                }
+            }
+
+            public KeyValuePair<string, object> Current
+            {
+                get
+                {
+#if !NET35 && !NET40
+                    if (_scopeList != null)
+                    {
+                        return _scopeList[_scopeIndex];
+                    }
+                    else
+#endif
+                    if (_scopeEnumerator != null)
+                    {
+                        return _scopeEnumerator.Current;
+                    }
+                    else
+                    {
+                        return _dicationaryEnumerator.Current;
+                    }
+                }
+            }
+
+            object System.Collections.IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+                if (_scopeEnumerator != null)
+                    _scopeEnumerator.Dispose();
+                else
+#if !NET35 && !NET40
+                if (_scopeList == null)
+#endif
+                    _dicationaryEnumerator.Dispose();
+            }
+
+            public bool MoveNext()
+            {
+#if !NET35 && !NET40
+                if (_scopeList != null)
+                {
+                    if (_scopeIndex < _scopeList.Count - 1)
+                    {
+                        ++_scopeIndex;
+                        return true;
+                    }
+                    return false;
+                }
+                else
+#endif
+                if (_scopeEnumerator != null)
+                {
+                    return _scopeEnumerator.MoveNext();
+                }
+                else
+                {
+                    return _dicationaryEnumerator.MoveNext();
+                }
+            }
+
+            public void Reset()
+            {
+#if !NET35 && !NET40
+                if (_scopeList != null)
+                {
+                    _scopeIndex = -1;
+                }
+                else
+#endif
+                if (_scopeEnumerator != null)
+                {
+                    _scopeEnumerator.Reset();
+                }
+                else
+                {
+                    _dicationaryEnumerator = default(Dictionary<string, object>.Enumerator);
+                }
+            }
+        }
+    }
+}

--- a/src/NLog/Contexts/ScopeContext.cs
+++ b/src/NLog/Contexts/ScopeContext.cs
@@ -149,8 +149,8 @@ namespace NLog
 #if !NET35 && !NET40 && !NET45
             SetThreadLocal(null);
 #else
-            MappedDiagnosticsLogicalContext.ClearDictionary();
-            NestedDiagnosticsLogicalContext.ClearStack();
+            MappedDiagnosticsLogicalContext.ClearMappedContext();
+            NestedDiagnosticsLogicalContext.ClearNestedContext();
 #endif
         }
 

--- a/src/NLog/Contexts/ScopeContext.cs
+++ b/src/NLog/Contexts/ScopeContext.cs
@@ -54,7 +54,7 @@ namespace NLog
         /// Creates logical operation scope that includes provided properties and stack-value
         /// </summary>
         /// <param name="operationState">Value to added to the scope operation stack</param>
-        /// <param name="properties">Properties being added to the scope dictionray</param>
+        /// <param name="properties">Properties being added to the scope dictionary</param>
         /// <returns>A disposable object that ends the logical operation scope on dispose.</returns>
         /// <remarks>Scope dictionary keys are case-insensitive</remarks>
         public static IDisposable PushOperationProperties(object operationState, IReadOnlyList<KeyValuePair<string, object>> properties)
@@ -87,7 +87,7 @@ namespace NLog
         /// <summary>
         /// Creates logical operation scope that includes provided properties
         /// </summary>
-        /// <param name="properties">Properties being added to the scope dictionray</param>
+        /// <param name="properties">Properties being added to the scope dictionary</param>
         /// <returns>A disposable object that ends the logical operation scope on dispose.</returns>
         /// <remarks>Scope dictionary keys are case-insensitive</remarks>
         public static IDisposable PushProperties(IReadOnlyList<KeyValuePair<string, object>> properties)

--- a/src/NLog/Contexts/ScopeContext.cs
+++ b/src/NLog/Contexts/ScopeContext.cs
@@ -51,7 +51,7 @@ namespace NLog
     {
 #if !NET35 && !NET40
         /// <summary>
-        /// Creates logical operation scope that includes provided properties and stack-value
+        /// Pushes new operation state on the logical context scope operation stack, and includes the provided properties
         /// </summary>
         /// <param name="operationState">Value to added to the scope operation stack</param>
         /// <param name="properties">Properties being added to the scope dictionary</param>
@@ -73,7 +73,7 @@ namespace NLog
             {
                 var mldcScope = MappedDiagnosticsLogicalContext.PushProperties(properties);
                 var ndlcScope = NestedDiagnosticsLogicalContext.PushOperationState(operationState);
-                return new ScopeProperties(ndlcScope, mldcScope);
+                return new ScopeContextOperationProperties(ndlcScope, mldcScope);
             }
             else
             {
@@ -85,7 +85,7 @@ namespace NLog
 
 #if !NET35 && !NET40
         /// <summary>
-        /// Creates logical operation scope that includes provided properties
+        /// Updates the logical scope context with provided properties
         /// </summary>
         /// <param name="properties">Properties being added to the scope dictionary</param>
         /// <returns>A disposable object that ends the logical operation scope on dispose.</returns>
@@ -104,7 +104,7 @@ namespace NLog
 #endif
 
         /// <summary>
-        /// Creates logical operation scope that includes provided property
+        /// Updates the logical scope context with provided property
         /// </summary>
         /// <param name="key">Name of property</param>
         /// <param name="value">Value of property</param>
@@ -124,7 +124,7 @@ namespace NLog
         }
 
         /// <summary>
-        /// Creates logical operation scope that includes provided state-value
+        /// Pushes new operation state on the logical context scope operation stack
         /// </summary>
         /// <param name="operationState">Value to added to the scope operation stack</param>
         /// <returns>A disposable object that ends the logical operation scope on dispose.</returns>
@@ -155,7 +155,7 @@ namespace NLog
         }
 
         /// <summary>
-        /// Retrieves all properties stored within the logical operation scopes
+        /// Retrieves all properties stored within the logical context scopes
         /// </summary>
         /// <returns>Collection of all properties</returns>
         public static IEnumerable<KeyValuePair<string, object>> GetAllProperties()
@@ -169,7 +169,7 @@ namespace NLog
         }
 
         /// <summary>
-        /// Lookup property key within the logical operation scopes
+        /// Lookup single property stored within the logical context scopes
         /// </summary>
         /// <param name="key">Name of property</param>
         /// <param name="value">When this method returns, contains the value associated with the specified key</param>
@@ -202,7 +202,7 @@ namespace NLog
         }
 
         /// <summary>
-        /// Retrieves all operation states stored within the current logical operation scope
+        /// Retrieves all operation states inside the logical context scope operation stack
         /// </summary>
         /// <returns>Array of operation state objects.</returns>
         public static object[] GetAllOperationStates()
@@ -216,7 +216,7 @@ namespace NLog
         }
 
         /// <summary>
-        /// Peeks the top value on the stack of operation states within the current logical operation scope
+        /// Peeks the top value from the logical context scope operation stack
         /// </summary>
         /// <returns>Value from the top of the stack.</returns>
         public static object PeekOperationState()
@@ -238,7 +238,7 @@ namespace NLog
         }
 
         /// <summary>
-        /// Peeks the inner operation scope, and returns its running duration
+        /// Peeks the inner operation from the logical context scope operation stack, and returns its running duration
         /// </summary>
         /// <returns>Scope Duration Time</returns>
         internal static TimeSpan? PeekInnerOperationDuration()
@@ -263,7 +263,7 @@ namespace NLog
         }
 
         /// <summary>
-        /// Peeks the outer operation scope, and returns its running duration
+        /// Peeks the outer operation from the logical context scope operation stack, and returns its running duration
         /// </summary>
         /// <returns>Scope Duration Time</returns>
         internal static TimeSpan? PeekOuterOperationDuration()
@@ -838,12 +838,12 @@ namespace NLog
 #endif
 
 #if NET45
-        private sealed class ScopeProperties : IDisposable
+        private sealed class ScopeContextOperationProperties : IDisposable
         {
             private readonly IDisposable _mldcScope;
             private readonly IDisposable _ndlcScope;
 
-            public ScopeProperties(IDisposable ndlcScope, IDisposable mldcScope)
+            public ScopeContextOperationProperties(IDisposable ndlcScope, IDisposable mldcScope)
             {
                 _ndlcScope = ndlcScope;
                 _mldcScope = mldcScope;

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -182,13 +182,13 @@ namespace NLog.LayoutRenderers
         public bool IncludeNdlc { get => IncludeScopeOperationStates; set => IncludeScopeOperationStates = value; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> properties-dictionary.
+        /// Gets or sets whether to include the contents of the <see cref="ScopeContext"/> properties-dictionary.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeScopeProperties { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> operation-states-stack.
+        /// Gets or sets whether to include the contents of the <see cref="ScopeContext"/> operation-call-stack.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeScopeOperationStates { get; set; }
@@ -301,7 +301,7 @@ namespace NLog.LayoutRenderers
                     }
                 }
 
-                AppendNdc(xtw, logEvent);
+                AppendScopeContextOperationStates(xtw, logEvent);
 
                 if (includeNLogCallsite)
                 {
@@ -312,7 +312,7 @@ namespace NLog.LayoutRenderers
 
                 AppendMdc(xtw);
 
-                AppendScopeProperties(xtw);
+                AppendScopeContextProperties(xtw);
 
                 if (IncludeEventProperties)
                 {
@@ -346,7 +346,7 @@ namespace NLog.LayoutRenderers
             }
         }
 
-        private void AppendScopeProperties(XmlWriter xtw)
+        private void AppendScopeContextProperties(XmlWriter xtw)
         {
             if (IncludeScopeProperties)
             {
@@ -371,7 +371,7 @@ namespace NLog.LayoutRenderers
             }
         }
 
-        private void AppendNdc(XmlWriter xtw, LogEventInfo logEvent)
+        private void AppendScopeContextOperationStates(XmlWriter xtw, LogEventInfo logEvent)
         {
             string ndcContent = null;
             if (IncludeNdc)

--- a/src/NLog/Layouts/JSON/JsonLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonLayout.cs
@@ -140,7 +140,7 @@ namespace NLog.Layouts
         public bool IncludeMdc { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> dictionary.
+        /// Gets or sets whether to include the contents of the <see cref="ScopeContext"/> dictionary.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeScopeProperties { get; set; }

--- a/src/NLog/Layouts/JSON/JsonLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonLayout.cs
@@ -94,7 +94,6 @@ namespace NLog.Layouts
         {
             Attributes = new List<JsonAttribute>();
             RenderEmptyObject = true;
-            IncludeAllProperties = false;
             ExcludeProperties = new HashSet<string>();
             MaxRecursionLimit = 1;
         }
@@ -121,6 +120,12 @@ namespace NLog.Layouts
         public bool RenderEmptyObject { get; set; }
 
         /// <summary>
+        /// Gets or sets the option to include all properties from the log event (as JSON)
+        /// </summary>
+        /// <docgen category='JSON Output' order='10' />
+        public bool IncludeEventProperties { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="GlobalDiagnosticsContext"/> dictionary.
         /// </summary>
         /// <docgen category='JSON Output' order='10' />
@@ -135,18 +140,24 @@ namespace NLog.Layouts
         public bool IncludeMdc { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
+        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> dictionary.
         /// </summary>
-        /// <docgen category='JSON Output' order='10' />
-        [DefaultValue(false)]
-        public bool IncludeMdlc { get; set; }
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeScopeProperties { get; set; }
 
         /// <summary>
         /// Gets or sets the option to include all properties from the log event (as JSON)
         /// </summary>
         /// <docgen category='JSON Output' order='10' />
-        [DefaultValue(false)]
-        public bool IncludeAllProperties { get; set; }
+        [Obsolete("Replaced by IncludeEventProperties. Marked obsolete on NLog 5.0")]
+        public bool IncludeAllProperties { get => IncludeEventProperties; set => IncludeEventProperties = value; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        [Obsolete("Replaced by IncludeScopeProperties. Marked obsolete on NLog 5.0")]
+        public bool IncludeMdlc { get => IncludeScopeProperties; set => IncludeScopeProperties = value; }
 
         /// <summary>
         /// List of property names to exclude when <see cref="IncludeAllProperties"/> is true
@@ -190,11 +201,11 @@ namespace NLog.Layouts
             {
                 ThreadAgnostic = false;
             }
-            if (IncludeMdlc)
+            if (IncludeScopeProperties)
             {
                 ThreadAgnostic = false;
             }
-            if (IncludeAllProperties)
+            if (IncludeEventProperties)
             {
                 MutableUnsafe = true;
             }
@@ -289,18 +300,22 @@ namespace NLog.Layouts
                 }
             }
 
-            if (IncludeMdlc)
+            if (IncludeScopeProperties)
             {
-                foreach (string key in MappedDiagnosticsLogicalContext.GetNames())
+                using (var scopeEnumerator = new ScopeContext.ScopePropertiesEnumerator(ScopeContext.GetAllProperties()))
                 {
-                    if (string.IsNullOrEmpty(key))
-                        continue;
-                    object propertyValue = MappedDiagnosticsLogicalContext.GetObject(key);
-                    AppendJsonPropertyValue(key, propertyValue, null, null, MessageTemplates.CaptureType.Unknown, sb, sb.Length == orgLength);
+                    while (scopeEnumerator.MoveNext())
+                    {
+                        var scopeProperty = scopeEnumerator.Current;
+                        if (string.IsNullOrEmpty(scopeProperty.Key))
+                            continue;
+
+                        AppendJsonPropertyValue(scopeProperty.Key, scopeProperty.Value, null, null, MessageTemplates.CaptureType.Unknown, sb, sb.Length == orgLength);
+                    }
                 }
             }
 
-            if (IncludeAllProperties && logEvent.HasProperties)
+            if (IncludeEventProperties && logEvent.HasProperties)
             {
                 IEnumerable<MessageTemplates.MessageTemplateParameter> propertiesList = logEvent.CreateOrUpdatePropertiesInternal(true);
                 foreach (var prop in propertiesList)

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.Layouts
 {
+    using System;
     using System.Collections.Generic;
     using System.Text;
     using NLog.Config;
@@ -75,6 +76,36 @@ namespace NLog.Layouts
         public IList<NLogViewerParameterInfo> Parameters { get => Renderer.Parameters; set => Renderer.Parameters = value;  }
 
         /// <summary>
+        /// Gets or sets the option to include all properties from the log events
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeEventProperties
+        {
+            get => Renderer.IncludeEventProperties;
+            set => Renderer.IncludeEventProperties = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> properties-dictionary.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeScopeProperties
+        {
+            get => Renderer.IncludeScopeProperties;
+            set => Renderer.IncludeScopeProperties = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> opreation-states-stack.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeScopeOperationStates
+        {
+            get => Renderer.IncludeScopeOperationStates;
+            set => Renderer.IncludeScopeOperationStates = value;
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsContext"/> dictionary.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
@@ -82,16 +113,6 @@ namespace NLog.Layouts
         {
             get => Renderer.IncludeMdc;
             set => Renderer.IncludeMdc = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the option to include all properties from the log events
-        /// </summary>
-        /// <docgen category='Payload Options' order='10' />
-        public bool IncludeAllProperties
-        {
-            get => Renderer.IncludeAllProperties;
-            set => Renderer.IncludeAllProperties = value;
         }
 
         /// <summary>
@@ -105,24 +126,25 @@ namespace NLog.Layouts
         }
 
         /// <summary>
+        /// Gets or sets the option to include all properties from the log events
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        [Obsolete("Replaced by IncludeEventProperties. Marked obsolete on NLog 5.0")]
+        public bool IncludeAllProperties { get => IncludeEventProperties; set => IncludeEventProperties = value; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        public bool IncludeMdlc
-        {
-            get => Renderer.IncludeMdlc;
-            set => Renderer.IncludeMdlc = value;
-        }
+        [Obsolete("Replaced by IncludeScopeProperties. Marked obsolete on NLog 5.0")]
+        public bool IncludeMdlc { get => IncludeScopeProperties; set => IncludeScopeProperties = value; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsLogicalContext"/> stack.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        public bool IncludeNdlc
-        {
-            get => Renderer.IncludeNdlc;
-            set => Renderer.IncludeNdlc = value;
-        }
+        [Obsolete("Replaced by IncludeScopeOperationStates. Marked obsolete on NLog 5.0")]
+        public bool IncludeNdlc { get => IncludeScopeOperationStates; set => IncludeScopeOperationStates = value; }
 
         /// <summary>
         /// Gets or sets the log4j:event logger-xml-attribute (Default ${logger})

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -86,7 +86,7 @@ namespace NLog.Layouts
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> properties-dictionary.
+        /// Gets or sets whether to include the contents of the <see cref="ScopeContext"/> properties-dictionary.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeScopeProperties
@@ -96,7 +96,7 @@ namespace NLog.Layouts
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> opreation-states-stack.
+        /// Gets or sets whether to include the contents of the <see cref="ScopeContext"/> operation-call-stack.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeScopeOperationStates

--- a/src/NLog/Layouts/XML/XmlElementBase.cs
+++ b/src/NLog/Layouts/XML/XmlElementBase.cs
@@ -109,6 +109,12 @@ namespace NLog.Layouts
         public bool IncludeEmptyValue { get; set; }
 
         /// <summary>
+        /// Gets or sets the option to include all properties from the log event (as XML)
+        /// </summary>
+        /// <docgen category='JSON Output' order='10' />
+        public bool IncludeEventProperties { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsContext"/> dictionary.
         /// </summary>
         /// <docgen category='LogEvent Properties XML Options' order='10' />
@@ -116,18 +122,26 @@ namespace NLog.Layouts
         public bool IncludeMdc { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> dictionary.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeScopeProperties { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
         /// <docgen category='LogEvent Properties XML Options' order='10' />
         [DefaultValue(false)]
-        public bool IncludeMdlc { get; set; }
+        [Obsolete("Replaced by IncludeScopeProperties. Marked obsolete on NLog 5.0")]
+        public bool IncludeMdlc { get => IncludeScopeProperties; set => IncludeScopeProperties = value; }
 
         /// <summary>
         /// Gets or sets the option to include all properties from the log event (as XML)
         /// </summary>
         /// <docgen category='LogEvent Properties XML Options' order='10' />
         [DefaultValue(false)]
-        public bool IncludeAllProperties { get; set; }
+        [Obsolete("Replaced by IncludeEventProperties. Marked obsolete on NLog 5.0")]
+        public bool IncludeAllProperties { get => IncludeEventProperties; set => IncludeEventProperties = value; }
 
         /// <summary>
         /// List of property names to exclude when <see cref="IncludeAllProperties"/> is true
@@ -216,12 +230,12 @@ namespace NLog.Layouts
                 ThreadAgnostic = false;
             }
 
-            if (IncludeMdlc)
+            if (IncludeScopeProperties)
             {
                 ThreadAgnostic = false;
             }
 
-            if (IncludeAllProperties)
+            if (IncludeEventProperties)
             {
                 MutableUnsafe = true;
             }
@@ -358,10 +372,10 @@ namespace NLog.Layouts
             if (IncludeMdc)
                 return true;
 
-            if (IncludeMdlc)
+            if (IncludeScopeProperties)
                 return true;
 
-            if (IncludeAllProperties && logEvent.HasProperties)
+            if (IncludeEventProperties && logEvent.HasProperties)
                 return true;
 
             return false;
@@ -381,19 +395,22 @@ namespace NLog.Layouts
                 }
             }
 
-            if (IncludeMdlc)
+            if (IncludeScopeProperties)
             {
-                foreach (string key in MappedDiagnosticsLogicalContext.GetNames())
+                using (var scopeEnumerator = new ScopeContext.ScopePropertiesEnumerator(ScopeContext.GetAllProperties()))
                 {
-                    if (string.IsNullOrEmpty(key))
-                        continue;
+                    while (scopeEnumerator.MoveNext())
+                    {
+                        var scopeProperty = scopeEnumerator.Current;
+                        if (string.IsNullOrEmpty(scopeProperty.Key))
+                            continue;
 
-                    object propertyValue = MappedDiagnosticsLogicalContext.GetObject(key);
-                    AppendXmlPropertyValue(key, propertyValue, sb, orgLength);
+                        AppendXmlPropertyValue(scopeProperty.Key, scopeProperty.Value, sb, orgLength);
+                    }
                 }
             }
 
-            if (IncludeAllProperties && logEventInfo.HasProperties)
+            if (IncludeEventProperties && logEventInfo.HasProperties)
             {
                 AppendLogEventProperties(logEventInfo, sb, orgLength);
             }

--- a/src/NLog/Layouts/XML/XmlElementBase.cs
+++ b/src/NLog/Layouts/XML/XmlElementBase.cs
@@ -122,7 +122,7 @@ namespace NLog.Layouts
         public bool IncludeMdc { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="ScopeContext"/> dictionary.
+        /// Gets or sets whether to include the contents of the <see cref="ScopeContext"/> dictionary.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
         public bool IncludeScopeProperties { get; set; }

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -158,44 +158,54 @@ namespace NLog.Targets
             set => Renderer.IncludeNdc = value;
         }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether to include <see cref="MappedDiagnosticsLogicalContext"/> dictionary contents.
-        /// </summary>
-        /// <docgen category='Payload Options' order='10' />
-        public bool IncludeMdlc
-        {
-            get => Renderer.IncludeMdlc;
-            set => Renderer.IncludeMdlc = value;
-        }
+        /// <inheritdoc/>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeEventProperties { get => Renderer.IncludeEventProperties; set => Renderer.IncludeEventProperties = value; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsLogicalContext"/> stack.
-        /// </summary>
-        /// <docgen category='Payload Options' order='10' />
-        public bool IncludeNdlc
-        {
-            get => Renderer.IncludeNdlc;
-            set => Renderer.IncludeNdlc = value;
-        }
+        /// <inheritdoc/>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeScopeProperties { get => Renderer.IncludeScopeProperties; set => Renderer.IncludeScopeProperties = value; }
 
-        /// <summary>
-        /// Gets or sets the NDLC item separator.
-        /// </summary>
-        /// <docgen category='Payload Options' order='10' />
-        public string NdlcItemSeparator
-        {
-            get => Renderer.NdlcItemSeparator;
-            set => Renderer.NdlcItemSeparator = value;
-        }
+        /// <inheritdoc/>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeScopeOperationStates { get => Renderer.IncludeScopeOperationStates; set => Renderer.IncludeScopeOperationStates = value; }
 
         /// <summary>
         /// Gets or sets the option to include all properties from the log events
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        public bool IncludeAllProperties
+        [Obsolete("Replaced by IncludeEventProperties. Marked obsolete on NLog 5.0")]
+        public bool IncludeAllProperties { get => IncludeEventProperties; set => IncludeEventProperties = value; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include <see cref="MappedDiagnosticsLogicalContext"/> dictionary contents.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        [Obsolete("Replaced by IncludeScopeProperties. Marked obsolete on NLog 5.0")]
+        public bool IncludeMdlc { get => IncludeScopeProperties; set => IncludeScopeProperties = value; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsLogicalContext"/> stack.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        [Obsolete("Replaced by IncludeScopeOperationStates. Marked obsolete on NLog 5.0")]
+        public bool IncludeNdlc { get => IncludeScopeOperationStates; set => IncludeScopeOperationStates = value; }
+
+        /// <summary>
+        /// Gets or sets the NDLC item separator.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        [Obsolete("Replaced by ScopeContextStackSeparator. Marked obsolete on NLog 5.0")]
+        public string NdlcItemSeparator { get => ScopeContextStackSeparator; set => ScopeContextStackSeparator = value; }
+
+        /// <summary>
+        /// Gets or sets the separator for <see cref="ScopeContext"/> operation-states-stack.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public string ScopeContextStackSeparator
         {
-            get => Renderer.IncludeAllProperties;
-            set => Renderer.IncludeAllProperties = value;
+            get => Renderer.ScopeOperationStatesSeparator;
+            set => Renderer.ScopeOperationStatesSeparator = value;
         }
 
         /// <summary>

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -175,7 +175,7 @@ namespace NLog.Targets
                 combinedProperties = CaptureContextProperties(logEvent, combinedProperties);
             }
 
-            if (IncludeScopeProperties && !CombineProperties(logEvent, _contextLayout.ScopePropertiesLayout, ref combinedProperties))
+            if (IncludeScopeProperties && !CombineProperties(logEvent, _contextLayout.ScopeContextPropertiesLayout, ref combinedProperties))
             {
                 combinedProperties = CaptureScopeContextProperties(logEvent, combinedProperties);
             }
@@ -314,7 +314,7 @@ namespace NLog.Targets
         /// <returns>Dictionary with ScopeContext properties if any, else null</returns>
         protected IDictionary<string, object> GetScopeContextProperties(LogEventInfo logEvent)
         {
-            if (logEvent.TryGetCachedLayoutValue(_contextLayout.ScopePropertiesLayout, out object value))
+            if (logEvent.TryGetCachedLayoutValue(_contextLayout.ScopeContextPropertiesLayout, out object value))
             {
                 return value as IDictionary<string, object>;
             }
@@ -329,7 +329,7 @@ namespace NLog.Targets
         [Obsolete("Replaced by GetScopeContextProperties. Marked obsolete on NLog 5.0")]
         protected IDictionary<string, object> GetContextMdlc(LogEventInfo logEvent)
         {
-            if (logEvent.TryGetCachedLayoutValue(_contextLayout.ScopePropertiesLayout, out object value))
+            if (logEvent.TryGetCachedLayoutValue(_contextLayout.ScopeContextPropertiesLayout, out object value))
             {
                 return value as IDictionary<string, object>;
             }
@@ -357,7 +357,7 @@ namespace NLog.Targets
         /// <returns>Collection of <see cref="ScopeContext"/> stack items if any, else null</returns>
         protected IList<object> GetScopeOperationStates(LogEventInfo logEvent)
         {
-            if (logEvent.TryGetCachedLayoutValue(_contextLayout.ScopeOperationStatesLayout, out object value))
+            if (logEvent.TryGetCachedLayoutValue(_contextLayout.ScopeContextOperationStatesLayout, out object value))
             {
                 return value as IList<object>;
             }
@@ -372,7 +372,7 @@ namespace NLog.Targets
         [Obsolete("Replaced by GetScopeContextStack. Marked obsolete on NLog 5.0")]
         protected IList<object> GetContextNdlc(LogEventInfo logEvent)
         {
-            if (logEvent.TryGetCachedLayoutValue(_contextLayout.ScopeOperationStatesLayout, out object value))
+            if (logEvent.TryGetCachedLayoutValue(_contextLayout.ScopeContextOperationStatesLayout, out object value))
             {
                 return value as IList<object>;
             }
@@ -751,9 +751,9 @@ namespace NLog.Targets
             /// <summary>Internal Layout that allows capture of NDC context</summary>
             internal LayoutContextNdc NdcLayout { get; }
             /// <summary>Internal Layout that allows capture of <see cref="ScopeContext"/> properties-dictionary</summary>
-            internal LayoutScopeProperties ScopePropertiesLayout { get; }
-            /// <summary>Internal Layout that allows capture of <see cref="ScopeContext"/> operation-states-stack</summary>
-            internal LayoutScopeOperationStates ScopeOperationStatesLayout { get; }
+            internal LayoutScopeContextProperties ScopeContextPropertiesLayout { get; }
+            /// <summary>Internal Layout that allows capture of <see cref="ScopeContext"/> operation-call-stack</summary>
+            internal LayoutScopeContextOperationStates ScopeContextOperationStatesLayout { get; }
 
             public bool IncludeEventProperties { get; set; }
             public bool IncludeCallSite { get; set; }
@@ -762,8 +762,8 @@ namespace NLog.Targets
             public bool IncludeMdc { get => MdcLayout.IsActive; set => MdcLayout.IsActive = value; }
             public bool IncludeNdc { get => NdcLayout.IsActive; set => NdcLayout.IsActive = value; }
 
-            public bool IncludeScopeProperties { get => ScopePropertiesLayout.IsActive; set => ScopePropertiesLayout.IsActive = value; }
-            public bool IncludeScopeOperationStates { get => ScopeOperationStatesLayout.IsActive; set => ScopeOperationStatesLayout.IsActive = value; }
+            public bool IncludeScopeProperties { get => ScopeContextPropertiesLayout.IsActive; set => ScopeContextPropertiesLayout.IsActive = value; }
+            public bool IncludeScopeOperationStates { get => ScopeContextOperationStatesLayout.IsActive; set => ScopeContextOperationStatesLayout.IsActive = value; }
 
             StackTraceUsage IUsesStackTrace.StackTraceUsage
             {
@@ -788,8 +788,8 @@ namespace NLog.Targets
 
                 MdcLayout = new LayoutContextMdc(owner);
                 NdcLayout = new LayoutContextNdc(owner);
-                ScopePropertiesLayout = new LayoutScopeProperties(owner);
-                ScopeOperationStatesLayout = new LayoutScopeOperationStates(owner);
+                ScopeContextPropertiesLayout = new LayoutScopeContextProperties(owner);
+                ScopeContextOperationStatesLayout = new LayoutScopeContextOperationStates(owner);
             }
 
             protected override void InitializeLayout()
@@ -845,9 +845,9 @@ namespace NLog.Targets
                 if (IncludeNdc)
                     NdcLayout.Precalculate(logEvent);
                 if (IncludeScopeProperties)
-                    ScopePropertiesLayout.Precalculate(logEvent);
+                    ScopeContextPropertiesLayout.Precalculate(logEvent);
                 if (IncludeScopeOperationStates)
-                    ScopeOperationStatesLayout.Precalculate(logEvent);
+                    ScopeContextOperationStatesLayout.Precalculate(logEvent);
             }
 
             protected override string GetFormattedMessage(LogEventInfo logEvent)
@@ -894,13 +894,13 @@ namespace NLog.Targets
             }
 
             [ThreadSafe]
-            public class LayoutScopeProperties : Layout
+            public class LayoutScopeContextProperties : Layout
             {
                 private readonly TargetWithContext _owner;
 
                 public bool IsActive { get; set; }
 
-                public LayoutScopeProperties(TargetWithContext owner)
+                public LayoutScopeContextProperties(TargetWithContext owner)
                 {
                     _owner = owner;
                 }
@@ -960,13 +960,13 @@ namespace NLog.Targets
             }
 
             [ThreadSafe]
-            public class LayoutScopeOperationStates : Layout
+            public class LayoutScopeContextOperationStates : Layout
             {
                 private readonly TargetWithContext _owner;
 
                 public bool IsActive { get; set; }
 
-                public LayoutScopeOperationStates(TargetWithContext owner)
+                public LayoutScopeContextOperationStates(TargetWithContext owner)
                 {
                     _owner = owner;
                 }

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -42,7 +42,7 @@ namespace NLog.Targets
     using NLog.Layouts;
 
     /// <summary>
-    /// Represents target that supports context capture using MDLC, MDC, NDLC and NDC
+    /// Represents target that supports context capture of <see cref="ScopeContext"/> Properties + Operation-states, MDC, NDC
     /// </summary>
     public abstract class TargetWithContext : TargetWithLayout, IIncludeContext
     {
@@ -62,10 +62,16 @@ namespace NLog.Targets
         private TargetWithContextLayout _contextLayout;
 
         /// <inheritdoc/>
-        bool IIncludeContext.IncludeAllProperties { get => IncludeEventProperties; set => IncludeEventProperties = value; }
-
         /// <docgen category='Layout Options' order='10' />
-        public bool IncludeEventProperties { get => _contextLayout.IncludeAllProperties; set => _contextLayout.IncludeAllProperties = value; }
+        public bool IncludeEventProperties { get => _contextLayout.IncludeEventProperties; set => _contextLayout.IncludeEventProperties = value; }
+
+        /// <inheritdoc/>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeScopeProperties { get => _contextLayout.IncludeScopeProperties; set => _contextLayout.IncludeScopeProperties = value; }
+
+        /// <inheritdoc/>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeScopeOperationStates { get => _contextLayout.IncludeScopeOperationStates; set => _contextLayout.IncludeScopeOperationStates = value; }
 
         /// <inheritdoc/>
         /// <docgen category='Layout Options' order='10' />
@@ -77,11 +83,13 @@ namespace NLog.Targets
 
         /// <inheritdoc/>
         /// <docgen category='Layout Options' order='10' />
-        public bool IncludeMdlc { get => _contextLayout.IncludeMdlc; set => _contextLayout.IncludeMdlc = value; }
+        [Obsolete("Replaced by IncludeScopeProperties. Marked obsolete on NLog 5.0")]
+        public bool IncludeMdlc { get => IncludeScopeProperties; set => IncludeScopeProperties = value; }
 
         /// <inheritdoc/>
         /// <docgen category='Layout Options' order='10' />
-        public bool IncludeNdlc { get => _contextLayout.IncludeNdlc; set => _contextLayout.IncludeNdlc = value; }
+        [Obsolete("Replaced by IncludeScopeOperationStates. Marked obsolete on NLog 5.0")]
+        public bool IncludeNdlc { get => IncludeScopeOperationStates; set => IncludeScopeOperationStates = value; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="GlobalDiagnosticsContext"/> dictionary
@@ -140,7 +148,7 @@ namespace NLog.Targets
         {
             return IncludeGdc
             || IncludeMdc
-            || IncludeMdlc
+            || IncludeScopeProperties
             || (IncludeEventProperties && (logEvent?.HasProperties ?? false));
         }
 
@@ -167,9 +175,9 @@ namespace NLog.Targets
                 combinedProperties = CaptureContextProperties(logEvent, combinedProperties);
             }
 
-            if (IncludeMdlc && !CombineProperties(logEvent, _contextLayout.MdlcLayout, ref combinedProperties))
+            if (IncludeScopeProperties && !CombineProperties(logEvent, _contextLayout.ScopePropertiesLayout, ref combinedProperties))
             {
-                combinedProperties = CaptureContextMdlc(logEvent, combinedProperties);
+                combinedProperties = CaptureScopeContextProperties(logEvent, combinedProperties);
             }
 
             if (IncludeMdc && !CombineProperties(logEvent, _contextLayout.MdcLayout, ref combinedProperties))
@@ -300,13 +308,28 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Returns the captured snapshot of <see cref="ScopeContext"/> dictionary for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns>Dictionary with ScopeContext properties if any, else null</returns>
+        protected IDictionary<string, object> GetScopeContextProperties(LogEventInfo logEvent)
+        {
+            if (logEvent.TryGetCachedLayoutValue(_contextLayout.ScopePropertiesLayout, out object value))
+            {
+                return value as IDictionary<string, object>;
+            }
+            return CaptureScopeContextProperties(logEvent, null);
+        }
+
+        /// <summary>
         /// Returns the captured snapshot of <see cref="MappedDiagnosticsLogicalContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
         /// <returns>Dictionary with MDLC context if any, else null</returns>
+        [Obsolete("Replaced by GetScopeContextProperties. Marked obsolete on NLog 5.0")]
         protected IDictionary<string, object> GetContextMdlc(LogEventInfo logEvent)
         {
-            if (logEvent.TryGetCachedLayoutValue(_contextLayout.MdlcLayout, out object value))
+            if (logEvent.TryGetCachedLayoutValue(_contextLayout.ScopePropertiesLayout, out object value))
             {
                 return value as IDictionary<string, object>;
             }
@@ -317,7 +340,7 @@ namespace NLog.Targets
         /// Returns the captured snapshot of <see cref="NestedDiagnosticsContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
-        /// <returns>Dictionary with NDC context if any, else null</returns>
+        /// <returns>Collection with NDC context if any, else null</returns>
         protected IList<object> GetContextNdc(LogEventInfo logEvent)
         {
             if (logEvent.TryGetCachedLayoutValue(_contextLayout.NdcLayout, out object value))
@@ -328,13 +351,28 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Returns the captured snapshot of <see cref="ScopeContext"/> operation-states for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns>Collection of <see cref="ScopeContext"/> stack items if any, else null</returns>
+        protected IList<object> GetScopeOperationStates(LogEventInfo logEvent)
+        {
+            if (logEvent.TryGetCachedLayoutValue(_contextLayout.ScopeOperationStatesLayout, out object value))
+            {
+                return value as IList<object>;
+            }
+            return CaptureScopeOperationStates(logEvent);
+        }
+
+        /// <summary>
         /// Returns the captured snapshot of <see cref="NestedDiagnosticsLogicalContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
-        /// <returns>Dictionary with NDLC context if any, else null</returns>
+        /// <returns>Collection with NDLC context if any, else null</returns>
+        [Obsolete("Replaced by GetScopeContextStack. Marked obsolete on NLog 5.0")]
         protected IList<object> GetContextNdlc(LogEventInfo logEvent)
         {
-            if (logEvent.TryGetCachedLayoutValue(_contextLayout.NdlcLayout, out object value))
+            if (logEvent.TryGetCachedLayoutValue(_contextLayout.ScopeOperationStatesLayout, out object value))
             {
                 return value as IList<object>;
             }
@@ -487,22 +525,39 @@ namespace NLog.Targets
         /// <param name="logEvent"></param>
         /// <param name="contextProperties">Optional pre-allocated dictionary for the snapshot</param>
         /// <returns>Dictionary with MDLC context if any, else null</returns>
+        [Obsolete("Replaced by CaptureScopeContextProperties. Marked obsolete on NLog 5.0")]
         protected virtual IDictionary<string, object> CaptureContextMdlc(LogEventInfo logEvent, IDictionary<string, object> contextProperties)
         {
-            var names = MappedDiagnosticsLogicalContext.GetNames();
-            if (names.Count == 0)
-                return contextProperties;
+            return CaptureScopeContextProperties(logEvent, contextProperties);
+        }
 
-            contextProperties = contextProperties ?? CreateNewDictionary(names.Count);
-            bool checkForDuplicates = contextProperties.Count > 0;
-            foreach (var name in names)
+        /// <summary>
+        /// Takes snapshot of <see cref="ScopeContext"/> dictionary for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <param name="contextProperties">Optional pre-allocated dictionary for the snapshot</param>
+        /// <returns>Dictionary with ScopeContext properties if any, else null</returns>
+        protected virtual IDictionary<string, object> CaptureScopeContextProperties(LogEventInfo logEvent, IDictionary<string, object> contextProperties)
+        {
+            using (var scopeEnumerator = new ScopeContext.ScopePropertiesEnumerator(ScopeContext.GetAllProperties()))
             {
-                object value = MappedDiagnosticsLogicalContext.GetObject(name);
-                if (SerializeMdlcItem(logEvent, name, value, out var serializedValue))
+                bool checkForDuplicates = contextProperties?.Count > 0;
+                while (scopeEnumerator.MoveNext())
                 {
-                    AddContextProperty(logEvent, name, serializedValue, checkForDuplicates, contextProperties);
+                    contextProperties = contextProperties ?? CreateNewDictionary(0);
+                    var scopeProperty = scopeEnumerator.Current;
+                    var name = scopeProperty.Key;
+                    if (string.IsNullOrEmpty(name))
+                        continue;
+
+                    object value = scopeProperty.Value;
+                    if (SerializeScopeContextProperty(logEvent, name, value, out var serializedValue))
+                    {
+                        AddContextProperty(logEvent, name, serializedValue, checkForDuplicates, contextProperties);
+                    }
                 }
             }
+
             return contextProperties;
         }
 
@@ -514,7 +569,21 @@ namespace NLog.Targets
         /// <param name="value">MDLC value</param>
         /// <param name="serializedValue">Snapshot of MDLC value</param>
         /// <returns>Include object value in snapshot</returns>
-        protected virtual bool SerializeMdlcItem(LogEventInfo logEvent, string name, object value, out object serializedValue)
+        [Obsolete("Replaced by SerializeScopeContextProperty. Marked obsolete on NLog 5.0")]
+        protected bool SerializeMdlcItem(LogEventInfo logEvent, string name, object value, out object serializedValue)
+        {
+            return SerializeScopeContextProperty(logEvent, name, value, out serializedValue);
+        }
+
+        /// <summary>
+        /// Take snapshot of a single object value from <see cref="ScopeContext"/> dictionary
+        /// </summary>
+        /// <param name="logEvent">Log event</param>
+        /// <param name="name">ScopeContext Dictionary key</param>
+        /// <param name="value">ScopeContext Dictionary value</param>
+        /// <param name="serializedValue">Snapshot of ScopeContext property-value</param>
+        /// <returns>Include object value in snapshot</returns>
+        protected virtual bool SerializeScopeContextProperty(LogEventInfo logEvent, string name, object value, out object serializedValue)
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -529,7 +598,7 @@ namespace NLog.Targets
         /// Takes snapshot of <see cref="NestedDiagnosticsContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
-        /// <returns>Dictionary with NDC context if any, else null</returns>
+        /// <returns>Collection with NDC context if any, else null</returns>
         protected virtual IList<object> CaptureContextNdc(LogEventInfo logEvent)
         {
             var stack = NestedDiagnosticsContext.GetAllObjects();
@@ -576,10 +645,21 @@ namespace NLog.Targets
         /// Takes snapshot of <see cref="NestedDiagnosticsLogicalContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
-        /// <returns>Dictionary with NDLC context if any, else null</returns>
+        /// <returns>Collection with NDLC context if any, else null</returns>
+        [Obsolete("Replaced by CaptureScopeStack. Marked obsolete on NLog 5.0")]
         protected virtual IList<object> CaptureContextNdlc(LogEventInfo logEvent)
         {
-            var stack = NestedDiagnosticsLogicalContext.GetAllObjects();
+            return CaptureScopeOperationStates(logEvent);
+        }
+
+        /// <summary>
+        /// Takes snapshot of <see cref="ScopeContext"/> operation states for the <see cref="LogEventInfo"/>
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <returns>Collection with <see cref="ScopeContext"/> stack items if any, else null</returns>
+        protected virtual IList<object> CaptureScopeOperationStates(LogEventInfo logEvent)
+        {
+            var stack = ScopeContext.GetAllOperationStates();
             if (stack.Length == 0)
                 return stack;
 
@@ -587,7 +667,7 @@ namespace NLog.Targets
             for (int i = 0; i < stack.Length; ++i)
             {
                 var ndcValue = stack[i];
-                if (SerializeNdlcItem(logEvent, ndcValue, out var serializedValue))
+                if (SerializeScopeContextOperationState(logEvent, ndcValue, out var serializedValue))
                 {
                     if (filteredStack != null)
                         filteredStack.Add(serializedValue);
@@ -614,7 +694,20 @@ namespace NLog.Targets
         /// <param name="value">NDLC value</param>
         /// <param name="serializedValue">Snapshot of NDLC value</param>
         /// <returns>Include object value in snapshot</returns>
+        [Obsolete("Replaced by SerializeScopeContextStackItem. Marked obsolete on NLog 5.0")]
         protected virtual bool SerializeNdlcItem(LogEventInfo logEvent, object value, out object serializedValue)
+        {
+            return SerializeScopeContextOperationState(logEvent, value, out serializedValue);
+        }
+
+        /// <summary>
+        /// Take snapshot of a single object value from <see cref="ScopeContext"/> operation-states
+        /// </summary>
+        /// <param name="logEvent">Log event</param>
+        /// <param name="value"><see cref="ScopeContext"/> operation state value</param>
+        /// <param name="serializedValue">Snapshot of <see cref="ScopeContext"/> stack item value</param>
+        /// <returns>Include object value in snapshot</returns>
+        protected virtual bool SerializeScopeContextOperationState(LogEventInfo logEvent, object value, out object serializedValue)
         {
             return SerializeItemValue(logEvent, null, value, out serializedValue);
         }
@@ -657,20 +750,20 @@ namespace NLog.Targets
             internal LayoutContextMdc MdcLayout { get; }
             /// <summary>Internal Layout that allows capture of NDC context</summary>
             internal LayoutContextNdc NdcLayout { get; }
-            /// <summary>Internal Layout that allows capture of MDLC context</summary>
-            internal LayoutContextMdlc MdlcLayout { get; }
-            /// <summary>Internal Layout that allows capture of NDLC context</summary>
-            internal LayoutContextNdlc NdlcLayout { get; }
+            /// <summary>Internal Layout that allows capture of <see cref="ScopeContext"/> properties-dictionary</summary>
+            internal LayoutScopeProperties ScopePropertiesLayout { get; }
+            /// <summary>Internal Layout that allows capture of <see cref="ScopeContext"/> operation-states-stack</summary>
+            internal LayoutScopeOperationStates ScopeOperationStatesLayout { get; }
 
-            public bool IncludeAllProperties { get; set; }
+            public bool IncludeEventProperties { get; set; }
             public bool IncludeCallSite { get; set; }
             public bool IncludeCallSiteStackTrace { get; set; }
 
             public bool IncludeMdc { get => MdcLayout.IsActive; set => MdcLayout.IsActive = value; }
             public bool IncludeNdc { get => NdcLayout.IsActive; set => NdcLayout.IsActive = value; }
 
-            public bool IncludeMdlc { get => MdlcLayout.IsActive; set => MdlcLayout.IsActive = value; }
-            public bool IncludeNdlc { get => NdlcLayout.IsActive; set => NdlcLayout.IsActive = value; }
+            public bool IncludeScopeProperties { get => ScopePropertiesLayout.IsActive; set => ScopePropertiesLayout.IsActive = value; }
+            public bool IncludeScopeOperationStates { get => ScopeOperationStatesLayout.IsActive; set => ScopeOperationStatesLayout.IsActive = value; }
 
             StackTraceUsage IUsesStackTrace.StackTraceUsage
             {
@@ -695,8 +788,8 @@ namespace NLog.Targets
 
                 MdcLayout = new LayoutContextMdc(owner);
                 NdcLayout = new LayoutContextNdc(owner);
-                MdlcLayout = new LayoutContextMdlc(owner);
-                NdlcLayout = new LayoutContextNdlc(owner);
+                ScopePropertiesLayout = new LayoutScopeProperties(owner);
+                ScopeOperationStatesLayout = new LayoutScopeOperationStates(owner);
             }
 
             protected override void InitializeLayout()
@@ -704,9 +797,9 @@ namespace NLog.Targets
                 base.InitializeLayout();
                 if (IncludeMdc || IncludeNdc)
                     ThreadAgnostic = false;
-                if (IncludeMdlc || IncludeNdlc)
+                if (IncludeScopeProperties || IncludeScopeOperationStates)
                     ThreadAgnostic = false;
-                if (IncludeAllProperties)
+                if (IncludeEventProperties)
                     MutableUnsafe = true;   // TODO Need to convert Properties to an immutable state
             }
 
@@ -751,10 +844,10 @@ namespace NLog.Targets
                     MdcLayout.Precalculate(logEvent);
                 if (IncludeNdc)
                     NdcLayout.Precalculate(logEvent);
-                if (IncludeMdlc)
-                    MdlcLayout.Precalculate(logEvent);
-                if (IncludeNdlc)
-                    NdlcLayout.Precalculate(logEvent);
+                if (IncludeScopeProperties)
+                    ScopePropertiesLayout.Precalculate(logEvent);
+                if (IncludeScopeOperationStates)
+                    ScopeOperationStatesLayout.Precalculate(logEvent);
             }
 
             protected override string GetFormattedMessage(LogEventInfo logEvent)
@@ -801,13 +894,13 @@ namespace NLog.Targets
             }
 
             [ThreadSafe]
-            public class LayoutContextMdlc : Layout
+            public class LayoutScopeProperties : Layout
             {
                 private readonly TargetWithContext _owner;
 
                 public bool IsActive { get; set; }
 
-                public LayoutContextMdlc(TargetWithContext owner)
+                public LayoutScopeProperties(TargetWithContext owner)
                 {
                     _owner = owner;
                 }
@@ -827,8 +920,8 @@ namespace NLog.Targets
                 {
                     if (IsActive)
                     {
-                        var contextMdlc = _owner.CaptureContextMdlc(logEvent, null);
-                        logEvent.AddCachedLayoutValue(this, contextMdlc);
+                        var scopeContextProperties = _owner.CaptureScopeContextProperties(logEvent, null);
+                        logEvent.AddCachedLayoutValue(this, scopeContextProperties);
                     }
                 }
             }
@@ -867,13 +960,13 @@ namespace NLog.Targets
             }
 
             [ThreadSafe]
-            public class LayoutContextNdlc : Layout
+            public class LayoutScopeOperationStates : Layout
             {
                 private readonly TargetWithContext _owner;
 
                 public bool IsActive { get; set; }
 
-                public LayoutContextNdlc(TargetWithContext owner)
+                public LayoutScopeOperationStates(TargetWithContext owner)
                 {
                     _owner = owner;
                 }
@@ -893,8 +986,8 @@ namespace NLog.Targets
                 {
                     if (IsActive)
                     {
-                        var contextNdlc = _owner.CaptureContextNdlc(logEvent);
-                        logEvent.AddCachedLayoutValue(this, contextNdlc);
+                        var scopeContextOperationStates = _owner.CaptureScopeOperationStates(logEvent);
+                        logEvent.AddCachedLayoutValue(this, scopeContextOperationStates);
                     }
                 }
             }

--- a/tests/NLog.UnitTests/Contexts/ScopeContextTest.cs
+++ b/tests/NLog.UnitTests/Contexts/ScopeContextTest.cs
@@ -1,0 +1,566 @@
+﻿// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.UnitTests.Contexts
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Xunit;
+
+    public class ScopeContextTest
+    {
+        [Fact]
+        public void PushPropertyCaseInsensitiveTest()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedValue = "World";
+            Dictionary<string, object> allProperties = null;
+            var success = false;
+            object value;
+
+            // Act
+            using (ScopeContext.PushProperty("HELLO", expectedValue))
+            {
+                success = ScopeContext.TryLookupProperty("hello", out value);
+                allProperties = ScopeContext.GetAllProperties().ToDictionary(x => x.Key, x => x.Value);
+            }
+            var failed = ScopeContext.TryLookupProperty("hello", out var _);
+
+            // Assert
+            Assert.True(success);
+            Assert.Equal(expectedValue, value);
+            Assert.Single(allProperties);
+            Assert.Equal(expectedValue, allProperties["HELLO"]);
+            Assert.False(failed);
+        }
+
+        [Fact]
+        public void PushPropertyNestedTest()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedString = "World";
+            var expectedGuid = System.Guid.NewGuid();
+            Dictionary<string, object> allProperties = null;
+            object stringValueLookup1 = null;
+            object stringValueLookup2 = null;
+            bool stringValueLookup3 = false;
+            object guidValueLookup1 = null;
+            bool guidValueLookup2 = false;
+            bool guidValueLookup3 = false;
+
+            // Act
+            using (ScopeContext.PushProperty("Hello", expectedString))
+            {
+                using (ScopeContext.PushProperty("RequestId", expectedGuid))
+                {
+                    ScopeContext.TryLookupProperty("Hello", out stringValueLookup1);
+                    ScopeContext.TryLookupProperty("RequestId", out guidValueLookup1);
+                    allProperties = ScopeContext.GetAllProperties().ToDictionary(x => x.Key, x => x.Value);
+                }
+
+                ScopeContext.TryLookupProperty("Hello", out stringValueLookup2);
+                guidValueLookup2 = ScopeContext.TryLookupProperty("RequestId", out var _);
+            }
+            guidValueLookup3 = ScopeContext.TryLookupProperty("RequestId", out var _);
+            stringValueLookup3 = ScopeContext.TryLookupProperty("Hello", out var _);
+
+            // Assert
+            Assert.Equal(2, allProperties.Count);
+            Assert.Equal(expectedString, allProperties["Hello"]);
+            Assert.Equal(expectedGuid, allProperties["RequestId"]);
+            Assert.Equal(expectedString, stringValueLookup1);
+            Assert.Equal(expectedString, stringValueLookup2);
+            Assert.Equal(expectedGuid, guidValueLookup1);
+            Assert.False(guidValueLookup2);
+            Assert.False(guidValueLookup3);
+            Assert.False(guidValueLookup3);
+            Assert.False(stringValueLookup3);
+        }
+
+#if !NET3_5 && !NET4_0
+        [Fact]
+        public void PushOperationPropertiesTest()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedString = "World";
+            var expectedGuid = System.Guid.NewGuid();
+            var expectedProperties = new[] { new KeyValuePair<string, object>("Hello", expectedString), new KeyValuePair<string, object>("RequestId", expectedGuid) };
+            var expectedOperationState = "First Push";
+            Dictionary<string, object> allProperties = null;
+            object[] allOperationStates = null;
+            object stringValueLookup = null;
+
+            // Act
+            using (ScopeContext.PushProperty("Hello", "People"))
+            {
+                using (ScopeContext.PushOperationProperties(expectedOperationState, expectedProperties))
+                {
+                    allOperationStates = ScopeContext.GetAllOperationStates();
+                    allProperties = ScopeContext.GetAllProperties().ToDictionary(x => x.Key, x => x.Value);
+                }
+                ScopeContext.TryLookupProperty("Hello", out stringValueLookup);
+            }
+
+            // Assert
+            Assert.Equal(2, allProperties.Count);
+            Assert.Equal(expectedString, allProperties["Hello"]);
+            Assert.Equal(expectedGuid, allProperties["RequestId"]);
+            Assert.Single(allOperationStates);
+            Assert.Equal(expectedOperationState, allOperationStates[0]);
+            Assert.Equal("People", stringValueLookup);
+        }
+#endif
+
+
+        [Fact]
+        public void PushOperationStateTest()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedOperationState = "First Push";
+            object topOperationState = null;
+            object[] allOperationStates = null;
+
+            // Act
+            using (ScopeContext.PushOperationState(expectedOperationState))
+            {
+                topOperationState = ScopeContext.PeekOperationState();
+                allOperationStates = ScopeContext.GetAllOperationStates();
+            }
+            var failed = ScopeContext.PeekOperationState() != null;
+
+            // Assert
+            Assert.Equal(expectedOperationState, topOperationState);
+            Assert.Single(allOperationStates);
+            Assert.Equal(expectedOperationState, allOperationStates[0]);
+            Assert.False(failed);
+        }
+
+        [Fact]
+        public void PushNestedOperationStateTest()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedOperationState1 = "First Push";
+            var expectedOperationState2 = System.Guid.NewGuid();
+            object topOperationState1 = null;
+            object topOperationState2 = null;
+            object[] allOperationStates = null;
+
+            // Act
+            using (ScopeContext.PushOperationState(expectedOperationState1))
+            {
+                topOperationState1 = ScopeContext.PeekOperationState();
+                using (ScopeContext.PushOperationState(expectedOperationState2))
+                {
+                    topOperationState2 = ScopeContext.PeekOperationState();
+                    allOperationStates = ScopeContext.GetAllOperationStates();
+                }                   
+            }
+            var failed = ScopeContext.PeekOperationState() != null;
+
+            // Assert
+            Assert.Equal(expectedOperationState1, topOperationState1);
+            Assert.Equal(expectedOperationState2, topOperationState2);
+            Assert.Equal(2, allOperationStates.Length);
+            Assert.Equal(expectedOperationState2, allOperationStates[0]);
+            Assert.Equal(expectedOperationState1, allOperationStates[1]);
+            Assert.False(failed);
+        }
+
+        [Fact]
+        public void ClearScopeContextTest()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedOperationState = "First Push";
+            var expectedString = "World";
+            var expectedGuid = System.Guid.NewGuid();
+            object[] allOperationStates1 = null;
+            object[] allOperationStates2 = null;
+            object stringValueLookup1 = null;
+            object stringValueLookup2 = null;
+
+            // Act
+            using (ScopeContext.PushProperty("Hello", expectedString))
+            {
+                using (ScopeContext.PushProperty("RequestId", expectedGuid))
+                {
+                    using (ScopeContext.PushOperationState(expectedOperationState))
+                    {
+                        ScopeContext.Clear();
+                        allOperationStates1 = ScopeContext.GetAllOperationStates();
+                        ScopeContext.TryLookupProperty("Hello", out stringValueLookup1);
+                    }
+                }
+
+                // Original scope was restored on dispose, verify expected behavior
+                allOperationStates2 = ScopeContext.GetAllOperationStates();
+                ScopeContext.TryLookupProperty("Hello", out stringValueLookup2);
+            }
+
+            // Assert
+            Assert.Null(stringValueLookup1);
+            Assert.Equal(expectedString, stringValueLookup2);
+            Assert.Empty(allOperationStates1);
+            Assert.Empty(allOperationStates2);
+        }
+
+        [Fact]
+        public void LegacyNdlcPopShouldNotAffectProperties1()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedValue = "World";
+            var success = false;
+            object propertyValue;
+
+            // Act
+            using (ScopeContext.PushProperty("Hello", expectedValue))
+            {
+                NestedDiagnosticsLogicalContext.PopObject();    // Should not pop anything (skip legacy mode)
+                success = ScopeContext.TryLookupProperty("Hello", out propertyValue);
+            }
+
+            // Assert
+            Assert.True(success);
+            Assert.Equal(expectedValue, propertyValue);
+        }
+
+        [Fact]
+        public void LegacyNdlcPopShouldNotAffectProperties2()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedValue = "World";
+            var expectedOperationState = "First Push";
+            var success = false;
+            object propertyValue;
+            object operationState;
+
+            // Act
+            using (ScopeContext.PushProperty("Hello", expectedValue))
+            {
+                ScopeContext.PushOperationState(expectedOperationState);
+                operationState = NestedDiagnosticsLogicalContext.PopObject();    // Should only pop active scope (skip legacy mode)
+                success = ScopeContext.TryLookupProperty("Hello", out propertyValue);
+            }
+
+            // Assert
+            Assert.True(success);
+            Assert.Equal(expectedValue, propertyValue);
+            Assert.Equal(expectedOperationState, operationState);
+        }
+
+        [Fact]
+        public void LegacyNdlcPopShouldNotAffectProperties3()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedValue1 = "World";
+            var expectedValue2 = System.Guid.NewGuid();
+            var expectedOperationState1 = "First Push";
+            var expectedOperationState2 = System.Guid.NewGuid();
+            var success1 = false;
+            var success2 = false;
+            object propertyValue1;
+            object propertyValue2;
+            object operationState1;
+            object operationState2;
+
+            // Act
+            using (ScopeContext.PushProperty("Hello", expectedValue1))
+            {
+                ScopeContext.PushOperationState(expectedOperationState1);
+                ScopeContext.PushOperationState(expectedOperationState2);
+                using (ScopeContext.PushProperty("RequestId", expectedValue2))
+                {
+                    operationState2 = NestedDiagnosticsLogicalContext.PopObject();    // Evil pop where it should leave properties alone (Legacy mode)
+                    operationState1 = NestedDiagnosticsLogicalContext.PopObject();    // Evil pop where it should leave properties alone (Legacy mode)
+
+                    success1 = ScopeContext.TryLookupProperty("Hello", out propertyValue1);
+                    success2 = ScopeContext.TryLookupProperty("RequestId", out propertyValue2);
+                }
+            }
+
+            // Assert
+            Assert.True(success1);
+            Assert.True(success2);
+            Assert.Equal(expectedValue1, propertyValue1);
+            Assert.Equal(expectedValue2, propertyValue2);
+            Assert.Equal(expectedOperationState1, operationState1);
+            Assert.Equal(expectedOperationState2, operationState2);
+        }
+
+        [Fact]
+        public void LegacyNdlcClearShouldNotAffectProperties1()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedValue = "World";
+            var success = false;
+            object propertyValue;
+
+            // Act
+            using (ScopeContext.PushProperty("Hello", expectedValue))
+            {
+                NestedDiagnosticsLogicalContext.Clear();    // Should not clear anything (skip legacy mode)
+                success = ScopeContext.TryLookupProperty("Hello", out propertyValue);
+            }
+
+            // Assert
+            Assert.True(success);
+            Assert.Equal(expectedValue, propertyValue);
+        }
+
+        [Fact]
+        public void LegacyNdlcClearShouldNotAffectProperties2()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedValue = "World";
+            var expectedOperationState = "First Push";
+            var success = false;
+            object propertyValue;
+
+            // Act
+            using (ScopeContext.PushProperty("Hello", expectedValue))
+            {
+                ScopeContext.PushOperationState(expectedOperationState);
+                NestedDiagnosticsLogicalContext.Clear();    // Should not clear properties (Legacy mode)
+                success = ScopeContext.TryLookupProperty("Hello", out propertyValue);
+            }
+
+            // Assert
+            Assert.True(success);
+            Assert.Equal(expectedValue, propertyValue);
+        }
+
+        [Fact]
+        public void LegacyMdlcClearShouldNotAffectStackValues1()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedOperationState = "First Push";
+            object[] allOperationStates = null;
+
+            // Act
+            using (ScopeContext.PushOperationState(expectedOperationState))
+            {
+                MappedDiagnosticsLogicalContext.Clear();    // Should not clear anything (skip legacy mode)
+                allOperationStates = ScopeContext.GetAllOperationStates();
+            }
+
+            // Assert
+            Assert.Single(allOperationStates);
+            Assert.Equal(expectedOperationState, allOperationStates[0]);
+        }
+
+        [Fact]
+        public void LegacyMdlcClearShouldNotAffectStackValues2()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedValue = "World";
+            var expectedOperationState = "First Push";
+            object[] allOperationStates = null;
+
+            // Act
+            using (ScopeContext.PushOperationState(expectedOperationState))
+            {
+                ScopeContext.PushProperty("Hello", expectedValue);
+                MappedDiagnosticsLogicalContext.Clear();    // Should not clear stack (Legacy mode)
+                allOperationStates = ScopeContext.GetAllOperationStates();
+            }
+
+            // Assert
+            Assert.Single(allOperationStates);
+            Assert.Equal(expectedOperationState, allOperationStates[0]);
+        }
+
+        [Fact]
+        public void LegacyMdlcRemoveShouldNotAffectStackValues1()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedOperationState = "First Push";
+            object[] allOperationStates = null;
+
+            // Act
+            using (ScopeContext.PushOperationState(expectedOperationState))
+            {
+                MappedDiagnosticsLogicalContext.Remove("Hello");    // Should not remove anything (skip legacy mode)
+                allOperationStates = ScopeContext.GetAllOperationStates();
+            }
+
+            // Assert
+            Assert.Single(allOperationStates);
+            Assert.Equal(expectedOperationState, allOperationStates[0]);
+        }
+
+        [Fact]
+        public void LegacyMdlcRemoveShouldNotAffectStackValues2()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedValue1 = "World";
+            var expectedValue2 = System.Guid.NewGuid();
+            var expectedOperationState1 = "First Push";
+            var expectedOperationState2 = System.Guid.NewGuid();
+            object propertyValue1;
+            object propertyValue2;
+            object[] allOperationStates = null;
+            var success1 = false;
+            var success2 = false;
+
+            // Act
+            using (ScopeContext.PushOperationState(expectedOperationState1))
+            {
+                using (ScopeContext.PushProperty("Hello", expectedValue1))
+                {
+                    using (ScopeContext.PushOperationState(expectedOperationState2))
+                    {
+                        ScopeContext.PushProperty("RequestId", expectedValue2);
+                        MappedDiagnosticsLogicalContext.Remove("RequestId");    // Should not change stack (Legacy mode)
+                        allOperationStates = ScopeContext.GetAllOperationStates();
+
+                        success1 = ScopeContext.TryLookupProperty("Hello", out propertyValue1);
+                        success2 = ScopeContext.TryLookupProperty("RequestId", out propertyValue2);
+                    }
+                }
+            }
+
+            // Assert
+            Assert.Equal(2, allOperationStates.Length);
+            Assert.Equal(expectedOperationState2, allOperationStates[0]);
+            Assert.Equal(expectedOperationState1, allOperationStates[1]);
+            Assert.True(success1);
+            Assert.False(success2);
+            Assert.Equal(expectedValue1, propertyValue1);
+            Assert.Null(propertyValue2);
+        }
+
+        [Fact]
+        public void LegacyMdlcSetShouldNotAffectStackValues1()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedValue = "World";
+            var expectedOperationState = "First Push";
+            object propertyValue;
+            object[] allOperationStates = null;
+            var success = false;
+
+            // Act
+            using (ScopeContext.PushOperationState(expectedOperationState))
+            {
+                MappedDiagnosticsLogicalContext.Set("Hello", expectedValue);    // Skip legacy mode (normal property push)
+                success = ScopeContext.TryLookupProperty("Hello", out propertyValue);
+                allOperationStates = ScopeContext.GetAllOperationStates();
+            }
+
+            // Assert
+            Assert.Single(allOperationStates);
+            Assert.Equal(expectedOperationState, allOperationStates[0]);
+            Assert.True(success);
+            Assert.Equal(expectedValue, propertyValue);
+        }
+
+        [Fact]
+        public void LegacyMdlcSetShouldNotAffectStackValues2()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedValue = "World";
+            var expectedOperationState = "First Push";
+            object propertyValue;
+            object[] allOperationStates = null;
+            var success = false;
+
+            // Act
+            using (ScopeContext.PushOperationState(expectedOperationState))
+            {
+                using (ScopeContext.PushProperty("Hello", expectedValue))
+                {
+                    MappedDiagnosticsLogicalContext.Set("Hello", expectedValue);    // Skip legacy mode (ignore when same value)
+                    success = ScopeContext.TryLookupProperty("Hello", out propertyValue);
+                    allOperationStates = ScopeContext.GetAllOperationStates();
+                }
+            }
+
+            // Assert
+            Assert.Single(allOperationStates);
+            Assert.Equal(expectedOperationState, allOperationStates[0]);
+            Assert.True(success);
+            Assert.Equal(expectedValue, propertyValue);
+        }
+
+        [Fact]
+        public void LegacyMdlcSetShouldNotAffectStackValues3()
+        {
+            // Arrange
+            ScopeContext.Clear();
+            var expectedValue = "Bob";
+            var expectedOperationState = "First Push";
+            object propertyValue1;
+            object propertyValue2;
+            object[] allOperationStates = null;
+            var success1 = false;
+            var success2 = false;
+
+            // Act
+            using (ScopeContext.PushOperationState(expectedOperationState))
+            {
+                using (ScopeContext.PushProperty("Hello", "World"))
+                {
+                    MappedDiagnosticsLogicalContext.Set("Hello", expectedValue);    // Enter legacy mode (need to overwrite)
+                    success1 = ScopeContext.TryLookupProperty("Hello", out propertyValue1);
+                    allOperationStates = ScopeContext.GetAllOperationStates();
+                }
+
+                success2 = ScopeContext.TryLookupProperty("Hello", out propertyValue2);
+            }
+
+            // Assert
+            Assert.Single(allOperationStates);
+            Assert.Equal(expectedOperationState, allOperationStates[0]);
+            Assert.True(success1);
+            Assert.Equal(expectedValue, propertyValue1);
+            Assert.False(success2);
+            Assert.Null(propertyValue2);
+        }
+    }
+}

--- a/tests/NLog.UnitTests/Internal/Reflection/PropertyHelperTests.cs
+++ b/tests/NLog.UnitTests/Internal/Reflection/PropertyHelperTests.cs
@@ -45,7 +45,7 @@ namespace NLog.UnitTests.Internal.Reflection
         {
             // Arrange
             var config = @"
-            <nlog>
+            <nlog throwExceptions='true'>
                 <targets>
                   <target name='f' type='File' filename='test.log'>
                     <layout type='CSVLayout' column='a'>

--- a/tests/NLog.UnitTests/LayoutRenderers/Contexts/NDLCTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Contexts/NDLCTests.cs
@@ -40,6 +40,24 @@ namespace NLog.UnitTests.LayoutRenderers
     public class NDLCTests : NLogTestBase
     {
         [Fact]
+        public void NdlcGetAllMessages()
+        {
+            object value = 5;
+
+            NestedDiagnosticsLogicalContext.Clear();
+            var popper = NestedDiagnosticsLogicalContext.Push(value);
+
+            string expected = "5";
+            string[] actual = NestedDiagnosticsLogicalContext.GetAllMessages();
+            Assert.Single(actual);
+            Assert.Equal(expected, actual[0]);
+
+            popper.Dispose();
+            actual = NestedDiagnosticsLogicalContext.GetAllMessages();
+            Assert.Empty(actual);
+        }
+
+        [Fact]
         public void NDLCTest()
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
@@ -293,6 +311,7 @@ namespace NLog.UnitTests.LayoutRenderers
             AssertDebugLastMessage("debug", " 2");
         }
 
+#if !NET3_5 && !NET4_0 && !NET4_5
         [Fact]
         public void NDLCTimingTest()
         {
@@ -368,6 +387,7 @@ namespace NLog.UnitTests.LayoutRenderers
             LogManager.GetLogger("A").Debug("0");
             AssertDebugLastMessage("debug", "|||||0");
         }
+#endif
 
         [Fact]
         public void NDLCAsyncLogging()

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -430,7 +430,7 @@ namespace NLog.UnitTests.Layouts
         {
             var jsonLayout = new JsonLayout()
             {
-                IncludeAllProperties = true
+                IncludeEventProperties = true
             };
 
             jsonLayout.ExcludeProperties.Add("Excluded1");
@@ -446,7 +446,7 @@ namespace NLog.UnitTests.Layouts
         {
             var jsonLayout = new JsonLayout()
             {
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
                 MaxRecursionLimit = 1,
             };
 

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -54,7 +54,7 @@ namespace NLog.UnitTests.Layouts
                         new XmlElement("message", "${message}"),
                     },
                 IndentXml = true,
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
             };
 
             var logEventInfo = new LogEventInfo
@@ -162,7 +162,7 @@ namespace NLog.UnitTests.Layouts
                 {
                     new XmlElement("message", "${message}") { IncludeEmptyValue = true },
                 },
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
                 IncludeEmptyValue = true,
             };
 
@@ -193,7 +193,7 @@ namespace NLog.UnitTests.Layouts
                     new XmlElement("message", "${message}"),
                 },
                 IndentXml = false,
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
             };
 
             var logEventInfo = new LogEventInfo
@@ -226,7 +226,7 @@ namespace NLog.UnitTests.Layouts
                 {
                     new XmlElement("message", "${message}"),
                 },
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
                 ExcludeProperties = new HashSet<string> { "prop2" }
             };
 
@@ -252,7 +252,7 @@ namespace NLog.UnitTests.Layouts
             // Arrange
             var xmlLayout = new XmlLayout()
             {
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
             };
 
             var logEventInfo = new LogEventInfo
@@ -277,7 +277,7 @@ namespace NLog.UnitTests.Layouts
             // Arrange
             var xmlLayout = new XmlLayout()
             {
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
                 PropertiesElementName = "{0}",
                 PropertiesElementKeyAttribute = "",
             };
@@ -305,7 +305,7 @@ namespace NLog.UnitTests.Layouts
             // Arrange
             var xmlLayout = new XmlLayout()
             {
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
                 PropertiesElementName = "p",
                 PropertiesElementKeyAttribute = "k",
                 PropertiesElementValueAttribute = "v",
@@ -332,7 +332,7 @@ namespace NLog.UnitTests.Layouts
             // Arrange
             var xmlLayout = new XmlLayout()
             {
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
                 PropertiesElementName = "{0}",
                 PropertiesElementKeyAttribute = "",
                 PropertiesElementValueAttribute = "v",
@@ -367,7 +367,7 @@ namespace NLog.UnitTests.Layouts
                         {
                             new XmlElement("level", "${level}")
                         },
-                        IncludeAllProperties = true,
+                        IncludeEventProperties = true,
                     }
 
                 },
@@ -396,7 +396,7 @@ namespace NLog.UnitTests.Layouts
             var xmlLayout = new XmlLayout()
             {
                 Elements = { new XmlElement("message", "${message}") },
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
             };
 
             var logEventInfo = new LogEventInfo
@@ -422,7 +422,7 @@ namespace NLog.UnitTests.Layouts
                 Elements = { new XmlElement("message", "${message}") },
                 PropertiesElementName = "{0}",
                 PropertiesElementKeyAttribute = "",
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
             };
 
             var logEventInfo = new LogEventInfo
@@ -446,7 +446,7 @@ namespace NLog.UnitTests.Layouts
             var xmlLayout = new XmlLayout()
             {
                 Elements = { new XmlElement("message", "${message}") },
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
             };
 
             var logEventInfo = new LogEventInfo
@@ -472,7 +472,7 @@ namespace NLog.UnitTests.Layouts
                 Elements = { new XmlElement("message", "${message}") },
                 PropertiesElementName = "{0}",
                 PropertiesElementKeyAttribute = "",
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
                 PropertiesCollectionItemName = "node",
                 PropertiesElementValueAttribute = "value",
             };
@@ -498,7 +498,7 @@ namespace NLog.UnitTests.Layouts
             var xmlLayout = new XmlLayout()
             {
                 Elements = { new XmlElement("message", "${message}") },
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
             };
 
             var guid = Guid.NewGuid();
@@ -525,7 +525,7 @@ namespace NLog.UnitTests.Layouts
                 Elements = { new XmlElement("message", "${message}") },
                 PropertiesElementName = "{0}",
                 PropertiesElementKeyAttribute = "",
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
             };
 
             var guid = Guid.NewGuid();
@@ -553,7 +553,7 @@ namespace NLog.UnitTests.Layouts
             var xmlLayout = new XmlLayout()
             {
                 Elements = { new XmlElement("message", "${message}") },
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
             };
 
             dynamic object1 = new System.Dynamic.ExpandoObject();
@@ -585,7 +585,7 @@ namespace NLog.UnitTests.Layouts
                 Elements = { new XmlElement("message", "${message}") },
                 PropertiesElementName = "{0}",
                 PropertiesElementKeyAttribute = "",
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
                 MaxRecursionLimit = 10,
             };
 
@@ -612,7 +612,7 @@ namespace NLog.UnitTests.Layouts
                 Elements = { new XmlElement("message", "${message}") },
                 PropertiesElementName = "{0}",
                 PropertiesElementKeyAttribute = "",
-                IncludeAllProperties = true,
+                IncludeEventProperties = true,
                 MaxRecursionLimit = 10,
             };
 

--- a/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
+++ b/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
@@ -83,11 +83,11 @@ namespace NLog.UnitTests.Targets
         {
             CustomTargetWithContext target = new CustomTargetWithContext();
             target.ContextProperties.Add(new TargetPropertyWithContext("threadid", "${threadid}"));
-            target.IncludeMdlc = true;
+            target.IncludeScopeProperties = true;
             target.IncludeMdc = true;
             target.IncludeGdc = true;
             target.IncludeNdc = true;
-            target.IncludeNdlc = true;
+            target.IncludeScopeOperationStates = true;
             target.IncludeCallSite = true;
 
             AsyncTargetWrapper wrapper = new AsyncTargetWrapper();
@@ -152,7 +152,7 @@ namespace NLog.UnitTests.Targets
             MappedDiagnosticsLogicalContext.Clear();
             MappedDiagnosticsLogicalContext.Set("TestKey", new { a = "b" });
 
-            CustomTargetWithContext target = new CustomTargetWithContext() { IncludeMdlc = true, SkipAssert = true };
+            CustomTargetWithContext target = new CustomTargetWithContext() { IncludeScopeProperties = true, SkipAssert = true };
 
             WriteAndAssertSingleKey(target);
         }


### PR DESCRIPTION
Resolves #4056

ScopeContext has some small behavior adjustments:
- Dictionary is case-insensitive (Breaking change)
- Dictionary is stacked, so it can restore old values
   - Special legacy-mode activates for MappedDiagnosticsLogicalContext.Set, but can still restore
   - Special legacy-mode activates for NestedDiagnosticsLogicalContext.Pop, but can still restore
- ScopeContext-Timing only works on NetStandard / Net46 (Breaking change)
   - This is because legacy CallContext do not like unknown NLog types
   - Added unit-test `NdlcGetAllMessages` that explodes when putting non-Microsoft objects into the CallContext. If adding this unit-test to master-branch then it will fail because NLog own objects are not welcome in the CallContext. 

ScopeContext has better performance since it performs lazy allocation of Dictionary (To ensure unique properties) until it actually has to write the log-message. And NLog PR now only uses a single AsyncLocal-variable to capture the BeginScope-state (Instead of one for NDLC and one for MDLC).

Because MDLC (and NDLC) are well-known constructs in the NLog-universe, then I prefer that `${mdlc}` and `${ndlc}` continue to work when people using NLog.Extension.Logging upgrade to lastest NLog 5.0 (Along with IncludeMdlc on JsonLayout), Then over time people can be convinced to move to the new `${scopecontext}` (New PR). 

Very happy that all the existing unit-test for MDLC + NDLC are working without any modifications. ScopeContext is also able to handle the more exotic methods of adding / removing properties within an active scope.