### PR TITLE
FileTarget - Attempt to write footer, before closing file appender

### DIFF
--- a/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
+++ b/src/NLog/Internal/FileAppenders/FileAppenderCache.cs
@@ -31,10 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !NETSTANDARD1_3
-#define SupportsMutex
-#endif
-
 namespace NLog.Internal.FileAppenders
 {
     using System;


### PR DESCRIPTION
With `KeepFileOpen = true` by default, then it is better to finalize files early, while the file-handle is open.