### PR TITLE
Fix CultureNotFoundException with .NET 6

### DIFF
--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -521,15 +521,13 @@ namespace NLog.Targets
 
         private static CultureInfo CreateFormatProvider()
         {
-#if SILVERLIGHT || NETSTANDARD1_0
-            var culture = new CultureInfo("en-US");
-#else
-            var culture = new CultureInfo("en-US", false);
-#endif
+            var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
             var numberFormat = culture.NumberFormat;
             numberFormat.NumberGroupSeparator = string.Empty;
             numberFormat.NumberDecimalSeparator = ".";
             numberFormat.NumberGroupSizes = new int[] { 0 };
+            numberFormat.NegativeInfinitySymbol = "Infinity";
+            numberFormat.PositiveInfinitySymbol = "Infinity";
             return culture;
         }
 


### PR DESCRIPTION
Resolves #4518

```bash
Unhandled exception. System.TypeInitializationException: The type initializer for 'NLog.Targets.DefaultJsonSerializer' threw an exception.
 ---> System.Globalization.CultureNotFoundException: Only the invariant culture is supported in globalization-invariant mode. See https://aka.ms/GlobalizationInvariantMode for more information. (Parameter 'name')
en-US is an invalid culture identifier.
   at System.Globalization.CultureInfo..ctor(String name, Boolean useUserOverride) in System.Private.CoreLib.dll:token 0x6002560+0x2f
   at NLog.Targets.DefaultJsonSerializer.CreateFormatProvider() in NLog.dll:token 0x6000622+0x0
   at NLog.Targets.DefaultJsonSerializer..ctor() in NLog.dll:token 0x6000611+0x38
   at NLog.Targets.DefaultJsonSerializer..cctor() in NLog.dll:token 0x6000610+0xa
   --- End of inner exception stack trace ---
   at NLog.Config.ConfigurationItemFactory..ctor(Assembly[] assemblies) in NLog.dll:token 0x6001139+0x0
   at NLog.Config.ConfigurationItemFactory.BuildDefaultFactory() in NLog.dll:token 0x600115a+0x10
   at NLog.Config.ConfigurationItemFactory.get_Default() in NLog.dll:token 0x600113a+0x9
   at NLog.Web.AspNetExtensions.AddNLogLoggerProvider(IServiceCollection services, IConfiguration configuration, NLogAspNetCoreOptions options, Func`4 factory) in NLog.Web.AspNetCore.dll:token 0x6000013+0x1b
   at NLog.Web.AspNetExtensions.<>c__DisplayClass17_0.<UseNLog>b__0(HostBuilderContext builderContext, IServiceCollection services) in NLog.Web.AspNetCore.dll:token 0x60000f0+0x19
   at Microsoft.Extensions.Hosting.HostBuilder.CreateServiceProvider() in Microsoft.Extensions.Hosting.dll:token 0x6000039+0xbc
   at Microsoft.Extensions.Hosting.HostBuilder.Build() in Microsoft.Extensions.Hosting.dll:token 0x6000032+0x5e
```

Bug introduced with #2128 and #2179