### PR TITLE
Added alias toupper and tolower

### DIFF
--- a/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
@@ -42,6 +42,7 @@ namespace NLog.LayoutRenderers
     /// The log level.
     /// </summary>
     [LayoutRenderer("level")]
+    [LayoutRenderer("loglevel")]
     [ThreadAgnostic]
     public class LevelLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {

--- a/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
@@ -42,7 +42,8 @@ namespace NLog.LayoutRenderers.Wrappers
     /// Converts the result of another layout output to lower case.
     /// </summary>
     [LayoutRenderer("lowercase")]
-    [AmbientProperty("Lowercase")]
+    [AmbientProperty(nameof(Lowercase))]
+    [AmbientProperty(nameof(ToLower))]
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     public sealed class LowercaseLayoutRendererWrapper : WrapperLayoutRendererBase
@@ -53,6 +54,15 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <value>A value of <c>true</c> if lower case conversion should be applied; otherwise, <c>false</c>.</value>
         /// <docgen category='Transformation Options' order='10' />
         public bool Lowercase { get; set; } = true;
+
+        /// <summary>
+        /// Same as <see cref="Lowercase"/>-property, so it can be used as ambient property.
+        /// </summary>
+        /// <example>
+        /// ${level:tolower}
+        /// </example>
+        /// <docgen category="Transformation Options" order="10"/>
+        public bool ToLower { get => Lowercase; set => Lowercase = value; }
 
         /// <summary>
         /// Gets or sets the culture used for rendering. 

--- a/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
@@ -48,6 +48,7 @@ namespace NLog.LayoutRenderers.Wrappers
     /// </example>
     [LayoutRenderer("uppercase")]
     [AmbientProperty(nameof(Uppercase))]
+    [AmbientProperty(nameof(ToUpper))]
     [AppDomainFixedOutput]
     [ThreadAgnostic]
     public sealed class UppercaseLayoutRendererWrapper : WrapperLayoutRendererBase
@@ -58,6 +59,15 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <value>A value of <c>true</c> if upper case conversion should be applied otherwise, <c>false</c>.</value>
         /// <docgen category='Transformation Options' order='10' />
         public bool Uppercase { get; set; } = true;
+
+        /// <summary>
+        /// Same as <see cref="Uppercase"/>-property, so it can be used as ambient property.
+        /// </summary>
+        /// <example>
+        /// ${level:toupper}
+        /// </example>
+        /// <docgen category="Transformation Options" order="10"/>
+        public bool ToUpper { get => Uppercase; set => Uppercase = value; }
 
         /// <summary>
         /// Gets or sets the culture used for rendering. 


### PR DESCRIPTION
Matching [String.ToUpper](https://docs.microsoft.com/en-us/dotnet/api/system.string.toupper) and [String.ToLower](https://docs.microsoft.com/en-us/dotnet/api/system.string.tolower) that are known in the DotNet-world.