### PR TITLE
 Added TypesInInternalNamespaceShouldBeInternalTest

### DIFF
--- a/src/NLog/Config/IUsesStackTrace.cs
+++ b/src/NLog/Config/IUsesStackTrace.cs
@@ -31,10 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.Internal
+namespace NLog.Config
 {
-    using Config;
-
     /// <summary>
     /// Allows components to request stack trace information to be provided in the <see cref="LogEventInfo"/>.
     /// </summary>

--- a/src/NLog/Internal/Abstractions/IAppDomain.cs
+++ b/src/NLog/Internal/Abstractions/IAppDomain.cs
@@ -77,7 +77,7 @@ namespace NLog.Internal.Fakeables
         /// Process exit event.
         /// </summary>
         event EventHandler<EventArgs> ProcessExit;
-        
+
         /// <summary>
         /// Domain unloaded event.
         /// </summary>

--- a/src/NLog/Internal/Abstractions/IConfigurationManager.cs
+++ b/src/NLog/Internal/Abstractions/IConfigurationManager.cs
@@ -40,7 +40,7 @@ namespace NLog.Internal
     /// <summary>
     /// Interface for the wrapper around System.Configuration.ConfigurationManager.
     /// </summary>
-    public interface IConfigurationManager
+    internal interface IConfigurationManager
     {
         /// <summary>
         /// Gets the wrapper around ConfigurationManager.AppSettings.

--- a/src/NLog/Internal/ConfigurationManager.cs
+++ b/src/NLog/Internal/ConfigurationManager.cs
@@ -42,7 +42,7 @@ namespace NLog.Internal
     /// Just a wrapper around the BCL ConfigurationManager, but used to enable
     /// unit testing.
     /// </summary>
-    public class ConfigurationManager : IConfigurationManager
+    internal class ConfigurationManager : IConfigurationManager
     {
         /// <summary>
         /// Gets the wrapper around ConfigurationManager.AppSettings.

--- a/src/NLog/Internal/StreamHelpers.cs
+++ b/src/NLog/Internal/StreamHelpers.cs
@@ -43,7 +43,7 @@ namespace NLog.Internal
     /// <summary>
     /// Stream helpers
     /// </summary>
-    public static class StreamHelpers
+    internal static class StreamHelpers
     {
         /// <summary>
         /// Copy to output stream and skip BOM if encoding is UTF8

--- a/src/NLog/Internal/Strings/StringHelpers.cs
+++ b/src/NLog/Internal/Strings/StringHelpers.cs
@@ -42,7 +42,7 @@ namespace NLog.Internal
     /// <summary>
     /// Helpers for <see cref="string"/>.
     /// </summary>
-    public static class StringHelpers
+    internal static class StringHelpers
     {
         /// <summary>
         /// IsNullOrWhiteSpace, including for .NET 3.5

--- a/src/NLog/Internal/XmlHelper.cs
+++ b/src/NLog/Internal/XmlHelper.cs
@@ -41,7 +41,7 @@ namespace NLog.Internal
     /// <summary>
     ///  Helper class for XML
     /// </summary>
-    public static class XmlHelper
+    internal static class XmlHelper
     {
         // found on https://stackoverflow.com/questions/397250/unicode-regex-invalid-xml-characters/961504#961504
         // filters control characters but allows only properly-formed surrogate sequences
@@ -68,7 +68,7 @@ namespace NLog.Internal
                 {
                     return CreateValidXmlString(text);   // rare expensive case
                 }
-                else 
+                else
                 {
                     ++i;
                 }

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Linq;
+
 namespace NLog.UnitTests
 {
     using System;
@@ -128,6 +130,21 @@ namespace NLog.UnitTests
             }
 
             Assert.Empty(unusedTypes);
+        }
+
+        [Fact]
+        public void TypesInInternalNamespaceShouldBeInternalTest()
+        {
+            var excludes = new HashSet<string> { "NLog.Internal.Xamarin.PreserveAttribute" };
+
+            var notInternalTypes = allTypes
+                .Where(t => t.Namespace != null && t.Namespace.Contains(".Internal"))
+                .Where(t => !t.IsNested && (t.IsVisible || t.IsPublic))
+                .Select(t => t.FullName)
+                .Where(n => !excludes.Contains(n))
+                .ToList();
+
+            Assert.Empty(notInternalTypes);
         }
 
         private void IncrementUsageCount(Type type)


### PR DESCRIPTION
Currently the issues: "NLog.Internal.Xamarin.PreserveAttribute" + "NLog.Internal.Fakeables.IAppDomain"

move the namepaces for those?

proposal:

-  "NLog.Internal.Xamarin.PreserveAttribute" -> "NLog.Xamarin.PreserveAttribute" 
- "NLog.Internal.Fakeables.IAppDomain" ->  "NLog.IAppDomain"