### PR TITLE
Handle OutOfMemoryException instead of crashing the application

### DIFF
--- a/src/NLog/Common/AsyncHelpers.cs
+++ b/src/NLog/Common/AsyncHelpers.cs
@@ -81,6 +81,7 @@ namespace NLog.Common
         /// <param name="asyncContinuation">The asynchronous continuation to invoke once all items
         /// have been iterated.</param>
         /// <param name="action">The action to invoke for each item.</param>
+        [Obsolete("Marked obsolete on NLog 5.0")]
         public static void ForEachItemSequentially<T>(IEnumerable<T> items, AsyncContinuation asyncContinuation, AsynchronousAction<T> action)
         {
             action = ExceptionGuard(action);
@@ -145,6 +146,7 @@ namespace NLog.Common
         /// <param name="asyncContinuation">The async continuation.</param>
         /// <param name="action">The action to pre-pend.</param>
         /// <returns>Continuation which will execute the given action before forwarding to the actual continuation.</returns>
+        [Obsolete("Marked obsolete on NLog 5.0")]
         public static AsyncContinuation PrecededBy(AsyncContinuation asyncContinuation, AsynchronousAction action)
         {
             action = ExceptionGuard(action);
@@ -236,12 +238,13 @@ namespace NLog.Common
                     }
                     catch (Exception ex)
                     {
-                        InternalLogger.Error(ex, "ForEachItemInParallel - Unhandled Exception");
+#if DEBUG
                         if (ex.MustBeRethrownImmediately())
                         {
                             throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                         }
-
+#endif
+                        InternalLogger.Error(ex, "ForEachItemInParallel - Unhandled Exception");
                         preventMultipleCalls.Invoke(ex);
                     }
                 }), null);
@@ -256,6 +259,7 @@ namespace NLog.Common
         /// <remarks>
         /// Using this method is not recommended because it will block the calling thread.
         /// </remarks>
+        [Obsolete("Marked obsolete on NLog 5.0")]
         public static void RunSynchronously(AsynchronousAction action)
         {
             var ev = new ManualResetEvent(false);

--- a/src/NLog/Config/LoggingConfigurationFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationFileLoader.cs
@@ -155,8 +155,9 @@ namespace NLog.Config
             }
             catch (Exception ex)
             {
-                if (ex.MustBeRethrownImmediately() || ex.MustBeRethrown() || (logFactory.ThrowConfigExceptions ?? logFactory.ThrowExceptions))
+                if (ex.MustBeRethrown() || (logFactory.ThrowConfigExceptions ?? logFactory.ThrowExceptions))
                     throw;
+
                 if (ThrowXmlConfigExceptions(configFile, xmlReader, logFactory, out var autoReload))
                     throw;
 

--- a/src/NLog/Config/LoggingConfigurationWatchableFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationWatchableFileLoader.cs
@@ -181,11 +181,12 @@ namespace NLog.Config
                 }
                 catch (Exception exception)
                 {
+#if DEBUG
                     if (exception.MustBeRethrownImmediately())
                     {
                         throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                     }
-
+#endif
                     InternalLogger.Warn(exception, "NLog configuration failed to reload");
                     _logFactory?.NotifyConfigurationReloaded(new LoggingConfigurationReloadedEventArgs(false, exception));
                     return;
@@ -201,11 +202,12 @@ namespace NLog.Config
                 }
                 catch (Exception exception)
                 {
+#if DEBUG
                     if (exception.MustBeRethrownImmediately())
                     {
                         throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                     }
-
+#endif
                     InternalLogger.Warn(exception, "NLog configuration reloaded, failed to be assigned");
                     _watcher.Watch(oldConfig.FileNamesToWatch);
                     _logFactory?.NotifyConfigurationReloaded(new LoggingConfigurationReloadedEventArgs(false, exception));

--- a/src/NLog/Internal/AppEnvironmentWrapper.cs
+++ b/src/NLog/Internal/AppEnvironmentWrapper.cs
@@ -38,6 +38,7 @@ namespace NLog.Internal.Fakeables
     using System.Diagnostics;
     using System.IO;
     using System.Xml;
+    using NLog.Common;
 
     internal class AppEnvironmentWrapper : IAppEnvironment
     {
@@ -131,7 +132,8 @@ namespace NLog.Internal.Fakeables
             {
                 if (ex.MustBeRethrownImmediately())
                     throw;
-
+                
+                InternalLogger.Debug("LookupEntryAssemblyFileName Failed - {0}", ex.Message);
                 return string.Empty;
             }
         }
@@ -148,6 +150,7 @@ namespace NLog.Internal.Fakeables
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
+                InternalLogger.Debug("LookupCurrentProcessFilePath Failed - {0}", ex.Message);
                 return LookupCurrentProcessFilePathNative();
             }
         }
@@ -165,6 +168,7 @@ namespace NLog.Internal.Fakeables
                     throw;
 
                 // May throw a SecurityException or Access Denied when running from an IIS app. pool process
+                InternalLogger.Debug("LookupCurrentProcessFilePath Failed - {0}", ex.Message);
                 return null;
             }
         }
@@ -182,6 +186,7 @@ namespace NLog.Internal.Fakeables
                     throw;
 
                 // May throw a SecurityException if running from an IIS app. pool process (Cannot compile method)
+                InternalLogger.Debug("LookupCurrentProcessId Failed - {0}", ex.Message);
                 return LookupCurrentProcessIdNative();
             }
         }
@@ -199,6 +204,7 @@ namespace NLog.Internal.Fakeables
                     throw;
 
                 // May throw a SecurityException or Access Denied when running from an IIS app. pool process
+                InternalLogger.Debug("LookupCurrentProcessId Failed - {0}", ex.Message);
                 return null;
             }
         }
@@ -216,6 +222,7 @@ namespace NLog.Internal.Fakeables
                     throw;
 
                 // May throw a SecurityException if running from an IIS app. pool process (Cannot compile method)
+                InternalLogger.Debug("LookupCurrentProcessName Failed - {0}", ex.Message);
                 return LookupCurrentProcessNameNative();
             }
         }
@@ -233,6 +240,8 @@ namespace NLog.Internal.Fakeables
             {
                 if (ex.MustBeRethrownImmediately())
                     throw;
+
+                InternalLogger.Debug("LookupCurrentProcessName Failed - {0}", ex.Message);
             }
 
             return null;
@@ -267,6 +276,7 @@ namespace NLog.Internal.Fakeables
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
+                InternalLogger.Debug("LookupCurrentProcessFilePath Failed - {0}", ex.Message);
                 return string.Empty;
             }
         }
@@ -289,6 +299,7 @@ namespace NLog.Internal.Fakeables
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
+                InternalLogger.Debug("LookupCurrentProcessFilePath Failed - {0}", ex.Message);
                 return string.Empty;
             }
         }
@@ -307,6 +318,7 @@ namespace NLog.Internal.Fakeables
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
+                InternalLogger.Debug("LookupCurrentProcessId Failed - {0}", ex.Message);
                 return 0;
             }
         }
@@ -323,6 +335,7 @@ namespace NLog.Internal.Fakeables
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
+                InternalLogger.Debug("LookupCurrentProcessId Failed - {0}", ex.Message);
                 return 0;
             }
         }

--- a/src/NLog/Internal/Files/MultiFileWatcher.cs
+++ b/src/NLog/Internal/Files/MultiFileWatcher.cs
@@ -222,9 +222,11 @@ namespace NLog.Internal
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "Error Handling File Changed");
+#if DEBUG
                     if (ex.MustBeRethrownImmediately())
-                        throw;
+                        throw;  // Throwing exceptions here might crash the entire application (.NET 2.0 behavior)
+#endif
+                    InternalLogger.Error(ex, "Error Handling File Changed");
                 }
             }
         }

--- a/src/NLog/Internal/NetworkSenders/HttpNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/HttpNetworkSender.cs
@@ -79,10 +79,12 @@ namespace NLog.Internal.NetworkSenders
                     }
                     catch (Exception ex)
                     {
+#if DEBUG
                         if (ex.MustBeRethrownImmediately())
                         {
                             throw; // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                         }
+#endif
 
                         CompleteRequest(_ => asyncContinuation(ex));
                     }
@@ -102,10 +104,12 @@ namespace NLog.Internal.NetworkSenders
                     }
                     catch (Exception ex)
                     {
+#if DEBUG
                         if (ex.MustBeRethrownImmediately())
                         {
                             throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                         }
+#endif
 
                         CompleteRequest(_ => asyncContinuation(ex));
                     }

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -718,13 +718,16 @@ namespace NLog
             }
             catch (Exception ex)
             {
+#if DEBUG
                 if (ex.MustBeRethrownImmediately())
-                    throw;
+                    throw;  // Throwing exceptions here might crash the entire application (.NET 2.0 behavior)
+#endif
+
+                InternalLogger.Error(ex, "Error during flush.");
 
                 if (throwExceptions)
                     throw new NLogRuntimeException("Asynchronous exception has occurred.", ex);
 
-                InternalLogger.Error(ex, "Error with flush.");
                 return false;
             }
 

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -714,12 +714,41 @@ namespace NLog
 
         private void WriteToTargets([NotNull] LogEventInfo logEvent, [NotNull] TargetWithFilterChain targetsForLevel)
         {
-            LoggerImpl.Write(DefaultLoggerType, targetsForLevel, PrepareLogEventInfo(logEvent), Factory);
+            try
+            {
+                LoggerImpl.Write(DefaultLoggerType, targetsForLevel, PrepareLogEventInfo(logEvent), Factory);
+            }
+            catch (Exception ex)
+            {
+#if DEBUG
+                if (ex.MustBeRethrownImmediately())
+                    throw;  // Throwing exceptions here might crash the entire application (.NET 2.0 behavior)
+
+#endif
+                if (Factory.ThrowExceptions || LogManager.ThrowExceptions)
+                    throw;
+
+                Common.InternalLogger.Error(ex, "Failed to write LogEvent");
+            }
         }
 
         private void WriteToTargets(Type wrapperType, [NotNull] LogEventInfo logEvent, [NotNull] TargetWithFilterChain targetsForLevel)
         {
-            LoggerImpl.Write(wrapperType ?? DefaultLoggerType, targetsForLevel, PrepareLogEventInfo(logEvent), Factory);
+            try
+            {
+                LoggerImpl.Write(wrapperType ?? DefaultLoggerType, targetsForLevel, PrepareLogEventInfo(logEvent), Factory);
+            }
+            catch (Exception ex)
+            {
+#if DEBUG
+                if (ex.MustBeRethrownImmediately())
+                    throw;  // Throwing exceptions here might crash the entire application (.NET 2.0 behavior)
+#endif
+                if (Factory.ThrowExceptions || LogManager.ThrowExceptions)
+                    throw;
+
+                Common.InternalLogger.Error(ex, "Failed to write LogEvent");
+            }
         }
 
         internal void SetConfiguration(TargetWithFilterChain[] targetsByLevel)

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -124,7 +124,12 @@ namespace NLog
             }
             catch (Exception ex)
             {
-                if (logFactory.ThrowExceptions || ex.MustBeRethrownImmediately())
+#if DEBUG
+                if (ex.MustBeRethrownImmediately())
+                    throw;
+#endif
+
+                if (logFactory.ThrowExceptions || LogManager.ThrowExceptions)
                     throw;
 
                 InternalLogger.Error(ex, "Failed to capture CallSite for Logger {0}. Platform might not support ${{callsite}}", logEvent.LoggerName);

--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -612,11 +612,18 @@ namespace NLog.Targets
             }
             catch (Exception ex)
             {
+#if DEBUG
                 if (ex.MustBeRethrownImmediately())
-                    throw;
+                    throw;  // Throwing exceptions here might crash the entire application (.NET 2.0 behavior)
+#endif
 
                 InternalLogger.Error(ex, "{0}: WriteAsyncTask failed on creation", this);
+
+#if !NET35 && !NET45
+                return Task.FromException(ex);
+#else
                 return Task.Factory.StartNew(e => throw (Exception)e, new AggregateException(ex), _cancelTokenSource.Token, TaskCreationOptions.None, TaskScheduler);
+#endif
             }
         }
 

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -2050,10 +2050,12 @@ namespace NLog.Targets
             }
             catch (Exception exception)
             {
+#if DEBUG
                 if (exception.MustBeRethrownImmediately())
                 {
                     throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                 }
+#endif
 
                 InternalLogger.Warn(exception, "{0}: Exception in AutoCloseAppendersAfterArchive", this);
             }
@@ -2090,10 +2092,12 @@ namespace NLog.Targets
             }
             catch (Exception exception)
             {
+#if DEBUG
                 if (exception.MustBeRethrownImmediately())
                 {
                     throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                 }
+#endif
 
                 InternalLogger.Warn(exception, "{0}: Exception in AutoClosingTimerCallback", this);
             }

--- a/src/NLog/Targets/WebServiceTarget.cs
+++ b/src/NLog/Targets/WebServiceTarget.cs
@@ -391,12 +391,13 @@ namespace NLog.Targets
                     }
                     catch (Exception ex)
                     {
-                        InternalLogger.Error(ex, "{0}: Error receiving response", this);
+#if DEBUG
                         if (ex.MustBeRethrownImmediately())
                         {
                             throw; // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                         }
-
+#endif
+                        InternalLogger.Error(ex, "{0}: Error receiving response", this);
                         DoInvokeCompleted(continuation, ex);
                     }
                 },
@@ -421,12 +422,13 @@ namespace NLog.Targets
                     }
                     catch (Exception ex)
                     {
-                        InternalLogger.Error(ex, "{0}: Error sending payload", this);
+#if DEBUG
                         if (ex.MustBeRethrownImmediately())
                         {
                             throw; // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                         }
-
+#endif
+                        InternalLogger.Error(ex, "{0}: Error sending payload", this);
                         postPayload.Dispose();
                         DoInvokeCompleted(continuation, ex);
                     }

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -472,13 +472,13 @@ namespace NLog.Targets.Wrappers
             catch (Exception exception)
             {
                 wroteFullBatchSize = false; // Something went wrong, lets throttle retry
-
-                InternalLogger.Error(exception, "{0}: Error in lazy writer timer procedure.", this);
-
+#if DEBUG
                 if (exception.MustBeRethrownImmediately())
                 {
                     throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                 }
+#endif
+                InternalLogger.Error(exception, "{0}: Error in lazy writer timer procedure.", this);
             }
             finally
             {
@@ -515,12 +515,13 @@ namespace NLog.Targets.Wrappers
             }
             catch (Exception exception)
             {
-                InternalLogger.Error(exception, "{0}: Error in flush procedure.", this);
-
+#if DEBUG
                 if (exception.MustBeRethrownImmediately())
                 {
                     throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                 }
+#endif
+                InternalLogger.Error(exception, "{0}: Error in flush procedure.", this);
             }
         }
 

--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -245,12 +245,13 @@ namespace NLog.Targets.Wrappers
             }
             catch (Exception exception)
             {
-                InternalLogger.Error(exception, "{0}: Error in flush procedure.", this);
-
+#if DEBUG
                 if (exception.MustBeRethrownImmediately())
                 {
                     throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                 }
+#endif
+                InternalLogger.Error(exception, "{0}: Error in flush procedure.", this);
             }
             finally
             {

--- a/tests/NLog.UnitTests/AsyncHelperTests.cs
+++ b/tests/NLog.UnitTests/AsyncHelperTests.cs
@@ -308,6 +308,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Marked obsolete on NLog 5.0")]
         public void ForEachItemSequentiallyTest1()
         {
             bool finalContinuationInvoked = false;
@@ -336,6 +337,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Marked obsolete on NLog 5.0")]
         public void ForEachItemSequentiallyTest2()
         {
             bool finalContinuationInvoked = false;
@@ -365,6 +367,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Marked obsolete on NLog 5.0")]
         public void ForEachItemSequentiallyTest3()
         {
             using (new NoThrowNLogExceptions())
@@ -527,6 +530,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Marked obsolete on NLog 5.0")]
         public void PrecededByTest1()
         {
             int invokedCount1 = 0;
@@ -561,6 +565,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Marked obsolete on NLog 5.0")]
         public void PrecededByTest2()
         {
             int invokedCount1 = 0;


### PR DESCRIPTION
Resolves #4616. NLog should not attempt to crash the application in low-memory-situation (Changing 10 year old behavior)

But NLog should still perform early abort, when meeting `OutOfMemoryException` and not continue trying to write the LogEvent (as it might be the cause of the low-memory-condition).