### PR TITLE
FileTarget - Only enable FileSystemWatcher when ConcurrentWrites = true

### DIFF
--- a/src/NLog/Internal/AppEnvironmentWrapper.cs
+++ b/src/NLog/Internal/AppEnvironmentWrapper.cs
@@ -168,7 +168,7 @@ namespace NLog.Internal.Fakeables
                     throw;
 
                 // May throw a SecurityException or Access Denied when running from an IIS app. pool process
-                InternalLogger.Debug("LookupCurrentProcessFilePath Failed - {0}", ex.Message);
+                InternalLogger.Debug("LookupCurrentProcessFilePath Managed Failed - {0}", ex.Message);
                 return null;
             }
         }
@@ -204,7 +204,7 @@ namespace NLog.Internal.Fakeables
                     throw;
 
                 // May throw a SecurityException or Access Denied when running from an IIS app. pool process
-                InternalLogger.Debug("LookupCurrentProcessId Failed - {0}", ex.Message);
+                InternalLogger.Debug("LookupCurrentProcessId Managed Failed - {0}", ex.Message);
                 return null;
             }
         }
@@ -241,7 +241,7 @@ namespace NLog.Internal.Fakeables
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
-                InternalLogger.Debug("LookupCurrentProcessName Failed - {0}", ex.Message);
+                InternalLogger.Debug("LookupCurrentProcessName Managed Failed - {0}", ex.Message);
             }
 
             return null;
@@ -276,7 +276,7 @@ namespace NLog.Internal.Fakeables
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
-                InternalLogger.Debug("LookupCurrentProcessFilePath Failed - {0}", ex.Message);
+                InternalLogger.Debug("LookupCurrentProcessFilePath Native Failed - {0}", ex.Message);
                 return string.Empty;
             }
         }
@@ -299,7 +299,7 @@ namespace NLog.Internal.Fakeables
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
-                InternalLogger.Debug("LookupCurrentProcessFilePath Failed - {0}", ex.Message);
+                InternalLogger.Debug("LookupCurrentProcessFilePath Win32 Failed - {0}", ex.Message);
                 return string.Empty;
             }
         }
@@ -318,7 +318,7 @@ namespace NLog.Internal.Fakeables
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
-                InternalLogger.Debug("LookupCurrentProcessId Failed - {0}", ex.Message);
+                InternalLogger.Debug("LookupCurrentProcessId Native Failed - {0}", ex.Message);
                 return 0;
             }
         }
@@ -335,7 +335,7 @@ namespace NLog.Internal.Fakeables
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
-                InternalLogger.Debug("LookupCurrentProcessId Failed - {0}", ex.Message);
+                InternalLogger.Debug("LookupCurrentProcessId Win32 Failed - {0}", ex.Message);
                 return 0;
             }
         }

--- a/src/NLog/SetupLoadConfigurationExtensions.cs
+++ b/src/NLog/SetupLoadConfigurationExtensions.cs
@@ -440,7 +440,7 @@ namespace NLog
         /// <param name="archiveAboveSize">Size in bytes where log files will be automatically archived.</param>
         /// <param name="maxArchiveFiles">Maximum number of archive files that should be kept.</param>
         /// <param name="maxArchiveDays">Maximum days of archive files that should be kept.</param>
-        public static ISetupConfigurationTargetBuilder WriteToFile(this ISetupConfigurationTargetBuilder configBuilder, Layout fileName, Layout layout = null, System.Text.Encoding encoding = null, LineEndingMode lineEnding = null, bool keepFileOpen = false, bool concurrentWrites = false, long archiveAboveSize = 0, int maxArchiveFiles = 0, int maxArchiveDays = 0)
+        public static ISetupConfigurationTargetBuilder WriteToFile(this ISetupConfigurationTargetBuilder configBuilder, Layout fileName, Layout layout = null, System.Text.Encoding encoding = null, LineEndingMode lineEnding = null, bool keepFileOpen = true, bool concurrentWrites = false, long archiveAboveSize = 0, int maxArchiveFiles = 0, int maxArchiveDays = 0)
         {
             if (fileName is null)
                 throw new ArgumentNullException(nameof(fileName));

--- a/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
+++ b/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
@@ -141,12 +141,12 @@ namespace NLog.UnitTests.Internal
 
             // NOTE Using BufferingWrapper to validate that DomainUnload remembers to perform flush
             var configXml = $@"
-            <nlog throwExceptions='false' autoShutdown='{autoShutdown}' internalLogLevel='Debug' internalLogToConsoleError='true'>
+            <nlog throwExceptions='false' autoShutdown='{autoShutdown}'>
                 <targets async='true'> 
                     <target name='file' type='BufferingWrapper' bufferSize='10000'>
                         <target name='filewrapped' type='file' layout='${{message}} ${{threadid}}' filename='{
                     filePath
-                }' LineEnding='lf' keepFileOpen='false' />
+                }' LineEnding='lf' concurrentWrites='true' />
                     </target>
                 </targets>
                 <rules>

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -83,10 +83,11 @@ namespace NLog.UnitTests.Targets
         public void SetupBuilder_WriteToFile()
         {
             var tempPath = Path.Combine(Path.GetTempPath(), "nlog_" + Guid.NewGuid().ToString());
+            LogFactory logFactory = null;
 
             try
             {
-                var logFactory = new LogFactory().Setup().LoadConfiguration(c =>
+                logFactory = new LogFactory().Setup().LoadConfiguration(c =>
                 {
                     c.ForLogger().WriteToFile(Path.Combine(tempPath, "${logger}.txt"), "${message}", Encoding.UTF8, LineEndingMode.LF);
                 }).LogFactory;
@@ -97,6 +98,7 @@ namespace NLog.UnitTests.Targets
             }
             finally
             {
+                logFactory?.Shutdown();
                 if (Directory.Exists(tempPath))
                     Directory.Delete(tempPath, true);
             }
@@ -143,7 +145,7 @@ namespace NLog.UnitTests.Targets
         [MemberData(nameof(SimpleFileTest_TestParameters))]
         public void SimpleFileDeleteTest(bool concurrentWrites, bool keepFileOpen, bool networkWrites, bool forceManaged, bool forceMutexConcurrentWrites)
         {
-            bool isSimpleKeepFileOpen = keepFileOpen && !networkWrites && !concurrentWrites && IsLinux();
+            bool isSimpleKeepFileOpen = keepFileOpen && !networkWrites && !concurrentWrites;
 #if MONO
             if (IsLinux() && concurrentWrites && keepFileOpen && !networkWrites)
             {


### PR DESCRIPTION
Only enable Win32-API-call when overriding FileAttributes. Refactor MultiFileWatcher to better handle medium trust.

Better chance of NLog FileTarget working on low-permission-platforms (UWP / Xamarin Android / Xamarin iOS). But it will take longer time (up to 1 sec) for NLog to recover from the user deleting the active file (before 100 ms)