### PR TITLE
NetworkTargetTest - All network senders are now QueuedNetworkSender

### DIFF
--- a/src/NLog/Internal/NetworkSenders/NetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/NetworkSender.cs
@@ -180,7 +180,8 @@ namespace NLog.Internal.NetworkSenders
 #else
                         var addresses = Dns.GetHostAddressesAsync(uri.Host).ConfigureAwait(false).GetAwaiter().GetResult();
 #endif
-                        foreach (var addr in addresses)
+                        // Only prioritize IPv6 addresses, when explictly specified or the only option
+                        foreach (var addr in System.Linq.Enumerable.OrderBy(addresses, a => a.AddressFamily))
                         {
                             if (addr.AddressFamily == addressFamily || addressFamily == AddressFamily.Unspecified)
                             {

--- a/src/NLog/Internal/NetworkSenders/UdpNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/UdpNetworkSender.cs
@@ -179,6 +179,7 @@ namespace NLog.Internal.NetworkSenders
             socketEventArgs.SetBuffer(networkRequest.RequestBuffer, networkRequest.RequestBufferOffset, messageLength);
             socketEventArgs.UserToken = networkRequest.AsyncContinuation;
         }
+
         private void SocketOperationCompletedAsync(object sender, SocketAsyncEventArgs args)
         {
             var nextRequest = SocketOperationCompleted(args);

--- a/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
@@ -70,7 +70,7 @@ namespace NLog.UnitTests.Targets
 
         private void HappyPathTest(LineEndingMode lineEnding, params string[] messages)
         {
-            var senderFactory = new MySenderFactory();
+            var senderFactory = new MyQueudSenderFactory();
             var target = new NetworkTarget();
             target.Address = "tcp://someaddress/";
             target.SenderFactory = senderFactory;
@@ -148,7 +148,7 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void NetworkTargetMultipleConnectionsTest()
         {
-            var senderFactory = new MySenderFactory();
+            var senderFactory = new MyQueudSenderFactory();
             var target = new NetworkTarget();
             target.Address = "tcp://${logger}.company.lan/";
             target.SenderFactory = senderFactory;
@@ -213,7 +213,7 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void NothingToFlushTest()
         {
-            var senderFactory = new MySenderFactory();
+            var senderFactory = new MyQueudSenderFactory();
             var target = new NetworkTarget();
             target.Address = "tcp://${logger}.company.lan/";
             target.SenderFactory = senderFactory;
@@ -239,7 +239,7 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void NetworkTargetMultipleConnectionsWithCacheOverflowTest()
         {
-            var senderFactory = new MySenderFactory();
+            var senderFactory = new MyQueudSenderFactory();
             var target = new NetworkTarget();
             target.Address = "tcp://${logger}.company.lan/";
             target.SenderFactory = senderFactory;
@@ -302,7 +302,7 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void NetworkTargetMultipleConnectionsWithoutKeepAliveTest()
         {
-            var senderFactory = new MySenderFactory();
+            var senderFactory = new MyQueudSenderFactory();
             var target = new NetworkTarget();
             target.Address = "tcp://${logger}.company.lan/";
             target.SenderFactory = senderFactory;
@@ -367,7 +367,7 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void NetworkTargetMultipleConnectionsWithMessageDiscardTest()
         {
-            var senderFactory = new MySenderFactory();
+            var senderFactory = new MyQueudSenderFactory();
             var target = new NetworkTarget();
             target.Address = "tcp://${logger}.company.lan/";
             target.SenderFactory = senderFactory;
@@ -419,7 +419,7 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void NetworkTargetMultipleConnectionsWithMessageErrorTest()
         {
-            var senderFactory = new MySenderFactory();
+            var senderFactory = new MyQueudSenderFactory();
             var target = new NetworkTarget();
             target.Address = "tcp://${logger}.company.lan/";
             target.SenderFactory = senderFactory;
@@ -468,7 +468,7 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void NetworkTargetSendFailureTests()
         {
-            var senderFactory = new MySenderFactory()
+            var senderFactory = new MyQueudSenderFactory()
             {
                 FailCounter = 3, // first 3 sends will fail
             };
@@ -796,7 +796,7 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void NetworkTargetSendFailureWithoutKeepAliveTests()
         {
-            var senderFactory = new MySenderFactory()
+            var senderFactory = new MyQueudSenderFactory()
             {
                 FailCounter = 3, // first 3 sends will fail
             };
@@ -978,145 +978,15 @@ namespace NLog.UnitTests.Targets
             Assert.NotNull(target);
         }
 
-        internal class MySenderFactory : INetworkSenderFactory
-        {
-            internal List<MyNetworkSender> Senders = new List<MyNetworkSender>();
-            internal StringWriter Log = new StringWriter();
-            private int idCounter;
-
-            public NetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, SslProtocols sslProtocols, TimeSpan keepAliveTime)
-            {
-                var sender = new MyNetworkSender(url, ++idCounter, Log, this);
-                Senders.Add(sender);
-                return sender;
-            }
-
-            public int FailCounter { get; set; }
-
-            public bool AsyncMode { get; set; }
-        }
-
-        internal class MyNetworkSender : NetworkSender
-        {
-            private readonly int id;
-            private readonly TextWriter log;
-            private readonly MySenderFactory senderFactory;
-            internal MemoryStream MemoryStream { get; }
-
-            public MyNetworkSender(string url, int id, TextWriter log, MySenderFactory senderFactory)
-                : base(url)
-            {
-                this.id = id;
-                this.log = log;
-                this.senderFactory = senderFactory;
-                MemoryStream = new MemoryStream();
-            }
-
-            protected override void DoInitialize()
-            {
-                base.DoInitialize();
-                lock (log)
-                {
-                    log.WriteLine("{0}: connect {1}", id, Address);
-                }
-            }
-
-            protected override void DoFlush(AsyncContinuation continuation)
-            {
-                if (senderFactory.AsyncMode)
-                {
-                    var asyncTask = new NLog.Internal.AsyncHelpersTask(state => { Thread.Sleep(1); FlushSync(continuation); });
-                    AsyncHelpers.StartAsyncTask(asyncTask, null);
-                }
-                else
-                {
-                    FlushSync(continuation);
-                }
-            }
-
-            private void FlushSync(AsyncContinuation continuation)
-            {
-                lock (log)
-                {
-                    log.WriteLine("{0}: flush", id);
-                }
-                continuation(null);
-            }
-
-            protected override void DoClose(AsyncContinuation continuation)
-            {
-                if (senderFactory.AsyncMode)
-                {
-                    var asyncTask = new NLog.Internal.AsyncHelpersTask(state => { Thread.Sleep(1); CloseSync(continuation); });
-                    AsyncHelpers.StartAsyncTask(asyncTask, null);
-                }
-                else
-                {
-                    CloseSync(continuation);
-                }
-            }
-
-            private void CloseSync(AsyncContinuation continuation)
-            {
-                lock (log)
-                {
-                    log.WriteLine("{0}: close", id);
-                }
-                continuation(null);
-            }
-
-            protected override void DoSend(byte[] bytes, int offset, int length, AsyncContinuation continuation)
-            {
-                if (senderFactory.AsyncMode)
-                {
-                    var asyncTask = new NLog.Internal.AsyncHelpersTask(state => { Thread.Sleep(1); SendSync(bytes, offset, length, continuation); });
-                    AsyncHelpers.StartAsyncTask(asyncTask, null);
-                }
-                else
-                {
-                    SendSync(bytes, offset, length, continuation);
-                }
-            }
-
-            private void SendSync(byte[] bytes, int offset, int length, AsyncContinuation continuation)
-            {
-                var failedException = CheckForFailedException();
-                lock (log)
-                {
-                    log.WriteLine("{0}: send {1} {2}", id, offset, length);
-                    MemoryStream.Write(bytes, offset, length);
-                    if (failedException != null)
-                    {
-                        log.WriteLine("{0}: failed", id);
-                    }
-                }
-                continuation(failedException);
-            }
-
-            private Exception CheckForFailedException()
-            {
-                lock (senderFactory)
-                {
-                    if (senderFactory.FailCounter > 0)
-                    {
-                        senderFactory.FailCounter--;
-                        return new IOException("some IO error has occured");
-                    }
-                }
-
-                return null;
-            }
-        }
-
         internal class MyQueudSenderFactory : INetworkSenderFactory
         {
             internal List<MyQueudNetworkSender> Senders = new List<MyQueudNetworkSender>();
             internal StringWriter Log = new StringWriter();
-            private int idCounter;
+            private int _idCounter;
 
             public NetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, SslProtocols sslProtocols, TimeSpan keepAliveTime)
             {
-                var sender = new MyQueudNetworkSender(url, ++idCounter, Log, this);
+                var sender = new MyQueudNetworkSender(url, ++_idCounter, Log, this);
                 Senders.Add(sender);
                 return sender;
             }
@@ -1128,34 +998,33 @@ namespace NLog.UnitTests.Targets
 
         internal class MyQueudNetworkSender : QueuedNetworkSender
         {
-            private readonly int id;
-            private readonly TextWriter log;
-            private readonly MyQueudSenderFactory senderFactory;
-            internal MemoryStream MemoryStream { get; }
+            private readonly int _id;
+            private readonly TextWriter _log;
+            private readonly MyQueudSenderFactory _senderFactory;
+            public MemoryStream MemoryStream { get; } = new MemoryStream();
 
             public MyQueudNetworkSender(string url, int id, TextWriter log, MyQueudSenderFactory senderFactory)
                 : base(url)
             {
-                this.id = id;
-                this.log = log;
-                this.senderFactory = senderFactory;
-                MemoryStream = new MemoryStream();
+                _id = id;
+                _log = log;
+                _senderFactory = senderFactory;
             }
 
             protected override void DoInitialize()
             {
                 base.DoInitialize();
-                lock (log)
+                lock (_log)
                 {
-                    log.WriteLine("{0}: connect {1}", id, Address);
+                    _log.WriteLine("{0}: connect {1}", _id, Address);
                 }
             }
 
             protected override void DoFlush(AsyncContinuation continuation)
             {
-                lock (log)
+                lock (_log)
                 {
-                    log.WriteLine("{0}: flush", id);
+                    _log.WriteLine("{0}: flush", _id);
                 }
 
                 base.DoFlush(continuation);
@@ -1163,16 +1032,16 @@ namespace NLog.UnitTests.Targets
 
             protected override void DoClose(AsyncContinuation continuation)
             {
-                lock (log)
+                lock (_log)
                 {
-                    log.WriteLine("{0}: close", id);
+                    _log.WriteLine("{0}: close", _id);
                 }
                 base.DoClose(continuation);
             }
 
             protected override void BeginRequest(NetworkRequestArgs eventArgs)
             {
-                if (senderFactory.AsyncMode)
+                if (_senderFactory.AsyncMode)
                 {
                     var asyncTask = new NLog.Internal.AsyncHelpersTask(state => { Thread.Sleep(1); SendSync(eventArgs); });
                     AsyncHelpers.StartAsyncTask(asyncTask, null);
@@ -1187,13 +1056,13 @@ namespace NLog.UnitTests.Targets
             {
                 var failedException = CheckForFailedException();
 
-                lock (log)
+                lock (_log)
                 {
-                    log.WriteLine("{0}: send {1} {2}", id, eventArgs.RequestBufferOffset, eventArgs.RequestBufferLength);
+                    _log.WriteLine("{0}: send {1} {2}", _id, eventArgs.RequestBufferOffset, eventArgs.RequestBufferLength);
                     MemoryStream.Write(eventArgs.RequestBuffer, eventArgs.RequestBufferOffset, eventArgs.RequestBufferLength);
                     if (failedException != null)
                     {
-                        log.WriteLine("{0}: failed", id);
+                        _log.WriteLine("{0}: failed", _id);
                     }
                 }
                 
@@ -1206,11 +1075,11 @@ namespace NLog.UnitTests.Targets
 
             private Exception CheckForFailedException()
             {
-                lock (senderFactory)
+                lock (_senderFactory)
                 {
-                    if (senderFactory.FailCounter > 0)
+                    if (_senderFactory.FailCounter > 0)
                     {
-                        senderFactory.FailCounter--;
+                        _senderFactory.FailCounter--;
                         return new IOException("some IO error has occured");
                     }
                 }


### PR DESCRIPTION
Now that also UDP and HTTP are using queued-behavior, then it only make sense that MockedNetworkSender is only based on QueuedNetworkSender.

And since TCP + UDP + HTTP all execute in async-manner to avoid blocking logger-thread, then MockedNetworkSender should also behave async-by-default (unless the unit-test does not handle async-behavior).