### PR TITLE
Layout Typed - Removed StaticValue and implicit conversion to avoid surprises

### DIFF
--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -726,7 +726,7 @@ namespace NLog.Targets
                 return defaultValue;
 
             if (layout.IsFixed)
-                return layout.StaticValue;
+                return layout.FixedValue;
 
             if (TryGetCachedValue(layout, logEvent, out var value))
             {

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -243,7 +243,7 @@ namespace NLog.Targets
         /// <param name="continuation">The continuation.</param>
         protected override void DoInvoke(object[] parameters, AsyncContinuation continuation)
         {
-            var url = Protocol != WebServiceProtocol.HttpGet ? Url.StaticValue : BuildWebServiceUrl(LogEventInfo.CreateNullEvent(), parameters);
+            var url = BuildWebServiceUrl(LogEventInfo.CreateNullEvent(), parameters);
             var webRequest = (HttpWebRequest)WebRequest.Create(url);
             DoInvoke(parameters, webRequest, continuation);
         }

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -51,7 +51,8 @@ namespace NLog.UnitTests.Layouts
             // Assert
             Assert.Equal(5, result);
             Assert.Equal("5", layout.Render(LogEventInfo.CreateNullEvent()));
-            Assert.Equal(5, layout.StaticValue);
+            Assert.True(layout.IsFixed);
+            Assert.Equal(5, layout.FixedValue);
             Assert.Equal("5", layout.ToString());
         }
 
@@ -67,7 +68,8 @@ namespace NLog.UnitTests.Layouts
             // Assert
             Assert.Equal(5, result);
             Assert.Equal("5", layout.Render(LogEventInfo.CreateNullEvent()));
-            Assert.Equal(5, layout.StaticValue);
+            Assert.True(layout.IsFixed);
+            Assert.Equal(5, layout.FixedValue);
             Assert.Equal("5", layout.ToString());
         }
 
@@ -85,7 +87,8 @@ namespace NLog.UnitTests.Layouts
             Assert.Null(result);
             Assert.Null(result5);
             Assert.Equal("", layout.Render(LogEventInfo.CreateNullEvent()));
-            Assert.Null(layout.StaticValue);
+            Assert.True(layout.IsFixed);
+            Assert.Null(layout.FixedValue);
             Assert.Equal("null", layout.ToString());
         }
 
@@ -103,8 +106,9 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(uri, result);
             Assert.Same(result, layout.RenderValue(LogEventInfo.CreateNullEvent()));
             Assert.Equal(uri.ToString(), layout.Render(LogEventInfo.CreateNullEvent()));
-            Assert.Equal(uri, layout.StaticValue);
-            Assert.Same(layout.StaticValue, layout.StaticValue);
+            Assert.True(layout.IsFixed);
+            Assert.Equal(uri, layout.FixedValue);
+            Assert.Same(layout.FixedValue, layout.FixedValue);
             Assert.Equal(uri.ToString(), layout.ToString());
         }
 
@@ -122,8 +126,9 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(uri, result);
             Assert.Same(result, layout.RenderValue(LogEventInfo.CreateNullEvent()));
             Assert.Equal("", layout.Render(LogEventInfo.CreateNullEvent()));
-            Assert.Equal(uri, layout.StaticValue);
-            Assert.Same(layout.StaticValue, layout.StaticValue);
+            Assert.True(layout.IsFixed);
+            Assert.Equal(uri, layout.FixedValue);
+            Assert.Same(layout.FixedValue, layout.FixedValue);
             Assert.Equal("null", layout.ToString());
         }
 
@@ -141,8 +146,9 @@ namespace NLog.UnitTests.Layouts
             // Assert
             Assert.Equal(5, result);
             Assert.Equal("5", layout.Render(logevent));
-            Assert.Equal(0, layout.StaticValue);
+            Assert.False(layout.IsFixed);
             Assert.Equal(simpleLayout, layout.ToString());
+            Assert.NotEqual(0, layout);
         }
 
         [Fact]
@@ -158,7 +164,9 @@ namespace NLog.UnitTests.Layouts
             // Assert
             Assert.Equal(5, result);
             Assert.Equal("5", layout.Render(logevent));
-            Assert.Null(layout.StaticValue);
+            Assert.False(layout.IsFixed);
+            Assert.NotEqual(0, layout);
+            Assert.NotEqual(default(int?), layout);
         }
 
         [Fact]
@@ -176,7 +184,6 @@ namespace NLog.UnitTests.Layouts
             Assert.Null(result);
             Assert.Equal(5, result5);
             Assert.Equal("", layout.Render(logevent));
-            Assert.Null(layout.StaticValue);
         }
 
         [Fact]
@@ -194,7 +201,9 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(uri, result);
             Assert.Same(result, layout.RenderValue(logevent));
             Assert.Equal(uri.ToString(), layout.Render(logevent));
-            Assert.Null(layout.StaticValue);
+            Assert.False(layout.IsFixed);
+            Assert.NotEqual(uri, layout);
+            Assert.NotEqual(default(Uri), layout);
         }
 
         [Fact]
@@ -212,7 +221,8 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(uri, result);
             Assert.Same(result, layout.RenderValue(logevent));
             Assert.Equal("", layout.Render(logevent));
-            Assert.Null(layout.StaticValue);
+            Assert.False(layout.IsFixed);
+            Assert.NotEqual(uri, layout);
         }
 
         [Fact]
@@ -231,7 +241,8 @@ namespace NLog.UnitTests.Layouts
             // Assert
             Assert.Equal(5, layout.RenderValue(logevent));
             Assert.Equal("5", layout.Render(logevent));
-            Assert.Equal(0, layout.StaticValue);
+            Assert.False(layout.IsFixed);
+            Assert.NotEqual(0, layout);
         }
 
         [Fact]
@@ -250,7 +261,9 @@ namespace NLog.UnitTests.Layouts
             // Assert
             Assert.Equal(5, layout.RenderValue(logevent));
             Assert.Equal("5", layout.Render(logevent));
-            Assert.Null(layout.StaticValue);
+            Assert.False(layout.IsFixed);
+            Assert.NotEqual(0, layout);
+            Assert.NotEqual(default(int?), layout);
         }
 
         [Fact]
@@ -271,7 +284,9 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(uri, layout.RenderValue(logevent));
             Assert.Same(layout.RenderValue(logevent), layout.RenderValue(logevent));
             Assert.Equal(uri.ToString(), layout.Render(logevent));
-            Assert.Null(layout.StaticValue);
+            Assert.False(layout.IsFixed);
+            Assert.NotEqual(uri, layout);
+            Assert.NotEqual(default(Uri), layout);
         }
 
         [Fact]
@@ -290,7 +305,9 @@ namespace NLog.UnitTests.Layouts
             Assert.Same(layout.RenderValue(logevent), layout.RenderValue(logevent));
             Assert.Same(uri, layout.RenderValue(logevent));
             Assert.Equal(uri.ToString(), layout.Render(logevent));
-            Assert.Null(layout.StaticValue);
+            Assert.False(layout.IsFixed);
+            Assert.NotEqual(uri, layout);
+            Assert.NotEqual(default(Uri), layout);
         }
 
         [Fact]
@@ -548,6 +565,7 @@ namespace NLog.UnitTests.Layouts
             // Act + Assert (LogEventInfo.LayoutCache must work)
             Assert.NotEqual(layout1, layout2);
             Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
+            Assert.NotEqual(0, layout1);
         }
 
         [Fact]
@@ -560,6 +578,8 @@ namespace NLog.UnitTests.Layouts
             // Act + Assert (LogEventInfo.LayoutCache must work)
             Assert.NotEqual(layout1, layout2);
             Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
+            Assert.NotEqual(0, layout1);
+            Assert.NotEqual(default(int?), layout1);
         }
 
         [Fact]
@@ -572,6 +592,7 @@ namespace NLog.UnitTests.Layouts
             // Act + Assert (LogEventInfo.LayoutCache must work)
             Assert.NotEqual(layout1, layout2);
             Assert.NotEqual(layout1.GetHashCode(), layout2.GetHashCode());
+            Assert.NotEqual(default(Uri), layout1);
         }
 
         [Theory]

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -797,21 +797,21 @@ namespace NLog.UnitTests.Targets
             var nullEvent = LogEventInfo.CreateNullEvent();
             var myTarget = c.FindTargetByName("myTarget") as MyTypedLayoutTarget;
             Assert.NotNull(myTarget);
-            Assert.Equal((byte)42, myTarget.ByteProperty.StaticValue);
-            Assert.Equal((short)43, myTarget.Int16Property.StaticValue);
-            Assert.Equal(44, myTarget.Int32Property.StaticValue);
-            Assert.Equal(45000000000L, myTarget.Int64Property.StaticValue);
-            Assert.Equal("foobar", myTarget.StringProperty.StaticValue);
-            Assert.True(myTarget.BoolProperty.StaticValue);
-            Assert.Equal(3.14159, myTarget.DoubleProperty.StaticValue);
-            Assert.Equal(3.24159f, myTarget.FloatProperty.StaticValue);
-            Assert.Equal(TargetConfigurationTests.MyEnum.Value3, myTarget.EnumProperty.StaticValue);
-            Assert.Equal(TargetConfigurationTests.MyFlagsEnum.Value1 | TargetConfigurationTests.MyFlagsEnum.Value3, myTarget.FlagsEnumProperty.StaticValue);
-            Assert.Equal(Encoding.UTF8, myTarget.EncodingProperty.StaticValue);
-            Assert.Equal("en-US", myTarget.CultureProperty.StaticValue.Name);
-            Assert.Equal(typeof(int), myTarget.TypeProperty.StaticValue);
-            Assert.Equal(new Uri("https://nlog-project.org"), myTarget.UriProperty.StaticValue);
-            Assert.Equal(LineEndingMode.Default, myTarget.LineEndingModeProperty.StaticValue);
+            Assert.Equal((byte)42, myTarget.ByteProperty.FixedValue);
+            Assert.Equal((short)43, myTarget.Int16Property.FixedValue);
+            Assert.Equal(44, myTarget.Int32Property.FixedValue);
+            Assert.Equal(45000000000L, myTarget.Int64Property.FixedValue);
+            Assert.Equal("foobar", myTarget.StringProperty.FixedValue);
+            Assert.True(myTarget.BoolProperty.FixedValue);
+            Assert.Equal(3.14159, myTarget.DoubleProperty.FixedValue);
+            Assert.Equal(3.24159f, myTarget.FloatProperty.FixedValue);
+            Assert.Equal(TargetConfigurationTests.MyEnum.Value3, myTarget.EnumProperty.FixedValue);
+            Assert.Equal(TargetConfigurationTests.MyFlagsEnum.Value1 | TargetConfigurationTests.MyFlagsEnum.Value3, myTarget.FlagsEnumProperty.FixedValue);
+            Assert.Equal(Encoding.UTF8, myTarget.EncodingProperty.FixedValue);
+            Assert.Equal("en-US", myTarget.CultureProperty.FixedValue.Name);
+            Assert.Equal(typeof(int), myTarget.TypeProperty.FixedValue);
+            Assert.Equal(new Uri("https://nlog-project.org"), myTarget.UriProperty.FixedValue);
+            Assert.Equal(LineEndingMode.Default, myTarget.LineEndingModeProperty.FixedValue);
         }
 
         [Fact]


### PR DESCRIPTION
It was a mistake to introduce the StaticValue-property (Caching stale data)

And implicit conversion of dynamic `Layout<T>` without FixedValue should not default to `default(T)`.

Follow up to #4306