### PR TITLE
NetworkTarget - Added OnQueueOverflow with default Discard

### DIFF
--- a/src/NLog/Internal/NetworkSenders/NetworkSenderFactory.cs
+++ b/src/NLog/Internal/NetworkSenders/NetworkSenderFactory.cs
@@ -35,6 +35,7 @@ namespace NLog.Internal.NetworkSenders
 {
     using System;
     using System.Net.Sockets;
+    using NLog.Targets;
 
     /// <summary>
     /// Default implementation of <see cref="INetworkSenderFactory"/>.
@@ -44,13 +45,14 @@ namespace NLog.Internal.NetworkSenders
         public static readonly INetworkSenderFactory Default = new NetworkSenderFactory();
 
         /// <inheritdoc />
-        public NetworkSender Create(string url, int maxQueueSize, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime)
+        public NetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime)
         {
             if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
             {
                 return new HttpNetworkSender(url)
                 {
                     MaxQueueSize = maxQueueSize,
+                    OnQueueOverflow = onQueueOverflow,
                 };
             }
 
@@ -59,6 +61,7 @@ namespace NLog.Internal.NetworkSenders
                 return new HttpNetworkSender(url)
                 {
                     MaxQueueSize = maxQueueSize,
+                    OnQueueOverflow = onQueueOverflow,
                 };
             }
 
@@ -67,6 +70,7 @@ namespace NLog.Internal.NetworkSenders
                 return new TcpNetworkSender(url, AddressFamily.Unspecified)
                 {
                     MaxQueueSize = maxQueueSize,
+                    OnQueueOverflow = onQueueOverflow,
                     SslProtocols = sslProtocols,
                     KeepAliveTime = keepAliveTime,
                 };
@@ -77,6 +81,7 @@ namespace NLog.Internal.NetworkSenders
                 return new TcpNetworkSender(url, AddressFamily.InterNetwork)
                 {
                     MaxQueueSize = maxQueueSize,
+                    OnQueueOverflow = onQueueOverflow,
                     SslProtocols = sslProtocols,
                     KeepAliveTime = keepAliveTime,
                 };
@@ -87,6 +92,7 @@ namespace NLog.Internal.NetworkSenders
                 return new TcpNetworkSender(url, AddressFamily.InterNetworkV6)
                 {
                     MaxQueueSize = maxQueueSize,
+                    OnQueueOverflow = onQueueOverflow,
                     SslProtocols = sslProtocols,
                     KeepAliveTime = keepAliveTime,
                 };
@@ -97,6 +103,7 @@ namespace NLog.Internal.NetworkSenders
                 return new UdpNetworkSender(url, AddressFamily.Unspecified)
                 {
                     MaxQueueSize = maxQueueSize,
+                    OnQueueOverflow = onQueueOverflow,
                     MaxMessageSize = maxMessageSize,
                 };
             }
@@ -106,6 +113,7 @@ namespace NLog.Internal.NetworkSenders
                 return new UdpNetworkSender(url, AddressFamily.InterNetwork)
                 {
                     MaxQueueSize = maxQueueSize,
+                    OnQueueOverflow = onQueueOverflow,
                     MaxMessageSize = maxMessageSize,
                 };
             }
@@ -115,9 +123,11 @@ namespace NLog.Internal.NetworkSenders
                 return new UdpNetworkSender(url, AddressFamily.InterNetworkV6)
                 {
                     MaxQueueSize = maxQueueSize,
+                    OnQueueOverflow = onQueueOverflow,
                     MaxMessageSize = maxMessageSize,
                 };
             }
+
             throw new ArgumentException("Unrecognized network address", nameof(url));
         }
     }

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -77,8 +77,6 @@ namespace NLog.Targets
         /// </remarks>
         public NLogViewerTarget()
         {
-            OnConnectionOverflow = NetworkTargetConnectionsOverflowAction.Block;
-            MaxConnections = 16;
             NewLine = false;
             IncludeNLogData = true;
         }

--- a/src/NLog/Targets/NetworkTargetQueueOverflowAction.cs
+++ b/src/NLog/Targets/NetworkTargetQueueOverflowAction.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,28 +31,26 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.Internal.NetworkSenders
+namespace NLog.Targets
 {
-    using System;
-    using NLog.Targets;
-
     /// <summary>
-    /// Creates instances of <see cref="NetworkSender"/> objects for given URLs.
+    /// The action to be taken when the queue overflows.
     /// </summary>
-    internal interface INetworkSenderFactory
+    public enum NetworkTargetQueueOverflowAction
     {
         /// <summary>
-        /// Creates a new instance of the network sender based on a network URL.
+        /// Grow the queue.
         /// </summary>
-        /// <param name="url">URL that determines the network sender to be created.</param>
-        /// <param name="maxQueueSize">The maximum queue size.</param>
-        /// <param name="onQueueOverflow">The overflow action when reaching maximum queue size.</param>
-        /// <param name="maxMessageSize">The maximum message size.</param>
-        /// <param name="sslProtocols">SSL protocols for TCP</param>
-        /// <param name="keepAliveTime">KeepAliveTime for TCP</param>
-        /// <returns>
-        /// A newly created network sender.
-        /// </returns>
-        NetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime);
+        Grow,
+
+        /// <summary>
+        /// Discard the overflowing item.
+        /// </summary>
+        Discard,
+
+        /// <summary>
+        /// Block until there's more room in the queue.
+        /// </summary>
+        Block,
     }
 }

--- a/tests/NLog.UnitTests/Internal/NetworkSenders/HttpNetworkSenderTests.cs
+++ b/tests/NLog.UnitTests/Internal/NetworkSenders/HttpNetworkSenderTests.cs
@@ -56,6 +56,8 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             {
                 Address = "http://test.with.mock",
                 Layout = "${logger}|${message}|${exception}",
+                MaxQueueSize = 1234,
+                OnQueueOverflow = NetworkTargetQueueOverflowAction.Block,
                 MaxMessageSize = 0,
             };
 
@@ -83,7 +85,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             Assert.Equal("HttpHappyPathTestLogger|test message1|", requestedString);
             Assert.Equal("POST", mock.Method);
 
-            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 0, 0, SslProtocols.None, new TimeSpan());
+            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 1234, NetworkTargetQueueOverflowAction.Block, 0, SslProtocols.None, new TimeSpan());
 
             // Cleanup
             mock.Dispose();
@@ -97,6 +99,8 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             {
                 Address = "http://test.with.mock",
                 Layout = "${logger}|${message}|${exception}",
+                MaxQueueSize = 1234,
+                OnQueueOverflow = NetworkTargetQueueOverflowAction.Block,
                 MaxMessageSize = 0,
             };
 
@@ -126,7 +130,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             Assert.Equal("HttpHappyPathTestLogger|test message2|", requestedString);
             Assert.Equal("POST", mock.Method);
 
-            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 0, 0, SslProtocols.None, new TimeSpan()); // Only created one HttpNetworkSender
+            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 1234, NetworkTargetQueueOverflowAction.Block, 0, SslProtocols.None, new TimeSpan()); // Only created one HttpNetworkSender
 
             // Cleanup
             mock.Dispose();
@@ -137,7 +141,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
         {
             var networkSenderFactoryMock = Substitute.For<INetworkSenderFactory>();
 
-            networkSenderFactoryMock.Create(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<SslProtocols>(), Arg.Any<TimeSpan>())
+            networkSenderFactoryMock.Create(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<NetworkTargetQueueOverflowAction>(), Arg.Any<int>(), Arg.Any<SslProtocols>(), Arg.Any<TimeSpan>())
                 .Returns(url => new HttpNetworkSender(url.Arg<string>())
                 {
                     HttpRequestFactory = new WebRequestFactoryMock(webRequestMock)

--- a/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
@@ -141,8 +141,8 @@ namespace NLog.UnitTests.Targets
             Assert.Equal("\r\n", target.LineEnding.NewLineCharacters);
             Assert.Equal(65000, target.MaxMessageSize);
             Assert.Equal(5, target.ConnectionCacheSize);
-            Assert.Equal(0, target.MaxConnections);
-            Assert.Equal(0, target.MaxQueueSize);
+            Assert.Equal(100, target.MaxConnections);
+            Assert.Equal(10000, target.MaxQueueSize);
             Assert.Equal(Encoding.UTF8, target.Encoding);
         }
 
@@ -977,7 +977,7 @@ namespace NLog.UnitTests.Targets
             internal StringWriter Log = new StringWriter();
             private int idCounter;
 
-            public NetworkSender Create(string url, int maxQueueSize, int maxMessageSize, SslProtocols sslProtocols, TimeSpan keepAliveTime)
+            public NetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, SslProtocols sslProtocols, TimeSpan keepAliveTime)
             {
                 var sender = new MyNetworkSender(url, ++idCounter, Log, this);
                 Senders.Add(sender);
@@ -1107,7 +1107,7 @@ namespace NLog.UnitTests.Targets
             internal StringWriter Log = new StringWriter();
             private int idCounter;
 
-            public NetworkSender Create(string url, int maxQueueSize, int maxMessageSize, SslProtocols sslProtocols, TimeSpan keepAliveTime)
+            public NetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, SslProtocols sslProtocols, TimeSpan keepAliveTime)
             {
                 var sender = new MyQueudNetworkSender(url, ++idCounter, Log, this);
                 Senders.Add(sender);


### PR DESCRIPTION
Avoid memory exhaustion by filling up the _pendingRequests-queue. `MaxQueueSize` is default 10000 and `OnQueueOverflow` is default discard. Have also changed `MaxConnections` default value 100 and `OnConnectionOverflow` = Discard. 

Fixed bug on NetCore that could cause StackOverflow, because SendAsync has been optimized to finish synchronous, thus starting recursive-loop when processing next request.

Improve thread-concurrency around _pendingRequests-queue, by not holding queue-lock while executing network-operation.

Optimized object-reuse of SocketAsyncEventArgs for the next socket-operation, because it is an expensive operating-system ressource.

Avoid blocking the logger-thread, incase the socket-operation completes synchronous. This also improves overall performance as logger-thread is not blocked by socket-operation and can produce the next LogEvent.