### PR TITLE
JsonAttribute + XmlAttribute with ValueType support for encoding the raw-value

### DIFF
--- a/src/NLog.Database/DatabaseObjectPropertyInfo.cs
+++ b/src/NLog.Database/DatabaseObjectPropertyInfo.cs
@@ -37,7 +37,6 @@ namespace NLog.Targets
     using System.ComponentModel;
     using System.Globalization;
     using System.Reflection;
-    using NLog.Common;
     using NLog.Config;
     using NLog.Internal;
     using NLog.Layouts;
@@ -46,8 +45,10 @@ namespace NLog.Targets
     /// Information about object-property for the database-connection-object
     /// </summary>
     [NLogConfigurationItem]
-    public class DatabaseObjectPropertyInfo : ValueTypeLayoutInfo
+    public class DatabaseObjectPropertyInfo
     {
+        private readonly ValueTypeLayoutInfo _layoutInfo = new ValueTypeLayoutInfo();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DatabaseObjectPropertyInfo"/> class.
         /// </summary>
@@ -67,28 +68,35 @@ namespace NLog.Targets
         /// </summary>
         /// <docgen category='Connection Options' order='10' />
         [RequiredParameter]
-        public new Layout Layout { get => base.Layout; set => base.Layout = value; }
+        public Layout Layout { get => _layoutInfo.Layout; set => _layoutInfo.Layout = value; }
 
         /// <summary>
         /// Gets or sets the type of the object-property
         /// </summary>
         /// <docgen category='Connection Options' order='10' />
         [DefaultValue(typeof(string))]
-        public Type PropertyType { get => ValueType ?? typeof(string); set => ValueType = value; }
+        public Type PropertyType { get => _layoutInfo.ValueType ?? typeof(string); set => _layoutInfo.ValueType = value; }
 
         /// <summary>
         /// Gets or sets convert format of the property value
         /// </summary>
         /// <docgen category='Connection Options' order='8' />
         [DefaultValue(null)]
-        public string Format { get => ValueParseFormat; set => ValueParseFormat = value; }
+        public string Format { get => _layoutInfo.ValueParseFormat; set => _layoutInfo.ValueParseFormat = value; }
 
         /// <summary>
         /// Gets or sets the culture used for parsing property string-value for type-conversion
         /// </summary>
         /// <docgen category='Connection Options' order='9' />
         [DefaultValue(null)]
-        public CultureInfo Culture { get => ValueParseCulture; set => ValueParseCulture = value; }
+        public CultureInfo Culture { get => _layoutInfo.ValueParseCulture; set => _layoutInfo.ValueParseCulture = value; }
+
+        /// <summary>
+        /// Render Result Value
+        /// </summary>
+        /// <param name="logEvent">Log event for rendering</param>
+        /// <returns>Result value when available, else fallback to defaultValue</returns>
+        public object RenderValue(LogEventInfo logEvent) => _layoutInfo.RenderValue(logEvent);
 
         internal bool SetPropertyValue(object dbObject, object propertyValue)
         {

--- a/src/NLog/Internal/XmlHelper.cs
+++ b/src/NLog/Internal/XmlHelper.cs
@@ -100,6 +100,38 @@ namespace NLog.Internal
         }
 #endif
 
+        internal static void PerformXmlEscapeWhenNeeded(StringBuilder builder, int startPos, bool xmlEncodeNewlines)
+        {
+            if (RequiresXmlEscape(builder, startPos, xmlEncodeNewlines))
+            {
+                var str = builder.ToString(startPos, builder.Length - startPos);
+                builder.Length = startPos;
+                EscapeXmlString(str, xmlEncodeNewlines, builder);
+            }
+        }
+
+        private static bool RequiresXmlEscape(StringBuilder target, int startPos, bool xmlEncodeNewlines)
+        {
+            for (int i = startPos; i < target.Length; ++i)
+            {
+                switch (target[i])
+                {
+                    case '<':
+                    case '>':
+                    case '&':
+                    case '\'':
+                    case '"':
+                        return true;
+                    case '\r':
+                    case '\n':
+                        if (xmlEncodeNewlines)
+                            return true;
+                        break;
+                }
+            }
+            return false;
+        }
+
         private static readonly char[] XmlEscapeChars = new char[] { '<', '>', '&', '\'', '"' };
         private static readonly char[] XmlEscapeNewlineChars = new char[] { '<', '>', '&', '\'', '"', '\r', '\n' };
 

--- a/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
@@ -79,22 +79,15 @@ namespace NLog.LayoutRenderers.Wrappers
         /// </remarks>
         /// <docgen category="Transformation Options" order="10"/>
         [DefaultValue(false)]
-        public bool EscapeForwardSlash
-        {
-            get => EscapeForwardSlashInternal ?? false;
-            set => EscapeForwardSlashInternal = value;
-        }
-        internal bool? EscapeForwardSlashInternal;
+        public bool EscapeForwardSlash { get; set; }
 
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
             Inner.RenderAppendBuilder(logEvent, builder);
-            if (JsonEncode && builder.Length > orgLength && RequiresJsonEncode(builder, orgLength))
+            if (JsonEncode && builder.Length > orgLength)
             {
-                var str = builder.ToString(orgLength, builder.Length - orgLength);
-                builder.Length = orgLength;
-                Targets.DefaultJsonSerializer.AppendStringEscape(builder, str, EscapeUnicode, EscapeForwardSlash);
+                Targets.DefaultJsonSerializer.PerformJsonEscapeWhenNeeded(builder, orgLength, EscapeUnicode, EscapeForwardSlash);
             }
         }
 
@@ -102,18 +95,6 @@ namespace NLog.LayoutRenderers.Wrappers
         protected override string Transform(string text)
         {
             throw new NotSupportedException();
-        }
-
-        private bool RequiresJsonEncode(StringBuilder target, int startPos = 0)
-        {
-            for (int i = startPos; i < target.Length; ++i)
-            {
-                if (Targets.DefaultJsonSerializer.RequiresJsonEscape(target[i], EscapeUnicode, EscapeForwardSlash))
-                {
-                    return true;
-                }
-            }
-            return false;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/XmlEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/XmlEncodeLayoutRendererWrapper.cs
@@ -76,11 +76,9 @@ namespace NLog.LayoutRenderers.Wrappers
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
             Inner.RenderAppendBuilder(logEvent, builder);
-            if (XmlEncode && RequiresXmlEncode(builder, orgLength))
+            if (XmlEncode)
             {
-                var str = builder.ToString(orgLength, builder.Length - orgLength);
-                builder.Length = orgLength;
-                XmlHelper.EscapeXmlString(str, XmlEncodeNewlines, builder);
+                XmlHelper.PerformXmlEscapeWhenNeeded(builder, orgLength, XmlEncodeNewlines);
             }
         }
 
@@ -92,28 +90,6 @@ namespace NLog.LayoutRenderers.Wrappers
                 return XmlHelper.EscapeXmlString(text, XmlEncodeNewlines);
             }
             return text;
-        }
-
-        private bool RequiresXmlEncode(StringBuilder target, int startPos = 0)
-        {
-            for (int i = startPos; i < target.Length; ++i)
-            {
-                switch (target[i])
-                {
-                    case '<':
-                    case '>':
-                    case '&':
-                    case '\'':
-                    case '"':
-                        return true;
-                    case '\r':
-                    case '\n':
-                        if (XmlEncodeNewlines)
-                            return true;
-                        break;
-                }
-            }
-            return false;
         }
     }
 }

--- a/src/NLog/Layouts/JSON/JsonLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonLayout.cs
@@ -222,9 +222,9 @@ namespace NLog.Layouts
             {
                 foreach (var attribute in Attributes)
                 {
-                    if (!attribute.LayoutWrapper.EscapeForwardSlashInternal.HasValue)
+                    if (!attribute.EscapeForwardSlashInternal.HasValue)
                     {
-                        attribute.LayoutWrapper.EscapeForwardSlashInternal = _escapeForwardSlashInternal.Value;
+                        attribute.EscapeForwardSlash = _escapeForwardSlashInternal.Value;
                     }
                 }
             }
@@ -416,21 +416,12 @@ namespace NLog.Layouts
         private bool RenderAppendJsonPropertyValue(JsonAttribute attrib, LogEventInfo logEvent, StringBuilder sb, bool beginJsonMessage)
         {
             BeginJsonProperty(sb, attrib.Name, beginJsonMessage, false);
-            if (attrib.Encode)
-            {
-                // "\"{0}\":{1}\"{2}\""
-                sb.Append('"');
-            }
-            int beforeValueLength = sb.Length;
-            attrib.LayoutWrapper.RenderAppendBuilder(logEvent, sb);
-            if (!attrib.IncludeEmptyValue && beforeValueLength == sb.Length)
+
+            if (!attrib.RenderAppendJsonValue(logEvent, JsonConverter, sb))
             {
                 return false;
             }
-            if (attrib.Encode)
-            {
-                sb.Append('"');
-            }
+
             return true;
         }
 

--- a/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
+++ b/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
@@ -35,59 +35,20 @@ using System;
 using System.Globalization;
 using System.Reflection;
 using NLog.Config;
-using NLog.Layouts;
 
-namespace NLog.Common
+namespace NLog.Layouts
 {
     /// <summary>
     /// Typed Value that is easily configured from NLog.config file
     /// </summary>
     [NLogConfigurationItem]
-    public abstract class ValueTypeLayoutInfo
+    public sealed class ValueTypeLayoutInfo
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ValueTypeLayoutInfo" /> class.
         /// </summary>
-        protected ValueTypeLayoutInfo()
+        public ValueTypeLayoutInfo()
         {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ValueTypeLayoutInfo" /> class.
-        /// </summary>
-        /// <param name="layout">Dynamic value</param>
-        protected ValueTypeLayoutInfo(Layout layout)
-            :this(layout, typeof(string))
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ValueTypeLayoutInfo" /> class.
-        /// </summary>
-        /// <param name="layout">Dynamic value</param>
-        /// <param name="valueType">Expected value type</param>
-        protected ValueTypeLayoutInfo(Layout layout, Type valueType)
-        {
-            _valueType = valueType ?? typeof(string);
-            Layout = layout;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ValueTypeLayoutInfo" /> class.
-        /// </summary>
-        /// <param name="fixedValue">Fixed value</param>
-        protected ValueTypeLayoutInfo(object fixedValue)
-        {
-            if (fixedValue is Layout layout)
-            {
-                _valueType = typeof(string);
-                Layout = layout;
-            }
-            else
-            {
-                _valueType = fixedValue?.GetType() ?? typeof(string);
-                _layout = _innerLayout = CreateTypedLayout(_valueType, fixedValue);
-            }
         }
 
         /// <summary>
@@ -121,7 +82,7 @@ namespace NLog.Common
         /// <summary>
         /// Gets or sets the result value type, for conversion of layout rendering output
         /// </summary>
-        protected virtual Type ValueType
+        public Type ValueType
         {
             get => _valueType;
             set
@@ -155,7 +116,7 @@ namespace NLog.Common
         /// <summary>
         /// Gets or sets format used for parsing parameter string-value for type-conversion
         /// </summary>
-        protected string ValueParseFormat
+        public string ValueParseFormat
         {
             get => _valueParseFormat;
             set
@@ -172,7 +133,7 @@ namespace NLog.Common
         /// Gets or sets the culture used for parsing parameter string-value for type-conversion
         /// </summary>
         /// <docgen category='Parameter Options' order='9' />
-        protected CultureInfo ValueParseCulture
+        public CultureInfo ValueParseCulture
         {
             get => _valueParseCulture;
             set

--- a/src/NLog/Layouts/XML/XmlElementBase.cs
+++ b/src/NLog/Layouts/XML/XmlElementBase.cs
@@ -713,9 +713,7 @@ namespace NLog.Layouts
             sb.Append(xmlKeyString);
             sb.Append("=\"");
 
-            int beforeValueLength = sb.Length;
-            xmlAttribute.LayoutWrapper.RenderAppendBuilder(logEvent, sb);
-            if (sb.Length == beforeValueLength && !xmlAttribute.IncludeEmptyValue)
+            if (!xmlAttribute.RenderAppendXmlValue(logEvent, sb))
                 return false;
 
             sb.Append('\"');

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -712,6 +712,20 @@ namespace NLog.Targets
                 destination.Append(text);   // Faster to make single Append
         }
 
+        internal static void PerformJsonEscapeWhenNeeded(StringBuilder builder, int startPos, bool escapeUnicode, bool escapeForwardSlash)
+        {
+            for (int i = startPos; i < builder.Length; ++i)
+            {
+                if (RequiresJsonEscape(builder[i], escapeUnicode, escapeForwardSlash))
+                {
+                    var str = builder.ToString(startPos, builder.Length - startPos);
+                    builder.Length = startPos;
+                    Targets.DefaultJsonSerializer.AppendStringEscape(builder, str, escapeUnicode, escapeForwardSlash);
+                    break;
+                }
+            }
+        }
+
         internal static bool RequiresJsonEscape(char ch, JsonSerializeOptions options)
         {
             return RequiresJsonEscape(ch, options.EscapeUnicode, options.EscapeForwardSlash);

--- a/src/NLog/Targets/MethodCallParameter.cs
+++ b/src/NLog/Targets/MethodCallParameter.cs
@@ -43,8 +43,10 @@ namespace NLog.Targets
     /// A parameter to MethodCall.
     /// </summary>
     [NLogConfigurationItem]
-    public class MethodCallParameter : ValueTypeLayoutInfo
+    public class MethodCallParameter
     {
+        private readonly ValueTypeLayoutInfo _layoutInfo = new ValueTypeLayoutInfo();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MethodCallParameter" /> class.
         /// </summary>
@@ -107,13 +109,25 @@ namespace NLog.Targets
         /// </summary>
         /// <docgen category='Parameter Options' order='10' />
         [DefaultValue(typeof(string))]
-        public Type ParameterType { get => ValueType ?? typeof(string); set => ValueType = value; }
+        public Type ParameterType { get => _layoutInfo.ValueType ?? typeof(string); set => _layoutInfo.ValueType = value; }
 
         /// <summary>
         /// Gets or sets the layout that should be use to calculate the value for the parameter.
         /// </summary>
         /// <docgen category='Parameter Options' order='10' />
         [RequiredParameter]
-        public new Layout Layout { get => base.Layout; set => base.Layout = value; }
+        public Layout Layout { get => _layoutInfo.Layout; set => _layoutInfo.Layout = value; }
+
+        /// <summary>
+        /// Gets or sets the fallback value when result value is not available
+        /// </summary>
+        public Layout DefaultValue { get => _layoutInfo.DefaultValue; set => _layoutInfo.DefaultValue = value; }
+
+        /// <summary>
+        /// Render Result Value
+        /// </summary>
+        /// <param name="logEvent">Log event for rendering</param>
+        /// <returns>Result value when available, else fallback to defaultValue</returns>
+        public object RenderValue(LogEventInfo logEvent) => _layoutInfo.RenderValue(logEvent);
     }
 }

--- a/src/NLog/Targets/TargetPropertyWithContext.cs
+++ b/src/NLog/Targets/TargetPropertyWithContext.cs
@@ -43,8 +43,10 @@ namespace NLog.Targets
     /// Attribute details for <see cref="TargetWithContext"/> 
     /// </summary>
     [NLogConfigurationItem]
-    public class TargetPropertyWithContext : ValueTypeLayoutInfo
+    public class TargetPropertyWithContext
     {
+        private readonly ValueTypeLayoutInfo _layoutInfo = new ValueTypeLayoutInfo();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TargetPropertyWithContext" /> class.
         /// </summary>
@@ -73,7 +75,18 @@ namespace NLog.Targets
         /// </summary>
         /// <docgen category='Property Options' order='10' />
         [RequiredParameter]
-        public new Layout Layout { get => base.Layout; set => base.Layout = value; }
+        public Layout Layout { get => _layoutInfo.Layout; set => _layoutInfo.Layout = value; }
+
+        /// <summary>
+        /// Gets or sets the type of the property.
+        /// </summary>
+        [DefaultValue(typeof(string))]
+        public Type PropertyType { get => _layoutInfo.ValueType ?? typeof(string); set => _layoutInfo.ValueType = value; }
+
+        /// <summary>
+        /// Gets or sets the fallback value when result value is not available
+        /// </summary>
+        public Layout DefaultValue { get => _layoutInfo.DefaultValue; set => _layoutInfo.DefaultValue = value; }
 
         /// <summary>
         /// Gets or sets when an empty value should cause the property to be included
@@ -94,9 +107,10 @@ namespace NLog.Targets
         private bool _includeEmptyValue = true;
 
         /// <summary>
-        /// Gets or sets the type of the property.
+        /// Render Result Value
         /// </summary>
-        [DefaultValue(typeof(string))]
-        public Type PropertyType { get => ValueType ?? typeof(string); set => ValueType = value; }
+        /// <param name="logEvent">Log event for rendering</param>
+        /// <returns>Result value when available, else fallback to defaultValue</returns>
+        public object RenderValue(LogEventInfo logEvent) => _layoutInfo.RenderValue(logEvent);
     }
 }

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -207,6 +207,29 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void JsonLayoutValueTypeAttribute()
+        {
+            var jsonLayout = new JsonLayout()
+            {
+                Attributes =
+                    {
+                        new JsonAttribute("date", "${longdate}") { ValueType = typeof(DateTime) },
+                        new JsonAttribute("level", "${level}"),
+                        new JsonAttribute("message", "${message}"),
+                    }
+            };
+
+            var logEventInfo = new LogEventInfo
+            {
+                TimeStamp = new DateTime(2010, 01, 01, 12, 34, 56),
+                Level = LogLevel.Info,
+                Message = "{ \"hello\" : \"world\" }"
+            };
+
+            Assert.Equal("{ \"date\": \"2010-01-01T12:34:56Z\", \"level\": \"Info\", \"message\": \"{ \\\"hello\\\" : \\\"world\\\" }\" }", jsonLayout.Render(logEventInfo));
+        }
+
+        [Fact]
         public void JsonAttributeThreadAgnosticTest()
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"


### PR DESCRIPTION
Continue the work from #4351

- JsonAttribute can render the raw-value as Json.
- XmlAttribute can render the raw-value as Xml (but only simple values).

The performance is not super-hot, since the raw-value has to travel through the layout-logic. And if raw-value is struct-type then it will always be boxed. Also added my thoughts to #3136