### PR TITLE
NetworkTarget - Fixed deadlock on shutdown when networksenders fails

### DIFF
--- a/src/NLog/Internal/NetworkSenders/HttpNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/HttpNetworkSender.cs
@@ -76,7 +76,7 @@ namespace NLog.Internal.NetworkSenders
                         }
 
                         // completed fine
-                        base.EndRequest(asyncContinuation, null);
+                        CompleteRequest(asyncContinuation);
                     }
                     catch (Exception ex)
                     {
@@ -85,7 +85,7 @@ namespace NLog.Internal.NetworkSenders
                             throw; // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                         }
 
-                        base.EndRequest(_ => asyncContinuation(ex), null);    // pendingException = null to keep sender alive
+                        CompleteRequest(_ => asyncContinuation(ex));
                     }
                 };
 
@@ -108,11 +108,20 @@ namespace NLog.Internal.NetworkSenders
                             throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                         }
 
-                        base.EndRequest(_ => asyncContinuation(ex), null);    // pendingException = null to keep sender alive
+                        CompleteRequest(_ => asyncContinuation(ex));
                     }
                 };
 
             webRequest.BeginGetRequestStream(onRequestStream, null);
+        }
+
+        private void CompleteRequest(Common.AsyncContinuation asyncContinuation)
+        {
+            var nextRequest = base.EndRequest(asyncContinuation, null);    // pendingException = null to keep sender alive
+            if (nextRequest.HasValue)
+            {
+                BeginRequest(nextRequest.Value);
+            }
         }
     }
 }

--- a/src/NLog/Internal/NetworkSenders/TcpNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/TcpNetworkSender.cs
@@ -240,7 +240,11 @@ namespace NLog.Internal.NetworkSenders
             args.Completed -= _socketOperationCompleted;    // Maybe consider reusing for next request?
             args.Dispose();
 
-            base.EndRequest(asyncContinuation, pendingException);
+            var nextRequest = base.EndRequest(asyncContinuation, pendingException);
+            if (nextRequest.HasValue)
+            {
+                BeginRequest(nextRequest.Value);
+            }
         }
 
         protected override void BeginRequest(NetworkRequestArgs eventArgs)

--- a/tests/NLog.UnitTests/Internal/NetworkSenders/TcpNetworkSenderTests.cs
+++ b/tests/NLog.UnitTests/Internal/NetworkSenders/TcpNetworkSenderTests.cs
@@ -81,7 +81,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
                         mre.Set();
                     });
 
-                mre.WaitOne();
+                Assert.True(mre.WaitOne(10000), "Network Flush not completed");
 
                 var actual = sender.Log.ToString();
                 Assert.True(actual.IndexOf("Parse endpoint address tcp://hostname:123/ Unspecified") != -1);
@@ -111,7 +111,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
                         mre.Set();
                     });
 
-                mre.WaitOne();
+                Assert.True(mre.WaitOne(10000), "Network Close not completed");
 
                 actual = sender.Log.ToString();
                 
@@ -172,11 +172,12 @@ namespace NLog.UnitTests.Internal.NetworkSenders
                     });
             }
 
-            Assert.True(allSent.WaitOne(3000, false));
+
+            Assert.True(allSent.WaitOne(10000), "Network Write not completed");
 
             var mre = new ManualResetEvent(false);
             sender.FlushAsync(ex => mre.Set());
-            mre.WaitOne(3000, false);
+            Assert.True(mre.WaitOne(10000), "Network Flush not completed");
 
             var actual = sender.Log.ToString();
 
@@ -227,9 +228,9 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             }
 
             var mre = new ManualResetEvent(false);
-            writeFinished.WaitOne();
+            Assert.True(writeFinished.WaitOne(10000), "Network Write not completed");
             sender.Close(ex => mre.Set());
-            mre.WaitOne();
+            Assert.True(mre.WaitOne(10000), "Network Flush not completed");
 
             var actual = sender.Log.ToString();
             Assert.True(actual.IndexOf("Parse endpoint address tcp://hostname:123/ Unspecified") != -1);


### PR DESCRIPTION
When NetworkTarget flushes/closes on shutdown then the lock-order is this:
- lock (_currentSenderCache)
  -  lock (_openNetworkSenders)
     - lock (_pendingRequests)

When TcpNetworkSender closes after failure, then the lock-order is this:
- lock (_pendingRequests)
   - lock (_currentSenderCache)
     - lock (_openNetworkSenders)

To avoid deadlocks, then one must always use same lock-order. Changed QueuedNetworkSender to not hold `lock (_pendingRequests)` when making callback to notify about failure. Again it is super important to be in a "safe" place when deciding to execute `AsyncContinuation`.

The deadlock-issue was revealed by the existing unit-test `NetworkTargetNotConnectedTest` that sometimes got stuck forever. I have now implemented a more aggressive unit-test that is able to trigger the deadlock every second time without the bug-fix. 

Have now also changed several `WaitOne()` without timeout, so they now will timeout after 10 secs. Maybe they have been causing trouble for the build-server-timeouts (together with the deadlock being fixed with this pull-request).