### PR TITLE
Enable LayoutRenderer to ResolveService during intialization

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -800,7 +800,7 @@ namespace NLog.Config
 
                         if (typeof(IServiceProvider).IsAssignableFrom(serviceType) || IsMissingServiceType(resolveException, serviceType))
                         {
-                            target.Close();
+                            target.Close(); // Close Target to allow re-initialize
                         }
                     }
                 }

--- a/src/NLog/Config/ServiceRepository.cs
+++ b/src/NLog/Config/ServiceRepository.cs
@@ -53,7 +53,7 @@ namespace NLog.Config
         /// <remarks>Avoid calling this while handling a LogEvent, since random deadlocks can occur.</remarks>
         public abstract object GetService(Type serviceType);
 
-        internal abstract object TryGetService(Type serviceType);
+        internal abstract bool TryGetService<T>(out T serviceInstance) where T : class;
 
         internal abstract ConfigurationItemCreator ConfigurationItemCreator { get; set; }
 

--- a/src/NLog/Config/ServiceRepository.cs
+++ b/src/NLog/Config/ServiceRepository.cs
@@ -53,6 +53,8 @@ namespace NLog.Config
         /// <remarks>Avoid calling this while handling a LogEvent, since random deadlocks can occur.</remarks>
         public abstract object GetService(Type serviceType);
 
+        internal abstract object TryGetService(Type serviceType);
+
         internal abstract ConfigurationItemCreator ConfigurationItemCreator { get; set; }
 
         internal ServiceRepository()

--- a/src/NLog/Config/ServiceRepositoryExtensions.cs
+++ b/src/NLog/Config/ServiceRepositoryExtensions.cs
@@ -57,9 +57,10 @@ namespace NLog.Config
 
                 try
                 {
-                    var service = serviceProvider.TryGetService(typeof(T)) as T;
-                    if (service != null)
+                    if (serviceProvider.TryGetService<T>(out var service))
+                    {
                         return service;
+                    }
                     
                     externalServiceProvider = serviceProvider.GetService<IServiceProvider>();
                 }

--- a/src/NLog/Config/ServiceRepositoryInternal.cs
+++ b/src/NLog/Config/ServiceRepositoryInternal.cs
@@ -83,17 +83,18 @@ namespace NLog.Config
 
         public override object GetService(Type serviceType)
         {
-            var service = DefaultResolveInstance(serviceType, null);
-            if (service is null && serviceType.IsAbstract())
+            var serviceInstance = DefaultResolveInstance(serviceType, null);
+            if (serviceInstance is null && serviceType.IsAbstract())
             {
                 throw new NLogDependencyResolveException("Instance of class must be registered", serviceType);
             }
-            return service;
+            return serviceInstance;
         }
 
-        internal override object TryGetService(Type serviceType)
+        internal override bool TryGetService<T>(out T serviceInstance)
         {
-            return DefaultResolveInstance(serviceType, null);
+            serviceInstance = DefaultResolveInstance(typeof(T), null) as T;
+            return !(serviceInstance is null);
         }
 
         private object DefaultResolveInstance(Type itemType, HashSet<Type> seenTypes)

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -129,7 +129,6 @@ namespace NLog.LayoutRenderers
 
             if (!_isInitialized)
             {
-                _isInitialized = true;
                 Initialize();
             }
         }
@@ -148,6 +147,10 @@ namespace NLog.LayoutRenderers
                 {
                     throw;
                 }
+            }
+            finally
+            {
+                _isInitialized = true;  // Only one attempt, must Close to retry
             }
         }
 
@@ -174,7 +177,6 @@ namespace NLog.LayoutRenderers
         {
             if (!_isInitialized)
             {
-                _isInitialized = true;
                 Initialize();
             }
 

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -328,19 +328,25 @@ namespace NLog.Layouts
         {
             if (!IsInitialized)
             {
-                LoggingConfiguration = configuration;
-
-                IsInitialized = true;
-                _scannedForObjects = false;
-
-                PropertyHelper.CheckRequiredParameters(this);
-
-                InitializeLayout();
-
-                if (!_scannedForObjects)
+                try
                 {
-                    InternalLogger.Debug("{0} Initialized Layout done but not scanned for objects", GetType());
-                    PerformObjectScanning();
+                    LoggingConfiguration = configuration;
+
+                    _scannedForObjects = false;
+
+                    PropertyHelper.CheckRequiredParameters(this);
+
+                    InitializeLayout();
+
+                    if (!_scannedForObjects)
+                    {
+                        InternalLogger.Debug("{0} Initialized Layout done but not scanned for objects", GetType());
+                        PerformObjectScanning();
+                    }
+                }
+                finally
+                {
+                    IsInitialized = true;
                 }
             }
         }

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -460,7 +460,7 @@ namespace NLog.Targets
                     }
                     finally
                     {
-                        _isInitialized = true;
+                        _isInitialized = true;  // Only one attempt, must Close to retry
                     }
                 }
             }


### PR DESCRIPTION
Also avoid throwing exceptions during initialization, when dependency is available from external service-provider (NLog should attempt to be silent partner).