### PR TITLE
JsonLayout - Apply EscapeForwardSlash for LogEventInfo.Properties

### DIFF
--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -49,7 +49,7 @@ namespace NLog.Layouts
     {
         private LimitRecursionJsonConvert JsonConverter
         {
-            get => _jsonConverter ?? (_jsonConverter = new LimitRecursionJsonConvert(MaxRecursionLimit, ConfigurationItemFactory.Default.JsonConverter));
+            get => _jsonConverter ?? (_jsonConverter = new LimitRecursionJsonConvert(ConfigurationItemFactory.Default.JsonConverter, MaxRecursionLimit, EscapeForwardSlash));
             set => _jsonConverter = value;
         }
         private LimitRecursionJsonConvert _jsonConverter;
@@ -66,11 +66,11 @@ namespace NLog.Layouts
             readonly Targets.DefaultJsonSerializer _serializer;
             readonly Targets.JsonSerializeOptions _serializerOptions;
 
-            public LimitRecursionJsonConvert(int maxRecursionLimit, IJsonConverter converter)
+            public LimitRecursionJsonConvert(IJsonConverter converter, int maxRecursionLimit, bool escapeForwardSlash)
             {
                 _converter = converter;
                 _serializer = converter as Targets.DefaultJsonSerializer;
-                _serializerOptions = new Targets.JsonSerializeOptions() { MaxRecursionLimit = Math.Max(0, maxRecursionLimit) };
+                _serializerOptions = new Targets.JsonSerializeOptions() { MaxRecursionLimit = Math.Max(0, maxRecursionLimit), EscapeForwardSlash = escapeForwardSlash };
             }
 
             public bool SerializeObject(object value, StringBuilder builder)

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -1027,7 +1027,7 @@ namespace NLog.UnitTests.Layouts
             <nlog throwExceptions='true'>
             <targets>
                 <target name='debug' type='Debug'  >
-                  <layout type='JsonLayout' escapeForwardSlash='false'>
+                  <layout type='JsonLayout' escapeForwardSlash='false' includeAllProperties='true'>
                     <attribute name='myurl1' layout='${event-properties:myurl}' />
                     <attribute name='myurl2' layout='${event-properties:myurl}' escapeForwardSlash='true' />
                   </layout>
@@ -1044,7 +1044,7 @@ namespace NLog.UnitTests.Layouts
             logEventInfo1.Properties.Add("myurl", "http://hello.world.com/");
             logger.Debug(logEventInfo1);
 
-            AssertDebugLastMessage("debug", "{ \"myurl1\": \"http://hello.world.com/\", \"myurl2\": \"http:\\/\\/hello.world.com\\/\" }");
+            AssertDebugLastMessage("debug", "{ \"myurl1\": \"http://hello.world.com/\", \"myurl2\": \"http:\\/\\/hello.world.com\\/\", \"myurl\": \"http://hello.world.com/\" }");
         }
 
         [Fact]


### PR DESCRIPTION
Resolves #4402. Missing feature from #3586.