### PR TITLE
JsonSerializer - Ensure invariant formatting of DateTimeOffset

### DIFF
--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -258,9 +258,9 @@ namespace NLog.Targets
                 return true;
             }
 
-            if (value is DateTimeOffset)
+            if (value is DateTimeOffset dateTimeOffset)
             {
-                QuoteValue(destination, $"{value:yyyy-MM-dd HH:mm:ss zzz}");
+                QuoteValue(destination, dateTimeOffset.ToString("yyyy-MM-dd HH:mm:ss zzz", CultureInfo.InvariantCulture));
                 return true;
             }
 

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
@@ -211,17 +211,41 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void SerializeDateTime_Test2()
         {
-            var val = new DateTime(2016, 12, 31);
-            var actual = SerializeObject(val);
-            Assert.Equal("\"" + "2016-12-31T00:00:00Z" + "\"", actual);
+            var culture = System.Threading.Thread.CurrentThread.CurrentCulture;
+
+            try
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo("en-GB");    // uses "." instead of ":" for time
+
+                var val = new DateTime(2016, 12, 31);
+                var actual = SerializeObject(val);
+                Assert.Equal("\"" + "2016-12-31T00:00:00Z" + "\"", actual);
+            }
+            finally
+            {
+                // Restore
+                System.Threading.Thread.CurrentThread.CurrentCulture = culture;
+            }
         }
 
         [Fact]
         public void SerializeDateTimeOffset_Test()
         {
-            var val = new DateTimeOffset(new DateTime(2016, 12, 31, 2, 30, 59), new TimeSpan(4, 30, 0));
-            var actual = SerializeObject(val);
-            Assert.Equal("\"" + "2016-12-31 02:30:59 +04:30" + "\"", actual);
+            var culture = System.Threading.Thread.CurrentThread.CurrentCulture;
+
+            try
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo("en-GB");    // uses "." instead of ":" for time
+
+                var val = new DateTimeOffset(new DateTime(2016, 12, 31, 2, 30, 59), new TimeSpan(4, 30, 0));
+                var actual = SerializeObject(val);
+                Assert.Equal("\"" + "2016-12-31 02:30:59 +04:30" + "\"", actual);
+            }
+            finally
+            {
+                // Restore
+                System.Threading.Thread.CurrentThread.CurrentCulture = culture;
+            }
         }
 
         [Fact]
@@ -241,8 +265,20 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void SerializeTime3_Test()
         {
-            var actual = SerializeObject(new TimeSpan(0, 0, 2, 3, 4));
-            Assert.Equal("\"00:02:03.0040000\"", actual);
+            var culture = System.Threading.Thread.CurrentThread.CurrentCulture;
+
+            try
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo("en-GB");    // uses "." instead of ":" for time
+
+                var actual = SerializeObject(new TimeSpan(0, 0, 2, 3, 4));
+                Assert.Equal("\"00:02:03.0040000\"", actual);
+            }
+            finally
+            {
+                // Restore
+                System.Threading.Thread.CurrentThread.CurrentCulture = culture;
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Really strange but VS2019 16.8 Preview then this:

> `QuoteValue(destination,` $"{value:yyyy-MM-dd HH:mm:ss zzz}");`

Fails in formatting:

```
   Expected: "2016-12-31 02:30:59 +04:30"
    Actual:   "2016-12-31 02.30.59 +04:30"
```

By forcing `CultureInfo.InvariantCulture` then it works as expected.
