### PR TITLE
Removed InternalLogger static constructor and added extension method SetupFromEnvironmentVariables

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -56,16 +56,7 @@ namespace NLog.Common
         private static readonly object LockObject = new object();
         private static string _logFile;
 
-        /// <summary>
-        /// Initializes static members of the InternalLogger class.
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline", Justification = "Significant logic in .cctor()")]
-        static InternalLogger()
-        {
-            Reset();
-        }
-
-        /// <summary>
+       /// <summary>
         /// Set the config of the InternalLogger with defaults and config.
         /// </summary>
         public static void Reset()

--- a/src/NLog/SetupInternalLoggerBuilderExtensions.cs
+++ b/src/NLog/SetupInternalLoggerBuilderExtensions.cs
@@ -106,5 +106,33 @@ namespace NLog
             InternalLogger.LogMessageReceived -= eventSubscriber;
             return setupBuilder;
         }
+
+        /// <summary>
+        /// Configure the InternalLogger properties from Environment-variables and App.config using <see cref="InternalLogger.Reset"/>
+        /// </summary>
+        /// <remarks>
+        /// Recognizes the following environment-variables:
+        /// 
+        /// - NLOG_INTERNAL_LOG_LEVEL
+        /// - NLOG_INTERNAL_LOG_FILE
+        /// - NLOG_INTERNAL_LOG_TO_CONSOLE
+        /// - NLOG_INTERNAL_LOG_TO_CONSOLE_ERROR
+        /// - NLOG_INTERNAL_LOG_TO_TRACE
+        /// - NLOG_INTERNAL_INCLUDE_TIMESTAMP
+        /// 
+        /// Legacy .NetFramework platform will also recognizes the following app.config settings:
+        /// 
+        /// - nlog.internalLogLevel
+        /// - nlog.internalLogFile
+        /// - nlog.internalLogToConsole
+        /// - nlog.internalLogToConsoleError
+        /// - nlog.internalLogToTrace
+        /// - nlog.internalLogIncludeTimestamp
+        /// </remarks>
+        public static ISetupInternalLoggerBuilder SetupFromEnvironmentVariables(this ISetupInternalLoggerBuilder setupBuilder)
+        {
+            InternalLogger.Reset();
+            return setupBuilder;
+        }
     }
 }

--- a/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
+++ b/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
@@ -537,6 +537,29 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        public void SetupInternalLoggerSetupFromEnvironmentVariablesTest()
+        {
+            try
+            {
+                // Arrange
+                InternalLogger.Reset();
+                var logFactory = new LogFactory();
+                InternalLogger.LogToConsole = true;
+
+                // Act
+                logFactory.Setup().SetupInternalLogger(b => b.SetupFromEnvironmentVariables().SetMinimumLogLevel(LogLevel.Fatal));
+
+                // Assert
+                Assert.False(InternalLogger.LogToConsole);
+                Assert.Equal(LogLevel.Fatal, InternalLogger.LogLevel);
+            }
+            finally
+            {
+                InternalLogger.Reset();
+            }
+        }
+
+        [Fact]
         public void SetupExtensionsRegisterConditionMethodTest()
         {
             try


### PR DESCRIPTION
Added `LogFactory.Setup().SetupInternalLogger(b => b.SetupFromEnvironmentVariables())`

Trying to resolve #4032 and reduce overhead from NLog initialization.