### PR TITLE
Handle Breaking change with string.IndexOf(string) in .NET 5

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -834,7 +834,7 @@ namespace NLog.Config
         {
             string output = input;
 
-            if (Variables.Count > 0 && output?.IndexOf("${") >= 0)
+            if (Variables.Count > 0 && output?.IndexOf('$') >= 0)
             {
                 // TODO - make this case-insensitive, will probably require a different approach
                 var variables = Variables.ToList();

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -249,7 +249,7 @@ namespace NLog.Config
                 if (ContainsSubStringIgnoreCase(internalLogFile, "${processdir}", out string processDirToken))
                     internalLogFile = internalLogFile.Replace(processDirToken, System.IO.Path.GetDirectoryName(LogFactory.CurrentAppEnvironment.CurrentProcessFilePath) + System.IO.Path.DirectorySeparatorChar.ToString());
 #endif
-                if (internalLogFile.IndexOf("%", StringComparison.OrdinalIgnoreCase) >= 0)
+                if (internalLogFile.IndexOf('%') >= 0)
                     internalLogFile = Environment.ExpandEnvironmentVariables(internalLogFile);
 #endif
                 return internalLogFile;

--- a/src/NLog/LayoutRenderers/AppSettingLayoutRenderer2.cs
+++ b/src/NLog/LayoutRenderers/AppSettingLayoutRenderer2.cs
@@ -83,7 +83,7 @@ namespace NLog.LayoutRenderers
         protected override void InitializeLayoutRenderer()
         {
             string connectionStringSection = "ConnectionStrings.";
-            _connectionStringName = Item?.TrimStart().StartsWith(connectionStringSection, StringComparison.InvariantCultureIgnoreCase) == true ?
+            _connectionStringName = Item?.TrimStart().StartsWith(connectionStringSection, StringComparison.OrdinalIgnoreCase) == true ?
                 Item.TrimStart().Substring(connectionStringSection.Length) : null;
         }
 

--- a/src/NLog/LayoutRenderers/RegistryLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/RegistryLayoutRenderer.cs
@@ -236,7 +236,7 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Aliases for the hives. See https://msdn.microsoft.com/en-us/library/ctb3kd86(v=vs.110).aspx
         /// </summary>
-        private static readonly Dictionary<string, RegistryHive> HiveAliases = new Dictionary<string, RegistryHive>(StringComparer.InvariantCultureIgnoreCase)
+        private static readonly Dictionary<string, RegistryHive> HiveAliases = new Dictionary<string, RegistryHive>(StringComparer.OrdinalIgnoreCase)
         {
             {"HKEY_LOCAL_MACHINE", RegistryHive.LocalMachine},
             {"HKLM", RegistryHive.LocalMachine},

--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -341,7 +341,7 @@ namespace NLog.Targets
                     else
                     {
                         var currentLogName = _eventLogWrapper.LogNameFromSourceName(eventLogSource, MachineName);
-                        if (!currentLogName.Equals(Log, StringComparison.CurrentCultureIgnoreCase))
+                        if (!currentLogName.Equals(Log, StringComparison.OrdinalIgnoreCase))
                         {
                             InternalLogger.Debug("EventLogTarget(Name={0}): Source {1} should be mapped to Log {2}, but EventLog.LogNameFromSourceName returns {3}", Name, eventLogSource, Log, currentLogName);
                         }
@@ -424,7 +424,7 @@ namespace NLog.Targets
                 if (_eventLogWrapper.SourceExists(fixedSource, MachineName))
                 {
                     string currentLogName = _eventLogWrapper.LogNameFromSourceName(fixedSource, MachineName);
-                    if (!currentLogName.Equals(Log, StringComparison.CurrentCultureIgnoreCase))
+                    if (!currentLogName.Equals(Log, StringComparison.OrdinalIgnoreCase))
                     {
                         InternalLogger.Debug("EventLogTarget(Name={0}): Updating source {1} to use log {2}, instead of {3} (Computer restart is needed)", Name, fixedSource, Log, currentLogName);
 


### PR DESCRIPTION
LoggingConfiguration - Expand NLog Config Variables without issues on Net50


Changed from CurrentCultureIgnoreCase to OrdinalIgnoreCase to avoid issue described here: https://github.com/dotnet/runtime/issues/43736

Issue was identified with #4271 