### PR TITLE
TargetWithLayout - Skip parsing of default Layout

### DIFF
--- a/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
@@ -34,6 +34,7 @@
 namespace NLog.LayoutRenderers
 {
     using System;
+    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Text;
     using NLog.Config;
@@ -47,12 +48,31 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class LevelLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {
+        private static readonly Dictionary<int, string> _upperCaseMapper = new Dictionary<int, string>()
+        {
+            { LogLevel.Trace.Ordinal, LogLevel.Trace.ToString().ToUpperInvariant() },
+            { LogLevel.Debug.Ordinal, LogLevel.Debug.ToString().ToUpperInvariant() },
+            { LogLevel.Info.Ordinal, LogLevel.Info.ToString().ToUpperInvariant() },
+            { LogLevel.Warn.Ordinal, LogLevel.Warn.ToString().ToUpperInvariant() },
+            { LogLevel.Error.Ordinal, LogLevel.Error.ToString().ToUpperInvariant() },
+            { LogLevel.Fatal.Ordinal, LogLevel.Fatal.ToString().ToUpperInvariant() },
+            { LogLevel.Off.Ordinal, LogLevel.Off.ToString().ToUpperInvariant() },
+        };
+
         /// <summary>
         /// Gets or sets a value indicating the output format of the level.
         /// </summary>
         /// <docgen category='Rendering Options' order='10' />
         [DefaultValue(LevelFormat.Name)]
         public LevelFormat Format { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether upper case conversion should be applied.
+        /// </summary>
+        /// <value>A value of <c>true</c> if upper case conversion should be applied otherwise, <c>false</c>.</value>
+        /// <docgen category='Rendering Options' order='10' />
+        [DefaultValue(true)]
+        public bool Uppercase { get; set; }
 
         /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
@@ -61,7 +81,7 @@ namespace NLog.LayoutRenderers
             switch (Format)
             {
                 case LevelFormat.Name:
-                    builder.Append(level.ToString());
+                    builder.Append(Uppercase ? GetUpperCaseString(level) : level.ToString());
                     break;
                 case LevelFormat.FirstCharacter:
                     builder.Append(level.ToString()[0]);
@@ -71,13 +91,21 @@ namespace NLog.LayoutRenderers
                     break;
                 case LevelFormat.FullName:
                     if (level == LogLevel.Info)
-                        builder.Append("Information");
+                        builder.Append(Uppercase ? "INFORMATION" : "Information");
                     else if (level == LogLevel.Warn)
-                        builder.Append("Warning");
+                        builder.Append(Uppercase ? "WARNING" : "Warning");
                     else
-                        builder.Append(level.ToString());
+                        builder.Append(Uppercase ? GetUpperCaseString(level) : level.ToString());
                     break;
             }
+        }
+
+        private string GetUpperCaseString(LogLevel level)
+        {
+            if (_upperCaseMapper.TryGetValue(level.Ordinal, out var uppercaseString))
+                return uppercaseString;
+            else
+                return level.ToString().ToUpperInvariant();
         }
 
         /// <inheritdoc/>
@@ -88,7 +116,15 @@ namespace NLog.LayoutRenderers
         }
 
         /// <inheritdoc/>
-        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => Format == LevelFormat.Name ? GetValue(logEvent).ToString() : null;
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent)
+        {
+            if (Format == LevelFormat.Name)
+            {
+                var level = GetValue(logEvent);
+                return Uppercase ? GetUpperCaseString(level) : level.ToString();
+            }
+            return null;
+        }
 
         private static LogLevel GetValue(LogEventInfo logEvent)
         {

--- a/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
@@ -102,10 +102,8 @@ namespace NLog.LayoutRenderers
 
         private string GetUpperCaseString(LogLevel level)
         {
-            if (_upperCaseMapper.TryGetValue(level.Ordinal, out var uppercaseString))
-                return uppercaseString;
-            else
-                return level.ToString().ToUpperInvariant();
+            _upperCaseMapper.TryGetValue(level.Ordinal, out var uppercaseString);
+            return uppercaseString ?? level.ToString().ToUpperInvariant();
         }
 
         /// <inheritdoc/>

--- a/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
@@ -71,7 +71,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <value>A value of <c>true</c> if upper case conversion should be applied otherwise, <c>false</c>.</value>
         /// <docgen category='Rendering Options' order='10' />
-        [DefaultValue(true)]
+        [DefaultValue(false)]
         public bool Uppercase { get; set; }
 
         /// <inheritdoc/>

--- a/src/NLog/Targets/TargetWithLayout.cs
+++ b/src/NLog/Targets/TargetWithLayout.cs
@@ -42,6 +42,18 @@ namespace NLog.Targets
     /// </summary>
     public abstract class TargetWithLayout : Target
     {
+        private const string DefaultLayoutText = "${longdate}|${level:uppercase=true}|${logger}|${message:withexception=true}";
+        private static NLog.LayoutRenderers.LayoutRenderer[] DefaultLayout => new NLog.LayoutRenderers.LayoutRenderer[]
+        {
+            new NLog.LayoutRenderers.LongDateLayoutRenderer(),
+            new NLog.LayoutRenderers.LiteralLayoutRenderer("|"),
+            new NLog.LayoutRenderers.LevelLayoutRenderer() { Uppercase = true },
+            new NLog.LayoutRenderers.LiteralLayoutRenderer("|"),
+            new NLog.LayoutRenderers.LoggerNameLayoutRenderer(),
+            new NLog.LayoutRenderers.LiteralLayoutRenderer("|"),
+            new NLog.LayoutRenderers.MessageLayoutRenderer() { WithException = true },
+        };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TargetWithLayout" /> class.
         /// </summary>
@@ -51,7 +63,7 @@ namespace NLog.Targets
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Justification = "This one is safe.")]
         protected TargetWithLayout()
         {
-            Layout = "${longdate}|${level:uppercase=true}|${logger}|${message:withexception=true}";
+            Layout = new SimpleLayout(DefaultLayout, DefaultLayoutText, ConfigurationItemFactory.Default);
         }
 
         /// <summary>
@@ -62,7 +74,7 @@ namespace NLog.Targets
         /// </remarks>
         /// <docgen category='Layout Options' order='1' />
         [RequiredParameter]
-        [DefaultValue("${longdate}|${level:uppercase=true}|${logger}|${message:withexception=true}")]
+        [DefaultValue(DefaultLayoutText)]
         public virtual Layout Layout { get; set; }
    }
 }

--- a/tests/NLog.UnitTests/Config/TargetConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/TargetConfigurationTests.cs
@@ -92,6 +92,24 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        public void TargetWithLayoutHasUniqueLayout()
+        {
+            var target1 = new StructuredDebugTarget();
+            var target2 = new StructuredDebugTarget();
+            var simpleLayout1 = target1.Layout as SimpleLayout;
+            var simpleLayout2 = target2.Layout as SimpleLayout;
+
+            // Ensure the default Layout for two Targets are not reusing objects
+            // As it would cause havoc with initializing / closing lifetime-events
+            Assert.NotSame(simpleLayout1, simpleLayout2);
+            Assert.Equal(simpleLayout1.Renderers.Count, simpleLayout1.Renderers.Count);
+            for (int i = 0; i < simpleLayout1.Renderers.Count; ++i)
+            {
+                Assert.NotSame(simpleLayout1.Renderers[i], simpleLayout2.Renderers[i]);
+            }
+        }
+
+        [Fact]
         public void NestedXmlConfigElementTest()
         {
             LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString(@"

--- a/tests/NLog.UnitTests/LayoutRenderers/LogLevelTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/LogLevelTests.cs
@@ -65,6 +65,30 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
+        public void LogLevelUppercaseTest()
+        {
+            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${level:uppercase=true} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>");
+
+            ILogger logger = LogManager.GetLogger("A");
+            logger.Debug("a");
+            AssertDebugLastMessage("debug", "DEBUG a");
+            logger.Info("a");
+            AssertDebugLastMessage("debug", "INFO a");
+            logger.Warn("a");
+            AssertDebugLastMessage("debug", "WARN a");
+            logger.Error("a");
+            AssertDebugLastMessage("debug", "ERROR a");
+            logger.Fatal("a");
+            AssertDebugLastMessage("debug", "FATAL a");
+        }
+
+        [Fact]
         public void LogLevelSingleCharacterTest()
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"


### PR DESCRIPTION
Skip parsing of Layout in constructor that resolves #4033 (Removes unnecessary parsing that might be thrown away, when Layout is re-assigned right after)

