### PR TITLE
NetworkTarget - Explicit assigning LineEnding activates NewLine automatically

### DIFF
--- a/src/NLog/Internal/NetworkSenders/SslSocketProxy.cs
+++ b/src/NLog/Internal/NetworkSenders/SslSocketProxy.cs
@@ -31,9 +31,10 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+
 namespace NLog.Internal.NetworkSenders
 {
-#if !NETSTANDARD1_3 && !NETSTANDARD1_5
     using System;
     using System.Net.Security;
     using System.Net.Sockets;
@@ -198,5 +199,6 @@ namespace NLog.Internal.NetworkSenders
                 _socketProxy.Dispose();
         }
     }
-#endif
 }
+
+#endif

--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -98,7 +98,6 @@ namespace NLog.Targets
         {
             SenderFactory = NetworkSenderFactory.Default;
             Encoding = Encoding.UTF8;
-            LineEnding = LineEndingMode.CRLF;
         }
 
         /// <summary>
@@ -152,7 +151,16 @@ namespace NLog.Targets
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
         [DefaultValue("CRLF")]
-        public LineEndingMode LineEnding { get; set; }
+        public LineEndingMode LineEnding
+        {
+            get => _lineEnding;
+            set 
+            {
+                _lineEnding = value;
+                NewLine = value != null;
+            }
+        }
+        private LineEndingMode _lineEnding = LineEndingMode.CRLF;
 
         /// <summary>
         /// Gets or sets the maximum message size in bytes. On limit breach then <see cref="OnOverflow"/> action is activated.

--- a/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
@@ -53,29 +53,28 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void HappyPathDefaultsTest()
         {
-            HappyPathTest(false, LineEndingMode.CRLF, "msg1", "msg2", "msg3");
+            HappyPathTest(null, "msg1", "msg2", "msg3");
         }
 
         [Fact]
         public void HappyPathCRLFTest()
         {
-            HappyPathTest(true, LineEndingMode.CRLF, "msg1", "msg2", "msg3");
+            HappyPathTest(LineEndingMode.CRLF, "msg1", "msg2", "msg3");
         }
 
         [Fact]
         public void HappyPathLFTest()
         {
-            HappyPathTest(true, LineEndingMode.LF, "msg1", "msg2", "msg3");
+            HappyPathTest(LineEndingMode.LF, "msg1", "msg2", "msg3");
         }
 
-        private void HappyPathTest(bool newLine, LineEndingMode lineEnding, params string[] messages)
+        private void HappyPathTest(LineEndingMode lineEnding, params string[] messages)
         {
             var senderFactory = new MySenderFactory();
             var target = new NetworkTarget();
             target.Address = "tcp://someaddress/";
             target.SenderFactory = senderFactory;
             target.Layout = "${message}";
-            target.NewLine = newLine;
             target.LineEnding = lineEnding;
             target.KeepConnection = true;
             target.Initialize(null);
@@ -114,7 +113,7 @@ namespace NLog.UnitTests.Targets
             target.Close();
 
             // Get the length of all the messages and their line endings
-            var eol = newLine ? lineEnding.NewLineCharacters : string.Empty;
+            var eol = lineEnding?.NewLineCharacters ?? string.Empty;
             var eolLength = eol.Length;
             var length = messages.Sum(m => m.Length) + (eolLength * messages.Length);
             Assert.Equal(length, sender.MemoryStream.Length);


### PR DESCRIPTION
Avoids the pitfall of explicit assigning `LineEnding`-property, but nothing happens until one also explicit assigns `Newline`-property.