### PR TITLE
Fixed FileTarget archive cleanup when using short filename

### DIFF
--- a/src/NLog/Targets/FileArchiveModes/FileArchiveModeDynamicSequence.cs
+++ b/src/NLog/Targets/FileArchiveModes/FileArchiveModeDynamicSequence.cs
@@ -155,7 +155,7 @@ namespace NLog.Targets.FileArchiveModes
                 case ArchiveNumberingMode.DateAndSequence:
                     {
                         // Force sequence-number into template (Just before extension)
-                        if (sb.Length > 3 && sb[sb.Length - 3] != '{' && sb[sb.Length - 2] != '#' && sb[sb.Length - 1] != '}')
+                        if (sb.Length < 3 || (sb[sb.Length - 3] != '{' && sb[sb.Length - 2] != '#' && sb[sb.Length - 1] != '}'))
                         {
                             if (digitsRemoved <= 1)
                             {

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -3037,7 +3037,7 @@ namespace NLog.UnitTests.Targets
             const int maxArchiveFiles = 1;
 
             var tempPath = ArchiveFileNameHelper.GenerateTempPath();
-            var logFile1 = Path.Combine(tempPath, "MyFile{0}.txt");
+            var logFile1 = Path.Combine(tempPath, "Log{0}.txt");
             try
             {
                 var fileTarget1 = new FileTarget


### PR DESCRIPTION
Resolves #4350 where archive cleanup failed when using short filename (3 characters or less. Ex. `App.log` ).

Old bug that have been around since NLog 4.5, where archive with dynamice sequence was introduced. See also #2524