### PR TITLE
Added DebuggerDisplay for custom dictionary-collections

### DIFF
--- a/src/NLog/Internal/PropertiesDictionary.cs
+++ b/src/NLog/Internal/PropertiesDictionary.cs
@@ -36,6 +36,7 @@ namespace NLog.Internal
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using MessageTemplates;
 
     /// <summary>
@@ -45,6 +46,7 @@ namespace NLog.Internal
     /// The <see cref="MessageProperties" /> are returned as the first items
     /// in the collection, and in positional order.
     /// </summary>
+    [DebuggerDisplay("Count = {Count}")]
     internal sealed class PropertiesDictionary : IDictionary<object, object>, IEnumerable<MessageTemplateParameter>
     {
         private struct PropertyValue
@@ -595,6 +597,7 @@ namespace NLog.Internal
             }
         }
 
+        [DebuggerDisplay("Count = {Count}")]
         private class DictionaryCollection : ICollection<object>
         {
             private readonly PropertiesDictionary _dictionary;

--- a/src/NLog/Internal/ThreadSafeDictionary.cs
+++ b/src/NLog/Internal/ThreadSafeDictionary.cs
@@ -36,8 +36,10 @@ namespace NLog.Internal
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
 
+    [DebuggerDisplay("Count = {Count}")]
     internal class ThreadSafeDictionary<TKey, TValue> : IDictionary<TKey, TValue>
     {
         private readonly object _lockObject = new object();


### PR DESCRIPTION
Improving debugger-display for `Logger.Properties` and `LogEventInfo.Properties`