### PR TITLE
Unnamed Target inside AsyncWrapper should inherit the name

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -933,10 +933,14 @@ namespace NLog.Config
                 if (newTarget != null)
                 {
                     ParseTargetElement(newTarget, childElement, typeNameToDefaultTargetParameters);
-                    if (newTarget.Name != null)
+                    if (!string.IsNullOrEmpty(newTarget.Name))
                     {
                         // if the new target has name, register it
                         AddTarget(newTarget.Name, newTarget);
+                    }
+                    else if (!string.IsNullOrEmpty(wrapper.Name))
+                    {
+                        newTarget.Name = wrapper.Name + "_wrapped";
                     }
 
                     if (wrapper.WrappedTarget != null)
@@ -1278,6 +1282,12 @@ namespace NLog.Config
                 return target;
             }
 #endif
+
+            if (target is AsyncTargetWrapper)
+            {
+                InternalLogger.Debug("Skip wrapping target '{0}' with AsyncTargetWrapper", target.Name);
+                return target;
+            }
 
             var asyncTargetWrapper = new AsyncTargetWrapper();
             asyncTargetWrapper.WrappedTarget = target;

--- a/tests/NLog.UnitTests/Config/TargetConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/TargetConfigurationTests.cs
@@ -417,6 +417,27 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        public void UnnamedWrappedTargetTest()
+        {
+            LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog>
+                <targets async='true'>
+                    <target type='AsyncWrapper' name='d'>
+                        <target type='Debug' />
+                    </target>
+                </targets>
+            </nlog>");
+
+            var t = c.FindTargetByName("d") as AsyncTargetWrapper;
+            Assert.NotNull(t);
+            Assert.Equal("d", t.Name);
+
+            var wrappedTarget = t.WrappedTarget as DebugTarget;
+            Assert.NotNull(wrappedTarget);
+            Assert.Equal("d_wrapped", wrappedTarget.Name);
+        }
+
+        [Fact]
         public void DefaultTargetParametersTest()
         {
             LoggingConfiguration c = XmlLoggingConfiguration.CreateFromXmlString(@"


### PR DESCRIPTION
Fixing:

```
2021-05-15 20:54:26.7246 Debug --- NLog configuration dump ---
2021-05-15 20:54:26.7246 Debug Targets:
2021-05-15 20:54:26.7552 Debug AsyncWrapper Target[TelemflowLog](Database Target[(unnamed)])
2021-05-15 20:54:29.9115 Error DatabaseTarget(Name=): Error when writing to database
```

So it becomes:

```
2021-05-15 20:54:26.7246 Debug --- NLog configuration dump ---
2021-05-15 20:54:26.7246 Debug Targets:
2021-05-15 20:54:26.7552 Debug AsyncWrapper Target[TelemflowLog](Database Target[TelemflowLog_wrapped])
2021-05-15 20:54:29.9115 Error DatabaseTarget(Name=TelemflowLog_wrapped): Error when writing to database
```

See also: https://github.com/NLog/NLog.Extensions.Logging/issues/506