### PR TITLE
Fixed LibLog integration that references obsolete methods

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -228,9 +228,9 @@ namespace NLog.Config
                 {
                     return false;
                 }
-                else if (messageFormatter is LogMessageTemplateFormatter messageTemplateFormatter)
+                else if ((messageFormatter as LogMessageTemplateFormatter)?.ForceTemplateRenderer == true)
                 {
-                    return messageTemplateFormatter.ForceTemplateRenderer;
+                    return true;
                 }
                 else
                 {

--- a/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
@@ -48,15 +48,15 @@ namespace NLog.LayoutRenderers
     [ThreadSafe]
     public class LevelLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {
-        private static readonly Dictionary<int, string> _upperCaseMapper = new Dictionary<int, string>()
+        private static readonly string[] _upperCaseMapper = new string[]
         {
-            { LogLevel.Trace.Ordinal, LogLevel.Trace.ToString().ToUpperInvariant() },
-            { LogLevel.Debug.Ordinal, LogLevel.Debug.ToString().ToUpperInvariant() },
-            { LogLevel.Info.Ordinal, LogLevel.Info.ToString().ToUpperInvariant() },
-            { LogLevel.Warn.Ordinal, LogLevel.Warn.ToString().ToUpperInvariant() },
-            { LogLevel.Error.Ordinal, LogLevel.Error.ToString().ToUpperInvariant() },
-            { LogLevel.Fatal.Ordinal, LogLevel.Fatal.ToString().ToUpperInvariant() },
-            { LogLevel.Off.Ordinal, LogLevel.Off.ToString().ToUpperInvariant() },
+            LogLevel.Trace.ToString().ToUpperInvariant(),
+            LogLevel.Debug.ToString().ToUpperInvariant(),
+            LogLevel.Info.ToString().ToUpperInvariant(),
+            LogLevel.Warn.ToString().ToUpperInvariant(),
+            LogLevel.Error.ToString().ToUpperInvariant(),
+            LogLevel.Fatal.ToString().ToUpperInvariant(),
+            LogLevel.Off.ToString().ToUpperInvariant(),
         };
 
         /// <summary>
@@ -102,8 +102,14 @@ namespace NLog.LayoutRenderers
 
         private string GetUpperCaseString(LogLevel level)
         {
-            _upperCaseMapper.TryGetValue(level.Ordinal, out var uppercaseString);
-            return uppercaseString ?? level.ToString().ToUpperInvariant();
+            try
+            {
+                return _upperCaseMapper[level.Ordinal];
+            }
+            catch (IndexOutOfRangeException)
+            {
+                return level.ToString().ToUpperInvariant();
+            }
         }
 
         /// <inheritdoc/>

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -377,14 +377,7 @@ namespace NLog
         /// Specific culture info or null to use <see cref="CultureInfo.CurrentCulture"/>
         /// </value>
         [CanBeNull]
-        public CultureInfo DefaultCultureInfo
-        {
-            get
-            {
-                var configuration = Configuration;
-                return configuration?.DefaultCultureInfo;
-            }
-        }
+        public CultureInfo DefaultCultureInfo => _configLoaded ? _config?.DefaultCultureInfo : null;
 
         internal static void LogConfigurationInitialized()
         {

--- a/src/NLog/Logger-V1Compat.cs
+++ b/src/NLog/Logger-V1Compat.cs
@@ -3326,7 +3326,9 @@ namespace NLog
             Log(level, exception, message, NLog.Internal.ArrayHelper.Empty<object>());
         }
 
-        void ILogger.TraceException([Localizable(false)] string message, Exception exception)
+        /// <inheritdoc/>
+        [Obsolete("Use Trace(Exception exception, string message, params object[] args) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
+        public void TraceException([Localizable(false)] string message, Exception exception)
         {
             Trace(exception, message);
         }
@@ -3336,7 +3338,10 @@ namespace NLog
             Trace(exception, message);
         }
 
-        void ILogger.DebugException([Localizable(false)] string message, Exception exception)
+        /// <inheritdoc/>
+        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
+
+        public void DebugException([Localizable(false)] string message, Exception exception)
         {
             Debug(exception, message);
         }
@@ -3346,7 +3351,9 @@ namespace NLog
             Debug(exception, message);
         }
 
-        void ILogger.InfoException([Localizable(false)] string message, Exception exception)
+        /// <inheritdoc/>
+        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
+        public void  InfoException([Localizable(false)] string message, Exception exception)
         {
             Info(exception, message);
         }
@@ -3356,7 +3363,9 @@ namespace NLog
             Info(exception, message);
         }
 
-        void ILogger.WarnException([Localizable(false)] string message, Exception exception)
+        /// <inheritdoc/>
+        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
+        public void  WarnException([Localizable(false)] string message, Exception exception)
         {
             Warn(exception, message);
         }
@@ -3366,7 +3375,9 @@ namespace NLog
             Warn(exception, message);
         }
 
-        void ILogger.ErrorException([Localizable(false)] string message, Exception exception)
+        /// <inheritdoc/>
+        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
+        public void ErrorException([Localizable(false)] string message, Exception exception)
         {
             Error(exception, message);
         }
@@ -3376,7 +3387,9 @@ namespace NLog
             Error(exception, message);
         }
 
-        void ILogger.FatalException([Localizable(false)] string message, Exception exception)
+        /// <inheritdoc/>
+        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
+        public void FatalException([Localizable(false)] string message, Exception exception)
         {
             Fatal(exception, message);
         }

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -192,7 +192,7 @@ For all config options and platform support, check https://nlog-project.org/conf
   </Target>
 
   <ItemGroup>
-    <None Include="N.png" Pack="true" PackagePath=""/>
+    <None Include="N.png" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
   <Target Name="DownloadMissingContent" BeforeTargets="GenerateNuspec">
     <DownloadFile SourceUrl="https://nlog-project.org/N.png" DestinationFolder="$(MSBuildThisFileDirectory)" />


### PR DESCRIPTION
LibLog explodes when failing to hookup with NLog. Hopefully when NLog 6 gets out, then LibLog is fully deprecated.