### PR TITLE
databasetarget: improved parsing of dbtype

### DIFF
--- a/src/NLog.Database/DatabaseParameterInfo.cs
+++ b/src/NLog.Database/DatabaseParameterInfo.cs
@@ -49,17 +49,21 @@ namespace NLog.Targets
     [NLogConfigurationItem]
     public class DatabaseParameterInfo
     {
+        /// <summary>
+        /// Mapping of System.Data.DbType, System.Data.SqlDbType and NpgsqlTypes.NpgsqlDbType members names
+        /// to their corresponding CLR types.
+        /// </summary>
         private static readonly Dictionary<string, Type> _typesByDbTypeName =
             new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
             {
-                { "Bool", typeof(bool) },
-                { "Timestamp", typeof(DateTime) }, // Npgsql ?
+                // Members from System.Data.DbType
+
                 { nameof(System.Data.DbType.AnsiString), typeof(string) },
-                { nameof(System.Data.DbType.Binary), typeof(byte[]) },
+                // { nameof(System.Data.DbType.Binary), typeof(byte[]) },  // not supported
                 { nameof(System.Data.DbType.Byte), typeof(byte) },
                 { nameof(System.Data.DbType.Boolean), typeof(bool) },
                 { nameof(System.Data.DbType.Currency), typeof(decimal) },
-                { nameof(System.Data.DbType.Date), typeof(DateTime) },
+                { nameof(System.Data.DbType.Date), typeof(DateTime) }, // DateOnly when .net framework will be deprecated
                 { nameof(System.Data.DbType.DateTime), typeof(DateTime) },
                 { nameof(System.Data.DbType.Decimal), typeof(decimal) },
                 { nameof(System.Data.DbType.Double), typeof(double) },
@@ -67,20 +71,136 @@ namespace NLog.Targets
                 { nameof(System.Data.DbType.Int16), typeof(short) },
                 { nameof(System.Data.DbType.Int32), typeof(int) },
                 { nameof(System.Data.DbType.Int64), typeof(long) },
-                { nameof(System.Data.DbType.Object), typeof(object) },
+                { nameof(System.Data.DbType.Object), typeof(object) }, // not sure if we should support this
                 { nameof(System.Data.DbType.SByte), typeof(sbyte) },
                 { nameof(System.Data.DbType.Single), typeof(float) },
                 { nameof(System.Data.DbType.String), typeof(string) },
-                { nameof(System.Data.DbType.Time), typeof(TimeSpan) },
+                { nameof(System.Data.DbType.Time), typeof(TimeSpan) }, // TimeOnly when .net framework will be deprecated
                 { nameof(System.Data.DbType.UInt16), typeof(ushort) },
                 { nameof(System.Data.DbType.UInt32), typeof(uint) },
                 { nameof(System.Data.DbType.UInt64), typeof(ulong) },
-                { nameof(System.Data.DbType.VarNumeric), typeof(decimal) }, // BigInt ?
+                { nameof(System.Data.DbType.VarNumeric), typeof(decimal) },
                 { nameof(System.Data.DbType.AnsiStringFixedLength), typeof(string) },
                 { nameof(System.Data.DbType.StringFixedLength), typeof(string) },
                 { nameof(System.Data.DbType.Xml), typeof(string) },
                 { nameof(System.Data.DbType.DateTime2), typeof(DateTime) },
-                { nameof(System.Data.DbType.DateTimeOffset), typeof(DateTimeOffset) }
+                { nameof(System.Data.DbType.DateTimeOffset), typeof(DateTimeOffset) },
+
+
+                // Members from System.Data.SqlDbType
+
+                { "BigInt", typeof(long) },
+                // { "Binary", typeof(byte[]) }, // not supported
+                { "Bit", typeof(bool?) },
+                { "Char", typeof(string) },
+                // { "DateTime", typeof(DateTime) }, // already been added
+                // { "Decimal", typeof(decimal) }, // already been added
+                { "Float", typeof(float) },
+                // { "Image", typeof() }, // not supported
+                { "Int", typeof(int) },
+                { "Money", typeof(decimal) },
+                { "NChar", typeof(string) },
+                { "NText", typeof(string) },
+                { "NVarChar", typeof(string) },
+                { "Real", typeof(float) },
+                { "UniqueIdentifier", typeof(Guid) },
+                { "SmallDateTime", typeof(DateTime) },
+                { "SmallInt", typeof(short) },
+                { "SmallMoney", typeof(decimal) },
+                { "Text", typeof(string) },
+                // { "Timestamp", typeof(byte[]) }, // not supported (actually not a Timestamp)
+                { "TinyInt", typeof(byte) },
+                // { "VarBinary", typeof(byte[]) }, // not supported
+                { "VarChar", typeof(string) },
+                { "Variant", typeof(object) }, // not sure if we should support this
+                // { "Xml", typeof(string) }, // already been added
+                // { "Udt", typeof() }, // not supported
+                // { "Structured", typeof() }, // not supported
+                // { "Date", typeof(DateTime) }, // already been added
+                // { "Time", typeof(TimeSpan) }, // already been added
+                // { "DateTime2", typeof(DateTime) }, // already been added
+                // { "DateTimeOffset", typeof(DateTimeOffset) } // already been added
+
+
+                // Members from NpgsqlTypes.NpgsqlDbType
+
+                // { "Bigint", typeof(long) }, // already been added
+                // { "Double", typeof(double) }, // already been added
+                { "Integer", typeof(int) },
+                { "Numeric", typeof(decimal) },
+                // { "Real", typeof(float) }, // already been added
+                // { "Smallint", typeof(short) }, // already been added
+                // { "Money", typeof(decimal) }, // already been added
+                // { "Boolean", typeof(bool) }, // already been added
+                // { "Box", typeof() }, // not supported
+                // { "Circle", typeof() }, // not supported
+                // { "Line", typeof() }, // not supported
+                // { "LSeg", typeof() }, // not supported
+                // { "Path", typeof() }, // not supported
+                // { "Point", typeof() }, // not supported
+                // { "Polygon", typeof() }, // not supported
+                // { "Char", typeof(string) }, // already been added
+                // { "Text", typeof(string) }, // already been added
+                // { "Varchar", typeof(string) }, // already been added
+                // { "Name", typeof() }, // not supported (internal)
+                // { "Citext", typeof() }, // not supported
+                // { "InternalChar", typeof() }, // not supported (internal)
+                // { "Bytea", typeof(byte[]) }, // not supported
+                // { "Date", typeof(DateTime) }, // already been added
+                // { "Time", typeof(TimeSpan) }, // already been added
+                { "Timestamp", typeof(DateTime) },// ** COLLIDE with System.Data.SqlDbType.Timestamp **
+                { "TimestampTZ", typeof(DateTimeOffset) },
+                // { "TimestampTz", typeof(DateTimeOffset) }, // already been added
+                { "Interval", typeof(TimeSpan) },
+                // { "TimeTZ", typeof() }, // not supported
+                // { "TimeTz", typeof() }, // not supported
+                // { "Abstime", typeof() }, // obshowlete
+                // { "Inet", typeof() }, // not supported
+                // { "Cidr", typeof() }, // not supported
+                // { "MacAddr", typeof() }, // not supported
+                // { "MacAddr8", typeof() }, // not supported
+                // { "Bit", typeof(bool[]) }, // not supported ** COLLIDE with System.Data.SqlDbType.Bit ** 
+                // { "Varbit", typeof(bool[]) }, // not supported
+                // { "TsVector", typeof() }, // not supported
+                // { "TsQuery", typeof() }, // not supported
+                // { "Regconfig", typeof() }, // not supported
+                { "Uuid", typeof(Guid) },
+                // { "Xml", typeof(string) }, // already been added
+                { "Json", typeof(string) },
+                // { "Jsonb", typeof(byte[]) }, // not supported
+                { "JsonPath", typeof(string) },
+                // { "Hstore", typeof(Dictionary<string, string>) },  // not supported
+                // { "Refcursor", typeof() }, // not supported
+                // { "Oidvector", typeof() }, // not supported
+                // { "Int2Vector", typeof() }, // not supported
+                // { "Oid", typeof() }, // not supported
+                // { "Xid", typeof() }, // not supported
+                // { "Xid8", typeof() }, // not supported
+                // { "Cid", typeof() }, // not supported
+                // { "Regtype", typeof() }, // not supported
+                // { "Tid", typeof() }, // not supported
+                // { "PgLsn", typeof() }, // not supported
+                // { "Unknown", typeof() }, // not supported
+                // { "Geometry", typeof() }, // not supported
+                // { "Geography", typeof() }, // not supported
+                // { "LTree", typeof() }, // not supported
+                // { "LQuery", typeof() }, // not supported
+                // { "LTxtQuery", typeof() }, // not supported
+                // { "IntegerRange", typeof() }, // not supported
+                // { "BigIntRange", typeof() }, // not supported
+                // { "NumericRange", typeof() }, // not supported
+                // { "TimestampRange", typeof() }, // not supported
+                // { "TimestampTzRange", typeof() }, // not supported
+                // { "DateRange", typeof() }, // not supported
+                // { "IntegerMultirange", typeof() }, // not supported
+                // { "BigIntMultirange", typeof() }, // not supported
+                // { "NumericMultirange", typeof() }, // not supported
+                // { "TimestampMultirange", typeof() }, // not supported
+                // { "TimestampTzMultirange", typeof() }, // not supported
+                // { "DateMultirange", typeof() }, // not supported
+                // { "Array", typeof() }, // not supported
+                // { "Range", typeof() }, // not supported
+                // { "Multirange", typeof() } // not supported
             };
 
         private readonly ValueTypeLayoutInfo _layoutInfo = new ValueTypeLayoutInfo();

--- a/src/NLog.Database/DatabaseParameterInfo.cs
+++ b/src/NLog.Database/DatabaseParameterInfo.cs
@@ -239,7 +239,7 @@ namespace NLog.Targets
         private static Type TryParseDbType(string dbTypeName)
         {
             // retrieve the type name if a full name is given
-            dbTypeName = dbTypeName?.Substring(dbTypeName.LastIndexOf('.') + 1);
+            dbTypeName = dbTypeName?.Substring(dbTypeName.LastIndexOf('.') + 1).Trim();
 
             if (string.IsNullOrEmpty(dbTypeName))
                 return null;

--- a/src/NLog.Database/DatabaseParameterInfo.cs
+++ b/src/NLog.Database/DatabaseParameterInfo.cs
@@ -49,15 +49,9 @@ namespace NLog.Targets
     [NLogConfigurationItem]
     public class DatabaseParameterInfo
     {
-        /// <summary>
-        /// Mapping of System.Data.DbType, System.Data.SqlDbType and NpgsqlTypes.NpgsqlDbType members names
-        /// to their corresponding CLR types.
-        /// </summary>
         private static readonly Dictionary<string, Type> _typesByDbTypeName =
             new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
             {
-                // Members from System.Data.DbType
-
                 { nameof(System.Data.DbType.AnsiString), typeof(string) },
                 // { nameof(System.Data.DbType.Binary), typeof(byte[]) },  // not supported
                 { nameof(System.Data.DbType.Byte), typeof(byte) },
@@ -84,123 +78,7 @@ namespace NLog.Targets
                 { nameof(System.Data.DbType.StringFixedLength), typeof(string) },
                 { nameof(System.Data.DbType.Xml), typeof(string) },
                 { nameof(System.Data.DbType.DateTime2), typeof(DateTime) },
-                { nameof(System.Data.DbType.DateTimeOffset), typeof(DateTimeOffset) },
-
-
-                // Members from System.Data.SqlDbType
-
-                { "BigInt", typeof(long) },
-                // { "Binary", typeof(byte[]) }, // not supported
-                { "Bit", typeof(bool?) },
-                { "Char", typeof(string) },
-                // { "DateTime", typeof(DateTime) }, // already been added
-                // { "Decimal", typeof(decimal) }, // already been added
-                { "Float", typeof(float) },
-                // { "Image", typeof() }, // not supported
-                { "Int", typeof(int) },
-                { "Money", typeof(decimal) },
-                { "NChar", typeof(string) },
-                { "NText", typeof(string) },
-                { "NVarChar", typeof(string) },
-                { "Real", typeof(float) },
-                { "UniqueIdentifier", typeof(Guid) },
-                { "SmallDateTime", typeof(DateTime) },
-                { "SmallInt", typeof(short) },
-                { "SmallMoney", typeof(decimal) },
-                { "Text", typeof(string) },
-                // { "Timestamp", typeof(byte[]) }, // not supported (actually not a Timestamp)
-                { "TinyInt", typeof(byte) },
-                // { "VarBinary", typeof(byte[]) }, // not supported
-                { "VarChar", typeof(string) },
-                { "Variant", typeof(object) }, // not sure if we should support this
-                // { "Xml", typeof(string) }, // already been added
-                // { "Udt", typeof() }, // not supported
-                // { "Structured", typeof() }, // not supported
-                // { "Date", typeof(DateTime) }, // already been added
-                // { "Time", typeof(TimeSpan) }, // already been added
-                // { "DateTime2", typeof(DateTime) }, // already been added
-                // { "DateTimeOffset", typeof(DateTimeOffset) } // already been added
-
-
-                // Members from NpgsqlTypes.NpgsqlDbType
-
-                // { "Bigint", typeof(long) }, // already been added
-                // { "Double", typeof(double) }, // already been added
-                { "Integer", typeof(int) },
-                { "Numeric", typeof(decimal) },
-                // { "Real", typeof(float) }, // already been added
-                // { "Smallint", typeof(short) }, // already been added
-                // { "Money", typeof(decimal) }, // already been added
-                // { "Boolean", typeof(bool) }, // already been added
-                // { "Box", typeof() }, // not supported
-                // { "Circle", typeof() }, // not supported
-                // { "Line", typeof() }, // not supported
-                // { "LSeg", typeof() }, // not supported
-                // { "Path", typeof() }, // not supported
-                // { "Point", typeof() }, // not supported
-                // { "Polygon", typeof() }, // not supported
-                // { "Char", typeof(string) }, // already been added
-                // { "Text", typeof(string) }, // already been added
-                // { "Varchar", typeof(string) }, // already been added
-                // { "Name", typeof() }, // not supported (internal)
-                // { "Citext", typeof() }, // not supported
-                // { "InternalChar", typeof() }, // not supported (internal)
-                // { "Bytea", typeof(byte[]) }, // not supported
-                // { "Date", typeof(DateTime) }, // already been added
-                // { "Time", typeof(TimeSpan) }, // already been added
-                { "Timestamp", typeof(DateTime) },// ** COLLIDE with System.Data.SqlDbType.Timestamp **
-                { "TimestampTZ", typeof(DateTimeOffset) },
-                // { "TimestampTz", typeof(DateTimeOffset) }, // already been added
-                { "Interval", typeof(TimeSpan) },
-                // { "TimeTZ", typeof() }, // not supported
-                // { "TimeTz", typeof() }, // not supported
-                // { "Abstime", typeof() }, // obshowlete
-                // { "Inet", typeof() }, // not supported
-                // { "Cidr", typeof() }, // not supported
-                // { "MacAddr", typeof() }, // not supported
-                // { "MacAddr8", typeof() }, // not supported
-                // { "Bit", typeof(bool[]) }, // not supported ** COLLIDE with System.Data.SqlDbType.Bit ** 
-                // { "Varbit", typeof(bool[]) }, // not supported
-                // { "TsVector", typeof() }, // not supported
-                // { "TsQuery", typeof() }, // not supported
-                // { "Regconfig", typeof() }, // not supported
-                { "Uuid", typeof(Guid) },
-                // { "Xml", typeof(string) }, // already been added
-                { "Json", typeof(string) },
-                // { "Jsonb", typeof(byte[]) }, // not supported
-                { "JsonPath", typeof(string) },
-                // { "Hstore", typeof(Dictionary<string, string>) },  // not supported
-                // { "Refcursor", typeof() }, // not supported
-                // { "Oidvector", typeof() }, // not supported
-                // { "Int2Vector", typeof() }, // not supported
-                // { "Oid", typeof() }, // not supported
-                // { "Xid", typeof() }, // not supported
-                // { "Xid8", typeof() }, // not supported
-                // { "Cid", typeof() }, // not supported
-                // { "Regtype", typeof() }, // not supported
-                // { "Tid", typeof() }, // not supported
-                // { "PgLsn", typeof() }, // not supported
-                // { "Unknown", typeof() }, // not supported
-                // { "Geometry", typeof() }, // not supported
-                // { "Geography", typeof() }, // not supported
-                // { "LTree", typeof() }, // not supported
-                // { "LQuery", typeof() }, // not supported
-                // { "LTxtQuery", typeof() }, // not supported
-                // { "IntegerRange", typeof() }, // not supported
-                // { "BigIntRange", typeof() }, // not supported
-                // { "NumericRange", typeof() }, // not supported
-                // { "TimestampRange", typeof() }, // not supported
-                // { "TimestampTzRange", typeof() }, // not supported
-                // { "DateRange", typeof() }, // not supported
-                // { "IntegerMultirange", typeof() }, // not supported
-                // { "BigIntMultirange", typeof() }, // not supported
-                // { "NumericMultirange", typeof() }, // not supported
-                // { "TimestampMultirange", typeof() }, // not supported
-                // { "TimestampTzMultirange", typeof() }, // not supported
-                // { "DateMultirange", typeof() }, // not supported
-                // { "Array", typeof() }, // not supported
-                // { "Range", typeof() }, // not supported
-                // { "Multirange", typeof() } // not supported
+                { nameof(System.Data.DbType.DateTimeOffset), typeof(DateTimeOffset) }
             };
 
         private readonly ValueTypeLayoutInfo _layoutInfo = new ValueTypeLayoutInfo();

--- a/src/NLog.Database/DatabaseParameterInfo.cs
+++ b/src/NLog.Database/DatabaseParameterInfo.cs
@@ -34,6 +34,7 @@
 namespace NLog.Targets
 {
     using System;
+    using System.Collections.Generic;
     using System.Data;
     using System.Globalization;
     using System.Reflection;
@@ -48,6 +49,40 @@ namespace NLog.Targets
     [NLogConfigurationItem]
     public class DatabaseParameterInfo
     {
+        private static readonly Dictionary<string, Type> _typesByDbTypeName =
+            new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "Bool", typeof(bool) },
+                { "Timestamp", typeof(DateTime) }, // Npgsql ?
+                { nameof(System.Data.DbType.AnsiString), typeof(string) },
+                { nameof(System.Data.DbType.Binary), typeof(byte[]) },
+                { nameof(System.Data.DbType.Byte), typeof(byte) },
+                { nameof(System.Data.DbType.Boolean), typeof(bool) },
+                { nameof(System.Data.DbType.Currency), typeof(decimal) },
+                { nameof(System.Data.DbType.Date), typeof(DateTime) },
+                { nameof(System.Data.DbType.DateTime), typeof(DateTime) },
+                { nameof(System.Data.DbType.Decimal), typeof(decimal) },
+                { nameof(System.Data.DbType.Double), typeof(double) },
+                { nameof(System.Data.DbType.Guid), typeof(Guid) },
+                { nameof(System.Data.DbType.Int16), typeof(short) },
+                { nameof(System.Data.DbType.Int32), typeof(int) },
+                { nameof(System.Data.DbType.Int64), typeof(long) },
+                { nameof(System.Data.DbType.Object), typeof(object) },
+                { nameof(System.Data.DbType.SByte), typeof(sbyte) },
+                { nameof(System.Data.DbType.Single), typeof(float) },
+                { nameof(System.Data.DbType.String), typeof(string) },
+                { nameof(System.Data.DbType.Time), typeof(TimeSpan) },
+                { nameof(System.Data.DbType.UInt16), typeof(ushort) },
+                { nameof(System.Data.DbType.UInt32), typeof(uint) },
+                { nameof(System.Data.DbType.UInt64), typeof(ulong) },
+                { nameof(System.Data.DbType.VarNumeric), typeof(decimal) }, // BigInt ?
+                { nameof(System.Data.DbType.AnsiStringFixedLength), typeof(string) },
+                { nameof(System.Data.DbType.StringFixedLength), typeof(string) },
+                { nameof(System.Data.DbType.Xml), typeof(string) },
+                { nameof(System.Data.DbType.DateTime2), typeof(DateTime) },
+                { nameof(System.Data.DbType.DateTimeOffset), typeof(DateTimeOffset) }
+            };
+
         private readonly ValueTypeLayoutInfo _layoutInfo = new ValueTypeLayoutInfo();
 
         /// <summary>
@@ -203,61 +238,15 @@ namespace NLog.Targets
             return true;    // DbType not in use
         }
 
-        private static Type TryParseDbType(string dbTypeString)
+        private static Type TryParseDbType(string dbTypeName)
         {
-            string[] dbTypeNames = dbTypeString?.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
-            dbTypeString = dbTypeNames?.Length > 0 ? dbTypeNames[dbTypeNames.Length - 1] : dbTypeString;
+            // retrieve the type name if a full name is given
+            dbTypeName = dbTypeName?.Substring(dbTypeName.LastIndexOf('.') + 1);
 
-            if (string.IsNullOrEmpty(dbTypeString))
+            if (string.IsNullOrEmpty(dbTypeName))
                 return null;
-            if (dbTypeString.IndexOf("Bool", StringComparison.OrdinalIgnoreCase) >= 0)
-                return typeof(bool);
-            if (dbTypeString.IndexOf("Timestamp", StringComparison.OrdinalIgnoreCase) >= 0)
-                return typeof(DateTime);
-            if (dbTypeString.IndexOf(nameof(System.Data.DbType.DateTimeOffset), StringComparison.OrdinalIgnoreCase) >= 0)
-                return typeof(DateTimeOffset);
-            if (dbTypeString.IndexOf(nameof(System.Data.DbType.DateTime), StringComparison.OrdinalIgnoreCase) >= 0)
-                return typeof(DateTime);
-            if (dbTypeString.IndexOf(nameof(System.Data.DbType.Date), StringComparison.OrdinalIgnoreCase) >= 0)
-                return typeof(DateTime);
-            if (dbTypeString.IndexOf(nameof(System.Data.DbType.Decimal), StringComparison.OrdinalIgnoreCase) >= 0)
-                return typeof(decimal);
-            if (dbTypeString.IndexOf(nameof(System.Data.DbType.Guid), StringComparison.OrdinalIgnoreCase) >= 0)
-                return typeof(Guid);
-            if (dbTypeString.IndexOf(nameof(System.Data.DbType.String), StringComparison.OrdinalIgnoreCase) >= 0)
-                return typeof(string);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.Xml), StringComparison.OrdinalIgnoreCase))
-                return typeof(string);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.UInt16), StringComparison.OrdinalIgnoreCase))
-                return typeof(ushort);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.UInt32), StringComparison.OrdinalIgnoreCase))
-                return typeof(uint);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.UInt64), StringComparison.OrdinalIgnoreCase))
-                return typeof(ulong);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.Int16), StringComparison.OrdinalIgnoreCase))
-                return typeof(short);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.Int32), StringComparison.OrdinalIgnoreCase))
-                return typeof(int);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.Int64), StringComparison.OrdinalIgnoreCase))
-                return typeof(long);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.Double), StringComparison.OrdinalIgnoreCase))
-                return typeof(double);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.Single), StringComparison.OrdinalIgnoreCase))
-                return typeof(float);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.Object), StringComparison.OrdinalIgnoreCase))
-                return typeof(object);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.SByte), StringComparison.OrdinalIgnoreCase))
-                return typeof(sbyte);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.Byte), StringComparison.OrdinalIgnoreCase))
-                return typeof(byte);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.VarNumeric), StringComparison.OrdinalIgnoreCase))
-                return typeof(decimal);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.Currency), StringComparison.OrdinalIgnoreCase))
-                return typeof(decimal);
-            if (dbTypeString.Equals(nameof(System.Data.DbType.Time), StringComparison.OrdinalIgnoreCase))
-                return typeof(TimeSpan);
 
-            return null;
+            return _typesByDbTypeName.TryGetValue(dbTypeName, out var type) ? type : null;
         }
 
         DbTypeSetter _cachedDbTypeSetter;

--- a/tests/NLog.Database.Tests/DatabaseTargetTests.cs
+++ b/tests/NLog.Database.Tests/DatabaseTargetTests.cs
@@ -826,6 +826,43 @@ Dispose()
             AssertLog(expectedLog);
         }
 
+        [Theory]
+        [InlineData(nameof(DbType.AnsiString), typeof(string))]
+        [InlineData(nameof(DbType.Byte), typeof(byte))]
+        [InlineData(nameof(DbType.Boolean), typeof(bool))]
+        [InlineData(nameof(DbType.Currency), typeof(decimal))]
+        [InlineData(nameof(DbType.Date), typeof(DateTime))]
+        [InlineData(nameof(DbType.DateTime), typeof(DateTime))]
+        [InlineData(nameof(DbType.Decimal), typeof(decimal))]
+        [InlineData(nameof(DbType.Double), typeof(double))]
+        [InlineData(nameof(DbType.Guid), typeof(Guid))]
+        [InlineData(nameof(DbType.Int16), typeof(short))]
+        [InlineData(nameof(DbType.Int32), typeof(int))]
+        [InlineData(nameof(DbType.Int64), typeof(long))]
+        [InlineData(nameof(DbType.Object), typeof(object))]
+        [InlineData(nameof(DbType.SByte), typeof(sbyte))]
+        [InlineData(nameof(DbType.Single), typeof(float))]
+        [InlineData(nameof(DbType.String), typeof(string))]
+        [InlineData(nameof(DbType.Time), typeof(TimeSpan))]
+        [InlineData(nameof(DbType.UInt16), typeof(ushort))]
+        [InlineData(nameof(DbType.UInt32), typeof(uint))]
+        [InlineData(nameof(DbType.UInt64), typeof(ulong))]
+        [InlineData(nameof(DbType.VarNumeric), typeof(decimal))]
+        [InlineData(nameof(DbType.AnsiStringFixedLength), typeof(string))]
+        [InlineData(nameof(DbType.StringFixedLength), typeof(string))]
+        [InlineData(nameof(DbType.Xml), typeof(string))]
+        [InlineData(nameof(DbType.DateTime2), typeof(DateTime))]
+        [InlineData(nameof(DbType.DateTimeOffset), typeof(DateTimeOffset))]
+        [InlineData(".Int32.", null)]
+        [InlineData(" . Int32 . ", null)]
+        [InlineData("MockSql.Int32", typeof(int))]
+        public void ParameterDbTypeParsingTest(string dbType, Type expectedParameterType)
+        {
+            var dataBaseParameterInfo = new DatabaseParameterInfo("", null) { DbType = dbType };
+            var actualParameterType = dataBaseParameterInfo.ParameterType;
+            Assert.Equal(expectedParameterType, actualParameterType);
+        }
+
         [Fact]
         public void ParameterDbTypePropertyNameTest()
         {

--- a/tests/NLog.Database.Tests/DatabaseTargetTests.cs
+++ b/tests/NLog.Database.Tests/DatabaseTargetTests.cs
@@ -868,7 +868,7 @@ CreateParameter(1)
 Parameter #1 Direction=Input
 Parameter #1 Name=@level
 Parameter #1 MockDbType=Int32
-Parameter #1 Value=""{0}""
+Parameter #1 Value={0}
 Add Parameter Parameter #1
 CreateParameter(2)
 Parameter #2 Direction=Input


### PR DESCRIPTION
Reduce the Cognitive Complexity of the `DatabaseParameterInfo.TryParseDbType` method.

Ref: [this sonarcloud issue](https://sonarcloud.io/project/issues?branch=dev&id=nlog2&open=AXokBhP1LhB_xjiWet68).