### PR TITLE
ScopeContextNestedStatesLayoutRenderer - Support Format with FormatAsJson

### DIFF
--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -159,6 +159,7 @@ namespace NLog.LayoutRenderers
             if (_isInitialized)
             {
                 LoggingConfiguration = null;
+                _valueFormatter = null;
                 _isInitialized = false;
                 CloseLayoutRenderer();
             }

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -209,8 +209,7 @@ namespace NLog.LayoutRenderers
         /// Gets or sets the stack separator for <see cref="ScopeContext"/> operation-call-stack.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        [DefaultValue(" ")]
-        public string ScopeNestedStateSeparator
+        public Layout ScopeNestedStateSeparator
         {
             get => _scopeNestedLayoutRenderer.Separator;
             set => _scopeNestedLayoutRenderer.Separator = value;
@@ -222,7 +221,7 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Payload Options' order='10' />
         [DefaultValue(" ")]
         [Obsolete("Replaced by ScopeNestedStateSeparator. Marked obsolete on NLog 5.0")]
-        public string NdlcItemSeparator { get => ScopeNestedStateSeparator; set => ScopeNestedStateSeparator = value; }
+        public string NdlcItemSeparator { get => (ScopeNestedStateSeparator as SimpleLayout)?.OriginalText; set => ScopeNestedStateSeparator = new SimpleLayout(value); }
 
         /// <summary>
         /// Gets or sets the option to include all properties from the log events
@@ -243,11 +242,7 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Payload Options' order='10' />
         [Obsolete("Replaced by ScopeNestedStateSeparator. Marked obsolete on NLog 5.0")]
         [DefaultValue(" ")]
-        public string NdcItemSeparator
-        {
-            get => _scopeNestedLayoutRenderer.Separator;
-            set => _scopeNestedLayoutRenderer.Separator = value;
-        }
+        public string NdcItemSeparator { get => (ScopeNestedStateSeparator as SimpleLayout)?.OriginalText; set => ScopeNestedStateSeparator = new SimpleLayout(value); }
 
         /// <summary>
         /// Gets or sets the log4j:event logger-xml-attribute (Default ${logger})

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -173,7 +173,7 @@ namespace NLog.Targets
         /// Gets or sets the separator for <see cref="ScopeContext"/> operation-states-stack.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
-        public string ScopeNestedStateSeparator { get => Renderer.ScopeNestedStateSeparator; set => Renderer.ScopeNestedStateSeparator = value; }
+        public Layout ScopeNestedStateSeparator { get => Renderer.ScopeNestedStateSeparator; set => Renderer.ScopeNestedStateSeparator = value; }
 
         /// <summary>
         /// Gets or sets the option to include all properties from the log events

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -152,7 +152,7 @@ namespace NLog.UnitTests.Layouts
             var nestedLayoutRenderer = nestedLayout.Renderers[0] as ScopeContextNestedStatesLayoutRenderer;
             Assert.NotNull(nestedLayoutRenderer);
             Assert.Equal(3, nestedLayoutRenderer.TopFrames);
-            Assert.Equal("x", nestedLayoutRenderer.Separator);
+            Assert.Equal("x", nestedLayoutRenderer.Separator.ToString());
         }
 
         [Fact]
@@ -173,7 +173,7 @@ namespace NLog.UnitTests.Layouts
             var nestedLayoutRenderer = nestedLayout.Renderers[0] as ScopeContextNestedStatesLayoutRenderer;
             Assert.NotNull(nestedLayoutRenderer);
             Assert.Equal(3, nestedLayoutRenderer.TopFrames);
-            Assert.Equal("x", nestedLayoutRenderer.Separator);
+            Assert.Equal("x", nestedLayoutRenderer.Separator.ToString());
         }
 
         [Fact]
@@ -194,7 +194,7 @@ namespace NLog.UnitTests.Layouts
             var nestedLayoutRenderer = nestedLayout.Renderers[0] as ScopeContextNestedStatesLayoutRenderer;
             Assert.NotNull(nestedLayoutRenderer);
             Assert.Equal(3, nestedLayoutRenderer.TopFrames);
-            Assert.Equal("x", nestedLayoutRenderer.Separator);
+            Assert.Equal("x", nestedLayoutRenderer.Separator.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
So you can do this:

`${scopenested:format=@}`

And use it in JsonLayout like this:

```xml
<layout type="JsonLayout">
     <attribute name="scopes" layout="${scopenested:format=@}" encode="false" />
</layout>
```

Resolves #4315 (But without support for pretty indented mode)