### PR TITLE
NetworkTarget - UdpNetworkSender changed to QueuedNetworkSender

### DIFF
--- a/src/NLog/Internal/NetworkSenders/INetworkSenderFactory.cs
+++ b/src/NLog/Internal/NetworkSenders/INetworkSenderFactory.cs
@@ -45,11 +45,12 @@ namespace NLog.Internal.NetworkSenders
         /// </summary>
         /// <param name="url">URL that determines the network sender to be created.</param>
         /// <param name="maxQueueSize">The maximum queue size.</param>
+        /// <param name="maxMessageSize">The maximum message size.</param>
         /// <param name="sslProtocols">SSL protocols for TCP</param>
         /// <param name="keepAliveTime">KeepAliveTime for TCP</param>
         /// <returns>
         /// A newly created network sender.
         /// </returns>
-        NetworkSender Create(string url, int maxQueueSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime);
+        NetworkSender Create(string url, int maxQueueSize, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime);
     }
 }

--- a/src/NLog/Internal/NetworkSenders/NetworkSenderFactory.cs
+++ b/src/NLog/Internal/NetworkSenders/NetworkSenderFactory.cs
@@ -44,7 +44,7 @@ namespace NLog.Internal.NetworkSenders
         public static readonly INetworkSenderFactory Default = new NetworkSenderFactory();
 
         /// <inheritdoc />
-        public NetworkSender Create(string url, int maxQueueSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime)
+        public NetworkSender Create(string url, int maxQueueSize, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime)
         {
             if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
             {
@@ -94,17 +94,29 @@ namespace NLog.Internal.NetworkSenders
 
             if (url.StartsWith("udp://", StringComparison.OrdinalIgnoreCase))
             {
-                return new UdpNetworkSender(url, AddressFamily.Unspecified);
+                return new UdpNetworkSender(url, AddressFamily.Unspecified)
+                {
+                    MaxQueueSize = maxQueueSize,
+                    MaxMessageSize = maxMessageSize,
+                };
             }
 
             if (url.StartsWith("udp4://", StringComparison.OrdinalIgnoreCase))
             {
-                return new UdpNetworkSender(url, AddressFamily.InterNetwork);
+                return new UdpNetworkSender(url, AddressFamily.InterNetwork)
+                {
+                    MaxQueueSize = maxQueueSize,
+                    MaxMessageSize = maxMessageSize,
+                };
             }
 
             if (url.StartsWith("udp6://", StringComparison.OrdinalIgnoreCase))
             {
-                return new UdpNetworkSender(url, AddressFamily.InterNetworkV6);
+                return new UdpNetworkSender(url, AddressFamily.InterNetworkV6)
+                {
+                    MaxQueueSize = maxQueueSize,
+                    MaxMessageSize = maxMessageSize,
+                };
             }
             throw new ArgumentException("Unrecognized network address", nameof(url));
         }

--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -159,7 +159,7 @@ namespace NLog.Targets
         public LineEndingMode LineEnding { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum message size in bytes.
+        /// Gets or sets the maximum message size in bytes. The action <see cref="OnOverflow"/> will be activated.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
         [DefaultValue(65000)]
@@ -192,9 +192,16 @@ namespace NLog.Targets
         public int MaxQueueSize { get; set; }
 
         /// <summary>
-        /// Gets or sets the action that should be taken if the message is larger than
-        /// maxMessageSize.
+        /// Gets or sets the action that should be taken if the message is larger than <see cref="MaxMessageSize" />
         /// </summary>
+        /// <remarks>
+        /// For TCP sockets then <see cref="NetworkTargetOverflowAction.Split"/> means no-limit, as TCP sockets
+        /// performs splitting automatically.
+        /// 
+        /// For UDP Network sender then <see cref="NetworkTargetOverflowAction.Split"/> means splitting the message
+        /// into smaller chunks. This can be useful on networks using DontFragment, which drops network packages
+        /// larger than MTU-size (1472 bytes).
+        /// </remarks>
         /// <docgen category='Connection Options' order='10' />
         [DefaultValue(NetworkTargetOverflowAction.Split)]
         public NetworkTargetOverflowAction OnOverflow { get; set; }
@@ -310,7 +317,7 @@ namespace NLog.Targets
                 throw;
             }
 
-            ChunkedSend(
+            WriteBytesToNetworkSender(
                 senderNode.Value,
                 bytes,
                 ex =>
@@ -373,7 +380,8 @@ namespace NLog.Targets
 
                 linkedListNode = _openNetworkSenders.AddLast(sender);
             }
-            ChunkedSend(
+
+            WriteBytesToNetworkSender(
                 sender,
                 bytes,
                 ex =>
@@ -511,9 +519,8 @@ namespace NLog.Targets
 
         private NetworkSender CreateNetworkSender(string address)
         {
-            var sender = SenderFactory.Create(address, MaxQueueSize, SslProtocols, TimeSpan.FromSeconds(KeepAliveTimeSeconds));
+            var sender = SenderFactory.Create(address, MaxQueueSize, MaxMessageSize, SslProtocols, TimeSpan.FromSeconds(KeepAliveTimeSeconds));
             sender.Initialize();
-
             return sender;
         }
 
@@ -540,68 +547,33 @@ namespace NLog.Targets
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", Justification = "Using property names in message.")]
-        private void ChunkedSend(NetworkSender sender, byte[] buffer, AsyncContinuation continuation)
+        private void WriteBytesToNetworkSender(NetworkSender sender, byte[] buffer, AsyncContinuation continuation)
         {
             int tosend = buffer.Length;
-            if (tosend <= MaxMessageSize)
+            if (tosend > MaxMessageSize)
             {
-                // Chunking is not needed, no need to perform delegate capture
-                InternalLogger.Trace("{0}: Sending chunk, position: {1}, length: {2}", this, 0, tosend);
-                if (tosend <= 0)
+                if (OnOverflow == NetworkTargetOverflowAction.Discard)
                 {
+                    InternalLogger.Trace("{0}: Discard because chunksize > this.MaxMessageSize", this);
                     continuation(null);
                     return;
                 }
 
-                sender.Send(buffer, 0, tosend, continuation);
-            }
-            else
-            {
-                int pos = 0;
-
-                void SendNextChunk(Exception ex)
+                if (OnOverflow == NetworkTargetOverflowAction.Error)
                 {
-                    if (ex != null)
-                    {
-                        continuation(ex);
-                        return;
-                    }
-
-                    InternalLogger.Trace("{0}: Sending chunk, position: {1}, length: {2}", this, pos, tosend);
-                    if (tosend <= 0)
-                    {
-                        continuation(null);
-                        return;
-                    }
-
-                    int chunksize = tosend;
-                    if (chunksize > MaxMessageSize)
-                    {
-                        if (OnOverflow == NetworkTargetOverflowAction.Discard)
-                        {
-                            InternalLogger.Trace("{0}: Discard because chunksize > this.MaxMessageSize", this);
-                            continuation(null);
-                            return;
-                        }
-
-                        if (OnOverflow == NetworkTargetOverflowAction.Error)
-                        {
-                            continuation(new OverflowException($"Attempted to send a message larger than MaxMessageSize ({MaxMessageSize}). Actual size was: {buffer.Length}. Adjust OnOverflow and MaxMessageSize parameters accordingly."));
-                            return;
-                        }
-
-                        chunksize = MaxMessageSize;
-                    }
-
-                    int pos0 = pos;
-                    tosend -= chunksize;
-                    pos += chunksize;
-
-                    sender.Send(buffer, pos0, chunksize, SendNextChunk);
+                    continuation(new OverflowException($"Attempted to send a message larger than MaxMessageSize ({MaxMessageSize}). Actual size was: {buffer.Length}. Adjust OnOverflow and MaxMessageSize parameters accordingly."));
+                    return;
                 }
-
-                SendNextChunk(null);
             }
+
+            InternalLogger.Trace("{0}: Sending chunk, position: {1}, length: {2}", this, 0, tosend);
+            if (tosend <= 0)
+            {
+                continuation(null);
+                return;
+            }
+
+            sender.Send(buffer, 0, tosend, continuation);
         }
     }
 }

--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -159,7 +159,7 @@ namespace NLog.Targets
         public LineEndingMode LineEnding { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum message size in bytes. The action <see cref="OnOverflow"/> will be activated.
+        /// Gets or sets the maximum message size in bytes. On limit breach then <see cref="OnOverflow"/> action is activated.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
         [DefaultValue(65000)]

--- a/src/NLog/Targets/NetworkTargetOverflowAction.cs
+++ b/src/NLog/Targets/NetworkTargetOverflowAction.cs
@@ -44,8 +44,12 @@ namespace NLog.Targets
         Error,
 
         /// <summary>
-        /// Split the message into smaller pieces.
+        /// Split the message into smaller pieces. Only relevant for UDP sockets, as TCP sockets does it automatically.
         /// </summary>
+        /// <remarks>
+        /// Udp-Network-Sender will split the message into smaller chunks that matches <see cref="NetworkTarget.MaxMessageSize"/>.
+        /// This can avoid network-package-drop when network uses DontFragment and message is larger than MTU-size (1472 bytes).
+        /// </remarks>
         Split,
 
         /// <summary>

--- a/tests/NLog.UnitTests/Internal/NetworkSenders/HttpNetworkSenderTests.cs
+++ b/tests/NLog.UnitTests/Internal/NetworkSenders/HttpNetworkSenderTests.cs
@@ -55,7 +55,8 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             var networkTarget = new NetworkTarget("target1")
             {
                 Address = "http://test.with.mock",
-                Layout = "${logger}|${message}|${exception}"
+                Layout = "${logger}|${message}|${exception}",
+                MaxMessageSize = 0,
             };
 
             var webRequestMock = new WebRequestMock();
@@ -82,7 +83,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             Assert.Equal("HttpHappyPathTestLogger|test message1|", requestedString);
             Assert.Equal("POST", mock.Method);
 
-            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 0, SslProtocols.None, new TimeSpan());
+            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 0, 0, SslProtocols.None, new TimeSpan());
 
             // Cleanup
             mock.Dispose();
@@ -95,7 +96,8 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             var networkTarget = new NetworkTarget("target1")
             {
                 Address = "http://test.with.mock",
-                Layout = "${logger}|${message}|${exception}"
+                Layout = "${logger}|${message}|${exception}",
+                MaxMessageSize = 0,
             };
 
             var webRequestMock = new WebRequestMock();
@@ -124,7 +126,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             Assert.Equal("HttpHappyPathTestLogger|test message2|", requestedString);
             Assert.Equal("POST", mock.Method);
 
-            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 0, SslProtocols.None, new TimeSpan()); // Only created one HttpNetworkSender
+            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 0, 0, SslProtocols.None, new TimeSpan()); // Only created one HttpNetworkSender
 
             // Cleanup
             mock.Dispose();
@@ -135,7 +137,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
         {
             var networkSenderFactoryMock = Substitute.For<INetworkSenderFactory>();
 
-            networkSenderFactoryMock.Create(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<SslProtocols>(), Arg.Any<TimeSpan>())
+            networkSenderFactoryMock.Create(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<SslProtocols>(), Arg.Any<TimeSpan>())
                 .Returns(url => new HttpNetworkSender(url.Arg<string>())
                 {
                     HttpRequestFactory = new WebRequestFactoryMock(webRequestMock)


### PR DESCRIPTION
Now performs "ordered" message split, so UDP network-packets will be sent in the order they have been logged (even when split into chunks). It will have the side-effect that if an UDP-socket fails, then all pending messages in queue will be marked as failed.

For TCP-network-senders then it removes the memory-allocation of the message-chunking-delegate (TCP network senders does not need help with splitting large messages).