### PR TITLE
Validate Target Layouts whether they are all marked as ThreadSafe

### DIFF
--- a/src/NLog/LayoutRenderers/ExceptionDataLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionDataLayoutRenderer.cs
@@ -34,10 +34,8 @@
 namespace NLog.LayoutRenderers
 {
     using System;
-    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Text;
-    using NLog.Common;
     using NLog.Config;
     using NLog.Internal;
 
@@ -49,6 +47,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("exception-data")]
     [ThreadAgnostic]
     [ThreadSafe]
+    [MutableUnsafe]
     public class ExceptionDataLayoutRenderer : LayoutRenderer
     {
         /// <summary>
@@ -65,7 +64,6 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Rendering Options' order='50' />
         public string Format { get; set; }
 
-
         /// <summary>
         /// Gets or sets whether to render innermost Exception from <see cref="Exception.GetBaseException()"/>
         /// </summary>
@@ -81,7 +79,6 @@ namespace NLog.LayoutRenderers
         /// <inheritdoc />
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-
             Exception primaryException = GetTopException(logEvent);
             if (primaryException != null)
             {

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -291,6 +291,7 @@ namespace NLog.Targets.Wrappers
             if (WrappedTarget != null && WrappedTarget.InitializeException is Config.NLogDependencyResolveException && OverflowAction == AsyncTargetWrapperOverflowAction.Discard)
             {
                 _missingServiceTypes = true;
+                InternalLogger.Debug("{0} WrappedTarget has unresolved missing dependencies.", this);
             }
 
             _requestQueue.Clear();


### PR DESCRIPTION
Make it easier to diagnose why NLog Target is not running a full speed when used with AsyncWrapper or AsyncTaskTarget.

Could also consider changing FileContentsLayoutRenderer into have its own lock, and then just ignore `[ThreadSafe]`-attribute (All NLog-core LayoutRenderers would then be ThreadSafe).