### PR TITLE
LogFactory - KeepVariablesOnReload = true by default for config variables

### DIFF
--- a/src/NLog/Config/ILoggingConfigurationElement.cs
+++ b/src/NLog/Config/ILoggingConfigurationElement.cs
@@ -41,7 +41,7 @@ namespace NLog.Config
     public interface ILoggingConfigurationElement
     {
         /// <summary>
-        /// Name of the config section
+        /// Name of this configuration element
         /// </summary>
         string Name { get; }
         /// <summary>
@@ -49,7 +49,7 @@ namespace NLog.Config
         /// </summary>
         IEnumerable<KeyValuePair<string, string>> Values { get; }
         /// <summary>
-        /// Child config sections
+        /// Child configuration elements
         /// </summary>
         IEnumerable<ILoggingConfigurationElement> Children { get; }
     }

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -182,9 +182,9 @@ namespace NLog.Config
         /// <summary>
         /// Inserts NLog Config Variable without overriding NLog Config Variable assigned from API
         /// </summary>
-        internal void InsertConfigFileVariable(string key, Layout value)
+        internal void InsertParsedConfigVariable(string key, Layout value)
         {
-            _variables.InsertConfigFileVariable(key, value, LogFactory.KeepVariablesOnReload);
+            _variables.InsertParsedConfigVariable(key, value, LogFactory.KeepVariablesOnReload);
         }
 
         /// <summary>

--- a/src/NLog/Config/LoggingConfigurationWatchableFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationWatchableFileLoader.cs
@@ -169,9 +169,15 @@ namespace NLog.Config
                         return;
                     }
 
-                    newConfig = oldConfig.ReloadNewConfig();
-                    if (newConfig == null || ReferenceEquals(newConfig, oldConfig))
+                    newConfig = oldConfig.Reload();
+                    if (ReferenceEquals(newConfig, oldConfig))
                         return;
+
+                    if (newConfig is IInitializeSucceeded config2 && config2.InitializeSucceeded != true)
+                    {
+                        InternalLogger.Warn("NLog Config Reload() failed. Invalid XML?");
+                        return;
+                    }
                 }
                 catch (Exception exception)
                 {

--- a/src/NLog/Internal/Collections/ConfigVariablesDictionary.cs
+++ b/src/NLog/Internal/Collections/ConfigVariablesDictionary.cs
@@ -1,0 +1,251 @@
+﻿// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using NLog.Config;
+using NLog.Layouts;
+
+namespace NLog.Internal
+{
+    [DebuggerDisplay("Count = {Count}")]
+    internal class ConfigVariablesDictionary : IDictionary<string, Layout>
+    {
+        private readonly ThreadSafeDictionary<string, Layout> _variables = new ThreadSafeDictionary<string, Layout>(StringComparer.OrdinalIgnoreCase);
+        private readonly LoggingConfiguration _configuration;
+        private ThreadSafeDictionary<string, Layout> _dynamicVariables;
+        private ThreadSafeDictionary<string, bool> _apiVariables;
+
+        public ConfigVariablesDictionary(LoggingConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public void InsertConfigFileVariable(string key, Layout value, bool keepVariablesOnReload)
+        {
+            if (keepVariablesOnReload && _apiVariables?.ContainsKey(key)==true && _variables.ContainsKey(key))
+                return;
+
+            _variables[key] = value;
+            _dynamicVariables?.Remove(key);
+        }
+
+        public bool TryLookupDynamicVariable(string key, out Layout dynamicLayout)
+        {
+            if (_dynamicVariables == null)
+            {
+                if (!_variables.TryGetValue(key, out dynamicLayout))
+                    return false;
+
+                System.Threading.Interlocked.CompareExchange(ref _dynamicVariables, new ThreadSafeDictionary<string, Layout>(_variables.Comparer), null);
+            }
+
+            bool variableExists = true;
+            if (!_dynamicVariables.TryGetValue(key, out dynamicLayout))
+            {
+                variableExists = false;
+
+                if (_variables.TryGetValue(key, out dynamicLayout))
+                {
+                    variableExists = true;
+
+                    if (dynamicLayout != null)
+                    {
+                        dynamicLayout.Initialize(_configuration);
+                        if (!dynamicLayout.ThreadSafe)
+                        {
+                            dynamicLayout = new ThreadSafeWrapLayout(dynamicLayout);
+                            dynamicLayout.Initialize(_configuration);
+                        }
+                    }
+                    
+                    _dynamicVariables[key] = dynamicLayout;
+                }
+            }
+
+            return variableExists;
+        }
+
+        public void PrepareForReload(ConfigVariablesDictionary oldVariables)
+        {
+            if (oldVariables._apiVariables != null)
+            {
+                foreach (var item in oldVariables._apiVariables)
+                {
+                    if (oldVariables._variables.TryGetValue(item.Key, out var value))
+                    {
+                        _variables[item.Key] = value;   // Reload will close the old-config and initialize the new-config (disconnects layout from old-config)
+                        RegisterApiVariable(item.Key);
+                    }
+                }
+            }
+        }
+
+        public int Count => _variables.Count;
+
+        ICollection<string> IDictionary<string, Layout>.Keys => _variables.Keys;
+
+        ICollection<Layout> IDictionary<string, Layout>.Values => _variables.Values;
+
+        bool ICollection<KeyValuePair<string, Layout>>.IsReadOnly => false;
+
+        bool IDictionary<string, Layout>.ContainsKey(string key) => _variables.ContainsKey(key);
+
+        bool IDictionary<string, Layout>.TryGetValue(string key, out Layout value) => _variables.TryGetValue(key, out value);
+
+        bool ICollection<KeyValuePair<string, Layout>>.Contains(KeyValuePair<string, Layout> item) => _variables.Contains(item);
+
+        void ICollection<KeyValuePair<string, Layout>>.CopyTo(KeyValuePair<string, Layout>[] array, int arrayIndex) => _variables.CopyTo(array, arrayIndex);
+
+        IEnumerator<KeyValuePair<string, Layout>> IEnumerable<KeyValuePair<string, Layout>>.GetEnumerator() => _variables.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _variables.GetEnumerator();
+
+        public ThreadSafeDictionary<string, Layout>.Enumerator GetEnumerator() => _variables.GetEnumerator();
+
+        Layout IDictionary<string, Layout>.this[string key]
+        {
+            get
+            {
+                return _variables[key];
+            }
+            set
+            {
+                _variables[key] = value;
+                RegisterApiVariable(key);
+            }
+        }
+
+        void IDictionary<string, Layout>.Add(string key, Layout value)
+        {
+            _variables.Add(key, value);
+            RegisterApiVariable(key);
+        }
+
+        void ICollection<KeyValuePair<string, Layout>>.Add(KeyValuePair<string, Layout> item)
+        {
+            _variables.Add(item);
+            RegisterApiVariable(item.Key);
+        }
+
+        bool IDictionary<string, Layout>.Remove(string key)
+        {
+            _apiVariables?.Remove(key);
+            _dynamicVariables?.Remove(key);
+            return _variables.Remove(key);
+        }
+
+        bool ICollection<KeyValuePair<string, Layout>>.Remove(KeyValuePair<string, Layout> item)
+        {
+            _apiVariables?.Remove(item.Key);
+            _dynamicVariables?.Remove(item.Key);
+            return _variables.Remove(item.Key);
+        }
+
+        void ICollection<KeyValuePair<string, Layout>>.Clear()
+        {
+            _variables.Clear();
+            _apiVariables?.Clear();
+            _dynamicVariables?.Clear();
+        }
+
+        private void RegisterApiVariable(string key)
+        {
+            if (_apiVariables == null)
+            {
+                System.Threading.Interlocked.CompareExchange(ref _apiVariables, new ThreadSafeDictionary<string, bool>(_variables.Comparer), null);
+            }
+            _apiVariables[key] = true;
+            _dynamicVariables?.Remove(key);
+        }
+
+        [ThreadAgnostic]
+        [ThreadSafe]
+        [AppDomainFixedOutput]
+        class ThreadSafeWrapLayout : Layout
+        {
+            private readonly object _lockObject = new object();
+
+            public Layout Unsafe { get; }
+
+            public ThreadSafeWrapLayout(Layout layout)
+            {
+                Unsafe = layout;
+                ThreadSafe = true;
+                ThreadAgnostic = true;
+            }
+
+            protected override void InitializeLayout()
+            {
+                lock (_lockObject)
+                {
+                    base.InitializeLayout();
+                    ThreadSafe = true;
+                }
+            }
+
+            public override void Precalculate(LogEventInfo logEvent)
+            {
+                lock (_lockObject)
+                    Unsafe.Precalculate(logEvent);
+            }
+
+            internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+            {
+                lock (_lockObject)
+                    Unsafe.PrecalculateBuilderInternal(logEvent, target);
+            }
+
+            protected override string GetFormattedMessage(LogEventInfo logEvent)
+            {
+                lock (_lockObject)
+                    return Unsafe.RenderAllocateBuilder(logEvent);
+            }
+
+            protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+            {
+                lock (_lockObject)
+                    Unsafe.RenderAppendBuilder(logEvent, target);
+            }
+
+            public override string ToString()
+            {
+                return Unsafe.ToString();
+            }
+        }
+    }
+}

--- a/src/NLog/Internal/Collections/ConfigVariablesDictionary.cs
+++ b/src/NLog/Internal/Collections/ConfigVariablesDictionary.cs
@@ -116,19 +116,13 @@ namespace NLog.Internal
 
         public int Count => _variables.Count;
 
-        ICollection<string> IDictionary<string, Layout>.Keys => _variables.Keys;
+        public ICollection<string> Keys => _variables.Keys;
 
-        ICollection<Layout> IDictionary<string, Layout>.Values => _variables.Values;
+        public ICollection<Layout> Values => _variables.Values;
 
-        bool ICollection<KeyValuePair<string, Layout>>.IsReadOnly => false;
+        public bool ContainsKey(string key) => _variables.ContainsKey(key);
 
-        bool IDictionary<string, Layout>.ContainsKey(string key) => _variables.ContainsKey(key);
-
-        bool IDictionary<string, Layout>.TryGetValue(string key, out Layout value) => _variables.TryGetValue(key, out value);
-
-        bool ICollection<KeyValuePair<string, Layout>>.Contains(KeyValuePair<string, Layout> item) => _variables.Contains(item);
-
-        void ICollection<KeyValuePair<string, Layout>>.CopyTo(KeyValuePair<string, Layout>[] array, int arrayIndex) => _variables.CopyTo(array, arrayIndex);
+        public bool TryGetValue(string key, out Layout value) => _variables.TryGetValue(key, out value);
 
         IEnumerator<KeyValuePair<string, Layout>> IEnumerable<KeyValuePair<string, Layout>>.GetEnumerator() => _variables.GetEnumerator();
 
@@ -136,7 +130,7 @@ namespace NLog.Internal
 
         public ThreadSafeDictionary<string, Layout>.Enumerator GetEnumerator() => _variables.GetEnumerator();
 
-        Layout IDictionary<string, Layout>.this[string key]
+        public Layout this[string key]
         {
             get
             {
@@ -149,38 +143,35 @@ namespace NLog.Internal
             }
         }
 
-        void IDictionary<string, Layout>.Add(string key, Layout value)
+        public void Add(string key, Layout value)
         {
             _variables.Add(key, value);
             RegisterApiVariable(key);
         }
 
-        void ICollection<KeyValuePair<string, Layout>>.Add(KeyValuePair<string, Layout> item)
-        {
-            _variables.Add(item);
-            RegisterApiVariable(item.Key);
-        }
-
-        bool IDictionary<string, Layout>.Remove(string key)
+        public bool Remove(string key)
         {
             _apiVariables?.Remove(key);
             _dynamicVariables?.Remove(key);
             return _variables.Remove(key);
         }
 
-        bool ICollection<KeyValuePair<string, Layout>>.Remove(KeyValuePair<string, Layout> item)
-        {
-            _apiVariables?.Remove(item.Key);
-            _dynamicVariables?.Remove(item.Key);
-            return _variables.Remove(item.Key);
-        }
-
-        void ICollection<KeyValuePair<string, Layout>>.Clear()
+        public void Clear()
         {
             _variables.Clear();
             _apiVariables?.Clear();
             _dynamicVariables?.Clear();
         }
+
+        bool ICollection<KeyValuePair<string, Layout>>.IsReadOnly => false;
+
+        bool ICollection<KeyValuePair<string, Layout>>.Contains(KeyValuePair<string, Layout> item) => _variables.Contains(item);
+
+        void ICollection<KeyValuePair<string, Layout>>.CopyTo(KeyValuePair<string, Layout>[] array, int arrayIndex) => _variables.CopyTo(array, arrayIndex);
+
+        void ICollection<KeyValuePair<string, Layout>>.Add(KeyValuePair<string, Layout> item) => Add(item.Key, item.Value);
+
+        bool ICollection<KeyValuePair<string, Layout>>.Remove(KeyValuePair<string, Layout> item) => Remove(item.Key);
 
         private void RegisterApiVariable(string key)
         {

--- a/src/NLog/Internal/Collections/ConfigVariablesDictionary.cs
+++ b/src/NLog/Internal/Collections/ConfigVariablesDictionary.cs
@@ -35,7 +35,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text;
 using NLog.Config;
 using NLog.Layouts;
@@ -55,7 +54,7 @@ namespace NLog.Internal
             _configuration = configuration;
         }
 
-        public void InsertConfigFileVariable(string key, Layout value, bool keepVariablesOnReload)
+        public void InsertParsedConfigVariable(string key, Layout value, bool keepVariablesOnReload)
         {
             if (keepVariablesOnReload && _apiVariables?.ContainsKey(key)==true && _variables.ContainsKey(key))
                 return;

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -207,7 +207,7 @@ namespace NLog
         /// Gets or sets a value indicating whether Variables should be kept on configuration reload.
         /// Default value - false.
         /// </summary>
-        public bool KeepVariablesOnReload { get; set; }
+        public bool KeepVariablesOnReload { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether to automatically call <see cref="LogFactory.Shutdown"/>

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -52,6 +52,7 @@ namespace NLog.UnitTests.Config
                 LogManager.LogFactory.ResetLoggerCache();
             }
         }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -593,9 +594,43 @@ namespace NLog.UnitTests.Config
             Assert.Equal("keep_value", logFactory.Configuration.Variables["var2"].Render(nullEvent));
             Assert.Equal("new_value3", logFactory.Configuration.Variables["var3"].Render(nullEvent));
 
-            logFactory.Configuration = configuration.ReloadNewConfig();
+            logFactory.Configuration = configuration.Reload();
             Assert.Equal("new_value", logFactory.Configuration.Variables["var1"].Render(nullEvent));
             Assert.Equal("keep_value", logFactory.Configuration.Variables["var2"].Render(nullEvent));
+            Assert.Equal("new_value3", logFactory.Configuration.Variables["var3"].Render(nullEvent));
+        }
+
+        [Fact]
+        public void TestKeepVariablesOnReloadAllowUpdate()
+        {
+            string config1 = @"<nlog autoReload='true' keepVariablesOnReload='true'>
+                                <variable name='var1' value='' />
+                                <variable name='var2' value='old_value2' />
+                                <targets><target name='mem' type='memory' layout='${var:var2}' /></targets>
+                                <rules><logger name='*' writeTo='mem' /></rules>
+                            </nlog>";
+
+            string config2 = @"<nlog autoReload='true' keepVariablesOnReload='true'>
+                                <variable name='var1' value='' />
+                                <variable name='var2' value='new_value2' />
+                                <targets><target name='mem' type='memory' layout='${var:var2}' /></targets>
+                                <rules><logger name='*' writeTo='mem' /></rules>
+                            </nlog>";
+
+            var logFactory = new LogFactory();
+            var xmlConfig = XmlLoggingConfigurationMock.CreateFromXml(logFactory, config1);
+            logFactory.Configuration = xmlConfig;
+
+            // Act
+            logFactory.Configuration.Variables.Remove("var1");
+            logFactory.Configuration.Variables.Add("var3", "new_value3");
+            xmlConfig.ConfigXml = config2;
+            logFactory.Configuration = xmlConfig.Reload();
+
+            // Assert
+            var nullEvent = LogEventInfo.CreateNullEvent();
+            Assert.Equal("", logFactory.Configuration.Variables["var1"].Render(nullEvent));
+            Assert.Equal("new_value2", logFactory.Configuration.Variables["var2"].Render(nullEvent));
             Assert.Equal("new_value3", logFactory.Configuration.Variables["var3"].Render(nullEvent));
         }
 
@@ -618,9 +653,39 @@ namespace NLog.UnitTests.Config
             Assert.Equal("", logFactory.Configuration.Variables["var1"].Render(nullEvent));
             Assert.Equal("keep_value", logFactory.Configuration.Variables["var2"].Render(nullEvent));
 
-            logFactory.Configuration = configuration.ReloadNewConfig();
+            logFactory.Configuration = configuration.Reload();
             Assert.Equal("", logFactory.Configuration.Variables["var1"].Render(nullEvent));
             Assert.Equal("keep_value", logFactory.Configuration.Variables["var2"].Render(nullEvent));
+        }
+
+        [Fact]
+        public void KeepVariablesOnReloadWithStaticMode()
+        {
+            // Arrange
+            string config = @"<nlog autoReload='true'>
+                                <variable name='maxArchiveDays' value='7' />
+                                <targets>
+                                    <target name='logfile' type='file' fileName='test.log' maxArchiveDays='${maxArchiveDays}' />
+                                </targets>
+                                <rules>
+                                    <logger name='*' minLevel='Debug' writeTo='logfile' />
+                                </rules>
+                            </nlog>";
+            var logFactory = new LogFactory();
+            logFactory.Configuration = XmlLoggingConfigurationMock.CreateFromXml(logFactory, config);
+
+            var fileTarget = logFactory.Configuration.AllTargets[0] as NLog.Targets.FileTarget;
+            var beforeValue = fileTarget.MaxArchiveDays;
+
+            // Act
+            logFactory.Configuration.Variables["MaxArchiveDays"] = "42";
+            logFactory.Configuration = logFactory.Configuration.Reload();
+            fileTarget = logFactory.Configuration.AllTargets[0] as NLog.Targets.FileTarget;
+            var afterValue = fileTarget.MaxArchiveDays;
+
+            // Assert
+            Assert.Equal(7, beforeValue);
+            Assert.Equal(42, afterValue);
         }
 
         [Fact]
@@ -773,23 +838,27 @@ namespace NLog.UnitTests.Config
     /// </summary>
     public class XmlLoggingConfigurationMock : XmlLoggingConfiguration
     {
-        private string _configXml;
-        private LogFactory _logFactory;
+        public string ConfigXml { get; set; }
 
-        private XmlLoggingConfigurationMock(LogFactory logFactory, string configXml) : base(XmlReader.Create(new StringReader(configXml)), null, logFactory)
+        private XmlLoggingConfigurationMock(LogFactory logFactory, string configXml)
+            :base(logFactory)
         {
-            _logFactory = logFactory;
-            _configXml = configXml;
+            ConfigXml = configXml;
         }
 
         public override LoggingConfiguration Reload()
         {
-            return new XmlLoggingConfigurationMock(_logFactory, _configXml);
+            var newConfig = new XmlLoggingConfigurationMock(LogFactory, ConfigXml);
+            newConfig.PrepareForReload(this);
+            newConfig.LoadFromXmlContent(ConfigXml, null);
+            return newConfig;
         }
 
         public static XmlLoggingConfigurationMock CreateFromXml(LogFactory logFactory, string configXml)
         {
-            return new XmlLoggingConfigurationMock(logFactory, configXml);
+            var newConfig = new XmlLoggingConfigurationMock(logFactory, configXml);
+            newConfig.LoadFromXmlContent(configXml, null);
+            return newConfig;
         }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
@@ -31,15 +31,13 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#region
-
+using System;
+using System.IO;
+using System.Linq;
 using NLog.Config;
 using NLog.Layouts;
 using NLog.Targets;
-using System.IO;
 using Xunit;
-
-#endregion
 
 namespace NLog.UnitTests.LayoutRenderers
 {
@@ -48,26 +46,50 @@ namespace NLog.UnitTests.LayoutRenderers
         [Fact]
         public void Var_from_xml()
         {
-            CreateConfigFromXml();
+            // Arrange
+            var logFactory = CreateConfigFromXml();
+            var logger = logFactory.GetLogger("A");
 
-            ILogger logger = LogManager.GetLogger("A");
-
+            // Act
             logger.Debug("msg");
-            var lastMessage = GetDebugLastMessage("debug");
-            Assert.Equal("msg and admin=realgoodpassword", lastMessage);
+            
+            // Assert
+            logFactory.AssertDebugLastMessage("msg and admin=realgoodpassword");
+            Assert.Equal(2, logFactory.Configuration.Variables.Count);
+            Assert.Equal(2, logFactory.Configuration.Variables.Keys.Count);
+            Assert.Equal(2, logFactory.Configuration.Variables.Values.Count);
+            Assert.True(logFactory.Configuration.Variables.ContainsKey("uSeR"));
+            Assert.True(logFactory.Configuration.Variables.TryGetValue("passWORD", out var _));
         }
 
         [Fact]
         public void Var_from_xml_and_edit()
         {
-            CreateConfigFromXml();
+            // Arrange
+            var logFactory = CreateConfigFromXml();
+            ILogger logger = logFactory.GetLogger("A");
 
-            LogManager.Configuration.Variables["password"] = "123";
-            ILogger logger = LogManager.GetLogger("A");
-
+            // Act
+            logFactory.Configuration.Variables["password"] = "123";
             logger.Debug("msg");
-            var lastMessage = GetDebugLastMessage("debug");
-            Assert.Equal("msg and admin=123", lastMessage);
+
+            // Assert
+            logFactory.AssertDebugLastMessage("msg and admin=123");
+        }
+
+        [Fact]
+        public void Var_from_xml_and_clear()
+        {
+            // Arrange
+            var logFactory = CreateConfigFromXml();
+            ILogger logger = logFactory.GetLogger("A");
+
+            // Act
+            logFactory.Configuration.Variables.Clear();
+            logger.Debug("msg");
+
+            // Assert
+            logFactory.AssertDebugLastMessage("msg and =");
         }
 
         [Fact]
@@ -148,6 +170,83 @@ namespace NLog.UnitTests.LayoutRenderers
             {
                 File.Delete(logFilePath);
             }
+        }
+
+        [Fact]
+        public void Var_Layout_Target_CallSite()
+        {
+
+            var logFactory = new LogFactory().Setup()
+                .LoadConfigurationFromXml(@"<nlog throwExceptions='true'>
+                    <variable name='myvar' value='${callsite}' />
+                    <targets>
+                        <target name='debug' type='Debug' layout='${var:myvar}' />
+                    </targets>
+                    <rules>
+                        <logger name='*' minLevel='Debug' writeTo='debug' />
+                    </rules>
+                </nlog>").LogFactory;
+
+            // Act
+            logFactory.GetCurrentClassLogger().Info("Hello");
+
+            // Assert
+            logFactory.AssertDebugLastMessage(GetType().ToString() + "." + nameof(Var_Layout_Target_CallSite));
+        }
+
+        [Fact]
+        public void Var_Layout_Target_ThreadSafe()
+        {
+            int checkThreadSafe = 1;
+
+            var logFactory = new LogFactory().Setup()
+                .SetupExtensions(ext => ext.RegisterLayoutRenderer("naked-runner", (evt) =>
+                {
+                    var orgValue = System.Threading.Interlocked.Exchange(ref checkThreadSafe, 0);
+                    if (orgValue == 0)
+                        throw new InvalidOperationException("Running naked in the woods");
+
+                    System.Threading.Thread.Sleep(10);
+                    System.Threading.Interlocked.Exchange(ref checkThreadSafe, orgValue);
+                    return "Running safely";
+                }))
+                .LoadConfigurationFromXml(@"<nlog throwExceptions='true'>
+                    <variable name='myvar' value='Hello' />
+                    <targets>
+                        <target name='debug1' type='Memory' layout='${logger}|${message}|${var:myvar}' />
+                        <target name='debug2' type='Memory' layout='${logger}|${message}|${var:myvar}' />
+                    </targets>
+                    <rules>
+                        <logger name='d1' minLevel='Debug' writeTo='debug1' />
+                        <logger name='d2' minLevel='Debug' writeTo='debug2' />
+                    </rules>
+                </nlog>")
+                .LoadConfiguration(cfg => cfg.Configuration.Variables["myvar"] = new SimpleLayout("${naked-runner}", cfg.LogFactory.ServiceRepository.ConfigurationItemFactory)).LogFactory;
+
+            // Act
+            int expectedLogCount = 100;
+            var manualEvent = new System.Threading.ManualResetEvent(false);
+            Action<Logger> runnerMethod = (logger) =>
+            {
+                manualEvent.WaitOne();
+                for (int i = 0; i < expectedLogCount / 2; ++i)
+                    logger.Info("Test {0}", i);
+            };
+
+            var logger1 = logFactory.GetLogger("d1");
+            var thread1 = new System.Threading.Thread((s) => runnerMethod((Logger)s)) { Name = logger1.Name, IsBackground = true };
+            thread1.Start(logger1);
+
+            var logger2 = logFactory.GetLogger("d2");
+            var thread2 = new System.Threading.Thread((s) => runnerMethod((Logger)s)) { Name = logger2.Name, IsBackground = true };
+            thread2.Start(logger2);
+
+            manualEvent.Set();
+            thread1.Join();
+            thread2.Join();
+
+            // Assert
+            Assert.Equal(expectedLogCount, logFactory.Configuration.AllTargets.OfType<MemoryTarget>().Sum(m => m.Logs.Count));
         }
 
         [Fact]
@@ -244,29 +343,31 @@ namespace NLog.UnitTests.LayoutRenderers
         [Fact]
         public void Var_default_after_set_null()
         {
-            CreateConfigFromXml();
+            // Arrange
+            var logFactory = CreateConfigFromXml();
+            ILogger logger = logFactory.GetLogger("A");
 
-            ILogger logger = LogManager.GetLogger("A");
-
-            LogManager.Configuration.Variables["password"] = null;
-
+            // Act
+            logFactory.Configuration.Variables["password"] = null;
             logger.Debug("msg");
-            var lastMessage = GetDebugLastMessage("debug");
-            Assert.Equal("msg and admin=", lastMessage);
+
+            // Assert
+            logFactory.AssertDebugLastMessage("msg and admin=");
         }
 
         [Fact]
         public void Var_default_after_set_emptyString()
         {
-            CreateConfigFromXml();
+            // Arrange
+            var logFactory = CreateConfigFromXml();
+            ILogger logger = logFactory.GetLogger("A");
 
-            ILogger logger = LogManager.GetLogger("A");
-
-            LogManager.Configuration.Variables["password"] = "";
-
+            // Act
+            logFactory.Configuration.Variables["password"] = "";
             logger.Debug("msg");
-            var lastMessage = GetDebugLastMessage("debug");
-            Assert.Equal("msg and admin=", lastMessage);
+
+            // Assert
+            logFactory.AssertDebugLastMessage("msg and admin=");
         }
 
         [Fact]
@@ -341,9 +442,9 @@ namespace NLog.UnitTests.LayoutRenderers
             Assert.Equal("msg|my-mocking-manager", debugTarget.LastMessage);
         }
 
-        private void CreateConfigFromXml()
+        private LogFactory CreateConfigFromXml()
         {
-            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            return new LogFactory().Setup().LoadConfigurationFromXml(@"
 <nlog throwExceptions='true'>
     <variable name='user' value='admin' />
     <variable name='password' value='realgoodpassword' />
@@ -353,7 +454,7 @@ namespace NLog.UnitTests.LayoutRenderers
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>
-            </nlog>");
+            </nlog>").LogFactory;
         }
     }
 }


### PR DESCRIPTION
Resolves #2509 and resolves #2960

The old way triggered variable-restore AFTER having loaded the new config from file. It would restore ALL values from the old config (Thus discarding any updates made in the new config files). And at the same time prevents static-mode variables from working with config-variables assigned from API.

The new way triggers variable-restore BEFORE starting to load the new file. It will ONLY restore config-variables that has been assigned from the API by using `LoggingConfiguration.Variables`-property.
- This means changes to config-variables in the new config file, will no longer be discarded (unless the config-variable has been assigned from the API). Less surprises when having KeepVariablesOnReload=true by default.
- This means use of config-variables in static-mode (without NLog Layout) will now apply values assigned from the API.

The new way will work automatically when manually calling `XmlLoggingConfiguration.Reload()`, instead of only when file-watcher detects file-changes and triggers special reload.

The new way will also automatically add extra protection for NLog-Config-Variable-Layout that is not ThreadSafe by default (Rare case). Thus removing the [possible issue with thread-safety](https://github.com/NLog/NLog/wiki/Var-Layout-Renderer) and NLog-Config-Variables.
 - The ThreadSafe-wrapper is hidden from the user, and is only used by `${var}` or when assigned as const-Layout.