### PR TITLE
Target.ToString cached and used as InternalLogger parameter

### DIFF
--- a/src/NLog.Wcf/Targets/LogReceiverWebServiceTarget.cs
+++ b/src/NLog.Wcf/Targets/LogReceiverWebServiceTarget.cs
@@ -206,7 +206,7 @@ namespace NLog.Targets
         {
             if (logEvents.Count == 0 && !LogManager.ThrowExceptions)
             {
-                InternalLogger.Error("LogReceiverServiceTarget(Name={0}): LogEvents array is empty, sending empty event...", Name);
+                InternalLogger.Error("{0}: LogEvents array is empty, sending empty event...", this);
                 return new NLogEvents();
             }
 
@@ -280,7 +280,7 @@ namespace NLog.Targets
             client.ProcessLogMessagesCompleted += (sender, e) =>
             {
                 if (e.Error != null)
-                    InternalLogger.Error(e.Error, "LogReceiverServiceTarget(Name={0}): Error while sending", Name);
+                    InternalLogger.Error(e.Error, "{0}: Error while sending", this);
 
                 // report error to the callers
                 for (int i = 0; i < asyncContinuations.Count; ++i)
@@ -379,7 +379,7 @@ namespace NLog.Targets
             {
                 if (flushContinuation != null)
                 {
-                    InternalLogger.Error(exception, "LogReceiverServiceTarget(Name={0}): Error in flush async", Name);
+                    InternalLogger.Error(exception, "{0}: Error in flush async", this);
                     if (LogManager.ThrowExceptions)
                         throw;
 
@@ -388,7 +388,7 @@ namespace NLog.Targets
                 else
                 {
                     // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
-                    InternalLogger.Error(exception, "LogReceiverServiceTarget(Name={0}): Error in send async", Name);
+                    InternalLogger.Error(exception, "{0}: Error in send async", this);
                 }
             }
         }

--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -256,7 +256,8 @@ namespace NLog.Common
                 if (hasEventListeners)
                 {
                     var loggerContext = args?.Length > 0 ? args[0] as IInternalLoggerContext : null;
-                    LogMessageReceived?.Invoke(null, new InternalLoggerMessageEventArgs(fullMessage, level, ex, loggerContext?.GetType(), loggerContext?.Name));
+                    var loggerContextName = string.IsNullOrEmpty(loggerContext?.Name) ? loggerContext?.ToString() : loggerContext.Name;
+                    LogMessageReceived?.Invoke(null, new InternalLoggerMessageEventArgs(fullMessage, level, ex, loggerContext?.GetType(), loggerContextName));
 
                     ex?.MarkAsLoggedToInternalLogger();
                 }

--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -169,7 +169,7 @@ namespace NLog.Internal.FileAppenders
         {
             int currentDelay = CreateFileParameters.FileOpenRetryDelay;
 
-            InternalLogger.Trace("Opening {0} with allowFileSharedWriting={1}", FileName, allowFileSharedWriting);
+            InternalLogger.Trace("{0}: Opening {1} with allowFileSharedWriting={2}", CreateFileParameters, FileName, allowFileSharedWriting);
             for (int i = 0; i <= CreateFileParameters.FileOpenRetryCount; ++i)
             {
                 try
@@ -208,7 +208,7 @@ namespace NLog.Internal.FileAppenders
                     }
 
                     int actualDelay = _random.Next(currentDelay);
-                    InternalLogger.Warn("Attempt #{0} to open {1} failed. Sleeping for {2}ms", i, FileName, actualDelay);
+                    InternalLogger.Warn("{0}: Attempt #{1} to open {2} failed. Sleeping for {3}ms", CreateFileParameters, i, FileName, actualDelay);
                     currentDelay *= 2;
                     AsyncHelpers.WaitForDelay(TimeSpan.FromMilliseconds(actualDelay));
                 }
@@ -282,7 +282,7 @@ namespace NLog.Internal.FileAppenders
             }
             catch (SecurityException)
             {
-                InternalLogger.Debug("Could not use native Windows create file, falling back to managed filestream: {0}", FileName);
+                InternalLogger.Debug("{0}: Could not use native Windows create file, falling back to managed filestream: {1}", CreateFileParameters, FileName);
             }
 #endif
 
@@ -333,7 +333,7 @@ namespace NLog.Internal.FileAppenders
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "Failed to check if File.Exists {0}", fileName);
+                    InternalLogger.Error(ex, "FileTarget: Failed to check if File.Exists {0}", fileName);
                     return true;
                 }
             }

--- a/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseMutexFileAppender.cs
@@ -80,7 +80,7 @@ namespace NLog.Internal.FileAppenders
                 }
                 else
                 {
-                    InternalLogger.Debug("Mutex for file archive not supported");
+                    InternalLogger.Debug("{0}: Mutex for file archive not supported", CreateFileParameters);
                 }
             }
         }
@@ -103,11 +103,11 @@ namespace NLog.Internal.FileAppenders
             {
                 if (ex is SecurityException || ex is UnauthorizedAccessException || ex is NotSupportedException || ex is NotImplementedException || ex is PlatformNotSupportedException)
                 {
-                    InternalLogger.Warn(ex, "Failed to create global archive mutex: {0}", FileName);
+                    InternalLogger.Warn(ex, "{0}: Failed to create global archive mutex: {1}", CreateFileParameters, FileName);
                     return new Mutex();
                 }
 
-                InternalLogger.Error(ex, "Failed to create global archive mutex: {0}", FileName);
+                InternalLogger.Error(ex, "{0}: Failed to create global archive mutex: {1}", CreateFileParameters, FileName);
                 if (ex.MustBeRethrown())
                     throw;
                 return new Mutex();

--- a/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/CountingSingleProcessFileAppender.cs
@@ -74,7 +74,7 @@ namespace NLog.Internal.FileAppenders
         {
             if (_file != null)
             {
-                InternalLogger.Trace("Closing '{0}'", FileName);
+                InternalLogger.Trace("{0}: Closing '{1}'", CreateFileParameters, FileName);
 
                 try
                 {
@@ -83,7 +83,7 @@ namespace NLog.Internal.FileAppenders
                 catch (Exception ex)
                 {
                     // Swallow exception as the file-stream now is in final state (broken instead of closed)
-                    InternalLogger.Warn(ex, "Failed to close file: '{0}'", FileName);
+                    InternalLogger.Warn(ex, "{0}: Failed to close file: '{1}'", CreateFileParameters, FileName);
                     AsyncHelpers.WaitForDelay(TimeSpan.FromMilliseconds(1));    // Artificial delay to avoid hammering a bad file location
                 }
                 finally

--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -175,7 +175,7 @@ namespace NLog.Internal.FileAppenders
             if (_logFileWasArchived)
             {
                 _logFileWasArchived = false;
-                InternalLogger.Trace("FileAppender: Invalidate archived files");
+                InternalLogger.Trace("{0}: Invalidate archived files", CreateFileParameters);
                 CloseAppenders("Cleanup Archive");
             }
         }
@@ -276,7 +276,7 @@ namespace NLog.Internal.FileAppenders
             BaseFileAppender appenderToWrite;
             try
             {
-                InternalLogger.Debug("Creating file appender: {0}", fileName);
+                InternalLogger.Debug("{0}: Creating file appender: {1}", CreateFileParameters, fileName);
                 BaseFileAppender newAppender = Factory.Open(fileName, CreateFileParameters);
 
                 if (_appenders[freeSpot] != null)
@@ -312,7 +312,7 @@ namespace NLog.Internal.FileAppenders
             }
             catch (Exception ex)
             {
-                InternalLogger.Warn(ex, "Failed to create file appender: {0}", fileName);
+                InternalLogger.Warn(ex, "{0}: Failed to create file appender: {1}", CreateFileParameters, fileName);
                 throw;
             }
             return appenderToWrite;
@@ -401,7 +401,7 @@ namespace NLog.Internal.FileAppenders
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "Failed to flush file '{0}'.", appender.FileName);
+                    InternalLogger.Error(ex, "{0}: Failed to flush file '{1}'.", CreateFileParameters, appender.FileName);
                     InvalidateAppender(appender.FileName)?.Dispose();
                     throw;
                 }
@@ -445,7 +445,7 @@ namespace NLog.Internal.FileAppenders
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "Failed to get file creation time for file '{0}'.", appender.FileName);
+                    InternalLogger.Error(ex, "{0}: Failed to get file creation time for file '{1}'.", CreateFileParameters, appender.FileName);
                     InvalidateAppender(appender.FileName)?.Dispose();
                     throw;
                 }
@@ -493,13 +493,13 @@ namespace NLog.Internal.FileAppenders
                 }
                 catch (IOException ex)
                 {
-                    InternalLogger.Error(ex, "Failed to get length for file '{0}'.", appender.FileName);
+                    InternalLogger.Error(ex, "{0}: Failed to get length for file '{1}'.", CreateFileParameters, appender.FileName);
                     InvalidateAppender(appender.FileName)?.Dispose();
                     // Do not rethrow as failed archive-file-size check should not drop logevents
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "Failed to get length for file '{0}'.", appender.FileName);
+                    InternalLogger.Error(ex, "{0}: Failed to get length for file '{1}'.", CreateFileParameters, appender.FileName);
                     InvalidateAppender(appender.FileName)?.Dispose();
                     throw;
                 }
@@ -545,7 +545,7 @@ namespace NLog.Internal.FileAppenders
 
         private void CloseAppender(BaseFileAppender appender, string reason, bool lastAppender)
         {
-            InternalLogger.Debug("FileAppender Closing {0} - {1}", reason, appender.FileName);
+            InternalLogger.Debug("{0}: FileAppender Closing {1} - {2}", CreateFileParameters, reason, appender.FileName);
 
             if (lastAppender)
             {

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -140,7 +140,7 @@ namespace NLog.Internal.FileAppenders
                 return;
             }
 
-            InternalLogger.Trace("Closing '{0}'", FileName);
+            InternalLogger.Trace("{0}: Closing '{1}'", CreateFileParameters, FileName);
             try
             {
                 _mutex?.Close();
@@ -148,7 +148,7 @@ namespace NLog.Internal.FileAppenders
             catch (Exception ex)
             {
                 // Swallow exception as the mutex now is in final state (abandoned instead of closed)
-                InternalLogger.Warn(ex, "Failed to close mutex: '{0}'", FileName);
+                InternalLogger.Warn(ex, "{0}: Failed to close mutex: '{1}'", CreateFileParameters, FileName);
             }
             finally
             {
@@ -162,7 +162,7 @@ namespace NLog.Internal.FileAppenders
             catch (Exception ex)
             {
                 // Swallow exception as the file-stream now is in final state (broken instead of closed)
-                InternalLogger.Warn(ex, "Failed to close file: '{0}'", FileName);
+                InternalLogger.Warn(ex, "{0}: Failed to close file: '{1}'", CreateFileParameters, FileName);
                 AsyncHelpers.WaitForDelay(TimeSpan.FromMilliseconds(1));    // Artificial delay to avoid hammering a bad file location
             }
             finally

--- a/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/WindowsMultiProcessFileAppender.cs
@@ -172,14 +172,14 @@ namespace NLog.Internal.FileAppenders
                 return;
             }
 
-            InternalLogger.Trace("Closing '{0}'", FileName);
+            InternalLogger.Trace("{0}: Closing '{1}'", CreateFileParameters, FileName);
             try
             {
                 _fileStream?.Dispose();
             }
             catch (Exception ex)
             {
-                InternalLogger.Warn(ex, "Failed to close file '{0}'", FileName);
+                InternalLogger.Warn(ex, "{0}: Failed to close file '{1}'", CreateFileParameters, FileName);
                 Thread.Sleep(1);   // Artificial delay to avoid hammering a bad file location
             }
             finally

--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -229,7 +229,7 @@ namespace NLog.Targets
                 _pauseLogging = !ConsoleTargetHelper.IsConsoleAvailable(out reason);
                 if (_pauseLogging)
                 {
-                    InternalLogger.Info("ColoredConsole(Name={0}): Console detected as turned off. Disable DetectConsoleAvailable to skip detection. Reason: {1}", Name, reason);
+                    InternalLogger.Info("{0}: Console detected as turned off. Disable DetectConsoleAvailable to skip detection. Reason: {1}", this, reason);
                 }
             }
 
@@ -244,7 +244,7 @@ namespace NLog.Targets
                     _disableColors = ErrorStream ? Console.IsErrorRedirected : Console.IsOutputRedirected;
                     if (_disableColors)
                     {
-                        InternalLogger.Info("ColoredConsole(Name={0}): Console output is redirected so no colors. Disable DetectOutputRedirected to skip detection.", Name);
+                        InternalLogger.Info("{0}: Console output is redirected so no colors. Disable DetectOutputRedirected to skip detection.", this);
                         if (!AutoFlush && GetOutput() is StreamWriter streamWriter && !streamWriter.AutoFlush)
                         {
                             AutoFlush = true;
@@ -253,7 +253,7 @@ namespace NLog.Targets
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "ColoredConsole(Name={0}): Failed checking if Console Output Redirected.", Name);
+                    InternalLogger.Error(ex, "{0}: Failed checking if Console Output Redirected.", this);
                 }
             }
 #endif
@@ -340,8 +340,8 @@ namespace NLog.Targets
             {
                 // This is a bug and will therefore stop the logging. For docs, see the PauseLogging property.
                 _pauseLogging = true;
-                InternalLogger.Warn(ex, "ColoredConsole(Name={0}): {1} has been thrown and this is probably due to a race condition." +
-                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets", Name, ex.GetType());
+                InternalLogger.Warn(ex, "{0}: {1} has been thrown and this is probably due to a race condition." +
+                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets", this, ex.GetType());
             }
         }
 

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -169,7 +169,7 @@ namespace NLog.Targets
                 _pauseLogging = !ConsoleTargetHelper.IsConsoleAvailable(out reason);
                 if (_pauseLogging)
                 {
-                    InternalLogger.Info("Console(Name={0}): Console has been detected as turned off. Disable DetectConsoleAvailable to skip detection. Reason: {1}", Name, reason);
+                    InternalLogger.Info("{0}: Console has been detected as turned off. Disable DetectConsoleAvailable to skip detection. Reason: {1}", this, reason);
                 }
             }
 
@@ -350,8 +350,8 @@ namespace NLog.Targets
             {
                 //this is a bug and therefor stopping logging. For docs, see PauseLogging property
                 _pauseLogging = true;
-                InternalLogger.Warn(ex, "Console(Name={0}): {1} has been thrown and this is probably due to a race condition." +
-                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets", Name, ex.GetType());
+                InternalLogger.Warn(ex, "{0}: {1} has been thrown and this is probably due to a race condition." +
+                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets", this, ex.GetType());
             }
         }
 
@@ -365,8 +365,8 @@ namespace NLog.Targets
             {
                 //this is a bug and therefor stopping logging. For docs, see PauseLogging property
                 _pauseLogging = true;
-                InternalLogger.Warn(ex, "Console(Name={0}): {1} has been thrown and this is probably due to a race condition." +
-                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets", Name, ex.GetType());
+                InternalLogger.Warn(ex, "{0}: {1} has been thrown and this is probably due to a race condition." +
+                                        "Logging to the console will be paused. Enable by reloading the config or re-initialize the targets", this, ex.GetType());
             }
         }
 

--- a/src/NLog/Targets/DatabaseTarget.cs
+++ b/src/NLog/Targets/DatabaseTarget.cs
@@ -366,12 +366,12 @@ namespace NLog.Targets
                     var propertyValue = GetDatabaseObjectPropertyValue(logEventInfo, propertyInfo);
                     if (!propertyInfo.SetPropertyValue(databaseObject, propertyValue))
                     {
-                        InternalLogger.Warn("DatabaseTarget(Name={0}): Failed to lookup property {1} on {2}", Name, propertyInfo.Name, databaseObject.GetType());
+                        InternalLogger.Warn("{0}: Failed to lookup property {1} on {2}", this, propertyInfo.Name, databaseObject.GetType());
                     }
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "DatabaseTarget(Name={0}): Failed to assign value for property {1} on {2}", Name, propertyInfo.Name, databaseObject.GetType());
+                    InternalLogger.Error(ex, "{0}: Failed to assign value for property {1} on {2}", this, propertyInfo.Name, databaseObject.GetType());
                     if (ExceptionMustBeRethrown(ex))
                         throw;
                 }
@@ -432,12 +432,12 @@ namespace NLog.Targets
                     SetConnectionType();
                     if (ConnectionType == null)
                     {
-                        InternalLogger.Warn("DatabaseTarget(Name={0}): No ConnectionType created from DBProvider={1}", Name, DBProvider);
+                        InternalLogger.Warn("{0}: No ConnectionType created from DBProvider={1}", this, DBProvider);
                     }
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "DatabaseTarget(Name={0}): Failed to create ConnectionType from DBProvider={1}", Name, DBProvider);
+                    InternalLogger.Error(ex, "{0}: Failed to create ConnectionType from DBProvider={1}", this, DBProvider);
                     throw;
                 }
             }
@@ -466,10 +466,10 @@ namespace NLog.Targets
             {
 #if !NETSTANDARD
                 if (!string.IsNullOrEmpty(ConnectionStringName))
-                    InternalLogger.Warn(ex, "DatabaseTarget(Name={0}): DbConnectionStringBuilder failed to parse '{1}' ConnectionString", Name, ConnectionStringName);
+                    InternalLogger.Warn(ex, "{0}: DbConnectionStringBuilder failed to parse '{1}' ConnectionString", this, ConnectionStringName);
                 else
 #endif
-                    InternalLogger.Warn(ex, "DatabaseTarget(Name={0}): DbConnectionStringBuilder failed to parse ConnectionString", Name);
+                    InternalLogger.Warn(ex, "{0}: DbConnectionStringBuilder failed to parse ConnectionString", this);
             }
 
             return providerName;
@@ -486,7 +486,7 @@ namespace NLog.Targets
             }
             catch (Exception ex)
             {
-                InternalLogger.Error(ex, "DatabaseTarget(Name={0}): DbProviderFactories failed to get factory from ProviderName={1}", Name, providerName);
+                InternalLogger.Error(ex, "{0}: DbProviderFactories failed to get factory from ProviderName={1}", this, providerName);
                 throw;
             }
 
@@ -533,7 +533,7 @@ namespace NLog.Targets
                         }
                         catch (Exception ex)
                         {
-                            InternalLogger.Warn(ex, "DatabaseTarget(Name={0}): Failed to load assembly 'Microsoft.Data.SqlClient'. Falling back to 'System.Data.SqlClient'.", Name);
+                            InternalLogger.Warn(ex, "{0}: Failed to load assembly 'Microsoft.Data.SqlClient'. Falling back to 'System.Data.SqlClient'.", this);
                             var assembly = Assembly.Load(new AssemblyName("System.Data.SqlClient"));
                             ConnectionType = assembly.GetType("System.Data.SqlClient.SqlConnection", true, true);
                         }
@@ -591,7 +591,7 @@ namespace NLog.Targets
         {
             PropertyTypeConverter = null;
             base.CloseTarget();
-            InternalLogger.Trace("DatabaseTarget(Name={0}): Close connection because of CloseTarget", Name);
+            InternalLogger.Trace("{0}: Close connection because of CloseTarget", this);
             CloseConnection();
         }
 
@@ -611,7 +611,7 @@ namespace NLog.Targets
             {
                 if (!KeepConnection)
                 {
-                    InternalLogger.Trace("DatabaseTarget(Name={0}): Close connection (KeepConnection = false).", Name);
+                    InternalLogger.Trace("{0}: Close connection (KeepConnection = false).", this);
                     CloseConnection();
                 }
             }
@@ -640,7 +640,7 @@ namespace NLog.Targets
                 {
                     if (!KeepConnection)
                     {
-                        InternalLogger.Trace("DatabaseTarget(Name={0}): Close connection because of KeepConnection=false", Name);
+                        InternalLogger.Trace("{0}: Close connection because of KeepConnection=false", this);
                         CloseConnection();
                     }
                 }
@@ -664,17 +664,12 @@ namespace NLog.Targets
                     }
                     catch (Exception exception)
                     {
-                        if (exception.MustBeRethrownImmediately())
+                        if (ExceptionMustBeRethrown(exception))
                         {
                             throw;
                         }
 
                         logEvents[i].Continuation(exception);
-
-                        if (ExceptionMustBeRethrown(exception))
-                        {
-                            throw;
-                        }
                     }
                 }
             }
@@ -720,7 +715,7 @@ namespace NLog.Targets
                         }
                         catch (Exception exception)
                         {
-                            InternalLogger.Error(exception, "DatabaseTarget(Name={0}): Error during rollback of batch writing {1} logevents to database.", Name, logEvents.Count);
+                            InternalLogger.Error(exception, "{0}: Error during rollback of batch writing {1} logevents to database.", this, logEvents.Count);
                             if (exception.MustBeRethrownImmediately())
                             {
                                 throw;
@@ -733,8 +728,8 @@ namespace NLog.Targets
             }
             catch (Exception exception)
             {
-                InternalLogger.Error(exception, "DatabaseTarget(Name={0}): Error when batch writing {1} logevents to database.", Name, logEvents.Count);
-                if (exception.MustBeRethrownImmediately())
+                InternalLogger.Error(exception, "{0}: Error when batch writing {1} logevents to database.", this, logEvents.Count);
+                if (ExceptionMustBeRethrown(exception))
                 {
                     throw;
                 }
@@ -744,12 +739,8 @@ namespace NLog.Targets
                     logEvents[i].Continuation(exception);
                 }
 
-                InternalLogger.Trace("DatabaseTarget(Name={0}): Close connection because of error", Name);
+                InternalLogger.Trace("{0}: Close connection because of error", this);
                 CloseConnection();
-                if (ExceptionMustBeRethrown(exception))
-                {
-                    throw;
-                }
             }
         }
 
@@ -769,14 +760,14 @@ namespace NLog.Targets
             }
             catch (Exception exception)
             {
-                InternalLogger.Error(exception, "DatabaseTarget(Name={0}): Error when writing to database.", Name);
+                InternalLogger.Error(exception, "{0}: Error when writing to database.", this);
 
                 if (exception.MustBeRethrownImmediately())
                 {
                     throw;
                 }
 
-                InternalLogger.Trace("DatabaseTarget(Name={0}): Close connection because of error", Name);
+                InternalLogger.Trace("{0}: Close connection because of error", this);
                 CloseConnection();
                 throw;
             }
@@ -793,14 +784,14 @@ namespace NLog.Targets
                     command.Transaction = dbTransaction;
 
                 int result = command.ExecuteNonQuery();
-                InternalLogger.Trace("DatabaseTarget(Name={0}): Finished execution, result = {1}", Name, result);
+                InternalLogger.Trace("{0}: Finished execution, result = {1}", this, result);
             }
         }
 
         internal IDbCommand CreateDbCommand(LogEventInfo logEvent, IDbConnection dbConnection)
         {
             var commandText = RenderLogEvent(CommandText, logEvent);
-            InternalLogger.Trace("DatabaseTarget(Name={0}): Executing {1}: {2}", Name, CommandType, commandText);
+            InternalLogger.Trace("{0}: Executing {1}: {2}", this, CommandType, commandText);
             return CreateDbCommandWithParameters(logEvent, dbConnection, CommandType, commandText, Parameters);
         }
 
@@ -918,7 +909,7 @@ namespace NLog.Targets
         {
             if (_activeConnection != null && _activeConnectionString != connectionString)
             {
-                InternalLogger.Trace("DatabaseTarget(Name={0}): Close connection because of opening new.", Name);
+                InternalLogger.Trace("{0}: Close connection because of opening new.", this);
                 CloseConnection();
             }
 
@@ -927,7 +918,7 @@ namespace NLog.Targets
                 return;
             }
 
-            InternalLogger.Trace("DatabaseTarget(Name={0}): Open connection.", Name);
+            InternalLogger.Trace("{0}: Open connection.", this);
             _activeConnection = OpenConnection(connectionString, logEventInfo);
             _activeConnectionString = connectionString;
         }
@@ -996,7 +987,7 @@ namespace NLog.Targets
             }
             finally
             {
-                InternalLogger.Trace("DatabaseTarget(Name={0}): Close connection after install.", Name);
+                InternalLogger.Trace("{0}: Close connection after install.", this);
 
                 CloseConnection();
             }

--- a/src/NLog/Targets/DebuggerTarget.cs
+++ b/src/NLog/Targets/DebuggerTarget.cs
@@ -89,7 +89,7 @@ namespace NLog.Targets
             base.InitializeTarget();
             if (!Debugger.IsLogging())
             {
-                InternalLogger.Debug("Debugger(Name={0}): System.Diagnostics.Debugger.IsLogging()==false. Output has been disabled.", Name);
+                InternalLogger.Debug("{0}: System.Diagnostics.Debugger.IsLogging()==false. Output has been disabled.", this);
             }
 
             if (Header != null)

--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -223,7 +223,7 @@ namespace NLog.Targets
 
             if (string.IsNullOrEmpty(fixedSource))
             {
-                InternalLogger.Debug("EventLogTarget(Name={0}): Skipping removing of event source because it contains layout renderers", Name);
+                InternalLogger.Debug("{0}: Skipping removing of event source because it contains layout renderers", this);
             }
             else
             {
@@ -246,7 +246,7 @@ namespace NLog.Targets
             {
                 return _eventLogWrapper.SourceExists(fixedSource, MachineName);
             }
-            InternalLogger.Debug("EventLogTarget(Name={0}): Unclear if event source exists because it contains layout renderers", Name);
+            InternalLogger.Debug("{0}: Unclear if event source exists because it contains layout renderers", this);
             return null; //unclear!
         }
 
@@ -274,20 +274,20 @@ namespace NLog.Targets
             string renderEventId = RenderLogEvent(EventId, logEvent);
             if (!string.IsNullOrEmpty(renderEventId) && !int.TryParse(renderEventId, out eventId))
             {
-                InternalLogger.Warn("EventLogTarget(Name={0}): WriteEntry failed to parse EventId={1}", Name, renderEventId);
+                InternalLogger.Warn("{0}: WriteEntry failed to parse EventId={1}", this, renderEventId);
             }
 
             short category = 0;
             string renderCategory = RenderLogEvent(Category, logEvent);
             if (!string.IsNullOrEmpty(renderCategory) && !short.TryParse(renderCategory, out category))
             {
-                InternalLogger.Warn("EventLogTarget(Name={0}): WriteEntry failed to parse Category={1}", Name, renderCategory);
+                InternalLogger.Warn("{0}: WriteEntry failed to parse Category={1}", this, renderCategory);
             }
 
             var eventLogSource = RenderLogEvent(Source, logEvent);
             if (string.IsNullOrEmpty(eventLogSource))
             {
-                InternalLogger.Warn("EventLogTarget(Name={0}): WriteEntry discarded because Source rendered as empty string", Name);
+                InternalLogger.Warn("{0}: WriteEntry discarded because Source rendered as empty string", this);
                 return;
             }
 
@@ -310,7 +310,7 @@ namespace NLog.Targets
                 else if (OnOverflow == EventLogTargetOverflowAction.Discard)
                 {
                     // message should not be written
-                    InternalLogger.Debug("EventLogTarget(Name={0}): WriteEntry discarded because too big message size: {1}", Name, message.Length);
+                    InternalLogger.Debug("{0}: WriteEntry discarded because too big message size: {1}", this, message.Length);
                 }
             }
             else
@@ -328,21 +328,21 @@ namespace NLog.Targets
 
             if (!isCacheUpToDate)
             {
-                InternalLogger.Debug("EventLogTarget(Name={0}): Refresh EventLog Source {1} and Log {2}", Name, eventLogSource, Log);
+                InternalLogger.Debug("{0}: Refresh EventLog Source {1} and Log {2}", this, eventLogSource, Log);
 
                 _eventLogWrapper.AssociateNewEventLog(Log, MachineName, eventLogSource);
                 try
                 {
                     if (!_eventLogWrapper.SourceExists(eventLogSource, MachineName))
                     {
-                        InternalLogger.Warn("EventLogTarget(Name={0}): Source {1} does not exist", Name, eventLogSource);
+                        InternalLogger.Warn("{0}: Source {1} does not exist", this, eventLogSource);
                     }
                     else
                     {
                         var currentLogName = _eventLogWrapper.LogNameFromSourceName(eventLogSource, MachineName);
                         if (!currentLogName.Equals(Log, StringComparison.CurrentCultureIgnoreCase))
                         {
-                            InternalLogger.Debug("EventLogTarget(Name={0}): Source {1} should be mapped to Log {2}, but EventLog.LogNameFromSourceName returns {3}", Name, eventLogSource, Log, currentLogName);
+                            InternalLogger.Debug("{0}: Source {1} should be mapped to Log {2}, but EventLog.LogNameFromSourceName returns {3}", this, eventLogSource, Log, currentLogName);
                         }
                     }
                 }
@@ -351,7 +351,7 @@ namespace NLog.Targets
                     if (LogManager.ThrowExceptions)
                         throw;
 
-                    InternalLogger.Warn(ex, "EventLogTarget(Name={0}): Exception thrown when checking if Source {1} and LogName {2} are valid", Name, eventLogSource, Log);
+                    InternalLogger.Warn(ex, "{0}: Exception thrown when checking if Source {1} and LogName {2} are valid", this, eventLogSource, Log);
                 }
             }
 
@@ -373,7 +373,7 @@ namespace NLog.Targets
                     return eventLogEntryType;
                 }
 
-                InternalLogger.Warn("EventLogTarget(Name={0}): WriteEntry failed to parse EntryType={1}", Name, renderEntryType);
+                InternalLogger.Warn("{0}: WriteEntry failed to parse EntryType={1}", this, renderEntryType);
             }
 
             // determine auto
@@ -412,7 +412,7 @@ namespace NLog.Targets
         {
             if (string.IsNullOrEmpty(fixedSource))
             {
-                InternalLogger.Debug("EventLogTarget(Name={0}): Skipping creation of event source because it contains layout renderers", Name);
+                InternalLogger.Debug("{0}: Skipping creation of event source because it contains layout renderers", this);
                 // we can only create event sources if the source is fixed (no layout)
                 return;
             }
@@ -425,7 +425,7 @@ namespace NLog.Targets
                     string currentLogName = _eventLogWrapper.LogNameFromSourceName(fixedSource, MachineName);
                     if (!currentLogName.Equals(Log, StringComparison.CurrentCultureIgnoreCase))
                     {
-                        InternalLogger.Debug("EventLogTarget(Name={0}): Updating source {1} to use log {2}, instead of {3} (Computer restart is needed)", Name, fixedSource, Log, currentLogName);
+                        InternalLogger.Debug("{0}: Updating source {1} to use log {2}, instead of {3} (Computer restart is needed)", this, fixedSource, Log, currentLogName);
 
                         // re-create the association between Log and Source
                         _eventLogWrapper.DeleteEventSource(fixedSource, MachineName);
@@ -439,7 +439,7 @@ namespace NLog.Targets
                 }
                 else
                 {
-                    InternalLogger.Debug("EventLogTarget(Name={0}): Creating source {1} to use log {2}", Name, fixedSource, Log);
+                    InternalLogger.Debug("{0}: Creating source {1} to use log {2}", this, fixedSource, Log);
                     var eventSourceCreationData = new EventSourceCreationData(fixedSource, Log)
                     {
                         MachineName = MachineName
@@ -456,7 +456,7 @@ namespace NLog.Targets
             }
             catch (Exception exception)
             {
-                InternalLogger.Error(exception, "EventLogTarget(Name={0}): Error when connecting to EventLog. Source={1} in Log={2}", Name, fixedSource, Log);
+                InternalLogger.Error(exception, "{0}: Error when connecting to EventLog. Source={1} in Log={2}", this, fixedSource, Log);
                 if (alwaysThrowError || LogManager.ThrowExceptions)
                 {
                     throw;

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -804,7 +804,7 @@ namespace NLog.Targets
         {
             if (InternalLogger.IsTraceEnabled)
             {
-                InternalLogger.Trace("FileTarget(Name={0}): Cleanup Initialized Files with cleanupThreshold {1}", Name, cleanupThreshold);
+                InternalLogger.Trace("{0}: Cleanup Initialized Files with cleanupThreshold {1}", this, cleanupThreshold);
             }
 
             List<string> filesToFinalize = null;
@@ -831,7 +831,7 @@ namespace NLog.Targets
                 }
             }
 
-            InternalLogger.Trace("FileTarget(Name={0}): CleanupInitializedFiles Done", Name);
+            InternalLogger.Trace("{0}: CleanupInitializedFiles Done", this);
         }
 
         /// <summary>
@@ -846,14 +846,13 @@ namespace NLog.Targets
         {
             try
             {
-                InternalLogger.Trace("FileTarget(Name={0}): FlushAsync", Name);
+                InternalLogger.Trace("{0}: FlushAsync", this);
                 _fileAppenderCache.FlushAppenders();
                 asyncContinuation(null);
-                InternalLogger.Trace("FileTarget(Name={0}): FlushAsync Done", Name);
+                InternalLogger.Trace("{0}: FlushAsync Done", this);
             }
             catch (Exception exception)
             {
-                InternalLogger.Warn(exception, "FileTarget(Name={0}): Exception in FlushAsync", Name);
                 if (ExceptionMustBeRethrown(exception))
                 {
                     throw;
@@ -937,7 +936,7 @@ namespace NLog.Targets
             var appenderFactory = GetFileAppenderFactory();
             if (InternalLogger.IsTraceEnabled)
             {
-                InternalLogger.Trace("FileTarget(Name={0}): Using appenderFactory: {1}", Name, appenderFactory.GetType());
+                InternalLogger.Trace("{0}: Using appenderFactory: {1}", this, appenderFactory.GetType());
             }
 
             _fileAppenderCache = new FileAppenderCache(OpenFileCacheSize, appenderFactory, this);
@@ -945,7 +944,7 @@ namespace NLog.Targets
             if ((OpenFileCacheSize > 0 || EnableFileDelete) && (OpenFileCacheTimeout > 0 || OpenFileFlushTimeout > 0))
             {
                 int openFileAutoTimeoutSecs = (OpenFileCacheTimeout > 0 && OpenFileFlushTimeout > 0) ? Math.Min(OpenFileCacheTimeout, OpenFileFlushTimeout) : Math.Max(OpenFileCacheTimeout, OpenFileFlushTimeout);
-                InternalLogger.Trace("FileTarget(Name={0}): Start autoClosingTimer", Name);
+                InternalLogger.Trace("{0}: Start autoClosingTimer", this);
                 _autoClosingTimer = new Timer(
                     (state) => AutoClosingTimerCallback(this, EventArgs.Empty),
                     null,
@@ -971,7 +970,7 @@ namespace NLog.Targets
             var currentTimer = _autoClosingTimer;
             if (currentTimer != null)
             {
-                InternalLogger.Trace("FileTarget(Name={0}): Stop autoClosingTimer", Name);
+                InternalLogger.Trace("{0}: Stop autoClosingTimer", this);
                 _autoClosingTimer = null;
                 currentTimer.WaitForDispose(TimeSpan.Zero);
             }
@@ -1069,7 +1068,7 @@ namespace NLog.Targets
                     string fileName = bucket.Key;
                     if (string.IsNullOrEmpty(fileName))
                     {
-                        InternalLogger.Warn("FileTarget(Name={0}): FileName Layout returned empty string. The path is not of a legal form.", Name);
+                        InternalLogger.Warn("{0}: FileName Layout returned empty string. The path is not of a legal form.", this);
                         var emptyPathException = new ArgumentException("The path is not of a legal form.");
                         for (int i = 0; i < bucketCount; ++i)
                         {
@@ -1262,17 +1261,17 @@ namespace NLog.Targets
 
             if (string.Equals(fileName, archiveFileName, StringComparison.OrdinalIgnoreCase))
             {
-                InternalLogger.Info("FileTarget(Name={0}): Archiving {1} skipped as ArchiveFileName equals FileName", Name, fileName);
+                InternalLogger.Info("{0}: Archiving {1} skipped as ArchiveFileName equals FileName", this, fileName);
             }
             else if (EnableArchiveFileCompression)
             {
-                InternalLogger.Info("FileTarget(Name={0}): Archiving {1} to compressed {2}", Name, fileName, archiveFileName);
+                InternalLogger.Info("{0}: Archiving {1} to compressed {2}", this, fileName, archiveFileName);
                 FileCompressor.CompressFile(fileName, archiveFileName);
                 DeleteAndWaitForFileDelete(fileName);
             }
             else
             {
-                InternalLogger.Info("FileTarget(Name={0}): Archiving {1} to {2}", Name, fileName, archiveFileName);
+                InternalLogger.Info("{0}: Archiving {1} to {2}", this, fileName, archiveFileName);
                 if (File.Exists(archiveFileName))
                 {
                     ArchiveFileAppendExisting(fileName, archiveFileName);
@@ -1287,7 +1286,7 @@ namespace NLog.Targets
         private void ArchiveFileAppendExisting(string fileName, string archiveFileName)
         {
             //todo handle double footer
-            InternalLogger.Info("FileTarget(Name={0}): Already exists, append to {1}", Name, archiveFileName);
+            InternalLogger.Info("{0}: Already exists, append to {1}", this, archiveFileName);
 
             //copy to archive file.
             var fileShare = FileShare.ReadWrite;
@@ -1327,7 +1326,7 @@ namespace NLog.Targets
         {
             try
             {
-                InternalLogger.Debug("FileTarget(Name={0}): Move file from '{1}' to '{2}'", Name, fileName, archiveFileName);
+                InternalLogger.Debug("{0}: Move file from '{1}' to '{2}'", this, fileName, archiveFileName);
                 File.Move(fileName, archiveFileName);
             }
             catch (IOException ex)
@@ -1344,7 +1343,7 @@ namespace NLog.Targets
                 // It is possible to move a file while other processes has open file-handles.
                 // Unless the other process is actively writing, then the file move might fail.
                 // We are already holding the archive-mutex, so lets retry if things are stable
-                InternalLogger.Warn(ex, "FileTarget(Name={0}): Archiving failed. Checking for retry move of {1} to {2}.", Name, fileName, archiveFileName);
+                InternalLogger.Warn(ex, "{0}: Archiving failed. Checking for retry move of {1} to {2}.", this, fileName, archiveFileName);
                 if (!File.Exists(fileName) || File.Exists(archiveFileName))
                     throw;
 
@@ -1353,7 +1352,7 @@ namespace NLog.Targets
                 if (!File.Exists(fileName) || File.Exists(archiveFileName))
                     throw;
 
-                InternalLogger.Debug("FileTarget(Name={0}): Archiving retrying move of {1} to {2}.", Name, fileName, archiveFileName);
+                InternalLogger.Debug("{0}: Archiving retrying move of {1} to {2}.", this, fileName, archiveFileName);
                 File.Move(fileName, archiveFileName);
             }
         }
@@ -1362,19 +1361,19 @@ namespace NLog.Targets
         {
             try
             {
-                InternalLogger.Info("FileTarget(Name={0}): Deleting old archive file: '{1}'.", Name, fileName);
+                InternalLogger.Info("{0}: Deleting old archive file: '{1}'.", this, fileName);
                 File.Delete(fileName);
                 return true;
             }
             catch (DirectoryNotFoundException exception)
             {
                 //never rethrow this, as this isn't an exceptional case.
-                InternalLogger.Debug(exception, "FileTarget(Name={0}): Failed to delete old log file '{1}' as directory is missing.", Name, fileName);
+                InternalLogger.Debug(exception, "{0}: Failed to delete old log file '{1}' as directory is missing.", this, fileName);
                 return false;
             }
             catch (Exception exception)
             {
-                InternalLogger.Warn(exception, "FileTarget(Name={0}): Failed to delete old archive file: '{1}'.", Name, fileName);
+                InternalLogger.Warn(exception, "{0}: Failed to delete old archive file: '{1}'.", this, fileName);
                 if (ExceptionMustBeRethrown(exception))
                 {
                     throw;
@@ -1388,7 +1387,7 @@ namespace NLog.Targets
         {
             try
             {
-                InternalLogger.Trace("FileTarget(Name={0}): Waiting for file delete of '{1}' for 12 sec", Name, fileName);
+                InternalLogger.Trace("{0}: Waiting for file delete of '{1}' for 12 sec", this, fileName);
                 var originalFileCreationTime = (new FileInfo(fileName)).CreationTime;
                 if (DeleteOldArchiveFile(fileName) && File.Exists(fileName))
                 {
@@ -1401,12 +1400,12 @@ namespace NLog.Targets
                             return;
                     }
 
-                    InternalLogger.Warn("FileTarget(Name={0}): Timeout while deleting old archive file: '{1}'.", Name, fileName);
+                    InternalLogger.Warn("{0}: Timeout while deleting old archive file: '{1}'.", this, fileName);
                 }
             }
             catch (Exception exception)
             {
-                InternalLogger.Warn(exception, "FileTarget(Name={0}): Failed to delete old archive file: '{1}'.", Name, fileName);
+                InternalLogger.Warn(exception, "{0}: Failed to delete old archive file: '{1}'.", this, fileName);
                 if (ExceptionMustBeRethrown(exception))
                 {
                     throw;
@@ -1450,12 +1449,12 @@ namespace NLog.Targets
             // Using File LastModified to handle FileArchivePeriod.Month (where file creation time is one month ago)
             var fileLastModifiedUtc = _fileAppenderCache.GetFileLastWriteTimeUtc(fileName);
 
-            InternalLogger.Trace("FileTarget(Name={0}): Calculating archive date. File-LastModifiedUtc: {1}; Previous LogEvent-TimeStamp: {2}", Name, fileLastModifiedUtc, previousLogEventTimestamp);
+            InternalLogger.Trace("{0}: Calculating archive date. File-LastModifiedUtc: {1}; Previous LogEvent-TimeStamp: {2}", this, fileLastModifiedUtc, previousLogEventTimestamp);
             if (!fileLastModifiedUtc.HasValue)
             {
                 if (previousLogEventTimestamp == DateTime.MinValue)
                 {
-                    InternalLogger.Info("FileTarget(Name={0}): Unable to acquire useful timestamp to archive file: {1}", Name, fileName);
+                    InternalLogger.Info("{0}: Unable to acquire useful timestamp to archive file: {1}", this, fileName);
                     return null;
                 }
                 return previousLogEventTimestamp;
@@ -1466,24 +1465,24 @@ namespace NLog.Targets
             {
                 if (previousLogEventTimestamp > lastWriteTimeSource)
                 {
-                    InternalLogger.Trace("FileTarget(Name={0}): Using previous LogEvent-TimeStamp {1}, because more recent than File-LastModified {2}", Name, previousLogEventTimestamp, lastWriteTimeSource);
+                    InternalLogger.Trace("{0}: Using previous LogEvent-TimeStamp {1}, because more recent than File-LastModified {2}", this, previousLogEventTimestamp, lastWriteTimeSource);
                     return previousLogEventTimestamp;
                 }
 
                 if (PreviousLogOverlappedPeriod(logEvent, previousLogEventTimestamp, lastWriteTimeSource))
                 {
-                    InternalLogger.Trace("FileTarget(Name={0}): Using previous LogEvent-TimeStamp {1}, because archive period is overlapping with File-LastModified {2}", Name, previousLogEventTimestamp, lastWriteTimeSource);
+                    InternalLogger.Trace("{0}: Using previous LogEvent-TimeStamp {1}, because archive period is overlapping with File-LastModified {2}", this, previousLogEventTimestamp, lastWriteTimeSource);
                     return previousLogEventTimestamp;
                 }
 
                 if (!AutoFlush && IsSimpleKeepFileOpen && previousLogEventTimestamp < lastWriteTimeSource)
                 {
-                    InternalLogger.Trace("FileTarget(Name={0}): Using previous LogEvent-TimeStamp {1}, because AutoFlush=false affects File-LastModified {2}", Name, previousLogEventTimestamp, lastWriteTimeSource);
+                    InternalLogger.Trace("{0}: Using previous LogEvent-TimeStamp {1}, because AutoFlush=false affects File-LastModified {2}", this, previousLogEventTimestamp, lastWriteTimeSource);
                     return previousLogEventTimestamp;
                 }
             }
 
-            InternalLogger.Trace("FileTarget(Name={0}): Using last write time: {1}", Name, lastWriteTimeSource);
+            InternalLogger.Trace("{0}: Using last write time: {1}", this, lastWriteTimeSource);
             return lastWriteTimeSource;
         }
 
@@ -1564,7 +1563,7 @@ namespace NLog.Targets
         /// <param name="initializedNewFile">File has just been opened.</param>
         private void DoAutoArchive(string fileName, LogEventInfo eventInfo, DateTime previousLogEventTimestamp, bool initializedNewFile)
         {
-            InternalLogger.Debug("FileTarget(Name={0}): Do archive file: '{1}'", Name, fileName);
+            InternalLogger.Debug("{0}: Do archive file: '{1}'", this, fileName);
             var fileInfo = new FileInfo(fileName);
             if (!fileInfo.Exists)
             {
@@ -1576,7 +1575,7 @@ namespace NLog.Targets
             string archiveFilePattern = GetArchiveFileNamePattern(fileName, eventInfo);
             if (string.IsNullOrEmpty(archiveFilePattern))
             {
-                InternalLogger.Warn("FileTarget(Name={0}): Skip auto archive because archiveFilePattern is NULL", Name);
+                InternalLogger.Warn("{0}: Skip auto archive because archiveFilePattern is blank", this);
                 return;
             }
 
@@ -1591,14 +1590,14 @@ namespace NLog.Targets
 
         private string GenerateArchiveFileNameAfterCleanup(string fileName, FileInfo fileInfo, string archiveFilePattern, DateTime? archiveDate, bool initializedNewFile)
         {
-            InternalLogger.Trace("FileTarget(Name={0}): Archive pattern '{1}'", Name, archiveFilePattern);
+            InternalLogger.Trace("{0}: Archive pattern '{1}'", this, archiveFilePattern);
 
             var fileArchiveStyle = GetFileArchiveHelper(archiveFilePattern);
             var existingArchiveFiles = fileArchiveStyle.GetExistingArchiveFiles(archiveFilePattern);
 
             if (MaxArchiveFiles == 1)
             {
-                InternalLogger.Trace("FileTarget(Name={0}): MaxArchiveFiles = 1", Name);
+                InternalLogger.Trace("{0}: MaxArchiveFiles = 1", this);
                 // Perform archive cleanup before generating the next filename,
                 // as next archive-filename can be affected by existing files.
                 for (int i = existingArchiveFiles.Count - 1; i >= 0; i--)
@@ -1712,7 +1711,7 @@ namespace NLog.Targets
             }
             catch (Exception exception)
             {
-                InternalLogger.Warn(exception, "FileTarget(Name={0}): Failed to check archive for file '{1}'.", Name, fileName);
+                InternalLogger.Warn(exception, "{0}: Failed to check archive for file '{1}'.", this, fileName);
                 if (ExceptionMustBeRethrown(exception))
                 {
                     throw;
@@ -1733,7 +1732,7 @@ namespace NLog.Targets
                     }
                     else if (!IsSimpleKeepFileOpen)
                     {
-                        InternalLogger.Debug("FileTarget(Name={0}): Archive mutex not available for file '{1}'", Name, archiveFile);
+                        InternalLogger.Debug("{0}: Archive mutex not available for file '{1}'", this, archiveFile);
                     }
                 }
                 catch (AbandonedMutexException)
@@ -1762,7 +1761,7 @@ namespace NLog.Targets
         /// </summary>
         private BaseFileAppender TryCloseFileAppenderBeforeArchive(string fileName, string archiveFile)
         {
-            InternalLogger.Trace("FileTarget(Name={0}): Archive attempt for file '{1}'", Name, archiveFile);
+            InternalLogger.Trace("{0}: Archive attempt for file '{1}'", this, archiveFile);
             BaseFileAppender archivedAppender = _fileAppenderCache.InvalidateAppender(fileName);
             if (fileName != archiveFile)
             {
@@ -1787,7 +1786,7 @@ namespace NLog.Targets
                 var validatedArchiveFile = GetArchiveFileName(archiveFile, ev, upcomingWriteSize, previousLogEventTimestamp, false);
                 if (string.IsNullOrEmpty(validatedArchiveFile))
                 {
-                    InternalLogger.Debug("FileTarget(Name={0}): Skip archiving '{1}' because no longer necessary", Name, archiveFile);
+                    InternalLogger.Debug("{0}: Skip archiving '{1}' because no longer necessary", this, archiveFile);
                     _initializedFiles.Remove(archiveFile);
                 }
                 else
@@ -1810,7 +1809,7 @@ namespace NLog.Targets
             }
             catch (Exception exception)
             {
-                InternalLogger.Warn(exception, "FileTarget(Name={0}): Failed to archive file '{1}'.", Name, archiveFile);
+                InternalLogger.Warn(exception, "{0}: Failed to archive file '{1}'.", this, archiveFile);
                 if (ExceptionMustBeRethrown(exception))
                 {
                     throw;
@@ -1901,7 +1900,7 @@ namespace NLog.Targets
             var shouldArchive = (fileLength.Value + upcomingWriteSize) > ArchiveAboveSize;
             if (shouldArchive)
             {
-                InternalLogger.Debug("FileTarget(Name={0}): Start archiving '{1}' because FileSize={2} + {3} is larger than ArchiveAboveSize={4}", Name, archiveFileName, fileLength.Value, upcomingWriteSize, ArchiveAboveSize);
+                InternalLogger.Debug("{0}: Start archiving '{1}' because FileSize={2} + {3} is larger than ArchiveAboveSize={4}", this, archiveFileName, fileLength.Value, upcomingWriteSize, ArchiveAboveSize);
                 return archiveFileName;    // Will re-check if archive is still necessary after flush/close file
             }
 
@@ -1916,7 +1915,7 @@ namespace NLog.Targets
             if (!initializedNewFile && _initializedFiles.Remove(archiveFileName))
             {
                 // Register current filename needs re-initialization
-                InternalLogger.Debug("FileTarget(Name={0}): Invalidates appender for archive file '{1}' since it no longer exists", Name, archiveFileName);
+                InternalLogger.Debug("{0}: Invalidates appender for archive file '{1}' since it no longer exists", this, archiveFileName);
                 _fileAppenderCache.InvalidateAppender(archiveFileName)?.Dispose();
             }
 
@@ -1974,7 +1973,7 @@ namespace NLog.Targets
                 var shouldArchive = fileCreated != logEventRecorded;
                 if (shouldArchive)
                 {
-                    InternalLogger.Debug("FileTarget(Name={0}): Start archiving '{1}' because FileCreatedTime='{2}' is older than now '{3}' using ArchiveEvery='{4}'", Name, archiveFileName, fileCreated, logEventRecorded, formatString);
+                    InternalLogger.Debug("{0}: Start archiving '{1}' because FileCreatedTime='{2}' is older than now '{3}' using ArchiveEvery='{4}'", this, archiveFileName, fileCreated, logEventRecorded, formatString);
                     return archiveFileName;    // Will re-check if archive is still necessary after flush/close file
                 }
             }
@@ -1996,12 +1995,12 @@ namespace NLog.Targets
                 {
                     if (IsSimpleKeepFileOpen)
                     {
-                        InternalLogger.Debug("FileTarget(Name={0}): Adjusted file creation time from {1} to {2}. Linux FileSystem probably don't support file birthtime.", Name, creationTimeSource, previousLogEventTimestamp);
+                        InternalLogger.Debug("{0}: Adjusted file creation time from {1} to {2}. Linux FileSystem probably don't support file birthtime.", this, creationTimeSource, previousLogEventTimestamp);
                         creationTimeSource = previousLogEventTimestamp;
                     }
                     else
                     {
-                        InternalLogger.Debug("FileTarget(Name={0}): File creation time {1} newer than previous file write time {2}. Linux FileSystem probably don't support file birthtime, unless multiple applications are writing to the same file. Configure FileTarget.KeepFileOpen=true AND FileTarget.ConcurrentWrites=false, so NLog can fix this.", Name, creationTimeSource, previousLogEventTimestamp);
+                        InternalLogger.Debug("{0}: File creation time {1} newer than previous file write time {2}. Linux FileSystem probably don't support file birthtime, unless multiple applications are writing to the same file. Configure FileTarget.KeepFileOpen=true AND FileTarget.ConcurrentWrites=false, so NLog can fix this.", this, creationTimeSource, previousLogEventTimestamp);
                     }
                 }
             }
@@ -2061,17 +2060,17 @@ namespace NLog.Targets
                     return;
                 }
 
-                InternalLogger.Trace("FileTarget(Name={0}): Auto Close FileAppenders after archive", Name);
+                InternalLogger.Trace("{0}: Auto Close FileAppenders after archive", this);
                 _fileAppenderCache.CloseAppenders(DateTime.MinValue);
             }
             catch (Exception exception)
             {
-                InternalLogger.Warn(exception, "FileTarget(Name={0}): Exception in AutoCloseAppendersAfterArchive", Name);
-
                 if (exception.MustBeRethrownImmediately())
                 {
                     throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                 }
+
+                InternalLogger.Warn(exception, "{0}: Exception in AutoCloseAppendersAfterArchive", this);
             }
             finally
             {
@@ -2095,7 +2094,7 @@ namespace NLog.Targets
                 if (OpenFileCacheTimeout > 0)
                 {
                     DateTime expireTime = DateTime.UtcNow.AddSeconds(-OpenFileCacheTimeout);
-                    InternalLogger.Trace("FileTarget(Name={0}): Auto Close FileAppenders", Name);
+                    InternalLogger.Trace("{0}: Auto Close FileAppenders", this);
                     _fileAppenderCache.CloseAppenders(expireTime);
                 }
 
@@ -2106,12 +2105,12 @@ namespace NLog.Targets
             }
             catch (Exception exception)
             {
-                InternalLogger.Warn(exception, "FileTarget(Name={0}): Exception in AutoClosingTimerCallback", Name);
-
                 if (exception.MustBeRethrownImmediately())
                 {
                     throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                 }
+
+                InternalLogger.Warn(exception, "{0}: Exception in AutoClosingTimerCallback", this);
             }
             finally
             {
@@ -2136,7 +2135,7 @@ namespace NLog.Targets
             if (flushAppenders)
             {
                 // Only request flush of file-handles, when something has been written
-                InternalLogger.Trace("FileTarget(Name={0}): Auto Flush FileAppenders", Name);
+                InternalLogger.Trace("{0}: Auto Flush FileAppenders", this);
                 _fileAppenderCache.FlushAppenders();
             }
         }
@@ -2167,7 +2166,7 @@ namespace NLog.Targets
             }
             catch (Exception ex)
             {
-                InternalLogger.Error(ex, "FileTarget(Name={0}): Failed write to file '{1}'.", Name, fileName);
+                InternalLogger.Error(ex, "{0}: Failed write to file '{1}'.", this, fileName);
                 _fileAppenderCache.InvalidateAppender(fileName)?.Dispose();
                 throw;
             }
@@ -2238,7 +2237,7 @@ namespace NLog.Targets
         /// <param name="isArchiving">Indicates if the file is being finalized for archiving.</param>
         private void FinalizeFile(string fileName, bool isArchiving = false)
         {
-            InternalLogger.Trace("FileTarget(Name={0}): FinalizeFile '{1}, isArchiving: {2}'", Name, fileName, isArchiving);
+            InternalLogger.Trace("{0}: FinalizeFile '{1}, isArchiving: {2}'", this, fileName, isArchiving);
             if ((isArchiving) || (!WriteFooterOnArchivingOnly))
                 WriteFooter(fileName);
 
@@ -2294,7 +2293,7 @@ namespace NLog.Targets
         /// <param name="logEvent">Log event that the <see cref="FileTarget"/> instance is currently processing.</param>
         private void PrepareForNewFile(string fileName, LogEventInfo logEvent)
         {
-            InternalLogger.Debug("FileTarget(Name={0}): Preparing for new file '{1}'", Name, fileName);
+            InternalLogger.Debug("{0}: Preparing for new file '{1}'", this, fileName);
             RefreshArchiveFilePatternToWatch(fileName, logEvent);
 
             try
@@ -2306,8 +2305,7 @@ namespace NLog.Targets
             }
             catch (Exception exception)
             {
-                InternalLogger.Warn(exception, "FileTarget(Name={0}): Unable to archive old log file '{1}'.", Name, fileName);
-
+                InternalLogger.Warn(exception, "{0}: Unable to archive old log file '{1}'.", this, fileName);
                 if (ExceptionMustBeRethrown(exception))
                 {
                     throw;
@@ -2405,7 +2403,7 @@ namespace NLog.Targets
             {
                 if (WriteBom)
                 {
-                    InternalLogger.Trace("FileTarget(Name={0}): Write byte order mark from encoding={1}", Name, Encoding);
+                    InternalLogger.Trace("{0}: Write byte order mark from encoding={1}", this, Encoding);
                     var preamble = Encoding.GetPreamble();
                     if (preamble.Length > 0)
                         appender.Write(preamble, 0, preamble.Length);
@@ -2413,7 +2411,7 @@ namespace NLog.Targets
 
                 if (Header != null)
                 {
-                    InternalLogger.Trace("FileTarget(Name={0}): Write header", Name);
+                    InternalLogger.Trace("{0}: Write header", this);
                     ArraySegment<byte> headerBytes = GetLayoutBytes(Header);
                     if (headerBytes.Count > 0)
                     {

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -131,7 +131,7 @@ namespace NLog.Targets
                     }
                     catch (Exception ex)
                     {
-                        InternalLogger.Warn(ex, "MailTarget(Name={0}): Reading 'From' from .config failed.", Name);
+                        InternalLogger.Warn(ex, "{0}: Reading 'From' from .config failed.", this);
 
                         if (ExceptionMustBeRethrown(ex))
                         {
@@ -396,12 +396,12 @@ namespace NLog.Targets
                         }
 
                         if (client.EnableSsl)
-                            InternalLogger.Debug("MailTarget(Name={0}): Sending mail to {1} using {2}:{3} (ssl=true)", Name, msg.To, client.Host, client.Port);
+                            InternalLogger.Debug("{0}: Sending mail to {1} using {2}:{3} (ssl=true)", this, msg.To, client.Host, client.Port);
                         else
-                            InternalLogger.Debug("MailTarget(Name={0}): Sending mail to {1} using {2}:{3} (ssl=false)", Name, msg.To, client.Host, client.Port);
+                            InternalLogger.Debug("{0}: Sending mail to {1} using {2}:{3} (ssl=false)", this, msg.To, client.Host, client.Port);
 
-                        InternalLogger.Trace("MailTarget(Name={0}):   Subject: '{1}'", Name, msg.Subject);
-                        InternalLogger.Trace("MailTarget(Name={0}):   From: '{1}'", Name, msg.From.ToString());
+                        InternalLogger.Trace("{0}:   Subject: '{1}'", this, msg.Subject);
+                        InternalLogger.Trace("{0}:   From: '{1}'", this, msg.From);
 
                         client.Send(msg);
 
@@ -415,7 +415,7 @@ namespace NLog.Targets
             catch (Exception exception)
             {
                 //always log
-                InternalLogger.Error(exception, "MailTarget(Name={0}): Error sending mail.", Name);
+                InternalLogger.Error(exception, "{0}: Error sending mail.", this);
 
                 if (ExceptionMustBeRethrown(exception))
                 {
@@ -507,7 +507,7 @@ namespace NLog.Targets
 
                 if (SmtpAuthentication == SmtpAuthenticationMode.Ntlm)
                 {
-                    InternalLogger.Trace("MailTarget(Name={0}):   Using NTLM authentication.", Name);
+                    InternalLogger.Trace("{0}:   Using NTLM authentication.", this);
                     client.Credentials = CredentialCache.DefaultNetworkCredentials;
                 }
                 else if (SmtpAuthentication == SmtpAuthenticationMode.Basic)
@@ -515,7 +515,7 @@ namespace NLog.Targets
                     string username = SmtpUserName.Render(lastEvent);
                     string password = SmtpPassword.Render(lastEvent);
 
-                    InternalLogger.Trace("MailTarget(Name={0}):   Using basic authentication: Username='{1}' Password='{2}'", Name, username, new string('*', password.Length));
+                    InternalLogger.Trace("{0}:   Using basic authentication: Username='{1}' Password='{2}'", this, username, new string('*', password.Length));
                     client.Credentials = new NetworkCredential(username, password);
                 }
             }
@@ -646,7 +646,7 @@ namespace NLog.Targets
                 else
                 {
                     msg.Priority = MailPriority.Normal;
-                    InternalLogger.Warn("MailTarget(Name={0}): Could not convert '{1}' to MailPriority, valid values are Low, Normal and High. Using normal priority as fallback.", Name, renderedPriority);
+                    InternalLogger.Warn("{0}: Could not convert '{1}' to MailPriority, valid values are Low, Normal and High. Using normal priority as fallback.", this, renderedPriority);
                 }
             }
             msg.Body = body;

--- a/src/NLog/Targets/MethodCallTarget.cs
+++ b/src/NLog/Targets/MethodCallTarget.cs
@@ -199,7 +199,7 @@ namespace NLog.Targets
             }
             else
             {
-                InternalLogger.Trace("No invoke because class/method was not found or set");
+                InternalLogger.Trace("{0}: No invoke because class/method was not found or set", this);
             }
         }
     }

--- a/src/NLog/Targets/MethodCallTargetBase.cs
+++ b/src/NLog/Targets/MethodCallTargetBase.cs
@@ -93,7 +93,7 @@ namespace NLog.Targets
                     if (ex.MustBeRethrownImmediately())
                         throw;
 
-                    Common.InternalLogger.Warn(ex, "{0}(Name={1}): Failed to get parameter value {2}", GetType(), Name, Parameters[i].Name);
+                    Common.InternalLogger.Warn(ex, "{0}: Failed to get parameter value {1}", this, Parameters[i].Name);
                     throw;
                 }
             }

--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -283,7 +283,7 @@ namespace NLog.Targets
         protected override void Write(AsyncLogEventInfo logEvent)
         {
             string address = RenderLogEvent(Address, logEvent.LogEvent);
-            InternalLogger.Trace("NetworkTarget(Name={0}): Sending to address: '{1}'", Name, address);
+            InternalLogger.Trace("{0}: Sending to address: '{1}'", this, address);
 
             byte[] bytes = GetBytesToWrite(logEvent.LogEvent);
 
@@ -296,7 +296,7 @@ namespace NLog.Targets
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "NetworkTarget(Name={0}): Failed to create sender to address: '{1}'", Name, address);
+                    InternalLogger.Error(ex, "{0}: Failed to create sender to address: '{1}'", this, address);
                     throw;
                 }
 
@@ -307,7 +307,7 @@ namespace NLog.Targets
                     {
                         if (ex != null)
                         {
-                            InternalLogger.Error(ex, "NetworkTarget(Name={0}): Error when sending.", Name);
+                            InternalLogger.Error(ex, "{0}: Error when sending.", this);
                             ReleaseCachedConnection(senderNode);
                         }
 
@@ -329,23 +329,23 @@ namespace NLog.Targets
                         switch (OnConnectionOverflow)
                         {
                             case NetworkTargetConnectionsOverflowAction.DiscardMessage:
-                                InternalLogger.Warn("NetworkTarget(Name={0}): Discarding message otherwise to many connections.", Name);
+                                InternalLogger.Warn("{0}: Discarding message otherwise to many connections.", this);
                                 logEvent.Continuation(null);
                                 return;
 
                             case NetworkTargetConnectionsOverflowAction.AllowNewConnnection:
-                                InternalLogger.Debug("NetworkTarget(Name={0}): Too may connections, but this is allowed", Name);
+                                InternalLogger.Debug("{0}: Too may connections, but this is allowed", this);
                                 break;
 
                             case NetworkTargetConnectionsOverflowAction.Block:
                                 while (_openNetworkSenders.Count >= MaxConnections)
                                 {
-                                    InternalLogger.Debug("NetworkTarget(Name={0}): Blocking networktarget otherwhise too many connections.", Name);
+                                    InternalLogger.Debug("{0}: Blocking networktarget otherwhise too many connections.", this);
                                     Monitor.Wait(_openNetworkSenders);
-                                    InternalLogger.Trace("NetworkTarget(Name={0}): Entered critical section.", Name);
+                                    InternalLogger.Trace("{0}: Entered critical section.", this);
                                 }
 
-                                InternalLogger.Trace("NetworkTarget(Name={0}): Limit ok.", Name);
+                                InternalLogger.Trace("{0}: Limit ok.", this);
                                 break;
                         }
                     }
@@ -356,7 +356,7 @@ namespace NLog.Targets
                     }
                     catch (Exception ex)
                     {
-                        InternalLogger.Error(ex, "NetworkTarget(Name={0}): Failed to create sender to address: '{1}'", Name, address);
+                        InternalLogger.Error(ex, "{0}: Failed to create sender to address: '{1}'", this, address);
                         throw;
                     }
 
@@ -378,7 +378,7 @@ namespace NLog.Targets
 
                         if (ex != null)
                         {
-                            InternalLogger.Error(ex, "NetworkTarget(Name={0}): Error when sending.", Name);
+                            InternalLogger.Error(ex, "{0}: Error when sending.", this);
                         }
 
                         sender.Close(ex2 => { });
@@ -435,7 +435,7 @@ namespace NLog.Targets
 
         private byte[] GetBytesFromStringBuilder(char[] charBuffer, StringBuilder stringBuilder)
         {
-            InternalLogger.Trace("NetworkTarget(Name={0}): Sending {1} chars", Name, stringBuilder.Length);
+            InternalLogger.Trace("{0}: Sending {1} chars", this, stringBuilder.Length);
             if (stringBuilder.Length <= charBuffer.Length)
             {
                 stringBuilder.CopyTo(0, charBuffer, 0, stringBuilder.Length);
@@ -446,7 +446,7 @@ namespace NLog.Targets
 
         private byte[] GetBytesFromString(char[] charBuffer, string layoutMessage)
         {
-            InternalLogger.Trace("NetworkTarget(Name={0}): Sending {1}", Name, layoutMessage);
+            InternalLogger.Trace("{0}: Sending {1}", this, layoutMessage);
             if (layoutMessage.Length <= charBuffer.Length)
             {
                 layoutMessage.CopyTo(0, charBuffer, 0, layoutMessage.Length);
@@ -536,7 +536,7 @@ namespace NLog.Targets
             if (tosend <= MaxMessageSize)
             {
                 // Chunking is not needed, no need to perform delegate capture
-                InternalLogger.Trace("NetworkTarget(Name={0}): Sending chunk, position: {1}, length: {2}", Name, 0, tosend);
+                InternalLogger.Trace("{0}: Sending chunk, position: {1}, length: {2}", this, 0, tosend);
                 if (tosend <= 0)
                 {
                     continuation(null);
@@ -557,7 +557,7 @@ namespace NLog.Targets
                         return;
                     }
 
-                    InternalLogger.Trace("NetworkTarget(Name={0}): Sending chunk, position: {1}, length: {2}", Name, pos, tosend);
+                    InternalLogger.Trace("{0}: Sending chunk, position: {1}, length: {2}", this, pos, tosend);
                     if (tosend <= 0)
                     {
                         continuation(null);
@@ -569,7 +569,7 @@ namespace NLog.Targets
                     {
                         if (OnOverflow == NetworkTargetOverflowAction.Discard)
                         {
-                            InternalLogger.Trace("NetworkTarget(Name={0}): Discard because chunksize > this.MaxMessageSize", Name);
+                            InternalLogger.Trace("{0}: Discard because chunksize > this.MaxMessageSize", this);
                             continuation(null);
                             return;
                         }

--- a/src/NLog/Targets/PerformanceCounterTarget.cs
+++ b/src/NLog/Targets/PerformanceCounterTarget.cs
@@ -261,7 +261,7 @@ namespace NLog.Targets
                 if (long.TryParse(incrementValueString, out incrementValue))
                     perfCounter.IncrementBy(incrementValue);
                 else
-                    InternalLogger.Error("PerfCounterTarget(Name={0}): Error incrementing PerfCounter {1}. IncrementValue must be an integer but was <{2}>", Name, CounterName, incrementValueString);
+                    InternalLogger.Error("{0}: Error incrementing PerfCounter {1}. IncrementValue must be an integer but was <{2}>", this, CounterName, incrementValueString);
             }
         }
 
@@ -323,7 +323,7 @@ namespace NLog.Targets
                 }
                 catch (Exception exception)
                 {
-                    InternalLogger.Error(exception, "PerfCounterTarget(Name={0}): Cannot open performance counter {1}/{2}/{3}.", Name, CategoryName, CounterName, InstanceName);
+                    InternalLogger.Error(exception, "{0}: Cannot open performance counter {1}/{2}/{3}.", this, CategoryName, CounterName, InstanceName);
 
                     if (ExceptionMustBeRethrown(exception))
                     {

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -47,6 +47,8 @@ namespace NLog.Targets
     [NLogConfigurationItem]
     public abstract class Target : ISupportsInitialize, IInternalLoggerContext, IDisposable
     {
+        internal string _tostring;
+
         private List<Layout> _allLayouts;
 
         /// <summary> Are all layouts in this target thread-agnostic, if so we don't precalculate the layouts </summary>
@@ -67,7 +69,16 @@ namespace NLog.Targets
         /// Gets or sets the name of the target.
         /// </summary>
         /// <docgen category='General Options' order='10' />
-        public string Name { get; set; }
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                _name = value;
+                _tostring = null;
+            }
+        }
+        private string _name;
         
         /// <summary>
         /// Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers
@@ -174,9 +185,7 @@ namespace NLog.Targets
                 catch (Exception exception)
                 {
                     if (ExceptionMustBeRethrown(exception))
-                    {
                         throw;
-                    }
 
                     asyncContinuation(exception);
                 }
@@ -261,13 +270,20 @@ namespace NLog.Targets
         /// </returns>
         public override string ToString()
         {
-            var targetAttribute = GetType().GetFirstCustomAttribute<TargetAttribute>();
-            if (targetAttribute != null)
-            {
-                return $"{targetAttribute.Name} Target[{(Name ?? "(unnamed)")}]";
-            }
+            return _tostring ?? (_tostring = GenerateTargetToString(false));
+        }
 
-            return GetType().Name;
+        internal string GenerateTargetToString(bool targetWrapper, string targetName = null)
+        {
+            var targetAttribute = GetType().GetFirstCustomAttribute<TargetAttribute>();
+            string targetType = (targetAttribute?.Name ?? GetType().Name).Trim();
+            targetWrapper = targetWrapper || targetAttribute?.IsCompound == true || targetAttribute?.IsWrapper == true;
+            if (!targetWrapper && targetType.IndexOf("Target", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                targetType += "Target";
+            }
+            targetName = targetName ?? Name;
+            return string.IsNullOrEmpty(targetName) ? targetType : $"{targetType}(Name={targetName})";
         }
 
         /// <summary>
@@ -370,9 +386,7 @@ namespace NLog.Targets
             catch (Exception exception)
             {
                 if (ExceptionMustBeRethrown(exception))
-                {
                     throw;
-                }
 
                 // in case of synchronous failure, assume that nothing is running asynchronously
                 for (int i = 0; i < logEvents.Count; ++i)
@@ -420,21 +434,15 @@ namespace NLog.Targets
                     {
                         // Target is now in disabled state, and cannot be used for writing LogEvents
                         _initializeException = exception;
-                        InternalLogger.Error(exception, "{0}: Error initializing target", this);
                         if (ExceptionMustBeRethrown(exception))
-                        {
                             throw;
-                        }
                     }
                     catch (Exception exception)
                     {
                         // Target is now in disabled state, and cannot be used for writing LogEvents
                         _initializeException = exception;
-                        InternalLogger.Error(exception, "{0}: Error initializing target", this);
                         if (ExceptionMustBeRethrown(exception))
-                        {
                             throw;
-                        }
 
                         var logFactory = LoggingConfiguration?.LogFactory ?? LogManager.LogFactory;
                         if ((logFactory.ThrowConfigExceptions ?? logFactory.ThrowExceptions))
@@ -468,19 +476,15 @@ namespace NLog.Targets
                         if (_initializeException == null)
                         {
                             // if Init succeeded, call Close()
-                            InternalLogger.Debug("Closing target '{0}'.", this);
+                            InternalLogger.Debug("{0}: Closing...", this);
                             CloseTarget();
-                            InternalLogger.Debug("Closed target '{0}'.", this);
+                            InternalLogger.Debug("{0}: Closed.", this);
                         }
                     }
                     catch (Exception exception)
                     {
-                        InternalLogger.Error(exception, "{0}: Error closing target", this);
-
                         if (ExceptionMustBeRethrown(exception))
-                        {
                             throw;
-                        }
                     }
                 }
             }
@@ -574,9 +578,7 @@ namespace NLog.Targets
             catch (Exception exception)
             {
                 if (ExceptionMustBeRethrown(exception))
-                {
                     throw;
-                }
 
                 logEvent.Continuation(exception);
             }
@@ -708,6 +710,29 @@ namespace NLog.Targets
             }
         }
 
+        /// <summary>
+        /// Resolve from DI <see cref="LogFactory.ServiceRepository"/>
+        /// </summary>
+        /// <remarks>Avoid calling this while handling a LogEvent, since random deadlocks can occur.</remarks>
+        protected T ResolveService<T>() where T : class
+        {
+            return LoggingConfiguration.GetServiceProvider().ResolveService<T>(IsInitialized);
+        }
+
+        /// <summary>
+        /// Should the exception be rethrown?
+        /// </summary>
+        /// <remarks>Upgrade to private protected when using C# 7.2 </remarks>
+        /// 
+        internal bool ExceptionMustBeRethrown(Exception exception,
+#if !NET35
+            [System.Runtime.CompilerServices.CallerMemberName]
+#endif
+            string callerMemberName = null)
+        {
+            return exception.MustBeRethrown(this, callerMemberName);
+        }
+
         private static bool TryGetCachedValue(Layout layout, LogEventInfo logEvent, out string value)
         {
             if ((!layout.ThreadAgnostic || layout.MutableUnsafe) && logEvent.TryGetCachedLayoutValue(layout, out var value2))
@@ -741,27 +766,7 @@ namespace NLog.Targets
         /// <param name="name"> Name of the Target.</param>
         public static void Register(string name, Type targetType)
         {
-            ConfigurationItemFactory.Default.Targets
-                .RegisterDefinition(name, targetType);
-        }
-
-        /// <summary>
-        /// Resolve from DI <see cref="LogFactory.ServiceRepository"/>
-        /// </summary>
-        /// <remarks>Avoid calling this while handling a LogEvent, since random deadlocks can occur.</remarks>
-        protected T ResolveService<T>() where T : class
-        {
-            return LoggingConfiguration.GetServiceProvider().ResolveService<T>(IsInitialized);
-        }
-
-        /// <summary>
-        /// Should the exception be rethrown?
-        /// </summary>
-        /// <param name="exception"></param>
-        /// <remarks>Upgrade to private protected when using C# 7.2 </remarks>
-        internal bool ExceptionMustBeRethrown(Exception exception)
-        {
-            return exception.MustBeRethrown(this);
+            ConfigurationItemFactory.Default.Targets.RegisterDefinition(name, targetType);
         }
     }
 }

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -397,7 +397,7 @@ namespace NLog.Targets
                     if (ex.MustBeRethrownImmediately())
                         throw;
 
-                    Common.InternalLogger.Warn(ex, "{0}(Name={1}): Failed to add context property {2}", GetType(), Name, contextProperty.Name);
+                    Common.InternalLogger.Warn(ex, "{0}: Failed to add context property {1}", this, contextProperty.Name);
                 }
             }
 

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -347,7 +347,7 @@ namespace NLog.Targets
             }
             catch (Exception ex)
             {
-                InternalLogger.Error(ex, "WebServiceTarget(Name={0}): Error starting request", Name);
+                InternalLogger.Error(ex, "{0}: Error starting request", this);
                 if (ExceptionMustBeRethrown(ex))
                 {
                     throw;
@@ -373,7 +373,7 @@ namespace NLog.Targets
                     }
                     catch (Exception ex)
                     {
-                        InternalLogger.Error(ex, "WebServiceTarget(Name={0}): Error receiving response", Name);
+                        InternalLogger.Error(ex, "{0}: Error receiving response", this);
                         if (ex.MustBeRethrownImmediately())
                         {
                             throw; // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
@@ -405,7 +405,7 @@ namespace NLog.Targets
                     }
                     catch (Exception ex)
                     {
-                        InternalLogger.Error(ex, "WebServiceTarget(Name={0}): Error sending payload", Name);
+                        InternalLogger.Error(ex, "{0}: Error sending payload", this);
                         if (ex.MustBeRethrownImmediately())
                         {
                             throw; // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -294,7 +294,7 @@ namespace NLog.Targets.Wrappers
             }
 
             _requestQueue.Clear();
-            InternalLogger.Trace("AsyncWrapper(Name={0}): Start Timer", Name);
+            InternalLogger.Trace("{0}: Start Timer", this);
             _lazyWriterTimer = new Timer(ProcessPendingEvents, null, Timeout.Infinite, Timeout.Infinite);
             StartLazyWriterTimer();
         }
@@ -338,7 +338,7 @@ namespace NLog.Targets.Wrappers
                 {
                     if (TimeToSleepBetweenBatches <= 1)
                     {
-                        InternalLogger.Trace("AsyncWrapper(Name={0}): Throttled timer scheduled", Name);
+                        InternalLogger.Trace("{0}: Throttled timer scheduled", this);
                         _lazyWriterTimer.Change(1, Timeout.Infinite);
                     }
                     else
@@ -481,7 +481,7 @@ namespace NLog.Targets.Wrappers
             {
                 wroteFullBatchSize = false; // Something went wrong, lets throttle retry
 
-                InternalLogger.Error(exception, "AsyncWrapper(Name={0}): Error in lazy writer timer procedure.", Name);
+                InternalLogger.Error(exception, "{0}: Error in lazy writer timer procedure.", this);
 
                 if (exception.MustBeRethrownImmediately())
                 {
@@ -523,7 +523,7 @@ namespace NLog.Targets.Wrappers
             }
             catch (Exception exception)
             {
-                InternalLogger.Error(exception, "AsyncWrapper(Name={0}): Error in flush procedure.", Name);
+                InternalLogger.Error(exception, "{0}: Error in flush procedure.", this);
 
                 if (exception.MustBeRethrownImmediately())
                 {
@@ -536,7 +536,7 @@ namespace NLog.Targets.Wrappers
         {
             if (WrappedTarget == null)
             {
-                InternalLogger.Error("AsyncWrapper(Name={0}): WrappedTarget is NULL", Name);
+                InternalLogger.Error("{0}: WrappedTarget is NULL", this);
                 return 0;
             }
 
@@ -548,7 +548,7 @@ namespace NLog.Targets.Wrappers
                 }
 
                 _missingServiceTypes = false;
-                InternalLogger.Debug("AsyncWrapper(Name={0}): WrappedTarget has resolved missing dependency", Name);
+                InternalLogger.Debug("{0}: WrappedTarget has resolved missing dependency", this);
             }
 
             int count = 0;
@@ -560,7 +560,7 @@ namespace NLog.Targets.Wrappers
                     if (logEvents.Length > 0)
                     {
                         if (reason != null)
-                            InternalLogger.Trace("AsyncWrapper(Name={0}): Writing {1} events ({2})", Name, logEvents.Length, reason);
+                            InternalLogger.Trace("{0}: Writing {1} events ({2})", this, logEvents.Length, reason);
                         WrappedTarget.WriteAsyncLogEvents(logEvents);
                     }
                     count = logEvents.Length;
@@ -574,7 +574,7 @@ namespace NLog.Targets.Wrappers
                         if (logEvents.Count > 0)
                         {
                             if (reason != null)
-                                InternalLogger.Trace("AsyncWrapper(Name={0}): Writing {1} events ({2})", Name, logEvents.Count, reason);
+                                InternalLogger.Trace("{0}: Writing {1} events ({2})", this, logEvents.Count, reason);
                             WrappedTarget.WriteAsyncLogEvents(logEvents);
                         }
                         count = logEvents.Count;

--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -172,7 +172,7 @@ namespace NLog.Targets.Wrappers
         {
             base.InitializeTarget();
             _buffer = new AsyncRequestQueue(BufferSize, AsyncTargetWrapperOverflowAction.Discard);
-            InternalLogger.Trace("BufferingWrapper(Name={0}): Create Timer", Name);
+            InternalLogger.Trace("{0}: Create Timer", this);
             _flushTimer = new Timer(FlushCallback, null, Timeout.Infinite, Timeout.Infinite);
         }
 
@@ -253,7 +253,7 @@ namespace NLog.Targets.Wrappers
             }
             catch (Exception exception)
             {
-                InternalLogger.Error(exception, "BufferingWrapper(Name={0}): Error in flush procedure.", Name);
+                InternalLogger.Error(exception, "{0}: Error in flush procedure.", this);
 
                 if (exception.MustBeRethrownImmediately())
                 {
@@ -273,7 +273,7 @@ namespace NLog.Targets.Wrappers
         {
             if (WrappedTarget == null)
             {
-                InternalLogger.Error("BufferingWrapper(Name={0}): WrappedTarget is NULL", Name);
+                InternalLogger.Error("{0}: WrappedTarget is NULL", this);
                 return;
             }
 
@@ -283,7 +283,7 @@ namespace NLog.Targets.Wrappers
                 if (logEvents.Length > 0)
                 {
                     if (reason != null)
-                        InternalLogger.Trace("BufferingWrapper(Name={0}): Writing {1} events ({2})", Name, logEvents.Length, reason);
+                        InternalLogger.Trace("{0}: Writing {1} events ({2})", this, logEvents.Length, reason);
                     WrappedTarget.WriteAsyncLogEvents(logEvents);
                 }
             }

--- a/src/NLog/Targets/Wrappers/CompoundTargetBase.cs
+++ b/src/NLog/Targets/Wrappers/CompoundTargetBase.cs
@@ -37,7 +37,6 @@ namespace NLog.Targets.Wrappers
     using System.Collections.Generic;
     using System.Text;
     using NLog.Common;
-    using NLog.Internal;
 
     /// <summary>
     /// A base class for targets which wrap other (multiple) targets
@@ -65,20 +64,30 @@ namespace NLog.Targets.Wrappers
         /// <returns>A string that describes the target.</returns>
         public override string ToString()
         {
-            string separator = string.Empty;
-            var sb = new StringBuilder();
-            sb.Append(base.ToString());
-            sb.Append("(");
+            return _tostring ?? (_tostring = GenerateTargetToString());
+        }
 
-            foreach (var t in Targets)
+        private string GenerateTargetToString()
+        {
+            if (string.IsNullOrEmpty(Name) && Targets?.Count > 0)
             {
-                sb.Append(separator);
-                sb.Append(t.ToString());
-                separator = ", ";
+                string separator = string.Empty;
+                var sb = new StringBuilder();
+                sb.Append(GenerateTargetToString(true));
+                sb.Append("[");
+
+                foreach (var t in Targets)
+                {
+                    sb.Append(separator);
+                    sb.Append(t.ToString());
+                    separator = ", ";
+                }
+
+                sb.Append("]");
+                return sb.ToString();
             }
 
-            sb.Append(")");
-            return sb.ToString();
+            return GenerateTargetToString(true);
         }
 
         /// <summary>

--- a/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/FallbackGroupTarget.cs
@@ -133,7 +133,7 @@ namespace NLog.Targets.Wrappers
                             if (Interlocked.Read(ref _currentTarget) != 0)
 #pragma warning restore S1066 // Collapsible "if" statements should be merged
                             {
-                                InternalLogger.Debug("FallbackGroup(Name={0}): Target '{1}' succeeded. Returning to the first one.", Name, Targets[targetToInvoke]);
+                                InternalLogger.Debug("{0}: Target '{1}' succeeded. Returning to the first one.", this, Targets[targetToInvoke]);
                                 Interlocked.Exchange(ref _currentTarget, 0);
                             }
                         }
@@ -143,7 +143,7 @@ namespace NLog.Targets.Wrappers
                     }
 
                     // failure
-                    InternalLogger.Warn(ex, "FallbackGroup(Name={0}): Target '{1}' failed. Proceeding to the next one.", Name, Targets[targetToInvoke]);
+                    InternalLogger.Warn(ex, "{0}: Target '{1}' failed. Proceeding to the next one.", this, Targets[targetToInvoke]);
 
                     // error while writing, go to the next one
                     tryCounter++;

--- a/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
@@ -132,7 +132,7 @@ namespace NLog.Targets.Wrappers
 
             base.InitializeTarget();
             ResetInterval();
-            InternalLogger.Trace("LimitingWrapper(Name={0}): Initialized with MessageLimit={1} and Interval={2}.", Name, MessageLimit, Interval);
+            InternalLogger.Trace("{0}: Initialized with MessageLimit={1} and Interval={2}.", this, MessageLimit, Interval);
         }
 
 
@@ -147,7 +147,7 @@ namespace NLog.Targets.Wrappers
             if (IsIntervalExpired())
             {
                 ResetInterval();
-                InternalLogger.Debug("LimitingWrapper(Name={0}): New interval of '{1}' started.", Name, Interval);
+                InternalLogger.Debug("{0}: New interval of '{1}' started.", this, Interval);
             }
 
             if (MessagesWrittenCount < MessageLimit)
@@ -158,7 +158,7 @@ namespace NLog.Targets.Wrappers
             else
             {
                 logEvent.Continuation(null);
-                InternalLogger.Trace("LimitingWrapper(Name={0}): Discarded event, because MessageLimit of '{1}' was reached.", Name, MessageLimit);
+                InternalLogger.Trace("{0}: Discarded event, because MessageLimit of '{1}' was reached.", this, MessageLimit);
             }
         }
 

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -130,7 +130,7 @@ namespace NLog.Targets.Wrappers
         /// <param name="logEvents">Array of log events to be post-filtered.</param>
         protected override void Write(IList<AsyncLogEventInfo> logEvents)
         {
-            InternalLogger.Trace("PostFilteringWrapper(Name={0}): Running on {1} events", Name, logEvents.Count);
+            InternalLogger.Trace("{0}: Running on {1} events", this, logEvents.Count);
 
             var resultFilter = EvaluateAllRules(logEvents) ?? DefaultFilter;
             if (resultFilter == null)
@@ -139,12 +139,12 @@ namespace NLog.Targets.Wrappers
             }
             else
             {
-                InternalLogger.Trace("PostFilteringWrapper(Name={0}): Filter to apply: {1}", Name, resultFilter);
+                InternalLogger.Trace("{0}: Filter to apply: {1}", this, resultFilter);
                 var resultBuffer = logEvents.Filter(resultFilter, (logEvent, filter) => ApplyFilter(logEvent, filter));
-                InternalLogger.Trace("PostFilteringWrapper(Name={0}): After filtering: {1} events.", Name, resultBuffer.Count);
+                InternalLogger.Trace("{0}: After filtering: {1} events.", this, resultBuffer.Count);
                 if (resultBuffer.Count > 0)
                 {
-                    InternalLogger.Trace("PostFilteringWrapper(Name={0}): Sending to {1}", Name, WrappedTarget);
+                    InternalLogger.Trace("{0}: Sending to {1}", this, WrappedTarget);
                     WrappedTarget.WriteAsyncLogEvents(resultBuffer);
                 }
             }
@@ -182,7 +182,7 @@ namespace NLog.Targets.Wrappers
                     object v = rule.Exists.Evaluate(logEvents[i].LogEvent);
                     if (boxedTrue.Equals(v))
                     {
-                        InternalLogger.Trace("PostFilteringWrapper(Name={0}): Rule matched: {1}", Name, rule.Exists);
+                        InternalLogger.Trace("{0}: Rule matched: {1}", this, rule.Exists);
                         return rule.Filter;
                     }
                 }

--- a/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
@@ -163,12 +163,12 @@ namespace NLog.Targets.Wrappers
                 }
 
                 int retryNumber = Interlocked.Increment(ref counter);
-                InternalLogger.Warn(ex, "RetryingWrapper(Name={0}): Error while writing to '{1}'. Try {2}/{3}", Name, WrappedTarget, retryNumber, RetryCount);
+                InternalLogger.Warn(ex, "{0}: Error while writing to '{1}'. Try {2}/{3}", this, WrappedTarget, retryNumber, RetryCount);
 
                 // exceeded retry count
                 if (retryNumber >= RetryCount)
                 {
-                    InternalLogger.Warn("Too many retries. Aborting.");
+                    InternalLogger.Warn("{0}: Too many retries. Aborting.", this);
                     logEvent.Continuation(ex);
                     return;
                 }
@@ -181,7 +181,7 @@ namespace NLog.Targets.Wrappers
                     i += retryDelay;
                     if (!IsInitialized)
                     {
-                        InternalLogger.Warn("RetryingWrapper(Name={0}): Target closed. Aborting.", Name);
+                        InternalLogger.Warn("{0}): Target closed. Aborting.", this);
                         logEvent.Continuation(ex);
                         return;
                     }

--- a/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
@@ -119,7 +119,7 @@ namespace NLog.Targets.Wrappers
         /// <param name="logEvents">Logging events to be written out.</param>
         protected override void Write(IList<AsyncLogEventInfo> logEvents)
         {
-            InternalLogger.Trace("SplitGroup(Name={0}): Writing {1} events", Name, logEvents.Count);
+            InternalLogger.Trace("{0}: Writing {1} events", this, logEvents.Count);
 
             if (logEvents.Count == 1)
             {
@@ -145,7 +145,7 @@ namespace NLog.Targets.Wrappers
 
                 for (int i = 0; i < Targets.Count; ++i)
                 {
-                    InternalLogger.Trace("SplitGroup(Name={0}): Sending {1} events to {2}", Name, logEvents.Count, Targets[i]);
+                    InternalLogger.Trace("{0}: Sending {1} events to {2}", this, logEvents.Count, Targets[i]);
 
                     var targetLogEvents = logEvents;
                     if (i < Targets.Count - 1)

--- a/src/NLog/Targets/Wrappers/WrapperTargetBase.cs
+++ b/src/NLog/Targets/Wrappers/WrapperTargetBase.cs
@@ -47,7 +47,16 @@ namespace NLog.Targets.Wrappers
         /// </summary>
         /// <docgen category='General Options' order='11' />
         [RequiredParameter]
-        public Target WrappedTarget { get; set; }
+        public Target WrappedTarget
+        {
+            get => _wrappedTarget;
+            set
+            {
+                _wrappedTarget = value;
+                _tostring = null;
+            }
+        }
+        private Target _wrappedTarget;
 
         /// <summary>
         /// Returns the text representation of the object. Used for diagnostics.
@@ -55,7 +64,17 @@ namespace NLog.Targets.Wrappers
         /// <returns>A string that describes the target.</returns>
         public override string ToString()
         {
-            return $"{base.ToString()}({WrappedTarget})";
+            return _tostring ?? (_tostring = GenerateTargetToString());
+        }
+
+        private string GenerateTargetToString()
+        {
+            if (string.IsNullOrEmpty(Name))
+                return $"{GenerateTargetToString(true)}_{WrappedTarget}";
+            else if (WrappedTarget == null)
+                return GenerateTargetToString(true);
+            else
+                return $"{GenerateTargetToString(true, "")}_{WrappedTarget.GenerateTargetToString(false, Name)}";
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Targets/Wrappers/RetryingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/RetryingTargetWrapperTests.cs
@@ -114,7 +114,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             Assert.True(result.IndexOf("Error while writing to 'MyTarget'. Try 2/4") != -1);
             Assert.True(result.IndexOf("Error while writing to 'MyTarget'. Try 3/4") != -1);
             Assert.True(result.IndexOf("Error while writing to 'MyTarget'. Try 4/4") != -1);
-            Assert.True(result.IndexOf("Warn Too many retries. Aborting.") != -1);
+            Assert.True(result.IndexOf("Too many retries. Aborting.") != -1);
             Assert.True(result.IndexOf("Error while writing to 'MyTarget'. Try 1/4") != -1);
             Assert.True(result.IndexOf("Error while writing to 'MyTarget'. Try 2/4") != -1);
 

--- a/tests/NLog.UnitTests/Targets/Wrappers/SplitGroupTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/SplitGroupTargetTests.cs
@@ -126,7 +126,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 Targets = { myTarget1, myTarget2, myTarget3 },
             };
 
-            Assert.Equal("SplitGroup Target[(unnamed)](MyTarget, File Target[file1], Console Target[Console2])", wrapper.ToString());
+            Assert.Equal("SplitGroup[MyTarget, FileTarget(Name=file1), ConsoleTarget(Name=Console2)]", wrapper.ToString());
         }
 
         public class MyTarget : Target

--- a/tests/NLog.UnitTests/Targets/Wrappers/WrapperTargetBaseTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/WrapperTargetBaseTests.cs
@@ -42,7 +42,7 @@ namespace NLog.UnitTests.Targets.Wrappers
     public class WrapperTargetBaseTests : NLogTestBase
     {
         [Fact]
-        public void WrapperTargetToStringTest()
+        public void WrapperTargetNestedToStringTest()
         {
             var wrapper = new MyWrapper
             {
@@ -54,7 +54,19 @@ namespace NLog.UnitTests.Targets.Wrappers
                 WrappedTarget = wrapper,
             };
 
-            Assert.Equal("MyWrapper(MyWrapper(Debug Target[foo]))", wrapper2.ToString());
+            Assert.Equal("MyWrapper_MyWrapper_DebugTarget(Name=foo)", wrapper2.ToString());
+        }
+
+        [Fact]
+        public void WrapperTargetToStringTest()
+        {
+            var wrapper = new MyWrapper
+            {
+                Name = "foo",
+                WrappedTarget = new DebugTarget() { Name = "foo_wrapped" },
+            };
+
+            Assert.Equal("MyWrapper_DebugTarget(Name=foo)", wrapper.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
Resolves #2508 and resolves #1193 with help from `LogMessageReceived`-event and InternalLogger-parameter (See also #3823)