### PR TITLE
NLog 5.0 preview 1 with strong-version 5.0.0.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 4.7.0-{build}
+version: 5.0.0-{build}
 image:
   - Visual Studio 2019
   - Previous Ubuntu

--- a/build.ps1
+++ b/build.ps1
@@ -2,8 +2,8 @@
 # creates NuGet package at \artifacts
 dotnet --version
 
-$versionPrefix = "4.7.10"
-$versionSuffix = ""
+$versionPrefix = "5.0.0"
+$versionSuffix = "preview.1"
 $versionFile = $versionPrefix + "." + ${env:APPVEYOR_BUILD_NUMBER}
 $versionProduct = $versionPrefix;
 if (-Not $versionSuffix.Equals(""))

--- a/src/NLog.Database/NLog.Database.csproj
+++ b/src/NLog.Database/NLog.Database.csproj
@@ -26,7 +26,7 @@
     <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 

--- a/src/NLog.MSMQ/NLog.MSMQ.csproj
+++ b/src/NLog.MSMQ/NLog.MSMQ.csproj
@@ -26,7 +26,7 @@
     <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 

--- a/src/NLog.OutputDebugString/NLog.OutputDebugString.csproj
+++ b/src/NLog.OutputDebugString/NLog.OutputDebugString.csproj
@@ -24,7 +24,7 @@
     <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 

--- a/src/NLog.PerformanceCounter/NLog.PerformanceCounter.csproj
+++ b/src/NLog.PerformanceCounter/NLog.PerformanceCounter.csproj
@@ -27,7 +27,7 @@ https://github.com/NLog/NLog/wiki/PerformanceCounter-Layout-Renderer
     <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 

--- a/src/NLog.Wcf/NLog.Wcf.csproj
+++ b/src/NLog.Wcf/NLog.Wcf.csproj
@@ -26,7 +26,7 @@
     <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 

--- a/src/NLog.WindowsEventLog/NLog.WindowsEventLog.csproj
+++ b/src/NLog.WindowsEventLog/NLog.WindowsEventLog.csproj
@@ -26,7 +26,7 @@
     <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 

--- a/src/NLog.WindowsIdentity/NLog.WindowsIdentity.csproj
+++ b/src/NLog.WindowsIdentity/NLog.WindowsIdentity.csproj
@@ -28,7 +28,7 @@
     <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 

--- a/src/NLog.WindowsRegistry/NLog.WindowsRegistry.csproj
+++ b/src/NLog.WindowsRegistry/NLog.WindowsRegistry.csproj
@@ -24,7 +24,7 @@
     <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -28,14 +28,7 @@ For ASP.NET Core, check: https://www.nuget.org/packages/NLog.Web.AspNetCore
     <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
-## Bugfixes
-- JsonSerializer - Fixed bug when handling custom IConvertible returning TypeCode.Empty (#4401) (@snakefoot)
-
-## Improvements
-- Support TargetDefaultParameters and TargetDefaultWrapper (#4391) (@snakefoot)
-- JsonLayout - Apply EscapeForwardSlash for LogEventInfo.Properties (#4403) (@snakefoot)
-      
-Full changelog: https://github.com/NLog/NLog/blob/master/CHANGELOG.md
+NLog 5.0 prerelease version 1.
 
 For all config options and platform support, check https://nlog-project.org/config/
     </PackageReleaseNotes>
@@ -47,7 +40,7 @@ For all config options and platform support, check https://nlog-project.org/conf
     <RepositoryUrl>https://github.com/NLog/NLog.git</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 


### PR DESCRIPTION
Guess release-notes should be published first: https://github.com/NLog/NLog.github.io/pull/158

So nuget-packages can link to the release-notes