### PR TITLE
Failing to lookup ProcessName because of Access Denied should fallback to Win32-API

### DIFF
--- a/src/NLog/Internal/Fakeables/AppEnvironmentWrapper.cs
+++ b/src/NLog/Internal/Fakeables/AppEnvironmentWrapper.cs
@@ -55,11 +55,11 @@ namespace NLog.Internal.Fakeables
         /// <inheritdoc />
         public string EntryAssemblyFileName => _entryAssemblyFileName ?? (_entryAssemblyFileName = LookupEntryAssemblyFileName());
         /// <inheritdoc />
-        public string CurrentProcessFilePath => _currentProcessFilePath ?? (_currentProcessFilePath = LookupCurrentProcessFilePath());
+        public string CurrentProcessFilePath => _currentProcessFilePath ?? (_currentProcessFilePath = LookupCurrentProcessFilePathWithFallback());
         /// <inheritdoc />
         public string CurrentProcessBaseName => _currentProcessBaseName ?? (_currentProcessBaseName = string.IsNullOrEmpty(CurrentProcessFilePath) ? UnknownProcessName : Path.GetFileNameWithoutExtension(CurrentProcessFilePath));
         /// <inheritdoc />
-        public int CurrentProcessId => _currentProcessId ?? (_currentProcessId = LookupCurrentProcessId()).Value;
+        public int CurrentProcessId => _currentProcessId ?? (_currentProcessId = LookupCurrentProcessIdWithFallback()).Value;
 #endif
         /// <inheritdoc />
         public string AppDomainBaseDirectory => AppDomain.BaseDirectory;
@@ -110,12 +110,83 @@ namespace NLog.Internal.Fakeables
             }
         }
 
+        private static string LookupCurrentProcessFilePathWithFallback()
+        {
+            try
+            {
+                var processFilePath = LookupCurrentProcessFilePath();
+                return processFilePath ?? LookupCurrentProcessFilePathNative();
+            }
+            catch (Exception ex)
+            {
+                if (ex.MustBeRethrownImmediately())
+                    throw;
+
+                return LookupCurrentProcessFilePathNative();
+            }
+        }
+
         private static string LookupCurrentProcessFilePath()
         {
             try
             {
                 var currentProcess = Process.GetCurrentProcess();
-                return currentProcess?.MainModule.FileName ?? string.Empty;
+                return currentProcess?.MainModule.FileName;
+            }
+            catch (Exception ex)
+            {
+                if (ex.MustBeRethrownImmediately())
+                    throw;
+
+                // May throw a SecurityException or Access Denied when running from an IIS app. pool process
+                return null;
+            }
+        }
+
+        private static int LookupCurrentProcessIdWithFallback()
+        {
+            try
+            {
+                var processId = LookupCurrentProcessId();
+                return processId ?? LookupCurrentProcessIdNative();
+            }
+            catch (Exception ex)
+            {
+                if (ex.MustBeRethrownImmediately())
+                    throw;
+
+                // May throw a SecurityException if running from an IIS app. pool process (Cannot compile method)
+                return LookupCurrentProcessIdNative();
+            }
+        }
+
+        private static int? LookupCurrentProcessId()
+        {
+            try
+            {
+                var currentProcess = Process.GetCurrentProcess();
+                return currentProcess?.Id;
+            }
+            catch (Exception ex)
+            {
+                if (ex.MustBeRethrownImmediately())
+                    throw;
+
+                // May throw a SecurityException or Access Denied when running from an IIS app. pool process
+                return null;
+            }
+        }
+#endif
+
+#if !SILVERLIGHT && !__IOS__ && !__ANDROID__ && !NETSTANDARD
+        private static string LookupCurrentProcessFilePathNative()
+        {
+            try
+            {
+                if (!PlatformDetector.IsWin32)
+                    return string.Empty;
+
+                return LookupCurrentProcessFilePathWin32();
             }
             catch (Exception ex)
             {
@@ -126,12 +197,36 @@ namespace NLog.Internal.Fakeables
             }
         }
 
-        private static int LookupCurrentProcessId()
+        [System.Security.SecuritySafeCritical]
+        private static string LookupCurrentProcessFilePathWin32()
         {
             try
             {
-                var currentProcess = Process.GetCurrentProcess();
-                return currentProcess?.Id ?? 0;
+                var sb = new System.Text.StringBuilder(512);
+                if (0 == NativeMethods.GetModuleFileName(IntPtr.Zero, sb, sb.Capacity))
+                {
+                    throw new InvalidOperationException("Cannot determine program name.");
+                }
+
+                return sb.ToString();
+            }
+            catch (Exception ex)
+            {
+                if (ex.MustBeRethrownImmediately())
+                    throw;
+
+                return string.Empty;
+            }
+        }
+
+        private static int LookupCurrentProcessIdNative()
+        {
+            try
+            {
+                if (!PlatformDetector.IsWin32)
+                    return 0;
+
+                return LookupCurrentProcessIdWin32();
             }
             catch (Exception ex)
             {
@@ -140,6 +235,32 @@ namespace NLog.Internal.Fakeables
 
                 return 0;
             }
+        }
+
+        [System.Security.SecuritySafeCritical]
+        private static int LookupCurrentProcessIdWin32()
+        {
+            try
+            {
+                return NativeMethods.GetCurrentProcessId();
+            }
+            catch (Exception ex)
+            {
+                if (ex.MustBeRethrownImmediately())
+                    throw;
+
+                return 0;
+            }
+        }
+#else
+        private static string LookupCurrentProcessFilePathNative()
+        {
+            return string.Empty;
+        }
+
+        private static int LookupCurrentProcessIdNative()
+        {
+            return 0;
         }
 #endif
     }

--- a/src/NLog/Internal/NativeMethods.cs
+++ b/src/NLog/Internal/NativeMethods.cs
@@ -68,6 +68,14 @@ namespace NLog.Internal
         [DllImport("kernel32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool QueryPerformanceFrequency(out ulong lpPerformanceFrequency);
+
+        [DllImport("kernel32.dll")]
+        internal static extern int GetCurrentProcessId();
+
+        [SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1305:FieldNamesMustNotUseHungarianNotation",
+            Justification = "Reviewed. Suppression is OK here.")]
+        [DllImport("kernel32.dll", SetLastError = true, PreserveSig = true, CharSet = CharSet.Unicode)]
+        internal static extern uint GetModuleFileName([In] IntPtr hModule, [Out] StringBuilder lpFilename, [In][MarshalAs(UnmanagedType.U4)] int nSize);
     }
 }
 


### PR DESCRIPTION
Trying to resolve #4181 where IIS-applications with medium-trust no longer can use `${processname}` and `${processid}`

Bug introduced with #3941 in NLog 4.7.1. Guess there was a reason for using Win32 API besides speed optimization :)