### PR TITLE
ScopeContext - Logger.PushScopeState with covariance support

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -59,9 +59,6 @@ namespace NLog
         private static IAppDomain currentAppDomain;
         private static AppEnvironmentWrapper defaultAppEnvironment;
 
-        /// <remarks>
-        /// Internal for unit tests
-        /// </remarks>
         internal readonly object _syncRoot = new object();
         private readonly LoggerCache _loggerCache = new LoggerCache();
         private ServiceRepositoryInternal _serviceRepository = new ServiceRepositoryInternal();
@@ -69,6 +66,9 @@ namespace NLog
         internal LoggingConfiguration _config;
         internal LogMessageFormatter ActiveMessageFormatter;
         internal LogMessageFormatter SingleTargetMessageFormatter;
+        internal ObjectReflectionCache ObjectReflectionCache => _objectReflectionCache ?? (_objectReflectionCache = new ObjectReflectionCache(_serviceRepository));
+        private ObjectReflectionCache _objectReflectionCache;
+
         private LogLevel _globalThreshold = LogLevel.MinLevel;
         private bool _configLoaded;
         // TODO: logsEnabled property might be possible to be encapsulated into LogFactory.LogsEnabler class. 

--- a/tests/NLog.UnitTests/LayoutRenderers/Contexts/ScopeNestedTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Contexts/ScopeNestedTests.cs
@@ -99,7 +99,7 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
-        public void scopenestedTopOneTest()
+        public void ScopeNestedTopOneTest()
         {
             // Arrange
             ScopeContext.Clear();

--- a/tests/NLog.UnitTests/LayoutRenderers/Processes/ProcessNameLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Processes/ProcessNameLayoutRendererTests.cs
@@ -56,7 +56,7 @@ namespace NLog.UnitTests.LayoutRenderers
             var lower = actual.ToLower();
 
             //lowercase
-            var allowedProcessNames = new List<string> {"vstest.executionengine", "xunit", "mono-sgen", "dotnet", "testhost.x86", "testhost.x64", "testhost.net452.x86", "testhost.net452.x64" };
+            var allowedProcessNames = new List<string> {"vstest.executionengine", "xunit", "mono-sgen", "dotnet", "testhost.x86", "testhost.x64", "testhost.net452.x86", "testhost.net452.x64", "testhost.net461.x86", "testhost.net461.x64" };
 
             Assert.True(allowedProcessNames.Any(p => lower.Contains(p)),
                 $"validating processname failed. Please add (if correct) '{actual}' to 'allowedProcessNames'");


### PR DESCRIPTION
NLog-Logger.PushScopeState now has extended support for extracting scope-properties. This matches the logic in MEL-ILogger BeginScope inside NLog.Extension.Logging. Besides making the behavior more similar, then it will also allow removal of scope-state-parser-logic from NLog.Extension.Logging.

It is ofcourse better and faster to use NLog-Logger.PushScopeProperties, that now supports both `KeyValuePair<string,object>[] `and `Dictionary<string,object>` as they matches `IReadOnlyCollection<KeyValuePair<string, object>>` as input-type.