### PR TITLE
JsonLayout - Avoid constant string-escape of JsonAttribute Name-property

### DIFF
--- a/src/NLog/Layouts/JsonAttribute.cs
+++ b/src/NLog/Layouts/JsonAttribute.cs
@@ -73,7 +73,24 @@ namespace NLog.Layouts
         /// </summary>
         /// <docgen category='JSON Attribute Options' order='10' />
         [RequiredParameter]
-        public string Name { get; set; }
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                    _name = value;
+                else if (System.Linq.Enumerable.All(value, chr => char.IsLetterOrDigit(chr)))
+                    _name = value;
+                else
+                {
+                    var builder = new System.Text.StringBuilder();
+                    Targets.DefaultJsonSerializer.AppendStringEscape(builder, value, false, false);
+                    _name = builder.ToString();
+                }
+            }
+        }
+        private string _name;
 
         /// <summary>
         /// Gets or sets the layout that will be rendered as the attribute's value.

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -334,25 +334,23 @@ namespace NLog.Layouts
                 CompleteJsonMessage(sb);
         }
 
-        private void BeginJsonProperty(StringBuilder sb, string propName, bool beginJsonMessage)
+        private void BeginJsonProperty(StringBuilder sb, string propName, bool beginJsonMessage, bool ensureStringEscape)
         {
             if (beginJsonMessage)
             {
-                sb.Append(SuppressSpaces ? "{" : "{ ");
+                sb.Append(SuppressSpaces ? "{\"" : "{ \"");
             }
             else
             {
-                sb.Append(',');
-                if (!SuppressSpaces)
-                    sb.Append(' ');
+                sb.Append(SuppressSpaces ? ",\"" : ", \"");
             }
 
-            sb.Append('"');
-            Targets.DefaultJsonSerializer.AppendStringEscape(sb, propName, false, false);
-            sb.Append('"');
-            sb.Append(':');
-            if (!SuppressSpaces)
-                sb.Append(' ');
+            if (ensureStringEscape)
+                Targets.DefaultJsonSerializer.AppendStringEscape(sb, propName, false, false);
+            else
+                sb.Append(propName);
+
+            sb.Append(SuppressSpaces ? "\":" : "\": ");
         }
 
         private void CompleteJsonMessage(StringBuilder sb)
@@ -367,7 +365,7 @@ namespace NLog.Layouts
 
             var initialLength = sb.Length;
 
-            BeginJsonProperty(sb, propName, beginJsonMessage);
+            BeginJsonProperty(sb, propName, beginJsonMessage, true);
             if (MaxRecursionLimit <= 1 && captureType == MessageTemplates.CaptureType.Serialize)
             {
                 // Overrides MaxRecursionLimit as message-template tells us it is safe
@@ -420,7 +418,7 @@ namespace NLog.Layouts
 
         private bool RenderAppendJsonPropertyValue(JsonAttribute attrib, LogEventInfo logEvent, StringBuilder sb, bool beginJsonMessage)
         {
-            BeginJsonProperty(sb, attrib.Name, beginJsonMessage);
+            BeginJsonProperty(sb, attrib.Name, beginJsonMessage, false);
             if (attrib.Encode)
             {
                 // "\"{0}\":{1}\"{2}\""

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -452,6 +452,15 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void AttributerKeyWithQuote()
+        {
+            var jsonLayout = new JsonLayout();
+            jsonLayout.Attributes.Add(new JsonAttribute(@"fo""o", "bar"));
+
+            Assert.Equal(@"{ ""fo\""o"": ""bar"" }", jsonLayout.Render(LogEventInfo.CreateNullEvent()));
+        }
+
+        [Fact]
         public void ExcludeEmptyJsonProperties()
         {
             var jsonLayout = new JsonLayout()


### PR DESCRIPTION
Reducing the performane overhead from #4202 (Only check property-name once, instead of for every logevent)