### PR TITLE
Ignore dash (-) when parsing (e.g. layouts, layout renderers, targets)

### DIFF
--- a/src/NLog/Config/Factory.cs
+++ b/src/NLog/Config/Factory.cs
@@ -269,15 +269,15 @@ namespace NLog.Config
             throw new ArgumentException(message);
         }
 
-        internal static string NormalizeName(string itemName)
+        protected static string NormalizeName(string itemName)
         {
             if (itemName == null)
             {
-                return null;
+                return string.Empty;
             }
 
-            var itemToBeRemoved = "-";
-            if (!itemName.Contains(itemToBeRemoved))
+            var delimitIndex = itemName.IndexOf('-');
+            if (delimitIndex < 0)
             {
                 return itemName;
             }
@@ -286,16 +286,14 @@ namespace NLog.Config
             var commaIndex = itemName.IndexOf(',');
             if (commaIndex >= 0)
             {
-                var left = itemName.Substring(0, commaIndex).Replace(itemToBeRemoved, string.Empty);
+                var left = itemName.Substring(0, commaIndex).Replace("-", string.Empty);
                 var right = itemName.Substring(commaIndex);
                 return left + right;
             }
 
-            return itemName.Replace(itemToBeRemoved, string.Empty);
+            return itemName.Replace("-", string.Empty);
         }
     }
-
-
 
     /// <summary>
     /// Factory specialized for <see cref="LayoutRenderer"/>s. 

--- a/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
@@ -86,24 +86,5 @@ namespace NLog.UnitTests.Config
             Assert.Contains(targets.CreateInstance(itemName).GetType().Name, expectedTypeNames);
         }
 #endif
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData("", "")]
-        [InlineData("name", "name")]
-        [InlineData("name-two", "nametwo")]
-        [InlineData("name-two, my-assembly", "nametwo, my-assembly")]
-        [InlineData(", my-assembly", ", my-assembly")] // border case
-        [InlineData("name,", "name,")] // border case
-        public void NormalizeNameTest(string input, string expected)
-        {
-            // Arrange
-
-            // Act
-            var result = LayoutRendererFactory.NormalizeName(input);
-
-            // Assert
-            Assert.Equal(expected, result);
-        }
     }
 }


### PR DESCRIPTION
Verify that all factory-methods are doing it correctly without exceptions. Faster with `IndexOf(char)` than `Contains(string)`

See also #4695 