### PR TITLE
When Condition Filters should recognize LogLevel-Type

### DIFF
--- a/src/NLog/Conditions/Expressions/ConditionExceptionExpression.cs
+++ b/src/NLog/Conditions/Expressions/ConditionExceptionExpression.cs
@@ -1,0 +1,60 @@
+// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Conditions
+{
+    /// <summary>
+    /// Condition message expression (represented by the <b>exception</b> keyword).
+    /// </summary>
+    internal sealed class ConditionExceptionExpression : ConditionExpression
+    {
+        /// <summary>
+        /// Returns a string representation of this expression.
+        /// </summary>
+        /// <returns>The '<b>message</b>' string.</returns>
+        public override string ToString()
+        {
+            return "exception";
+        }
+
+        /// <summary>
+        /// Evaluates to the logger message.
+        /// </summary>
+        /// <param name="context">Evaluation context.</param>
+        /// <returns>The logger message.</returns>
+        protected override object EvaluateNode(LogEventInfo context)
+        {
+            return context.Exception;
+        }
+    }
+}

--- a/src/NLog/Conditions/Expressions/ConditionRelationalExpression.cs
+++ b/src/NLog/Conditions/Expressions/ConditionRelationalExpression.cs
@@ -227,6 +227,13 @@ namespace NLog.Conditions
                     return true;
                 }
 
+                if (type1 == typeof(LogLevel))
+                {
+                    string strval = Convert.ToString(val, CultureInfo.InvariantCulture);
+                    val = LogLevel.FromString(strval);
+                    return true;
+                }
+
                 if (type1 == typeof(string))
                 {
                     val = Convert.ToString(val, CultureInfo.InvariantCulture);
@@ -288,6 +295,7 @@ namespace NLog.Conditions
                 typeof(long),
                 typeof(int),
                 typeof(bool),
+                typeof(LogLevel),
                 typeof(string),
             };
 

--- a/src/NLog/Conditions/Parsing/ConditionParser.cs
+++ b/src/NLog/Conditions/Parsing/ConditionParser.cs
@@ -216,26 +216,26 @@ namespace NLog.Conditions
         {
             if (0 == string.Compare(keyword, "level", StringComparison.OrdinalIgnoreCase))
             {
-                {
-                    expression = new ConditionLevelExpression();
-                    return true;
-                }
+                expression = new ConditionLevelExpression();
+                return true;
             }
 
             if (0 == string.Compare(keyword, "logger", StringComparison.OrdinalIgnoreCase))
             {
-                {
-                    expression = new ConditionLoggerNameExpression();
-                    return true;
-                }
+                expression = new ConditionLoggerNameExpression();
+                return true;
             }
 
             if (0 == string.Compare(keyword, "message", StringComparison.OrdinalIgnoreCase))
             {
-                {
-                    expression = new ConditionMessageExpression();
-                    return true;
-                }
+                expression = new ConditionMessageExpression();
+                return true;
+            }
+
+            if (0 == string.Compare(keyword, "exception", StringComparison.OrdinalIgnoreCase))
+            {
+                expression = new ConditionExceptionExpression();
+                return true;
             }
 
             if (0 == string.Compare(keyword, "loglevel", StringComparison.OrdinalIgnoreCase))

--- a/tests/NLog.UnitTests/Filters/ConditionBasedFilterTests.cs
+++ b/tests/NLog.UnitTests/Filters/ConditionBasedFilterTests.cs
@@ -92,5 +92,29 @@ namespace NLog.UnitTests.Filters
                 logFactory.AssertDebugLastMessage("Hello can you hear me");
             }
         }
+
+        [Fact]
+        public void WhenExceptionTest()
+        {
+            var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
+                <nlog>
+                    <targets><target name='debug' type='debug' layout='${message}' /></targets>
+                    <rules>
+                        <logger name='*' minLevel='Debug' writeTo='debug'>
+                            <filters defaultAction='ignore'>
+                                <when condition='exception != null' action='Log' />
+                            </filters>
+                        </logger>
+                    </rules>
+                </nlog>
+            ").LogFactory;
+            var logger = logFactory.GetCurrentClassLogger();
+
+            logger.Fatal("Hello missing Exception");
+            logFactory.AssertDebugLastMessage("");
+
+            logger.Error(new System.Exception("Oh no"), "Hello with Exception");
+            logFactory.AssertDebugLastMessage("Hello with Exception");
+        }
     }
 }

--- a/tests/NLog.UnitTests/Filters/ConditionBasedFilterTests.cs
+++ b/tests/NLog.UnitTests/Filters/ConditionBasedFilterTests.cs
@@ -65,5 +65,32 @@ namespace NLog.UnitTests.Filters
             logger.Debug("Zz");
             AssertDebugCounter("debug", 2);
         }
+
+        [Fact]
+        public void WhenLogLevelTest()
+        {
+            var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
+                <nlog>
+                    <targets><target name='debug' type='debug' layout='${message}' /></targets>
+                    <rules>
+                        <logger name='*' minLevel='Debug' writeTo='debug'>
+                            <filters defaultAction='ignore'>
+                                <when condition=""level >= '${scopeproperty:filterlevel:whenEmpty=Off}'"" action='Log' />
+                            </filters>
+                        </logger>
+                    </rules>
+                </nlog>
+            ").LogFactory;
+            var logger = logFactory.GetCurrentClassLogger();
+
+            logger.Fatal("Hello Emptiness");
+            logFactory.AssertDebugLastMessage("");
+
+            using (logger.PushScopeProperty("filterLevel", LogLevel.Warn))
+            {
+                logger.Error("Hello can you hear me");
+                logFactory.AssertDebugLastMessage("Hello can you hear me");
+            }
+        }
     }
 }


### PR DESCRIPTION
Support compare of LogLevel instead of just string-comparison. Ex. "Error" >= "Warn".

See also: https://stackoverflow.com/questions/64984152/set-logger-max-log-level-per-http-request-via-filter

And also: https://stackoverflow.com/questions/47475698/how-to-control-nlog-loglevel-using-environment-variables/47517826#47517826

Then one can do this:

```xml
<logger name="*"  writeTo="console">
          <filters>
              <when condition="level >= `${environment:LOG_LEVEL:cachedSeconds=5}'" action="Log"/>
          </filters>
 </logger>
```


Instead of this:

```xml
<logger name="*"  writeTo="console">
          <filters>
              <when condition="(level >= LogLevel.Fatal and equals('${environment:LOG_LEVEL:cachedSeconds=5}','LogLevel.Fatal)" action="Log"/>
              <when condition="(level >= LogLevel.Error and equals('${environment:LOG_LEVEL:cachedSeconds=5}','LogLevel.Error')" action="Log"/>
              <when condition="(level >= LogLevel.Info and equals('${environment:LOG_LEVEL:cachedSeconds=5}','LogLevel.Info')" action="Log"/>
              <when condition="(level >= LogLevel.Debug and equals('${environment:LOG_LEVEL:cachedSeconds=5}','LogLevel.Debug')" action="Log"/>
              <when condition="(level >= LogLevel.Trace and equals('${environment:LOG_LEVEL:cachedSeconds=5}','LogLevel.Trace')" action="Log"/>
          </filters>
 </logger>
```