### PR TITLE
Time + ProcessTime still allow Culture override from LogEventInfo

### DIFF
--- a/src/NLog/LayoutRenderers/DateTime/ProcessTimeLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/DateTime/ProcessTimeLayoutRenderer.cs
@@ -63,7 +63,8 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var ts = GetValue(logEvent);
-            WritetTimestamp(builder, ts, Culture);
+            var culture = GetCulture(logEvent, Culture);
+            WritetTimestamp(builder, ts, culture);
         }
 
         /// <inheritdoc />

--- a/src/NLog/LayoutRenderers/DateTime/TimeLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/DateTime/TimeLayoutRenderer.cs
@@ -69,15 +69,16 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var dt = GetValue(logEvent);
+            var culture = GetCulture(logEvent, Culture);
 
             string timeSeparator = ":";
             string ticksSeparator = ".";
-            if (!ReferenceEquals(Culture, CultureInfo.InvariantCulture))
+            if (!ReferenceEquals(culture, CultureInfo.InvariantCulture))
             {
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
-                timeSeparator = Culture.DateTimeFormat.TimeSeparator;
+                timeSeparator = culture.DateTimeFormat.TimeSeparator;
 #endif
-                ticksSeparator = Culture.NumberFormat.NumberDecimalSeparator;
+                ticksSeparator = culture.NumberFormat.NumberDecimalSeparator;
             }
 
             builder.Append2DigitsZeroPadded(dt.Hour);


### PR DESCRIPTION
Follow up to #4599. Aligns `${time}` with `${date}` (LogEventInfo can override Culture, but using Invariant-Culture by default)