### PR TITLE
Typed Layout for easy conversion from Layout to actual value

### DIFF
--- a/src/NLog/Internal/Reflection/PropertyHelper.cs
+++ b/src/NLog/Internal/Reflection/PropertyHelper.cs
@@ -271,6 +271,14 @@ namespace NLog.Internal
                 return true;
             }
 
+            if (propertyType.IsGenericType() && propertyType.GetGenericTypeDefinition() == typeof(Layout<>))
+            {
+                var simpleLayout = new SimpleLayout(value, configurationItemFactory);
+                var concreteType = typeof(Layout<>).MakeGenericType(propertyType.GetGenericArguments());
+                newValue = Activator.CreateInstance(concreteType, BindingFlags.Instance | BindingFlags.Public, null, new object[] { simpleLayout }, null);
+                return true;
+            }
+
             newValue = null;
             return false;
         }
@@ -436,7 +444,7 @@ namespace NLog.Internal
             return null;
         }
 
-        private static bool TryTypeConverterConversion(Type type, string value, out object newValue)
+        internal static bool TryTypeConverterConversion(Type type, string value, out object newValue)
         {
             try
             {

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -83,7 +83,7 @@ namespace NLog.Layouts
         /// Gets the logging configuration this target is part of.
         /// </summary>
         [CanBeNull]
-        protected LoggingConfiguration LoggingConfiguration { get; private set; }
+        protected internal LoggingConfiguration LoggingConfiguration { get; private set; }
 
         /// <summary>
         /// Converts a given text to a <see cref="Layout" />.

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -224,12 +224,7 @@ namespace NLog.Layouts
             return Evaluate(text, LogEventInfo.CreateNullEvent());
         }
 
-        /// <summary>
-        /// Returns a <see cref="T:System.String"></see> that represents the current object.
-        /// </summary>
-        /// <returns>
-        /// A <see cref="T:System.String"></see> that represents the current object.
-        /// </returns>
+        /// <inheritdoc />
         public override string ToString()
         {
             if (string.IsNullOrEmpty(Text) && Renderers?.Count > 0)
@@ -238,6 +233,18 @@ namespace NLog.Layouts
             }
 
             return Text;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return obj is SimpleLayout other && string.Equals(OriginalText, other.OriginalText);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(this);
         }
 
         internal void SetRenderers(LayoutRenderer[] renderers, string text)

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -235,18 +235,6 @@ namespace NLog.Layouts
             return Text;
         }
 
-        /// <inheritdoc />
-        public override bool Equals(object obj)
-        {
-            return obj is SimpleLayout other && string.Equals(OriginalText, other.OriginalText);
-        }
-
-        /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(this);
-        }
-
         internal void SetRenderers(LayoutRenderer[] renderers, string text)
         {
             Renderers = new ReadOnlyCollection<LayoutRenderer>(renderers);

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -1,0 +1,387 @@
+﻿// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using NLog.Common;
+using NLog.Config;
+
+namespace NLog.Layouts
+{
+    /// <summary>
+    /// Typed Layout for easy conversion from NLog Layout logic to a simple value (ex. integer or enum)
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    [ThreadAgnostic]
+    [ThreadSafe]
+    [AppDomainFixedOutput]
+    public class Layout<T> : Layout, ITypedLayout
+    {
+        private static readonly Type UnderlyingType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+
+        private readonly Layout _innerLayout;
+        private readonly CultureInfo _parseFormatCulture;
+        private readonly string _parseFormat;
+        private string _previousStringValue;
+        private object _previousValue;
+        private readonly T _fixedValue;
+        private T _staticValue;
+        private bool _createdStaticValue;
+
+        /// <summary>
+        /// Is fixed value?
+        /// </summary>
+        public bool IsFixed => ReferenceEquals(_innerLayout, null);
+
+        Layout ITypedLayout.InnerLayout => _innerLayout;
+
+        Type ITypedLayout.ValueType => typeof(T);
+
+        object ITypedLayout.StaticValue => FixedObjectValue ?? StaticValue;
+
+        private object FixedObjectValue => IsFixed ? (_previousValue ?? (_previousValue = _fixedValue)) : null;
+
+        private IPropertyTypeConverter ValueTypeConverter => _valueTypeConverter ?? (_valueTypeConverter = ResolveService<IPropertyTypeConverter>());
+        IPropertyTypeConverter _valueTypeConverter;
+
+        /// <summary>
+        /// Static value independent of LogEvent being processed. Remains static until LoggingConfiguration is closed.
+        /// </summary>
+        public T StaticValue
+        {
+            get
+            {
+                if (IsFixed)
+                    return _fixedValue;
+
+                if (_createdStaticValue)
+                    return _staticValue;
+
+                // Would be great if ReconfigExistingLoggers() caused all StaticValue's to reset
+                var staticValue = RenderValue(LogEventInfo.CreateNullEvent(), default(T));
+                _staticValue = staticValue;
+                _createdStaticValue = true;
+                return staticValue;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Layout{T}" /> class.
+        /// </summary>
+        /// <param name="layout">Dynamic NLog Layout</param>
+        public Layout(Layout layout)
+            :this(layout, null, CultureInfo.InvariantCulture)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Layout{T}" /> class.
+        /// </summary>
+        /// <param name="layout">Dynamic NLog Layout</param>
+        /// <param name="parseValueFormat">Format used for parsing string-value into actual value type</param>
+        /// <param name="parseValueCulture">Culture used for parsing string-value into actual value type</param>
+        public Layout(Layout layout, string parseValueFormat, CultureInfo parseValueCulture)
+        {
+            if (layout is SimpleLayout simpleLayout && simpleLayout.IsFixedText)
+            {
+                if (TryParseValueFromString(simpleLayout.Text, parseValueFormat, parseValueCulture, out var value) && value != null)
+                {
+                    _fixedValue = (T)value;
+                }
+                else
+                {
+                    _innerLayout = simpleLayout;
+                    _parseFormat = parseValueFormat;
+                    _parseFormatCulture = parseValueCulture;
+                }
+            }
+            else if (ReferenceEquals(layout, null))
+            {
+                _fixedValue = default(T);
+            }
+            else
+            {
+                _innerLayout = layout;
+                _parseFormat = parseValueFormat;
+                _parseFormatCulture = parseValueCulture;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Layout{T}" /> class.
+        /// </summary>
+        /// <param name="value">Fixed value</param>
+        public Layout(T value)
+        {
+            _fixedValue = value;
+        }
+
+        /// <summary>
+        /// Render Value
+        /// </summary>
+        /// <param name="logEvent">Log event for rendering</param>
+        /// <param name="defaultValue">Fallback value when no value available</param>
+        /// <returns></returns>
+        public T RenderValue(LogEventInfo logEvent, T defaultValue = default(T))
+        {
+            return RenderValue(logEvent, null, defaultValue);
+        }
+
+        internal T RenderValue(LogEventInfo logEvent, StringBuilder stringBuilder, T defaultValue)
+        {
+            if (IsFixed)
+                return _fixedValue;
+
+            return RenderTypedValue(logEvent, stringBuilder, defaultValue);
+        }
+
+        object ITypedLayout.RenderValue(LogEventInfo logEvent, object defaultValue)
+        {
+            var value = FixedObjectValue ?? RenderTypedValue(logEvent, null, defaultValue);
+            if (ReferenceEquals(value, defaultValue) && ReferenceEquals(defaultValue, string.Empty) && UnderlyingType != typeof(string))
+                return default(T);
+            else
+                return value;
+        }
+
+        /// <summary>
+        /// Renders the value and converts the value into string format
+        /// </summary>
+        /// <remarks>
+        /// Only to implement abstract method from <see cref="Layout"/>, and only used when calling <see cref="Layout.Render(LogEventInfo)"/> instead of <see cref="RenderValue(LogEventInfo, T)"/>
+        /// </remarks>
+        protected override string GetFormattedMessage(LogEventInfo logEvent)
+        {
+            var value = FixedObjectValue ?? RenderTypedValue<object>(logEvent, null, null);
+            var formatProvider = logEvent.FormatProvider ?? LoggingConfiguration?.DefaultCultureInfo;
+            return Convert.ToString(value, formatProvider);
+        }
+
+        /// <inheritdoc />
+        protected override void InitializeLayout()
+        {
+            base.InitializeLayout();
+            _innerLayout?.Initialize(LoggingConfiguration);
+            ThreadSafe = _innerLayout?.ThreadSafe ?? true;
+            ThreadAgnostic = _innerLayout?.ThreadAgnostic ?? true;
+            MutableUnsafe = _innerLayout?.MutableUnsafe ?? false;
+            _valueTypeConverter = null;
+            _createdStaticValue = false;
+            _previousStringValue = null;
+            _previousValue = null;
+        }
+
+        /// <inheritdoc />
+        protected override void CloseLayout()
+        {
+            _innerLayout?.Close();
+            _valueTypeConverter = null;
+            _createdStaticValue = false;
+            _previousStringValue = null;
+            _previousValue = null;
+            base.CloseLayout();
+        }
+
+        /// <inheritdoc />
+        public override void Precalculate(LogEventInfo logEvent)
+        {
+            PrecalculateInnerLayout(logEvent, null);
+        }
+
+        /// <inheritdoc />
+        internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+        {
+            PrecalculateInnerLayout(logEvent, target);
+        }
+
+        private void PrecalculateInnerLayout(LogEventInfo logEvent, StringBuilder target)
+        {
+            if (IsFixed || (_innerLayout.ThreadAgnostic && !_innerLayout.MutableUnsafe))
+                return;
+
+            if (TryRenderObjectValue(logEvent, target, out var cachedValue))
+            {
+                logEvent.AddCachedLayoutValue(this, cachedValue);
+            }
+        }
+
+        private TValueType RenderTypedValue<TValueType>(LogEventInfo logEvent, StringBuilder stringBuilder, TValueType defaultValue)
+        {
+            if (logEvent.TryGetCachedLayoutValue(this, out var cachedValue))
+            {
+                if (cachedValue == null || string.Empty.Equals(cachedValue))
+                    return defaultValue;
+                else
+                    return (TValueType)cachedValue;
+            }
+
+            if (TryRenderObjectValue(logEvent, stringBuilder, out var value) && value != null)
+            {
+                return (TValueType)value;
+            }
+
+            return defaultValue;
+        }
+
+        private bool TryRenderObjectValue(LogEventInfo logEvent, StringBuilder stringBuilder, out object value)
+        {
+            if (_innerLayout.TryGetRawValue(logEvent, out var rawValue))
+            {
+                if (rawValue is string rawStringValue)
+                {
+                    if (string.IsNullOrEmpty(rawStringValue))
+                    {
+                        value = UnderlyingType == typeof(string) ? rawStringValue : null;
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (ReferenceEquals(rawValue, null))
+                    {
+                        value = null;
+                        return true;
+                    }
+
+                    return TryParseValueFromObject(rawValue, _parseFormat, _parseFormatCulture, out value);
+                }
+            }
+
+            var previousStringValue = _previousStringValue;
+            var previousValue = _previousValue;
+            var stringValue = stringBuilder != null ? _innerLayout.RenderAllocateBuilder(logEvent, stringBuilder) : _innerLayout.Render(logEvent);
+            if (previousStringValue != null && previousStringValue == stringValue)
+            {
+                value = previousValue;
+                return true;
+            }
+
+            if (TryParseValueFromString(stringValue, _parseFormat, _parseFormatCulture, out value))
+            {
+                _previousValue = value;
+                _previousStringValue = stringValue;
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool TryParseValueFromString(string stringValue, string parseValueFormat, CultureInfo parseValueCulture, out object parsedValue)
+        {
+            if (string.IsNullOrEmpty(stringValue))
+            {
+                parsedValue = null;
+                return true;
+            }
+
+            return TryParseValueFromObject(stringValue, parseValueFormat, parseValueCulture, out parsedValue);
+        }
+
+        bool ITypedLayout.TryParseValueFromString(string stringValue, out object parsedValue)
+        {
+            return TryParseValueFromString(stringValue, _parseFormat, _parseFormatCulture, out parsedValue);
+        }
+
+        bool TryParseValueFromObject(object rawValue, string parseValueFormat, CultureInfo parseValueCulture, out object parsedValue)
+        {
+            try
+            {
+                parsedValue = ValueTypeConverter.Convert(rawValue, UnderlyingType, parseValueFormat, parseValueCulture);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                parsedValue = null;
+                InternalLogger.Warn(ex, "Failed converting object '{0}' of type {1} into type {2}", rawValue, rawValue?.GetType(), typeof(T));
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return (IsFixed ? _fixedValue.ToString() : _innerLayout?.ToString()) ?? string.Empty;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return obj is Layout<T> other && object.Equals(_innerLayout, other._innerLayout) && object.Equals(FixedObjectValue, other.FixedObjectValue);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(this);
+        }
+
+        /// <summary>
+        /// Converts a given value to a <see cref="Layout{T}" />.
+        /// </summary>
+        /// <param name="value">Text to be converted.</param>
+        public static implicit operator Layout<T>(T value)
+        {
+            return new Layout<T>(value);
+        }
+
+        /// <summary>
+        /// Converts a given text to a <see cref="Layout{T}" />.
+        /// </summary>
+        /// <param name="layout">Text to be converted.</param>
+        public static implicit operator Layout<T>([Localizable(false)] string layout)
+        {
+            return new Layout<T>(layout);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Layout{T}" /> its current value
+        /// </summary>
+        /// <param name="layout">Text to be converted.</param>
+        public static implicit operator T(Layout<T> layout) => layout.StaticValue;
+    }
+
+    /// <summary>
+    /// Provides access to untyped value without knowing underlying generic type
+    /// </summary>
+    internal interface ITypedLayout
+    {
+        Layout InnerLayout { get; }
+        Type ValueType { get; }
+        bool IsFixed { get; }
+        object StaticValue { get; }
+        object RenderValue(LogEventInfo logEvent, object defaultValue);
+        bool TryParseValueFromString(string stringValue, out object parsedValue);
+    }
+}

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -344,7 +344,7 @@ namespace NLog.Layouts
         /// <inheritdoc />
         public override string ToString()
         {
-            return (IsFixed ? _fixedValue.ToString() : _innerLayout?.ToString()) ?? string.Empty;
+            return IsFixed ? (FixedObjectValue?.ToString() ?? "null") : (_innerLayout?.ToString() ?? base.ToString());
         }
 
         /// <inheritdoc />
@@ -355,8 +355,10 @@ namespace NLog.Layouts
                 // Support property-compare
                 if (obj is Layout<T> other)
                     return other.IsFixed && object.Equals(FixedObjectValue, other.FixedObjectValue);
+                else if (obj is T)
+                    return object.Equals(FixedObjectValue, obj);
                 else
-                    return obj is T && object.Equals(FixedObjectValue, obj);
+                    return obj == null && FixedObjectValue == null;
             }
             else
             {

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -176,7 +176,7 @@ namespace NLog.Layouts
         {
             var value = FixedObjectValue ?? RenderTypedValue(logEvent, null, defaultValue);
             if (ReferenceEquals(value, defaultValue) && ReferenceEquals(defaultValue, string.Empty) && typeof(T) != typeof(string))
-                return default(T);
+                return default(T);  // Translate defaultValue = string.Empty into unspecified defaultValue
             else
                 return value;
         }
@@ -276,8 +276,7 @@ namespace NLog.Layouts
                 {
                     if (string.IsNullOrEmpty(rawStringValue))
                     {
-                        value = typeof(T) == typeof(string) ? rawStringValue : null;
-                        return true;
+                        return TryParseValueFromString(rawStringValue, _parseFormat, _parseFormatCulture, out value);
                     }
                 }
                 else
@@ -340,7 +339,7 @@ namespace NLog.Layouts
         {
             if (string.IsNullOrEmpty(stringValue))
             {
-                parsedValue = null;
+                parsedValue = typeof(T) == typeof(string) ? stringValue : null;
                 return true;
             }
 

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -48,7 +48,7 @@ namespace NLog.Layouts
     [ThreadAgnostic]
     [ThreadSafe]
     [AppDomainFixedOutput]
-    public class Layout<T> : Layout, ITypedLayout
+    public sealed class Layout<T> : Layout, ITypedLayout
     {
         private static readonly Type UnderlyingType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
 
@@ -115,6 +115,11 @@ namespace NLog.Layouts
         /// <param name="parseValueCulture">Culture used for parsing string-value into result value type</param>
         public Layout(Layout layout, string parseValueFormat, CultureInfo parseValueCulture)
         {
+            if (PropertyTypeConverter.IsComplexType(typeof(T)))
+            {
+                throw new NLogConfigurationException($"Layout<{typeof(T).ToString()}> not supported. Immutable value type is recommended");
+            }
+
             if (layout is SimpleLayout simpleLayout && simpleLayout.IsFixedText)
             {
                 if (TryParseValueFromString(simpleLayout.FixedText, parseValueFormat, parseValueCulture, out var value) && value != null)

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -35,6 +35,7 @@ using System;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
+using JetBrains.Annotations;
 using NLog.Common;
 using NLog.Config;
 
@@ -90,7 +91,7 @@ namespace NLog.Layouts
                     return _staticValue;
 
                 // Would be great if ReconfigExistingLoggers() caused all StaticValue's to reset
-                var staticValue = RenderValue(LogEventInfo.CreateNullEvent(), default(T));
+                var staticValue = RenderTypedValue(LogEventInfo.CreateNullEvent(), default(T));
                 _staticValue = staticValue;
                 _createdStaticValue = true;
                 return staticValue;
@@ -154,17 +155,17 @@ namespace NLog.Layouts
         /// <param name="logEvent">Log event for rendering</param>
         /// <param name="defaultValue">Fallback value when no value available</param>
         /// <returns>Result value when available, else fallback to defaultValue</returns>
-        public T RenderValue(LogEventInfo logEvent, T defaultValue = default(T))
+        internal T RenderTypedValue([CanBeNull] LogEventInfo logEvent, T defaultValue = default(T))
         {
-            return RenderValue(logEvent, null, defaultValue);
+            return RenderTypedValue(logEvent, null, defaultValue);
         }
 
-        internal T RenderValue(LogEventInfo logEvent, StringBuilder stringBuilder, T defaultValue)
+        internal T RenderTypedValue([CanBeNull] LogEventInfo logEvent, [CanBeNull] StringBuilder stringBuilder, T defaultValue)
         {
             if (IsFixed)
                 return _fixedValue;
 
-            return RenderTypedValue(logEvent, stringBuilder, defaultValue);
+            return RenderTypedValue<T>(logEvent, stringBuilder, defaultValue);
         }
 
         object ITypedLayout.RenderValue(LogEventInfo logEvent, object defaultValue)
@@ -180,7 +181,7 @@ namespace NLog.Layouts
         /// Renders the value and converts the value into string format
         /// </summary>
         /// <remarks>
-        /// Only to implement abstract method from <see cref="Layout"/>, and only used when calling <see cref="Layout.Render(LogEventInfo)"/> instead of <see cref="RenderValue(LogEventInfo, T)"/>
+        /// Only to implement abstract method from <see cref="Layout"/>, and only used when calling <see cref="Layout.Render(LogEventInfo)"/>
         /// </remarks>
         protected override string GetFormattedMessage(LogEventInfo logEvent)
         {

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -190,7 +190,7 @@ namespace NLog.Layouts
         /// </remarks>
         protected override string GetFormattedMessage(LogEventInfo logEvent)
         {
-            var value = FixedObjectValue ?? RenderTypedValue<object>(logEvent, null, null);
+            var value = IsFixed ? FixedObjectValue : RenderTypedValue<object>(logEvent, null, null);
             var formatProvider = logEvent.FormatProvider ?? LoggingConfiguration?.DefaultCultureInfo;
             return Convert.ToString(value, formatProvider);
         }
@@ -253,9 +253,12 @@ namespace NLog.Layouts
                     return (TValueType)cachedValue;
             }
 
-            if (TryRenderObjectValue(logEvent, stringBuilder, out var value) && value != null)
+            if (TryRenderObjectValue(logEvent, stringBuilder, out var value))
             {
-                return (TValueType)value;
+                if (value != null)
+                    return (TValueType)value;
+                else if (typeof(T) != UnderlyingType)
+                    return (TValueType)value;
             }
 
             return defaultValue;
@@ -374,7 +377,7 @@ namespace NLog.Layouts
         public override int GetHashCode()
         {
             if (IsFixed)
-                return FixedObjectValue.GetHashCode();   // Support property-compare
+                return FixedObjectValue?.GetHashCode() ?? UnderlyingType.GetHashCode();     // Support property-compare
             else
                 return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(this);    // Support LogEventInfo.LayoutCache
         }

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -343,13 +343,34 @@ namespace NLog.Layouts
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            return obj is Layout<T> other && object.Equals(_innerLayout, other._innerLayout) && object.Equals(FixedObjectValue, other.FixedObjectValue);
+            if (IsFixed)
+            {
+                // Support property-compare
+                if (obj is Layout<T> other)
+                    return other.IsFixed && object.Equals(FixedObjectValue, other.FixedObjectValue);
+                else
+                    return obj is T && object.Equals(FixedObjectValue, obj);
+            }
+            else
+            {
+                return ReferenceEquals(this, obj);  // Support LogEventInfo.LayoutCache
+            }
+        }
+
+        /// <inheritdoc />
+        public bool Equals(T other)
+        {
+            // Support property-compare
+            return IsFixed && object.Equals(FixedObjectValue, other);
         }
 
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(this);
+            if (IsFixed)
+                return FixedObjectValue.GetHashCode();   // Support property-compare
+            else
+                return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(this);    // Support LogEventInfo.LayoutCache
         }
 
         /// <summary>

--- a/src/NLog/Layouts/Typed/LayoutTypedExtensions.cs
+++ b/src/NLog/Layouts/Typed/LayoutTypedExtensions.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+//  
+//  All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without 
+//  modification, are permitted provided that the following conditions 
+//  are met:
+//  
+//  * Redistributions of source code must retain the above copyright notice, 
+//    this list of conditions and the following disclaimer. 
+//  
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution. 
+//  
+//  * Neither the name of Jaroslaw Kowalski nor the names of its 
+//    contributors may be used to endorse or promote products derived from this
+//    software without specific prior written permission. 
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES
+
+using JetBrains.Annotations;
+using NLog.Layouts;
+
+namespace NLog
+{
+    /// <summary>
+    /// Extensions for NLog <see cref="Layout{T}"/>.
+    /// </summary>
+    public static class LayoutTypedExtensions
+    {
+        /// <summary>
+        /// Renders the logevent into a result-value by using the provided layout
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="layout">The layout.</param>
+        /// <param name="logEvent">The logevent info.</param>
+        /// <param name="defaultValue">Fallback value when no value available</param>
+        /// <returns>Result value when available, else fallback to defaultValue</returns>
+        public static T RenderValue<T>([CanBeNull] this Layout<T> layout, [CanBeNull] LogEventInfo logEvent, T defaultValue = default(T))
+        {
+            if (layout != null)
+                return layout.RenderTypedValue(logEvent, defaultValue);
+            else
+                return defaultValue;
+        }
+    }
+}

--- a/src/NLog/Layouts/Typed/LayoutTypedExtensions.cs
+++ b/src/NLog/Layouts/Typed/LayoutTypedExtensions.cs
@@ -1,29 +1,35 @@
-﻿// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
-//  
-//  All rights reserved.
-//  
-//  Redistribution and use in source and binary forms, with or without 
-//  modification, are permitted provided that the following conditions 
-//  are met:
-//  
-//  * Redistributions of source code must retain the above copyright notice, 
-//    this list of conditions and the following disclaimer. 
-//  
-//  * Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution. 
-//  
-//  * Neither the name of Jaroslaw Kowalski nor the names of its 
-//    contributors may be used to endorse or promote products derived from this
-//    software without specific prior written permission. 
-//  
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-//  SUBSTITUTE GOODS OR SERVICES
+﻿// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
 
 using JetBrains.Annotations;
 using NLog.Layouts;

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -308,7 +308,7 @@ namespace NLog.Targets
         /// Gets or sets the priority used for sending mails.
         /// </summary>
         /// <docgen category='Message Options' order='100' />
-        public Layout Priority { get; set; }
+        public Layout<MailPriority> Priority { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether NewLine characters in the body should be replaced with <br/> tags.
@@ -636,21 +636,7 @@ namespace NLog.Targets
 
             if (Priority != null)
             {
-                var renderedPriority = Priority.Render(lastEvent);
-
-                if (string.IsNullOrEmpty(renderedPriority))
-                {
-                    msg.Priority = MailPriority.Normal;
-                }
-                else if (ConversionHelpers.TryParseEnum(renderedPriority, out MailPriority mailPriority))
-                {
-                    msg.Priority = mailPriority;
-                }
-                else
-                {
-                    msg.Priority = MailPriority.Normal;
-                    InternalLogger.Warn("{0}: Could not convert '{1}' to MailPriority, valid values are Low, Normal and High. Using normal priority as fallback.", this, renderedPriority);
-                }
+                msg.Priority = Priority.RenderValue(lastEvent, MailPriority.Normal);
             }
             msg.Body = body;
             if (msg.IsBodyHtml && ReplaceNewlineWithBrTagInHtml && msg.Body != null)

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -604,8 +604,6 @@ namespace NLog.Targets
                 sb.Append(layout.Render(logEvent));
         }
 
-
-
         /// <summary>
         /// Create the mail message with the addresses, properties and body.
         /// </summary>
@@ -636,8 +634,9 @@ namespace NLog.Targets
 
             if (Priority != null)
             {
-                msg.Priority = Priority.RenderValue(lastEvent, MailPriority.Normal);
+                msg.Priority = RenderLogEvent(Priority, lastEvent, MailPriority.Normal);
             }
+
             msg.Body = body;
             if (msg.IsBodyHtml && ReplaceNewlineWithBrTagInHtml && msg.Body != null)
                 msg.Body = msg.Body.Replace(Environment.NewLine, "<br/>");

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -36,6 +36,7 @@ namespace NLog.Targets
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using JetBrains.Annotations;
     using NLog.Common;
     using NLog.Config;
     using NLog.Internal;
@@ -683,7 +684,7 @@ namespace NLog.Targets
         /// <param name="layout">The layout.</param>
         /// <param name="logEvent">The logevent info.</param>
         /// <returns>String representing log event.</returns>
-        protected string RenderLogEvent(Layout layout, LogEventInfo logEvent)
+        protected string RenderLogEvent([CanBeNull] Layout layout, [CanBeNull] LogEventInfo logEvent)
         {
             if (layout == null || logEvent == null)
                 return null;    // Signal that input was wrong
@@ -718,7 +719,7 @@ namespace NLog.Targets
         /// <param name="logEvent">The logevent info.</param>
         /// <param name="defaultValue">Fallback value when no value available</param>
         /// <returns>Result value when available, else fallback to defaultValue</returns>
-        protected T RenderLogEvent<T>(Layout<T> layout, LogEventInfo logEvent, T defaultValue = default(T))
+        protected T RenderLogEvent<T>([CanBeNull] Layout<T> layout, [CanBeNull] LogEventInfo logEvent, T defaultValue = default(T))
         {
             if (layout == null || logEvent == null)
                 return defaultValue;
@@ -736,7 +737,7 @@ namespace NLog.Targets
 
             using (var localTarget = ReusableLayoutBuilder.Allocate())
             {
-                return layout.RenderValue(logEvent, localTarget.Result, defaultValue);
+                return layout.RenderTypedValue(logEvent, localTarget.Result, defaultValue);
             }
         }
 

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -678,10 +678,10 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// Renders the event info in layout.
+        /// Renders the logevent into a string-result using the provided layout
         /// </summary>
         /// <param name="layout">The layout.</param>
-        /// <param name="logEvent">The event info.</param>
+        /// <param name="logEvent">The logevent info.</param>
         /// <returns>String representing log event.</returns>
         protected string RenderLogEvent(Layout layout, LogEventInfo logEvent)
         {
@@ -711,13 +711,13 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// 
+        /// Renders the logevent into a result-value by using the provided layout
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="layout"></param>
-        /// <param name="logEvent"></param>
-        /// <param name="defaultValue"></param>
-        /// <returns></returns>
+        /// <param name="layout">The layout.</param>
+        /// <param name="logEvent">The logevent info.</param>
+        /// <param name="defaultValue">Fallback value when no value available</param>
+        /// <returns>Result value when available, else fallback to defaultValue</returns>
         protected T RenderLogEvent<T>(Layout<T> layout, LogEventInfo logEvent, T defaultValue = default(T))
         {
             if (layout == null || logEvent == null)

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -167,7 +167,7 @@ namespace NLog.UnitTests.Layouts
 
             // Assert
             Assert.Null(result);
-            Assert.Null(result5);
+            Assert.Equal(5, result5);
             Assert.Equal("", layout.Render(logevent));
             Assert.Null(layout.StaticValue);
         }

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -55,6 +55,38 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void LayoutFixedNullableIntValueTest()
+        {
+            // Arrange
+            Layout<int?> layout = 5;
+
+            // Act
+            var result = layout.RenderValue(LogEventInfo.CreateNullEvent());
+
+            // Assert
+            Assert.Equal(5, result);
+            Assert.Equal("5", layout.Render(LogEventInfo.CreateNullEvent()));
+            Assert.Equal(5, layout.StaticValue);
+        }
+
+        [Fact]
+        public void LayoutFixedNullIntValueTest()
+        {
+            // Arrange
+            Layout<int?> layout = new Layout<int?>((int?)null);
+
+            // Act
+            var result = layout.RenderValue(LogEventInfo.CreateNullEvent());
+            var result5 = layout.RenderValue(LogEventInfo.CreateNullEvent(), 5);
+
+            // Assert
+            Assert.Null(result);
+            Assert.Null(result5);
+            Assert.Equal("", layout.Render(LogEventInfo.CreateNullEvent()));
+            Assert.Null(layout.StaticValue);
+        }
+
+        [Fact]
         public void LayoutFixedUrlValueTest()
         {
             // Arrange
@@ -68,6 +100,24 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(uri, result);
             Assert.Same(result, layout.RenderValue(LogEventInfo.CreateNullEvent()));
             Assert.Equal(uri.ToString(), layout.Render(LogEventInfo.CreateNullEvent()));
+            Assert.Equal(uri, layout.StaticValue);
+            Assert.Same(layout.StaticValue, layout.StaticValue);
+        }
+
+        [Fact]
+        public void LayoutFixedNullUrlValueTest()
+        {
+            // Arrange
+            Uri uri = null;
+            Layout<Uri> layout = new Layout<Uri>(uri);
+
+            // Act
+            var result = layout.RenderValue(LogEventInfo.CreateNullEvent());
+
+            // Assert
+            Assert.Equal(uri, result);
+            Assert.Same(result, layout.RenderValue(LogEventInfo.CreateNullEvent()));
+            Assert.Equal("", layout.Render(LogEventInfo.CreateNullEvent()));
             Assert.Equal(uri, layout.StaticValue);
             Assert.Same(layout.StaticValue, layout.StaticValue);
         }
@@ -89,6 +139,40 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void LayoutDynamicNullableIntValueTest()
+        {
+            // Arrange
+            Layout<int?> layout = "${event-properties:intvalue}";
+
+            // Act
+            var logevent = LogEventInfo.Create(LogLevel.Info, null, null, "{intvalue}", new object[] { 5 });
+            var result = layout.RenderValue(logevent);
+
+            // Assert
+            Assert.Equal(5, result);
+            Assert.Equal("5", layout.Render(logevent));
+            Assert.Null(layout.StaticValue);
+        }
+
+        [Fact]
+        public void LayoutDynamicNullIntValueTest()
+        {
+            // Arrange
+            Layout<int?> layout = "${event-properties:intvalue}";
+
+            // Act
+            var logevent = LogEventInfo.Create(LogLevel.Info, null, null, "{intvalue}", new object[] { null });
+            var result = layout.RenderValue(logevent);
+            var result5 = layout.RenderValue(logevent, 5);
+
+            // Assert
+            Assert.Null(result);
+            Assert.Null(result5);
+            Assert.Equal("", layout.Render(logevent));
+            Assert.Null(layout.StaticValue);
+        }
+
+        [Fact]
         public void LayoutDynamicUrlValueTest()
         {
             // Arrange
@@ -103,6 +187,24 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(uri, result);
             Assert.Same(result, layout.RenderValue(logevent));
             Assert.Equal(uri.ToString(), layout.Render(logevent));
+            Assert.Null(layout.StaticValue);
+        }
+
+        [Fact]
+        public void LayoutDynamicNullUrlValueTest()
+        {
+            // Arrange
+            Layout<Uri> layout = "${event-properties:urlvalue}";
+            Uri uri = null;
+
+            // Act
+            var logevent = LogEventInfo.Create(LogLevel.Info, null, null, "{urlvalue}", new object[] { uri });
+            var result = layout.RenderValue(logevent);
+
+            // Assert
+            Assert.Equal(uri, result);
+            Assert.Same(result, layout.RenderValue(logevent));
+            Assert.Equal("", layout.Render(logevent));
             Assert.Null(layout.StaticValue);
         }
 
@@ -123,6 +225,25 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(5, layout.RenderValue(logevent));
             Assert.Equal("5", layout.Render(logevent));
             Assert.Equal(0, layout.StaticValue);
+        }
+
+        [Fact]
+        public void LayoutDynamicNullableIntValueAsyncTest()
+        {
+            // Arrange
+            Layout<int?> layout = "${scopeproperty:intvalue}";
+
+            // Act
+            var logevent = LogEventInfo.CreateNullEvent();
+            using (ScopeContext.PushProperty("intvalue", 5))
+            {
+                layout.Precalculate(logevent);
+            }
+
+            // Assert
+            Assert.Equal(5, layout.RenderValue(logevent));
+            Assert.Equal("5", layout.Render(logevent));
+            Assert.Null(layout.StaticValue);
         }
 
         [Fact]
@@ -181,6 +302,20 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void LayoutRenderNullableIntValueWhenNull()
+        {
+            // Arrange
+            var integer = 42;
+            Layout<int?> layout = null;
+
+            // Act
+            var value = LayoutTypedExtensions.RenderValue(layout, null, integer);
+
+            // Assert
+            Assert.Equal(integer, value);
+        }
+
+        [Fact]
         public void LayoutRenderUrlValueWhenNull()
         {
             // Arrange
@@ -203,7 +338,39 @@ namespace NLog.UnitTests.Layouts
 
             // Act + Assert
             Assert.True(layout1 == 42);
+            Assert.True(42 == layout1);
             Assert.True(layout1.Equals(42));
+            Assert.Equal(layout1, layout2);
+            Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
+        }
+
+        [Fact]
+        public void LayoutEqualsNullableIntValueFixedTest()
+        {
+            // Arrange
+            Layout<int?> layout1 = "42";
+            Layout<int?> layout2 = "42";
+
+            // Act + Assert
+            Assert.True(layout1 == 42);
+            Assert.True(42 == layout1);
+            Assert.True(layout1.Equals(42));
+            Assert.Equal(layout1, layout2);
+            Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
+        }
+
+        [Fact]
+        public void LayoutEqualsNullIntValueFixedTest()
+        {
+            // Arrange
+            int? nullInt = null;
+            Layout<int?> layout1 = nullInt;
+            Layout<int?> layout2 = nullInt;
+
+            // Act + Assert
+            Assert.True(layout1 == nullInt);
+            Assert.True(nullInt == layout1);
+            Assert.True(layout1.Equals(nullInt));
             Assert.Equal(layout1, layout2);
             Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
         }
@@ -217,7 +384,39 @@ namespace NLog.UnitTests.Layouts
 
             // Act + Assert
             Assert.False(layout1 == 42);
+            Assert.False(42 == layout1);
             Assert.False(layout1.Equals(42));
+            Assert.NotEqual(layout1, layout2);
+            Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
+        }
+
+        [Fact]
+        public void LayoutNotEqualsNullableIntValueFixedTest()
+        {
+            // Arrange
+            Layout<int?> layout1 = "2";
+            Layout<int?> layout2 = "42";
+
+            // Act + Assert
+            Assert.False(layout1 == 42);
+            Assert.False(42 == layout1);
+            Assert.False(layout1.Equals(42));
+            Assert.NotEqual(layout1, layout2);
+            Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
+        }
+
+        [Fact]
+        public void LayoutNotEqualsNullIntValueFixedTest()
+        {
+            // Arrange
+            int? nullInt = null;
+            Layout<int?> layout1 = "2";
+            Layout<int?> layout2 = nullInt;
+
+            // Act + Assert
+            Assert.False(layout1 == nullInt);
+            Assert.False(nullInt == layout1);
+            Assert.False(layout1.Equals(nullInt));
             Assert.NotEqual(layout1, layout2);
             Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
         }
@@ -232,6 +431,23 @@ namespace NLog.UnitTests.Layouts
 
             // Act + Assert
             Assert.True(layout1 == url);
+            Assert.True(url == layout1);
+            Assert.True(layout1.Equals(url));
+            Assert.Equal(layout1, layout2);
+            Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
+        }
+
+        [Fact]
+        public void LayoutEqualsNullUrlValueFixedTest()
+        {
+            // Arrange
+            Uri url = null;
+            Layout<Uri> layout1 = url;
+            Layout<Uri> layout2 = url;
+
+            // Act + Assert
+            Assert.True(layout1 == url);
+            Assert.True(url == layout1);
             Assert.True(layout1.Equals(url));
             Assert.Equal(layout1, layout2);
             Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
@@ -248,6 +464,24 @@ namespace NLog.UnitTests.Layouts
 
             // Act + Assert
             Assert.False(layout1 == url);
+            Assert.False(url == layout1);
+            Assert.False(layout1.Equals(url));
+            Assert.NotEqual(layout1, layout2);
+            Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
+        }
+
+        [Fact]
+        public void LayoutNotEqualsNullUrlValueFixedTest()
+        {
+            // Arrange
+            Uri url = null;
+            var url2 = new Uri("http://nlog");
+            Layout<Uri> layout1 = url2;
+            Layout<Uri> layout2 = url;
+
+            // Act + Assert
+            Assert.False(layout1 == url);
+            Assert.False(url == layout1);
             Assert.False(layout1.Equals(url));
             Assert.NotEqual(layout1, layout2);
             Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
@@ -259,6 +493,18 @@ namespace NLog.UnitTests.Layouts
             // Arrange
             Layout<int> layout1 = "${event-properties:intvalue}";
             Layout<int> layout2 = "${event-properties:intvalue}";
+
+            // Act + Assert (LogEventInfo.LayoutCache must work)
+            Assert.NotEqual(layout1, layout2);
+            Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
+        }
+
+        [Fact]
+        public void LayoutEqualsNullableIntValueDynamicTest()
+        {
+            // Arrange
+            Layout<int?> layout1 = "${event-properties:intvalue}";
+            Layout<int?> layout2 = "${event-properties:intvalue}";
 
             // Act + Assert (LogEventInfo.LayoutCache must work)
             Assert.NotEqual(layout1, layout2);

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -401,16 +401,8 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void ComplexTypeTest()
         {
-            // Arrange
-            var value = new TestObject { Value = "123" };
-            var layout = CreateLayoutRenderedFromProperty<TestObject>();
-            var logEventInfo = CreateLogEventInfoWithValue(value);
-
-            // Act
-            var result = layout.RenderValue(logEventInfo);
-
-            // Assert
-            Assert.Equal(value, result);
+            // Arrange + Act + Assert
+            Assert.Throws<NLogConfigurationException>(() => CreateLayoutRenderedFromProperty<TestObject>());
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -294,6 +294,24 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void LayoutDynamicRenderExceptionTypeTest()
+        {
+            // Arrange
+            Layout<Type> layout = "${exception:format=type:norawvalue=true}";
+            var exception = new System.ApplicationException("Test");
+            var stringBuilder = new System.Text.StringBuilder();
+
+            // Act
+            var logevent = LogEventInfo.Create(LogLevel.Info, null, exception, null, "");
+            var exceptionType = layout.RenderTypedValue(logevent, stringBuilder, null);
+            stringBuilder.Length = 0;
+
+            // Assert
+            Assert.Equal(exception.GetType(), exceptionType);
+            Assert.Same(exceptionType, layout.RenderTypedValue(logevent, stringBuilder, null));
+        }
+
+        [Fact]
         public void LayoutRenderIntValueWhenNull()
         {
             // Arrange

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -52,6 +52,7 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(5, result);
             Assert.Equal("5", layout.Render(LogEventInfo.CreateNullEvent()));
             Assert.Equal(5, layout.StaticValue);
+            Assert.Equal("5", layout.ToString());
         }
 
         [Fact]
@@ -67,6 +68,7 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(5, result);
             Assert.Equal("5", layout.Render(LogEventInfo.CreateNullEvent()));
             Assert.Equal(5, layout.StaticValue);
+            Assert.Equal("5", layout.ToString());
         }
 
         [Fact]
@@ -84,6 +86,7 @@ namespace NLog.UnitTests.Layouts
             Assert.Null(result5);
             Assert.Equal("", layout.Render(LogEventInfo.CreateNullEvent()));
             Assert.Null(layout.StaticValue);
+            Assert.Equal("null", layout.ToString());
         }
 
         [Fact]
@@ -102,6 +105,7 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(uri.ToString(), layout.Render(LogEventInfo.CreateNullEvent()));
             Assert.Equal(uri, layout.StaticValue);
             Assert.Same(layout.StaticValue, layout.StaticValue);
+            Assert.Equal(uri.ToString(), layout.ToString());
         }
 
         [Fact]
@@ -120,13 +124,15 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal("", layout.Render(LogEventInfo.CreateNullEvent()));
             Assert.Equal(uri, layout.StaticValue);
             Assert.Same(layout.StaticValue, layout.StaticValue);
+            Assert.Equal("null", layout.ToString());
         }
 
         [Fact]
         public void LayoutDynamicIntValueTest()
         {
             // Arrange
-            Layout<int> layout = "${event-properties:intvalue}";
+            string simpleLayout = "${event-properties:intvalue}";
+            Layout<int> layout = simpleLayout;
 
             // Act
             var logevent = LogEventInfo.Create(LogLevel.Info, null, null, "{intvalue}", new object[] { 5 });
@@ -136,6 +142,7 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(5, result);
             Assert.Equal("5", layout.Render(logevent));
             Assert.Equal(0, layout.StaticValue);
+            Assert.Equal(simpleLayout, layout.ToString());
         }
 
         [Fact]
@@ -257,7 +264,6 @@ namespace NLog.UnitTests.Layouts
             var logevent = LogEventInfo.CreateNullEvent();
             using (ScopeContext.PushProperty("urlvalue", uri.ToString()))
             {
-  
                 layout.Precalculate(logevent);
             }
 
@@ -340,6 +346,7 @@ namespace NLog.UnitTests.Layouts
             Assert.True(layout1 == 42);
             Assert.True(42 == layout1);
             Assert.True(layout1.Equals(42));
+            Assert.True(layout1.Equals((object)42));
             Assert.Equal(layout1, layout2);
             Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
         }
@@ -355,6 +362,7 @@ namespace NLog.UnitTests.Layouts
             Assert.True(layout1 == 42);
             Assert.True(42 == layout1);
             Assert.True(layout1.Equals(42));
+            Assert.True(layout1.Equals((object)42));
             Assert.Equal(layout1, layout2);
             Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
         }
@@ -371,6 +379,7 @@ namespace NLog.UnitTests.Layouts
             Assert.True(layout1 == nullInt);
             Assert.True(nullInt == layout1);
             Assert.True(layout1.Equals(nullInt));
+            Assert.True(layout1.Equals((object)nullInt));
             Assert.Equal(layout1, layout2);
             Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
         }
@@ -386,6 +395,7 @@ namespace NLog.UnitTests.Layouts
             Assert.False(layout1 == 42);
             Assert.False(42 == layout1);
             Assert.False(layout1.Equals(42));
+            Assert.False(layout1.Equals((object)42));
             Assert.NotEqual(layout1, layout2);
             Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
         }
@@ -401,6 +411,7 @@ namespace NLog.UnitTests.Layouts
             Assert.False(layout1 == 42);
             Assert.False(42 == layout1);
             Assert.False(layout1.Equals(42));
+            Assert.False(layout1.Equals((object)42));
             Assert.NotEqual(layout1, layout2);
             Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
         }
@@ -417,6 +428,7 @@ namespace NLog.UnitTests.Layouts
             Assert.False(layout1 == nullInt);
             Assert.False(nullInt == layout1);
             Assert.False(layout1.Equals(nullInt));
+            Assert.False(layout1.Equals((object)nullInt));
             Assert.NotEqual(layout1, layout2);
             Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
         }
@@ -433,6 +445,7 @@ namespace NLog.UnitTests.Layouts
             Assert.True(layout1 == url);
             Assert.True(url == layout1);
             Assert.True(layout1.Equals(url));
+            Assert.True(layout1.Equals((object)url));
             Assert.Equal(layout1, layout2);
             Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
         }
@@ -449,6 +462,7 @@ namespace NLog.UnitTests.Layouts
             Assert.True(layout1 == url);
             Assert.True(url == layout1);
             Assert.True(layout1.Equals(url));
+            Assert.True(layout1.Equals((object)url));
             Assert.Equal(layout1, layout2);
             Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
         }
@@ -466,6 +480,7 @@ namespace NLog.UnitTests.Layouts
             Assert.False(layout1 == url);
             Assert.False(url == layout1);
             Assert.False(layout1.Equals(url));
+            Assert.False(layout1.Equals((object)url));
             Assert.NotEqual(layout1, layout2);
             Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
         }
@@ -483,6 +498,7 @@ namespace NLog.UnitTests.Layouts
             Assert.False(layout1 == url);
             Assert.False(url == layout1);
             Assert.False(layout1.Equals(url));
+            Assert.False(layout1.Equals((object)url));
             Assert.NotEqual(layout1, layout2);
             Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
         }

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -1,0 +1,169 @@
+﻿// 
+// Copyright (c) 2004-2020 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+using System;
+using NLog.Layouts;
+using Xunit;
+
+namespace NLog.UnitTests.Layouts
+{
+    public class LayoutTypedTests : NLogTestBase
+    {
+        [Fact]
+        public void LayoutFixedIntValueTest()
+        {
+            // Arrange
+            Layout<int> layout = 5;
+
+            // Act
+            var result = layout.RenderValue(LogEventInfo.CreateNullEvent());
+
+            // Assert
+            Assert.Equal(5, result);
+            Assert.Equal("5", layout.Render(LogEventInfo.CreateNullEvent()));
+            Assert.Equal(5, layout.StaticValue);
+        }
+
+        [Fact]
+        public void LayoutFixedUrlValueTest()
+        {
+            // Arrange
+            var uri = new Uri("http://nlog");
+            Layout<Uri> layout = uri.ToString();
+
+            // Act
+            var result = layout.RenderValue(LogEventInfo.CreateNullEvent());
+
+            // Assert
+            Assert.Equal(uri, result);
+            Assert.Same(result, layout.RenderValue(LogEventInfo.CreateNullEvent()));
+            Assert.Equal(uri.ToString(), layout.Render(LogEventInfo.CreateNullEvent()));
+            Assert.Equal(uri, layout.StaticValue);
+            Assert.Same(layout.StaticValue, layout.StaticValue);
+        }
+
+        [Fact]
+        public void LayoutDynamicIntValueTest()
+        {
+            // Arrange
+            Layout<int> layout = "${event-properties:intvalue}";
+
+            // Act
+            var logevent = LogEventInfo.Create(LogLevel.Info, null, null, "{intvalue}", new object[] { 5 });
+            var result = layout.RenderValue(logevent);
+
+            // Assert
+            Assert.Equal(5, result);
+            Assert.Equal("5", layout.Render(logevent));
+            Assert.Equal(0, layout.StaticValue);
+        }
+
+        [Fact]
+        public void LayoutDynamicUrlValueTest()
+        {
+            // Arrange
+            Layout<Uri> layout = "${event-properties:urlvalue}";
+            var uri = new Uri("http://nlog");
+
+            // Act
+            var logevent = LogEventInfo.Create(LogLevel.Info, null, null, "{urlvalue}", new object[] { uri.ToString() });
+            var result = layout.RenderValue(logevent);
+
+            // Assert
+            Assert.Equal(uri, result);
+            Assert.Same(result, layout.RenderValue(logevent));
+            Assert.Equal(uri.ToString(), layout.Render(logevent));
+            Assert.Null(layout.StaticValue);
+        }
+
+        [Fact]
+        public void LayoutDynamicIntValueAsyncTest()
+        {
+            // Arrange
+            Layout<int> layout = "${scopeproperty:intvalue}";
+
+            // Act
+            var logevent = LogEventInfo.CreateNullEvent();
+            using (ScopeContext.PushProperty("intvalue", 5))
+            {
+                layout.Precalculate(logevent);
+            }
+
+            // Assert
+            Assert.Equal(5, layout.RenderValue(logevent));
+            Assert.Equal("5", layout.Render(logevent));
+            Assert.Equal(0, layout.StaticValue);
+        }
+
+        [Fact]
+        public void LayoutDynamicUrlValueAsyncTest()
+        {
+            // Arrange
+            Layout<Uri> layout = "${scopeproperty:urlvalue}";
+            var uri = new Uri("http://nlog");
+
+            // Act
+            var logevent = LogEventInfo.CreateNullEvent();
+            using (ScopeContext.PushProperty("urlvalue", uri.ToString()))
+            {
+  
+                layout.Precalculate(logevent);
+            }
+
+            // Assert
+            Assert.Equal(uri, layout.RenderValue(logevent));
+            Assert.Same(layout.RenderValue(logevent), layout.RenderValue(logevent));
+            Assert.Equal(uri.ToString(), layout.Render(logevent));
+            Assert.Null(layout.StaticValue);
+        }
+
+        [Fact]
+        public void LayoutDynamicUrlValueRawAsyncTest()
+        {
+            // Arrange
+            Layout<Uri> layout = "${event-properties:urlvalue}";
+            var uri = new Uri("http://nlog");
+
+            // Act
+            var logevent = LogEventInfo.Create(LogLevel.Info, null, null, "{urlvalue}", new object[] { uri });
+            layout.Precalculate(logevent);
+
+            // Assert
+            Assert.Same(uri, layout.RenderValue(logevent));
+            Assert.Same(layout.RenderValue(logevent), layout.RenderValue(logevent));
+            Assert.Same(uri, layout.RenderValue(logevent));
+            Assert.Equal(uri.ToString(), layout.Render(logevent));
+            Assert.Null(layout.StaticValue);
+        }
+    }
+}

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -167,6 +167,34 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void LayoutRenderIntValueWhenNull()
+        {
+            // Arrange
+            var integer = 42;
+            Layout<int> layout = null;
+
+            // Act
+            var value = LayoutTypedExtensions.RenderValue(layout, null, integer);
+
+            // Assert
+            Assert.Equal(integer, value);
+        }
+
+        [Fact]
+        public void LayoutRenderUrlValueWhenNull()
+        {
+            // Arrange
+            var url = new Uri("http://nlog");
+            Layout<Uri> layout = null;
+
+            // Act
+            var value = LayoutTypedExtensions.RenderValue(layout, null, url);
+
+            // Assert
+            Assert.Equal(url, value);
+        }
+
+        [Fact]
         public void LayoutEqualsIntValueFixedTest()
         {
             // Arrange

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -312,6 +312,21 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void ComplexTypeTestWithStringConversion()
+        {
+            // Arrange
+            var value = "utf8";
+            var layout = CreateLayoutRenderedFromProperty<System.Text.Encoding>();
+            var logEventInfo = CreateLogEventInfoWithValue(value);
+
+            // Act
+            var result = layout.RenderValue(logEventInfo);
+
+            // Assert
+            Assert.Equal(System.Text.Encoding.UTF8.EncodingName, result.EncodingName);
+        }
+
+        [Fact]
         public void LayoutRenderIntValueWhenNull()
         {
             // Arrange

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -165,5 +165,58 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(uri.ToString(), layout.Render(logevent));
             Assert.Null(layout.StaticValue);
         }
+
+        [Fact]
+        public void LayoutEqualsIntValueFixedTest()
+        {
+            // Arrange
+            Layout<int> layout1 = "42";
+            Layout<int> layout2 = "42";
+
+            // Act + Assert
+            Assert.True(layout1 == 42);
+            Assert.True(layout1.Equals(42));
+            Assert.Equal(layout1, layout2);
+            Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
+        }
+
+        [Fact]
+        public void LayoutEqualsUrlValueFixedTest()
+        {
+            // Arrange
+            var url = new Uri("http://nlog");
+            Layout<Uri> layout1 = url;
+            Layout<Uri> layout2 = url;
+
+            // Act + Assert
+            Assert.True(layout1 == url);
+            Assert.True(layout1.Equals(url));
+            Assert.Equal(layout1, layout2);
+            Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
+        }
+
+        [Fact]
+        public void LayoutEqualsIntValueDynamicTest()
+        {
+            // Arrange
+            Layout<int> layout1 = "${event-properties:intvalue}";
+            Layout<int> layout2 = "${event-properties:intvalue}";
+
+            // Act + Assert (LogEventInfo.LayoutCache must work)
+            Assert.NotEqual(layout1, layout2);
+            Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
+        }
+
+        [Fact]
+        public void LayoutEqualsUrlValueDynamicTest()
+        {
+            // Arrange
+            Layout<Uri> layout1 = "${event-properties:urlvalue}";
+            Layout<Uri> layout2 = "${event-properties:urlvalue}";
+
+            // Act + Assert (LogEventInfo.LayoutCache must work)
+            Assert.NotEqual(layout1, layout2);
+            Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
+        }
     }
 }

--- a/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
@@ -245,7 +245,6 @@ namespace NLog.UnitTests.Targets
             Layout entryTypeLayout = layoutString != null ? new SimpleLayout(layoutString) : null;
 
             var eventRecords = WriteWithMock(logLevel, expectedEventLogEntryType, expectedMessage, entryTypeLayout).ToList();
-
             Assert.Single(eventRecords);
             AssertWrittenMessage(eventRecords, expectedMessage);
         }
@@ -271,7 +270,6 @@ namespace NLog.UnitTests.Targets
             string messagePart2 = "this part must be split";
             string testMessage = messagePart1 + messagePart2;
             var entries = WriteWithMock(logLevel, expectedEventLogEntryType, testMessage, entryTypeLayout, EventLogTargetOverflowAction.Split).ToList();
-
             Assert.Equal(expectedEntryCount, entries.Count);
         }
 
@@ -506,8 +504,8 @@ namespace NLog.UnitTests.Targets
             int eventId = rnd.Next(1, short.MaxValue);
             int category = rnd.Next(1, short.MaxValue);
             var target = CreateEventLogTarget("NLog.UnitTests" + Guid.NewGuid().ToString("N"), EventLogTargetOverflowAction.Truncate, 5000);
-            target.EventId = new SimpleLayout(eventId.ToString());
-            target.Category = new SimpleLayout(category.ToString());
+            target.EventId = eventId;
+            target.Category = (short)category;
             SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
             var logger = LogManager.GetLogger("WriteEventLogEntry");
             logger.Log(LogLevel.Error, "Simple Test Message");
@@ -531,8 +529,8 @@ namespace NLog.UnitTests.Targets
             int eventId = rnd.Next(1, short.MaxValue);
             int category = rnd.Next(1, short.MaxValue);
             var target = CreateEventLogTarget("NLog.UnitTests" + Guid.NewGuid().ToString("N"), EventLogTargetOverflowAction.Truncate, 5000);
-            target.EventId = new SimpleLayout("${event-properties:EventId}");
-            target.Category = new SimpleLayout("${event-properties:Category}");
+            target.EventId = "${event-properties:EventId}";
+            target.Category = "${event-properties:Category}";
             SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
             var logger = LogManager.GetLogger("WriteEventLogEntry");
             LogEventInfo theEvent = new LogEventInfo(LogLevel.Error, "TestLoggerName", "Simple Message");
@@ -620,7 +618,7 @@ namespace NLog.UnitTests.Targets
 
             if (entryType != null)
             {
-                target.EntryType = entryType;
+                target.EntryType = new Layout<EventLogEntryType>(entryType);
             }
 
             return target;

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -31,16 +31,15 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System.Globalization;
 using System.Linq;
+using System.Text;
 using NLog.Conditions;
 using NLog.Config;
 using NLog.Internal;
-using NLog.LayoutRenderers;
 using NLog.Layouts;
 using NLog.Targets.Wrappers;
-using NLog.UnitTests.Targets.Wrappers;
-using NSubstitute;
-using NSubstitute.ExceptionExtensions;
+using NLog.UnitTests.Config;
 
 namespace NLog.UnitTests.Targets
 {
@@ -541,10 +540,10 @@ namespace NLog.UnitTests.Targets
         }
 
         [Theory]
-        [InlineData("Database")]
-        [InlineData("DATABASE")]
-        [InlineData("DB")]
-        [InlineData("db")]
+        [InlineData("Trace")]
+        [InlineData("TRACE")]
+        [InlineData("TraceSystem")]
+        [InlineData("TraceSYSTEM")]
         public void TargetAliasShouldWork(string typeName)
         {
             LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString($@"
@@ -554,11 +553,9 @@ namespace NLog.UnitTests.Targets
                 </targets>
             </nlog>");
 
-            var t = c.FindTargetByName<DatabaseTarget>("d");
+            var t = c.FindTargetByName<TraceTarget>("d");
             Assert.NotNull(t);
         }
-
-
 
         [Fact]
         public void FlushOnClosedTargetTest()
@@ -763,6 +760,209 @@ namespace NLog.UnitTests.Targets
             protected override void InitializeTarget()
             {
                 //base.InitializeTarget() should be called
+            }
+        }
+
+
+        [Fact]
+        public void TypedLayoutTargetTest()
+        {
+            LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog>
+                <extensions>
+                    <add type='" + typeof(MyTypedLayoutTarget).AssemblyQualifiedName + @"' />
+                </extensions>
+
+                <targets>
+                    <target type='MyTypedLayoutTarget' name='myTarget'
+                        byteProperty='42' 
+                        int16Property='43' 
+                        int32Property='44' 
+                        int64Property='45000000000' 
+                        stringProperty='foobar'
+                        boolProperty='true'
+                        doubleProperty='3.14159'
+                        floatProperty='3.24159'
+                        enumProperty='Value3'
+                        flagsEnumProperty='Value1,Value3'
+                        encodingProperty='utf-8'
+                        cultureProperty='en-US'
+                        typeProperty='System.Int32'
+                        uriProperty='https://nlog-project.org'
+                        lineEndingModeProperty='default'
+                        />
+                </targets>
+            </nlog>");
+
+            var nullEvent = LogEventInfo.CreateNullEvent();
+            var myTarget = c.FindTargetByName("myTarget") as MyTypedLayoutTarget;
+            Assert.NotNull(myTarget);
+            Assert.Equal((byte)42, myTarget.ByteProperty.StaticValue);
+            Assert.Equal((short)43, myTarget.Int16Property.StaticValue);
+            Assert.Equal(44, myTarget.Int32Property.StaticValue);
+            Assert.Equal(45000000000L, myTarget.Int64Property.StaticValue);
+            Assert.Equal("foobar", myTarget.StringProperty.StaticValue);
+            Assert.True(myTarget.BoolProperty.StaticValue);
+            Assert.Equal(3.14159, myTarget.DoubleProperty.StaticValue);
+            Assert.Equal(3.24159f, myTarget.FloatProperty.StaticValue);
+            Assert.Equal(TargetConfigurationTests.MyEnum.Value3, myTarget.EnumProperty.StaticValue);
+            Assert.Equal(TargetConfigurationTests.MyFlagsEnum.Value1 | TargetConfigurationTests.MyFlagsEnum.Value3, myTarget.FlagsEnumProperty.StaticValue);
+            Assert.Equal(Encoding.UTF8, myTarget.EncodingProperty.StaticValue);
+            Assert.Equal("en-US", myTarget.CultureProperty.StaticValue.Name);
+            Assert.Equal(typeof(int), myTarget.TypeProperty.StaticValue);
+            Assert.Equal(new Uri("https://nlog-project.org"), myTarget.UriProperty.StaticValue);
+            Assert.Equal(LineEndingMode.Default, myTarget.LineEndingModeProperty.StaticValue);
+        }
+
+        [Fact]
+        public void TypedLayoutTargetAsyncTest()
+        {
+            // Arrange
+            LogFactory logFactory = new LogFactory();
+            LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog throwExceptions='true'>
+                <extensions>
+                    <add type='" + typeof(MyTypedLayoutTarget).AssemblyQualifiedName + @"' />
+                </extensions>
+
+                <variable name='value3' value='Value3' />
+
+                <targets async='true'>
+                    <target type='MyTypedLayoutTarget' name='myTarget'
+                        byteProperty='42' 
+                        int16Property='43' 
+                        int32Property='44' 
+                        int64Property='45000000000' 
+                        stringProperty='foobar'
+                        boolProperty='true'
+                        doubleProperty='3.14159'
+                        floatProperty='3.24159'
+                        enumProperty='Value3'
+                        flagsEnumProperty='Value1,Value3'
+                        encodingProperty='utf-8'
+                        cultureProperty='en-US'
+                        typeProperty='System.Int32'
+                        uriProperty='https://nlog-project.org'
+                        lineEndingModeProperty='default'
+                        />
+                </targets>
+
+                <rules>
+                    <logger minlevel='trace' writeTo='myTarget' />
+                </rules>
+            </nlog>", logFactory);
+            logFactory.Configuration = c;
+
+            // Act
+            var logger = logFactory.GetLogger(nameof(TypedLayoutTargetAsyncTest));
+            var logEvent = new LogEventInfo(LogLevel.Info, null, "Hello");
+            logger.Log(logEvent);
+            logFactory.Flush();
+
+            // Assert
+            Assert.Equal((byte)42, logEvent.Properties["ByteProperty"]);
+            Assert.Equal((short)43, logEvent.Properties["Int16Property"]);
+            Assert.Equal(44, logEvent.Properties["Int32Property"]);
+            Assert.Equal(45000000000L, logEvent.Properties["Int64Property"]);
+            Assert.Equal("foobar", logEvent.Properties["StringProperty"]);
+            Assert.Equal(true, logEvent.Properties["BoolProperty"]);
+            Assert.Equal(3.14159, logEvent.Properties["DoubleProperty"]);
+            Assert.Equal(3.24159f, logEvent.Properties["FloatProperty"]);
+            Assert.Equal(TargetConfigurationTests.MyEnum.Value3, logEvent.Properties["EnumProperty"]);
+            Assert.Equal(TargetConfigurationTests.MyFlagsEnum.Value1 | TargetConfigurationTests.MyFlagsEnum.Value3, logEvent.Properties["FlagsEnumProperty"]);
+            Assert.Equal(Encoding.UTF8, logEvent.Properties["EncodingProperty"]);
+            Assert.Equal(CultureInfo.GetCultureInfo("en-US"), logEvent.Properties["CultureProperty"]);
+            Assert.Equal(typeof(int), logEvent.Properties["TypeProperty"]);
+            Assert.Equal(new Uri("https://nlog-project.org"), logEvent.Properties["UriProperty"]);
+            Assert.Equal(LineEndingMode.Default, logEvent.Properties["LineEndingModeProperty"]);
+
+        }
+        [Fact]
+        public void TypedLayoutTargetAsyncDynamicTest()
+        {
+            // Arrange
+            LogFactory logFactory = new LogFactory();
+            LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog throwExceptions='true'>
+                <extensions>
+                    <add type='" + typeof(MyTypedLayoutTarget).AssemblyQualifiedName + @"' />
+                </extensions>
+
+                <variable name='value3' value='Value3' />
+
+                <targets async='true'>
+                    <target type='MyTypedLayoutTarget' name='myTarget'
+                        int32Property='${threadid}' 
+                        />
+                </targets>
+
+                <rules>
+                    <logger minlevel='trace' writeTo='myTarget' />
+                </rules>
+            </nlog>", logFactory);
+            logFactory.Configuration = c;
+
+            // Act
+            var logger = logFactory.GetLogger(nameof(TypedLayoutTargetAsyncTest));
+            var logEvent = new LogEventInfo(LogLevel.Info, null, "Hello");
+            logger.Log(logEvent);
+            logFactory.Flush();
+
+            // Assert
+            Assert.Equal(Thread.CurrentThread.ManagedThreadId, logEvent.Properties["Int32Property"]);
+
+        }
+
+        [Target("MyTypedLayoutTarget")]
+        public class MyTypedLayoutTarget : Target
+        {
+            public Layout<byte> ByteProperty { get; set; }
+
+            public Layout<short> Int16Property { get; set; }
+
+            public Layout<int> Int32Property { get; set; }
+
+            public Layout<long> Int64Property { get; set; }
+
+            public Layout<string> StringProperty { get; set; }
+
+            public Layout<bool> BoolProperty { get; set; }
+
+            public Layout<double> DoubleProperty { get; set; }
+
+            public Layout<float> FloatProperty { get; set; }
+
+            public Layout<TargetConfigurationTests.MyEnum> EnumProperty { get; set; }
+
+            public Layout<TargetConfigurationTests.MyFlagsEnum> FlagsEnumProperty { get; set; }
+
+            public Layout<Encoding> EncodingProperty { get; set; }
+
+            public Layout<CultureInfo> CultureProperty { get; set; }
+
+            public Layout<Type> TypeProperty { get; set; }
+
+            public Layout<Uri> UriProperty { get; set; }
+
+            public Layout<LineEndingMode> LineEndingModeProperty { get; set; }
+
+            protected override void Write(LogEventInfo logEvent)
+            {
+                logEvent.Properties[nameof(ByteProperty)] = RenderLogEvent(ByteProperty, logEvent);
+                logEvent.Properties[nameof(Int16Property)] = RenderLogEvent(Int16Property, logEvent);
+                logEvent.Properties[nameof(Int32Property)] = RenderLogEvent(Int32Property, logEvent);
+                logEvent.Properties[nameof(Int64Property)] = RenderLogEvent(Int64Property, logEvent);
+                logEvent.Properties[nameof(StringProperty)] = RenderLogEvent(StringProperty, logEvent);
+                logEvent.Properties[nameof(BoolProperty)] = RenderLogEvent(BoolProperty, logEvent);
+                logEvent.Properties[nameof(DoubleProperty)] = RenderLogEvent(DoubleProperty, logEvent);
+                logEvent.Properties[nameof(FloatProperty)] = RenderLogEvent(FloatProperty, logEvent);
+                logEvent.Properties[nameof(EnumProperty)] = RenderLogEvent(EnumProperty, logEvent);
+                logEvent.Properties[nameof(FlagsEnumProperty)] = RenderLogEvent(FlagsEnumProperty, logEvent);
+                logEvent.Properties[nameof(EncodingProperty)] = RenderLogEvent(EncodingProperty, logEvent);
+                logEvent.Properties[nameof(CultureProperty)] = RenderLogEvent(CultureProperty, logEvent);
+                logEvent.Properties[nameof(TypeProperty)] = RenderLogEvent(TypeProperty, logEvent);
+                logEvent.Properties[nameof(UriProperty)] = RenderLogEvent(UriProperty, logEvent);
+                logEvent.Properties[nameof(LineEndingModeProperty)] = RenderLogEvent(LineEndingModeProperty, logEvent);
             }
         }
     }

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -831,13 +831,13 @@ namespace NLog.UnitTests.Targets
                     <target type='MyTypedLayoutTarget' name='myTarget'
                         byteProperty='42' 
                         int16Property='43' 
-                        int32Property='44' 
-                        int64Property='45000000000' 
-                        stringProperty='foobar'
+                        int32Property='${threadid}' 
+                        int64Property='${sequenceid}' 
+                        stringProperty='${appdomain:format=\{1\}}'
                         boolProperty='true'
                         doubleProperty='3.14159'
                         floatProperty='3.24159'
-                        enumProperty='Value3'
+                        enumProperty='${var:value3}'
                         flagsEnumProperty='Value1,Value3'
                         encodingProperty='utf-8'
                         cultureProperty='en-US'
@@ -862,9 +862,9 @@ namespace NLog.UnitTests.Targets
             // Assert
             Assert.Equal((byte)42, logEvent.Properties["ByteProperty"]);
             Assert.Equal((short)43, logEvent.Properties["Int16Property"]);
-            Assert.Equal(44, logEvent.Properties["Int32Property"]);
-            Assert.Equal(45000000000L, logEvent.Properties["Int64Property"]);
-            Assert.Equal("foobar", logEvent.Properties["StringProperty"]);
+            Assert.Equal(Thread.CurrentThread.ManagedThreadId, logEvent.Properties["Int32Property"]);
+            Assert.Equal((long)logEvent.SequenceID, logEvent.Properties["Int64Property"]);
+            Assert.Equal(AppDomain.CurrentDomain.FriendlyName, logEvent.Properties["StringProperty"]);
             Assert.Equal(true, logEvent.Properties["BoolProperty"]);
             Assert.Equal(3.14159, logEvent.Properties["DoubleProperty"]);
             Assert.Equal(3.24159f, logEvent.Properties["FloatProperty"]);
@@ -875,42 +875,6 @@ namespace NLog.UnitTests.Targets
             Assert.Equal(typeof(int), logEvent.Properties["TypeProperty"]);
             Assert.Equal(new Uri("https://nlog-project.org"), logEvent.Properties["UriProperty"]);
             Assert.Equal(LineEndingMode.Default, logEvent.Properties["LineEndingModeProperty"]);
-
-        }
-        [Fact]
-        public void TypedLayoutTargetAsyncDynamicTest()
-        {
-            // Arrange
-            LogFactory logFactory = new LogFactory();
-            LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString(@"
-            <nlog throwExceptions='true'>
-                <extensions>
-                    <add type='" + typeof(MyTypedLayoutTarget).AssemblyQualifiedName + @"' />
-                </extensions>
-
-                <variable name='value3' value='Value3' />
-
-                <targets async='true'>
-                    <target type='MyTypedLayoutTarget' name='myTarget'
-                        int32Property='${threadid}' 
-                        />
-                </targets>
-
-                <rules>
-                    <logger minlevel='trace' writeTo='myTarget' />
-                </rules>
-            </nlog>", logFactory);
-            logFactory.Configuration = c;
-
-            // Act
-            var logger = logFactory.GetLogger(nameof(TypedLayoutTargetAsyncTest));
-            var logEvent = new LogEventInfo(LogLevel.Info, null, "Hello");
-            logger.Log(logEvent);
-            logFactory.Flush();
-
-            // Assert
-            Assert.Equal(Thread.CurrentThread.ManagedThreadId, logEvent.Properties["Int32Property"]);
-
         }
 
         [Target("MyTypedLayoutTarget")]

--- a/tools/MakeNLogXSD/XsdFileGenerator.cs
+++ b/tools/MakeNLogXSD/XsdFileGenerator.cs
@@ -206,7 +206,7 @@ namespace MakeNLogXSD
 
                 result.Add(new XAttribute("type", enumType));
             }
-            else 
+            else
             {
                 string xsdType = GetXsdType(propertyType, true);
                 if (xsdType == null)
@@ -303,7 +303,7 @@ namespace MakeNLogXSD
         {
             if (string.IsNullOrWhiteSpace(apiTypeName))
             {
-                throw new NotSupportedException("Unknown API type '" + apiTypeName + "'.");
+                throw new NotSupportedException("Unknown API empty type '" + apiTypeName + "'.");
             }
 
             if (IgnoreTypes.Contains(apiTypeName))
@@ -314,7 +314,7 @@ namespace MakeNLogXSD
             switch (apiTypeName)
             {
                 case "Layout":
-                    return attribute ? "SimpleLayoutAttribute" : "Layout";
+                    return GetLayoutType(attribute);
 
                 case "NLog.Filters.Filter":
                     return attribute ? null : "Filter";
@@ -360,7 +360,7 @@ namespace MakeNLogXSD
 
                 default:
                     if (
-                        apiTypeName.StartsWith("System.Collections.Generic.ISet")|| 
+                        apiTypeName.StartsWith("System.Collections.Generic.ISet") ||
                         apiTypeName.StartsWith("System.Collections.Generic.HashSet") ||
                         apiTypeName.StartsWith("System.Collections.Generic.IList") ||
                         apiTypeName.StartsWith("System.Collections.Generic.List") ||
@@ -371,8 +371,19 @@ namespace MakeNLogXSD
                         return "xs:string";
                     }
 
+                    if (apiTypeName.StartsWith("NLog.Layouts.Layout`1"))
+                    {
+                        // Layout<T>
+                        return GetLayoutType(attribute);
+                    }
+
                     throw new NotSupportedException("Unknown API type '" + apiTypeName + "'.");
             }
+        }
+
+        private static string GetLayoutType(bool attribute)
+        {
+            return attribute ? "SimpleLayoutAttribute" : "Layout";
         }
     }
 }


### PR DESCRIPTION
Completed my own version of #3656. That resolves #1811 and resolves #3994

With full optimization of layout-precalculation and caching of previous value to reduce boxing.

Created my own version because I wasn't sure #3656 would be completed. Maybe steal the precalculate-logic from this PR ?

Notice that I have decided to always use the `Layout<T>` type-converter-abilities, instead of depending on `PropertyHelper`. This makes the behavior more predictable for users creating their own `Layout<T>`.