### PR TITLE
AsyncTargetWrapper - Better performance when using OverflowAction Block

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -428,7 +428,7 @@ namespace NLog.Targets.Wrappers
                 if (TimeToSleepBetweenBatches == 0)
                     StartInstantWriterTimer();
                 else if (TimeToSleepBetweenBatches <= 1)
-                    StartLazyWriterTimer();
+                    StartTimerUnlessWriterActive(false);
             }
         }
 


### PR DESCRIPTION
When constantly being blocked, then "updating" the timer to be forced "lazy" actually hurts performance ("only" affects NetCore with ConcurrentQueue)