### PR TITLE
Renamed setting from defaultFilterAction to filterDefaultAction

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -568,7 +568,7 @@ namespace NLog.Config
             bool enabled = true;
             bool final = false;
             string writeTargets = null;
-            string defaultFilterAction = null;
+            string filterDefaultAction = null;
             foreach (var childProperty in loggerElement.Values)
             {
                 switch (childProperty.Key?.Trim().ToUpperInvariant())
@@ -609,8 +609,8 @@ namespace NLog.Config
                     case "MAXLEVEL":
                         maxLevel = childProperty.Value;
                         break;
-                    case "DEFAULTFILTERACTION":
-                        defaultFilterAction = childProperty.Value;
+                    case "FILTERDEFAULTACTION":
+                        filterDefaultAction = childProperty.Value;
                         break;
                     default:
                         InternalLogger.Debug("Skipping unknown property {0} for element {1} in section {2}",
@@ -644,7 +644,7 @@ namespace NLog.Config
 
             ParseLoggingRuleTargets(writeTargets, rule);
 
-            ParseLoggingRuleChildren(loggerElement, rule, defaultFilterAction);
+            ParseLoggingRuleChildren(loggerElement, rule, filterDefaultAction);
 
             return rule;
         }
@@ -728,14 +728,14 @@ namespace NLog.Config
             }
         }
 
-        private void ParseLoggingRuleChildren(ILoggingConfigurationElement loggerElement, LoggingRule rule, string defaultFilterAction = null)
+        private void ParseLoggingRuleChildren(ILoggingConfigurationElement loggerElement, LoggingRule rule, string filterDefaultAction = null)
         {
             foreach (var child in loggerElement.Children)
             {
                 LoggingRule childRule = null;
                 if (child.MatchesName("filters"))
                 {
-                    ParseFilters(rule, child, defaultFilterAction);
+                    ParseFilters(rule, child, filterDefaultAction);
                 }
                 else if (child.MatchesName("logger") && loggerElement.MatchesName("logger"))
                 {
@@ -761,14 +761,14 @@ namespace NLog.Config
             }
         }
 
-        private void ParseFilters(LoggingRule rule, ILoggingConfigurationElement filtersElement, string defaultFilterAction = null)
+        private void ParseFilters(LoggingRule rule, ILoggingConfigurationElement filtersElement, string filterDefaultAction = null)
         {
             filtersElement.AssertName("filters");
 
-            defaultFilterAction = filtersElement.GetOptionalValue("defaultAction", null) ?? filtersElement.GetOptionalValue("defaultFilterAction", null) ?? defaultFilterAction;
-            if (defaultFilterAction != null)
+            filterDefaultAction = filtersElement.GetOptionalValue("defaultAction", null) ?? filtersElement.GetOptionalValue("filterDefaultAction", null) ?? filterDefaultAction;
+            if (filterDefaultAction != null)
             {
-                PropertyHelper.SetPropertyFromString(rule, nameof(rule.DefaultFilterResult), defaultFilterAction,
+                PropertyHelper.SetPropertyFromString(rule, nameof(rule.DefaultFilterResult), filterDefaultAction,
                     _configurationItemFactory);
             }
 

--- a/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
@@ -404,7 +404,7 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
-        public void FiltersTest_defaultFilterAction()
+        public void FiltersTest_DefaultAction()
         {
             LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString(@"
             <nlog>
@@ -432,7 +432,7 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
-        public void FiltersTest_defaultFilterResult()
+        public void FiltersTest_FilterDefaultAction()
         {
             LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString(@"
             <nlog>
@@ -442,7 +442,7 @@ namespace NLog.UnitTests.Config
 
                 <rules>
                     <logger name='*' level='Warn' writeTo='d1'>
-                        <filters defaultFilterAction='Ignore'>
+                        <filters filterDefaultAction='Ignore'>
                             <filter type='when' condition=""starts-with(message, 't')"" action='Log' />
                         </filters>
                     </logger>
@@ -459,7 +459,7 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
-        public void FiltersTest_defaultFilterAction_noRules()
+        public void FiltersTest_DefaultAction_noRules()
         {
             LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString(@"
             <nlog>

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -229,7 +229,7 @@ namespace NLog.UnitTests.Config
                         <target name='debug' type='Debug' layout='${message}' />
                     </targets>
                     <rules>
-                        <logger name='*' minlevel='debug' appendto='debug' defaultFilterAction='ignore'>
+                        <logger name='*' minlevel='debug' appendto='debug' filterDefaultAction='ignore'>
                             <filters>
                                 <whenContains />
                             </filters>


### PR DESCRIPTION
Followup to #4369 `filterDefaultAction` is closer to exising `DefaultAction`.