### PR TITLE
LoggingConfigurationParser - Recognize LoggingRule.DefaultFilterAction

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -568,6 +568,7 @@ namespace NLog.Config
             bool enabled = true;
             bool final = false;
             string writeTargets = null;
+            string defaultFilterResult = null;
             foreach (var childProperty in loggerElement.Values)
             {
                 switch (childProperty.Key?.Trim().ToUpperInvariant())
@@ -608,6 +609,9 @@ namespace NLog.Config
                     case "MAXLEVEL":
                         maxLevel = childProperty.Value;
                         break;
+                    case "DEFAULTFILTERRESULT":
+                        defaultFilterResult = childProperty.Value;
+                        break;
                     default:
                         InternalLogger.Debug("Skipping unknown property {0} for element {1} in section {2}",
                             childProperty.Key, loggerElement.Name, "rules");
@@ -640,7 +644,7 @@ namespace NLog.Config
 
             ParseLoggingRuleTargets(writeTargets, rule);
 
-            ParseLoggingRuleChildren(loggerElement, rule);
+            ParseLoggingRuleChildren(loggerElement, rule, defaultFilterResult);
 
             return rule;
         }
@@ -724,14 +728,14 @@ namespace NLog.Config
             }
         }
 
-        private void ParseLoggingRuleChildren(ILoggingConfigurationElement loggerElement, LoggingRule rule)
+        private void ParseLoggingRuleChildren(ILoggingConfigurationElement loggerElement, LoggingRule rule, string defaultFilterResult = null)
         {
             foreach (var child in loggerElement.Children)
             {
                 LoggingRule childRule = null;
                 if (child.MatchesName("filters"))
                 {
-                    ParseFilters(rule, child);
+                    ParseFilters(rule, child, defaultFilterResult);
                 }
                 else if (child.MatchesName("logger") && loggerElement.MatchesName("logger"))
                 {
@@ -757,23 +761,22 @@ namespace NLog.Config
             }
         }
 
-        private void ParseFilters(LoggingRule rule, ILoggingConfigurationElement filtersElement)
+        private void ParseFilters(LoggingRule rule, ILoggingConfigurationElement filtersElement, string defaultFilterResult = null)
         {
             filtersElement.AssertName("filters");
 
-            var defaultActionResult = filtersElement.GetOptionalValue("defaultAction", null);
-            if (defaultActionResult != null)
+            defaultFilterResult = filtersElement.GetOptionalValue("defaultAction", null) ?? filtersElement.GetOptionalValue("defaultFilterResult", null) ?? defaultFilterResult;
+            if (defaultFilterResult != null)
             {
-                PropertyHelper.SetPropertyFromString(rule, nameof(rule.DefaultFilterResult), defaultActionResult,
+                PropertyHelper.SetPropertyFromString(rule, nameof(rule.DefaultFilterResult), defaultFilterResult,
                     _configurationItemFactory);
             }
 
             foreach (var filterElement in filtersElement.Children)
             {
-                string name = filterElement.Name;
-
-                Filter filter = _configurationItemFactory.Filters.CreateInstance(name);
-                ConfigureObjectFromAttributes(filter, filterElement, false);
+                var filterType = filterElement.GetOptionalValue("type", null) ?? filterElement.Name;
+                Filter filter = _configurationItemFactory.Filters.CreateInstance(filterType);
+                ConfigureObjectFromAttributes(filter, filterElement, true);
                 rule.Filters.Add(filter);
             }
         }
@@ -1044,10 +1047,19 @@ namespace NLog.Config
                     PropertyHelper.SetPropertyFromString(targetObject, childName, ExpandSimpleVariables(childValue),
                         _configurationItemFactory);
                 }
+                catch (NLogConfigurationException ex)
+                {
+                    if (MustThrowConfigException(ex))
+                        throw;
+                }
                 catch (Exception ex)
                 {
-                    InternalLogger.Warn(ex, "Error when setting '{0}' on attibute '{1}'", childValue, childName);
-                    throw;
+                    if (ex.MustBeRethrownImmediately())
+                        throw;
+
+                    var configException = new NLogConfigurationException(ex, $"Error when setting value '{childValue}' for property '{childName}' on element '{element}'");
+                    if (MustThrowConfigException(configException))
+                        throw;
                 }
             }
         }

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -568,7 +568,7 @@ namespace NLog.Config
             bool enabled = true;
             bool final = false;
             string writeTargets = null;
-            string defaultFilterResult = null;
+            string defaultFilterAction = null;
             foreach (var childProperty in loggerElement.Values)
             {
                 switch (childProperty.Key?.Trim().ToUpperInvariant())
@@ -609,8 +609,8 @@ namespace NLog.Config
                     case "MAXLEVEL":
                         maxLevel = childProperty.Value;
                         break;
-                    case "DEFAULTFILTERRESULT":
-                        defaultFilterResult = childProperty.Value;
+                    case "DEFAULTFILTERACTION":
+                        defaultFilterAction = childProperty.Value;
                         break;
                     default:
                         InternalLogger.Debug("Skipping unknown property {0} for element {1} in section {2}",
@@ -644,7 +644,7 @@ namespace NLog.Config
 
             ParseLoggingRuleTargets(writeTargets, rule);
 
-            ParseLoggingRuleChildren(loggerElement, rule, defaultFilterResult);
+            ParseLoggingRuleChildren(loggerElement, rule, defaultFilterAction);
 
             return rule;
         }
@@ -728,14 +728,14 @@ namespace NLog.Config
             }
         }
 
-        private void ParseLoggingRuleChildren(ILoggingConfigurationElement loggerElement, LoggingRule rule, string defaultFilterResult = null)
+        private void ParseLoggingRuleChildren(ILoggingConfigurationElement loggerElement, LoggingRule rule, string defaultFilterAction = null)
         {
             foreach (var child in loggerElement.Children)
             {
                 LoggingRule childRule = null;
                 if (child.MatchesName("filters"))
                 {
-                    ParseFilters(rule, child, defaultFilterResult);
+                    ParseFilters(rule, child, defaultFilterAction);
                 }
                 else if (child.MatchesName("logger") && loggerElement.MatchesName("logger"))
                 {
@@ -761,14 +761,14 @@ namespace NLog.Config
             }
         }
 
-        private void ParseFilters(LoggingRule rule, ILoggingConfigurationElement filtersElement, string defaultFilterResult = null)
+        private void ParseFilters(LoggingRule rule, ILoggingConfigurationElement filtersElement, string defaultFilterAction = null)
         {
             filtersElement.AssertName("filters");
 
-            defaultFilterResult = filtersElement.GetOptionalValue("defaultAction", null) ?? filtersElement.GetOptionalValue("defaultFilterResult", null) ?? defaultFilterResult;
-            if (defaultFilterResult != null)
+            defaultFilterAction = filtersElement.GetOptionalValue("defaultAction", null) ?? filtersElement.GetOptionalValue("defaultFilterAction", null) ?? defaultFilterAction;
+            if (defaultFilterAction != null)
             {
-                PropertyHelper.SetPropertyFromString(rule, nameof(rule.DefaultFilterResult), defaultFilterResult,
+                PropertyHelper.SetPropertyFromString(rule, nameof(rule.DefaultFilterResult), defaultFilterAction,
                     _configurationItemFactory);
             }
 

--- a/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
@@ -432,6 +432,33 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        public void FiltersTest_defaultFilterResult()
+        {
+            LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog>
+                <targets>
+                    <target name='d1' type='Debug' layout='${message}' />
+                </targets>
+
+                <rules>
+                    <logger name='*' level='Warn' writeTo='d1'>
+                        <filters defaultFilterResult='Ignore'>
+                            <filter type='when' condition=""starts-with(message, 't')"" action='Log' />
+                        </filters>
+                    </logger>
+                </rules>
+            </nlog>");
+
+            LogManager.Configuration = c;
+            var logger = LogManager.GetLogger("logger1");
+            logger.Warn("test 1");
+            AssertDebugLastMessage("d1", "test 1");
+
+            logger.Warn("x-mass");
+            AssertDebugLastMessage("d1", "test 1");
+        }
+
+        [Fact]
         public void FiltersTest_defaultFilterAction_noRules()
         {
             LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString(@"

--- a/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
@@ -442,7 +442,7 @@ namespace NLog.UnitTests.Config
 
                 <rules>
                     <logger name='*' level='Warn' writeTo='d1'>
-                        <filters defaultFilterResult='Ignore'>
+                        <filters defaultFilterAction='Ignore'>
                             <filter type='when' condition=""starts-with(message, 't')"" action='Log' />
                         </filters>
                     </logger>

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -229,7 +229,7 @@ namespace NLog.UnitTests.Config
                         <target name='debug' type='Debug' layout='${message}' />
                     </targets>
                     <rules>
-                        <logger name='*' minlevel='debug' appendto='debug' defaultFilterResult='ignore'>
+                        <logger name='*' minlevel='debug' appendto='debug' defaultFilterAction='ignore'>
                             <filters>
                                 <whenContains />
                             </filters>


### PR DESCRIPTION
Like that the recognized properties matches the name of the actual properties. Ex, [LoggingRule.DefaultFilterResult](https://nlog-project.org/documentation/v4.6.0/html/P_NLog_Config_LoggingRule_DefaultFilterResult.htm) (Though it would be a better match if the property was named `DefaultFilterAction`)

Adds support for doing this in appsetting.json:
```json
        "rules": [
          {
            "logger": "*",
            "minLevel": "Trace",
            "writeTo": "Console",
            "defaultFilterAction": "Log",
            "filters": [
              {
                "type": "when",
                "condition": "contains('${message}','HeartbeatRequest')",
                "action": "Ignore"
              },
              {
                "type": "when",
                "condition": "contains('${message}','HeartbeatResponse')",
                "action": "Ignore"
              }
            ]
          }
        ]
```

See also: https://github.com/NLog/NLog.Extensions.Logging/issues/491