### PR TITLE
Enable deterministic build and SourceLink for all projects

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -23,7 +23,7 @@ if (-Not (test-path $targetNugetExe))
 	Invoke-WebRequest $sourceNugetExe -OutFile $targetNugetExe
 }
 
-msbuild /t:Restore,Pack .\src\NLog\ /p:targetFrameworks='"net46;net45;net35;netstandard1.3;netstandard1.5;netstandard2.0"' /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:PackageOutputPath=..\..\artifacts /verbosity:minimal /maxcpucount
+msbuild /t:Restore,Pack .\src\NLog\ /p:targetFrameworks='"net46;net45;net35;netstandard1.3;netstandard1.5;netstandard2.0"' /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:ContinuousIntegrationBuild=true /p:PackageOutputPath=..\..\artifacts /verbosity:minimal /maxcpucount
 if (-Not $LastExitCode -eq 0)
 	{ exit $LastExitCode }
 
@@ -31,7 +31,7 @@ function create-package($packageName)
 {
 
 	$path = ".\src\$packageName\"
-	msbuild /t:Restore,Pack $path /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:PackageOutputPath=..\..\artifacts /verbosity:minimal  /maxcpucount
+	msbuild /t:Restore,Pack $path /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:ContinuousIntegrationBuild=true /p:PackageOutputPath=..\..\artifacts /verbosity:minimal  /maxcpucount
 	if (-Not $LastExitCode -eq 0)
 		{ exit $LastExitCode }
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,42 @@
+<Project>
+  <ItemGroup>
+    <SourceRoot Include="$(MSBuildThisFileDirectory)/"/>
+  </ItemGroup>
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+
+    <Company>NLog</Company>
+    <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
+    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
+    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
+
+    <PackageIconUrl>https://nlog-project.org/N.png</PackageIconUrl>
+    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/NLog/NLog/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
+    
+    <SignAssembly>true</SignAssembly>
+    <InformationalVersion>$(ProductVersion)</InformationalVersion>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <AssemblyTitle>$(Title)</AssemblyTitle>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageIcon>N.png</PackageIcon>
+
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!-- EmbedUntrackedSources for deterministic build -->
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="N.png" Pack="true" PackagePath=""/>
+  </ItemGroup>
+  <Target Name="DownloadMissingContent" BeforeTargets="GenerateNuspec">
+    <DownloadFile SourceUrl="https://nlog-project.org/N.png" DestinationFolder="$(MSBuildThisFileDirectory)" />
+  </Target>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/src/NLog.MSMQ/NLog.MSMQ.csproj
+++ b/src/NLog.MSMQ/NLog.MSMQ.csproj
@@ -1,38 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-
     <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net46;net45;net35</TargetFrameworks>
 
     <Title>NLog MSMQ target</Title>
-    <Company>NLog</Company>
     <Description>NLog MSMQ target - write to the Microsoft Message Queuing</Description>
     <Product>NLog MSMQ target</Product>
-    <InformationalVersion>$(ProductVersion)</InformationalVersion>
-    <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
-    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
       Docs:
       https://github.com/NLog/NLog/wiki/MSMQ-target
-</PackageReleaseNotes>
+    </PackageReleaseNotes>
     <PackageTags>NLog;MSMQ;logging;log</PackageTags>
-    <PackageIcon>N.png</PackageIcon>
-    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
-
-    <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
@@ -69,16 +48,5 @@
   <ItemGroup>
     <EmbeddedResource Include="..\NLog\Resources\NLog.ico" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <AssemblyTitle>$(Title)</AssemblyTitle>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="N.png" Pack="true" PackagePath=""/>
-  </ItemGroup>
-  <Target Name="DownloadMissingContent" BeforeTargets="GenerateNuspec">
-    <DownloadFile SourceUrl="https://nlog-project.org/N.png" DestinationFolder="$(MSBuildThisFileDirectory)" />
-  </Target>
 
 </Project>

--- a/src/NLog.OutputDebugString/NLog.OutputDebugString.csproj
+++ b/src/NLog.OutputDebugString/NLog.OutputDebugString.csproj
@@ -4,32 +4,14 @@
     <TargetFrameworks>net35;net45;net46</TargetFrameworks>
 
     <Title>NLog.OutputDebugString</Title>
-    <Company>NLog</Company>
     <Description>NLog.OutputDebugString provides support for DebugView output</Description>
     <Product>NLog.PerformanceCounter v$(ProductVersion)</Product>
-    <InformationalVersion>$(ProductVersion)</InformationalVersion>
-    <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
-    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
       OutputDebugStringTarget Docs:
       https://github.com/NLog/NLog/wiki/OutputDebugString-target
     </PackageReleaseNotes>
     <PackageTags>NLog;Windows;DebugView;logging;log</PackageTags>
-    <PackageIcon>N.png</PackageIcon>
-    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
-
-    <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
@@ -50,12 +32,5 @@
   <ItemGroup>
     <ProjectReference Include="..\NLog\NLog.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <None Include="N.png" Pack="true" PackagePath=""/>
-  </ItemGroup>
-  <Target Name="DownloadMissingContent" BeforeTargets="GenerateNuspec">
-    <DownloadFile SourceUrl="https://nlog-project.org/N.png" DestinationFolder="$(MSBuildThisFileDirectory)" />
-  </Target>
 
 </Project>

--- a/src/NLog.PerformanceCounter/NLog.PerformanceCounter.csproj
+++ b/src/NLog.PerformanceCounter/NLog.PerformanceCounter.csproj
@@ -4,13 +4,8 @@
     <TargetFrameworks>net35;net45;net46;netstandard2.0</TargetFrameworks>
 
     <Title>NLog.PerformanceCounter</Title>
-    <Company>NLog</Company>
     <Description>NLog.PerformanceCounter provides support for Windows Performance Counters</Description>
     <Product>NLog.PerformanceCounter v$(ProductVersion)</Product>
-    <InformationalVersion>$(ProductVersion)</InformationalVersion>
-    <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
-    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
 PerformanceCounterTarget Docs:
@@ -20,19 +15,6 @@ PerformanceCounterLayoutRenderer Docs:
 https://github.com/NLog/NLog/wiki/PerformanceCounter-Layout-Renderer
     </PackageReleaseNotes>
     <PackageTags>NLog;Windows;PerformanceCounter;logging;log</PackageTags>
-    <PackageIcon>N.png</PackageIcon>
-    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
-
-    <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
@@ -67,12 +49,5 @@ https://github.com/NLog/NLog/wiki/PerformanceCounter-Layout-Renderer
   <ItemGroup>
     <ProjectReference Include="..\NLog\NLog.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <None Include="N.png" Pack="true" PackagePath=""/>
-  </ItemGroup>
-  <Target Name="DownloadMissingContent" BeforeTargets="GenerateNuspec">
-    <DownloadFile SourceUrl="https://nlog-project.org/N.png" DestinationFolder="$(MSBuildThisFileDirectory)" />
-  </Target>
 
 </Project>

--- a/src/NLog.Wcf/NLog.Wcf.csproj
+++ b/src/NLog.Wcf/NLog.Wcf.csproj
@@ -1,37 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-
     <TargetFrameworks>net46;net45;net35;netstandard1.3;netstandard1.5;netstandard2.0</TargetFrameworks>
 
     <Title>NLog.WCF for .NET Standard and .NetFramework</Title>
-    <Company>NLog</Company>
     <Description>NLog.WCF ServiceModel provides LogReceiverService target and the WCF contract interfaces/implementations for NetStandard</Description>
     <Product>NLog WCF v$(ProductVersion)</Product>
-    <InformationalVersion>$(ProductVersion)</InformationalVersion>
-    <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
-    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
       Docs:
       https://github.com/NLog/NLog/wiki/LogReceiverService-target
     </PackageReleaseNotes>
     <PackageTags>NLog;WCF;ServiceModel;logging;log</PackageTags>
-    <PackageIcon>N.png</PackageIcon>
-    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
-
-    <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
@@ -95,16 +75,5 @@
   <ItemGroup>
     <EmbeddedResource Include="..\NLog\Resources\NLog.ico" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <AssemblyTitle>$(Title)</AssemblyTitle>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="N.png" Pack="true" PackagePath=""/>
-  </ItemGroup>
-  <Target Name="DownloadMissingContent" BeforeTargets="GenerateNuspec">
-    <DownloadFile SourceUrl="https://nlog-project.org/N.png" DestinationFolder="$(MSBuildThisFileDirectory)" />
-  </Target>
 
 </Project>

--- a/src/NLog.WindowsEventLog/NLog.WindowsEventLog.csproj
+++ b/src/NLog.WindowsEventLog/NLog.WindowsEventLog.csproj
@@ -1,37 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
 
     <Title>NLog.WindowsEventLog for .NET Standard</Title>
-    <Company>NLog</Company>
     <Description>NLog.WindowsEventLog provides access to the EventLog-target for NetStandard</Description>
     <Product>NLog Windows EventLog v$(ProductVersion)</Product>
-    <InformationalVersion>$(ProductVersion)</InformationalVersion>
-    <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
-    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
       Docs:
       https://github.com/nlog/NLog/wiki/EventLog-target
     </PackageReleaseNotes>
     <PackageTags>NLog;EventLog;logging;log</PackageTags>
-    <PackageIcon>N.png</PackageIcon>
-    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
-
-    <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
@@ -55,16 +35,5 @@
   <ItemGroup>
     <EmbeddedResource Include="..\NLog\Resources\NLog.ico" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <AssemblyTitle>$(Title)</AssemblyTitle>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="N.png" Pack="true" PackagePath=""/>
-  </ItemGroup>
-  <Target Name="DownloadMissingContent" BeforeTargets="GenerateNuspec">
-    <DownloadFile SourceUrl="https://nlog-project.org/N.png" DestinationFolder="$(MSBuildThisFileDirectory)" />
-  </Target>
 
 </Project>

--- a/src/NLog.WindowsIdentity/NLog.WindowsIdentity.csproj
+++ b/src/NLog.WindowsIdentity/NLog.WindowsIdentity.csproj
@@ -1,37 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-
     <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net46;net45;net35;netstandard1.5;netstandard2.0</TargetFrameworks>
-
     <Title>NLog.WindowsIdentity for .NET Standard and .NetFramework</Title>
-    <Company>NLog</Company>
     <Description>NLog.WindowsIdentity.dll provides windows-identity renderer</Description>
     <Product>NLog WindowsIdentity v$(ProductVersion)</Product>
-    <InformationalVersion>$(ProductVersion)</InformationalVersion>
-    <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
-    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
-
     <PackageReleaseNotes>     
       Docs:
       https://github.com/NLog/NLog/wiki/Windows-Identity-Layout-Renderer
     </PackageReleaseNotes>
     <PackageTags>NLog;WindowsIdentity;logging;log</PackageTags>
-    <PackageIcon>N.png</PackageIcon>
-    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
-
-    <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
@@ -78,16 +56,5 @@
   <ItemGroup>
     <EmbeddedResource Include="..\NLog\Resources\NLog.ico" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <AssemblyTitle>$(Title)</AssemblyTitle>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="N.png" Pack="true" PackagePath=""/>
-  </ItemGroup>
-  <Target Name="DownloadMissingContent" BeforeTargets="GenerateNuspec">
-    <DownloadFile SourceUrl="https://nlog-project.org/N.png" DestinationFolder="$(MSBuildThisFileDirectory)" />
-  </Target>
 
 </Project>

--- a/src/NLog.WindowsRegistry/NLog.WindowsRegistry.csproj
+++ b/src/NLog.WindowsRegistry/NLog.WindowsRegistry.csproj
@@ -4,32 +4,14 @@
     <TargetFrameworks>net35;net45;net46;netstandard2.0</TargetFrameworks>
 
     <Title>NLog.WindowsRegistry</Title>
-    <Company>NLog</Company>
     <Description>NLog.WindowsRegistry provides support for Windows Registry</Description>
     <Product>NLog.WindowsRegistry v$(ProductVersion)</Product>
-    <InformationalVersion>$(ProductVersion)</InformationalVersion>
-    <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
-    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
       RegistryLayoutRenderer Docs:
       https://github.com/NLog/NLog/wiki/Registry-Layout-Renderer
     </PackageReleaseNotes>
     <PackageTags>NLog;Windows;Registry;logging;log</PackageTags>
-    <PackageIcon>N.png</PackageIcon>
-    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
-
-    <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
@@ -64,12 +46,5 @@
   <ItemGroup>
     <ProjectReference Include="..\NLog\NLog.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <None Include="N.png" Pack="true" PackagePath=""/>
-  </ItemGroup>
-  <Target Name="DownloadMissingContent" BeforeTargets="GenerateNuspec">
-    <DownloadFile SourceUrl="https://nlog-project.org/N.png" DestinationFolder="$(MSBuildThisFileDirectory)" />
-  </Target>
 
 </Project>

--- a/src/NLog.sln
+++ b/src/NLog.sln
@@ -41,6 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\appveyor.yml = ..\appveyor.yml
 		..\build.ps1 = ..\build.ps1
 		..\CHANGELOG.md = ..\CHANGELOG.md
+		Directory.Build.props = Directory.Build.props
 		..\run-tests.ps1 = ..\run-tests.ps1
 	EndProjectSection
 EndProject

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-
     <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net46;net45;net35;netstandard1.3;netstandard1.5;netstandard2.0</TargetFrameworks>
 
     <Title>NLog for .NET Framework and .NET Standard</Title>
-    <Company>NLog</Company>
     <Description>NLog is a logging platform for .NET with rich log routing and management capabilities.
 NLog supports traditional logging, structured logging and the combination of both.
 
@@ -22,10 +19,6 @@ For ASP.NET Core, check: https://www.nuget.org/packages/NLog.Web.AspNetCore
     
     </Description>
     <Product>NLog v$(ProductVersion)</Product>
-    <InformationalVersion>$(ProductVersion)</InformationalVersion>
-    <Authors>Jarek Kowalski,Kim Christensen,Julian Verdurmen</Authors>
-    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
 ## Bug fixes
@@ -41,19 +34,6 @@ For all config options and platform support, check https://nlog-project.org/conf
 
     </PackageReleaseNotes>
     <PackageTags>NLog;logging;log;structured;tracing;logfiles;database;eventlog;console;email</PackageTags>
-    <PackageIcon>N.png</PackageIcon>
-    <PackageProjectUrl>https://nlog-project.org/</PackageProjectUrl>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
-
-    <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
@@ -92,10 +72,6 @@ For all config options and platform support, check https://nlog-project.org/conf
     <Title>$(Title) - Mono</Title>
     <DefineConstants>$(DefineConstants);MONO</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
@@ -198,20 +174,12 @@ For all config options and platform support, check https://nlog-project.org/conf
   </ItemGroup>
 
   <PropertyGroup>
-    <AssemblyTitle>$(Title)</AssemblyTitle>
     <!-- SonarQube WARNING: The following projects do not have a valid ProjectGuid and were not built using a valid solution (.sln) thus will be skipped from analysis… -->
     <ProjectGuid>{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}</ProjectGuid>
   </PropertyGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="echo building $(TargetFramework) ..." />
-  </Target>
-
-  <ItemGroup>
-    <None Include="N.png" Pack="true" PackagePath=""/>
-  </ItemGroup>
-  <Target Name="DownloadMissingContent" BeforeTargets="GenerateNuspec">
-    <DownloadFile SourceUrl="https://nlog-project.org/N.png" DestinationFolder="$(MSBuildThisFileDirectory)" />
   </Target>
 
 </Project>


### PR DESCRIPTION

supersedes #4360

- Enabled sourcelink and deterministic build  for all projects
- Moved duplicate csproj properties to src/Directory.Build.props

Todo:
- [ ] test publish before merge!