### PR TITLE
JsonLayout - Unwind after invalid property value to avoid invalid Json

### DIFF
--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -81,9 +81,9 @@ namespace NLog.Layouts
                     return _converter.SerializeObject(value, builder);
             }
 
-            public void SerializeObjectNoLimit(object value, StringBuilder builder)
+            public bool SerializeObjectNoLimit(object value, StringBuilder builder)
             {
-                _converter.SerializeObject(value, builder);
+                return _converter.SerializeObject(value, builder);
             }
         }
 
@@ -371,7 +371,11 @@ namespace NLog.Layouts
             if (MaxRecursionLimit <= 1 && captureType == MessageTemplates.CaptureType.Serialize)
             {
                 // Overrides MaxRecursionLimit as message-template tells us it is safe
-                JsonConverter.SerializeObjectNoLimit(propertyValue, sb);
+                if (!JsonConverter.SerializeObjectNoLimit(propertyValue, sb))
+                {
+                    sb.Length = initialLength;
+                    return;
+                }
             }
             else if (captureType == MessageTemplates.CaptureType.Stringify)
             {
@@ -382,7 +386,11 @@ namespace NLog.Layouts
             }
             else
             {
-                JsonConverter.SerializeObject(propertyValue, sb);
+                if (!JsonConverter.SerializeObject(propertyValue, sb))
+                {
+                    sb.Length = initialLength;
+                    return;
+                }
             }
 
             if (ExcludeEmptyProperties && (sb[sb.Length-1] == '"' && sb[sb.Length-2] == '"'))

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -257,10 +257,17 @@ namespace NLog.Targets
                 SerializeSimpleTypeCodeValue(convertibleValue, objTypeCode, destination, options, forceToString);
                 return true;
             }
-
+            
             if (value is DateTimeOffset dateTimeOffset)
             {
                 QuoteValue(destination, dateTimeOffset.ToString("yyyy-MM-dd HH:mm:ss zzz", CultureInfo.InvariantCulture));
+                return true;
+            }
+
+            if (value is IFormattable formattable)
+            {
+                var hasFormat = !StringHelpers.IsNullOrWhiteSpace(options.Format);
+                SerializeWithFormatProvider(formattable, true, destination, options, hasFormat);
                 return true;
             }
 


### PR DESCRIPTION
Resolves  #4241 

Also a minor performance optimization as it skips object-graph-loop detections for simple types that implements IFormattable (Ex. Guid) as they always converts ToString().