### PR TITLE
LoggingRule - Added FinalMinLevel to quit further processing

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -582,6 +582,7 @@ namespace NLog.Config
         {
             string minLevel = null;
             string maxLevel = null;
+            string finalMinLevel = null;
             string enableLevels = null;
 
             string ruleName = null;
@@ -628,6 +629,9 @@ namespace NLog.Config
                     case "MAXLEVEL":
                         maxLevel = childProperty.Value;
                         break;
+                    case "FINALMINLEVEL":
+                        finalMinLevel = childProperty.Value;
+                        break;
                     case "FILTERDEFAULTACTION":
                         filterDefaultAction = childProperty.Value;
                         break;
@@ -659,6 +663,15 @@ namespace NLog.Config
                 LoggerNamePattern = namePattern,
                 Final = final,
             };
+
+            if (!string.IsNullOrEmpty(finalMinLevel))
+            {
+                rule.FinalMinLevel = LogLevelFromString(finalMinLevel);
+                if (string.IsNullOrEmpty(enableLevels) && string.IsNullOrEmpty(minLevel))
+                {
+                    minLevel = finalMinLevel;
+                }
+            }
 
             EnableLevelsForRule(rule, enableLevels, minLevel, maxLevel);
 

--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -141,6 +141,11 @@ namespace NLog.Config
         public bool Final { get; set; }
 
         /// <summary>
+        /// Gets or sets a LogLevel whether to quit processing any further rule for loglevels with lower severity.
+        /// </summary>
+        public LogLevel FinalMinLevel { get; set; }
+
+        /// <summary>
         /// Gets or sets logger name pattern.
         /// </summary>
         /// <remarks>

--- a/src/NLog/Filters/ConditionBasedFilter.cs
+++ b/src/NLog/Filters/ConditionBasedFilter.cs
@@ -33,8 +33,8 @@
 
 namespace NLog.Filters
 {
-    using Conditions;
-    using Config;
+    using NLog.Conditions;
+    using NLog.Config;
 
     /// <summary>
     /// Matches when the specified condition is met.
@@ -46,8 +46,6 @@ namespace NLog.Filters
     [Filter("when")]
     public class ConditionBasedFilter : Filter
     {
-        private static readonly object boxedTrue = true;
-
         /// <summary>
         /// Gets or sets the condition expression.
         /// </summary>
@@ -69,7 +67,7 @@ namespace NLog.Filters
         protected override FilterResult Check(LogEventInfo logEvent)
         {
             object val = Condition.Evaluate(logEvent);
-            if (boxedTrue.Equals(val))
+            if (ConditionExpression.BoxedTrue.Equals(val))
             {
                 return Action;
             }

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -860,13 +860,10 @@ namespace NLog
 
             for (int i = 0; i <= LogLevel.MaxLevel.Ordinal; ++i)
             {
-                if (i < GlobalThreshold.Ordinal || suppressedLevels[i] || !rule.IsLoggingEnabledForLevel(LogLevel.FromOrdinal(i)))
+                if (SuppressLogLevel(rule, i, ref suppressedLevels[i]))
                 {
                     continue;
                 }
-
-                if (rule.Final)
-                    suppressedLevels[i] = true;
 
                 foreach (Target target in rule.GetTargetsThreadSafe())
                 {
@@ -896,6 +893,31 @@ namespace NLog
             }
 
             return targetsFound;
+        }
+
+        private bool SuppressLogLevel(LoggingRule rule, int logLevelOrdinal, ref bool suppressedLevels)
+        {
+            if (logLevelOrdinal < GlobalThreshold.Ordinal || suppressedLevels)
+            {
+                return true;
+            }
+
+            if (rule.FinalMinLevel?.Ordinal > logLevelOrdinal)
+            {
+                suppressedLevels = true;
+            }
+
+            if (!rule.IsLoggingEnabledForLevel(LogLevel.FromOrdinal(logLevelOrdinal)))
+            {
+                return true;
+            }
+
+            if (rule.Final)
+            {
+                suppressedLevels = true;
+            }
+
+            return false;
         }
 
         private static TargetWithFilterChain CreateTargetChainFromLoggingRule(LoggingRule rule, Target target, TargetWithFilterChain existingTargets)


### PR DESCRIPTION
Instead of having to specify both `maxLevel="Warn"` + `final="true"` then it could be nice a combined-property, with a name that makes it easy to understand. 

FinalMinLevel signals that all following catch-all rules will also have this MinLevel applied when matching same logger:
 - Extended version of `Final=true` that only applies when LogLevel-severity is below the specified Level.

```xml
<rules>
    <!--Skip non-critical Microsoft logs and so log only own logs (BlackHole) -->
    <logger name="Microsoft.*" finalMinLevel="Warn" />
    <logger name="System.Net.Http.*" finalMinLevel="Warn" />

    <logger name="*" minlevel="Trace" writeTo="ownFile-web" />
</rules>
```

Other possible names:
- FinalLevel / FinalLogLevel (Similar to Microsoft Extension Logging)
- RestrictMinLevel (Similar to Serilog)
- FinalThreshold
- FinalStartLevel
- FinalAcceptLevel
- FinalBelowLevel
- SuppressMinLevel
- CapMinLevel
- FinalizeMaxLevel
- BlockMaxLevel
- TrapMaxLevel
- DrainMaxLevel
- SapMaxLevel
- TruncateMaxLevel
- FinalMaxLevel (Signal that both MaxLevel and Final is configured in one go)

The same property could also provide a more elegant solution for this simple application example:

```xml
<nlog>
    <targets>
        <target name="logconsole" xsi:type="Console" />
    </targets>

    <rules>
        <logger name="*" minlevel="Info" writeTo="logconsole" />
    </rules>
</nlog>
```

Where the application gets a new exciting sub-component is added, that is a little noisy. So you redirect to its own isolated target:

```xml
<nlog>
    <targets>
        <target name="logconsole" xsi:type="Console" />
        <target name="logfile" xsi:type="File" fileName="requests.txt" />
    </targets>

    <rules>
        <logger name="Requests" minlevel="Debug" writeTo="logfile" final="true" />
        <logger name="*" minlevel="Info" writeTo="logconsole" />
    </rules>
</nlog>
```

Then you discover that some of the noise is rather important, then you need to add it twice (Having to add your `catch-all` target several times):

```xml
<nlog>
    <targets>
        <target name="logconsole" xsi:type="Console" />
        <target name="logfile" xsi:type="File" fileName="requests.txt" />
    </targets>

    <rules>
        <logger name="Requests" minlevel="Warn" writeTo="logconsole" />
        <logger name="Requests" minlevel="Debug" writeTo="logfile" final="true" />
        <logger name="*" minlevel="Info" writeTo="logconsole" />
    </rules>
</nlog>
```

This pull-request add support for `finalThreshold`, that works like a conditional-final (Without enforcing MaxLevel for the LoggingRule, so both logging-rules will receive the error-logevents):

```xml
<nlog>
    <targets>
        <target name="logconsole" xsi:type="Console" />
        <target name="logfile" xsi:type="File" fileName="requests.txt" />
    </targets>

    <rules>
        <logger name="Requests" writeTo="logfile" minLevel="Debug" finalMinLevel="Warn" />
        <logger name="*" minlevel="Info" writeTo="logconsole" />
    </rules>
</nlog>
```