### PR TITLE
LoggingConfigurationParser - Added support for using assembly-name in type-name

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -305,10 +305,14 @@ namespace NLog.Config
 
             InternalLogger.Debug("ScanAssembly('{0}')", assembly.FullName);
             var typesToScan = assembly.SafeGetTypes();
-            PreloadAssembly(typesToScan);
-            foreach (IFactory f in _allFactories)
+            if (typesToScan?.Length > 0)
             {
-                f.ScanTypes(typesToScan, itemNamePrefix);
+                var assemblyName = new AssemblyName(assembly.FullName).Name;
+                PreloadAssembly(typesToScan);
+                foreach (IFactory f in _allFactories)
+                {
+                    f.ScanTypes(typesToScan, assemblyName, itemNamePrefix);
+                }
             }
         }
 

--- a/src/NLog/Config/IFactory.cs
+++ b/src/NLog/Config/IFactory.cs
@@ -42,7 +42,7 @@ namespace NLog.Config
     {
         void Clear();
 
-        void ScanTypes(Type[] types, string prefix);
+        void ScanTypes(Type[] types, string assemblyName, string itemNamePrefix);
 
         void RegisterType(Type type, string itemNamePrefix);
     }

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -360,7 +360,7 @@ namespace NLog.Config
                     throw;
                 }
 
-                var configurationException = new NLogConfigurationException(exception, "Exception when parsing {0}. ", fileName);
+                var configurationException = new NLogConfigurationException(exception, "Exception when loading configuration {0}", fileName);
                 InternalLogger.Error(exception, configurationException.Message);
                 if (!ignoreErrors && (LogFactory.ThrowConfigExceptions ?? LogFactory.ThrowExceptions || configurationException.MustBeRethrown()))
                     throw configurationException;

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -405,6 +405,23 @@ namespace NLog.UnitTests.Config
             Assert.Equal("NLogAutloadExtension.AutoLoadTarget", autoLoadedTarget.GetType().FullName);
         }
 
+        [Fact]
+        public void ExtensionTypeWithAssemblyNameCanLoad()
+        {
+            var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
+<nlog throwExceptions='true'>
+<targets>
+    <target name='t' type='NLogAutoLoadExtension.AutoLoadTarget' />
+</targets>
+<rules>
+    <logger name='*' writeTo='t' />
+</rules>
+</nlog>").LogFactory;
+
+            var autoLoadedTarget = logFactory.Configuration.FindTargetByName("t");
+            Assert.Equal("NLogAutloadExtension.AutoLoadTarget", autoLoadedTarget.GetType().FullName);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/tests/NLog.UnitTests/Targets/MailTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MailTargetTests.cs
@@ -594,6 +594,7 @@ namespace NLog.UnitTests.Targets
 
             var logFactory = new LogFactory().Setup().LoadConfiguration(cfg =>
             {
+                cfg.LogFactory.ThrowExceptions = true;
                 cfg.Configuration.AddRuleForAllLevels(mmt);
             }).LogFactory;
 
@@ -614,6 +615,7 @@ namespace NLog.UnitTests.Targets
             };
             var logFactory = new LogFactory().Setup().LoadConfiguration(cfg =>
             {
+                cfg.LogFactory.ThrowExceptions = true;
                 cfg.Configuration.AddRuleForAllLevels(mmt);
             }).LogFactory;
 
@@ -634,6 +636,7 @@ namespace NLog.UnitTests.Targets
             };
             var logFactory = new LogFactory().Setup().LoadConfiguration(cfg =>
             {
+                cfg.LogFactory.ThrowExceptions = true;
                 cfg.Configuration.AddRuleForAllLevels(mmt);
             }).LogFactory;
 
@@ -654,6 +657,7 @@ namespace NLog.UnitTests.Targets
 
             Assert.Throws<NLogConfigurationException>(() =>
                 new LogFactory().Setup().LoadConfiguration(cfg => {
+                    cfg.LogFactory.ThrowConfigExceptions = true;
                     cfg.Configuration.AddRuleForAllLevels(mmt);
                 })
             );
@@ -674,6 +678,7 @@ namespace NLog.UnitTests.Targets
 
             Assert.Throws<NLogConfigurationException>(() =>
                 new LogFactory().Setup().LoadConfiguration(cfg => {
+                    cfg.LogFactory.ThrowConfigExceptions = true;
                     cfg.Configuration.AddRuleForAllLevels(mmt);
                 })
             );
@@ -713,6 +718,7 @@ namespace NLog.UnitTests.Targets
 
             Assert.Throws<NLogConfigurationException>(() =>
                 new LogFactory().Setup().LoadConfiguration(cfg => {
+                    cfg.LogFactory.ThrowConfigExceptions = true;
                     cfg.Configuration.AddRuleForAllLevels(mmt);
                 })
             );
@@ -867,6 +873,7 @@ namespace NLog.UnitTests.Targets
 
             Assert.Throws<NLogConfigurationException>(() =>
                 new LogFactory().Setup().LoadConfiguration(cfg => {
+                    cfg.LogFactory.ThrowConfigExceptions = true;
                     cfg.Configuration.AddRuleForAllLevels(mmt);
                 })
             );


### PR DESCRIPTION
Resolves #2944 by allowing you to do this:

```xml
<targets>
   <target name="evt" type="NLog.WindowsEventLog.EventLog" />
</targets>
```

Making it easier to specify types from NLog-extension-assemblies without also having to update `<extensions>`