### PR TITLE
PropertiesDictionary - Fixed threading issue in EventProperties (bug fix release)

### DIFF
--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -143,9 +143,9 @@ namespace NLog
         {
             Level = level;
             LoggerName = loggerName;
-            Message = message;
+            _formatProvider = formatProvider;
+            _message = message;
             Parameters = parameters;
-            FormatProvider = formatProvider;
             Exception = exception;
          
             if (NeedToPreformatMessage(parameters))


### PR DESCRIPTION
The property allowed multiple threads to be reading and modifying the same collection. Maybe fixing #4496

The issue can be triggered by using structured-logging with message-templates, and having multiple targets doing logevent-property-lookup and also enumerating the logevent-properties concurrently.

The issue has been there since NLog ver. 4.5 (4 years ago)

See also #4626