### PR TITLE
MemoryTarget - Updated to implement TargetWithLayoutHeaderAndFooter

### DIFF
--- a/src/NLog/Targets/MemoryTarget.cs
+++ b/src/NLog/Targets/MemoryTarget.cs
@@ -55,7 +55,7 @@ namespace NLog.Targets
     /// <code lang="C#" source="examples/targets/Configuration API/Memory/Simple/Example.cs" />
     /// </example>
     [Target("Memory")]
-    public sealed class MemoryTarget : TargetWithLayout
+    public sealed class MemoryTarget : TargetWithLayoutHeaderAndFooter
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MemoryTarget" /> class.
@@ -90,6 +90,28 @@ namespace NLog.Targets
         /// </summary>
         /// <docgen category='Buffering Options' order='10' />
         public int MaxLogsCount { get; set; }
+
+        /// <inheritdoc/>
+        protected override void InitializeTarget()
+        {
+            base.InitializeTarget();
+
+            if (Header != null)
+            {
+                Logs.Add(RenderLogEvent(Header, LogEventInfo.CreateNullEvent()));
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void CloseTarget()
+        {
+            if (Footer != null)
+            {
+                Logs.Add(RenderLogEvent(Footer, LogEventInfo.CreateNullEvent()));
+            }
+
+            base.CloseTarget();
+        }
 
         /// <summary>
         /// Renders the logging event message and adds to <see cref="Logs"/>

--- a/src/NLog/Targets/TraceTarget.cs
+++ b/src/NLog/Targets/TraceTarget.cs
@@ -60,7 +60,7 @@ namespace NLog.Targets
     /// </example>
     [Target("Trace")]
     [Target("TraceSystem")]
-    public sealed class TraceTarget : TargetWithLayout
+    public sealed class TraceTarget : TargetWithLayoutHeaderAndFooter
     {
         /// <summary>
         /// Force use <see cref="Trace.WriteLine(string)"/> independent of <see cref="LogLevel"/>
@@ -97,6 +97,28 @@ namespace NLog.Targets
         public TraceTarget(string name) : this()
         {
             Name = name;
+        }
+
+        /// <inheritdoc/>
+        protected override void InitializeTarget()
+        {
+            base.InitializeTarget();
+
+            if (Header != null)
+            {
+                Trace.WriteLine(RenderLogEvent(Footer, LogEventInfo.CreateNullEvent()));
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void CloseTarget()
+        {
+            if (Footer != null)
+            {
+                Trace.WriteLine(RenderLogEvent(Footer, LogEventInfo.CreateNullEvent()));
+            }
+
+            base.CloseTarget();
         }
 
         /// <summary>


### PR DESCRIPTION
Makes it easier to test complex layouts with header-support (Ex. CsvLayout)