### PR TITLE
Fix TrimDirectorySeparators to skip Linux-root-path since off limits

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -505,11 +505,13 @@ namespace NLog.Config
         {
             var nlogAssembly = typeof(ILogger).GetAssembly();
             var assemblyLocation = PathHelpers.TrimDirectorySeparators(AssemblyHelpers.GetAssemblyFileLocation(nlogAssembly));
+            InternalLogger.Debug("Auto loading based on NLog-Assembly found location: {0}", assemblyLocation);
             if (!string.IsNullOrEmpty(assemblyLocation))
                 yield return new KeyValuePair<string, Assembly>(assemblyLocation, nlogAssembly);
 
             var entryAssembly = Assembly.GetEntryAssembly();
-            var entryLocation = PathHelpers.TrimDirectorySeparators(AssemblyHelpers.GetAssemblyFileLocation(Assembly.GetEntryAssembly()));
+            var entryLocation = PathHelpers.TrimDirectorySeparators(AssemblyHelpers.GetAssemblyFileLocation(entryAssembly));
+            InternalLogger.Debug("Auto loading based on GetEntryAssembly-Assembly found location: {0}", entryLocation);
             if (!string.IsNullOrEmpty(entryLocation) && !string.Equals(entryLocation, assemblyLocation, StringComparison.OrdinalIgnoreCase))
                 yield return new KeyValuePair<string, Assembly>(entryLocation, entryAssembly);
 

--- a/src/NLog/Internal/PathHelpers.cs
+++ b/src/NLog/Internal/PathHelpers.cs
@@ -71,10 +71,8 @@ namespace NLog.Internal
         public static string TrimDirectorySeparators(string path)
         {
             var newpath = path?.TrimEnd(DirectorySeparatorChars) ?? string.Empty;
-            if (newpath.EndsWith(":", System.StringComparison.OrdinalIgnoreCase))
-                return path;    // Support root-path on Windows
-            else if (string.IsNullOrEmpty(newpath) && !string.IsNullOrEmpty(path))
-                return path;    // Support root-path on Linux
+            if (newpath.EndsWith(":", System.StringComparison.Ordinal))
+                return path;    // Support root-path on Windows (But Linux root-path is off limits)
             else
                 return newpath;
         }

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -126,8 +126,11 @@ namespace NLog.UnitTests
             var d = Path.DirectorySeparatorChar;
             var baseDir = Path.GetTempPath();
             var dirInBaseDir = $"{baseDir}dir1";
-            var rootBaseDir = Path.GetPathRoot(baseDir);
-            yield return new object[] { "nlog.config", $"{rootBaseDir}nlog.config", $"{rootBaseDir}nlog.config", rootBaseDir };
+            if (!IsTravis())
+            {
+                var rootBaseDir = Path.GetPathRoot(baseDir);
+                yield return new object[] { "nlog.config", $"{rootBaseDir}nlog.config", $"{rootBaseDir}nlog.config", rootBaseDir };
+            }
             yield return new object[] { $"{baseDir}configfile", $"{baseDir}configfile", $"{baseDir}configfile", dirInBaseDir };
             yield return new object[] { "nlog.config", $"{baseDir}dir1{d}nlog.config", $"{baseDir}dir1{d}nlog.config", dirInBaseDir }; //exists
             yield return new object[] { "nlog.config", $"{baseDir}dir1{d}nlog2.config", null, dirInBaseDir }; //not existing, fallback


### PR DESCRIPTION
Resolves #4346 that was caused by #4316 (Windows Root-Path can be used, but never Linux-Root-Path)

2 steps forward, and now 1 step back. Restricted platforms are tricky, especially when app-environment returns garbage paths.