### PR TITLE
Skip allocation of SingleCallContinuation when ThrowExceptions = false

### DIFF
--- a/src/NLog/Internal/SingleCallContinuation.cs
+++ b/src/NLog/Internal/SingleCallContinuation.cs
@@ -42,6 +42,8 @@ namespace NLog.Internal
     /// </summary>
     internal class SingleCallContinuation
     {
+        internal static readonly AsyncContinuation Completed = new SingleCallContinuation(null).CompletedFunction;
+
         private AsyncContinuation _asyncContinuation;
 
         /// <summary>
@@ -76,6 +78,11 @@ namespace NLog.Internal
                     throw;
                 }       
             }
+        }
+
+        private void CompletedFunction(Exception exception)
+        {
+            // Completed, nothing to do
         }
     }
 }

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -64,7 +64,7 @@ namespace NLog
             }
 #endif
 
-            AsyncContinuation exceptionHandler = (ex) => { };
+            AsyncContinuation exceptionHandler = SingleCallContinuation.Completed;
             if (factory.ThrowExceptions)
             {
                 int originalThreadId = AsyncHelpers.GetManagedThreadId();


### PR DESCRIPTION
This should reduce NLog memory allocations a lot. Instead of allocating 3 objects (LogEventInfo + SingleCallContinuation +  SingleCallContinuation.Function-delegate-instance) then it will just be the actual LogEventInfo.

Also a small bonus speed optimization on many-core-machines, as it can skip an interlocked-operation for every logevent (skip unnecessary cpu-cache synchronization).