### PR TITLE
ExceptionLayoutRenderer - Support layout for Separator

### DIFF
--- a/src/NLog/Internal/Reflection/PropertyHelper.cs
+++ b/src/NLog/Internal/Reflection/PropertyHelper.cs
@@ -100,6 +100,11 @@ namespace NLog.Internal
                 throw new NLogConfigurationException($"Unknown property '{propertyName}'='{value}' for '{objType.Name}'");
             }
 
+            SetPropertyFromString(obj, propertyName, value, propInfo, configurationItemFactory);
+        }
+
+        internal static void SetPropertyFromString(object obj, string propertyName, string value, PropertyInfo propInfo, ConfigurationItemFactory configurationItemFactory)
+        {
             try
             {
                 Type propertyType = propInfo.PropertyType;
@@ -108,7 +113,7 @@ namespace NLog.Internal
                 {
                     if (propInfo.IsDefined(_arrayParameterAttribute.GetType(), false))
                     {
-                        throw new NotSupportedException($"Property {propertyName} on {objType.Name} is an array, and cannot be assigned a scalar value: '{value}'.");
+                        throw new NotSupportedException($"Property {propertyName} on {obj.GetType().Name} is an array, and cannot be assigned a scalar value: '{value}'.");
                     }
 
                     propertyType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
@@ -124,7 +129,7 @@ namespace NLog.Internal
             }
             catch (TargetInvocationException ex)
             {
-                throw new NLogConfigurationException($"Error when setting property '{propInfo.Name}'='{value}' on {objType.Name}", ex.InnerException);
+                throw new NLogConfigurationException($"Error when setting property '{propInfo.Name}'='{value}' on {obj.GetType().Name}", ex.InnerException);
             }
             catch (Exception exception)
             {
@@ -133,7 +138,7 @@ namespace NLog.Internal
                     throw;
                 }
 
-                throw new NLogConfigurationException($"Error when setting property '{propInfo.Name}'='{value}' on {objType.Name}", exception);
+                throw new NLogConfigurationException($"Error when setting property '{propInfo.Name}'='{value}' on {obj.GetType().Name}", exception);
             }
         }
 

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -100,7 +100,7 @@ namespace NLog.Layouts
         /// </summary>
         /// <param name="layoutText">The layout string.</param>
         /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>'
-        public static Layout FromString(string layoutText)
+        public static Layout FromString([Localizable(false)] string layoutText)
         {
             return FromString(layoutText, ConfigurationItemFactory.Default);
         }
@@ -111,7 +111,7 @@ namespace NLog.Layouts
         /// <param name="layoutText">The layout string.</param>
         /// <param name="configurationItemFactory">The NLog factories to use when resolving layout renderers.</param>
         /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
-        public static Layout FromString(string layoutText, ConfigurationItemFactory configurationItemFactory)
+        public static Layout FromString([Localizable(false)] string layoutText, ConfigurationItemFactory configurationItemFactory)
         {
             return new SimpleLayout(layoutText, configurationItemFactory);
         }
@@ -122,7 +122,7 @@ namespace NLog.Layouts
         /// <param name="layoutText">The layout string.</param>
         /// <param name="throwConfigExceptions">Whether <see cref="NLogConfigurationException"/> should be thrown on parse errors (false = replace unrecognized tokens with a space).</param>
         /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
-        public static Layout FromString(string layoutText, bool throwConfigExceptions)
+        public static Layout FromString([Localizable(false)] string layoutText, bool throwConfigExceptions)
         {
             try
             {

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -36,6 +36,7 @@ namespace NLog.Layouts
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.ComponentModel;
     using System.Text;
     using NLog.Common;
     using NLog.Config;
@@ -73,7 +74,7 @@ namespace NLog.Layouts
         /// Initializes a new instance of the <see cref="SimpleLayout" /> class.
         /// </summary>
         /// <param name="txt">The layout string to parse.</param>
-        public SimpleLayout(string txt)
+        public SimpleLayout([Localizable(false)] string txt)
             : this(txt, ConfigurationItemFactory.Default)
         {
         }
@@ -83,7 +84,7 @@ namespace NLog.Layouts
         /// </summary>
         /// <param name="txt">The layout string to parse.</param>
         /// <param name="configurationItemFactory">The NLog factories to use when creating references to layout renderers.</param>
-        public SimpleLayout(string txt, ConfigurationItemFactory configurationItemFactory)
+        public SimpleLayout([Localizable(false)] string txt, ConfigurationItemFactory configurationItemFactory)
             :this(txt, configurationItemFactory, null)
         {
         }
@@ -94,13 +95,13 @@ namespace NLog.Layouts
         /// <param name="txt">The layout string to parse.</param>
         /// <param name="configurationItemFactory">The NLog factories to use when creating references to layout renderers.</param>
         /// <param name="throwConfigExceptions">Whether <see cref="NLogConfigurationException"/> should be thrown on parse errors.</param>
-        internal SimpleLayout(string txt, ConfigurationItemFactory configurationItemFactory, bool? throwConfigExceptions)
+        internal SimpleLayout([Localizable(false)] string txt, ConfigurationItemFactory configurationItemFactory, bool? throwConfigExceptions)
         {
             _configurationItemFactory = configurationItemFactory;
             SetLayoutText(txt, throwConfigExceptions);
         }
 
-        internal SimpleLayout(LayoutRenderer[] renderers, string text, ConfigurationItemFactory configurationItemFactory)
+        internal SimpleLayout(LayoutRenderer[] renderers, [Localizable(false)] string text, ConfigurationItemFactory configurationItemFactory)
         {
             _configurationItemFactory = configurationItemFactory;
             OriginalText = text;
@@ -167,7 +168,7 @@ namespace NLog.Layouts
         /// </summary>
         /// <param name="text">Text to be converted.</param>
         /// <returns>A <see cref="SimpleLayout"/> object.</returns>
-        public static implicit operator SimpleLayout(string text)
+        public static implicit operator SimpleLayout([Localizable(false)] string text)
         {
             if (text is null) return null;
 
@@ -186,9 +187,9 @@ namespace NLog.Layouts
         /// Escaping is done by replacing all occurrences of
         /// '${' with '${literal:text=${}'
         /// </remarks>
-        public static string Escape(string text)
+        public static string Escape([Localizable(false)] string text)
         {
-            return text.Replace("${", "${literal:text=${}");
+            return text.Replace("${", @"${literal:text=\$\{}");
         }
 
         /// <summary>
@@ -198,7 +199,7 @@ namespace NLog.Layouts
         /// <param name="logEvent">Log event to be used for evaluation.</param>
         /// <returns>The input text with all occurrences of ${} replaced with
         /// values provided by the appropriate layout renderers.</returns>
-        public static string Evaluate(string text, LogEventInfo logEvent)
+        public static string Evaluate([Localizable(false)] string text, LogEventInfo logEvent)
         {
             var layout = new SimpleLayout(text);
             return layout.Render(logEvent);
@@ -211,7 +212,7 @@ namespace NLog.Layouts
         /// <param name="text">The text to be evaluated.</param>
         /// <returns>The input text with all occurrences of ${} replaced with
         /// values provided by the appropriate layout renderers.</returns>
-        public static string Evaluate(string text)
+        public static string Evaluate([Localizable(false)] string text)
         {
             return Evaluate(text, LogEventInfo.CreateNullEvent());
         }

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -189,7 +189,7 @@ namespace NLog.Layouts
         /// </remarks>
         public static string Escape([Localizable(false)] string text)
         {
-            return text.Replace("${", @"${literal:text=\$\{}");
+            return text.Replace("${", "${literal:text=${}");
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -219,6 +219,26 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
+        public void ExceptionNewLineSeparatorLayoutTest()
+        {
+            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+            <nlog>
+                <targets>
+                    <target name='debug1' type='Debug' layout='${exception:separator= ${NewLine} :format=message,shorttype}' />
+                </targets>
+                <rules>
+                    <logger minlevel='Info' writeTo='debug1' />
+                </rules>
+            </nlog>");
+
+            string exceptionMessage = "Test exception";
+            Exception ex = GetExceptionWithStackTrace(exceptionMessage);
+
+            logger.Error(ex, "msg");
+            AssertDebugLastMessage("debug1", $"Test exception {System.Environment.NewLine} {typeof(CustomArgumentException).Name}");
+        }
+
+        [Fact]
         public void ExceptionUsingLogMethodTest()
         {
             SetConfigurationForExceptionUsingRootMethodTests();
@@ -1097,9 +1117,9 @@ namespace NLog.UnitTests.LayoutRenderers
             sb.Append("\r\ncustom-exception-renderer");
         }
 
-        protected override void AppendData(System.Text.StringBuilder sb, Exception ex)
+        protected override void AppendData(LogEventInfo logEvent, System.Text.StringBuilder sb, Exception ex)
         {
-            base.AppendData(sb, ex);
+            base.AppendData(logEvent, sb, ex);
             sb.Append("\r\ncustom-exception-renderer-data");
         }
     }

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -392,7 +392,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             var t = (DebugTarget)LogManager.Configuration.AllTargets[0];
             var elr = ((SimpleLayout)t.Layout).Renderers[0] as ExceptionLayoutRenderer;
-            Assert.Equal("\r\n----INNER----\r\n", elr.InnerExceptionSeparator);
+            Assert.Equal("\r\n----INNER----\r\n", elr.InnerExceptionSeparator.Render(LogEventInfo.CreateNullEvent()));
 
             string exceptionMessage = "Test exception";
             const string exceptionDataKey = "testkey";
@@ -914,7 +914,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             var t = (DebugTarget)logFactory.Configuration.AllTargets[0];
             var elr = ((SimpleLayout)t.Layout).Renderers[0] as CustomExceptionLayoutRendrer;
-            Assert.Equal("\r\n----INNER----\r\n", elr.InnerExceptionSeparator);
+            Assert.Equal("\r\n----INNER----\r\n", elr.InnerExceptionSeparator.Render(LogEventInfo.CreateNullEvent()));
 
             string exceptionMessage = "Test exception";
             const string exceptionDataKey = "testkey";
@@ -955,7 +955,7 @@ namespace NLog.UnitTests.LayoutRenderers
             var target = (DebugTarget)LogManager.Configuration.AllTargets[0];
             var exceptionLayoutRenderer = ((SimpleLayout)target.Layout).Renderers[0] as ExceptionLayoutRenderer;
             Assert.NotNull(exceptionLayoutRenderer);
-            Assert.Equal(defaultExceptionDataSeparator, exceptionLayoutRenderer.ExceptionDataSeparator);
+            Assert.Equal(defaultExceptionDataSeparator, exceptionLayoutRenderer.ExceptionDataSeparator.Render(LogEventInfo.CreateNullEvent()));
 
             Exception ex = GetExceptionWithStackTrace(exceptionMessage);
             ex.Data.Add(exceptionDataKey1, exceptionDataValue1);
@@ -1117,9 +1117,9 @@ namespace NLog.UnitTests.LayoutRenderers
             sb.Append("\r\ncustom-exception-renderer");
         }
 
-        protected override void AppendData(LogEventInfo logEvent, System.Text.StringBuilder sb, Exception ex)
+        protected override void AppendData(System.Text.StringBuilder sb, Exception ex, LogEventInfo logEvent)
         {
-            base.AppendData(logEvent, sb, ex);
+            base.AppendData(sb, ex, logEvent);
             sb.Append("\r\ncustom-exception-renderer-data");
         }
     }

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -125,7 +125,7 @@ namespace NLog.UnitTests.Layouts
             ExceptionLayoutRenderer elr = l.Renderers[0] as ExceptionLayoutRenderer;
             Assert.NotNull(elr);
             Assert.Equal("message,type", elr.Format);
-            Assert.Equal("x", elr.Separator);
+            Assert.Equal("x", elr.Separator.Render(LogEventInfo.CreateNullEvent()));
         }
 
         [Fact]


### PR DESCRIPTION
Changed Separator-property from `string` to `Layout`, but added bonus-logic so the property still supports standard string-escape-logic. So it might be confusing for users that these Seperator-properties behaves a little differently from other Layout-properties.

It would ofcourse be nice if one could have both string-escape-logic and Layout-logic together. But because NLog FileTarget was the first real target with its FileName-option as Layout, then the Layout parsing was highly optimized for parsing Windows-File-Paths where single-slash does not mean "escape". But actually it is ONLY when Layout is used for File-Paths that this rules makes sense. I guess with NLog 6.0 then the `FilePathLayout` should become public and should be used for all filepath-related-properties.