### PR TITLE
Adding support for const NLog Config Variables

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -851,8 +851,15 @@ namespace NLog.Config
         [NotNull]
         internal string ExpandSimpleVariables(string input)
         {
+            return ExpandSimpleVariables(input, out var _);
+        }
+
+        [NotNull]
+        internal string ExpandSimpleVariables(string input, out Layout matchingLayout)
+        {
             string output = input;
             var culture = StringComparison.CurrentCultureIgnoreCase;
+            matchingLayout = null;
 
             if (Variables.Count > 0 && output?.IndexOf("${") >= 0)
             {
@@ -875,8 +882,14 @@ namespace NLog.Config
                     //this value is set from xml and that's a string. Because of that, we can use SimpleLayout here.
                     if (layout is SimpleLayout simpleLayout)
                     {
-
                         output = StringHelpers.Replace(output, layoutText, simpleLayout.OriginalText, culture);
+                    }
+                    else
+                    {
+                        if (layoutText == input.Trim())
+                        {
+                            matchingLayout = layout;
+                        }
                     }
                 }
             }

--- a/src/NLog/Config/LoggingConfigurationElementExtensions.cs
+++ b/src/NLog/Config/LoggingConfigurationElementExtensions.cs
@@ -117,7 +117,7 @@ namespace NLog.Config
         public static string GetConfigItemTypeAttribute(this ILoggingConfigurationElement element, string sectionNameForRequiredValue = null)
         {
             var typeAttributeValue = sectionNameForRequiredValue != null ? element.GetRequiredValue("type", sectionNameForRequiredValue) : element.GetOptionalValue("type", null);
-            return StripOptionalNamespacePrefix(typeAttributeValue);
+            return StripOptionalNamespacePrefix(typeAttributeValue)?.Trim();
         }
 
         /// <summary>

--- a/src/NLog/Internal/Reflection/PropertyHelper.cs
+++ b/src/NLog/Internal/Reflection/PropertyHelper.cs
@@ -97,7 +97,7 @@ namespace NLog.Internal
 
             if (!TryGetPropertyInfo(objType, propertyName, out var propInfo))
             {
-                throw new NotSupportedException($"Parameter {propertyName} not supported on {objType.Name}");
+                throw new NLogConfigurationException($"Unknown property '{propertyName}'='{value}' for '{objType.Name}'");
             }
 
             try
@@ -108,7 +108,7 @@ namespace NLog.Internal
                 {
                     if (propInfo.IsDefined(_arrayParameterAttribute.GetType(), false))
                     {
-                        throw new NotSupportedException($"Parameter {propertyName} of {objType.Name} is an array and cannot be assigned a scalar value.");
+                        throw new NotSupportedException($"Property {propertyName} on {objType.Name} is an array, and cannot be assigned a scalar value: '{value}'.");
                     }
 
                     propertyType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
@@ -124,18 +124,16 @@ namespace NLog.Internal
             }
             catch (TargetInvocationException ex)
             {
-                throw new NLogConfigurationException($"Error when setting property '{propInfo.Name}' on {objType.Name}", ex.InnerException);
+                throw new NLogConfigurationException($"Error when setting property '{propInfo.Name}'='{value}' on {objType.Name}", ex.InnerException);
             }
             catch (Exception exception)
             {
-                InternalLogger.Warn(exception, "Error when setting property '{0}' on '{1}'", propInfo.Name, objType);
-
                 if (exception.MustBeRethrownImmediately())
                 {
                     throw;
                 }
 
-                throw new NLogConfigurationException($"Error when setting property '{propInfo.Name}' on {objType.Name}", exception);
+                throw new NLogConfigurationException($"Error when setting property '{propInfo.Name}'='{value}' on {objType.Name}", exception);
             }
         }
 

--- a/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
@@ -61,6 +61,12 @@ namespace NLog.LayoutRenderers
         public string Default { get; set; }
 
         /// <summary>
+        /// Gets the configuration variable layout matching the configured Name
+        /// </summary>
+        /// <remarks>Mostly relevant for the scanning of active NLog Layouts</remarks>
+        public Layout ActiveLayout => TryGetLayout(out var layout) ? layout : null;
+
+        /// <summary>
         /// Initializes the layout renderer.
         /// </summary>
         protected override void InitializeLayoutRenderer()
@@ -86,17 +92,14 @@ namespace NLog.LayoutRenderers
         }
 
         /// <summary>
-        /// Try get the 
+        /// Try lookup the configuration variable layout matching the configured Name
         /// </summary>
-        /// <param name="layout"></param>
-        /// <returns></returns>
         private bool TryGetLayout(out Layout layout)
         {
             layout = null;
             //Note: don't use LogManager (locking, recursion)
             return Name != null && LoggingConfiguration?.Variables?.TryGetValue(Name, out layout) == true;
         }
-
 
         /// <summary>
         /// Renders the specified variable and appends it to the specified <see cref="StringBuilder" />.

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -386,7 +386,7 @@ namespace NLog.Layouts
                         var value = ParseParameterValue(stringReader);
                         if (!string.IsNullOrEmpty(parameterName) || !StringHelpers.IsNullOrWhiteSpace(value))
                         {
-                            var configException = new NLogConfigurationException($"Unrecognized property '{parameterName}={value}` for ${{{name}}} ({layoutRenderer?.GetType()})");
+                            var configException = new NLogConfigurationException($"Unknown property '{parameterName}={value}` for ${{{name}}} ({layoutRenderer?.GetType()})");
                             if (throwConfigExceptions ?? configException.MustBeRethrown())
                             {
                                 throw configException;

--- a/tests/NLog.UnitTests/Config/VariableTests.cs
+++ b/tests/NLog.UnitTests/Config/VariableTests.cs
@@ -144,8 +144,10 @@ namespace NLog.UnitTests.Config
         {
             var configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
 <nlog throwExceptions='true'>
-    <variable name='prefix' value='[[' />
-    <variable name='suffix' value=']]' />
+    <variables>
+        <variable name='prefix' value='[[' />
+        <variable name='suffix' value=']]' />
+    </variables>
 </nlog>");
 
 

--- a/tests/NLog.UnitTests/Internal/Reflection/PropertyHelperTests.cs
+++ b/tests/NLog.UnitTests/Internal/Reflection/PropertyHelperTests.cs
@@ -62,7 +62,7 @@ namespace NLog.UnitTests.Internal.Reflection
             // Assert
             Assert.IsType<NLogConfigurationException>(ex.InnerException);
             Assert.IsType<NotSupportedException>(ex.InnerException.InnerException);
-            Assert.Contains("is an array and cannot be assigned a scalar value.", ex.InnerException.InnerException.Message);
+            Assert.Contains("is an array, and cannot be assigned a scalar value", ex.InnerException.InnerException.Message);
         }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
@@ -93,20 +93,22 @@ namespace NLog.UnitTests.LayoutRenderers
             Assert.Equal("msg and logger=A=123", lastMessage);
         }
 
-        [Fact]
-        public void Var_with_layout()
+        [Theory]
+        [InlineData("myJson", "${myJson}")]
+        [InlineData("myJson", "${var:myJson}")]
+        public void Var_with_layout(string variableName, string layoutStyle)
         {
-            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString($@"
 <nlog throwExceptions='true'>
-    <variable name='myJson'  >
+    <variable name='{variableName}'  >
         <layout type='JsonLayout'>
-            <attribute name='short date' layout='${level}' />
-            <attribute name='message' layout='${message}' />
+            <attribute name='short date' layout='${{level}}' />
+            <attribute name='message' layout='${{message}}' />
         </layout>
     </variable>
             
                 <targets>
-                    <target name='debug' type='Debug' layout='${var:myJson}' /></targets>
+                    <target name='debug' type='Debug' layout='{layoutStyle}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>


### PR DESCRIPTION
Trying to resolve #3470 by skipping the need for dynamic lookup using `${var}`

Minor enhancement of #3459