### PR TITLE
WebServiceTarget - Added support for assigning UserAgent-Header

### DIFF
--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -42,6 +42,7 @@ namespace NLog.Targets
     using System.Xml;
     using NLog.Common;
     using NLog.Config;
+    using NLog.Layouts;
     using NLog.Internal;
 
     /// <summary>
@@ -123,6 +124,12 @@ namespace NLog.Targets
         /// </summary>
         /// <docgen category='Web Service Options' order='10' />
         public Uri Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value of the User-agent HTTP header.
+        /// </summary>
+        /// <docgen category='Web Service Options' order='10' />
+        public Layout UserAgent { get; set; }
 
         /// <summary>
         /// Gets or sets the Web service method name. Only used with Soap.
@@ -260,7 +267,7 @@ namespace NLog.Targets
         {
             var webRequest = (HttpWebRequest)WebRequest.Create(BuildWebServiceUrl(parameters));
 
-            if (Headers != null && Headers.Count > 0)
+            if (Headers?.Count > 0)
             {
                 for (int i = 0; i < Headers.Count; i++)
                 {
@@ -271,6 +278,14 @@ namespace NLog.Targets
                     webRequest.Headers[Headers[i].Name] = headerValue;
                 }
             }
+
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            var userAgent = RenderLogEvent(UserAgent, logEvent.LogEvent);
+            if (!string.IsNullOrEmpty(userAgent))
+            {
+                webRequest.UserAgent = userAgent;
+            }
+#endif
 
             DoInvoke(parameters, webRequest, logEvent.Continuation);
         }

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -498,6 +498,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
                                 protocol='JsonPost'
                                 encoding='UTF-8'
                                >
+                            <UserAgent>SecretAgent</UserAgent>
                             <header name='Authorization' layout='OpenBackDoor' />
                             <parameter name='param1' ParameterType='System.String' layout='${{message}}'/> 
                             <parameter name='param2' ParameterType='System.String' layout='${{level}}'/>
@@ -518,7 +519,7 @@ Morbi Nulla justo Aenean orci Vestibulum ullamcorper tincidunt mollis et hendrer
 
             var txt = "message 1 with a JSON POST<hello><again\\>\"\b";   // Lets tease the JSON serializer and see it can handle valid and invalid xml chars
             var count = 101;
-            var context = new LogDocController.TestContext(1, count, false, new Dictionary<string, string>() { { "Authorization", "OpenBackDoor" } }, txt, "info", true, DateTime.UtcNow);
+            var context = new LogDocController.TestContext(1, count, false, new Dictionary<string, string>() { { "Authorization", "OpenBackDoor" }, { "User-Agent", "SecretAgent" } }, txt, "info", true, DateTime.UtcNow);
 
             StartOwinDocTest(context, () =>
             {


### PR DESCRIPTION
Possible solution for #4474. So you can do this:

`<UserAgent>SecretAgent</UserAgent>`