### PR TITLE
Disable automatic assembly loading by default

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -418,10 +418,16 @@ namespace NLog.Config
             var nlogAssembly = typeof(ILogger).GetAssembly();
             var factory = new ConfigurationItemFactory(LogManager.LogFactory.ServiceRepository, null, nlogAssembly);
             factory.RegisterExternalItems();
+            return factory;
+        }
 
+        internal static void ScanForAutoLoadExtensions(LogFactory logFactory)
+        {
 #if !NETSTANDARD1_3
             try
             {
+                var factory = logFactory.ServiceRepository.ConfigurationItemFactory;
+                var nlogAssembly = typeof(ILogger).GetAssembly();
                 var assemblyLocation = string.Empty;
                 var extensionDlls = ArrayHelper.Empty<string>();
                 var fileLocations = GetAutoLoadingFileLocations();
@@ -461,8 +467,9 @@ namespace NLog.Config
                 }
             }
             InternalLogger.Debug("Auto loading done");
+#else
+            // Nothing to do for Sonar Cube
 #endif
-            return factory;
         }
 
 #if !NETSTANDARD1_3

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -120,6 +120,7 @@ namespace NLog.Config
 
             bool? parseMessageTemplates = null;
             bool internalLoggerEnabled = false;
+            bool autoLoadExtensions = false;
             foreach (var configItem in sortedList)
             {
                 switch (configItem.Key.ToUpperInvariant())
@@ -172,6 +173,9 @@ namespace NLog.Config
                         break;
                     case "AUTORELOAD":
                         break;  // Ignore here, used by other logic
+                    case "AUTOLOADEXTENSIONS":
+                        autoLoadExtensions = ParseBooleanValue(configItem.Key, configItem.Value, false);
+                        break;
                     default:
                         InternalLogger.Debug("Skipping unknown 'NLog' property {0}={1}", configItem.Key, configItem.Value);
                         break;
@@ -181,6 +185,11 @@ namespace NLog.Config
             if (!internalLoggerEnabled && !InternalLogger.HasActiveLoggers())
             {
                 InternalLogger.LogLevel = LogLevel.Off; // Reduce overhead of the InternalLogger when not configured
+            }
+
+            if (autoLoadExtensions)
+            {
+                ConfigurationItemFactory.ScanForAutoLoadExtensions(LogFactory);
             }
 
             _serviceRepository.ConfigurationItemFactory.ParseMessageTemplates = parseMessageTemplates;

--- a/src/NLog/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog/SetupExtensionsBuilderExtensions.cs
@@ -50,11 +50,25 @@ namespace NLog
         /// Enable/disables autoloading of NLog extensions by scanning and loading available assemblies
         /// </summary>
         /// <remarks>
-        /// Enabled by default, and gives a huge performance hit during startup. Recommended to disable this when running in the cloud.
+        /// Disabled by default as it can give a huge performance hit during startup. Recommended to keep it disabled especially when running in the cloud.
         /// </remarks>
+        [Obsolete("AutoLoadAssemblies(true) has been replaced by AutoLoadExtensions(), that matches the name of nlog-attribute in NLog.config. Marked obsolete on NLog 5.0")]
         public static ISetupExtensionsBuilder AutoLoadAssemblies(this ISetupExtensionsBuilder setupBuilder, bool enable)
         {
-            ConfigurationItemFactory.Default = enable ? null : new ConfigurationItemFactory(typeof(SetupBuilderExtensions).GetAssembly());
+            if (enable)
+                AutoLoadExtensions(setupBuilder);
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Enable/disables autoloading of NLog extensions by scanning and loading available assemblies
+        /// </summary>
+        /// <remarks>
+        /// Disabled by default as it can give a huge performance hit during startup. Recommended to keep it disabled especially when running in the cloud.
+        /// </remarks>
+        public static ISetupExtensionsBuilder AutoLoadExtensions(this ISetupExtensionsBuilder setupBuilder)
+        {
+            ConfigurationItemFactory.ScanForAutoLoadExtensions(setupBuilder.LogFactory);
             return setupBuilder;
         }
 

--- a/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
@@ -77,14 +77,6 @@ namespace NLog.UnitTests.Config
 #if !NETSTANDARD && !MONO
 
         [Fact]
-        public void ExtendedTargetTest()
-        {
-            var targets = ConfigurationItemFactory.Default.Targets;
-
-            AssertInstance(targets, "MSMQ", "MessageQueueTarget");
-        }
-
-        [Fact]
         public void ExtendedLayoutRendererTest()
         {
             var layoutRenderers = ConfigurationItemFactory.Default.LayoutRenderers;

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -402,7 +402,7 @@ namespace NLog.UnitTests.Config
                 Assert.Equal(fileLocations.Length, fileLocations.Select(f => f.Key).Distinct().Count());
 
                 var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
-<nlog throwExceptions='true'>
+<nlog throwExceptions='true' autoLoadExtensions='true'>
     <targets>
         <target name='t' type='AutoLoadTarget' />
     </targets>
@@ -447,7 +447,7 @@ namespace NLog.UnitTests.Config
                     LogManager.ThrowExceptions = true;
 
                     var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
-<nlog throwExceptions='false'>
+<nlog throwExceptions='false' autoLoadExtensions='true'>
     <targets>
         <target name='t' type='AutoLoadTarget' />
     </targets>

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -66,11 +66,9 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void ExtensionTest1()
         {
-            LogManager.LogFactory.ServiceRepository = new ServiceRepositoryInternal(true);
-
             Assert.NotNull(typeof(FooLayout));
 
-            var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            var configuration = new LogFactory().Setup().LoadConfigurationFromXml(@"
 <nlog throwExceptions='true'>
     <extensions>
         <add assemblyFile='" + GetExtensionAssemblyFullPath() + @"' />
@@ -92,7 +90,7 @@ namespace NLog.UnitTests.Config
         </filters>
       </logger>
     </rules>
-</nlog>");
+</nlog>").LogFactory.Configuration;
 
             Target myTarget = configuration.FindTargetByName("t");
             Assert.Equal("MyExtensionNamespace.MyTarget", myTarget.GetType().FullName);
@@ -113,9 +111,7 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void ExtensionTest2()
         {
-            LogManager.LogFactory.ServiceRepository = new ServiceRepositoryInternal(true);
-
-            var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            var configuration = new LogFactory().Setup().LoadConfigurationFromXml(@"
 <nlog throwExceptions='true'>
     <extensions>
         <add assembly='" + extensionAssemblyName1 + @"' />
@@ -138,7 +134,7 @@ namespace NLog.UnitTests.Config
         </filters>
       </logger>
     </rules>
-</nlog>");
+</nlog>").LogFactory.Configuration;
 
             Target myTarget = configuration.FindTargetByName("t");
             Assert.Equal("MyExtensionNamespace.MyTarget", myTarget.GetType().FullName);
@@ -162,9 +158,7 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void ExtensionWithPrefixTest()
         {
-            LogManager.LogFactory.ServiceRepository = new ServiceRepositoryInternal(true);
-
-            var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            var configuration = new LogFactory().Setup().LoadConfigurationFromXml(@"
 <nlog throwExceptions='true'>
     <extensions>
         <add prefix='myprefix' assemblyFile='" + GetExtensionAssemblyFullPath() + @"' />
@@ -186,7 +180,7 @@ namespace NLog.UnitTests.Config
         </filters>
       </logger>
     </rules>
-</nlog>");
+</nlog>").LogFactory.Configuration;
 
             Target myTarget = configuration.FindTargetByName("t");
             Assert.Equal("MyExtensionNamespace.MyTarget", myTarget.GetType().FullName);
@@ -209,9 +203,7 @@ namespace NLog.UnitTests.Config
         {
             Assert.NotNull(typeof(FooLayout));
 
-            LogManager.LogFactory.ServiceRepository = new ServiceRepositoryInternal(true);
-
-            var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            var configuration = new LogFactory().Setup().LoadConfigurationFromXml(@"
 <nlog throwExceptions='true'>
     <extensions>
         <add type='" + typeof(MyTarget).AssemblyQualifiedName + @"' />
@@ -236,7 +228,7 @@ namespace NLog.UnitTests.Config
         </filters>
       </logger>
     </rules>
-</nlog>");
+</nlog>").LogFactory.Configuration;
 
             Target myTarget = configuration.FindTargetByName("t");
             Assert.Equal("MyExtensionNamespace.MyTarget", myTarget.GetType().FullName);
@@ -259,9 +251,7 @@ namespace NLog.UnitTests.Config
         {
             Assert.NotNull(typeof(FooLayout));
 
-            LogManager.LogFactory.ServiceRepository = new ServiceRepositoryInternal(true);
-
-            var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            var configuration = new LogFactory().Setup().LoadConfigurationFromXml(@"
 <nlog throwExceptions='true'>
     
     <targets>
@@ -285,7 +275,7 @@ namespace NLog.UnitTests.Config
         <add assemblyFile='" + GetExtensionAssemblyFullPath() + @"' />
     </extensions>
 
-</nlog>");
+</nlog>").LogFactory.Configuration;
 
             Target myTarget = configuration.FindTargetByName("t");
             Assert.Equal("MyExtensionNamespace.MyTarget", myTarget.GetType().FullName);
@@ -393,34 +383,26 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void Extension_should_be_auto_loaded_when_following_NLog_dll_format()
         {
-            try
-            {
-                var fileLocations = ConfigurationItemFactory.GetAutoLoadingFileLocations().ToArray();
-                Assert.NotEmpty(fileLocations);
-                Assert.NotNull(fileLocations[0].Key);
-                Assert.NotNull(fileLocations[0].Value); // Primary search location is NLog-assembly
-                Assert.Equal(fileLocations.Length, fileLocations.Select(f => f.Key).Distinct().Count());
+            var fileLocations = ConfigurationItemFactory.GetAutoLoadingFileLocations().ToArray();
+            Assert.NotEmpty(fileLocations);
+            Assert.NotNull(fileLocations[0].Key);
+            Assert.NotNull(fileLocations[0].Value); // Primary search location is NLog-assembly
+            Assert.Equal(fileLocations.Length, fileLocations.Select(f => f.Key).Distinct().Count());
 
-                var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
 <nlog throwExceptions='true' autoLoadExtensions='true'>
-    <targets>
-        <target name='t' type='AutoLoadTarget' />
-    </targets>
+<targets>
+    <target name='t' type='AutoLoadTarget' />
+</targets>
 
-    <rules>
-      <logger name='*' writeTo='t'>
-      </logger>
-    </rules>
-</nlog>");
+<rules>
+    <logger name='*' writeTo='t'>
+    </logger>
+</rules>
+</nlog>").LogFactory;
 
-                var autoLoadedTarget = configuration.FindTargetByName("t");
-                Assert.Equal("NLogAutloadExtension.AutoLoadTarget", autoLoadedTarget.GetType().FullName);
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default.Clear();
-                LogManager.LogFactory.ServiceRepository = new ServiceRepositoryInternal(true);
-            }
+            var autoLoadedTarget = logFactory.Configuration.FindTargetByName("t");
+            Assert.Equal("NLogAutloadExtension.AutoLoadTarget", autoLoadedTarget.GetType().FullName);
         }
 
         [Theory]
@@ -428,7 +410,6 @@ namespace NLog.UnitTests.Config
         [InlineData(false)]
         public void Extension_loading_could_be_canceled(bool cancel)
         {
-
             EventHandler<AssemblyLoadingEventArgs> onAssemblyLoading = (sender, e) =>
             {
                 if (e.Assembly.FullName.Contains("NLogAutoLoadExtension"))
@@ -439,14 +420,11 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                LogManager.LogFactory.ServiceRepository = new ServiceRepositoryInternal(true);
                 ConfigurationItemFactory.AssemblyLoading += onAssemblyLoading;
 
                 using(new NoThrowNLogExceptions())
                 {
-                    LogManager.ThrowExceptions = true;
-
-                    var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+                    var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
 <nlog throwExceptions='false' autoLoadExtensions='true'>
     <targets>
         <target name='t' type='AutoLoadTarget' />
@@ -456,9 +434,9 @@ namespace NLog.UnitTests.Config
       <logger name='*' writeTo='t'>
       </logger>
     </rules>
-</nlog>");
+</nlog>").LogFactory;
 
-                    var autoLoadedTarget = configuration.FindTargetByName("t");
+                    var autoLoadedTarget = logFactory.Configuration.FindTargetByName("t");
 
                     if (cancel)
                     {
@@ -474,8 +452,6 @@ namespace NLog.UnitTests.Config
             {
                 //cleanup
                 ConfigurationItemFactory.AssemblyLoading -= onAssemblyLoading;
-                ConfigurationItemFactory.Default.Clear();
-                LogManager.LogFactory.ServiceRepository = new ServiceRepositoryInternal(true);
             }
         }
 
@@ -488,12 +464,8 @@ namespace NLog.UnitTests.Config
                 var writer = new StringWriter();
                 InternalLogger.LogWriter = writer;
                 InternalLogger.LogLevel = LogLevel.Debug;
-                LogManager.LogFactory.ServiceRepository = new ServiceRepositoryInternal(true);
 
-                var fact = ConfigurationItemFactory.Default;
-
-                //also throw exceptions 
-                LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+                var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
 <nlog throwExceptions='true'>
 <extensions>
  <add assembly='PackageLoaderTestAssembly' />

--- a/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
+++ b/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
@@ -74,10 +74,8 @@ namespace NLog.UnitTests.Config
             Assert.Same(logger1, logger2);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void SetupExtensionsAutoLoadExtensionsTest(bool autoLoadAssemblies)
+        [Fact]
+        public void SetupExtensionsAutoLoadExtensionsTest()
         {
             try
             {
@@ -85,7 +83,7 @@ namespace NLog.UnitTests.Config
                 var logFactory = new LogFactory();
 
                 // Act
-                logFactory.Setup().SetupExtensions(ext => ext.AutoLoadAssemblies(autoLoadAssemblies));
+                logFactory.Setup().SetupExtensions(ext => ext.AutoLoadExtensions());
                 Func<LogFactory, LoggingConfiguration> buildConfig = (f) => new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
                     <targets>
                         <target name='t' type='AutoLoadTarget' />
@@ -97,15 +95,8 @@ namespace NLog.UnitTests.Config
                 </nlog>", null, f);
 
                 // Assert
-                if (autoLoadAssemblies)
-                {
-                    logFactory.Configuration = buildConfig(logFactory);
-                    Assert.NotNull(logFactory.Configuration.FindTargetByName("t"));
-                }
-                else
-                {
-                    Assert.Throws<NLogConfigurationException>(() => buildConfig(logFactory));
-                }
+                logFactory.Configuration = buildConfig(logFactory);
+                Assert.NotNull(logFactory.Configuration.FindTargetByName("t"));
             }
             finally
             {
@@ -122,7 +113,7 @@ namespace NLog.UnitTests.Config
                 var logFactory = new LogFactory();
 
                 // Act
-                logFactory.Setup().SetupExtensions(ext => ext.AutoLoadAssemblies(false).RegisterAssembly("NLogAutoLoadExtension"));
+                logFactory.Setup().SetupExtensions(ext => ext.RegisterAssembly("NLogAutoLoadExtension"));
                 logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
                     <targets>
                         <target name='t' type='AutoLoadTarget' />
@@ -151,7 +142,7 @@ namespace NLog.UnitTests.Config
                 var logFactory = new LogFactory();
 
                 // Act
-                logFactory.Setup().SetupExtensions(ext => ext.AutoLoadAssemblies(false).RegisterAssembly(typeof(MyExtensionNamespace.MyTarget).Assembly));
+                logFactory.Setup().SetupExtensions(ext => ext.RegisterAssembly(typeof(MyExtensionNamespace.MyTarget).Assembly));
                 logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
                     <targets>
                         <target name='t' type='MyTarget' />
@@ -180,7 +171,7 @@ namespace NLog.UnitTests.Config
                 var logFactory = new LogFactory();
 
                 // Act
-                logFactory.Setup().SetupExtensions(ext => ext.AutoLoadAssemblies(false).RegisterTarget<MyExtensionNamespace.MyTarget>("MyTarget"));
+                logFactory.Setup().SetupExtensions(ext => ext.RegisterTarget<MyExtensionNamespace.MyTarget>("MyTarget"));
                 logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
                     <targets>
                         <target name='t' type='MyTarget' />
@@ -209,7 +200,7 @@ namespace NLog.UnitTests.Config
                 var logFactory = new LogFactory();
 
                 // Act
-                logFactory.Setup().SetupExtensions(ext => ext.AutoLoadAssemblies(false).RegisterTarget("MyTarget", typeof(MyExtensionNamespace.MyTarget)));
+                logFactory.Setup().SetupExtensions(ext => ext.RegisterTarget("MyTarget", typeof(MyExtensionNamespace.MyTarget)));
                 logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
                     <targets>
                         <target name='t' type='MyTarget' />

--- a/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
+++ b/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
@@ -77,345 +77,268 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void SetupExtensionsAutoLoadExtensionsTest()
         {
-            try
-            {
-                // Arrange
-                var logFactory = new LogFactory();
+            // Arrange
+            var logFactory = new LogFactory();
 
-                // Act
-                logFactory.Setup().SetupExtensions(ext => ext.AutoLoadExtensions());
-                Func<LogFactory, LoggingConfiguration> buildConfig = (f) => new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
-                    <targets>
-                        <target name='t' type='AutoLoadTarget' />
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='t'>
-                      </logger>
-                    </rules>
-                </nlog>", null, f);
+            // Act
+            logFactory.Setup().SetupExtensions(ext => ext.AutoLoadExtensions());
+            Func<LogFactory, LoggingConfiguration> buildConfig = (f) => new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='t' type='AutoLoadTarget' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='t'>
+                    </logger>
+                </rules>
+            </nlog>", null, f);
 
-                // Assert
-                logFactory.Configuration = buildConfig(logFactory);
-                Assert.NotNull(logFactory.Configuration.FindTargetByName("t"));
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;    // Restore global default
-            }
+            // Assert
+            logFactory.Configuration = buildConfig(logFactory);
+            Assert.NotNull(logFactory.Configuration.FindTargetByName("t"));
         }
 
         [Fact]
         public void SetupExtensionsRegisterAssemblyNameTest()
         {
-            try
-            {
-                // Arrange
-                var logFactory = new LogFactory();
+            // Arrange
+            var logFactory = new LogFactory();
 
-                // Act
-                logFactory.Setup().SetupExtensions(ext => ext.RegisterAssembly("NLogAutoLoadExtension"));
-                logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
-                    <targets>
-                        <target name='t' type='AutoLoadTarget' />
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='t'>
-                      </logger>
-                    </rules>
-                </nlog>", null, logFactory);
+            // Act
+            logFactory.Setup().SetupExtensions(ext => ext.RegisterAssembly("NLogAutoLoadExtension"));
+            logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='t' type='AutoLoadTarget' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='t'>
+                    </logger>
+                </rules>
+            </nlog>", null, logFactory);
 
-                // Assert
-                Assert.NotNull(logFactory.Configuration.FindTargetByName("t"));
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;    // Restore global default
-            }
+            // Assert
+            Assert.NotNull(logFactory.Configuration.FindTargetByName("t"));
         }
 
         [Fact]
         public void SetupExtensionsRegisterAssemblyTest()
         {
-            try
-            {
-                // Arrange
-                var logFactory = new LogFactory();
+            // Arrange
+            var logFactory = new LogFactory();
 
-                // Act
-                logFactory.Setup().SetupExtensions(ext => ext.RegisterAssembly(typeof(MyExtensionNamespace.MyTarget).Assembly));
-                logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
-                    <targets>
-                        <target name='t' type='MyTarget' />
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='t'>
-                      </logger>
-                    </rules>
-                </nlog>", null, logFactory);
+            // Act
+            logFactory.Setup().SetupExtensions(ext => ext.RegisterAssembly(typeof(MyExtensionNamespace.MyTarget).Assembly));
+            logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='t' type='MyTarget' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='t'>
+                    </logger>
+                </rules>
+            </nlog>", null, logFactory);
 
-                // Assert
-                Assert.NotNull(logFactory.Configuration.FindTargetByName<MyExtensionNamespace.MyTarget>("t"));
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;    // Restore global default
-            }
+            // Assert
+            Assert.NotNull(logFactory.Configuration.FindTargetByName<MyExtensionNamespace.MyTarget>("t"));
         }
 
         [Fact]
         public void SetupExtensionsRegisterTargetTest()
         {
-            try
-            {
-                // Arrange
-                var logFactory = new LogFactory();
+            // Arrange
+            var logFactory = new LogFactory();
 
-                // Act
-                logFactory.Setup().SetupExtensions(ext => ext.RegisterTarget<MyExtensionNamespace.MyTarget>("MyTarget"));
-                logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
-                    <targets>
-                        <target name='t' type='MyTarget' />
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='t'>
-                      </logger>
-                    </rules>
-                </nlog>", null, logFactory);
+            // Act
+            logFactory.Setup().SetupExtensions(ext => ext.RegisterTarget<MyExtensionNamespace.MyTarget>("MyTarget"));
+            logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='t' type='MyTarget' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='t'>
+                    </logger>
+                </rules>
+            </nlog>", null, logFactory);
 
-                // Assert
-                Assert.NotNull(logFactory.Configuration.FindTargetByName<MyExtensionNamespace.MyTarget>("t"));
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;    // Restore global default
-            }
+            // Assert
+            Assert.NotNull(logFactory.Configuration.FindTargetByName<MyExtensionNamespace.MyTarget>("t"));
         }
 
         [Fact]
         public void SetupExtensionsRegisterTargetTypeTest()
         {
-            try
-            {
-                // Arrange
-                var logFactory = new LogFactory();
+            // Arrange
+            var logFactory = new LogFactory();
 
-                // Act
-                logFactory.Setup().SetupExtensions(ext => ext.RegisterTarget("MyTarget", typeof(MyExtensionNamespace.MyTarget)));
-                logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
-                    <targets>
-                        <target name='t' type='MyTarget' />
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='t'>
-                      </logger>
-                    </rules>
-                </nlog>", null, logFactory);
+            // Act
+            logFactory.Setup().SetupExtensions(ext => ext.RegisterTarget("MyTarget", typeof(MyExtensionNamespace.MyTarget)));
+            logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='t' type='MyTarget' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='t'>
+                    </logger>
+                </rules>
+            </nlog>", null, logFactory);
 
-                // Assert
-                Assert.NotNull(logFactory.Configuration.FindTargetByName<MyExtensionNamespace.MyTarget>("t"));
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;    // Restore global default
-            }
+            // Assert
+            Assert.NotNull(logFactory.Configuration.FindTargetByName<MyExtensionNamespace.MyTarget>("t"));
         }
 
         [Fact]
         public void SetupExtensionsRegisterLayoutMethodTest()
         {
-            try
-            {
-                // Arrange
-                var logFactory = new LogFactory();
+            // Arrange
+            var logFactory = new LogFactory();
 
-                // Act
-                logFactory.Setup(b => b.SetupExtensions(ext => ext.RegisterLayoutRenderer("mylayout", (l) => "42")));
-                logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
-                    <targets>
-                        <target name='debug' type='Debug' layout='${mylayout}' />
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='debug'>
-                      </logger>
-                    </rules>
-                </nlog>", null, logFactory);
-                logFactory.GetLogger("Hello").Info("World");
+            // Act
+            logFactory.Setup(b => b.SetupExtensions(ext => ext.RegisterLayoutRenderer("mylayout", (l) => "42")));
+            logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='debug' type='Debug' layout='${mylayout}' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='debug'>
+                    </logger>
+                </rules>
+            </nlog>", null, logFactory);
+            logFactory.GetLogger("Hello").Info("World");
 
-                // Assert
-                Assert.Equal("42", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;    // Restore global default
-            }
+            // Assert
+            Assert.Equal("42", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
         }
 
         [Fact]
         public void SetupExtensionsRegisterLayoutMethodThreadUnsafeTest()
         {
-            try
-            {
-                // Arrange
-                var logFactory = new LogFactory();
+            // Arrange
+            var logFactory = new LogFactory();
 
-                // Act
-                logFactory.Setup(b => b.SetupExtensions(ext => ext.RegisterLayoutRenderer("mylayout", (l) => "42", LayoutRenderOptions.None)));
-                logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
-                    <targets>
-                        <target name='debug' type='Debug' layout='${mylayout}' />
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='debug'>
-                      </logger>
-                    </rules>
-                </nlog>", null, logFactory);
-                logFactory.GetLogger("Hello").Info("World");
+            // Act
+            logFactory.Setup(b => b.SetupExtensions(ext => ext.RegisterLayoutRenderer("mylayout", (l) => "42", LayoutRenderOptions.None)));
+            logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='debug' type='Debug' layout='${mylayout}' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='debug'>
+                    </logger>
+                </rules>
+            </nlog>", null, logFactory);
+            logFactory.GetLogger("Hello").Info("World");
 
-                logFactory.ServiceRepository.ConfigurationItemFactory.GetLayoutRenderers().TryCreateInstance("mylayout", out var layoutRenderer);
-                var layout = new SimpleLayout(new LayoutRenderer[] { layoutRenderer }, "mylayout", ConfigurationItemFactory.Default);
-                layout.Render(LogEventInfo.CreateNullEvent());
+            logFactory.ServiceRepository.ConfigurationItemFactory.GetLayoutRenderers().TryCreateInstance("mylayout", out var layoutRenderer);
+            var layout = new SimpleLayout(new LayoutRenderer[] { layoutRenderer }, "mylayout", logFactory.ServiceRepository.ConfigurationItemFactory);
+            layout.Render(LogEventInfo.CreateNullEvent());
 
-                // Assert
-                Assert.Equal("42", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
-                Assert.False(layout.ThreadAgnostic);
-                Assert.False(layout.ThreadSafe);
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;    // Restore global default
-            }
+            // Assert
+            Assert.Equal("42", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
+            Assert.False(layout.ThreadAgnostic);
+            Assert.False(layout.ThreadSafe);
         }
 
         [Fact]
         public void SetupExtensionsRegisterLayoutMethodThreadSafeTest()
         {
-            try
-            {
-                // Arrange
-                var logFactory = new LogFactory();
+            // Arrange
+            var logFactory = new LogFactory();
 
-                // Act
-                logFactory.Setup(b => b.SetupExtensions(ext => ext.RegisterLayoutRenderer("mylayout", (l) => "42", LayoutRenderOptions.ThreadSafe)));
-                logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
-                    <targets>
-                        <target name='debug' type='Debug' layout='${mylayout}' />
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='debug'>
-                      </logger>
-                    </rules>
-                </nlog>", null, logFactory);
-                logFactory.GetLogger("Hello").Info("World");
+            // Act
+            logFactory.Setup(b => b.SetupExtensions(ext => ext.RegisterLayoutRenderer("mylayout", (l) => "42", LayoutRenderOptions.ThreadSafe)));
+            logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='debug' type='Debug' layout='${mylayout}' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='debug'>
+                    </logger>
+                </rules>
+            </nlog>", null, logFactory);
+            logFactory.GetLogger("Hello").Info("World");
 
-                logFactory.ServiceRepository.ConfigurationItemFactory.GetLayoutRenderers().TryCreateInstance("mylayout", out var layoutRenderer);
-                var layout = new SimpleLayout(new LayoutRenderer[] { layoutRenderer }, "mylayout", ConfigurationItemFactory.Default);
-                layout.Render(LogEventInfo.CreateNullEvent());
+            logFactory.ServiceRepository.ConfigurationItemFactory.GetLayoutRenderers().TryCreateInstance("mylayout", out var layoutRenderer);
+            var layout = new SimpleLayout(new LayoutRenderer[] { layoutRenderer }, "mylayout", logFactory.ServiceRepository.ConfigurationItemFactory);
+            layout.Render(LogEventInfo.CreateNullEvent());
 
-                // Assert
-                Assert.Equal("42", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
-                Assert.False(layout.ThreadAgnostic);
-                Assert.True(layout.ThreadSafe);
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;    // Restore global default
-            }
+            // Assert
+            Assert.Equal("42", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
+            Assert.False(layout.ThreadAgnostic);
+            Assert.True(layout.ThreadSafe);
         }
 
         [Fact]
         public void SetupExtensionsRegisterLayoutMethodThreadAgnosticTest()
         {
-            try
-            {
-                // Arrange
-                var logFactory = new LogFactory();
+            // Arrange
+            var logFactory = new LogFactory();
 
-                // Act
-                logFactory.Setup(b => b.SetupExtensions(ext => ext.RegisterLayoutRenderer("mylayout", (l) => "42", LayoutRenderOptions.ThreadAgnostic)));
-                logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
-                    <targets>
-                        <target name='debug' type='Debug' layout='${mylayout}' />
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='debug'>
-                      </logger>
-                    </rules>
-                </nlog>", null, logFactory);
-                logFactory.GetLogger("Hello").Info("World");
+            // Act
+            logFactory.Setup(b => b.SetupExtensions(ext => ext.RegisterLayoutRenderer("mylayout", (l) => "42", LayoutRenderOptions.ThreadAgnostic)));
+            logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='debug' type='Debug' layout='${mylayout}' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='debug'>
+                    </logger>
+                </rules>
+            </nlog>", null, logFactory);
+            logFactory.GetLogger("Hello").Info("World");
 
-                logFactory.ServiceRepository.ConfigurationItemFactory.GetLayoutRenderers().TryCreateInstance("mylayout", out var layoutRenderer);
-                var layout = new SimpleLayout(new LayoutRenderer[] { layoutRenderer }, "mylayout", ConfigurationItemFactory.Default);
-                layout.Render(LogEventInfo.CreateNullEvent());
+            logFactory.ServiceRepository.ConfigurationItemFactory.GetLayoutRenderers().TryCreateInstance("mylayout", out var layoutRenderer);
+            var layout = new SimpleLayout(new LayoutRenderer[] { layoutRenderer }, "mylayout", logFactory.ServiceRepository.ConfigurationItemFactory);
+            layout.Render(LogEventInfo.CreateNullEvent());
 
-                // Assert
-                Assert.Equal("42", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
-                Assert.True(layout.ThreadAgnostic);
-                Assert.True(layout.ThreadSafe);
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;    // Restore global default
-            }
+            // Assert
+            Assert.Equal("42", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
+            Assert.True(layout.ThreadAgnostic);
+            Assert.True(layout.ThreadSafe);
         }
 
         [Fact]
         public void SetupExtensionsRegisterLayoutRendererTest()
         {
-            try
-            {
-                // Arrange
-                var logFactory = new LogFactory();
+            // Arrange
+            var logFactory = new LogFactory();
 
-                // Act
-                logFactory.Setup().SetupExtensions(ext => ext.RegisterLayoutRenderer<MyExtensionNamespace.FooLayoutRenderer>("foo"));
-                logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
-                    <targets>
-                        <target name='debug' type='Debug' layout='${foo}' />
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='debug'>
-                      </logger>
-                    </rules>
-                </nlog>", null, logFactory);
-                logFactory.GetLogger("Hello").Info("World");
+            // Act
+            logFactory.Setup().SetupExtensions(ext => ext.RegisterLayoutRenderer<MyExtensionNamespace.FooLayoutRenderer>("foo"));
+            logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='debug' type='Debug' layout='${foo}' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='debug'>
+                    </logger>
+                </rules>
+            </nlog>", null, logFactory);
+            logFactory.GetLogger("Hello").Info("World");
 
-                // Assert
-                Assert.Equal("foo", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;    // Restore global default
-            }
+            // Assert
+            Assert.Equal("foo", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
         }
 
         [Fact]
         public void SetupExtensionsRegisterLayoutRendererTypeTest()
         {
-            try
-            {
-                // Arrange
-                var logFactory = new LogFactory();
+            // Arrange
+            var logFactory = new LogFactory();
 
-                // Act
-                logFactory.Setup().SetupExtensions(ext => ext.RegisterLayoutRenderer("foo", typeof(MyExtensionNamespace.FooLayoutRenderer)));
-                logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
-                    <targets>
-                        <target name='debug' type='Debug' layout='${foo}' />
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='debug'>
-                      </logger>
-                    </rules>
-                </nlog>", null, logFactory);
-                logFactory.GetLogger("Hello").Info("World");
+            // Act
+            logFactory.Setup().SetupExtensions(ext => ext.RegisterLayoutRenderer("foo", typeof(MyExtensionNamespace.FooLayoutRenderer)));
+            logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='debug' type='Debug' layout='${foo}' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='debug'>
+                    </logger>
+                </rules>
+            </nlog>", null, logFactory);
+            logFactory.GetLogger("Hello").Info("World");
 
-                // Assert
-                Assert.Equal("foo", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;    // Restore global default
-            }
+            // Assert
+            Assert.Equal("foo", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
         }
 
         [Theory]
@@ -553,39 +476,32 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void SetupExtensionsRegisterConditionMethodTest()
         {
-            try
-            {
-                // Arrange
-                var logFactory = new LogFactory();
-                logFactory.Setup().SetupExtensions(s => s.RegisterConditionMethod("hasParameters", evt => evt.Parameters?.Length > 0));
-                logFactory.Setup().SetupExtensions(s => s.RegisterConditionMethod("isProduction", () => false));
-                logFactory.Setup().SetupExtensions(s => s.RegisterConditionMethod("isValid", typeof(Conditions.ConditionEvaluatorTests.MyConditionMethods).GetMethod(nameof(Conditions.ConditionEvaluatorTests.MyConditionMethods.IsValid))));
+            // Arrange
+            var logFactory = new LogFactory();
+            logFactory.Setup().SetupExtensions(s => s.RegisterConditionMethod("hasParameters", evt => evt.Parameters?.Length > 0));
+            logFactory.Setup().SetupExtensions(s => s.RegisterConditionMethod("isProduction", () => false));
+            logFactory.Setup().SetupExtensions(s => s.RegisterConditionMethod("isValid", typeof(Conditions.ConditionEvaluatorTests.MyConditionMethods).GetMethod(nameof(Conditions.ConditionEvaluatorTests.MyConditionMethods.IsValid))));
 
-                // Act
-                logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
-                    <targets>
-                        <target name='debug' type='Debug' layout='${message}' />
-                    </targets>
-                    <rules>
-                      <logger name='*' writeTo='debug'>
-			            <filters defaultAction='Neutral'>
-				            <when condition='hasParameters()' action='Ignore' />
-                            <when condition='isProduction()' action='Ignore' />
-                            <when condition='isValid()==false' action='Ignore' />
-			            </filters>
-                      </logger>
-                    </rules>
-                </nlog>", null, logFactory);
-                logFactory.GetLogger("Hello").Info("World");
-                logFactory.GetLogger("Hello").Info("{0}", "Earth");
+            // Act
+            logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='debug' type='Debug' layout='${message}' />
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='debug'>
+			        <filters defaultAction='Neutral'>
+				        <when condition='hasParameters()' action='Ignore' />
+                        <when condition='isProduction()' action='Ignore' />
+                        <when condition='isValid()==false' action='Ignore' />
+			        </filters>
+                    </logger>
+                </rules>
+            </nlog>", null, logFactory);
+            logFactory.GetLogger("Hello").Info("World");
+            logFactory.GetLogger("Hello").Info("{0}", "Earth");
 
-                // Assert
-                Assert.Equal("World", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;    // Restore global default
-            }
+            // Assert
+            Assert.Equal("World", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -259,10 +259,6 @@ namespace NLog.UnitTests.Config
 
             try
             {
-
-                // ReSharper disable once UnusedVariable
-                var factory = ConfigurationItemFactory.Default; // retrieve factory for calling preload and so won't assert those warnings
-
                 TextWriter textWriter = new StringWriter();
                 InternalLogger.LogWriter = textWriter;
                 InternalLogger.IncludeTimestamp = false;

--- a/tests/NLog.UnitTests/LogFactoryTestExtensions.cs
+++ b/tests/NLog.UnitTests/LogFactoryTestExtensions.cs
@@ -1,0 +1,64 @@
+﻿// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using NLog.Config;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.UnitTests
+{
+    static class LogFactoryTestExtensions
+    {
+        public static void AssertDebugLastMessage(this LogFactory logFactory, string message)
+        {
+            AssertDebugLastMessage(logFactory, "Debug", message);
+        }
+
+        public static void AssertDebugLastMessage(this LogFactory logFactory, string targetName, string message)
+        {
+            var debugTarget = GetDebugTarget(targetName, logFactory.Configuration);
+            Assert.Equal(message, debugTarget.LastMessage);
+        }
+
+        public static DebugTarget GetDebugTarget(string targetName, LoggingConfiguration configuration)
+        {
+            var debugTarget = configuration.FindTargetByName<DebugTarget>(targetName);
+            if (debugTarget == null)
+            {
+                throw new Exception($"debugtarget with name {targetName} not found in configuration");
+            }
+            return debugTarget;
+        }
+    }
+}

--- a/tests/NLog.UnitTests/LogReceiverService/LogReceiverServiceTests.cs
+++ b/tests/NLog.UnitTests/LogReceiverService/LogReceiverServiceTests.cs
@@ -257,7 +257,7 @@ namespace NLog.UnitTests.LogReceiverService
 
         private void RealTestLogReciever(bool useOneWayContract, bool binaryEncode)
         {
-            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString($@"
+            var logFactory = new LogFactory().Setup().LoadConfigurationFromXml($@"
           <nlog throwExceptions='true' autoLoadExtensions='true'>
                 <targets>
                    <target type='LogReceiverService'
@@ -277,11 +277,9 @@ namespace NLog.UnitTests.LogReceiverService
                     <logger name='logger1' minlevel='Trace' writeTo='s1' />
               
                 </rules>
-            </nlog>");
+            </nlog>").LogFactory;
 
-
-            ExecLogRecieverAndCheck(ExecLogging1, CheckReceived1, 2);
-
+            ExecLogRecieverAndCheck(ExecLogging1, CheckReceived1, 2, logFactory);
         }
 
         /// <summary>
@@ -290,7 +288,7 @@ namespace NLog.UnitTests.LogReceiverService
         /// <param name="logFunc">function for logging the messages</param>
         /// <param name="logCheckFunc">function for checking the received messages</param>
         /// <param name="messageCount">message count for wait for listen and checking</param>
-        private void ExecLogRecieverAndCheck(Action<Logger> logFunc, Action<List<NLogEvents>> logCheckFunc, int messageCount)
+        private void ExecLogRecieverAndCheck(Action<Logger> logFunc, Action<List<NLogEvents>> logCheckFunc, int messageCount, LogFactory logFactory)
         {
 
             Uri baseAddress = new Uri(logRecieverUrl);
@@ -324,7 +322,7 @@ namespace NLog.UnitTests.LogReceiverService
 
               
 
-                var logger1 = LogManager.GetLogger("logger1");
+                var logger1 = logFactory.GetLogger("logger1");
                 logFunc(logger1);
 
                 countdownEvent.Wait(20000);

--- a/tests/NLog.UnitTests/LogReceiverService/LogReceiverServiceTests.cs
+++ b/tests/NLog.UnitTests/LogReceiverService/LogReceiverServiceTests.cs
@@ -258,7 +258,7 @@ namespace NLog.UnitTests.LogReceiverService
         private void RealTestLogReciever(bool useOneWayContract, bool binaryEncode)
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString($@"
-          <nlog throwExceptions='true'>
+          <nlog throwExceptions='true' autoLoadExtensions='true'>
                 <targets>
                    <target type='LogReceiverService'
                           name='s1'

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -104,12 +104,7 @@ namespace NLog.UnitTests
 
         protected DebugTarget GetDebugTarget(string targetName, LoggingConfiguration configuration)
         {
-            var debugTarget = configuration.FindTargetByName<DebugTarget>(targetName);
-            if (debugTarget == null)
-            {
-                throw new Exception($"debugtarget with name {targetName} not found in configuration");
-            }
-            return debugTarget;
+            return LogFactoryTestExtensions.GetDebugTarget(targetName, configuration);
         }
 
         protected void AssertFileContentsStartsWith(string fileName, string contents, Encoding encoding)

--- a/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
+++ b/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
@@ -165,81 +165,63 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void AsyncTaskTarget_SkipAsyncTargetWrapper()
         {
-            try
-            {
-                ConfigurationItemFactory.Default.RegisterType(typeof(AsyncTaskTestTarget), null);
-                LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
-            <nlog throwExceptions='true'>
-            <targets async='true'>
-                <target name='asyncDebug' type='AsyncTaskTest' />
-                <target name='debug' type='Debug' />
-            </targets>
-                <rules>
-                    <logger name='*' minlevel='Debug' writeTo='debug' />
-                </rules>
-            </nlog>");
+            var logFactory = new LogFactory().Setup()
+                .SetupExtensions(ext => ext.RegisterTarget<AsyncTaskTestTarget>("AsyncTaskTest"))
+                .LoadConfigurationFromXml(@"
+                <nlog throwExceptions='true'>
+                <targets async='true'>
+                    <target name='asyncDebug' type='AsyncTaskTest' />
+                    <target name='debug' type='Debug' />
+                </targets>
+                    <rules>
+                        <logger name='*' minlevel='Debug' writeTo='debug' />
+                    </rules>
+                </nlog>").LogFactory;
 
-                Assert.NotNull(LogManager.Configuration.FindTargetByName<AsyncTaskTestTarget>("asyncDebug"));
-                Assert.NotNull(LogManager.Configuration.FindTargetByName<NLog.Targets.Wrappers.AsyncTargetWrapper>("debug"));
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;
-            }
+            Assert.NotNull(logFactory.Configuration.FindTargetByName<AsyncTaskTestTarget>("asyncDebug"));
+            Assert.NotNull(logFactory.Configuration.FindTargetByName<NLog.Targets.Wrappers.AsyncTargetWrapper>("debug"));
         }
 
         [Fact]
         public void AsyncTaskTarget_SkipDefaultAsyncWrapper()
         {
-            try
-            {
-                ConfigurationItemFactory.Default.RegisterType(typeof(AsyncTaskTestTarget), null);
-                LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
-            <nlog throwExceptions='true'>
-            <targets>
-                <default-wrapper type='AsyncWrapper' />
-                <target name='asyncDebug' type='AsyncTaskTest' />
-                <target name='debug' type='Debug' />
-            </targets>
-                <rules>
-                    <logger name='*' minlevel='Debug' writeTo='debug' />
-                </rules>
-            </nlog>");
+            var logFactory = new LogFactory().Setup()
+                .SetupExtensions(ext => ext.RegisterTarget<AsyncTaskTestTarget>("AsyncTaskTest"))
+                .LoadConfigurationFromXml(@"
+                <nlog throwExceptions='true'>
+                <targets>
+                    <default-wrapper type='AsyncWrapper' />
+                    <target name='asyncDebug' type='AsyncTaskTest' />
+                    <target name='debug' type='Debug' />
+                </targets>
+                    <rules>
+                        <logger name='*' minlevel='Debug' writeTo='debug' />
+                    </rules>
+                </nlog>").LogFactory;
 
-                Assert.NotNull(LogManager.Configuration.FindTargetByName<AsyncTaskTestTarget>("asyncDebug"));
-                Assert.NotNull(LogManager.Configuration.FindTargetByName<NLog.Targets.Wrappers.AsyncTargetWrapper>("debug"));
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;
-            }
+            Assert.NotNull(logFactory.Configuration.FindTargetByName<AsyncTaskTestTarget>("asyncDebug"));
+            Assert.NotNull(logFactory.Configuration.FindTargetByName<NLog.Targets.Wrappers.AsyncTargetWrapper>("debug"));
         }
 
         [Fact]
         public void AsyncTaskTarget_AllowDefaultBufferWrapper()
         {
-            try
-            {
-                ConfigurationItemFactory.Default.RegisterType(typeof(AsyncTaskTestTarget), null);
-                LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
-            <nlog throwExceptions='true'>
-            <targets>
-                <default-wrapper type='BufferingWrapper' />
-                <target name='asyncDebug' type='AsyncTaskTest' />
-                <target name='debug' type='Debug' />
-            </targets>
-                <rules>
-                    <logger name='*' minlevel='Debug' writeTo='debug' />
-                </rules>
-            </nlog>");
+            var logFactory = new LogFactory().Setup()
+                .SetupExtensions(ext => ext.RegisterTarget<AsyncTaskTestTarget>("AsyncTaskTest"))
+                .LoadConfigurationFromXml(@"
+                <nlog throwExceptions='true'>
+                <targets>
+                    <default-wrapper type='BufferingWrapper' />
+                    <target name='asyncDebug' type='AsyncTaskTest' />
+                    <target name='debug' type='Debug' />
+                </targets>
+                    <rules>
+                        <logger name='*' minlevel='Debug' writeTo='debug' />
+                    </rules>
+                </nlog>").LogFactory;
 
-                Assert.NotNull(LogManager.Configuration.FindTargetByName<NLog.Targets.Wrappers.BufferingTargetWrapper>("asyncDebug"));
-                Assert.NotNull(LogManager.Configuration.FindTargetByName<NLog.Targets.Wrappers.BufferingTargetWrapper>("debug"));
-            }
-            finally
-            {
-                ConfigurationItemFactory.Default = null;
-            }
+            Assert.NotNull(logFactory.Configuration.FindTargetByName<NLog.Targets.Wrappers.BufferingTargetWrapper>("asyncDebug"));
+            Assert.NotNull(logFactory.Configuration.FindTargetByName<NLog.Targets.Wrappers.BufferingTargetWrapper>("debug"));
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Targets/MessageQueueTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MessageQueueTargetTests.cs
@@ -128,8 +128,9 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void MessageQueueTarget_CheckIfQueueExists_setting_should_work()
         {
+            var logFactory = new LogFactory();
             var configuration = XmlLoggingConfiguration.CreateFromXmlString(string.Format(@"
-                <nlog throwExceptions='true' >
+                <nlog throwExceptions='true' autoLoadExtensions='true' >
                     <targets>
                         <target type='MSMQ'
                                 name='q'
@@ -142,10 +143,8 @@ namespace NLog.UnitTests.Targets
                        
                       </logger>
                     </rules>
-                </nlog>"));
-
-
-            LogManager.Configuration = configuration;
+                </nlog>"), logFactory);
+            logFactory.Configuration = configuration;
             var messageQueueTarget = configuration.FindTargetByName("q") as MessageQueueTarget;
 
             Assert.NotNull(messageQueueTarget);


### PR DESCRIPTION
Added new NLog.config option `autoLoadExtensions='true'`. Resolves #3798 and resolves #3674 

Faster startup for light-weight application like cloud-functions, and improve security against code-injection.