### PR TITLE
Improve InternalLogger output for unnamed nested wrapper targets

### DIFF
--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -290,7 +290,7 @@ namespace NLog.Targets
             }
             targetName = targetName ?? Name;
             if (string.IsNullOrEmpty(targetName))
-                return string.IsNullOrEmpty(Name) ? $"{targetType}([unnamed])" : targetType;
+                return targetWrapper ? targetType : $"{targetType}([unnamed])";
             else
                 return $"{targetType}(Name={targetName})";
         }

--- a/src/NLog/Targets/Wrappers/WrapperTargetBase.cs
+++ b/src/NLog/Targets/Wrappers/WrapperTargetBase.cs
@@ -66,10 +66,10 @@ namespace NLog.Targets.Wrappers
 
         private string GenerateTargetToString()
         {
-            if (string.IsNullOrEmpty(Name))
-                return $"{GenerateTargetToString(true)}_{WrappedTarget}";
-            else if (WrappedTarget is null)
+            if (WrappedTarget is null)
                 return GenerateTargetToString(true);
+            else if (string.IsNullOrEmpty(Name))
+                return $"{GenerateTargetToString(true, "")}_{WrappedTarget}";
             else
                 return $"{GenerateTargetToString(true, "")}_{WrappedTarget.GenerateTargetToString(false, Name)}";
         }
@@ -80,10 +80,10 @@ namespace NLog.Targets.Wrappers
         /// <param name="asyncContinuation">The asynchronous continuation.</param>
         protected override void FlushAsync(AsyncContinuation asyncContinuation)
         {
-            if (WrappedTarget != null)
-                WrappedTarget.Flush(asyncContinuation);
-            else
+            if (WrappedTarget is null)
                 asyncContinuation(null);
+            else
+                WrappedTarget.Flush(asyncContinuation);
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Targets/Wrappers/SplitGroupTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/SplitGroupTargetTests.cs
@@ -126,7 +126,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 Targets = { myTarget1, myTarget2, myTarget3 },
             };
 
-            Assert.Equal("SplitGroup([unnamed])[MyTarget([unnamed]), FileTarget(Name=file1), ConsoleTarget(Name=Console2)]", wrapper.ToString());
+            Assert.Equal("SplitGroup[MyTarget([unnamed]), FileTarget(Name=file1), ConsoleTarget(Name=Console2)]", wrapper.ToString());
         }
 
         public class MyTarget : Target

--- a/tests/NLog.UnitTests/Targets/Wrappers/WrapperTargetBaseTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/WrapperTargetBaseTests.cs
@@ -54,7 +54,7 @@ namespace NLog.UnitTests.Targets.Wrappers
                 WrappedTarget = wrapper,
             };
 
-            Assert.Equal("MyWrapper([unnamed])_MyWrapper([unnamed])_DebugTarget(Name=foo)", wrapper2.ToString());
+            Assert.Equal("MyWrapper_MyWrapper_DebugTarget(Name=foo)", wrapper2.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
Followup to #4431. When having several nested and unnamed Wrapper-Targets then all should not say `[unnamed]`