### PR TITLE
Fix LayoutParser should throw ConfigExceptions on unknown properties

### DIFF
--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -386,11 +386,11 @@ namespace NLog.Layouts
                         var value = ParseParameterValue(stringReader);
                         if (!string.IsNullOrEmpty(parameterName) || !StringHelpers.IsNullOrWhiteSpace(value))
                         {
-                            if (throwConfigExceptions ?? LogManager.ThrowConfigExceptions ?? LogManager.ThrowExceptions)
+                            var configException = new NLogConfigurationException($"Unrecognized property '{parameterName}={value}` for ${{{name}}} ({layoutRenderer?.GetType()})");
+                            if (throwConfigExceptions ?? configException.MustBeRethrown())
                             {
-                                throw new NLogConfigurationException($"Unrecognized property '{parameterName}={value}` for ${{{name}}} ({layoutRenderer?.GetType()})");
+                                throw configException;
                             }
-                            InternalLogger.Warn("Skipping unrecognized property '{0}={1}` for ${{{2}}} ({3})", parameterName, value, name, layoutRenderer?.GetType());
                         }
                     }
                     else
@@ -444,7 +444,6 @@ namespace NLog.Layouts
                 {
                     throw configException;
                 }
-                InternalLogger.Error(ex, "{0} will be ignored.", configException.Message);
                 // replace with empty values
                 layoutRenderer = new LiteralLayoutRenderer(string.Empty);
             }
@@ -466,7 +465,6 @@ namespace NLog.Layouts
                 {
                     throw configException;
                 }
-                InternalLogger.Warn(configException.Message);
             }
         }
 

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenEmptyTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenEmptyTests.cs
@@ -71,10 +71,13 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
         [Fact]
         public void WhenEmpty_MissingInner_ShouldNotThrow()
         {
-            LogManager.ThrowExceptions = true;
-            SimpleLayout l = @"${whenEmpty:whenEmpty=${literal:text=c:\logs\}:inner=${environment:LOG_DIR_XXX}}api.log";
-            var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
-            Assert.Equal("api.log", l.Render(le));
+            using (new NoThrowNLogExceptions())
+            {
+                SimpleLayout l = @"${whenEmpty:whenEmpty=${literal:text=c\:\\logs\\}}api.log";
+                var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
+                LogManager.ThrowExceptions = true;
+                Assert.Equal("api.log", l.Render(le));
+            }
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenEmptyTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenEmptyTests.cs
@@ -73,7 +73,7 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
         {
             using (new NoThrowNLogExceptions())
             {
-                SimpleLayout l = @"${whenEmpty:whenEmpty=${literal:text=c\:\\logs\\}}api.log";
+                SimpleLayout l = @"${whenEmpty:whenEmpty=${literal:text=c:\logs\}:inner=${environment:LOG_DIR_XXX}}api.log";
                 var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
                 LogManager.ThrowExceptions = true;
                 Assert.Equal("api.log", l.Render(le));

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -520,21 +520,30 @@ namespace NLog.UnitTests.Layouts
             }
         }
 
-        [Theory]
-        [InlineData(@"aaa ${iDontExist} bbb")]
-        [InlineData(@"${layoutrenderer-with-list:}")]
-        public void InvalidLayoutWillThrowIfExceptionThrowingIsOn(string layout)
+        [Fact]
+        public void InvalidLayoutWillThrowIfExceptionThrowingIsOn()
         {
             LogManager.ThrowConfigExceptions = true;
             Assert.Throws<NLogConfigurationException>(() =>
             {
-                SimpleLayout l = layout;
+                SimpleLayout l = @"aaa ${iDontExist} bbb";
+            });
+        }
+
+        [Fact]
+        public void InvalidLayoutWithExistingRenderer_WillThrowIfExceptionThrowingIsOn()
+        {
+            ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition("layoutrenderer-with-list", typeof(LayoutRendererWithListParam));
+            LogManager.ThrowConfigExceptions = true;
+            Assert.Throws<NLogConfigurationException>(() =>
+            {
+                SimpleLayout l = @"${layoutrenderer-with-list:}";
             });
 
         }
 
         [Fact]
-        public void UnknownPropertyInLayoutWillThrowIfExceptionThrowingIsOn()
+        public void UnknownPropertyInLayout_WillThrowIfExceptionThrowingIsOn()
         {
             ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition("layoutrenderer-with-list", typeof(LayoutRendererWithListParam));
             LogManager.ThrowConfigExceptions = true;

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -520,15 +520,29 @@ namespace NLog.UnitTests.Layouts
             }
         }
 
-        [Fact]
-        public void InvalidLayoutWillThrowIfExceptionThrowingIsOn()
+        [Theory]
+        [InlineData(@"aaa ${iDontExist} bbb")]
+        [InlineData(@"${layoutrenderer-with-list:}")]
+        public void InvalidLayoutWillThrowIfExceptionThrowingIsOn(string layout)
         {
             LogManager.ThrowConfigExceptions = true;
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<NLogConfigurationException>(() =>
             {
-                SimpleLayout l = @"aaa ${iDontExist} bbb";
+                SimpleLayout l = layout;
             });
 
+        }
+
+        [Fact]
+        public void UnknownPropertyInLayoutWillThrowIfExceptionThrowingIsOn()
+        {
+            ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition("layoutrenderer-with-list", typeof(LayoutRendererWithListParam));
+            LogManager.ThrowConfigExceptions = true;
+
+            Assert.Throws<NLogConfigurationException>(() =>
+            {
+                SimpleLayout l = @"${layoutrenderer-with-list:iDontExist=1}";
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #3996 

I added a test for https://github.com/NLog/NLog/blob/733ce6e65045fd93de8bad6f9c5c67639e2d0978/src/NLog/Layouts/LayoutParser.cs#L384-L385 

And another for https://github.com/NLog/NLog/blob/733ce6e65045fd93de8bad6f9c5c67639e2d0978/src/NLog/Layouts/LayoutParser.cs#L455-L456