### PR TITLE
Reverted: FileTarget - Validate the FileName when fixed value

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -951,61 +951,6 @@ namespace NLog.Targets
                     openFileAutoTimeoutSecs * 1000,
                     openFileAutoTimeoutSecs * 1000);
             }
-
-            if (CleanupFileName && _fullFileName.IsFixedFilePath && (LogManager.ThrowConfigExceptions ?? LogManager.ThrowExceptions))
-            {
-                ValidateFilePath(LogEventInfo.CreateNullEvent());
-            }
-        }
-
-        private void ValidateFilePath(LogEventInfo logEventInfo)
-        {
-            string fixedFilePath = null;
-
-            try
-            {
-                fixedFilePath = _fullFileName.Render(logEventInfo);
-                if (StringHelpers.IsNullOrWhiteSpace(PathHelpers.TrimDirectorySeparators(fixedFilePath)))
-                    throw new ArgumentException("The path is not of a legal form.");
-
-                using (var fileStream = new FileStream(fixedFilePath, FileMode.Open, FileAccess.Write, FileShare.ReadWrite))
-                {
-                    // Its working
-                }
-            }
-            catch (ArgumentException ex)
-            {
-                var configException = new NLogConfigurationException($"FileName has invalid path: {fixedFilePath ?? FileName?.ToString()}", ex);
-                if (configException.MustBeRethrown(this))
-                    throw configException;
-            }
-            catch (System.IO.DirectoryNotFoundException)
-            {
-                // Acceptable
-            }
-            catch (System.IO.FileNotFoundException)
-            {
-                // Acceptable
-            }
-            catch (System.IO.IOException ex)
-            {
-#if !NETSTANDARD1_3 && !NET35
-                if (ex.HResult == -2147024773 /* 0x8007007B = ERROR_INVALID_NAME */ || ex.HResult == -2147024735 /* 0x800700A1 - ERROR_BAD_PATHNAME */)
-                {
-                    var configException = new NLogConfigurationException($"FileName has invalid path: {fixedFilePath ?? FileName?.ToString()}", ex);
-                    if (configException.MustBeRethrown(this))
-                        throw configException;
-                }
-                else
-#endif
-                {
-                    InternalLogger.Debug("{0}: Cannot validate FileName: {1} - {2} {3}", this, fixedFilePath, ex.GetType(), ex.Message);
-                }
-            }
-            catch (Exception ex)
-            {
-                InternalLogger.Debug("{0}: Cannot validate FileName: {1} - {2} {3}", this, fixedFilePath, ex.GetType(), ex.Message);
-            }
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -2658,34 +2658,6 @@ namespace NLog.UnitTests.Targets
             }
         }
 
-        [Theory]
-        [InlineData(@"""D:\Temp\Test.txt""\.txt")]
-        [InlineData("")]
-        [InlineData("\\")]
-        [InlineData("\\\\localhost\\")]
-        public void FileTarget_InvalidPathValidation(string invalidFileName)
-        {
-            if (IsLinux())
-            {
-                Console.WriteLine("[SKIP] FileTargetTests.FileTarget_InvalidPathValidation Not supported on Travis, because it only throws FileNotFoundException");
-                return;
-            }
-
-            using (new NoThrowNLogExceptions())
-            {
-                LogManager.ThrowConfigExceptions = true;
-
-                var logFactory = new LogFactory();
-                var logConfig = new LoggingConfiguration(logFactory);
-                logConfig.AddRuleForAllLevels(new FileTarget
-                {
-                    FileName = SimpleLayout.Escape(invalidFileName),
-                    Layout = "${level} ${message}",
-                });
-                Assert.Throws<NLogConfigurationException>(() => logFactory.Configuration = logConfig);
-            }
-        }
-
         [Fact]
         public void FileTarget_LogAndArchiveFilesWithSameName_ShouldArchive()
         {


### PR DESCRIPTION
Reverting #4481 since it was a bad idea as it can give unwanted stalls during startup. Async-wrappers does not hide overhead from checking filenames of 50 files.

Better to optimize for the succes case, than to optimize for the invalid case.