### PR TITLE
NetworkTarget - Added more logging to NetworkTargetUdpTest since unstable

### DIFF
--- a/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
@@ -716,7 +716,7 @@ namespace NLog.UnitTests.Targets
 
                 Assert.True(writeCompleted.WaitOne(10000), "Network Write not completed");
                 target.Close();
-                Assert.True(receiveFinished.WaitOne(10000), "Network Receive not completed");
+                Assert.True(receiveFinished.WaitOne(10000), $"Network Receive not completed. Count={receivedMessages.Count}, LastMsg={receivedMessages.LastOrDefault()}");
                 Assert.True(receiveException == null, $"Network Exception: {receiveException?.ToString()}");
                 Assert.Equal(toWrite, receivedMessages.Count);
                 for (int i = 0; i < toWrite; ++i)


### PR DESCRIPTION
```
[xUnit.net 00:00:28.69]     NLog.UnitTests.Targets.NetworkTargetTests.NetworkTargetUdpTest(splitMessage: True) [FAIL]
  Failed NLog.UnitTests.Targets.NetworkTargetTests.NetworkTargetUdpTest(splitMessage: True) [10 s]
  Error Message:
   Network Receive not completed
Expected: True
Actual:   False
  Stack Trace:
     at NLog.UnitTests.Targets.NetworkTargetTests.NetworkTargetUdpTest(Boolean splitMessage) in /home/appveyor/projects/nlog/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs:line 721
```

https://ci.appveyor.com/project/nlog/nlog/builds/40731363/job/clenvuyfwsekx6o4

```
[xUnit.net 00:01:14.71]     NLog.UnitTests.Targets.NetworkTargetTests.NetworkTargetUdpTest(splitMessage: True) [FAIL]
  Failed NLog.UnitTests.Targets.NetworkTargetTests.NetworkTargetUdpTest(splitMessage: True) [10 s]
  Error Message:
   Network Receive not completed
Expected: True
Actual:   False
  Stack Trace:
     at NLog.UnitTests.Targets.NetworkTargetTests.NetworkTargetUdpTest(Boolean splitMessage) in /home/appveyor/projects/nlog/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs:line 720
```
https://ci.appveyor.com/project/nlog/nlog/builds/40731806/job/1y7i2qdomq3rf6s5