### PR TITLE
Support for overriding AssemblyLoader for loading NLog extensions

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -142,6 +142,11 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Gets or sets the assembly loader used for loading NLog extension-assemblies
+        /// </summary>
+        public Func<string, Assembly> AssemblyLoader { get; set; } = AssemblyHelpers.LoadFromName;
+
+        /// <summary>
         /// Gets the <see cref="Target"/> factory.
         /// </summary>
         /// <value>The target factory.</value>

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -69,7 +69,7 @@ namespace NLog.Config
         /// Loads NLog configuration from provided config section
         /// </summary>
         /// <param name="nlogConfig"></param>
-        /// <param name="basePath"></param>
+        /// <param name="basePath">Directory where the NLog-config-file was loaded from</param>
         protected void LoadConfig(ILoggingConfigurationElement nlogConfig, string basePath)
         {
             InternalLogger.Trace("ParseNLogConfig");
@@ -322,9 +322,6 @@ namespace NLog.Config
             return false;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability",
-            "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadFrom",
-            Justification = "Need to load external assembly.")]
         private void ParseExtensionsElement(ValidatedConfigurationElement extensionsElement, string baseDirectory)
         {
             extensionsElement.AssertName("extensions");
@@ -424,7 +421,7 @@ namespace NLog.Config
         {
             try
             {
-                Assembly asm = AssemblyHelpers.LoadFromName(assemblyName);
+                Assembly asm = _serviceRepository.ConfigurationItemFactory.AssemblyLoader(assemblyName);
                 _serviceRepository.ConfigurationItemFactory.RegisterItemsFromAssembly(asm, prefix);
             }
             catch (Exception exception)

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -436,17 +436,22 @@ namespace NLog.Config
             nlogElement.AssertName("nlog");
 
             bool autoReload = nlogElement.GetOptionalBooleanValue("autoReload", autoReloadDefault);
-            if (!string.IsNullOrEmpty(filePath))
-                _fileMustAutoReloadLookup[GetFileLookupKey(filePath)] = autoReload;
 
             try
             {
-                _currentFilePath.Push(filePath);
-                base.LoadConfig(nlogElement, Path.GetDirectoryName(filePath));
+                string baseDirectory = null;
+                if (!string.IsNullOrEmpty(filePath))
+                {
+                    _fileMustAutoReloadLookup[GetFileLookupKey(filePath)] = autoReload;
+                    _currentFilePath.Push(filePath);
+                    baseDirectory = Path.GetDirectoryName(filePath);
+                }
+                base.LoadConfig(nlogElement, baseDirectory);
             }
             finally
             {
-                _currentFilePath.Pop();
+                if (!string.IsNullOrEmpty(filePath))
+                    _currentFilePath.Pop();
             }
         }
 

--- a/src/NLog/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog/SetupExtensionsBuilderExtensions.cs
@@ -73,6 +73,17 @@ namespace NLog
         }
 
         /// <summary>
+        /// Overrides the assembly loader used for loading NLog extension-assemblies
+        /// </summary>
+        /// <param name="setupBuilder"></param>
+        /// <param name="assemblyLoader"></param>
+        public static ISetupExtensionsBuilder RegisterAssemblyLoader(this ISetupExtensionsBuilder setupBuilder, Func<string, Assembly> assemblyLoader)
+        {
+            setupBuilder.LogFactory.ServiceRepository.ConfigurationItemFactory.AssemblyLoader = assemblyLoader;
+            return setupBuilder;
+        }
+
+        /// <summary>
         /// Registers NLog extensions from the assembly.
         /// </summary>
         public static ISetupExtensionsBuilder RegisterAssembly(this ISetupExtensionsBuilder setupBuilder, Assembly assembly)
@@ -86,7 +97,7 @@ namespace NLog
         /// </summary>
         public static ISetupExtensionsBuilder RegisterAssembly(this ISetupExtensionsBuilder setupBuilder, string assemblyName)
         {
-            Assembly assembly = AssemblyHelpers.LoadFromName(assemblyName);
+            Assembly assembly = setupBuilder.LogFactory.ServiceRepository.ConfigurationItemFactory.AssemblyLoader(assemblyName);
             setupBuilder.LogFactory.ServiceRepository.ConfigurationItemFactory.RegisterItemsFromAssembly(assembly);
             return setupBuilder;
         }

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -355,6 +355,20 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        public void OverrideAssemblyLoaderForLoadingExtensions()
+        {
+            var assemblyName = "some_assembly_that_doesnt_exist";
+            var configXml = $@"
+<nlog throwConfigExceptions='true'>
+    <extensions>
+        <add assembly='{assemblyName}'/>
+    </extensions>
+</nlog>";
+            var configException = Assert.Throws<NLogConfigurationException>(() => new LogFactory().Setup().SetupExtensions(ext => ext.RegisterAssemblyLoader(asmName => throw new ApplicationException(asmName))).LoadConfigurationFromXml(configXml));
+            Assert.Equal(assemblyName, configException.GetBaseException().Message);
+        }
+
+        [Fact]
         public void ExtensionShouldNotThrowWhenRegisteringInvalidAssemblyFileIfThrowConfigExceptionsFalse()
         {
             var configXml = @"


### PR DESCRIPTION
Resolves #3981

So you can do this:

```c#
NLog.LogFactory().Setup().SetupExtensions(ext => ext.RegisterAssemblyLoader(asmName => {
   var assemblyName = new AssemblyName() { Name = asmName };
   var assemblyContext = AssemblyLoadContext.GetLoadContext(typeof(NLog.LogFactory).Assembly);
   return assemblyContext.LoadFromAssemblyName(assemblyName);
}));
```

The AssemblyLoader will not be used for the NLog-Auto-Extension-Loader-Logic, but it also often fails and is disabled by default with NLog5.

Guess this could also be used by the application to restrict that assemblies are allowed to be loaded, when specified from NLog-configuration-file.