### PR TITLE
Fix NetworkTargetConnectionsOverflowAction to match normal OverflowAction-values

### DIFF
--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -329,12 +329,12 @@ namespace NLog.Targets
                     {
                         switch (OnConnectionOverflow)
                         {
-                            case NetworkTargetConnectionsOverflowAction.DiscardMessage:
-                                InternalLogger.Warn("NetworkTarget(Name={0}): Discarding message otherwise to many connections.", Name);
+                            case NetworkTargetConnectionsOverflowAction.Discard:
+                                InternalLogger.Warn("NetworkTarget(Name={0}): Discarding message otherwise too many connections.", Name);
                                 logEvent.Continuation(null);
                                 return;
 
-                            case NetworkTargetConnectionsOverflowAction.AllowNewConnnection:
+                            case NetworkTargetConnectionsOverflowAction.Grow:
                                 InternalLogger.Debug("NetworkTarget(Name={0}): Too may connections, but this is allowed", Name);
                                 break;
 

--- a/src/NLog/Targets/NetworkTargetConnectionsOverflowAction.cs
+++ b/src/NLog/Targets/NetworkTargetConnectionsOverflowAction.cs
@@ -32,8 +32,6 @@
 // 
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace NLog.Targets
 {
@@ -43,18 +41,30 @@ namespace NLog.Targets
     public enum NetworkTargetConnectionsOverflowAction
     {
         /// <summary>
+        /// Allow new connections when reaching max connection limit
+        /// </summary>
+        Grow = 0,
+
+        /// <summary>
         /// Just allow it.
         /// </summary>
-        AllowNewConnnection, //TODO Nlog 5 - fix typo and obsolete this one
+        [Obsolete("Replaced by Grow. Marked obsolete on NLog 5.0")]
+        AllowNewConnnection = 0,
+
+        /// <summary>
+        /// Discard new messages when reaching max connection limit
+        /// </summary>
+        Discard = 1,
 
         /// <summary>
         /// Discard the connection item.
         /// </summary>
-        DiscardMessage,
+        [Obsolete("Replaced by Discard. Marked obsolete on NLog 5.0")]
+        DiscardMessage = 1,
 
         /// <summary>
         /// Block until there's more room in the queue.
         /// </summary>
-        Block,
+        Block = 2,
     }
 }


### PR DESCRIPTION
Fixes typo in `AllowNewConnnection` by making it obsolete and replacing it with `Grow`.

Also replaced `DiscardMessage` with `Discard` to match the standard overflow-actions-names.