### PR TITLE
AsyncTaskTarget - Flush when buffer is full should not block forever

### DIFF
--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -56,7 +56,8 @@ namespace NLog.Targets
         private Task _previousTask;
         private readonly Timer _lazyWriterTimer;
         private readonly ReusableAsyncLogEventList _reusableAsyncLogEventList = new ReusableAsyncLogEventList(200);
-        private System.Tuple<List<LogEventInfo>, List<AsyncContinuation>> _reusableLogEvents;
+        private Tuple<List<LogEventInfo>, List<AsyncContinuation>> _reusableLogEvents;
+        private AsyncHelpersTask? _flushEventsInQueueDelegate;
 
         /// <summary>
         /// How many milliseconds to delay the actual write operation to optimize for batching
@@ -324,8 +325,26 @@ namespace NLog.Targets
             if (_previousTask?.IsCompleted == false || !_requestQueue.IsEmpty)
             {
                 InternalLogger.Debug("{0} Flushing {1}", Name, _requestQueue.IsEmpty ? "empty queue" : "pending queue items");
-                _requestQueue.Enqueue(new AsyncLogEventInfo(null, asyncContinuation));
-                _lazyWriterTimer.Change(0, Timeout.Infinite);
+                if (_requestQueue.OnOverflow != AsyncTargetWrapperOverflowAction.Block)
+                {
+                    _requestQueue.Enqueue(new AsyncLogEventInfo(null, asyncContinuation));
+                    _lazyWriterTimer.Change(0, Timeout.Infinite);    // Schedule timer to empty queue, and execute asyncContinuation
+                }
+                else
+                {
+                    // We are holding target-SyncRoot, and might get blocked in queue, so need to schedule flush using async-task
+                    if (_flushEventsInQueueDelegate == null)
+                    {
+                        _flushEventsInQueueDelegate = new AsyncHelpersTask(cont =>
+                        {
+                            _requestQueue.Enqueue(new AsyncLogEventInfo(null, (AsyncContinuation)cont));
+                            lock (SyncRoot)
+                                _lazyWriterTimer.Change(0, Timeout.Infinite);    // Schedule timer to empty queue, and execute asyncContinuation
+                        });
+                    }
+                    AsyncHelpers.StartAsyncTask(_flushEventsInQueueDelegate.Value, asyncContinuation);
+                    _lazyWriterTimer.Change(0, Timeout.Infinite);   // Schedule timer to empty queue, so room for flush-request
+                }
             }
             else
             {

--- a/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
+++ b/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
@@ -501,6 +501,33 @@ namespace NLog.UnitTests.Targets
             Assert.True(asyncTarget.WaitForWriteEvent());
             Assert.NotEmpty(asyncTarget.Logs);
         }
+
+        [Fact]
+        public void AsyncTaskTarget_FlushWhenBlocked()
+        {
+            // Arrange
+            var logFactory = new LogFactory();
+            var logConfig = new LoggingConfiguration(logFactory);
+            var asyncTarget = new AsyncTaskBatchTestTarget
+            {
+                Layout = "${level}",
+                TaskDelayMilliseconds = 10000,
+                BatchSize = 10,
+                QueueLimit = 10,
+                OverflowAction = NLog.Targets.Wrappers.AsyncTargetWrapperOverflowAction.Block,
+            };
+            logConfig.AddRuleForAllLevels(asyncTarget);
+            logFactory.Configuration = logConfig;
+            var logger = logFactory.GetLogger(nameof(AsyncTaskTarget_FlushWhenBlocked));
+
+            // Act
+            for (int i = 0; i < 10; ++i)
+                logger.Info("Testing {0}", i);
+            logFactory.Flush(TimeSpan.FromSeconds(5));
+
+            // Assert
+            Assert.Equal(1, asyncTarget.WriteTasks);
+        }
     }
 #endif
 }


### PR DESCRIPTION
bug is about using `overflow="Block"` and flushing when the queue is completely full: