### PR TITLE
Improve InternalLogger output for named wrapper targets

### DIFF
--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -289,7 +289,10 @@ namespace NLog.Targets
                 targetType += "Target";
             }
             targetName = targetName ?? Name;
-            return string.IsNullOrEmpty(targetName) ? $"{targetType}([unnamed])" : $"{targetType}(Name={targetName})";
+            if (string.IsNullOrEmpty(targetName))
+                return string.IsNullOrEmpty(Name) ? $"{targetType}([unnamed])" : targetType;
+            else
+                return $"{targetType}(Name={targetName})";
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Targets/Wrappers/WrapperTargetBaseTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/WrapperTargetBaseTests.cs
@@ -66,7 +66,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 WrappedTarget = new DebugTarget() { Name = "foo_wrapped" },
             };
 
-            Assert.Equal("MyWrapper([unnamed])_DebugTarget(Name=foo)", wrapper.ToString());
+            Assert.Equal("MyWrapper_DebugTarget(Name=foo)", wrapper.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
Followup to #4431. When Wrapper-Target has Name, then it should not say `[unnamed]`