### PR TITLE
ProcessNameLayoutRenderer - Use ProcessName instead of MainModule.FileName

### DIFF
--- a/tests/NLog.UnitTests/LayoutRenderers/Processes/ProcessNameLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Processes/ProcessNameLayoutRendererTests.cs
@@ -56,7 +56,7 @@ namespace NLog.UnitTests.LayoutRenderers
             var lower = actual.ToLower();
 
             //lowercase
-            var allowedProcessNames = new List<string> {"vstest.executionengine", "xunit", "mono-sgen", "dotnet", "testhost.x86", "testhost.x64" };
+            var allowedProcessNames = new List<string> {"vstest.executionengine", "xunit", "mono-sgen", "dotnet", "testhost.x86", "testhost.x64", "testhost.net452.x86", "testhost.net452.x64" };
 
             Assert.True(allowedProcessNames.Any(p => lower.Contains(p)),
                 $"validating processname failed. Please add (if correct) '{actual}' to 'allowedProcessNames'");


### PR DESCRIPTION
Most people will expect the ProcessName instead of the ProcessFileName.

I'm guessing for 99 out of 100, then the result is the same.