### PR TITLE
JsonSerializer - Fixed bug when handling custom IConvertible returning TypeCode.Empty

### DIFF
--- a/src/NLog/Internal/StringHelpers.cs
+++ b/src/NLog/Internal/StringHelpers.cs
@@ -51,10 +51,7 @@ namespace NLog.Internal
         internal static bool IsNullOrWhiteSpace(string value)
         {
 #if NET3_5
-
-            if (value == null) return true;
-            if (value.Length == 0) return true;
-            return String.IsNullOrEmpty(value.Trim());
+            return value?.Length > 0 ? string.IsNullOrEmpty(value.Trim()) : true;
 #else
             return string.IsNullOrWhiteSpace(value);
 #endif

--- a/src/NLog/Internal/StringHelpers.cs
+++ b/src/NLog/Internal/StringHelpers.cs
@@ -51,7 +51,10 @@ namespace NLog.Internal
         internal static bool IsNullOrWhiteSpace(string value)
         {
 #if NET3_5
-            return value?.Length > 0 ? string.IsNullOrEmpty(value.Trim()) : true;
+
+            if (value == null) return true;
+            if (value.Length == 0) return true;
+            return String.IsNullOrEmpty(value.Trim());
 #else
             return string.IsNullOrWhiteSpace(value);
 #endif

--- a/src/NLog/Internal/XmlHelper.cs
+++ b/src/NLog/Internal/XmlHelper.cs
@@ -310,7 +310,7 @@ namespace NLog.Internal
         /// <returns>Object value converted to string</returns>
         internal static string XmlConvertToString(IConvertible value, TypeCode objTypeCode, bool safeConversion = false)
         {
-            if (value == null)
+            if (objTypeCode == TypeCode.Empty || value == null)
             {
                 return "null";
             }

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -452,7 +452,7 @@ namespace NLog.Targets
 
         private void SerializeSimpleTypeCodeValue(IConvertible value, TypeCode objTypeCode, StringBuilder destination, JsonSerializeOptions options, bool forceToString = false)
         {
-            if (value == null)
+            if (objTypeCode == TypeCode.Empty || value == null)
             {
                 destination.Append(forceToString ? "\"\"" : "null");
             }
@@ -492,7 +492,7 @@ namespace NLog.Targets
             else
             {
                 string str = XmlHelper.XmlConvertToString(value, objTypeCode);
-                if (!forceToString && str != null && SkipQuotes(value, objTypeCode))
+                if (!forceToString && SkipQuotes(value, objTypeCode) && !string.IsNullOrEmpty(str))
                 {
                     destination.Append(str);
                 }

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
@@ -299,6 +299,16 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void SerializeCustomNullDict_Test()
+        {
+            var dictionary = new Dictionary<string, object>();
+            dictionary.Add("key1", 13);
+            dictionary.Add("key 2", new CustomNullProperty());
+            var actual = SerializeObject(dictionary);
+            Assert.Equal("{\"key1\":13,\"key 2\":null}", actual);
+        }
+
+        [Fact]
         public void SerializeTrickyDict_Test()
         {
             IDictionary<object,object> dictionary = new Internal.TrickyTestDictionary();
@@ -480,6 +490,31 @@ namespace NLog.UnitTests.Targets
             Assert.Equal("{\"Id\":123, \"Name\":\"test name\"}", actual);
         }
 
+        /// <summary>
+        /// Simulate behavior of JProperty("nullValue", null) from Newtonsoft.Json
+        /// </summary>
+        private class CustomNullProperty : IConvertible
+        {
+            TypeCode IConvertible.GetTypeCode() => TypeCode.Empty;
+            bool IConvertible.ToBoolean(IFormatProvider provider) => default(bool);
+            byte IConvertible.ToByte(IFormatProvider provider) => default(byte);
+            char IConvertible.ToChar(IFormatProvider provider) => default(char);
+            DateTime IConvertible.ToDateTime(IFormatProvider provider) => default(DateTime);
+            decimal IConvertible.ToDecimal(IFormatProvider provider) => default(decimal);
+            double IConvertible.ToDouble(IFormatProvider provider) => default(double);
+            short IConvertible.ToInt16(IFormatProvider provider) => default(short);
+            int IConvertible.ToInt32(IFormatProvider provider) => default(int);
+            long IConvertible.ToInt64(IFormatProvider provider) => default(long);
+            sbyte IConvertible.ToSByte(IFormatProvider provider) => default(sbyte);
+            float IConvertible.ToSingle(IFormatProvider provider) => default(float);
+            string IConvertible.ToString(IFormatProvider provider) => default(string);
+            object IConvertible.ToType(Type conversionType, IFormatProvider provider) => default(object);
+            ushort IConvertible.ToUInt16(IFormatProvider provider) => default(ushort);
+            uint IConvertible.ToUInt32(IFormatProvider provider) => default(uint);
+            ulong IConvertible.ToUInt64(IFormatProvider provider) => default(ulong);
+            public override string ToString() => "nullValue";
+        }
+
 #if DYNAMIC_OBJECT
 
         [Fact]
@@ -588,7 +623,7 @@ namespace NLog.UnitTests.Targets
 
         protected class NoPropsObject
         {
-            private string something = "something";
+            private readonly string something = "something";
 
             #region Overrides of Object
 


### PR DESCRIPTION
Alternative of #4399 to fix invalid JSON format when JProperty is null