### PR TITLE
Invalid JSON format when JProperty is null

### DIFF
--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -492,7 +492,7 @@ namespace NLog.Targets
             else
             {
                 string str = XmlHelper.XmlConvertToString(value, objTypeCode);
-                if (!forceToString && str != null && SkipQuotes(value, objTypeCode))
+                if (!forceToString && !string.IsNullOrEmpty(str) && SkipQuotes(value, objTypeCode))
                 {
                     destination.Append(str);
                 }

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
@@ -37,6 +37,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
 using NLog.Config;
 using NLog.Internal;
 using NLog.Targets;
@@ -124,6 +125,25 @@ namespace NLog.UnitTests.Targets
             };
 
             var expected = "{\"Name\":\"TestObject\",\"Assets\":{\"First\":17}}";
+            var actual = SerializeObject(target);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReferenceLoopInDictionaryWithJObject_Test()
+        {
+            var d = new Dictionary<string, object>();
+            d.Add("First", 17);
+            d.Add("Loop", d);
+            var target = new Dictionary<string, object>
+            {
+                {"Name", "TestObject" },
+                {"Second", new JObject(new JProperty("subSecond", new JObject(new JProperty("nullValue",null))))},
+                {"Assets" , d },
+            };
+
+            var expected = "{\"Name\":\"TestObject\",\"Second\":{\"subSecond\":{\"nullValue\":\"\"}},\"Assets\":{\"First\":17}}";
             var actual = SerializeObject(target);
 
             Assert.Equal(expected, actual);

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
@@ -131,25 +131,6 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
-        public void ReferenceLoopInDictionaryWithJObject_Test()
-        {
-            var d = new Dictionary<string, object>();
-            d.Add("First", 17);
-            d.Add("Loop", d);
-            var target = new Dictionary<string, object>
-            {
-                {"Name", "TestObject" },
-                {"Second", new JObject(new JProperty("subSecond", new JObject(new JProperty("nullValue",null))))},
-                {"Assets" , d },
-            };
-
-            var expected = "{\"Name\":\"TestObject\",\"Second\":{\"subSecond\":{\"nullValue\":\"\"}},\"Assets\":{\"First\":17}}";
-            var actual = SerializeObject(target);
-
-            Assert.Equal(expected, actual);
-        }
-
-        [Fact]
         public void ReferenceLoopInList_Test()
         {
             var d = new List<object>();
@@ -316,6 +297,18 @@ namespace NLog.UnitTests.Targets
             dictionary.Add("key 2", 1.3m);
             var actual = SerializeObject(dictionary);
             Assert.Equal("{\"key1\":13,\"key 2\":1.3}", actual);
+        }
+
+        [Fact]
+        public void SerializeDictWithJObject_Test()
+        {
+            var dictionary = new Dictionary<string, object>();
+            dictionary.Add("key1", new JObject(new JProperty("subKey1", new JObject(new JProperty("nullValue", null)))));
+            dictionary.Add("key 2", 1.3m);
+
+            var actual = SerializeObject(dictionary);
+
+            Assert.Equal("{\"key1\":{\"subKey1\":{\"nullValue\":\"\"}},\"key 2\":1.3}", actual);
         }
 
         [Fact]


### PR DESCRIPTION
Hi!!

We have noticed a strange behavior when using structured logs and the object that is passed to the NLog provider for logging is of type JObject, sometimes it generates a malformed JSON, which breaks the structured log.

An example of the log entry it generates is as follows.

`{"test":{"id": ,"description":"descriptionValue"}}`

The behavior I expect to have for these specific cases could be anything that does not generate an invalid JSON.

That's why I created this PR, I checked your development branch and it works correctly there, but in Master branch the change is not replicated yet. 

With the change I have applied the result of the JSON for these cases would be...

`{"test":{"id":"", "description":"descriptionValue"}}`


If you have any questions please let me know.

Thank you very much in advance! 
