### PR TITLE
NLog ConfigurationItemFactory must be global, because of SimpleLayout

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -196,7 +196,7 @@ namespace NLog.Config
                 ConfigurationItemFactory.ScanForAutoLoadExtensions(LogFactory);
             }
 
-            _serviceRepository.ConfigurationItemFactory.ParseMessageTemplates = parseMessageTemplates;
+            _serviceRepository.RegisterMessageTemplateParser(parseMessageTemplates);
         }
 
         /// <summary>
@@ -382,7 +382,7 @@ namespace NLog.Config
         {
             try
             {
-                _serviceRepository.ConfigurationItemFactory.RegisterType(Type.GetType(type, true), itemNamePrefix);
+                ConfigurationItemFactory.Default.RegisterType(Type.GetType(type, true), itemNamePrefix);
             }
             catch (Exception exception)
             {
@@ -402,7 +402,7 @@ namespace NLog.Config
             try
             {
                 Assembly asm = AssemblyHelpers.LoadFromPath(assemblyFile, baseDirectory);
-                _serviceRepository.ConfigurationItemFactory.RegisterItemsFromAssembly(asm, prefix);
+                ConfigurationItemFactory.Default.RegisterItemsFromAssembly(asm, prefix);
             }
             catch (Exception exception)
             {
@@ -422,7 +422,7 @@ namespace NLog.Config
             try
             {
                 Assembly asm = AssemblyHelpers.LoadFromName(assemblyName);
-                _serviceRepository.ConfigurationItemFactory.RegisterItemsFromAssembly(asm, prefix);
+                ConfigurationItemFactory.Default.RegisterItemsFromAssembly(asm, prefix);
             }
             catch (Exception exception)
             {
@@ -515,7 +515,7 @@ namespace NLog.Config
             if (!AssertNonEmptyValue(timeSourceType, "type", timeElement.Name, string.Empty))
                 return;
 
-            TimeSource newTimeSource = FactoryCreateInstance(timeSourceType, _serviceRepository.ConfigurationItemFactory.TimeSources);
+            TimeSource newTimeSource = FactoryCreateInstance(timeSourceType, ConfigurationItemFactory.Default.TimeSources);
             if (newTimeSource != null)
             {
                 ConfigureFromAttributesAndElements(newTimeSource, timeElement);
@@ -795,7 +795,7 @@ namespace NLog.Config
             foreach (var filterElement in filtersElement.ValidChildren)
             {
                 var filterType = filterElement.GetOptionalValue("type", null) ?? filterElement.Name;
-                Filter filter = FactoryCreateInstance(filterType, _serviceRepository.ConfigurationItemFactory.Filters);
+                Filter filter = FactoryCreateInstance(filterType, ConfigurationItemFactory.Default.Filters);
                 ConfigureFromAttributesAndElements(filter, filterElement, true);
                 rule.Filters.Add(filter);
             }
@@ -881,7 +881,7 @@ namespace NLog.Config
 
         private Target CreateTargetType(string targetTypeName)
         {
-            return FactoryCreateInstance(targetTypeName, _serviceRepository.ConfigurationItemFactory.Targets);
+            return FactoryCreateInstance(targetTypeName, ConfigurationItemFactory.Default.Targets);
         }
 
         private void ParseTargetElement(Target target, ValidatedConfigurationElement targetElement,
@@ -1051,7 +1051,7 @@ namespace NLog.Config
                 if (matchingVariableName != null && propertyValueExpanded == propertyValue && TrySetPropertyFromConfigVariableLayout(targetObject, propertyName, matchingVariableName))
                     return;
 
-                PropertyHelper.SetPropertyFromString(targetObject, propertyName, propertyValueExpanded, _serviceRepository.ConfigurationItemFactory);
+                PropertyHelper.SetPropertyFromString(targetObject, propertyName, propertyValueExpanded, ConfigurationItemFactory.Default);
             }
             catch (NLogConfigurationException ex)
             {
@@ -1179,17 +1179,17 @@ namespace NLog.Config
 
         private SimpleLayout CreateSimpleLayout(string layoutText)
         {
-            return new SimpleLayout(layoutText, _serviceRepository.ConfigurationItemFactory, LogFactory.ThrowConfigExceptions);
+            return new SimpleLayout(layoutText, ConfigurationItemFactory.Default, LogFactory.ThrowConfigExceptions);
         }
 
         private Layout TryCreateLayoutInstance(ValidatedConfigurationElement element, Type type)
         {
-            return TryCreateInstance(element, type, _serviceRepository.ConfigurationItemFactory.Layouts);
+            return TryCreateInstance(element, type, ConfigurationItemFactory.Default.Layouts);
         }
 
         private Filter TryCreateFilterInstance(ValidatedConfigurationElement element, Type type)
         {
-            return TryCreateInstance(element, type, _serviceRepository.ConfigurationItemFactory.Filters);
+            return TryCreateInstance(element, type, ConfigurationItemFactory.Default.Filters);
         }
 
         private T TryCreateInstance<T>(ValidatedConfigurationElement element, Type type, INamedItemFactory<T, Type> factory)

--- a/src/NLog/Config/ServiceRepository.cs
+++ b/src/NLog/Config/ServiceRepository.cs
@@ -53,11 +53,6 @@ namespace NLog.Config
         /// <remarks>Avoid calling this while handling a LogEvent, since random deadlocks can occur.</remarks>
         public abstract object GetService(Type serviceType);
 
-        /// <summary>
-        /// Mapping of symbol name to actual <see cref="System.Type"/>
-        /// </summary>
-        public abstract ConfigurationItemFactory ConfigurationItemFactory { get; internal set; }
-
         internal abstract ConfigurationItemCreator ConfigurationItemCreator { get; set; }
 
         internal ServiceRepository()

--- a/src/NLog/Config/ServiceRepositoryExtensions.cs
+++ b/src/NLog/Config/ServiceRepositoryExtensions.cs
@@ -161,6 +161,44 @@ namespace NLog.Config
             return serviceRepository;
         }
 
+        public static ServiceRepository RegisterMessageTemplateParser(this ServiceRepository serviceRepository, bool? messageTemplateParser)
+        {
+            if (messageTemplateParser == false)
+            {
+                NLog.Common.InternalLogger.Info("Message Template String Format always enabled");
+                serviceRepository.RegisterSingleton<ILogMessageFormatter>(LogMessageStringFormatter.Default);
+            }
+            else if (messageTemplateParser == true)
+            {
+                NLog.Common.InternalLogger.Info("Message Template Format always enabled");
+                serviceRepository.RegisterSingleton<ILogMessageFormatter>(new LogMessageTemplateFormatter(serviceRepository, true, false));
+            }
+            else
+            {
+                //null = auto
+                NLog.Common.InternalLogger.Info("Message Template Auto Format enabled");
+                serviceRepository.RegisterSingleton<ILogMessageFormatter>(new LogMessageTemplateFormatter(serviceRepository, false, false));
+            }
+            return serviceRepository;
+        }
+
+        public static bool? ResolveMessageTemplateParser(this ServiceRepository serviceRepository)
+        {
+            var messageFormatter = serviceRepository.GetService<ILogMessageFormatter>();
+            if (ReferenceEquals(messageFormatter, LogMessageStringFormatter.Default))
+            {
+                return false;
+            }
+            else if ((messageFormatter as LogMessageTemplateFormatter)?.ForceTemplateRenderer == true)
+            {
+                return true;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         public static ServiceRepository RegisterDefaults(this ServiceRepository serviceRepository)
         {
             serviceRepository.RegisterSingleton<IServiceProvider>(serviceRepository);

--- a/src/NLog/Config/ServiceRepositoryInternal.cs
+++ b/src/NLog/Config/ServiceRepositoryInternal.cs
@@ -48,14 +48,7 @@ namespace NLog.Config
         private readonly Dictionary<Type, ConfigurationItemCreator> _creatorMap = new Dictionary<Type, ConfigurationItemCreator>();
         private readonly Dictionary<Type, CompiledConstructor> _lateBoundMap = new Dictionary<Type, CompiledConstructor>();
         private readonly object _lockObject = new object();
-        private ConfigurationItemFactory _localItemFactory;
         public event EventHandler<ServiceRepositoryUpdateEventArgs> TypeRegistered;
-
-        public override ConfigurationItemFactory ConfigurationItemFactory
-        {
-            get => _localItemFactory ?? (_localItemFactory = new ConfigurationItemFactory(this, ConfigurationItemFactory.Default, ArrayHelper.Empty<Assembly>()));
-            internal set => _localItemFactory = value;
-        }
 
         internal override ConfigurationItemCreator ConfigurationItemCreator { get; set; }
 

--- a/src/NLog/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog/SetupExtensionsBuilderExtensions.cs
@@ -77,7 +77,7 @@ namespace NLog
         /// </summary>
         public static ISetupExtensionsBuilder RegisterAssembly(this ISetupExtensionsBuilder setupBuilder, Assembly assembly)
         {
-            setupBuilder.LogFactory.ServiceRepository.ConfigurationItemFactory.RegisterItemsFromAssembly(assembly);
+            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(assembly);
             return setupBuilder;
         }
 
@@ -87,7 +87,7 @@ namespace NLog
         public static ISetupExtensionsBuilder RegisterAssembly(this ISetupExtensionsBuilder setupBuilder, string assemblyName)
         {
             Assembly assembly = AssemblyHelpers.LoadFromName(assemblyName);
-            setupBuilder.LogFactory.ServiceRepository.ConfigurationItemFactory.RegisterItemsFromAssembly(assembly);
+            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(assembly);
             return setupBuilder;
         }
 
@@ -114,7 +114,7 @@ namespace NLog
         {
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentException("Missing type symbol name", nameof(name));
-            setupBuilder.LogFactory.ServiceRepository.ConfigurationItemFactory.Targets.RegisterDefinition(name, targetType);
+            ConfigurationItemFactory.Default.Targets.RegisterDefinition(name, targetType);
             return setupBuilder;
         }
 
@@ -142,7 +142,7 @@ namespace NLog
         {
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentException("Missing type symbol name", nameof(name));
-            setupBuilder.LogFactory.ServiceRepository.ConfigurationItemFactory.LayoutRenderers.RegisterDefinition(name, layoutRendererType);
+            ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition(name, layoutRendererType);
             return setupBuilder;
         }
 
@@ -190,7 +190,7 @@ namespace NLog
         public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder setupBuilder, string name, Func<LogEventInfo, LoggingConfiguration, object> layoutMethod, LayoutRenderOptions options)
         {
             FuncLayoutRenderer layoutRenderer = Layout.CreateFuncLayoutRenderer(layoutMethod, options, name);
-            setupBuilder.LogFactory.ServiceRepository.ConfigurationItemFactory.GetLayoutRenderers().RegisterFuncLayout(name, layoutRenderer);
+            ConfigurationItemFactory.Default.GetLayoutRenderers().RegisterFuncLayout(name, layoutRenderer);
             return setupBuilder;
         }
 
@@ -207,7 +207,7 @@ namespace NLog
             if (!conditionMethod.IsStatic)
                 throw new ArgumentException($"{conditionMethod.Name} must be static", nameof(conditionMethod));
 
-            setupBuilder.LogFactory.ServiceRepository.ConfigurationItemFactory.ConditionMethods.RegisterDefinition(name, conditionMethod);
+            ConfigurationItemFactory.Default.ConditionMethods.RegisterDefinition(name, conditionMethod);
             return setupBuilder;
         }
 
@@ -241,7 +241,7 @@ namespace NLog
 
         private static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, Delegate conditionMethod, ReflectionHelpers.LateBoundMethod lateBoundMethod)
         {
-            setupBuilder.LogFactory.ServiceRepository.ConfigurationItemFactory.ConditionMethodDelegates.RegisterDefinition(name, conditionMethod.GetDelegateInfo(), lateBoundMethod);
+            ConfigurationItemFactory.Default.ConditionMethodDelegates.RegisterDefinition(name, conditionMethod.GetDelegateInfo(), lateBoundMethod);
             return setupBuilder;
         }
 

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -426,6 +426,8 @@ namespace NLog.UnitTests.Config
         [InlineData(false)]
         public void Extension_loading_could_be_canceled(bool cancel)
         {
+            ConfigurationItemFactory.Default = null;
+
             EventHandler<AssemblyLoadingEventArgs> onAssemblyLoading = (sender, e) =>
             {
                 if (e.Assembly.FullName.Contains("NLogAutoLoadExtension"))

--- a/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
+++ b/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
@@ -247,8 +247,8 @@ namespace NLog.UnitTests.Config
             </nlog>", null, logFactory);
             logFactory.GetLogger("Hello").Info("World");
 
-            logFactory.ServiceRepository.ConfigurationItemFactory.GetLayoutRenderers().TryCreateInstance("mylayout", out var layoutRenderer);
-            var layout = new SimpleLayout(new LayoutRenderer[] { layoutRenderer }, "mylayout", logFactory.ServiceRepository.ConfigurationItemFactory);
+            ConfigurationItemFactory.Default.GetLayoutRenderers().TryCreateInstance("mylayout", out var layoutRenderer);
+            var layout = new SimpleLayout(new LayoutRenderer[] { layoutRenderer }, "mylayout", ConfigurationItemFactory.Default);
             layout.Render(LogEventInfo.CreateNullEvent());
 
             // Assert
@@ -275,8 +275,8 @@ namespace NLog.UnitTests.Config
             </nlog>", null, logFactory);
             logFactory.GetLogger("Hello").Info("World");
 
-            logFactory.ServiceRepository.ConfigurationItemFactory.GetLayoutRenderers().TryCreateInstance("mylayout", out var layoutRenderer);
-            var layout = new SimpleLayout(new LayoutRenderer[] { layoutRenderer }, "mylayout", logFactory.ServiceRepository.ConfigurationItemFactory);
+            ConfigurationItemFactory.Default.GetLayoutRenderers().TryCreateInstance("mylayout", out var layoutRenderer);
+            var layout = new SimpleLayout(new LayoutRenderer[] { layoutRenderer }, "mylayout", ConfigurationItemFactory.Default);
             layout.Render(LogEventInfo.CreateNullEvent());
 
             // Assert

--- a/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
+++ b/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
@@ -210,6 +210,25 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        public void SetupExtensionsRegisterLayoutMethodFluentTest()
+        {
+            // Arrange
+            var logFactory = new LogFactory();
+
+            // Act
+            logFactory.Setup()
+                .SetupExtensions(ext => ext.RegisterLayoutRenderer("mylayout", (l) => "42"))
+                .LoadConfiguration(builder =>
+                {
+                    builder.ForLogger().WriteTo(new DebugTarget() { Layout = "${myLayout}" });
+                });
+            logFactory.GetLogger("Hello").Info("World");
+
+            // Assert
+            Assert.Equal("42", logFactory.Configuration.FindTargetByName<DebugTarget>("debug").LastMessage);
+        }
+
+        [Fact]
         public void SetupExtensionsRegisterLayoutMethodThreadUnsafeTest()
         {
             // Arrange


### PR DESCRIPTION
Discovered a bug in the registration and usage of config-items in `ConfigurationItemFactory`.

The new idea was that each LogFactory had their own `ConfigurationItemFactory`, so they would not disturb each other. But this doesn't work well with this `SimpleLayout`-constructor:

```c#
        public SimpleLayout(string txt)
            : this(txt, ConfigurationItemFactory.Default)
        {
        }
```

The ServiceRepository can remain isolated for each LogFactory-instance, but the registration of config-item-factories must remain global.