### PR TITLE
SimpleLayout - Faster parsing of simple values and reduced allocation

### DIFF
--- a/src/NLog/Internal/Reflection/ObjectGraphScanner.cs
+++ b/src/NLog/Internal/Reflection/ObjectGraphScanner.cs
@@ -170,8 +170,9 @@ namespace NLog.Internal
 
             if (enumerable is IList list)
             {
-                if (!list.IsReadOnly)
+                if (!list.IsReadOnly && !(list is Array))
                 {
+                    // Protect against collection was modified
                     List<object> elements = new List<object>(list.Count);
                     lock (list.SyncRoot)
                     {

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -50,6 +50,26 @@ namespace NLog.Layouts
     /// </summary>
     internal static class LayoutParser
     {
+        private static readonly char[] SpecialTokens = new char[] { '$', '\\', '}', ':' };
+
+        internal static LayoutRenderer[] CompileLayout(string value, ConfigurationItemFactory configurationItemFactory, bool? throwConfigExceptions, out string text)
+        {
+            if (value == null)
+            {
+                text = string.Empty;
+                return ArrayHelper.Empty<LayoutRenderer>();
+            }
+            else if (value.Length < 128 && value.IndexOfAny(SpecialTokens) < 0)
+            {
+                text = value;
+                return new LayoutRenderer[] { new LiteralLayoutRenderer(value) };
+            }
+            else
+            {
+                return CompileLayout(configurationItemFactory, new SimpleStringReader(value), throwConfigExceptions, false, out text);
+            }
+        }
+
         internal static LayoutRenderer[] CompileLayout(ConfigurationItemFactory configurationItemFactory, SimpleStringReader sr, bool? throwConfigExceptions, bool isNested, out string text)
         {
             var result = new List<LayoutRenderer>();

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -413,6 +413,8 @@ namespace NLog.Layouts
         /// <param name="value">Text to be converted.</param>
         public static implicit operator Layout<T>(T value)
         {
+            if (value == null && !typeof(T).IsValueType()) return null;
+
             return new Layout<T>(value);
         }
 
@@ -422,6 +424,8 @@ namespace NLog.Layouts
         /// <param name="layout">Text to be converted.</param>
         public static implicit operator Layout<T>([Localizable(false)] string layout)
         {
+            if (layout == null) return null;
+
             return new Layout<T>(layout);
         }
 
@@ -429,7 +433,7 @@ namespace NLog.Layouts
         /// Converts a <see cref="Layout{T}" /> its current value
         /// </summary>
         /// <param name="layout">Text to be converted.</param>
-        public static implicit operator T(Layout<T> layout) => layout.StaticValue;
+        public static implicit operator T(Layout<T> layout) => ReferenceEquals(layout, null) ? default(T) : layout.StaticValue;
     }
 
     /// <summary>

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -489,15 +489,17 @@ namespace NLog.UnitTests.Layouts
             // Arrange
             Uri url = null;
             Layout<Uri> layout1 = url;
-            Layout<Uri> layout2 = url;
+            Layout<Uri> layout2 = new Layout<Uri>(url);
 
             // Act + Assert
+            Assert.Null(layout1);
             Assert.True(layout1 == url);
+            Assert.True(layout2 == url);
             Assert.True(url == layout1);
-            Assert.True(layout1.Equals(url));
-            Assert.True(layout1.Equals((object)url));
-            Assert.Equal(layout1, layout2);
-            Assert.Equal(layout1.GetHashCode(), layout2.GetHashCode());
+            Assert.True(url == layout2);
+            Assert.True(layout2.Equals(url));
+            Assert.True(layout2.Equals((object)url));
+            Assert.NotEqual(layout1, layout2);
         }
 
         [Fact]
@@ -525,7 +527,7 @@ namespace NLog.UnitTests.Layouts
             Uri url = null;
             var url2 = new Uri("http://nlog");
             Layout<Uri> layout1 = url2;
-            Layout<Uri> layout2 = url;
+            Layout<Uri> layout2 = new Layout<Uri>(url);
 
             // Act + Assert
             Assert.False(layout1 == url);


### PR DESCRIPTION
When assigning simple value to Layout, then it now skips allocation of these objects:
- `SimpleStringReader`
- `StringBuilder`
- `List<LayoutRenderer>`
- `ReadOnlyCollection<LayoutRenderer>`