### PR TITLE
Add aliases for layout renderers

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/NoRawValueLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/NoRawValueLayoutRendererWrapper.cs
@@ -44,6 +44,7 @@ namespace NLog.LayoutRenderers.Wrappers
     /// </summary>
     /// <remarks>For performance and/or full (formatted) control of the output.</remarks>
     [LayoutRenderer("norawvalue")]
+    [LayoutRenderer("no-rawvalue")]
     [AmbientProperty("NoRawValue")]
     [AppDomainFixedOutput]
     [ThreadAgnostic]

--- a/src/NLog/LayoutRenderers/Wrappers/WrapLineLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapLineLayoutRendererWrapper.cs
@@ -42,6 +42,7 @@ namespace NLog.LayoutRenderers.Wrappers
     /// Replaces newline characters from the result of another layout renderer with spaces.
     /// </summary>
     [LayoutRenderer("wrapline")]
+    [LayoutRenderer("wrap-line")]
     [AmbientProperty("WrapLine")]
     [AppDomainFixedOutput]
     [ThreadAgnostic]

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/String transformations/WrapLineTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/String transformations/WrapLineTests.cs
@@ -43,25 +43,18 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
 
     public class WrapLineTests : NLogTestBase
     {
-        [Fact]
-        public void WrapLineWithInnerLayoutDefaultTest()
+        [Theory]
+        [InlineData("${wrapline:${scopeproperty:foo}:WrapLine=3}")]
+        [InlineData("${wrap-line:${scopeproperty:foo}:WrapLine=3}")] // Alias
+        [InlineData("${wrapline:Inner=${scopeproperty:foo}:WrapLine=3}")] // Inner syntax
+        public void WrapLineWithInnerLayoutDefaultTest(string layout)
         {
             ScopeContext.PushProperty("foo", "foobar");
 
-            SimpleLayout le = "${wrapline:${scopeproperty:foo}:WrapLine=3}";
+            SimpleLayout le = layout;
 
             Assert.Equal("foo" + System.Environment.NewLine + "bar", le.Render(LogEventInfo.CreateNullEvent()));
-        }
-
-        [Fact]
-        public void WrapLineWithInnerLayoutTest()
-        {
-            ScopeContext.PushProperty("foo", "foobar");
-
-            SimpleLayout le = "${wrapline:Inner=${scopeproperty:foo}:WrapLine=3}";
-
-            Assert.Equal("foo" + System.Environment.NewLine + "bar", le.Render(LogEventInfo.CreateNullEvent()));
-        }
+        }    
 
         [Fact]
         public void WrapLineAtPositionOnceTest()


### PR DESCRIPTION
To make things consistent

But another way would be to ignore `-` when parsing. 