### PR TITLE
PropertiesDictionary - Fixed threading issue in EventProperties

### DIFF
--- a/src/NLog/Internal/Collections/PropertiesDictionary.cs
+++ b/src/NLog/Internal/Collections/PropertiesDictionary.cs
@@ -103,18 +103,7 @@ namespace NLog.Internal
             {
                 if (_eventProperties is null)
                 {
-                    if (_messageProperties != null && _messageProperties.Count > 0)
-                    {
-                        _eventProperties = new Dictionary<object, PropertyValue>(_messageProperties.Count);
-                        if (!InsertMessagePropertiesIntoEmptyDictionary(_messageProperties, _eventProperties))
-                        {
-                            _messageProperties = CreateUniqueMessagePropertiesListSlow(_messageProperties, _eventProperties);
-                        }
-                    }
-                    else
-                    {
-                        _eventProperties = new Dictionary<object, PropertyValue>();
-                    }
+                    System.Threading.Interlocked.CompareExchange(ref _eventProperties, BuildEventProperties(_messageProperties), null);
                 }
                 return _eventProperties;
             }
@@ -163,6 +152,23 @@ namespace NLog.Internal
                 {
                     _eventProperties.Remove(oldMessageProperties[i].Name);
                 }
+            }
+        }
+
+        private static Dictionary<object, PropertyValue> BuildEventProperties(IList<MessageTemplateParameter> messageProperties)
+        {
+            if (messageProperties?.Count > 0)
+            {
+                var eventProperties = new Dictionary<object, PropertyValue>(messageProperties.Count);
+                if (!InsertMessagePropertiesIntoEmptyDictionary(messageProperties, eventProperties))
+                {
+                    CreateUniqueMessagePropertiesListSlow(messageProperties, eventProperties);  // Should never happen
+                }
+                return eventProperties;
+            }
+            else
+            {
+                return new Dictionary<object, PropertyValue>();
             }
         }
 
@@ -326,10 +332,24 @@ namespace NLog.Internal
         /// <inheritDoc/>
         public bool TryGetValue(object key, out object value)
         {
-            if (!IsEmpty && EventProperties.TryGetValue(key, out var valueItem))
+            if (!IsEmpty)
             {
-                value = valueItem.Value;
-                return true;
+                if (_eventProperties is null && key is string keyString && _messageProperties?.Count < 5)
+                {
+                    for (int i = 0; i < _messageProperties.Count; ++i)
+                    {
+                        if (keyString.Equals(_messageProperties[i].Name, StringComparison.Ordinal))
+                        {
+                            value = _messageProperties[i].Value;
+                            return true;
+                        }
+                    }
+                }
+                else if (EventProperties.TryGetValue(key, out var valueItem))
+                {
+                    value = valueItem.Value;
+                    return true;
+                }
             }
 
             value = null;

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -138,9 +138,9 @@ namespace NLog
         {
             Level = level;
             LoggerName = loggerName;
-            Message = message;
+            _formatProvider = formatProvider;
+            _message = message;
             Parameters = parameters;
-            FormatProvider = formatProvider;
             Exception = exception;
         }
 


### PR DESCRIPTION
The property allowed multiple threads to be reading and modifying the same collection. Maybe fixing #4496

The issue can be triggered by using structured-logging with message-templates, and having multiple targets doing logevent-property-lookup and also enumerating the logevent-properties.

If 2 targets has layouts where target1 uses `${event-properties}` and target2 uses `JsonLayout.IncludeAllProperties`. Then the following can happen:
- Target1 wants to lookup property, and starts building the lookup-dictionary.
- Target2 wants to enumerate properties, and sees lookup-dictionary is available and runs with it.
- Target1 continues to build the lookup-dictionary.
- Target2 enumerates the lookup-dictionary, and might get collection was modified.

Have not been able to implement an unit-test that reproduced the issue, but was able to get `Dictionary.Add` to fail with key already exists by introducing "artificial sleep" with the debugger (Two threads were working on building the same lookup-dictionary)

The issue has been there since NLog ver. 4.5 (4 years ago)