### PR TITLE
Make NLog.config bool attributes configurable through variables.

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -1301,7 +1301,9 @@ namespace NLog.Config
         {
             try
             {
-                return Convert.ToBoolean(value?.Trim(), CultureInfo.InvariantCulture);
+                string expandedValue;
+                ExpandSimpleVariables(value, out expandedValue);
+                return Convert.ToBoolean(expandedValue?.Trim(), CultureInfo.InvariantCulture);
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
With the current code is not possible to pass variables to set bool values in the nlog.config file. I want to be able to pass some config to file from a previously defined variable. For example:

`<variable name="LOGGER_ENABLED" value="${environment:LOGGER_ENABLED}" />`

`<logger name="*" minlevel="Trace" writeTo="myLogger"  enabled="${LOGGER_ENABLED}" >`

Added value expansion to allow method Parse Boolean to accept variables.