### PR TITLE
Fixed validation of nlog-element when nested within configuration-element

### DIFF
--- a/src/NLog/Config/NLogXmlElement.cs
+++ b/src/NLog/Config/NLogXmlElement.cs
@@ -157,9 +157,9 @@ namespace NLog.Config
             throw new InvalidOperationException("Assertion failed. Expected element name '" + string.Join("|", allowedNames) + "', actual: '" + LocalName + "'.");
         }
 
-        private void Parse(XmlReader reader, bool topElement, out IList<KeyValuePair<string,string>> attributes, out IList<NLogXmlElement> children)
+        private void Parse(XmlReader reader, bool nestedElement, out IList<KeyValuePair<string,string>> attributes, out IList<NLogXmlElement> children)
         {
-            ParseAttributes(reader, topElement, out attributes);
+            ParseAttributes(reader, nestedElement, out attributes);
 
             LocalName = reader.LocalName;
 
@@ -179,11 +179,12 @@ namespace NLog.Config
                         Value += reader.Value;
                         continue;
                     }
-
+                    
                     if (reader.NodeType == XmlNodeType.Element)
                     {
                         children = children ?? new List<NLogXmlElement>();
-                        children.Add(new NLogXmlElement(reader, true));
+                        var nestedChild = nestedElement || !string.Equals(reader.LocalName, "nlog", StringComparison.OrdinalIgnoreCase);
+                        children.Add(new NLogXmlElement(reader, nestedChild));
                     }
                 }
             }

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -246,17 +246,21 @@ namespace NLog.UnitTests.Config
         }
 
         [Theory]
-        [InlineData("xsi")]
-        [InlineData("test")]
-        public void XmlConfig_attributes_shouldNotLogWarningsToInternalLog(string @namespace)
+        [InlineData("xsi", false)]
+        [InlineData("test", false)]
+        [InlineData("xsi", true)]
+        [InlineData("test", true)]
+        public void XmlConfig_attributes_shouldNotLogWarningsToInternalLog(string @namespace, bool nestedConfig)
         {
             // Arrange
             var xml = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+{(nestedConfig ? "<configuration>" : "")}
 <nlog xmlns=""http://www.nlog-project.org/schemas/NLog.xsd"" 
       xmlns:{@namespace}=""http://www.w3.org/2001/XMLSchema-instance"" 
       {@namespace}:schemaLocation=""somewhere"" 
       internalLogToConsole=""true"" internalLogLevel=""Warn"">
-</nlog>";
+</nlog>
+{(nestedConfig ? "</configuration>" : "")}";
 
             try
             {


### PR DESCRIPTION
Found another bug in unknown-element-validation (Again exotic scenario)