### PR TITLE
RetryingWrapper - Added support for EnableBatchWrite

### DIFF
--- a/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
@@ -113,8 +113,8 @@ namespace NLog.Targets.Wrappers
         /// Gets or sets whether to enable batching, and only apply single delay when a whole batch fails
         /// </summary>
         /// <docgen category='Retrying Options' order='10' />
-        [DefaultValue(false)]
-        public bool EnableBatchWrite { get; set; }
+        [DefaultValue(true)]
+        public bool EnableBatchWrite { get; set; } = true;
 
         /// <summary>
         /// Special SyncObject to allow closing down Target while busy retrying
@@ -151,10 +151,7 @@ namespace NLog.Targets.Wrappers
                 {
                     for (int i = 0; i < logEvents.Count; ++i)
                     {
-                        if (!IsInitialized)
-                            logEvents[i].Continuation(null);
-                        else
-                            WriteAsyncThreadSafe(logEvents[i]);
+                        WriteAsyncThreadSafe(logEvents[i]);
                     }
                 }
             }

--- a/tests/NLog.UnitTests/Targets/Wrappers/RetryingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/RetryingTargetWrapperTests.cs
@@ -205,15 +205,16 @@ namespace NLog.UnitTests.Targets.Wrappers
                 builder.ForLogger().WriteTo(asyncWrapper);
             }).LogFactory;
 
+            // Verify that RetryingTargetWrapper is not sleeping for every LogEvent in single batch
+            var stopWatch = new System.Diagnostics.Stopwatch();
+            stopWatch.Start();
+
             var logger = logFactory.GetCurrentClassLogger();
             for (int i = 1; i <= 500; ++i)
                 logger.Info("Test {0}", i);
             logFactory.Flush();
             Assert.Equal(1, target.WriteBatchCount);
 
-            // Verify that RetryingTargetWrapper is not sleeping for every LogEvent in single batch
-            var stopWatch = new System.Diagnostics.Stopwatch();
-            stopWatch.Start();
             for (int i = 0; i < 5000; ++i)
             {
                 if (target.Events.Count >= 495)
@@ -223,7 +224,7 @@ namespace NLog.UnitTests.Targets.Wrappers
 
             Assert.Equal(1, target.WriteBatchCount);
             Assert.InRange(target.Events.Count, 495, 500);
-            Assert.InRange(stopWatch.ElapsedMilliseconds, 0, 2000);
+            Assert.InRange(stopWatch.ElapsedMilliseconds, 0, 3000);
         } 
 
         public class MyTarget : Target

--- a/tests/NLog.UnitTests/Targets/Wrappers/RetryingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/RetryingTargetWrapperTests.cs
@@ -184,6 +184,48 @@ namespace NLog.UnitTests.Targets.Wrappers
             });
         }
 
+        [Fact]
+        public void RetryingTargetWrapperBatchingTest()
+        {
+            var target = new MyTarget()
+            {
+                ThrowExceptions = 3,
+            };
+            var retryWrapper = new RetryingTargetWrapper()
+            {
+                WrappedTarget = target,
+                RetryCount = 2,
+                RetryDelayMilliseconds = 10,
+                EnableBatchWrite = true,
+            };
+            var asyncWrapper = new AsyncTargetWrapper(retryWrapper) { TimeToSleepBetweenBatches = 5000 };
+
+            var logFactory = new LogFactory().Setup().LoadConfiguration(builder =>
+            {
+                builder.ForLogger().WriteTo(asyncWrapper);
+            }).LogFactory;
+
+            var logger = logFactory.GetCurrentClassLogger();
+            for (int i = 1; i <= 500; ++i)
+                logger.Info("Test {0}", i);
+            logFactory.Flush();
+            Assert.Equal(1, target.WriteBatchCount);
+
+            // Verify that RetryingTargetWrapper is not sleeping for every LogEvent in single batch
+            var stopWatch = new System.Diagnostics.Stopwatch();
+            stopWatch.Start();
+            for (int i = 0; i < 5000; ++i)
+            {
+                if (target.Events.Count >= 495)
+                    break;
+                System.Threading.Thread.Sleep(1);
+            }
+
+            Assert.Equal(1, target.WriteBatchCount);
+            Assert.InRange(target.Events.Count, 495, 500);
+            Assert.InRange(stopWatch.ElapsedMilliseconds, 0, 2000);
+        } 
+
         public class MyTarget : Target
         {
             public MyTarget()
@@ -196,9 +238,27 @@ namespace NLog.UnitTests.Targets.Wrappers
                 Name = name;
             }
 
-            public List<LogEventInfo> Events { get; set; }
+            public List<LogEventInfo> Events { get; private set; }
 
             public int ThrowExceptions { get; set; }
+
+            public int WriteBatchCount { get; private set; }
+
+            protected override void Write(IList<AsyncLogEventInfo> logEvents)
+            {
+                if (logEvents.Count > 1)
+                {
+                    ++WriteBatchCount;
+                    if (ThrowExceptions-- > 0)
+                    {
+                        for (int i = 0; i < logEvents.Count; ++i)
+                            logEvents[i].Continuation(new ApplicationException("Some exception has occurred."));
+                        return;
+                    }
+                }
+
+                base.Write(logEvents);
+            }
 
             protected override void Write(AsyncLogEventInfo logEvent)
             {


### PR DESCRIPTION
Maybe consider having `EnableBatchWrite = true` by default ?

Also recognized that when calling `AsyncLogEventInfo.Continue(ex)` then one should be a in "stable" place. Not holding locks or resources. This is expecially important when using RetryingWrapper, that will perform recursive call on the same target. Imagine processing a single bucket from `BucketSort()` and suddenly perform try retry-logic while in the middle of handling one of the buckets. The target might not be in a state where it can handle a recursive call.

Similar issue can happen with FallbackWrapper, where one is deep-down into a callstack where logevent fails, and then FallbackWrapper causes one to jump further down the rabbit-hole to forward the logevent to another target.