### PR TITLE
Throw NLogConfigurationException for unknown properties when parsing config

### DIFF
--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -216,6 +216,8 @@ namespace NLog.Config
         {
             if (reader.LocalName?.Equals("xmlns", StringComparison.OrdinalIgnoreCase) == true)
                 return true;
+            if (reader.LocalName?.Equals("schemaLocation", StringComparison.OrdinalIgnoreCase) == true && !StringHelpers.IsNullOrWhiteSpace(reader.Prefix))
+                return true;
             if (reader.Prefix?.Equals("xsi", StringComparison.OrdinalIgnoreCase) == true)
                 return true;
             if (reader.Prefix?.Equals("xmlns", StringComparison.OrdinalIgnoreCase) == true)

--- a/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
@@ -323,7 +323,7 @@ namespace NLog.UnitTests.Config
 
         private class ExternalServiceRepository : IServiceProvider
         {
-            Func<Type, object> _serviceResolver;
+            private readonly Func<Type, object> _serviceResolver;
 
             public ExternalServiceRepository(Func<Type, object> serviceResolver)
             {

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -68,17 +68,20 @@ namespace NLog.UnitTests.Config
         {
             using (new InternalLoggerScope(true))
             {
-                var xml = "<nlog logfile='test.txt' internalLogIncludeTimestamp='false' internalLogToConsole='true' internalLogToConsoleError='true'></nlog>";
-                var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+                using (new NoThrowNLogExceptions())
+                {
+                    var xml = "<nlog logfile='test.txt' internalLogIncludeTimestamp='false' internalLogToConsole='true' internalLogToConsoleError='true'></nlog>";
+                    var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
 
-                Assert.False(config.AutoReload);
-                Assert.True(config.InitializeSucceeded);
-                Assert.Equal("", InternalLogger.LogFile);
-                Assert.False(InternalLogger.IncludeTimestamp);
-                Assert.True(InternalLogger.LogToConsole);
-                Assert.True(InternalLogger.LogToConsoleError);
-                Assert.Null(InternalLogger.LogWriter);
-                Assert.Equal(LogLevel.Info, InternalLogger.LogLevel);
+                    Assert.False(config.AutoReload);
+                    Assert.True(config.InitializeSucceeded);
+                    Assert.Equal("", InternalLogger.LogFile);
+                    Assert.False(InternalLogger.IncludeTimestamp);
+                    Assert.True(InternalLogger.LogToConsole);
+                    Assert.True(InternalLogger.LogToConsoleError);
+                    Assert.Null(InternalLogger.LogWriter);
+                    Assert.Equal(LogLevel.Info, InternalLogger.LogLevel);
+                }
             }
         }
 
@@ -229,8 +232,8 @@ namespace NLog.UnitTests.Config
                         <target name='debug' type='Debug' layout='${message}' />
                     </targets>
                     <rules>
-                        <logger name='*' minlevel='debug' appendto='debug' defaultFilterResult='ignore'>
-                            <filters>
+                        <logger name='*' minlevel='debug' appendto='debug'>
+                            <filters defaultFilterResult='ignore'>
                                 <whenContains />
                             </filters>
                         </logger>
@@ -252,10 +255,8 @@ namespace NLog.UnitTests.Config
 <nlog xmlns=""http://www.nlog-project.org/schemas/NLog.xsd"" 
       xmlns:{@namespace}=""http://www.w3.org/2001/XMLSchema-instance"" 
       {@namespace}:schemaLocation=""somewhere"" 
-      {@namespace}:type=""asa""
       internalLogToConsole=""true"" internalLogLevel=""Warn"">
 </nlog>";
-
 
             try
             {

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -285,13 +285,16 @@ namespace NLog.UnitTests
         [Fact]
         public void NewAttrOnNLogLevelShouldNotThrowError()
         {
-            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
-            <nlog throwExceptions='true' imAnewAttribute='noError'>
-                <targets><target type='file' name='f1' filename='test.log' /></targets>
-                <rules>
-                    <logger name='*' minlevel='Debug' writeto='f1'></logger>
-                </rules>
-            </nlog>");
+            using (new NoThrowNLogExceptions())
+            {
+                LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+                <nlog imAnewAttribute='noError'>
+                    <targets><target type='file' name='f1' filename='test.log' /></targets>
+                    <rules>
+                        <logger name='*' minlevel='Debug' writeto='f1'></logger>
+                    </rules>
+                </nlog>");
+            }
         }
 
         [Fact]


### PR DESCRIPTION
When ThrowConfigExceptions=true. Resolves #4000