### PR TITLE
LoggingConfigurationParser - Added support for using assembly-name in type-name (comma delimiter)

### DIFF
--- a/src/NLog/Config/Factory.cs
+++ b/src/NLog/Config/Factory.cs
@@ -158,7 +158,11 @@ namespace NLog.Config
             GetTypeDelegate typeLookup = () => itemDefinition;
             _items[itemNamePrefix + itemName] = typeLookup;
             if (!string.IsNullOrEmpty(assemblyName))
-                _items[assemblyName + "." + itemName] = typeLookup;
+            {
+                _items[itemName + ", " + assemblyName] = typeLookup;
+                _items[itemDefinition.Name + ", " + assemblyName] = typeLookup;
+                _items[itemDefinition.ToString() + ", " + assemblyName] = typeLookup;
+            }
         }
 
         /// <summary>

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -1192,14 +1192,14 @@ namespace NLog.Config
             try
             {
                 classType = ExpandSimpleVariables(classType);
-                if (classType.Contains('.'))
+                if (classType.Contains(','))
                 {
-                    // Possible prefix detected, that could be assembly-name-as-prefix
+                    // Possible specification of assemlby-name detected
                     if (factory.TryCreateInstance(classType, out newInstance) && newInstance != null)
                         return newInstance;
 
                     // Attempt to load the assembly name extracted from the prefix
-                    RegisterExtensionAssemblyFromPrefix(classType);
+                    classType = RegisterExtensionFromAssemblyName(classType);
                 }
 
                 newInstance = factory.CreateInstance(classType);
@@ -1226,14 +1226,15 @@ namespace NLog.Config
             return newInstance;
         }
 
-        private void RegisterExtensionAssemblyFromPrefix(string classType)
+        private string RegisterExtensionFromAssemblyName(string classType)
         {
-            var assemblyName = classType.Substring(0, classType.LastIndexOf('.'));
+            var assemblyName = classType.Substring(classType.IndexOf(',') + 1).Trim();
             if (!string.IsNullOrEmpty(assemblyName))
             {
                 try
                 {
                     ParseExtensionWithAssembly(assemblyName, string.Empty);
+                    return classType.Substring(0, classType.IndexOf(',')).Trim() + ", " + assemblyName; // uniform format
                 }
                 catch (Exception ex)
                 {
@@ -1241,6 +1242,8 @@ namespace NLog.Config
                         throw;
                 }
             }
+
+            return classType;
         }
 
         private void SetItemOnProperty(object o, PropertyInfo propInfo, ValidatedConfigurationElement element, object properyValue)

--- a/src/NLog/Config/MethodFactory.cs
+++ b/src/NLog/Config/MethodFactory.cs
@@ -175,12 +175,16 @@ namespace NLog.Config
         {
             _nameToMethodInfo[itemName + itemNamePrefix] = itemDefinition;
             if (!string.IsNullOrEmpty(assemblyName))
-                _nameToMethodInfo[itemName + "." + assemblyName] = itemDefinition;
+            {
+                _nameToMethodInfo[itemName + ", " + assemblyName] = itemDefinition;
+            }
             lock (_nameToLateBoundMethod)
             {
                 _nameToLateBoundMethod.Remove(itemName + itemNamePrefix);
                 if (!string.IsNullOrEmpty(assemblyName))
-                    _nameToLateBoundMethod.Remove(itemName + "." + assemblyName);
+                {
+                    _nameToMethodInfo.Remove(itemName + ", " + assemblyName);
+                }
             }
         }
 

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -396,13 +396,12 @@ namespace NLog.UnitTests.Config
 </targets>
 
 <rules>
-    <logger name='*' writeTo='t'>
-    </logger>
+    <logger name='*' writeTo='t' />
 </rules>
 </nlog>").LogFactory;
 
             var autoLoadedTarget = logFactory.Configuration.FindTargetByName("t");
-            Assert.Equal("NLogAutloadExtension.AutoLoadTarget", autoLoadedTarget.GetType().FullName);
+            Assert.Equal("NLogAutloadExtension.AutoLoadTarget", autoLoadedTarget.GetType().ToString());
         }
 
         [Fact]
@@ -411,7 +410,7 @@ namespace NLog.UnitTests.Config
             var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
 <nlog throwExceptions='true'>
 <targets>
-    <target name='t' type='NLogAutoLoadExtension.AutoLoadTarget' />
+    <target name='t' type='AutoLoadTarget,  NLogAutoLoadExtension' />
 </targets>
 <rules>
     <logger name='*' writeTo='t' />
@@ -419,7 +418,7 @@ namespace NLog.UnitTests.Config
 </nlog>").LogFactory;
 
             var autoLoadedTarget = logFactory.Configuration.FindTargetByName("t");
-            Assert.Equal("NLogAutloadExtension.AutoLoadTarget", autoLoadedTarget.GetType().FullName);
+            Assert.Equal("NLogAutloadExtension.AutoLoadTarget", autoLoadedTarget.GetType().ToString());
         }
 
         [Theory]
@@ -448,8 +447,7 @@ namespace NLog.UnitTests.Config
     </targets>
 
     <rules>
-      <logger name='*' writeTo='t'>
-      </logger>
+      <logger name='*' writeTo='t' />
     </rules>
 </nlog>").LogFactory;
 
@@ -461,7 +459,7 @@ namespace NLog.UnitTests.Config
                     }
                     else
                     {
-                        Assert.Equal("NLogAutloadExtension.AutoLoadTarget", autoLoadedTarget.GetType().FullName);
+                        Assert.Equal("NLogAutloadExtension.AutoLoadTarget", autoLoadedTarget.GetType().ToString());
                     }
                 }
             }


### PR DESCRIPTION
Follow up to #4300, so instead you can do this:

```xml
<targets>
   <target name="evt" type="EventLog, NLog.WindowsEventLog" />
</targets>
```

Or like this:

```xml
<targets>
   <target name="elmah" type="elmah.io, Elmah.Io.NLog" />
</targets>
```