### PR TITLE
Ignore - when parsing layout renderers

### DIFF
--- a/src/NLog/LayoutRenderers/DbNullLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/DbNullLayoutRenderer.cs
@@ -41,7 +41,6 @@ namespace NLog.LayoutRenderers
     /// <summary>
     /// DB null for a database
     /// </summary>
-    [LayoutRenderer("db-null")]
     [LayoutRenderer("dbnull")]
     [ThreadSafe]
     [ThreadAgnostic]

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenEmptyTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/WhenEmptyTests.cs
@@ -80,10 +80,13 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
             }
         }
 
-        [Fact]
-        public void WhenDbNullRawValueShouldWork()
+        [Theory]
+        [InlineData("${db-null}")]
+        [InlineData("${dbnull}")]
+        [InlineData("${db-n-u-l-l}")]
+        public void WhenDbNullRawValueShouldWork(string layoutRenderer)
         {
-            SimpleLayout l = @"${event-properties:prop1:whenEmpty=${db-null}}";
+            SimpleLayout l = $@"${{event-properties:prop1:whenEmpty={layoutRenderer}}}";
             {
                 var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
                 le.Properties["prop1"] = 1;


### PR DESCRIPTION
Just an idea, 

Because [the list](https://nlog-project.org/config/?tab=layout-renderers) is inconsistent. 

@snakefoot please share your opinion.

supersedes https://github.com/NLog/NLog/pull/4536

PS The replace could be more efficient, but not sure if that's is an problem. We aren't parsing when logging