### PR TITLE
Implementation of TcpThreadNetworkSender

### DIFF
--- a/src/NLog/Internal/NetworkSenders/INetworkSenderFactory.cs
+++ b/src/NLog/Internal/NetworkSenders/INetworkSenderFactory.cs
@@ -47,9 +47,10 @@ namespace NLog.Internal.NetworkSenders
         /// <param name="maxQueueSize">The maximum queue size.</param>
         /// <param name="sslProtocols">SSL protocols for TCP</param>
         /// <param name="keepAliveTime">KeepAliveTime for TCP</param>
+        /// <param name="connectionTimeout">ConnectionTimeout for TcpThreadNetworkSender</param>
         /// <returns>
         /// A newly created network sender.
         /// </returns>
-        NetworkSender Create(string url, int maxQueueSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime);
+        NetworkSender Create(string url, int maxQueueSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime, TimeSpan connectionTimeout);
     }
 }

--- a/src/NLog/Internal/NetworkSenders/ISocket.cs
+++ b/src/NLog/Internal/NetworkSenders/ISocket.cs
@@ -34,6 +34,8 @@
 
 namespace NLog.Internal.NetworkSenders
 {
+    using System;
+    using System.Net;
     using System.Net.Sockets;
 
     /// <summary>
@@ -48,5 +50,17 @@ namespace NLog.Internal.NetworkSenders
         bool SendAsync(SocketAsyncEventArgs args);
 
         bool SendToAsync(SocketAsyncEventArgs args);
+
+#if !NET35 && !NETSTANDARD1_3 && !NETSTANDARD1_5
+        bool Connected { get; }
+
+        IAsyncResult BeginConnect(EndPoint remoteEP, AsyncCallback callback, object state);
+
+        void EndConnect(IAsyncResult asyncResult);
+
+        int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags);
+#endif
+
+        void Dispose();
     }
 }

--- a/src/NLog/Internal/NetworkSenders/NetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/NetworkSender.cs
@@ -69,6 +69,11 @@ namespace NLog.Internal.NetworkSenders
         public int LastSendTime { get; private set; }
 
         /// <summary>
+        /// Indicates wether this sender should be released on error.
+        /// </summary>
+        protected internal bool ReleaseOnError { get; protected set; } = true;
+
+        /// <summary>
         /// Initializes this network sender.
         /// </summary>
         public void Initialize()

--- a/src/NLog/Internal/NetworkSenders/NetworkSenderFactory.cs
+++ b/src/NLog/Internal/NetworkSenders/NetworkSenderFactory.cs
@@ -44,7 +44,7 @@ namespace NLog.Internal.NetworkSenders
         public static readonly INetworkSenderFactory Default = new NetworkSenderFactory();
 
         /// <inheritdoc />
-        public NetworkSender Create(string url, int maxQueueSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime)
+        public NetworkSender Create(string url, int maxQueueSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime, TimeSpan connectionTimeout)
         {
             if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
             {
@@ -91,6 +91,41 @@ namespace NLog.Internal.NetworkSenders
                     KeepAliveTime = keepAliveTime,
                 };
             }
+
+#if !NET35 && !NETSTANDARD1_3 && !NETSTANDARD1_5
+            if (url.StartsWith("tcp+thread://", StringComparison.OrdinalIgnoreCase))
+            {
+                return new TcpThreadNetworkSender(url, AddressFamily.Unspecified)
+                {
+                    ConnectionTimeout = connectionTimeout,
+                    KeepAliveTime = keepAliveTime,
+                    SslProtocols = sslProtocols,
+                    MaxQueueSize = maxQueueSize,
+                };
+            }
+
+            if (url.StartsWith("tcp4+thread://", StringComparison.OrdinalIgnoreCase))
+            {
+                return new TcpThreadNetworkSender(url, AddressFamily.InterNetwork)
+                {
+                    ConnectionTimeout = connectionTimeout,
+                    KeepAliveTime = keepAliveTime,
+                    SslProtocols = sslProtocols,
+                    MaxQueueSize = maxQueueSize,
+                };
+            }
+
+            if (url.StartsWith("tcp6+thread://", StringComparison.OrdinalIgnoreCase))
+            {
+                return new TcpThreadNetworkSender(url, AddressFamily.InterNetworkV6)
+                {
+                    ConnectionTimeout = connectionTimeout,
+                    KeepAliveTime = keepAliveTime,
+                    SslProtocols = sslProtocols,
+                    MaxQueueSize = maxQueueSize,
+                };
+            }
+#endif
 
             if (url.StartsWith("udp://", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/NLog/Internal/NetworkSenders/SocketProxy.cs
+++ b/src/NLog/Internal/NetworkSenders/SocketProxy.cs
@@ -34,6 +34,7 @@
 namespace NLog.Internal.NetworkSenders
 {
     using System;
+    using System.Net;
     using System.Net.Sockets;
 
     /// <summary>
@@ -96,6 +97,37 @@ namespace NLog.Internal.NetworkSenders
         {
             return _socket.SendToAsync(args);
         }
+
+#if !NET35 && !NETSTANDARD1_3 && !NETSTANDARD1_5
+        /// <summary>
+        /// Gets the status connection of the wrapped socket.
+        /// </summary>
+        public bool Connected => _socket.Connected;
+
+        /// <summary>
+        /// Invokes BeginConnect method on the wrapped socket.
+        /// </summary>
+        public IAsyncResult BeginConnect(EndPoint remoteEP, AsyncCallback callback, object state)
+        {
+            return _socket.BeginConnect(remoteEP, callback, state);
+        }
+
+        /// <summary>
+        /// Invokes EndConnect method on the wrapped socket.
+        /// </summary>
+        public void EndConnect(IAsyncResult asyncResult)
+        {
+            _socket.EndConnect(asyncResult);
+        }
+
+        /// <summary>
+        /// Invokes Send method on the wrapped socket.
+        /// </summary>
+        public int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        {
+            return _socket.Send(buffer, offset, size, socketFlags);
+        }
+#endif
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.

--- a/src/NLog/Internal/NetworkSenders/SslSocketProxy.cs
+++ b/src/NLog/Internal/NetworkSenders/SslSocketProxy.cs
@@ -35,6 +35,7 @@ namespace NLog.Internal.NetworkSenders
 {
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
     using System;
+    using System.Net;
     using System.Net.Security;
     using System.Net.Sockets;
     using System.Security.Authentication;
@@ -189,6 +190,37 @@ namespace NLog.Internal.NetworkSenders
         {
             return SendAsync(args);
         }
+
+#if !NET35
+        /// <summary>
+        /// Gets the status connection of the wrapped socket.
+        /// </summary>
+        public bool Connected => _socketProxy.Connected;
+
+        /// <summary>
+        /// Invokes BeginConnect method on the wrapped socket.
+        /// </summary>
+        public IAsyncResult BeginConnect(EndPoint remoteEP, AsyncCallback callback, object state)
+        {
+            return _socketProxy.BeginConnect(remoteEP, callback, state);
+        }
+
+        /// <summary>
+        /// Invokes EndConnect method on the wrapped socket.
+        /// </summary>
+        public void EndConnect(IAsyncResult asyncResult)
+        {
+            _socketProxy.EndConnect(asyncResult);
+        }
+
+        /// <summary>
+        /// Invokes Send method on the wrapped socket.
+        /// </summary>
+        public int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        {
+            return _socketProxy.Send(buffer, offset, size, socketFlags);
+        }
+#endif
 
         public void Dispose()
         {

--- a/src/NLog/Internal/NetworkSenders/TcpThreadNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/TcpThreadNetworkSender.cs
@@ -1,0 +1,374 @@
+﻿// 
+// Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Copyright (c) 2021 @pruiz <pruiz@evicertia.com>, @rvinaa <jespinosa@evicertia.com>
+// 
+
+#if !NET35 && !NETSTANDARD1_3 && !NETSTANDARD1_5
+namespace NLog.Internal.NetworkSenders
+{
+    using System;
+    using System.Threading;
+    using System.Diagnostics;
+    using System.Net.Sockets;
+    using System.Collections.Concurrent;
+    using System.Security.Authentication;
+    using System.Runtime.CompilerServices;
+
+    using NLog.Common;
+
+    internal class TcpThreadNetworkSender : NetworkSender
+    {
+        #region Inner types
+
+        private struct Item
+        {
+            public AsyncContinuation continuation;
+            public byte[] bytes;
+            public int length;
+        }
+
+        #endregion
+
+        #region Common fields & properties
+
+        private static bool? EnableKeepAliveSuccessful;
+        private const int CLOSE_SIGNAL = -31337;
+        private const int FLUSH_SIGNAL = -31338;
+        private BlockingCollection<Item> _items;
+        private Uri _uri;
+
+        private readonly CancellationTokenSource _cancellator = new CancellationTokenSource();
+        private readonly object _lock = new object();
+
+        internal AddressFamily AddressFamily { get; set; }
+        internal SslProtocols SslProtocols { get; set; }
+        internal TimeSpan KeepAliveTime { get; set; }
+        internal TimeSpan ConnectionTimeout { get; set; }
+        internal int MaxQueueSize { get; set; }
+
+        #endregion
+
+        #region .ctors
+
+        public TcpThreadNetworkSender(string url, AddressFamily addressFamily)
+            : base(url)
+        {
+            ReleaseOnError = false; //< XXX: We do handle errors by ourselves (like reconnecting, etc.)
+            AddressFamily = addressFamily;
+        }
+
+        #endregion
+
+        #region NetworkSender methods
+
+        protected override void DoInitialize()
+        {
+            if (_thread == null)
+            {
+                lock (_lock)
+                {
+                    if (_thread == null)
+                    {
+                        _uri = new Uri(Address);
+                        _items = new BlockingCollection<Item>(MaxQueueSize);
+                        _thread = new Thread(Main)
+                        {
+                            Name = $"{nameof(TcpThreadNetworkSender)} - {Address}"
+                        };
+
+                        _thread.Start();
+                    }
+                }
+            }
+
+            base.DoInitialize();
+        }
+
+        protected override void DoSend(byte[] bytes, int offset, int length, AsyncContinuation asyncContinuation)
+        {
+            if (!_items.IsCompleted)
+                _items.Add(new Item { bytes = bytes, length = length, continuation = asyncContinuation }, _cancellator.Token);
+        }
+
+        protected override void DoFlush(AsyncContinuation continuation)
+        {
+            if (_items.IsCompleted)
+            {
+                continuation?.Invoke(null);
+                return;
+            }
+
+            _items.Add(new Item { length = FLUSH_SIGNAL, continuation = continuation }, _cancellator.Token);
+        }
+
+        protected override void DoClose(AsyncContinuation continuation)
+        {
+            if (_items.IsCompleted)
+            {
+                continuation?.Invoke(null);
+                return;
+            }
+
+            lock (_items)
+            {
+                continuation = ex => { _thread.Join(); continuation?.Invoke(ex); };
+                _items.Add(new Item { length = CLOSE_SIGNAL, continuation = continuation });
+                _cancellator.Cancel();
+                _items.CompleteAdding();
+            }
+        }
+
+        #endregion
+
+        #region Thread methods
+
+        private volatile Thread _thread;
+        private ISocket _socket;
+
+        private static readonly int[] DelayIntervals = new[] { 50, 100, 250, 500, 1000 };
+
+        private static int GetDelay(uint step) => DelayIntervals[Math.Min(DelayIntervals.Length - 1, step)];
+
+        private static bool TrySetSocketOption(Socket socket, SocketOptionLevel level, SocketOptionName name, object value)
+        {
+            try
+            {
+                socket.SetSocketOption(level, name, value);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Warn(ex, "Failed to configure socket option with level: {0}, name: {1}, value: {2}.", level, name, value);
+                return false;
+            }
+        }
+
+        private static bool TryEnableKeepAlive(Socket socket, int keepAliveTimeSeconds)
+        {
+            if (TrySetSocketOption(socket, SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true))
+            {
+                // SOCKET OPTION NAME CONSTANT
+                // Ws2ipdef.h (Windows SDK)
+                // #define    TCP_KEEPALIVE      3
+                // #define    TCP_KEEPINTVL      17
+                var TcpKeepAliveTime = (SocketOptionName)0x3;
+                var TcpKeepAliveInterval = (SocketOptionName)0x11;
+
+                if (PlatformDetector.CurrentOS == RuntimeOS.Linux)
+                {
+                    // https://github.com/torvalds/linux/blob/v4.16/include/net/tcp.h
+                    // #define    TCP_KEEPIDLE            4              /* Start keepalives after this period */
+                    // #define    TCP_KEEPINTVL           5              /* Interval between keepalives */
+                    TcpKeepAliveTime = (SocketOptionName)0x4;
+                    TcpKeepAliveInterval = (SocketOptionName)0x5;
+                }
+                else if (PlatformDetector.CurrentOS == RuntimeOS.MacOSX)
+                {
+                    // https://opensource.apple.com/source/xnu/xnu-4570.41.2/bsd/netinet/tcp.h.auto.html
+                    // #define    TCP_KEEPALIVE      0x10                      /* idle time used when SO_KEEPALIVE is enabled */
+                    // #define    TCP_KEEPINTVL      0x101                     /* interval between keepalives */
+                    TcpKeepAliveTime = (SocketOptionName)0x10;
+                    TcpKeepAliveInterval = (SocketOptionName)0x101;
+                }
+
+                if (TrySetSocketOption(socket, SocketOptionLevel.Tcp, TcpKeepAliveTime, keepAliveTimeSeconds))
+                {
+                    // Configure retransmission interval when missing acknowledge of keep-alive-probe
+                    TrySetSocketOption(socket, SocketOptionLevel.Tcp, TcpKeepAliveInterval, 1); //< Default 1 sec on Windows (75 sec on Linux)
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        protected internal virtual ISocket CreateSocket(string host, AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
+        {
+            var result = new SocketProxy(addressFamily, socketType, protocolType);
+            var socket = result.UnderlyingSocket;
+
+            if (KeepAliveTime.TotalSeconds >= 1.0 && EnableKeepAliveSuccessful != false)
+                EnableKeepAliveSuccessful = TryEnableKeepAlive(socket, (int)KeepAliveTime.TotalSeconds);
+
+            if (SslProtocols != SslProtocols.None)
+                return new SslSocketProxy(host, SslProtocols, result);
+
+            return result;
+        }
+
+        private void Connect()
+        {
+            _socket = CreateSocket(_uri.Host, AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
+            var asyncResult = _socket.BeginConnect(ParseEndpointAddress(new Uri(Address), AddressFamily), null, null);
+            var signalReceived = asyncResult.AsyncWaitHandle.WaitOne(ConnectionTimeout, true);
+
+            if (!signalReceived)
+            {
+                try
+                {
+                    Close(); //< XXX: Timeout reached? Close and throw.
+                }
+                catch (Exception)
+                {
+                    // Swallow the exception since this is considered a timeout..
+                }
+
+                throw new SocketException((int)SocketError.TimedOut);
+            }
+
+            _socket.EndConnect(asyncResult);
+        }
+
+        private void Send(Item item)
+        {
+            var left = item.length;
+
+            while (left > 0)
+            {
+                try
+                {
+                    left -= _socket.Send(item.bytes, (item.length - left), left, SocketFlags.None);
+                    item.continuation?.Invoke(null);
+                }
+                catch (Exception ex) when (item.continuation != null)
+                {
+                    item.continuation(ex);
+                    throw;
+                }
+            }
+        }
+
+        private void Close()
+        {
+            var sock = _socket;
+            _socket = null;
+
+            if (sock?.Connected != null)
+                sock.Close();
+
+            sock?.Dispose();
+        }
+
+        private void Close(Item item)
+        {
+
+            try
+            {
+                Close();
+
+                item.continuation?.Invoke(null);
+            }
+            catch (Exception exception)
+            {
+                item.continuation?.Invoke(exception);
+            }
+        }
+
+#if !NET40
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private bool DoWork()
+        {
+            if (_socket?.Connected != true)
+            {
+                Close();
+                Connect();
+            }
+
+            var item = _items.Take();
+            if (item.length == CLOSE_SIGNAL)
+            {
+                Close(item);
+                return false;
+            }
+            else if (item.length == FLUSH_SIGNAL)
+            {
+                item.continuation?.Invoke(null);
+                return true;
+            }
+
+            Send(item);
+            return true;
+        }
+
+        private void Main()
+        {
+            uint step = 0;
+            var sw = new Stopwatch();
+
+            while (true)
+            {
+                try
+                {
+                    if (!DoWork())
+                        break;
+
+                    step = 0;
+                }
+                catch (Exception ex)
+                {
+                    InternalLogger.Error(ex, "Unexpected error while sending log data to {0}", _uri);
+
+                    var delay = GetDelay(step++);
+                    var tmout = delay;
+
+                    sw.Restart();
+
+                    do
+                    {
+                        // XXX: Flush queue if sender is not connected..
+                        while (_items.TryTake(out var item, tmout < 0 ? 0 : tmout))
+                        {
+                            if (item.length == CLOSE_SIGNAL)
+                            {
+                                Close(item);
+                                goto done;
+                            }
+
+                            item.continuation?.Invoke(ex);
+                            tmout = (int)(delay - sw.ElapsedMilliseconds);
+                        }
+                    }
+                    while (sw.ElapsedMilliseconds < delay);
+
+                done:
+                    sw.Stop();
+                }
+            }
+        }
+
+        #endregion
+    }
+}
+#endif

--- a/tests/NLog.UnitTests/Internal/NetworkSenders/HttpNetworkSenderTests.cs
+++ b/tests/NLog.UnitTests/Internal/NetworkSenders/HttpNetworkSenderTests.cs
@@ -82,7 +82,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             Assert.Equal("HttpHappyPathTestLogger|test message1|", requestedString);
             Assert.Equal("POST", mock.Method);
 
-            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 0, SslProtocols.None, new TimeSpan());
+            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 0, SslProtocols.None, new TimeSpan(), TimeSpan.FromSeconds(1));
 
             // Cleanup
             mock.Dispose();
@@ -124,7 +124,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             Assert.Equal("HttpHappyPathTestLogger|test message2|", requestedString);
             Assert.Equal("POST", mock.Method);
 
-            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 0, SslProtocols.None, new TimeSpan()); // Only created one HttpNetworkSender
+            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 0, SslProtocols.None, new TimeSpan(), TimeSpan.FromSeconds(1)); // Only created one HttpNetworkSender
 
             // Cleanup
             mock.Dispose();
@@ -135,7 +135,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
         {
             var networkSenderFactoryMock = Substitute.For<INetworkSenderFactory>();
 
-            networkSenderFactoryMock.Create(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<SslProtocols>(), Arg.Any<TimeSpan>())
+            networkSenderFactoryMock.Create(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<SslProtocols>(), Arg.Any<TimeSpan>(), Arg.Any<TimeSpan>())
                 .Returns(url => new HttpNetworkSender(url.Arg<string>())
                 {
                     HttpRequestFactory = new WebRequestFactoryMock(webRequestMock)

--- a/tests/NLog.UnitTests/Internal/NetworkSenders/TcpNetworkSenderTests.cs
+++ b/tests/NLog.UnitTests/Internal/NetworkSenders/TcpNetworkSenderTests.cs
@@ -288,6 +288,8 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             private readonly StringWriter log;
             private bool faulted;
 
+            public bool Connected => throw new NotImplementedException();
+
             public MockSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, MyTcpNetworkSender sender)
             {
                 this.sender = sender;
@@ -375,6 +377,26 @@ namespace NLog.UnitTests.Internal.NetworkSenders
                     log.WriteLine("sendto async {0} {1} '{2}' {3}", args.Offset, args.Count, Encoding.UTF8.GetString(args.Buffer, args.Offset, args.Count), args.RemoteEndPoint);
                     return InvokeCallback(args);
                 }
+            }
+
+            public IAsyncResult BeginConnect(EndPoint remoteEP, AsyncCallback callback, object state)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void EndConnect(IAsyncResult asyncResult)
+            {
+                throw new NotImplementedException();
+            }
+
+            public int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Dispose()
+            {
+                throw new NotImplementedException();
             }
         }
 

--- a/tests/NLog.UnitTests/Internal/NetworkSenders/TcpThreadNetworkSenderTests.cs
+++ b/tests/NLog.UnitTests/Internal/NetworkSenders/TcpThreadNetworkSenderTests.cs
@@ -1,0 +1,401 @@
+﻿// 
+// Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Copyright (c) 2021 @pruiz <pruiz@evicertia.com>, @rvinaa <jespinosa@evicertia.com>
+// 
+
+#if !NET35
+namespace NLog.UnitTests.Internal.NetworkSenders
+{
+    using System;
+    using System.IO;
+    using System.Net;
+    using System.Text;
+    using System.Threading;
+    using System.Net.Sockets;
+    using System.Collections.Generic;
+
+    using Xunit;
+    using NSubstitute;
+
+    using NLog.Internal.NetworkSenders;
+
+    public class TcpThreadNetworkSenderTests : NLogTestBase
+    {
+        [Fact]
+        public void TcpThreadHappyPathTest()
+        {
+            var sender = new MyTcpThreadNetworkSender("tcp+thread://hostname:123", AddressFamily.Unspecified);
+            sender.Initialize();
+
+            var buffer = Encoding.UTF8.GetBytes("quick brown fox jumps over the lazy dog");
+            var allSent = new ManualResetEvent(false);
+            var exceptions = new List<Exception>();
+
+            for (var i = 1; i < 8; i *= 2)
+            {
+                sender.Send(
+                    buffer, 0, i, ex =>
+                    {
+                        lock (exceptions)
+                            exceptions.Add(ex);
+                    });
+            }
+
+            var mre = new ManualResetEvent(false);
+
+            sender.FlushAsync(ex =>
+            {
+                lock (exceptions)
+                    exceptions.Add(ex);
+
+                mre.Set();
+            });
+
+            mre.WaitOne();
+
+            var actual = sender.Log.ToString();
+            Assert.True(actual.IndexOf("Create socket Unspecified Stream Tcp") != -1);
+            Assert.True(actual.IndexOf("Parse endpoint address tcp+thread://hostname:123/ Unspecified") != -1);
+            Assert.True(actual.IndexOf("Connect async to {mock end point: tcp+thread://hostname:123/}") != -1);
+            Assert.True(actual.IndexOf("Conection ended") != -1);
+            Assert.True(actual.IndexOf("Send sync 0 1 'q'") != -1);
+            Assert.True(actual.IndexOf("Send sync 0 2 'qu'") != -1);
+            Assert.True(actual.IndexOf("Send sync 0 4 'quic'") != -1);
+
+            for (var i = 1; i < 8; i *= 2)
+            {
+                sender.Send(
+                    buffer, 0, i, ex =>
+                    {
+                        lock (exceptions)
+                        {
+                            exceptions.Add(ex);
+                            if (exceptions.Count == 7)
+                                allSent.Set();
+                        }
+                    });
+            }
+
+            Assert.True(allSent.WaitOne(3000, false));
+
+            actual = sender.Log.ToString();
+
+            Assert.True(actual.IndexOf("Create socket Unspecified Stream Tcp") != -1);
+            Assert.True(actual.IndexOf("Parse endpoint address tcp+thread://hostname:123/ Unspecified") != -1);
+            Assert.True(actual.IndexOf("Connect async to {mock end point: tcp+thread://hostname:123/}") != -1);
+            Assert.True(actual.IndexOf("Conection ended") != -1);
+            Assert.True(actual.IndexOf("Send sync 0 1 'q'") != -1);
+            Assert.True(actual.IndexOf("Send sync 0 2 'qu'") != -1);
+            Assert.True(actual.IndexOf("Send sync 0 4 'quic'") != -1);
+            Assert.True(actual.IndexOf("Send sync 0 1 'q'") != -1);
+            Assert.True(actual.IndexOf("Send sync 0 2 'qu'") != -1);
+            Assert.True(actual.IndexOf("Send sync 0 4 'quic'") != -1);
+
+            foreach (var ex in exceptions)
+                Assert.Null(ex);
+        }
+
+        [Fact]
+        public void TcpProxyTest()
+        {
+            var sender = new TcpNetworkSender("tcp+thread://foo:1234", AddressFamily.Unspecified);
+            var socket = sender.CreateSocket("foo", AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            Assert.IsType<SocketProxy>(socket);
+        }
+
+        [Fact]
+        public void TcpConnectFailureTest()
+        {
+            var sender = new MyTcpThreadNetworkSender("tcp+thread://hostname:123", AddressFamily.Unspecified)
+            {
+                ConnectFailure = 1
+            };
+
+            sender.Initialize();
+
+            var buffer = Encoding.UTF8.GetBytes("quick brown fox jumps over the lazy dog");
+            var allSent = new ManualResetEvent(false);
+            var exceptions = new List<Exception>();
+
+            for (var i = 1; i < 8; i++)
+            {
+                sender.Send(
+                    buffer, 0, i, ex =>
+                    {
+                        lock (exceptions)
+                        {
+                            exceptions.Add(ex);
+                            if (exceptions.Count == 7)
+                                allSent.Set();
+                        }
+                    });
+            }
+
+            Assert.True(allSent.WaitOne(3000, false));
+
+            var mre = new ManualResetEvent(false);
+            sender.FlushAsync(ex => mre.Set());
+            mre.WaitOne(3000, false);
+
+            var actual = sender.Log.ToString();
+            Assert.True(actual.IndexOf("Create socket Unspecified Stream Tcp") != -1);
+            Assert.True(actual.IndexOf("Parse endpoint address tcp+thread://hostname:123/ Unspecified") != -1);
+            Assert.True(actual.IndexOf("Connect async to {mock end point: tcp+thread://hostname:123/}") != -1);
+            Assert.True(actual.IndexOf("Failed") != -1);
+
+            foreach (var ex in exceptions)
+                Assert.NotNull(ex);
+        }
+
+        [Fact]
+        public void TcpSendFailureTest()
+        {
+            var sender = new MyTcpThreadNetworkSender("tcp+thread://hostname:123", AddressFamily.Unspecified)
+            {
+                SendFailureIn = 3, // Will cause failure on 3rd send
+            };
+
+            sender.Initialize();
+
+            var buffer = Encoding.UTF8.GetBytes("quick brown fox jumps over the lazy dog");
+            var writeFinished = new ManualResetEvent(false);
+            var exceptions = new Exception[9];
+            var remaining = exceptions.Length;
+
+            for (var i = 1; i < 10; i++)
+            {
+                var pos = i - 1;
+
+                sender.Send(
+                    buffer, 0, i, ex =>
+                    {
+                        lock (exceptions)
+                        {
+                            exceptions[pos] = ex;
+                            if (--remaining == 0)
+                                writeFinished.Set();
+                        }
+                    });
+            }
+
+            writeFinished.WaitOne();
+
+            var actual = sender.Log.ToString();
+            Assert.True(actual.IndexOf("Create socket Unspecified Stream Tcp") != -1);
+            Assert.True(actual.IndexOf("Parse endpoint address tcp+thread://hostname:123/ Unspecified") != -1);
+            Assert.True(actual.IndexOf("Connect async to {mock end point: tcp+thread://hostname:123/}") != -1);
+            Assert.True(actual.IndexOf("Conection ended") != -1);
+            Assert.True(actual.IndexOf("Send sync 0 1 'q'") != -1);
+            Assert.True(actual.IndexOf("Send sync 0 2 'qu'") != -1);
+            Assert.True(actual.IndexOf("Send sync 0 3 'qui'") != -1);
+            Assert.True(actual.IndexOf("Failed") != -1);
+
+            for (var i = 0; i < exceptions.Length; ++i)
+            {
+                if (i < 2)
+                    Assert.Null(exceptions[i]);
+                else
+                    Assert.NotNull(exceptions[i]);
+            }
+        }
+
+        internal sealed class MockSocket : ISocket
+        {
+            #region Fields & Properties
+
+            private readonly MyTcpThreadNetworkSender _sender;
+            private readonly StringWriter _log;
+            private bool _connected;
+            private bool _faulted;
+
+            public bool Connected => _connected;
+
+            #endregion
+
+            #region .ctors
+
+            public MockSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, MyTcpThreadNetworkSender sender)
+            {
+                _sender = sender;
+                _connected = true;
+                _log = sender.Log;
+                _log.WriteLine("Create socket {0} {1} {2}", addressFamily, socketType, protocolType);
+            }
+
+            #endregion
+
+            public bool ConnectAsync(SocketAsyncEventArgs args)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Close()
+            {
+                lock (this)
+                    _log.WriteLine("Close");
+            }
+
+            public bool SendAsync(SocketAsyncEventArgs args)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool SendToAsync(SocketAsyncEventArgs args)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IAsyncResult BeginConnect(EndPoint remoteEP, AsyncCallback callback, object state)
+            {
+                _log.WriteLine("Connect async to {0}", remoteEP);
+
+                lock (this)
+                {
+                    if (_sender.ConnectFailure > 0)
+                    {
+                        _sender.ConnectFailure--;
+                        _connected = false;
+                        _faulted = true;
+                        _log.WriteLine("Failed");
+                    }
+                }
+
+                if (!_connected)
+                    throw new SocketException((int)SocketError.NotConnected);
+
+                var asyncResult = Substitute.For<IAsyncResult>();
+                asyncResult.AsyncWaitHandle.Returns(new ManualResetEvent(true));
+                asyncResult.CompletedSynchronously.Returns(true);
+                asyncResult.IsCompleted.Returns(false);
+                asyncResult.AsyncState.Returns(state);
+
+                return asyncResult;
+            }
+
+            public void EndConnect(IAsyncResult asyncResult)
+            {
+                lock (this)
+                    _log.WriteLine("Conection ended");
+            }
+
+            public int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags)
+            {
+                lock (this)
+                {
+                    _log.WriteLine("Send sync {0} {1} '{2}'", offset, size, Encoding.UTF8.GetString(buffer, offset, size));
+
+                    if (_sender.SendFailureIn > 0)
+                    {
+                        _sender.SendFailureIn--;
+
+                        if (_sender.SendFailureIn == 0)
+                        {
+                            _connected = false;
+                            _faulted = true;
+                        }
+                    }
+
+                    if (_faulted)
+                        _log.WriteLine("Failed");
+
+                    if (!_connected)
+                        throw new SocketException((int)SocketError.NotConnected);
+                }
+
+                return size;
+            }
+
+            public void Dispose()
+            {
+                // Do nothing..
+            }
+        }
+
+        internal class MockEndPoint : EndPoint
+        {
+            #region Fields
+
+            private readonly Uri _uri;
+
+            #endregion
+
+            #region .ctors
+
+            public MockEndPoint(Uri uri)
+            {
+                _uri = uri;
+            }
+
+            #endregion
+
+            public override AddressFamily AddressFamily => (AddressFamily)10000;
+
+            public override string ToString() => $"{{mock end point: {_uri}}}";
+        }
+
+        internal class MyTcpThreadNetworkSender : TcpThreadNetworkSender
+        {
+            #region Properties
+
+            public int SendFailureIn { get; set; }
+            public int ConnectFailure { get; set; }
+            public StringWriter Log { get; set; }
+
+            #endregion
+
+            #region .ctors
+
+            public MyTcpThreadNetworkSender(string url, AddressFamily addressFamily)
+                : base(url, addressFamily)
+            {
+                MaxQueueSize = 100;
+                Log = new StringWriter();
+                ConnectionTimeout = TimeSpan.FromSeconds(1);
+            }
+
+            #endregion
+
+            protected internal override ISocket CreateSocket(string host, AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
+            {
+                return new MockSocket(addressFamily, socketType, protocolType, this);
+            }
+
+            protected override EndPoint ParseEndpointAddress(Uri uri, AddressFamily addressFamily)
+            {
+                Log.WriteLine("Parse endpoint address {0} {1}", uri, addressFamily);
+                return new MockEndPoint(uri);
+            }
+        }
+    }
+}
+#endif

--- a/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
@@ -951,7 +951,7 @@ namespace NLog.UnitTests.Targets
             internal StringWriter Log = new StringWriter();
             private int idCounter;
 
-            public NetworkSender Create(string url, int maxQueueSize, SslProtocols sslProtocols, TimeSpan keepAliveTime)
+            public NetworkSender Create(string url, int maxQueueSize, SslProtocols sslProtocols, TimeSpan keepAliveTime, TimeSpan connectionTimeout)
             {
                 var sender = new MyNetworkSender(url, ++idCounter, Log, this);
                 Senders.Add(sender);


### PR DESCRIPTION
Hi, I'm creating this pull request to add a new TCP network sender with the following reasons:

In our enviroment, with an average of <100k logs per minute; when using a network target with a tcp sender, we've found memory usage to go crazy.

The new proposed sender is based on a  dedicated thread making the actual network calls, as to avoid async callbacks which under high volume impose additional overhead/delays.

However, we understand this implementation might apply only to scenarios with high (network) logging volumes, and thus we thought it better to provide it as alternative to the actual TcpNetworkSender, by using a new uri prefix (tcp+thread://).

Thorough testing has been done against this implementation, trying different cases like, timeouts, disconnections in the middle of a run, in order to test sender recovery, etc.

Regarding performance, we can appreciate that (with high network output):
- The difference in memory is quite significant, with the original sender consuming a total of 2GB compared to this implementation, which consumed about 40MB in a stable way. 
- With our implementation, the total logs generated in one minute have been sent out without problems, but with the original sender only 1/3 of the generated logs have arrived (giving exception in the flush as they are still queued in the sender and cannot be dequeued in less than 15secs).

_These benchmarks have taken into consideration the tuning recommendations to be applied in the configuration file._ 

-------

### Attached are some images explaining what I am talking about.

### The image below is of the original sender in the course of one minute, where after having generated a total of **1.9M logs**, the **ncat has only received 440k lines and the flush cannot complete**.
![image](https://user-images.githubusercontent.com/49149147/131497963-cc0553bb-fd18-472b-8372-dba4a9b9e961.png)

### This bench was with our thread sender; **all the generated logs (1.8M) were received in ncat (no loss) and memory usage is constant** 
![image](https://user-images.githubusercontent.com/49149147/131498894-0e6f6660-8ef4-43af-9348-b9405501378d.png)

-------

## In conclusion
**In this scenario our implementation seems to fit well and we believe that both implementations should coexist.**

Also we provide unit tests for this new TcpSender which replicate the ones found for existing ones.

Any question or missing information.. feel free to ask.
Thanks for your time!