### PR TITLE
Added retry to unstable tests on Azure DevOps Pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 
 mono: 5.8.0
 dotnet: 2.0.0
-dist: bionic
+dist: xenial
 
 
 install:

--- a/src/NLog.sln
+++ b/src/NLog.sln
@@ -38,6 +38,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.editorconfig = ..\.editorconfig
 		..\.gitattributes = ..\.gitattributes
 		..\.gitignore = ..\.gitignore
+		..\.travis.yml = ..\.travis.yml
+		..\appveyor.yml = ..\appveyor.yml
 		..\CHANGELOG.md = ..\CHANGELOG.md
 	EndProjectSection
 EndProject

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -362,6 +362,7 @@ namespace NLog.UnitTests
 
             return stringWriter.ToString();
         }
+
         /// <summary>
         /// To handle unstable integration tests, retry if failed
         /// </summary>
@@ -384,8 +385,9 @@ namespace NLog.UnitTests
                     {
                         throw;
                     }
-                }
 
+                    System.Threading.Thread.Sleep(1000);
+                }
             }
         }
 


### PR DESCRIPTION
SqlServer_NoTargetInstallException +  SqlServer_InstallAndLogMessage

Also noticed the default automatic retry of failing tests, then caused this [check to break](https://dev.azure.com/NLogLogging/NLog/_build/results?buildId=2002&view=results) because it only retried 2 tests:

> ##[error]The specified minimum number of tests 100 were not executed in the test run.