### PR TITLE
FileTarget - KeepFileOpen = true by default to avoid loosing file handle

### DIFF
--- a/src/NLog/Internal/ExceptionHelper.cs
+++ b/src/NLog/Internal/ExceptionHelper.cs
@@ -123,12 +123,12 @@ namespace NLog.Internal
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
             if (exception is StackOverflowException)
             {
-                return true;
+                return true; // StackOverflowException cannot be caught since .NetFramework 2.0
             }
 
             if (exception is ThreadAbortException)
             {
-                return true;
+                return true; // ThreadAbortException will automatically be rethrown at end of catch-block
             }
 #endif
 

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -136,7 +136,6 @@ namespace NLog.Targets
         private string _previousLogFileName;
 
         private bool _concurrentWrites;
-        private bool _keepFileOpen;
         private bool _cleanupFileName;
         private FilePathKind _fileNameKind = FilePathKind.Unknown;
         private FilePathKind _archiveFileKind;
@@ -287,7 +286,8 @@ namespace NLog.Targets
         /// Gets or sets a value indicating whether to keep log file open instead of opening and closing it on each logging event.
         /// </summary>
         /// <remarks>
-        /// Setting this property to <c>True</c> helps improve performance.
+        /// KeepFileOpen = true gives the best performance, and ensure the file-lock is not lost to other applications.<br/>
+        /// KeepFileOpen = false gives the best compability, but slow performance and lead to file-locking issues with other applications.
         /// </remarks>
         /// <docgen category='Performance Tuning Options' order='10' />
         public bool KeepFileOpen
@@ -302,6 +302,7 @@ namespace NLog.Targets
                 }
             }
         }
+        private bool _keepFileOpen = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether to enable log file(s) to be deleted.
@@ -1326,6 +1327,10 @@ namespace NLog.Targets
             try
             {
                 InternalLogger.Info("{0}: Deleting old archive file: '{1}'.", this, fileName);
+                if (_initializedFiles.ContainsKey(fileName))
+                {
+                    FinalizeFile(fileName, false);
+                }
                 File.Delete(fileName);
                 return true;
             }

--- a/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
+++ b/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
@@ -141,12 +141,12 @@ namespace NLog.UnitTests.Internal
 
             // NOTE Using BufferingWrapper to validate that DomainUnload remembers to perform flush
             var configXml = $@"
-            <nlog throwExceptions='false' autoShutdown='{autoShutdown}'>
+            <nlog throwExceptions='false' autoShutdown='{autoShutdown}' internalLogLevel='Debug' internalLogToConsoleError='true'>
                 <targets async='true'> 
                     <target name='file' type='BufferingWrapper' bufferSize='10000'>
                         <target name='filewrapped' type='file' layout='${{message}} ${{threadid}}' filename='{
                     filePath
-                }' LineEnding='lf' />
+                }' LineEnding='lf' keepFileOpen='false' />
                     </target>
                 </targets>
                 <rules>

--- a/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/VariableLayoutRendererTests.cs
@@ -146,12 +146,12 @@ namespace NLog.UnitTests.LayoutRenderers
         [Fact]
         public void Var_in_file_target()
         {
-            string folderPath = Path.GetTempPath();
-            string logFilePath = Path.Combine(folderPath, "test.log");
+            string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string logFilePath = Path.Combine(tempPath, "test.log");
 
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString($@"
             <nlog>
-                <variable name='dir' value='{folderPath}' />
+                <variable name='dir' value='{tempPath}' />
                 <targets>
                     <target name='f' type='file' fileName='${{var:dir}}/test.log' layout='${{message}}' lineEnding='LF' />
                 </targets>
@@ -164,7 +164,7 @@ namespace NLog.UnitTests.LayoutRenderers
                 LogManager.GetLogger("A").Debug("msg");
 
                 Assert.True(File.Exists(logFilePath), "Log file was not created at expected file path.");
-                Assert.Equal("msg\n", File.ReadAllText(logFilePath));
+                AssertFileContents(logFilePath, "msg\n", System.Text.Encoding.UTF8);
             }
             finally
             {

--- a/tests/NLog.UnitTests/Layouts/CsvLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/CsvLayoutTests.cs
@@ -55,7 +55,7 @@ namespace NLog.UnitTests.Layouts
                 LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
             <nlog>
                 <targets>
-                  <target name='f' type='File' fileName='" + tempFile + @"'>
+                  <target name='f' type='File' fileName='" + tempFile + @"' keepFileOpen='false'>
                     <layout type='CSVLayout'>
                       <column name='level' layout='${level}' />
                       <column name='message' layout='${message}' />
@@ -107,7 +107,7 @@ namespace NLog.UnitTests.Layouts
                 LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
             <nlog>
                 <targets>
-                  <target name='f' type='File' fileName='" + tempFile + @"'>
+                  <target name='f' type='File' fileName='" + tempFile + @"' keepFileOpen='false'>
                     <layout type='CSVLayout'>
                       <header>headertest</header>
                       <column name='level' layout='${level}' quoting='Nothing' />
@@ -156,7 +156,7 @@ namespace NLog.UnitTests.Layouts
                 LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
             <nlog>
                 <targets>
-                  <target name='f' type='File' fileName='" + tempFile + @"'>
+                  <target name='f' type='File' fileName='" + tempFile + @"' keepFileOpen='false'>
                     <layout type='CSVLayout' withHeader='false'>
                       <delimiter>Comma</delimiter>
                       <column name='level' layout='${level}' />

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -407,6 +407,8 @@ namespace NLog.UnitTests.Targets
                 {
                     Assert.Equal(14, Path.GetFileName(file).Length);
                 }
+
+                fileTarget.Close();
             }
             finally
             {
@@ -598,6 +600,8 @@ namespace NLog.UnitTests.Targets
                 AssertFileContents(logFile, "name;level;message\nNLog.UnitTests.Targets.FileTargetTests;Debug;aaa\nNLog.UnitTests.Targets.FileTargetTests;Debug;aaa\n", Encoding.UTF8);
 
                 Assert.NotEqual(3, Directory.GetFiles(tempPath).Count());   // See that archive cleanup worked
+
+                LogManager.Configuration = null;    // Close
             }
             finally
             {
@@ -3520,6 +3524,8 @@ namespace NLog.UnitTests.Targets
 
                 var currentFilesCount = archiveDir.GetFiles().Length;
                 Assert.Equal(expectedArchiveFiles, currentFilesCount);
+
+                LogManager.Configuration = null;    // Flush
             }
             finally
             {
@@ -4078,6 +4084,7 @@ namespace NLog.UnitTests.Targets
 
                 // Act
                 fileTarget.WriteAsyncLogEvents(events);
+                fileTarget.Close();
 
                 // Assert
                 Assert.Equal(Enumerable.Range(1, times).ToList(), result);


### PR DESCRIPTION
Resolves #2758. See also #4608

Applications will now fail with `System.IO.IOException: The process cannot access the file` when using `File.OpenText` or `File.ReadAllText` to read files created by NLog (Unless having explicitly configured `KeepFileOpen="false"`). But at the same time it will avoid failing application-logging caused by external application wrongly trying to use exclusive file-locking