### PR TITLE
Fix AsyncTaskTarget retry timings

### DIFF
--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -256,7 +256,7 @@ namespace NLog.Targets
                 return false;
             }
 
-            retryDelay = TimeSpan.FromMilliseconds(RetryDelayMilliseconds * (RetryCount - retryCountRemaining) * 2 + RetryDelayMilliseconds);
+            retryDelay = TimeSpan.FromMilliseconds(RetryDelayMilliseconds * Math.Pow(2d, RetryCount - (1 + retryCountRemaining)));
             return true;
         }
 


### PR DESCRIPTION
When a write is retried in AsyncTaskTarget, double the retry time on each try. Resolves #4310