### PR TITLE
NLog.OutputDebugString - Extracted to own package

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -38,6 +38,7 @@ function create-package($packageName)
 }
 
 create-package('NLog.MSMQ')
+create-package('NLog.OutputDebugString')
 create-package('NLog.PerformanceCounter')
 create-package('NLog.Wcf')
 create-package('NLog.WindowsEventLog')

--- a/src/NLog.OutputDebugString/NLog.OutputDebugString.csproj
+++ b/src/NLog.OutputDebugString/NLog.OutputDebugString.csproj
@@ -1,0 +1,54 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net35;net45;net46</TargetFrameworks>
+
+    <Title>NLog.OutputDebugString</Title>
+    <Company>NLog</Company>
+    <Description>NLog.OutputDebugString provides support for DebugView output</Description>
+    <Product>NLog.PerformanceCounter v$(ProductVersion)</Product>
+    <InformationalVersion>$(ProductVersion)</InformationalVersion>
+    <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
+    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
+    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
+
+    <PackageReleaseNotes>
+      OutputDebugStringTarget Docs:
+      https://github.com/NLog/NLog/wiki/OutputDebugString-target
+    </PackageReleaseNotes>
+    <PackageTags>NLog;Windows;DebugView;logging;log</PackageTags>
+    <PackageIconUrl>https://nlog-project.org/N.png</PackageIconUrl>
+    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/NLog/NLog/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
+
+    <SignAssembly>true</SignAssembly>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Title>NLog.OutputDebugString for .NET Framework 4.6</Title>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Title>NLog.OutputDebugString for .NET Framework 4.5</Title>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">
+    <Title>NLog.OutputDebugString for .NET Framework 3.5</Title>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NLog\NLog.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NLog.OutputDebugString/NativeMethods.cs
+++ b/src/NLog.OutputDebugString/NativeMethods.cs
@@ -31,25 +31,15 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !NETSTANDARD
-
 namespace NLog.Internal
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Runtime.InteropServices;
-    using System.Text;
 
     internal static class NativeMethods
     {
-        [DllImport("kernel32.dll")]
-        internal static extern int GetCurrentProcessId();
-
-        [SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1305:FieldNamesMustNotUseHungarianNotation",
-            Justification = "Reviewed. Suppression is OK here.")]
-        [DllImport("kernel32.dll", SetLastError = true, PreserveSig = true, CharSet = CharSet.Unicode)]
-        internal static extern uint GetModuleFileName([In] IntPtr hModule, [Out] StringBuilder lpFilename, [In][MarshalAs(UnmanagedType.U4)] int nSize);
+        [SuppressMessage("Microsoft.Usage", "CA2205:UseManagedEquivalentsOfWin32Api", Justification = "We specifically need this API")]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal static extern void OutputDebugString(string message);
     }
 }
-
-#endif

--- a/src/NLog.OutputDebugString/OutputDebugStringTarget.cs
+++ b/src/NLog.OutputDebugString/OutputDebugStringTarget.cs
@@ -1,0 +1,118 @@
+// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Targets
+{
+    using NLog.Internal;
+
+    /// <summary>
+    /// Outputs log messages through the <c>OutputDebugString()</c> Win32 API.
+    /// </summary>
+    /// <seealso href="https://github.com/nlog/nlog/wiki/OutputDebugString-target">Documentation on NLog Wiki</seealso>
+    /// <example>
+    /// <p>
+    /// To set up the target in the <a href="config.html">configuration file</a>, 
+    /// use the following syntax:
+    /// </p>
+    /// <code lang="XML" source="examples/targets/Configuration File/OutputDebugString/NLog.config" />
+    /// <p>
+    /// This assumes just one target and a single rule. More configuration
+    /// options are described <a href="config.html">here</a>.
+    /// </p>
+    /// <p>
+    /// To set up the log target programmatically use code like this:
+    /// </p>
+    /// <code lang="C#" source="examples/targets/Configuration API/OutputDebugString/Simple/Example.cs" />
+    /// </example>
+    [Target("OutputDebugString")]
+    public sealed class OutputDebugStringTarget : TargetWithLayoutHeaderAndFooter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutputDebugStringTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message:withexception=true}</code>
+        /// </remarks>
+        public OutputDebugStringTarget() : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutputDebugStringTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message:withexception=true}</code>
+        /// </remarks>
+        /// <param name="name">Name of the target.</param>
+        public OutputDebugStringTarget(string name) : this()
+        {
+            Name = name;
+        }
+
+        /// <inheritdoc />
+        protected override void InitializeTarget()
+        {
+            base.InitializeTarget();
+
+            if (Header != null)
+            {
+                WriteDebugString(RenderLogEvent(Header, LogEventInfo.CreateNullEvent()));
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void CloseTarget()
+        {
+            if (Footer != null)
+            {
+                WriteDebugString(RenderLogEvent(Footer, LogEventInfo.CreateNullEvent()));
+            }
+
+            base.CloseTarget();
+        }
+
+        /// <summary>
+        /// Outputs the rendered logging event through the <c>OutputDebugString()</c> Win32 API.
+        /// </summary>
+        /// <param name="logEvent">The logging event.</param>
+        protected override void Write(LogEventInfo logEvent)
+        {
+            WriteDebugString(RenderLogEvent(Layout, logEvent));
+        }
+
+        private void WriteDebugString(string message)
+        {
+            NativeMethods.OutputDebugString(message);
+        }
+    }
+}

--- a/src/NLog.sln
+++ b/src/NLog.sln
@@ -59,6 +59,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.WindowsRegistry", "NLo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.WindowsRegistry.Tests", "..\tests\NLog.WindowsRegistry.Tests\NLog.WindowsRegistry.Tests.csproj", "{1648106F-CD67-4009-878B-96B5D2369B6C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.OutputDebugString", "NLog.OutputDebugString\NLog.OutputDebugString.csproj", "{FDABA8A6-80EE-4FBA-A5AA-2EB972DC4F17}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -133,6 +135,10 @@ Global
 		{1648106F-CD67-4009-878B-96B5D2369B6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1648106F-CD67-4009-878B-96B5D2369B6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1648106F-CD67-4009-878B-96B5D2369B6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FDABA8A6-80EE-4FBA-A5AA-2EB972DC4F17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDABA8A6-80EE-4FBA-A5AA-2EB972DC4F17}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDABA8A6-80EE-4FBA-A5AA-2EB972DC4F17}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDABA8A6-80EE-4FBA-A5AA-2EB972DC4F17}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -153,6 +159,7 @@ Global
 		{4F298FBF-A2E8-45E2-ADE5-056EEDF2C611} = {194AB4BD-C817-4C59-A86C-49D89B8C3A64}
 		{BFE365AA-A01F-4E8B-B540-3F8DF0466CE6} = {194AB4BD-C817-4C59-A86C-49D89B8C3A64}
 		{1648106F-CD67-4009-878B-96B5D2369B6C} = {194AB4BD-C817-4C59-A86C-49D89B8C3A64}
+		{FDABA8A6-80EE-4FBA-A5AA-2EB972DC4F17} = {194AB4BD-C817-4C59-A86C-49D89B8C3A64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6B4C8E9F-1E2F-4AB3-993A-8776CFA08DC0}

--- a/src/NLog/Targets/TraceTarget.cs
+++ b/src/NLog/Targets/TraceTarget.cs
@@ -60,6 +60,7 @@ namespace NLog.Targets
     /// <code lang="C#" source="examples/targets/Configuration API/Trace/Simple/Example.cs" />
     /// </example>
     [Target("Trace")]
+    [Target("TraceSystem")]
     public sealed class TraceTarget : TargetWithLayout
     {
         /// <summary>

--- a/tests/NLog.UnitTests/Targets/DebugSystemTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DebugSystemTargetTests.cs
@@ -1,0 +1,127 @@
+﻿// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System.Diagnostics;
+using Xunit;
+
+namespace NLog.UnitTests.Targets
+{
+    public class DebugSystemTargetTests : NLogTestBase
+    {
+        [Fact]
+        public void DebugWriteLineTest()
+        {
+            var sw = new System.IO.StringWriter();
+
+            try
+            {
+                // Arrange
+#if !NETSTANDARD
+                Debug.Listeners.Clear();
+                Debug.Listeners.Add(new TextWriterTraceListener(sw));
+#endif
+                var logger = new LogFactory().Setup().LoadConfigurationFromXml(@"
+                <nlog>
+                    <targets>
+                        <target type='debugsystem' name='Debug' layout='${message}' />
+                    </targets>
+                    <rules>
+                        <logger name='*' writeTo='Debug' />
+                    </rules>
+                </nlog>").GetCurrentClassLogger();
+
+                // Act
+                logger.Info("Hello World");
+
+                // Assert
+#if !NETSTANDARD
+                Assert.Contains("Hello World", sw.ToString());
+#endif
+            }
+            finally
+            {
+#if !NETSTANDARD
+                Debug.Listeners.Clear();
+#endif
+            }
+        }
+
+        [Fact]
+        public void DebugWriteLineHeaderFooterTest()
+        {
+            var sw = new System.IO.StringWriter();
+
+            try
+            {
+                // Arrange
+#if !NETSTANDARD
+                Debug.Listeners.Clear();
+                Debug.Listeners.Add(new TextWriterTraceListener(sw));
+#endif
+                var logger = new LogFactory().Setup().LoadConfigurationFromXml(@"
+                <nlog>
+                    <targets>
+                        <target type='debugsystem' name='Debug' layout='${message}'>
+                            <header>Startup</header>
+                            <footer>Shutdown</footer>
+                        </target>
+                    </targets>
+                    <rules>
+                        <logger name='*' writeTo='Debug' />
+                    </rules>
+                </nlog>").GetCurrentClassLogger();
+
+                // Act
+                logger.Info("Hello World");
+
+                // Assert
+#if !NETSTANDARD
+                Assert.Contains("Startup", sw.ToString());
+                Assert.Contains("Hello World", sw.ToString());
+                Assert.DoesNotContain("Shutdown", sw.ToString());
+
+                logger.Factory.Shutdown();
+                Assert.Contains("Shutdown", sw.ToString());
+#endif
+
+
+            }
+            finally
+            {
+#if !NETSTANDARD
+                Debug.Listeners.Clear();
+#endif
+            }
+        }
+    }
+}


### PR DESCRIPTION
But left behind DebugSystemTarget with alias "DebugSystem" and added alias "TraceSystem" to TraceTarget for consistency.