### PR TITLE
Update docs, remove out dated "ArrayList"

### DIFF
--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -336,7 +336,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// Renders the logging event message and adds it to the internal ArrayList of log messages.
+        /// Writes async log event to the mail target.
         /// </summary>
         /// <param name="logEvent">The logging event.</param>
         protected override void Write(AsyncLogEventInfo logEvent)
@@ -359,7 +359,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// Renders an array logging events.
+        /// Writes log events to the mail target.
         /// </summary>
         /// <param name="logEvents">Array of logging events.</param>
         protected override void Write(IList<AsyncLogEventInfo> logEvents)

--- a/src/NLog/Targets/MemoryTarget.cs
+++ b/src/NLog/Targets/MemoryTarget.cs
@@ -37,7 +37,7 @@ namespace NLog.Targets
     using System.ComponentModel;
 
     /// <summary>
-    /// Writes log messages to an ArrayList in memory for programmatic retrieval.
+    /// Writes log messages to <see cref="Logs"/> in memory for programmatic retrieval.
     /// </summary>
     /// <seealso href="https://github.com/nlog/nlog/wiki/Memory-target">Documentation on NLog Wiki</seealso>
     /// <example>
@@ -95,7 +95,7 @@ namespace NLog.Targets
         public int MaxLogsCount { get; set; }
 
         /// <summary>
-        /// Renders the logging event message and adds it to the internal ArrayList of log messages.
+        /// Renders the logging event message and adds to <see cref="Logs"/>
         /// </summary>
         /// <param name="logEvent">The logging event.</param>
         protected override void Write(LogEventInfo logEvent)


### PR DESCRIPTION
The word "ArrayList" confused me in the docs, and it's also outdated (not only arraylist, but also the docs)