### PR TITLE
NetworkTarget - Pending network errors handled when OnQueueOverflow=Block

### DIFF
--- a/src/NLog/Internal/NetworkSenders/QueuedNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/QueuedNetworkSender.cs
@@ -124,13 +124,21 @@ namespace NLog.Internal.NetworkSenders
                         }
                     }
 
-                    if (!_asyncOperationInProgress)
+                    if (_pendingError is null)
                     {
-                        _asyncOperationInProgress = true;
+                        if (!_asyncOperationInProgress)
+                        {
+                            _asyncOperationInProgress = true;
+                        }
+                        else
+                        {
+                            _pendingRequests.Enqueue(eventArgs.Value);
+                            eventArgs = null;
+                        }
                     }
                     else
                     {
-                        _pendingRequests.Enqueue(eventArgs.Value);
+                        failedContinuation = asyncContinuation;
                         eventArgs = null;
                     }
                 }

--- a/src/NLog/Internal/NetworkSenders/TcpNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/TcpNetworkSender.cs
@@ -294,7 +294,7 @@ namespace NLog.Internal.NetworkSenders
             Exception socketException = null;
             if (args.SocketError != SocketError.Success)
             {
-                socketException = new IOException("Error: " + args.SocketError);
+                socketException = new IOException($"Error: {args.SocketError.ToString()}, Address: {Address}");
             }
 
             var asyncContinuation = args.UserToken as AsyncContinuation;

--- a/src/NLog/Internal/NetworkSenders/UdpNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/UdpNetworkSender.cs
@@ -194,7 +194,7 @@ namespace NLog.Internal.NetworkSenders
             Exception socketException = null;
             if (args.SocketError != SocketError.Success)
             {
-                socketException = new IOException("Error: " + args.SocketError);
+                socketException = new IOException($"Error: {args.SocketError.ToString()}, Address: {Address}");
             }
 
             if (socketException is null && (args.Buffer.Length - args.Offset) > MaxMessageSize && MaxMessageSize > 0)

--- a/src/NLog/Targets/ChainsawTarget.cs
+++ b/src/NLog/Targets/ChainsawTarget.cs
@@ -51,12 +51,6 @@ namespace NLog.Targets
     /// To set up the log target programmatically use code like this:
     /// </p>
     /// <code lang="C#" source="examples/targets/Configuration API/Chainsaw/Simple/Example.cs" />
-    /// <p>
-    /// NOTE: If your receiver application is ever likely to be off-line, don't use TCP protocol
-    /// or you'll get TCP timeouts and your application will crawl. 
-    /// Either switch to UDP transport or use <a href="target.AsyncWrapper.html">AsyncWrapper</a> target
-    /// so that your application threads will not be blocked by the timing-out connection attempts.
-    /// </p>
     /// </example>
     [Target("Chainsaw")]
     public class ChainsawTarget : NLogViewerTarget

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -57,12 +57,6 @@ namespace NLog.Targets
     /// To set up the log target programmatically use code like this:
     /// </p>
     /// <code lang="C#" source="examples/targets/Configuration API/NLogViewer/Simple/Example.cs" />
-    /// <p>
-    /// NOTE: If your receiver application is ever likely to be off-line, don't use TCP protocol
-    /// or you'll get TCP timeouts and your application will crawl. 
-    /// Either switch to UDP transport or use <a href="target.AsyncWrapper.html">AsyncWrapper</a> target
-    /// so that your application threads will not be blocked by the timing-out connection attempts.
-    /// </p>
     /// </example>
     [Target("NLogViewer")]
     public class NLogViewerTarget : NetworkTarget, IIncludeContext
@@ -77,7 +71,6 @@ namespace NLog.Targets
         /// </remarks>
         public NLogViewerTarget()
         {
-            NewLine = false;
             IncludeNLogData = true;
         }
 


### PR DESCRIPTION
Minor fix to #4542 where OnQueueOverflow=Block hits `Monitor.Wait()` and if `_pendingError` is assigned while waiting, then one should handled it as failed.

Also fixed a minor issue in `NetworkTarget.CloseTarget` where it was missing a clear of `_currentSenderCache`.

Also removed comment about TCP being dangerous and blocking. Think it was a comment from NLog 1.0 where NetworkTarget was always blocking.