### PR TITLE
Fixed RegisterObjectTransformation to handle conversion to simple values

### DIFF
--- a/src/NLog/Internal/Reflection/ObjectReflectionCache.cs
+++ b/src/NLog/Internal/Reflection/ObjectReflectionCache.cs
@@ -336,7 +336,9 @@ namespace NLog.Internal
                 }
             }
 
-            public bool ConvertToString => _properties?.Length == 0;
+            public bool IsSimpleValue => _properties?.Length == 0;
+
+            public object ObjectValue => _object;
 
             internal ObjectPropertyList(object value, PropertyInfo[] properties, FastPropertyLookup[] fastLookup)
             {

--- a/src/NLog/Layouts/XML/XmlElementBase.cs
+++ b/src/NLog/Layouts/XML/XmlElementBase.cs
@@ -517,9 +517,9 @@ namespace NLog.Layouts
 
         private void AppendXmlObjectPropertyValues(string propName, ref ObjectReflectionCache.ObjectPropertyList propertyValues, StringBuilder sb, int orgLength, ref SingleItemOptimizedHashSet<object> objectsInPath, int depth, bool ignorePropertiesElementName = false)
         {
-            if (propertyValues.ConvertToString)
+            if (propertyValues.IsSimpleValue)
             {
-                AppendXmlPropertyValue(propName, propertyValues.ToString(), sb, orgLength, false, ignorePropertiesElementName);
+                AppendXmlPropertyValue(propName, propertyValues.ObjectValue, sb, orgLength, false, ignorePropertiesElementName);
             }
             else
             {

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerClassTests.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerClassTests.cs
@@ -81,6 +81,22 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void SimpleValue_RegistersSerializeAsToString_ConvertsValue()
+        {
+            var logFactory = new LogFactory();
+            logFactory.Setup().SetupSerialization(s => s.RegisterObjectTransformation<System.IO.MemoryStream>(o => o.Capacity));
+
+            var testObject = new System.IO.MemoryStream(42);
+            
+            var sb = new StringBuilder();
+            var options = new JsonSerializeOptions();
+            var jsonSerializer = new DefaultJsonSerializer(logFactory.ServiceRepository);
+            jsonSerializer.SerializeObject(testObject, sb, options);
+
+            Assert.Equal($"{testObject.Capacity}", sb.ToString());
+        }
+
+        [Fact]
         public void IExcludedInterfaceSerializer_RegistersSerializeAsToString_InvokesToString()
         {
             var testObject = BuildSampleObject();


### PR DESCRIPTION
Allow RegisterObjectTransformation to return value-types like `int`, without json-serializer converting them to string.