### PR TITLE
Fix TrimDirectorySeparators to handle root-path on Windows and Linux

### DIFF
--- a/src/NLog/Internal/PathHelpers.cs
+++ b/src/NLog/Internal/PathHelpers.cs
@@ -70,7 +70,13 @@ namespace NLog.Internal
         /// <returns>never null</returns>
         public static string TrimDirectorySeparators(string path)
         {
-            return path?.TrimEnd(DirectorySeparatorChars) ?? string.Empty;
+            var newpath = path?.TrimEnd(DirectorySeparatorChars) ?? string.Empty;
+            if (newpath.EndsWith(":", System.StringComparison.OrdinalIgnoreCase))
+                return path;    // Support root-path on Windows
+            else if (string.IsNullOrEmpty(newpath) && !string.IsNullOrEmpty(path))
+                return path;    // Support root-path on Linux
+            else
+                return newpath;
         }
 
         public static bool IsTempDir(string directory, string tempDir)

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -41,9 +41,9 @@ namespace NLog.UnitTests
     using System.Linq;
     using System.Text;
     using Microsoft.CSharp;
-    using Xunit;
     using NLog.Config;
     using NLog.UnitTests.Mocks;
+    using Xunit;
 
     public sealed class ConfigFileLocatorTests : NLogTestBase, IDisposable
     {
@@ -126,6 +126,8 @@ namespace NLog.UnitTests
             var d = Path.DirectorySeparatorChar;
             var baseDir = Path.GetTempPath();
             var dirInBaseDir = $"{baseDir}dir1";
+            var rootBaseDir = Path.GetPathRoot(baseDir);
+            yield return new object[] { "nlog.config", $"{rootBaseDir}nlog.config", $"{rootBaseDir}nlog.config", rootBaseDir };
             yield return new object[] { $"{baseDir}configfile", $"{baseDir}configfile", $"{baseDir}configfile", dirInBaseDir };
             yield return new object[] { "nlog.config", $"{baseDir}dir1{d}nlog.config", $"{baseDir}dir1{d}nlog.config", dirInBaseDir }; //exists
             yield return new object[] { "nlog.config", $"{baseDir}dir1{d}nlog2.config", null, dirInBaseDir }; //not existing, fallback


### PR DESCRIPTION
Fix loading Nlog.config from root-path. Resolves #4314

Bug introduced with #2846 in NLog 4.5.9