### PR TITLE
Handle OutOfMemoryException instead of crashing the application

### DIFF
--- a/src/NLog/Internal/ExceptionHelper.cs
+++ b/src/NLog/Internal/ExceptionHelper.cs
@@ -121,12 +121,12 @@ namespace NLog.Internal
 #if !NETSTANDARD1_0
             if (exception is StackOverflowException)
             {
-                return true;
+                return true; // StackOverflowException cannot be caught since .NetFramework 2.0
             }
 
             if (exception is ThreadAbortException)
             {
-                return true;
+                return true; // ThreadAbortException will automatically be rethrown at end of catch-block
             }
 #endif
 

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -485,11 +485,12 @@ namespace NLog.Targets.Wrappers
                 wroteFullBatchSize = false; // Something went wrong, lets throttle retry
 
                 InternalLogger.Error(exception, "AsyncWrapper(Name={0}): Error in lazy writer timer procedure.", Name);
-
+#if DEBUG
                 if (exception.MustBeRethrownImmediately())
                 {
                     throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                 }
+#endif
             }
             finally
             {
@@ -527,11 +528,12 @@ namespace NLog.Targets.Wrappers
             catch (Exception exception)
             {
                 InternalLogger.Error(exception, "AsyncWrapper(Name={0}): Error in flush procedure.", Name);
-
+#if DEBUG
                 if (exception.MustBeRethrownImmediately())
                 {
                     throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                 }
+#endif
             }
         }
 

--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -254,11 +254,12 @@ namespace NLog.Targets.Wrappers
             catch (Exception exception)
             {
                 InternalLogger.Error(exception, "BufferingWrapper(Name={0}): Error in flush procedure.", Name);
-
+#if DEBUG
                 if (exception.MustBeRethrownImmediately())
                 {
                     throw;  // Throwing exceptions here will crash the entire application (.NET 2.0 behavior)
                 }
+#endif
             }
             finally
             {


### PR DESCRIPTION
Resolves #4616 (Avoid having `AsyncTargetWrapper` killing the application). Light weight version of #4622

Just created in case there should be a NLog ver. 4.7.13