### PR TITLE
Layout - Render with StringBuilder target made public

### DIFF
--- a/src/NLog/Conditions/Expressions/ConditionLayoutExpression.cs
+++ b/src/NLog/Conditions/Expressions/ConditionLayoutExpression.cs
@@ -84,7 +84,7 @@ namespace NLog.Conditions
             var stringBuilder = System.Threading.Interlocked.Exchange(ref _fastObjectPool, null) ?? new StringBuilder();
             try
             {
-                _simpleLayout.RenderAppendBuilder(context, stringBuilder);
+                _simpleLayout.Render(context, stringBuilder);
                 return stringBuilder.ToString();
             }
             finally

--- a/src/NLog/Filters/WhenRepeatedFilter.cs
+++ b/src/NLog/Filters/WhenRepeatedFilter.cs
@@ -266,7 +266,7 @@ namespace NLog.Filters
         {
             if (targetBuilder != null)
             {
-                Layout.RenderAppendBuilder(logEvent, targetBuilder);
+                Layout.Render(logEvent, targetBuilder);
                 if (targetBuilder.Length > MaxLength)
                     targetBuilder.Length = MaxLength;
                 return new FilterInfoKey(targetBuilder, null);

--- a/src/NLog/Internal/Files/FilePathLayout.cs
+++ b/src/NLog/Internal/Files/FilePathLayout.cs
@@ -185,7 +185,7 @@ namespace NLog.Internal
                     }
                 }
 
-                _layout.RenderAppendBuilder(logEvent, reusableBuilder);
+                _layout.Render(logEvent, reusableBuilder);
 
                 if (_cachedPrevRawFileName != null && reusableBuilder.EqualTo(_cachedPrevRawFileName))
                 {

--- a/src/NLog/Internal/ObjectPools/AppendBuilderCreator.cs
+++ b/src/NLog/Internal/ObjectPools/AppendBuilderCreator.cs
@@ -51,6 +51,12 @@ namespace NLog.Internal
 
         private StringBuilderPool.ItemHolder _builder;  // Not readonly to avoid struct-copy on Dispose(), and to avoid VerificationException when medium-trust AppDomain
 
+        public AppendBuilderCreator(bool mustBeEmpty)
+        {
+            _builder = _builderPool.Acquire();
+            _appendTarget = _builder.Item;
+        }
+
         public AppendBuilderCreator(StringBuilder appendTarget, bool mustBeEmpty)
         {
             _appendTarget = appendTarget;

--- a/src/NLog/LayoutRenderers/Machine/EnvironmentLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Machine/EnvironmentLayoutRenderer.cs
@@ -64,7 +64,7 @@ namespace NLog.LayoutRenderers
         /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            GetSimpleLayout()?.RenderAppendBuilder(logEvent, builder);
+            GetSimpleLayout()?.Render(logEvent, builder);
         }
 
         /// <inheritdoc/>

--- a/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/VariableLayoutRenderer.cs
@@ -100,7 +100,7 @@ namespace NLog.LayoutRenderers
                 if (TryGetLayout(out var layout))
                 {
                     //ignore NULL, but it set, so don't use default.
-                    layout?.RenderAppendBuilder(logEvent, builder);
+                    layout?.Render(logEvent, builder);
                 }
                 else if (Default != null)
                 {

--- a/src/NLog/LayoutRenderers/Wrappers/FileSystemNormalizeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/FileSystemNormalizeLayoutRendererWrapper.cs
@@ -66,7 +66,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             if (FSNormalize && builder.Length > orgLength)
             {
                 TransformFileSystemNormalize(builder, orgLength);

--- a/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
@@ -83,7 +83,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             if (JsonEncode && builder.Length > orgLength)
             {
                 Targets.DefaultJsonSerializer.PerformJsonEscapeWhenNeeded(builder, orgLength, EscapeUnicode, EscapeForwardSlash);

--- a/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LeftLayoutRendererWrapper.cs
@@ -70,7 +70,7 @@ namespace NLog.LayoutRenderers.Wrappers
                 return;
             }
 
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             var renderedLength = builder.Length - orgLength;
             if (renderedLength > Length)
             {

--- a/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
@@ -74,7 +74,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             if (Lowercase && builder.Length > orgLength)
             {
                 TransformToLowerCase(builder, orgLength);

--- a/src/NLog/LayoutRenderers/Wrappers/NoRawValueLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/NoRawValueLayoutRendererWrapper.cs
@@ -60,7 +60,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            Inner?.RenderAppendBuilder(logEvent, builder);
+            Inner?.Render(logEvent, builder);
         }
 
         /// <inheritdoc/>

--- a/src/NLog/LayoutRenderers/Wrappers/OnExceptionLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/OnExceptionLayoutRendererWrapper.cs
@@ -48,7 +48,7 @@ namespace NLog.LayoutRenderers.Wrappers
         {
             if (logEvent.Exception != null)
             {
-                Inner.RenderAppendBuilder(logEvent, builder);
+                Inner.Render(logEvent, builder);
             }
         }
 

--- a/src/NLog/LayoutRenderers/Wrappers/OnHasPropertiesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/OnHasPropertiesLayoutRendererWrapper.cs
@@ -51,7 +51,7 @@ namespace NLog.LayoutRenderers.Wrappers
         {
             if (logEvent.HasProperties)
             {
-                Inner.RenderAppendBuilder(logEvent, builder);
+                Inner.Render(logEvent, builder);
             }
         }
 

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -69,7 +69,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             if (builder.Length > orgLength)
             {
                 var containsNewLines = builder.IndexOf('\n', orgLength) >= 0;

--- a/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/RightLayoutRendererWrapper.cs
@@ -60,7 +60,7 @@ namespace NLog.LayoutRenderers.Wrappers
                 return;
             }
 
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             var renderedLength = builder.Length - orgLength;
             if (renderedLength > Length)
             {

--- a/src/NLog/LayoutRenderers/Wrappers/Rot13LayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/Rot13LayoutRendererWrapper.cs
@@ -77,7 +77,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             if (builder.Length > orgLength)
             {
                 DecodeRot13(builder, orgLength);

--- a/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/SubstringLayoutRendererWrapper.cs
@@ -84,7 +84,7 @@ namespace NLog.LayoutRenderers.Wrappers
                 return;
             }
 
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             var renderedLength = builder.Length - orgLength;
 
             if (renderedLength > 0)

--- a/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/TrimWhiteSpaceLayoutRendererWrapper.cs
@@ -67,7 +67,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             if (TrimWhiteSpace && builder.Length > orgLength)
             {
                 TransformTrimWhiteSpaces(builder, orgLength);

--- a/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
@@ -79,7 +79,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             if (Uppercase && builder.Length > orgLength)
             {
                 TransformToUpperCase(builder, orgLength);

--- a/src/NLog/LayoutRenderers/Wrappers/UrlEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/UrlEncodeLayoutRendererWrapper.cs
@@ -90,7 +90,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             if (builder.Length > orgLength)
             {
                 var text = builder.ToString(orgLength, builder.Length - orgLength);

--- a/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
@@ -68,12 +68,12 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             if (builder.Length > orgLength)
                 return;
 
             // render WhenEmpty when the inner layout was empty
-            WhenEmpty.RenderAppendBuilder(logEvent, builder);
+            WhenEmpty.Render(logEvent, builder);
         }
 
         /// <inheritdoc/>

--- a/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
@@ -69,11 +69,11 @@ namespace NLog.LayoutRenderers.Wrappers
             {
                 if (ShouldRenderInner(logEvent))
                 {
-                    Inner?.RenderAppendBuilder(logEvent, builder);
+                    Inner?.Render(logEvent, builder);
                 }
                 else
                 {
-                    Else?.RenderAppendBuilder(logEvent, builder);
+                    Else?.Render(logEvent, builder);
                 }
             }
             catch

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBuilderBase.cs
@@ -82,7 +82,7 @@ namespace NLog.LayoutRenderers.Wrappers
         [Obsolete("Inherit from WrapperLayoutRendererBase and override RenderInnerAndTransform() instead. Marked obsolete in NLog 4.6")]
         protected virtual void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
-            Inner.RenderAppendBuilder(logEvent, target);
+            Inner.Render(logEvent, target);
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/Wrappers/XmlEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/XmlEncodeLayoutRendererWrapper.cs
@@ -74,7 +74,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
-            Inner.RenderAppendBuilder(logEvent, builder);
+            Inner.Render(logEvent, builder);
             if (XmlEncode)
             {
                 XmlHelper.PerformXmlEscapeWhenNeeded(builder, orgLength, XmlEncodeNewlines);

--- a/src/NLog/Layouts/CSV/CsvLayout.cs
+++ b/src/NLog/Layouts/CSV/CsvLayout.cs
@@ -201,7 +201,7 @@ namespace NLog.Layouts
             }
 
             int orgLength = target.Length;
-            columnLayout.RenderAppendBuilder(logEvent, target);
+            columnLayout.Render(logEvent, target);
             if (orgLength != target.Length && ColumnValueRequiresQuotes(quoting, target, orgLength))
             {
                 string columnValue = target.ToString(orgLength, target.Length - orgLength);

--- a/src/NLog/Layouts/CompoundLayout.cs
+++ b/src/NLog/Layouts/CompoundLayout.cs
@@ -98,7 +98,7 @@ namespace NLog.Layouts
             for (int i = 0; i < Layouts.Count; i++)
             {
                 Layout layout = Layouts[i];
-                layout.RenderAppendBuilder(logEvent, target);
+                layout.Render(logEvent, target);
             }
         }
 

--- a/src/NLog/Layouts/JSON/JsonAttribute.cs
+++ b/src/NLog/Layouts/JSON/JsonAttribute.cs
@@ -165,7 +165,7 @@ namespace NLog.Layouts
                 }
 
                 int orgLength = builder.Length;
-                Layout.RenderAppendBuilder(logEvent, builder);
+                Layout.Render(logEvent, builder);
                 if (!IncludeEmptyValue && builder.Length <= orgLength)
                 {
                     return false;

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -218,20 +218,20 @@ namespace NLog.Layouts
             return layoutValue;
         }
 
-        internal virtual void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
-        {
-            Precalculate(logEvent); // Allow custom Layouts to also work
-        }
-
         /// <summary>
         /// Optimized version of <see cref="Render(LogEventInfo)"/> that works best when
         /// override of <see cref="RenderFormattedMessage(LogEventInfo, StringBuilder)"/> is available.
         /// </summary>
         /// <param name="logEvent">The event info.</param>
         /// <param name="target">Appends the string representing log event to target</param>
-        public void RenderAppendBuilder(LogEventInfo logEvent, StringBuilder target)
+        public void Render(LogEventInfo logEvent, StringBuilder target)
         {
             RenderAppendBuilder(logEvent, target, false);
+        }
+
+        internal virtual void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+        {
+            Precalculate(logEvent); // Allow custom Layouts to also work
         }
 
         /// <summary>

--- a/src/NLog/Layouts/LayoutWithHeaderAndFooter.cs
+++ b/src/NLog/Layouts/LayoutWithHeaderAndFooter.cs
@@ -79,7 +79,7 @@ namespace NLog.Layouts
         /// <param name="target"><see cref="System.Text.StringBuilder"/> for the result.</param>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, System.Text.StringBuilder target)
         {
-            Layout.RenderAppendBuilder(logEvent, target);
+            Layout.Render(logEvent, target);
         }
     }
 }

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -322,12 +322,19 @@ namespace NLog.Layouts
                         Initialize(LoggingConfiguration);
                     }
 
-                    if (ThreadAgnostic && MutableUnsafe)
+                    if (ThreadAgnostic)
                     {
-                        // If raw value doesn't have the ability to mutate, then we can skip precalculate
-                        var success = _rawValueRenderer.TryGetRawValue(logEvent, out var value);
-                        if (success && value != null && (Convert.GetTypeCode(value) != TypeCode.Object || value.GetType().IsValueType()))
+                        if (MutableUnsafe)
+                        {
+                            // If raw value doesn't have the ability to mutate, then we can skip precalculate
+                            var success = _rawValueRenderer.TryGetRawValue(logEvent, out var value);
+                            if (success && value != null && (Convert.GetTypeCode(value) != TypeCode.Object || value.GetType().IsValueType()))
+                                return true;
+                        }
+                        else
+                        {
                             return true;
+                        }
                     }
 
                     return false;

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -297,6 +297,22 @@ namespace NLog.Layouts
         /// <inheritdoc />
         public override void Precalculate(LogEventInfo logEvent)
         {
+            if (!IsLogEventMutableSafe(logEvent))
+            {
+                Render(logEvent);
+            }
+        }
+
+        internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
+        {
+            if (!IsLogEventMutableSafe(logEvent))
+            {
+                PrecalculateBuilderInternal(logEvent, target);
+            }
+        }
+
+        private bool IsLogEventMutableSafe(LogEventInfo logEvent)
+        {
             if (_rawValueRenderer != null)
             {
                 try
@@ -311,8 +327,10 @@ namespace NLog.Layouts
                         // If raw value doesn't have the ability to mutate, then we can skip precalculate
                         var success = _rawValueRenderer.TryGetRawValue(logEvent, out var value);
                         if (success && value != null && (Convert.GetTypeCode(value) != TypeCode.Object || value.GetType().IsValueType()))
-                            return;
+                            return true;
                     }
+
+                    return false;
                 }
                 catch (Exception exception)
                 {
@@ -331,12 +349,7 @@ namespace NLog.Layouts
                 }
             }
 
-            base.Precalculate(logEvent);
-        }
-
-        internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
-        {
-            PrecalculateBuilderInternal(logEvent, target);
+            return ThreadAgnostic && !MutableUnsafe;
         }
 
         /// <inheritdoc />

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -304,7 +304,7 @@ namespace NLog.Layouts
 
             if (stringBuilder?.Length == 0)
             {
-                _innerLayout.RenderAppendBuilder(logEvent, stringBuilder);
+                _innerLayout.Render(logEvent, stringBuilder);
                 if (stringBuilder.Length == 0)
                     return string.Empty;
                 else if (!string.IsNullOrEmpty(previousStringValue) && stringBuilder.EqualTo(previousStringValue))

--- a/src/NLog/Layouts/XML/XmlAttribute.cs
+++ b/src/NLog/Layouts/XML/XmlAttribute.cs
@@ -128,7 +128,7 @@ namespace NLog.Layouts
             if (ValueType is null)
             {
                 int orgLength = builder.Length;
-                Layout.RenderAppendBuilder(logEvent, builder);
+                Layout.Render(logEvent, builder);
                 if (!IncludeEmptyValue && builder.Length <= orgLength)
                 {
                     return false;

--- a/src/NLog/Layouts/XML/XmlElementBase.cs
+++ b/src/NLog/Layouts/XML/XmlElementBase.cs
@@ -687,7 +687,7 @@ namespace NLog.Layouts
                 sb.Append("  ");
 
             int beforeValueLength = sb.Length;
-            xmlElement.RenderAppendBuilder(logEvent, sb);
+            xmlElement.Render(logEvent, sb);
             if (sb.Length == beforeValueLength && !xmlElement.IncludeEmptyValue)
                 return false;
 

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -328,7 +328,7 @@ namespace NLog.Targets
         private void RenderLogEventToWriteBuffer(TextWriter output, Layout layout, LogEventInfo logEvent, StringBuilder targetBuilder, char[] targetBuffer, ref int targetBufferPosition)
         {
             int environmentNewLineLength = System.Environment.NewLine.Length;
-            layout.RenderAppendBuilder(logEvent, targetBuilder);
+            layout.Render(logEvent, targetBuilder);
             if (targetBuilder.Length > targetBuffer.Length - targetBufferPosition - environmentNewLineLength)
             {
                 if (targetBufferPosition > 0)

--- a/src/NLog/Targets/DebuggerTarget.cs
+++ b/src/NLog/Targets/DebuggerTarget.cs
@@ -122,7 +122,7 @@ namespace NLog.Targets
                 string logMessage;
                 using (var localTarget = ReusableLayoutBuilder.Allocate())
                 {
-                    Layout.RenderAppendBuilder(logEvent, localTarget.Result);
+                    Layout.Render(logEvent, localTarget.Result);
                     localTarget.Result.Append('\n');
                     logMessage = localTarget.Result.ToString();
                 }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1218,7 +1218,7 @@ namespace NLog.Targets
         /// <param name="target"><see cref="StringBuilder"/> for the result.</param>
         protected virtual void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
-            Layout.RenderAppendBuilder(logEvent, target);
+            Layout.Render(logEvent, target);
         }
 
         private void TransformBuilderToStream(LogEventInfo logEvent, StringBuilder builder, char[] transformBuffer, MemoryStream workStream)
@@ -2493,7 +2493,7 @@ namespace NLog.Targets
             using (var targetBuffer = _reusableEncodingBuffer.Allocate())
             {
                 var nullEvent = LogEventInfo.CreateNullEvent();
-                layout.RenderAppendBuilder(nullEvent, targetBuilder.Result);
+                layout.Render(nullEvent, targetBuilder.Result);
                 targetBuilder.Result.Append(NewLineChars);
                 using (MemoryStream ms = new MemoryStream(targetBuilder.Result.Length))
                 {

--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -456,7 +456,7 @@ namespace NLog.Targets
                 {
                     using (var localBuilder = ReusableLayoutBuilder.Allocate())
                     {
-                        Layout.RenderAppendBuilder(logEvent, localBuilder.Result, false);
+                        Layout.RenderAppendBuilder(logEvent, localBuilder.Result);
                         if (NewLine)
                         {
                             localBuilder.Result.Append(LineEnding.NewLineCharacters);

--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -456,7 +456,7 @@ namespace NLog.Targets
                 {
                     using (var localBuilder = ReusableLayoutBuilder.Allocate())
                     {
-                        Layout.RenderAppendBuilder(logEvent, localBuilder.Result);
+                        Layout.Render(logEvent, localBuilder.Result);
                         if (NewLine)
                         {
                             localBuilder.Result.Append(LineEnding.NewLineCharacters);

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -855,7 +855,7 @@ namespace NLog.Targets
 
             protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
             {
-                TargetLayout?.RenderAppendBuilder(logEvent, target);
+                TargetLayout?.Render(logEvent, target);
             }
 
             public class LayoutScopeContextProperties : Layout

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -855,7 +855,7 @@ namespace NLog.Targets
 
             protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
             {
-                TargetLayout?.RenderAppendBuilder(logEvent, target, false);
+                TargetLayout?.RenderAppendBuilder(logEvent, target);
             }
 
             public class LayoutScopeContextProperties : Layout


### PR DESCRIPTION
Allow 3rd party layouts to render complex output using sub-layouts with less memory-allocation of strings.

And now NLog `Layout.Precalculate` will call `RenderFormattedMessage` for 3rd party layouts, with help from NLog internal StringBuilder-pool. Before `Layout.Precalculate` would always call `GetFormattedMessage` directly.