### PR TITLE
ConditionLayoutExpression - Skip allocating StringBuilder for every condition check

### DIFF
--- a/src/NLog/Conditions/ConditionLayoutExpression.cs
+++ b/src/NLog/Conditions/ConditionLayoutExpression.cs
@@ -34,6 +34,7 @@
 namespace NLog.Conditions
 {
     using Layouts;
+    using System.Text;
 
     /// <summary>
     /// Condition layout expression (represented by a string literal
@@ -41,20 +42,23 @@ namespace NLog.Conditions
     /// </summary>
     internal sealed class ConditionLayoutExpression : ConditionExpression
     {
+        private readonly SimpleLayout _simpleLayout;
+        private StringBuilder _fastObjectPool;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ConditionLayoutExpression" /> class.
         /// </summary>
         /// <param name="layout">The layout.</param>
-        public ConditionLayoutExpression(Layout layout)
+        public ConditionLayoutExpression(SimpleLayout layout)
         {
-            Layout = layout;
+            _simpleLayout = layout;
         }
 
         /// <summary>
         /// Gets the layout.
         /// </summary>
         /// <value>The layout.</value>
-        public Layout Layout { get; private set; }
+        public Layout Layout => _simpleLayout;
 
         /// <summary>
         /// Returns a string representation of this expression.
@@ -62,7 +66,7 @@ namespace NLog.Conditions
         /// <returns>String literal in single quotes.</returns>
         public override string ToString()
         {
-            return Layout.ToString();
+            return _simpleLayout.ToString();
         }
 
         /// <summary>
@@ -73,7 +77,20 @@ namespace NLog.Conditions
         /// <returns>The value of the layout.</returns>
         protected override object EvaluateNode(LogEventInfo context)
         {
-            return Layout.Render(context);
+            if (_simpleLayout.IsSimpleStringText || !_simpleLayout.ThreadAgnostic)
+                return _simpleLayout.Render(context);
+
+            var stringBuilder = System.Threading.Interlocked.Exchange(ref _fastObjectPool, null) ?? new StringBuilder();
+            try
+            {
+                _simpleLayout.RenderAppendBuilder(context, stringBuilder);
+                return stringBuilder.ToString();
+            }
+            finally
+            {
+                stringBuilder.Length = 0;
+                System.Threading.Interlocked.Exchange(ref _fastObjectPool, stringBuilder);
+            }
         }
     }
 }

--- a/src/NLog/Conditions/ConditionLiteralExpression.cs
+++ b/src/NLog/Conditions/ConditionLiteralExpression.cs
@@ -41,13 +41,17 @@ namespace NLog.Conditions
     /// </summary>
     internal sealed class ConditionLiteralExpression : ConditionExpression
     {
+        private readonly string _toStringValue;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ConditionLiteralExpression" /> class.
         /// </summary>
         /// <param name="literalValue">Literal value.</param>
-        public ConditionLiteralExpression(object literalValue)
+        /// <param name="toStringValue">ToString value.</param>
+        public ConditionLiteralExpression(object literalValue, string toStringValue = null)
         {
             LiteralValue = literalValue;
+            _toStringValue = toStringValue;
         }
 
         /// <summary>
@@ -62,6 +66,9 @@ namespace NLog.Conditions
         /// <returns>The literal value.</returns>
         public override string ToString()
         {
+            if (_toStringValue != null)
+                return _toStringValue;
+
             if (LiteralValue == null)
             {
                 return "null";

--- a/src/NLog/Conditions/ConditionParser.cs
+++ b/src/NLog/Conditions/ConditionParser.cs
@@ -177,9 +177,12 @@ namespace NLog.Conditions
 
             if (_tokenizer.TokenType == ConditionTokenType.String)
             {
-                ConditionExpression e = new ConditionLayoutExpression(new SimpleLayout(_tokenizer.StringTokenValue, _configurationItemFactory));
+                var simpleLayout = new SimpleLayout(_tokenizer.StringTokenValue, _configurationItemFactory);
                 _tokenizer.GetNextToken();
-                return e;
+                if (simpleLayout.IsFixedText)
+                    return new ConditionLiteralExpression(simpleLayout.FixedText, simpleLayout.ToString());
+                else
+                    return new ConditionLayoutExpression(simpleLayout);
             }
 
             if (_tokenizer.TokenType == ConditionTokenType.Keyword)

--- a/tests/NLog.UnitTests/Conditions/ConditionEvaluatorTests.cs
+++ b/tests/NLog.UnitTests/Conditions/ConditionEvaluatorTests.cs
@@ -65,6 +65,7 @@ namespace NLog.UnitTests.Conditions
         [Fact]
         public void ConditionMethodsTest()
         {
+            AssertEvaluationResult(true, "'${exception:format=type}'==''");
             AssertEvaluationResult(true, "starts-with('foobar','foo')");
             AssertEvaluationResult(false, "starts-with('foobar','bar')");
             AssertEvaluationResult(true, "ends-with('foobar','bar')");


### PR DESCRIPTION
This filter will now only allocate a StringBuilder once (But will still allocate a string for every LogEvent with Exception):

```xml
        <logger name="*" minLevel="Info" writeTo="exceptionFile">
          <filters defaultFilterResult="Log">
            <when condition="'${exception:format=type}' == ''" action="Ignore" />
          </filters>
        </logger>
```