### PR TITLE
Fix sonar cube warning about not using value in property-setter

### DIFF
--- a/src/NLog/Filters/WhenRepeatedFilter.cs
+++ b/src/NLog/Filters/WhenRepeatedFilter.cs
@@ -103,7 +103,8 @@ namespace NLog.Filters
         /// <docgen category='Performance Options' order='10' />
         [Obsolete("No longer used, and always returns true. Marked obsolete on NLog 5.0")]
         [DefaultValue(true)]
-        public bool OptimizeBufferReuse { get => true; set { } }
+        public bool OptimizeBufferReuse { get => _optimizeBufferReuse ?? true; set => _optimizeBufferReuse = value ? true : (bool?)null; }
+        private bool? _optimizeBufferReuse;
 
         /// <summary>
         /// Default buffer size for the internal buffers

--- a/src/NLog/Internal/ObjectPools/ReusableObjectCreator.cs
+++ b/src/NLog/Internal/ObjectPools/ReusableObjectCreator.cs
@@ -38,15 +38,12 @@ namespace NLog.Internal
     /// <summary>
     /// Controls a single allocated object for reuse (only one active user)
     /// </summary>
-    class ReusableObjectCreator<T> where T : class
+    internal class ReusableObjectCreator<T> where T : class
     {
         protected T _reusableObject;
         private readonly Action<T> _clearObject;
         private readonly Func<int, T> _createObject;
         private readonly int _initialCapacity;
-
-        /// <summary>Empty handle when <see cref="Targets.Target.OptimizeBufferReuse"/> is disabled</summary>
-        public readonly LockOject None = default(LockOject);
 
         protected ReusableObjectCreator(int initialCapacity, Func<int, T> createObject, Action<T> clearObject)
         {

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -87,7 +87,8 @@ namespace NLog.Targets
         /// </summary>
         /// <docgen category='Performance Tuning Options' order='10' />
         [Obsolete("No longer used, and always returns true. Marked obsolete on NLog 5.0")]
-        public bool OptimizeBufferReuse { get => true; set { } }
+        public bool OptimizeBufferReuse { get => _optimizeBufferReuse ?? true; set => _optimizeBufferReuse = value ? true : (bool?)null; }
+        private bool? _optimizeBufferReuse;
 
         /// <summary>
         /// Gets the object which can be used to synchronize asynchronous operations that must rely on the .


### PR DESCRIPTION
False positive since the setter-property is only there to avoid breaking interface.

![image](https://user-images.githubusercontent.com/11509660/111086950-44390500-851f-11eb-8839-40293817e561.png)
