### PR TITLE
fix: generate legal json for keys that contain quote

### DIFF
--- a/src/NLog/Layouts/JSON/JsonLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonLayout.cs
@@ -333,7 +333,7 @@ namespace NLog.Layouts
             }
 
             sb.Append('"');
-            sb.Append(propName);
+            Targets.DefaultJsonSerializer.AppendStringEscape(sb, propName, false, false);
             sb.Append('"');
             sb.Append(':');
             if (!SuppressSpaces)

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -442,6 +442,19 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void PropertyKeyWithQuote()
+        {
+            var jsonLayout = new JsonLayout()
+            {
+                IncludeAllProperties = true,
+            };
+
+            var logEventInfo = new LogEventInfo();
+            logEventInfo.Properties.Add(@"fo""o", "bar");
+            Assert.Equal(@"{ ""fo\""o"": ""bar"" }", jsonLayout.Render(logEventInfo));
+        }
+
+        [Fact]
         public void IncludeAllJsonPropertiesMaxRecursionLimit()
         {
             var jsonLayout = new JsonLayout()


### PR DESCRIPTION
Bugfix for self-explanatory bug in `JsonLayout` (see test)