### PR TITLE
Skip lookup MainModule.FileName on Android platform to avoid crash

### DIFF
--- a/src/NLog/Config/LoggingConfigurationFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationFileLoader.cs
@@ -311,7 +311,7 @@ namespace NLog.Config
             if (filename == null)
             {
                 // Scan for process specific nlog-files
-                foreach (var filePath in GetAppSpecificNLogLocations(entryAssemblyLocation))
+                foreach (var filePath in GetAppSpecificNLogLocations(baseDirectory, entryAssemblyLocation))
                     yield return filePath;
             }
 
@@ -340,7 +340,7 @@ namespace NLog.Config
         /// <summary>
         /// Get default file paths (including filename) for possible NLog config files. 
         /// </summary>
-        public IEnumerable<string> GetAppSpecificNLogLocations(string entryAssemblyLocation)
+        public IEnumerable<string> GetAppSpecificNLogLocations(string baseDirectory, string entryAssemblyLocation)
         {
             // Current config file with .config renamed to .nlog
             string configurationFile = _appEnvironment.AppDomainConfigurationFile;
@@ -358,36 +358,30 @@ namespace NLog.Config
 #if NETSTANDARD && !NETSTANDARD1_3
             else
             {
-                string processFilePath = _appEnvironment.CurrentProcessFilePath;
-                string processDirectory = !string.IsNullOrEmpty(processFilePath) ? PathHelpers.TrimDirectorySeparators(Path.GetDirectoryName(processFilePath)) : string.Empty;
+                if (string.IsNullOrEmpty(entryAssemblyLocation))
+                    entryAssemblyLocation = baseDirectory;
 
-                if (!IsValidProcessDirectory(processDirectory, entryAssemblyLocation, _appEnvironment))
+                if (PathHelpers.IsTempDir(entryAssemblyLocation, _appEnvironment.UserTempFilePath))
                 {
-                    // Handle dotnet-process loading .NET Core-assembly, or IIS-process loading website
-                    string assemblyFileName = _appEnvironment.EntryAssemblyFileName;
-                    yield return Path.Combine(entryAssemblyLocation, assemblyFileName + ".nlog");
-
-                    // Handle unpublished .NET Core Application
-                    assemblyFileName = Path.GetFileNameWithoutExtension(assemblyFileName);
-                    if (!string.IsNullOrEmpty(assemblyFileName))
-                        yield return Path.Combine(entryAssemblyLocation, assemblyFileName + ".exe.nlog");
-                }
-                else if (!string.IsNullOrEmpty(processFilePath))
-                {
-                    yield return processFilePath + ".nlog";
-
-                    // Handle published .NET Core Application with assembly-nlog-file
-                    if (!string.IsNullOrEmpty(entryAssemblyLocation))
+                    // Handle Single File Published on NetCore 3.1 and loading side-by-side exe.nlog (Not relevant for Net5.0)
+                    string processFilePath = _appEnvironment.CurrentProcessFilePath;
+                    if (!string.IsNullOrEmpty(processFilePath))
                     {
-                        string assemblyFileName = _appEnvironment.EntryAssemblyFileName;
-                        if (!string.IsNullOrEmpty(assemblyFileName))
-                            yield return Path.Combine(entryAssemblyLocation, assemblyFileName + ".nlog");
+                        yield return processFilePath + ".nlog";
                     }
-                    else
+                }
+
+                if (!string.IsNullOrEmpty(entryAssemblyLocation))
+                {
+                    string assemblyFileName = _appEnvironment.EntryAssemblyFileName;
+                    if (!string.IsNullOrEmpty(assemblyFileName))
                     {
-                        string processFileName = Path.GetFileNameWithoutExtension(processFilePath);
-                        if (!string.IsNullOrEmpty(processFileName))
-                            yield return Path.Combine(processDirectory, processFileName + ".dll.nlog");
+                        // Handle unpublished .NET Core Application
+                        var assemblyBaseName = Path.GetFileNameWithoutExtension(assemblyFileName);
+                        if (!string.IsNullOrEmpty(assemblyBaseName))
+                            yield return Path.Combine(entryAssemblyLocation, assemblyBaseName + ".exe.nlog");
+
+                        yield return Path.Combine(entryAssemblyLocation, assemblyFileName + ".nlog");
                     }
                 }
             }
@@ -411,25 +405,6 @@ namespace NLog.Config
                 }
             }
         }
-
-#if NETSTANDARD && !NETSTANDARD1_3
-        private static bool IsValidProcessDirectory(string processDirectory, string entryAssemblyLocation, IAppEnvironment appEnvironment)
-        {
-            if (string.IsNullOrEmpty(entryAssemblyLocation))
-                return true;
-
-            if (string.Equals(entryAssemblyLocation, processDirectory, StringComparison.OrdinalIgnoreCase))
-                return true;
-
-            if (string.IsNullOrEmpty(processDirectory))
-                return false;
-
-            if (PathHelpers.IsTempDir(entryAssemblyLocation, appEnvironment.UserTempFilePath))
-                return true;    // Hack for .NET Core 3 - Single File Publish that unpacks Entry-Assembly into temp-folder, and process-directory is valid
-
-            return false;   // NetCore Application is not published and is possible being executed by dotnet-process
-        }
-#endif
 
         protected virtual void Dispose(bool disposing)
         {

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -161,7 +161,7 @@ namespace NLog.UnitTests
 #else
                 AppDomainConfigurationFile = Path.Combine(tmpDir, "EntryDir", "Entry.exe.config"),
 #endif
-                CurrentProcessFilePath = Path.Combine(tmpDir, "ProcessDir", "Process.exe"),// NetCore dotnet.exe
+                CurrentProcessFilePath = Path.Combine(tmpDir, "ProcessDir", "dotnet.exe"),  // NetCore dotnet.exe
                 EntryAssemblyLocation = Path.Combine(tmpDir, "EntryDir"),
                 EntryAssemblyFileName = "Entry.dll"
             };
@@ -186,9 +186,9 @@ namespace NLog.UnitTests
 #if NETSTANDARD
                 AppDomainConfigurationFile = string.Empty,                  // NetCore style
 #else
-                AppDomainConfigurationFile = Path.Combine(tmpDir, "ProcessDir", "Process.exe.config"),
+                AppDomainConfigurationFile = Path.Combine(tmpDir, "ProcessDir", "Entry.exe.config"),
 #endif
-                CurrentProcessFilePath = Path.Combine(tmpDir, "ProcessDir", "Process.exe"),    // NetCore published exe
+                CurrentProcessFilePath = Path.Combine(tmpDir, "ProcessDir", "Entry.exe"),    // NetCore published exe
                 EntryAssemblyLocation = Path.Combine(tmpDir, "ProcessDir"),
                 EntryAssemblyFileName = "Entry.dll"
             };
@@ -199,7 +199,7 @@ namespace NLog.UnitTests
             var result = fileLoader.GetDefaultCandidateConfigFilePaths().ToList();
 
             // Assert base-directory + process-directory + nlog-assembly-directory
-            AssertResult(tmpDir, "ProcessDir", "ProcessDir", "Process", result);
+            AssertResult(tmpDir, "ProcessDir", "ProcessDir", "Entry", result);
         }
 
         [Fact]
@@ -213,9 +213,9 @@ namespace NLog.UnitTests
 #if NETSTANDARD
                 AppDomainConfigurationFile = string.Empty,                  // NetCore style
 #else
-                AppDomainConfigurationFile = Path.Combine(tmpDir, "ProcessDir", "Process.exe.config"),
+                AppDomainConfigurationFile = Path.Combine(tmpDir, "ProcessDir", "Entry.exe.config"),
 #endif
-                CurrentProcessFilePath = Path.Combine(tmpDir, "ProcessDir", "Process.exe"),    // NetCore published exe
+                CurrentProcessFilePath = Path.Combine(tmpDir, "ProcessDir", "Entry.exe"),    // NetCore published exe
                 EntryAssemblyLocation = Path.Combine(tmpDir, "TempProcessDir"),
                 UserTempFilePath = Path.Combine(tmpDir, "TempProcessDir"),
                 EntryAssemblyFileName = "Entry.dll"
@@ -227,7 +227,7 @@ namespace NLog.UnitTests
             var result = fileLoader.GetDefaultCandidateConfigFilePaths().ToList();
 
             // Assert base-directory + process-directory + nlog-assembly-directory
-            AssertResult(tmpDir, "TempProcessDir", "ProcessDir", "Process", result);
+            AssertResult(tmpDir, "TempProcessDir", "ProcessDir", "Entry", result);
         }
 
         [Fact]
@@ -241,9 +241,9 @@ namespace NLog.UnitTests
 #if NETSTANDARD
                 AppDomainConfigurationFile = string.Empty,                  // NetCore style
 #else
-                AppDomainConfigurationFile = Path.Combine(tmpDir, "ProcessDir", "Process.exe.config"),
+                AppDomainConfigurationFile = Path.Combine(tmpDir, "ProcessDir", "Entry.exe.config"),
 #endif
-                CurrentProcessFilePath = Path.Combine(tmpDir, "ProcessDir", "Process.exe"),    // NetCore published exe
+                CurrentProcessFilePath = Path.Combine(tmpDir, "ProcessDir", "Entry.exe"),    // NetCore published exe
                 EntryAssemblyLocation = Path.Combine(tmpDir, "TempProcessDir"),
                 UserTempFilePath = "/tmp/",
                 EntryAssemblyFileName = "Entry.dll"
@@ -255,24 +255,30 @@ namespace NLog.UnitTests
             var result = fileLoader.GetDefaultCandidateConfigFilePaths().ToList();
 
             // Assert base-directory + process-directory + nlog-assembly-directory
-            AssertResult(tmpDir, "TempProcessDir", "ProcessDir", "Process", result);
+            AssertResult(tmpDir, "TempProcessDir", "ProcessDir", "Entry", result);
         }
 
         private static void AssertResult(string tmpDir, string appDir, string processDir, string appName, List<string> result)
         {
-            if (NLog.Internal.PlatformDetector.IsWin32)
-            {
-#if NETSTANDARD
-                Assert.Equal(5, result.Count);  // Case insensitive
-#else
-                Assert.Equal(4, result.Count);  // Case insensitive
-#endif
-            }
             Assert.Equal(Path.Combine(tmpDir, "BaseDir", "NLog.config"), result.First(), StringComparer.OrdinalIgnoreCase);
             Assert.Contains(Path.Combine(tmpDir, appDir, "NLog.config"), result, StringComparer.OrdinalIgnoreCase);
             Assert.Contains(Path.Combine(tmpDir, processDir, appName + ".exe.nlog"), result, StringComparer.OrdinalIgnoreCase);
 #if NETSTANDARD
             Assert.Contains(Path.Combine(tmpDir, appDir, "Entry.dll.nlog"), result, StringComparer.OrdinalIgnoreCase);
+            if (NLog.Internal.PlatformDetector.IsWin32)
+            {
+                if (appDir != processDir)
+                    Assert.Equal(6, result.Count);  // Single File Publish on NetCore 3.1 - Case insensitive
+                else
+                    Assert.Equal(5, result.Count);  // Case insensitive
+            }
+            // Verify Single File Publish will always load "exe.nlog" before "dll.nlog"
+            var priorityIndexExe = result.FindIndex(s => s.EndsWith(appName+".exe.nlog"));
+            var priorityIndexDll = result.FindIndex(s => s.EndsWith(appName+".dll.nlog"));
+            Assert.True(priorityIndexExe <  priorityIndexDll, $"{appName+".exe.nlog"}={priorityIndexExe} < {appName+".dll.nlog"}={priorityIndexDll}"); // Always scan for exe.nlog first
+#else
+            if (NLog.Internal.PlatformDetector.IsWin32)
+                Assert.Equal(4, result.Count);  // Case insensitive
 #endif
             Assert.Contains("NLog.dll.nlog", result.Last(), StringComparison.OrdinalIgnoreCase);
         }


### PR DESCRIPTION
Fixes #4228 by skipping lookup of `GetCurrentProcess().MainModule.FileName`, when EntryAssemblyLocation does not match Tmp-directory.

Bug introduced with: #3261(Support autoloading NLog.config on single-file-publish) in NLog 4.6.3