### PR TITLE
Improve InternalLogger output for unnamed targets

### DIFF
--- a/src/NLog/Config/LoggerNameMatcher.cs
+++ b/src/NLog/Config/LoggerNameMatcher.cs
@@ -35,7 +35,6 @@ namespace NLog.Config
 {
     using System;
     using System.Text.RegularExpressions;
-    using NLog.Common;
 
     /// <summary>
     /// Encapsulates <see cref="LoggingRule.LoggerNamePattern"/> and the logic to match the actual logger name
@@ -75,14 +74,15 @@ namespace NLog.Config
         {
             if (loggerNamePattern == null)
                 return NoneLoggerNameMatcher.Instance;
+            if (loggerNamePattern.Trim()=="*")
+                return AllLoggerNameMatcher.Instance;
 
             int starPos1 = loggerNamePattern.IndexOf('*');
             int starPos2 = loggerNamePattern.IndexOf('*', starPos1 + 1);
             int questionPos = loggerNamePattern.IndexOf('?');
             if (starPos1 < 0 && questionPos < 0)
                 return new EqualsLoggerNameMatcher(loggerNamePattern);
-            if (loggerNamePattern == "*")
-                return AllLoggerNameMatcher.Instance;
+
             if (questionPos < 0)
             {
                 if (starPos1 == 0 && starPos2 == loggerNamePattern.Length - 1)
@@ -119,13 +119,13 @@ namespace NLog.Config
         {
             Pattern = pattern;
             _matchingArgument = matchingArgument;
-            _toString = "logNamePattern: (" + matchingArgument + ":" + Name + ")";
+            _toString = $"logNamePattern: ({matchingArgument}:{MatchMode})";
         }
         public override string ToString()
         {
             return _toString;
         }
-        protected abstract string Name { get; }
+        protected abstract string MatchMode { get; }
 
         /// <summary>
         /// Checks whether given name matches the logger name pattern.
@@ -140,7 +140,7 @@ namespace NLog.Config
         /// </summary>
         class NoneLoggerNameMatcher : LoggerNameMatcher
         {
-            protected override string Name => "None";
+            protected override string MatchMode => "None";
             public static readonly NoneLoggerNameMatcher Instance = new NoneLoggerNameMatcher();
             private NoneLoggerNameMatcher() 
                 : base(null, null)
@@ -159,7 +159,7 @@ namespace NLog.Config
         /// </summary>
         class AllLoggerNameMatcher : LoggerNameMatcher
         {
-            protected override string Name => "All";
+            protected override string MatchMode => "All";
             public static readonly AllLoggerNameMatcher Instance = new AllLoggerNameMatcher();
             private AllLoggerNameMatcher() 
                 : base("*", null) { }
@@ -175,7 +175,7 @@ namespace NLog.Config
         /// </summary>
         class EqualsLoggerNameMatcher : LoggerNameMatcher
         {
-            protected override string Name => "Equals";
+            protected override string MatchMode => "Equals";
             public EqualsLoggerNameMatcher(string pattern) 
                 : base(pattern, pattern) { }
             public override bool NameMatches(string loggerName)
@@ -191,7 +191,7 @@ namespace NLog.Config
         /// </summary>
         class StartsWithLoggerNameMatcher : LoggerNameMatcher
         {
-            protected override string Name => "StartsWith";
+            protected override string MatchMode => "StartsWith";
             public StartsWithLoggerNameMatcher(string pattern) 
                 : base(pattern, pattern.Substring(0, pattern.Length - 1)) { }
             public override bool NameMatches(string loggerName)
@@ -207,7 +207,7 @@ namespace NLog.Config
         /// </summary>
         class EndsWithLoggerNameMatcher : LoggerNameMatcher
         {
-            protected override string Name => "EndsWith";
+            protected override string MatchMode => "EndsWith";
             public EndsWithLoggerNameMatcher(string pattern) 
                 : base(pattern, pattern.Substring(1)) { }
             public override bool NameMatches(string loggerName)
@@ -223,7 +223,7 @@ namespace NLog.Config
         /// </summary>
         class ContainsLoggerNameMatcher : LoggerNameMatcher
         {
-            protected override string Name => "Contains";
+            protected override string MatchMode => "Contains";
             public ContainsLoggerNameMatcher(string pattern) 
                 : base(pattern, pattern.Substring(1, pattern.Length - 2)) { }
             public override bool NameMatches(string loggerName)
@@ -244,7 +244,7 @@ namespace NLog.Config
         /// </summary>
         class MultiplePatternLoggerNameMatcher : LoggerNameMatcher
         {
-            protected override string Name => "MultiplePattern";
+            protected override string MatchMode => "MultiplePattern";
             private readonly Regex _regex;
             private static string ConvertToRegex(string wildcardsPattern)
             {

--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -284,10 +284,11 @@ namespace NLog.Config
                 }
             }
 
-            sb.Append("] appendTo: [ ");
-            foreach (Target app in GetTargetsThreadSafe())
+            sb.Append("] writeTo: [ ");
+            foreach (Target writeTo in GetTargetsThreadSafe())
             {
-                sb.AppendFormat(CultureInfo.InvariantCulture, "{0} ", app.Name);
+                var targetName = string.IsNullOrEmpty(writeTo.Name) ? writeTo.ToString() : writeTo.Name;
+                sb.AppendFormat(CultureInfo.InvariantCulture, "{0} ", targetName);
             }
 
             sb.Append("]");

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -285,7 +285,7 @@ namespace NLog.Targets
                 targetType += "Target";
             }
             targetName = targetName ?? Name;
-            return string.IsNullOrEmpty(targetName) ? targetType : $"{targetType}(Name={targetName})";
+            return string.IsNullOrEmpty(targetName) ? $"{targetType}([unnamed])" : $"{targetType}(Name={targetName})";
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Config/ConfigApiTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigApiTests.cs
@@ -229,7 +229,7 @@ namespace NLog.UnitTests.Config
             var target = new FileTarget { Name = "file1" };
             var loggingRule = new LoggingRule("*", LogLevel.Error, target);
             var s = loggingRule.ToString();
-            Assert.Equal("logNamePattern: (:All) levels: [ Error Fatal ] appendTo: [ file1 ]", s);
+            Assert.Equal("logNamePattern: (:All) levels: [ Error Fatal ] writeTo: [ file1 ]", s);
         }
 
         [Fact]
@@ -238,7 +238,7 @@ namespace NLog.UnitTests.Config
             var target = new FileTarget { Name = "file1" };
             var loggingRule = new LoggingRule("*", LogLevel.Debug, LogLevel.Error, target);
             var s = loggingRule.ToString();
-            Assert.Equal("logNamePattern: (:All) levels: [ Debug Info Warn Error ] appendTo: [ file1 ]", s);
+            Assert.Equal("logNamePattern: (:All) levels: [ Debug Info Warn Error ] writeTo: [ file1 ]", s);
         }
 
         [Fact]
@@ -247,7 +247,7 @@ namespace NLog.UnitTests.Config
             var target = new FileTarget { Name = "file1" };
             var loggingRule = new LoggingRule("*", target);
             var s = loggingRule.ToString();
-            Assert.Equal("logNamePattern: (:All) levels: [ ] appendTo: [ file1 ]", s);
+            Assert.Equal("logNamePattern: (:All) levels: [ ] writeTo: [ file1 ]", s);
         }
 
         [Fact]
@@ -256,7 +256,7 @@ namespace NLog.UnitTests.Config
             var target = new FileTarget { Name = "file1" };
             var loggingRule = new LoggingRule("", target);
             var s = loggingRule.ToString();
-            Assert.Equal("logNamePattern: (:Equals) levels: [ ] appendTo: [ file1 ]", s);
+            Assert.Equal("logNamePattern: (:Equals) levels: [ ] writeTo: [ file1 ]", s);
         }
 
         [Fact]
@@ -265,7 +265,7 @@ namespace NLog.UnitTests.Config
             var target = new FileTarget { Name = "file1" };
             var loggingRule = new LoggingRule("namespace.comp1", target);
             var s = loggingRule.ToString();
-            Assert.Equal("logNamePattern: (namespace.comp1:Equals) levels: [ ] appendTo: [ file1 ]", s);
+            Assert.Equal("logNamePattern: (namespace.comp1:Equals) levels: [ ] writeTo: [ file1 ]", s);
         }
 
         [Fact]
@@ -276,7 +276,7 @@ namespace NLog.UnitTests.Config
             var loggingRule = new LoggingRule("namespace.comp1", target);
             loggingRule.Targets.Add(target2);
             var s = loggingRule.ToString();
-            Assert.Equal("logNamePattern: (namespace.comp1:Equals) levels: [ ] appendTo: [ file1 file2 ]", s);
+            Assert.Equal("logNamePattern: (namespace.comp1:Equals) levels: [ ] writeTo: [ file1 file2 ]", s);
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Targets/Wrappers/RetryingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/RetryingTargetWrapperTests.cs
@@ -110,13 +110,13 @@ namespace NLog.UnitTests.Targets.Wrappers
             };
 
             var result = RunAndCaptureInternalLog(() => wrapper.WriteAsyncLogEvents(events), LogLevel.Trace);
-            Assert.True(result.IndexOf("Error while writing to 'MyTarget'. Try 1/4") != -1);
-            Assert.True(result.IndexOf("Error while writing to 'MyTarget'. Try 2/4") != -1);
-            Assert.True(result.IndexOf("Error while writing to 'MyTarget'. Try 3/4") != -1);
-            Assert.True(result.IndexOf("Error while writing to 'MyTarget'. Try 4/4") != -1);
+            Assert.True(result.IndexOf("Error while writing to 'MyTarget([unnamed])'. Try 1/4") != -1);
+            Assert.True(result.IndexOf("Error while writing to 'MyTarget([unnamed])'. Try 2/4") != -1);
+            Assert.True(result.IndexOf("Error while writing to 'MyTarget([unnamed])'. Try 3/4") != -1);
+            Assert.True(result.IndexOf("Error while writing to 'MyTarget([unnamed])'. Try 4/4") != -1);
             Assert.True(result.IndexOf("Too many retries. Aborting.") != -1);
-            Assert.True(result.IndexOf("Error while writing to 'MyTarget'. Try 1/4") != -1);
-            Assert.True(result.IndexOf("Error while writing to 'MyTarget'. Try 2/4") != -1);
+            Assert.True(result.IndexOf("Error while writing to 'MyTarget([unnamed])'. Try 1/4") != -1);
+            Assert.True(result.IndexOf("Error while writing to 'MyTarget([unnamed])'. Try 2/4") != -1);
 
             // first event does not get to wrapped target because of too many attempts.
             // second event gets there in 3rd retry

--- a/tests/NLog.UnitTests/Targets/Wrappers/SplitGroupTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/SplitGroupTargetTests.cs
@@ -126,7 +126,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 Targets = { myTarget1, myTarget2, myTarget3 },
             };
 
-            Assert.Equal("SplitGroup[MyTarget, FileTarget(Name=file1), ConsoleTarget(Name=Console2)]", wrapper.ToString());
+            Assert.Equal("SplitGroup([unnamed])[MyTarget([unnamed]), FileTarget(Name=file1), ConsoleTarget(Name=Console2)]", wrapper.ToString());
         }
 
         public class MyTarget : Target

--- a/tests/NLog.UnitTests/Targets/Wrappers/WrapperTargetBaseTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/WrapperTargetBaseTests.cs
@@ -54,7 +54,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 WrappedTarget = wrapper,
             };
 
-            Assert.Equal("MyWrapper_MyWrapper_DebugTarget(Name=foo)", wrapper2.ToString());
+            Assert.Equal("MyWrapper([unnamed])_MyWrapper([unnamed])_DebugTarget(Name=foo)", wrapper2.ToString());
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 WrappedTarget = new DebugTarget() { Name = "foo_wrapped" },
             };
 
-            Assert.Equal("MyWrapper_DebugTarget(Name=foo)", wrapper.ToString());
+            Assert.Equal("MyWrapper([unnamed])_DebugTarget(Name=foo)", wrapper.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
Instead of writing this:

`2021-05-15 20:54:26.7775 Debug logNamePattern: (:All) levels: [ Error Fatal ] appendTo: [   ]`

Then it will write this:

`2021-05-15 20:54:26.7775 Debug logNamePattern: (:All) levels: [ Error Fatal ] writeTo: [ FileTarget([unnamed]) ]`