### PR TITLE
LogLevel - Replaced IConvertible with IFormattable for better Json serialization

### DIFF
--- a/src/NLog/Attributes/LogLevelTypeConverter.cs
+++ b/src/NLog/Attributes/LogLevelTypeConverter.cs
@@ -51,9 +51,10 @@ namespace NLog.Attributes
         /// <inheritdoc/>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            if (value?.GetType() == typeof(string))
-                return LogLevel.FromString(value.ToString());
-            else if (IsNumericType(value?.GetType()))
+            var valueType = value?.GetType();
+            if (typeof(string).Equals(valueType))
+                return LogLevel.FromString(value?.ToString());
+            else if (IsNumericType(valueType))
                 return LogLevel.FromOrdinal(Convert.ToInt32(value));
             else 
                 return base.ConvertFrom(context, culture, value);
@@ -80,19 +81,18 @@ namespace NLog.Attributes
 
         private static bool IsNumericType(Type sourceType)
         {
-            if (sourceType == typeof(int))
+            if (typeof(int).Equals(sourceType))
                 return true;
-            if (sourceType == typeof(uint))
+            if (typeof(uint).Equals(sourceType))
                 return true;
-            if (sourceType == typeof(long))
+            if (typeof(long).Equals(sourceType))
                 return true;
-            if (sourceType == typeof(ulong))
+            if (typeof(ulong).Equals(sourceType))
                 return true;
-            if (sourceType == typeof(short))
+            if (typeof(short).Equals(sourceType))
                 return true;
-            if (sourceType == typeof(ushort))
+            if (typeof(ushort).Equals(sourceType))
                 return true;
-
             return false;
         }
     }

--- a/src/NLog/Config/PropertyTypeConverter.cs
+++ b/src/NLog/Config/PropertyTypeConverter.cs
@@ -59,11 +59,12 @@ namespace NLog.Config
                 { typeof(System.Globalization.CultureInfo), (stringvalue, format, formatProvider) => new System.Globalization.CultureInfo(stringvalue) },
                 { typeof(Type), (stringvalue, format, formatProvider) => Type.GetType(stringvalue, true) },
                 { typeof(NLog.Targets.LineEndingMode), (stringvalue, format, formatProvider) => NLog.Targets.LineEndingMode.FromString(stringvalue) },
+                { typeof(LogLevel), (stringvalue, format, formatProvider) => LogLevel.FromString(stringvalue) },
                 { typeof(Uri), (stringvalue, format, formatProvider) => new Uri(stringvalue) },
                 { typeof(DateTime), (stringvalue, format, formatProvider) => ConvertToDateTime(format, formatProvider, stringvalue) },
                 { typeof(DateTimeOffset), (stringvalue, format, formatProvider) => ConvertToDateTimeOffset(format, formatProvider, stringvalue) },
                 { typeof(TimeSpan), (stringvalue, format, formatProvider) => ConvertToTimeSpan(format, formatProvider, stringvalue) },
-                { typeof(Guid), (stringvalue, format, formatProvider) => ConvertGuid(format, stringvalue) }
+                { typeof(Guid), (stringvalue, format, formatProvider) => ConvertGuid(format, stringvalue) },
             };
         }
 
@@ -81,7 +82,7 @@ namespace NLog.Config
             }
 
             var propertyValueType = propertyValue.GetType();
-            if (propertyType == propertyValueType)
+            if (propertyType.Equals(propertyValueType))
             {
                 return propertyValue;   // Same type
             }
@@ -89,7 +90,7 @@ namespace NLog.Config
             var nullableType = Nullable.GetUnderlyingType(propertyType);
             if (nullableType != null)
             {
-                if (nullableType == propertyValueType)
+                if (nullableType.Equals(propertyValueType))
                 {
                     return propertyValue;   // Same type
                 }
@@ -105,30 +106,36 @@ namespace NLog.Config
             return ChangeObjectType(propertyValue, propertyType, format, formatProvider);
         }
 
+        private static bool TryConvertFromString(string propertyString, Type propertyType, string format, IFormatProvider formatProvider, out object propertyValue)
+        {
+            propertyValue = propertyString = propertyString.Trim();
+
+            if (StringConverterLookup.TryGetValue(propertyType, out var converter))
+            {
+                propertyValue = converter.Invoke(propertyString, format, formatProvider);
+                return true;
+            }
+
+            if (propertyType.IsEnum() && NLog.Common.ConversionHelpers.TryParseEnum(propertyString, propertyType, out var enumValue))
+            {
+                propertyValue = enumValue;
+                return true;
+            }
+
+            if (!typeof(IConvertible).IsAssignableFrom(propertyType) && PropertyHelper.TryTypeConverterConversion(propertyType, propertyString, out var convertedValue))
+            {
+                propertyValue = convertedValue;
+                return true;
+            }
+
+            return false;
+        }
+
         private static object ChangeObjectType(object propertyValue, Type propertyType, string format, IFormatProvider formatProvider)
         {
-            if (propertyValue is string propertyString)
+            if (propertyValue is string propertyString && TryConvertFromString(propertyString, propertyType, format, formatProvider, out propertyValue))
             {
-                propertyValue = propertyString = propertyString.Trim();
-
-                if (StringConverterLookup.TryGetValue(propertyType, out var converter))
-                {
-                    return converter.Invoke(propertyString, format, formatProvider);
-                }
-
-                if (propertyType.IsEnum() && NLog.Common.ConversionHelpers.TryParseEnum(propertyString, propertyType, out var enumValue))
-                {
-                    return enumValue;
-                }
-
-                if (!typeof(IConvertible).IsAssignableFrom(propertyType) && PropertyHelper.TryTypeConverterConversion(propertyType, propertyString, out var convertedValue))
-                {
-                    return convertedValue;
-                }
-            }
-            else if (!string.IsNullOrEmpty(format) && propertyValue is IFormattable formattableValue)
-            {
-                propertyValue = formattableValue.ToString(format, formatProvider);
+                return propertyValue;
             }
 
             if (propertyValue is IConvertible convertibleValue)
@@ -136,10 +143,23 @@ namespace NLog.Config
                 var typeCode = convertibleValue.GetTypeCode();
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
                 if (typeCode == TypeCode.DBNull)
-                    return propertyValue;
+                    return convertibleValue;
 #endif
                 if (typeCode == TypeCode.Empty)
                     return null;
+            }
+            else
+            {
+                var logConverter = System.ComponentModel.TypeDescriptor.GetConverter(propertyValue.GetType());
+                if (logConverter != null && logConverter.CanConvertTo(propertyType))
+                {
+                    return logConverter.ConvertTo(propertyValue, propertyType);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(format) && propertyValue is IFormattable formattableValue)
+            {
+                propertyValue = formattableValue.ToString(format, formatProvider);
             }
 
             return System.Convert.ChangeType(propertyValue, propertyType, formatProvider);

--- a/src/NLog/LogLevel.cs
+++ b/src/NLog/LogLevel.cs
@@ -41,7 +41,7 @@ namespace NLog
     /// Defines available log levels.
     /// </summary>
     [TypeConverter(typeof(Attributes.LogLevelTypeConverter))]
-    public sealed class LogLevel : IComparable<LogLevel>, IComparable, IEquatable<LogLevel>, IConvertible
+    public sealed class LogLevel : IComparable<LogLevel>, IComparable, IEquatable<LogLevel>, IFormattable
     {
         /// <summary>
         /// Trace log level.
@@ -320,6 +320,14 @@ namespace NLog
             return _name;
         }
 
+        string IFormattable.ToString(string format, IFormatProvider formatProvider)
+        {
+            if (string.IsNullOrEmpty(format) || (!"D".Equals(format, StringComparison.OrdinalIgnoreCase)))
+                return _name;
+            else
+                return _ordinal.ToString(); // Like Enum.ToString()
+        }
+
         /// <inheritdoc/>
         public override int GetHashCode()
         {
@@ -372,97 +380,5 @@ namespace NLog
         {
             return _ordinal - (other ?? LogLevel.Off)._ordinal;
         }
-
-        #region Implementation of IConvertible
-
-        TypeCode IConvertible.GetTypeCode()
-        {
-            return TypeCode.Object;
-        }
-
-        byte IConvertible.ToByte(IFormatProvider provider)
-        {
-            return Convert.ToByte(_ordinal);
-        }
-
-        bool IConvertible.ToBoolean(IFormatProvider provider)
-        {
-            throw new InvalidCastException();
-        }
-
-        char IConvertible.ToChar(IFormatProvider provider)
-        {
-            return Convert.ToChar(_ordinal);
-        }
-
-        DateTime IConvertible.ToDateTime(IFormatProvider provider)
-        {
-            throw new InvalidCastException();
-        }
-
-        decimal IConvertible.ToDecimal(IFormatProvider provider)
-        {
-            return Convert.ToDecimal(_ordinal);
-        }
-
-        double IConvertible.ToDouble(IFormatProvider provider)
-        {
-            return _ordinal;
-        }
-
-        short IConvertible.ToInt16(IFormatProvider provider)
-        {
-            return Convert.ToInt16(_ordinal);
-        }
-
-        int IConvertible.ToInt32(IFormatProvider provider)
-        {
-            return Convert.ToInt32(_ordinal);
-        }
-
-        long IConvertible.ToInt64(IFormatProvider provider)
-        {
-            return Convert.ToInt64(_ordinal);
-        }
-
-        sbyte IConvertible.ToSByte(IFormatProvider provider)
-        {
-            return Convert.ToSByte(_ordinal);
-        }
-
-        float IConvertible.ToSingle(IFormatProvider provider)
-        {
-            return Convert.ToSingle(_ordinal);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return _name;
-        }
-
-        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
-        {
-            if (conversionType == typeof(string))
-                return _name;
-            else
-                return Convert.ChangeType(_ordinal, conversionType, provider);
-        }
-
-        ushort IConvertible.ToUInt16(IFormatProvider provider)
-        {
-            return Convert.ToUInt16(_ordinal);
-        }
-
-        uint IConvertible.ToUInt32(IFormatProvider provider)
-        {
-            return Convert.ToUInt32(_ordinal);
-        }
-
-        ulong IConvertible.ToUInt64(IFormatProvider provider)
-        {
-            return Convert.ToUInt64(_ordinal);
-        }
-
-        #endregion
     }
 }

--- a/tests/NLog.UnitTests/Internal/ExpandoTestDictionary.cs
+++ b/tests/NLog.UnitTests/Internal/ExpandoTestDictionary.cs
@@ -40,73 +40,73 @@ namespace NLog.UnitTests.Internal
     /// <summary>
     /// Special Expando-Object that has custom object-value (Similar to JObject)
     /// </summary>
-    internal class ExpandoTestDictionary : IDictionary<string, IConvertible>
+    internal class ExpandoTestDictionary : IDictionary<string, IFormattable>
     {
-        private readonly Dictionary<string, IConvertible> _properties = new Dictionary<string, IConvertible>();
+        private readonly Dictionary<string, IFormattable> _properties = new Dictionary<string, IFormattable>();
 
-        public IConvertible this[string key] { get => ((IDictionary<string, IConvertible>)_properties)[key]; set => ((IDictionary<string, IConvertible>)_properties)[key] = value; }
+        public IFormattable this[string key] { get => ((IDictionary<string, IFormattable>)_properties)[key]; set => ((IDictionary<string, IFormattable>)_properties)[key] = value; }
 
-        public ICollection<string> Keys => ((IDictionary<string, IConvertible>)_properties).Keys;
+        public ICollection<string> Keys => ((IDictionary<string, IFormattable>)_properties).Keys;
 
-        public ICollection<IConvertible> Values => ((IDictionary<string, IConvertible>)_properties).Values;
+        public ICollection<IFormattable> Values => ((IDictionary<string, IFormattable>)_properties).Values;
 
-        public int Count => ((IDictionary<string, IConvertible>)_properties).Count;
+        public int Count => ((IDictionary<string, IFormattable>)_properties).Count;
 
-        public bool IsReadOnly => ((IDictionary<string, IConvertible>)_properties).IsReadOnly;
+        public bool IsReadOnly => ((IDictionary<string, IFormattable>)_properties).IsReadOnly;
 
-        public void Add(string key, IConvertible value)
+        public void Add(string key, IFormattable value)
         {
-            ((IDictionary<string, IConvertible>)_properties).Add(key, value);
+            ((IDictionary<string, IFormattable>)_properties).Add(key, value);
         }
 
-        public void Add(KeyValuePair<string, IConvertible> item)
+        public void Add(KeyValuePair<string, IFormattable> item)
         {
-            ((IDictionary<string, IConvertible>)_properties).Add(item);
+            ((IDictionary<string, IFormattable>)_properties).Add(item);
         }
 
         public void Clear()
         {
-            ((IDictionary<string, IConvertible>)_properties).Clear();
+            ((IDictionary<string, IFormattable>)_properties).Clear();
         }
 
-        public bool Contains(KeyValuePair<string, IConvertible> item)
+        public bool Contains(KeyValuePair<string, IFormattable> item)
         {
-            return ((IDictionary<string, IConvertible>)_properties).Contains(item);
+            return ((IDictionary<string, IFormattable>)_properties).Contains(item);
         }
 
         public bool ContainsKey(string key)
         {
-            return ((IDictionary<string, IConvertible>)_properties).ContainsKey(key);
+            return ((IDictionary<string, IFormattable>)_properties).ContainsKey(key);
         }
 
-        public void CopyTo(KeyValuePair<string, IConvertible>[] array, int arrayIndex)
+        public void CopyTo(KeyValuePair<string, IFormattable>[] array, int arrayIndex)
         {
-            ((IDictionary<string, IConvertible>)_properties).CopyTo(array, arrayIndex);
+            ((IDictionary<string, IFormattable>)_properties).CopyTo(array, arrayIndex);
         }
 
-        public IEnumerator<KeyValuePair<string, IConvertible>> GetEnumerator()
+        public IEnumerator<KeyValuePair<string, IFormattable>> GetEnumerator()
         {
-            return ((IDictionary<string, IConvertible>)_properties).GetEnumerator();
+            return ((IDictionary<string, IFormattable>)_properties).GetEnumerator();
         }
 
         public bool Remove(string key)
         {
-            return ((IDictionary<string, IConvertible>)_properties).Remove(key);
+            return ((IDictionary<string, IFormattable>)_properties).Remove(key);
         }
 
-        public bool Remove(KeyValuePair<string, IConvertible> item)
+        public bool Remove(KeyValuePair<string, IFormattable> item)
         {
-            return ((IDictionary<string, IConvertible>)_properties).Remove(item);
+            return ((IDictionary<string, IFormattable>)_properties).Remove(item);
         }
 
-        public bool TryGetValue(string key, out IConvertible value)
+        public bool TryGetValue(string key, out IFormattable value)
         {
-            return ((IDictionary<string, IConvertible>)_properties).TryGetValue(key, out value);
+            return ((IDictionary<string, IFormattable>)_properties).TryGetValue(key, out value);
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IDictionary<string, IConvertible>)_properties).GetEnumerator();
+            return ((IDictionary<string, IFormattable>)_properties).GetEnumerator();
         }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/LogLevelTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/LogLevelTests.cs
@@ -187,18 +187,14 @@ namespace NLog.UnitTests.LayoutRenderers
         public void LogLevelConvertTest(Type type, object expected)
         {
             // Arrange
-            IConvertible logLevel = LogLevel.Info;
+            IFormattable logLevel = LogLevel.Info;
             var logConverter = System.ComponentModel.TypeDescriptor.GetConverter(typeof(LogLevel));
                 
             // Act
-            var changeTypeResult = Convert.ChangeType(logLevel, type);
-            var changeToResult = logLevel.ToType(type, System.Globalization.CultureInfo.CurrentCulture);
             var convertToResult = logConverter.CanConvertTo(type) ? logConverter.ConvertTo(logLevel, type) : null;
             var convertFromResult = logConverter.CanConvertFrom(expected.GetType()) ? logConverter.ConvertFrom(expected) : null;
 
             // Assert
-            Assert.Equal(expected, changeTypeResult);
-            Assert.Equal(expected, changeToResult);
             Assert.Equal(expected, convertToResult);
             Assert.Equal(logLevel, convertFromResult);
         }

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
@@ -368,17 +368,17 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void SerializeExpandoDict_Test()
         {
-            IDictionary<string, IConvertible> dictionary = new Internal.ExpandoTestDictionary();
+            IDictionary<string, IFormattable> dictionary = new Internal.ExpandoTestDictionary();
             dictionary.Add("key 2", 1.3m);
             dictionary.Add("level", LogLevel.Info);
             var actual = SerializeObject(dictionary);
-            Assert.Equal("{\"key 2\":1.3, \"level\":{\"Name\":\"Info\", \"Ordinal\":2}}", actual);
+            Assert.Equal("{\"key 2\":1.3, \"level\":\"Info\"}", actual);
         }
 
         [Fact]
         public void SerializEmptyExpandoDict_Test()
         {
-            IDictionary<string, IConvertible> dictionary = new Internal.ExpandoTestDictionary();
+            IDictionary<string, IFormattable> dictionary = new Internal.ExpandoTestDictionary();
             var actual = SerializeObject(dictionary);
             Assert.Equal("{}", actual);
         }
@@ -393,7 +393,7 @@ namespace NLog.UnitTests.Targets
 
             var readonlyDictionary = new Internal.ReadOnlyExpandoTestDictionary(dictionary);
             var actual = SerializeObject(readonlyDictionary);
-            Assert.Equal("{\"key 2\":1.3, \"level\":{\"Name\":\"Info\", \"Ordinal\":2}}", actual);
+            Assert.Equal("{\"key 2\":1.3, \"level\":\"Info\"}", actual);
         }
 #endif
 


### PR DESCRIPTION
Converts NLog LogLevel into just Name, instead of complex object with properties (Not returning `TypeCode.Object`)