### PR TITLE
Reduce InternalLogger debug-output when no targets configured for loglevel

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -886,7 +886,7 @@ namespace NLog
 
             if (InternalLogger.IsDebugEnabled)
             {
-                targetsFound = targetsFound && CheckTargetsConfiguredForLogger(loggerName, targetsByLevel);
+                targetsFound = targetsFound && DumpTargetConfigurationForLogger(loggerName, targetsByLevel);
                 if (!targetsFound)
                     InternalLogger.Debug("Targets not configured for Logger: {0}", loggerName);
             }
@@ -894,7 +894,7 @@ namespace NLog
             return new LoggerConfiguration(targetsByLevel);
         }
 
-        private static bool CheckTargetsConfiguredForLogger(string loggerName, TargetWithFilterChain[] targetsByLevel)
+        private static bool DumpTargetConfigurationForLogger(string loggerName, TargetWithFilterChain[] targetsByLevel)
         {
             StringBuilder sb = null;
             for (int i = 0; i <= LogLevel.MaxLevel.Ordinal; ++i)

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -886,44 +886,46 @@ namespace NLog
 
             if (InternalLogger.IsDebugEnabled)
             {
-                StringBuilder sb = null;
-
-                if (targetsFound)
-                {
-                    for (int i = 0; i <= LogLevel.MaxLevel.Ordinal; ++i)
-                    {
-                        if (sb != null)
-                        {
-                            sb.Length = 0;
-                            sb.AppendFormat(CultureInfo.InvariantCulture, "Logger {0} [{1}] =>", loggerName, LogLevel.FromOrdinal(i));
-                        }
-
-                        for (TargetWithFilterChain afc = targetsByLevel[i]; afc != null; afc = afc.NextInChain)
-                        {
-                            if (sb == null)
-                            {
-                                InternalLogger.Debug("Targets configured when LogLevel >= {0} for Logger: {1}", LogLevel.FromOrdinal(i), loggerName);
-                                sb = new StringBuilder();
-                                sb.AppendFormat(CultureInfo.InvariantCulture, "Logger {0} [{1}] =>", loggerName, LogLevel.FromOrdinal(i));
-                            }
-
-                            sb.AppendFormat(CultureInfo.InvariantCulture, " {0}", afc.Target.Name);
-                            if (afc.FilterChain.Count > 0)
-                            {
-                                sb.AppendFormat(CultureInfo.InvariantCulture, " ({0} filters)", afc.FilterChain.Count);
-                            }
-                        }
-                        
-                        if (sb != null)
-                            InternalLogger.Debug(sb.ToString());
-                    }
-                }
-
-                if (sb == null)
+                targetsFound = targetsFound && CheckTargetsConfiguredForLogger(loggerName, targetsByLevel);
+                if (!targetsFound)
                     InternalLogger.Debug("Targets not configured for Logger: {0}", loggerName);
             }
 
             return new LoggerConfiguration(targetsByLevel);
+        }
+
+        private static bool CheckTargetsConfiguredForLogger(string loggerName, TargetWithFilterChain[] targetsByLevel)
+        {
+            StringBuilder sb = null;
+            for (int i = 0; i <= LogLevel.MaxLevel.Ordinal; ++i)
+            {
+                if (sb != null)
+                {
+                    sb.Length = 0;
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "Logger {0} [{1}] =>", loggerName, LogLevel.FromOrdinal(i));
+                }
+
+                for (TargetWithFilterChain afc = targetsByLevel[i]; afc != null; afc = afc.NextInChain)
+                {
+                    if (sb == null)
+                    {
+                        InternalLogger.Debug("Targets configured when LogLevel >= {0} for Logger: {1}", LogLevel.FromOrdinal(i), loggerName);
+                        sb = new StringBuilder();
+                        sb.AppendFormat(CultureInfo.InvariantCulture, "Logger {0} [{1}] =>", loggerName, LogLevel.FromOrdinal(i));
+                    }
+
+                    sb.AppendFormat(CultureInfo.InvariantCulture, " {0}", afc.Target.Name);
+                    if (afc.FilterChain.Count > 0)
+                    {
+                        sb.AppendFormat(CultureInfo.InvariantCulture, " ({0} filters)", afc.FilterChain.Count);
+                    }
+                }
+
+                if (sb != null)
+                    InternalLogger.Debug(sb.ToString());
+            }
+
+            return sb != null;
         }
 
         /// <summary>

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -895,16 +895,16 @@ namespace NLog
                         if (sb != null)
                         {
                             sb.Length = 0;
-                            sb.AppendFormat(CultureInfo.InvariantCulture, "{0} =>", LogLevel.FromOrdinal(i));
+                            sb.AppendFormat(CultureInfo.InvariantCulture, "Logger {0} [{1}] =>", loggerName, LogLevel.FromOrdinal(i));
                         }
 
                         for (TargetWithFilterChain afc = targetsByLevel[i]; afc != null; afc = afc.NextInChain)
                         {
                             if (sb == null)
                             {
-                                InternalLogger.Debug("Targets configured when LogLevel >= {0} for logger: {1}", LogLevel.FromOrdinal(i), loggerName);
+                                InternalLogger.Debug("Targets configured when LogLevel >= {0} for Logger: {1}", LogLevel.FromOrdinal(i), loggerName);
                                 sb = new StringBuilder();
-                                sb.AppendFormat(CultureInfo.InvariantCulture, "{0} =>", LogLevel.FromOrdinal(i));
+                                sb.AppendFormat(CultureInfo.InvariantCulture, "Logger {0} [{1}] =>", loggerName, LogLevel.FromOrdinal(i));
                             }
 
                             sb.AppendFormat(CultureInfo.InvariantCulture, " {0}", afc.Target.Name);
@@ -920,7 +920,7 @@ namespace NLog
                 }
 
                 if (sb == null)
-                    InternalLogger.Debug("Targets not configured for logger: {0}", loggerName);
+                    InternalLogger.Debug("Targets not configured for Logger: {0}", loggerName);
             }
 
             return new LoggerConfiguration(targetsByLevel);


### PR DESCRIPTION
Instead of writing this:

```
2021-05-05 13:53:15.3036 Debug Targets for UserManager by level:
2021-05-05 13:53:15.3036 Debug Trace =>
2021-05-05 13:53:15.3036 Debug Debug =>
2021-05-05 13:53:15.3036 Debug Info =>
2021-05-05 13:53:15.3036 Debug Warn =>
2021-05-05 13:53:15.3036 Debug Error => logfile
2021-05-05 13:53:15.3036 Debug Fatal => logfile
```

Then it will write this:

```
2021-05-09 18:52:32.3902 Debug Targets configured when LogLevel >= Error for Logger: UserManager
2021-05-05 13:53:15.3036 Debug Logger: UserManager [Error] => logfile
2021-05-05 13:53:15.3036 Debug Logger: UserManager [Fatal] => logfile
```
