### PR TITLE
LoggingConfiguration - FindTargetByName with better WrapperTarget handling

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -267,7 +267,20 @@ namespace NLog.Config
         public TTarget FindTargetByName<TTarget>(string name)
             where TTarget : Target
         {
-            return FindTargetByName(name) as TTarget;
+            var target = FindTargetByName(name);
+            if (target is TTarget specificTarget)
+            {
+                return specificTarget;
+            }
+            else if (target is WrapperTargetBase wrapperTarget)
+            {
+                if (wrapperTarget.WrappedTarget is TTarget wrappedTarget)
+                    return wrappedTarget;
+                else if (wrapperTarget.WrappedTarget is WrapperTargetBase nestedWrapperTarget && nestedWrapperTarget.WrappedTarget is TTarget nestedTarget)
+                    return nestedTarget;
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Config/TargetConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/TargetConfigurationTests.cs
@@ -466,6 +466,9 @@ namespace NLog.UnitTests.Config
             Assert.NotNull(debugTarget);
             Assert.Equal("d_wrapped", debugTarget.Name);
             Assert.Equal("${level}", debugTarget.Layout.ToString());
+
+            var debugTarget2 = c.FindTargetByName<DebugTarget>("d");
+            Assert.Same(debugTarget, debugTarget2);
         }
 
         [Fact]


### PR DESCRIPTION
See also: #4290

When using `<targets async="true">` then it actually becomes:

```xml
<targets>
    <target type="AsyncWrapper" name="LogDB">
                <target type="Database" name="LogDB_wrapped">
                </target>
    </target>
</targets>
```

Now one can do this:

```c#
            var dbTarget = config.FindTargetByName<DatabaseTarget>("LogDB"); 
            dbTarget.ConnectionString = ApplicationDbContext.GetConnectionString;
```

