### PR TITLE
Update Logger-methods with JetBrains StructuredMessageTemplateAttribute (missing V1 legacy)

### DIFF
--- a/src/NLog/Abstractions/ILoggerBase.cs
+++ b/src/NLog/Abstractions/ILoggerBase.cs
@@ -35,6 +35,7 @@ namespace NLog
 {
     using System;
     using System.ComponentModel;
+    using JetBrains.Annotations;
 
     /// <summary>
     /// Logger with only generic methods (passing 'LogLevel' to methods) and core properties.
@@ -119,6 +120,7 @@ namespace NLog
         /// <param name="exception">An exception to be logged.</param>
         /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
         [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args) instead. Marked obsolete before v4.3.11")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void LogException(LogLevel level, [Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -129,7 +131,7 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         /// <param name="exception">An exception to be logged.</param>
         [MessageTemplateFormatMethod("message")]
-        void Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args);
+        void Log(LogLevel level, Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
 
         /// <summary>
         /// Writes the diagnostic message and exception at the specified level.
@@ -140,7 +142,7 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         /// <param name="exception">An exception to be logged.</param>
         [MessageTemplateFormatMethod("message")]
-        void Log(LogLevel level, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
+        void Log(LogLevel level, Exception exception, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
 
         /// <summary>
         /// Writes the diagnostic message at the specified level using the specified parameters and formatting them with the supplied format provider.
@@ -150,7 +152,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing format items.</param>
         /// <param name="args">Arguments to format.</param>
         [MessageTemplateFormatMethod("message")]
-        void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
+        void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
 
         /// <summary>
         /// Writes the diagnostic message at the specified level.
@@ -166,7 +168,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing format items.</param>
         /// <param name="args">Arguments to format.</param>
         [MessageTemplateFormatMethod("message")]
-        void Log(LogLevel level, [Localizable(false)] string message, params object[] args);
+        void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
 
         /// <summary>
         /// Writes the diagnostic message and exception at the specified level.
@@ -176,6 +178,7 @@ namespace NLog
         /// <param name="exception">An exception to be logged.</param>
         /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
         [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args) instead. Marked obsolete before v4.3.11")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void Log(LogLevel level, [Localizable(false)] string message, Exception exception);
 
         /// <summary>
@@ -187,7 +190,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [MessageTemplateFormatMethod("message")]
-        void Log<TArgument>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument);
+        void Log<TArgument>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, TArgument argument);
 
         /// <summary>
         /// Writes the diagnostic message at the specified level using the specified parameter.
@@ -197,7 +200,7 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [MessageTemplateFormatMethod("message")]
-        void Log<TArgument>(LogLevel level, [Localizable(false)] string message, TArgument argument);
+        void Log<TArgument>(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, TArgument argument);
 
         /// <summary>
         /// Writes the diagnostic message at the specified level using the specified arguments formatting it with the supplied format provider.
@@ -210,7 +213,7 @@ namespace NLog
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
         [MessageTemplateFormatMethod("message")]
-        void Log<TArgument1, TArgument2>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Log<TArgument1, TArgument2>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2);
 
         /// <summary>
         /// Writes the diagnostic message at the specified level using the specified parameters.
@@ -222,7 +225,7 @@ namespace NLog
         /// <param name="argument1">The first argument to format.</param>
         /// <param name="argument2">The second argument to format.</param>
         [MessageTemplateFormatMethod("message")]
-        void Log<TArgument1, TArgument2>(LogLevel level, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Log<TArgument1, TArgument2>(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2);
 
         /// <summary>
         /// Writes the diagnostic message at the specified level using the specified arguments formatting it with the supplied format provider.
@@ -237,7 +240,7 @@ namespace NLog
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
         [MessageTemplateFormatMethod("message")]
-        void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
         /// <summary>
         /// Writes the diagnostic message at the specified level using the specified parameters.
@@ -251,7 +254,7 @@ namespace NLog
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
         [MessageTemplateFormatMethod("message")]
-        void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
         #endregion
     }

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -443,7 +443,8 @@ namespace NLog
         /// <param name="message">The message.</param>
         /// <param name="parameters">The parameters.</param>
         /// <returns>Instance of <see cref="LogEventInfo"/>.</returns>
-        public static LogEventInfo Create(LogLevel logLevel, string loggerName, IFormatProvider formatProvider, [Localizable(false)] string message, object[] parameters)
+        [MessageTemplateFormatMethod("message")]
+        public static LogEventInfo Create(LogLevel logLevel, string loggerName, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object[] parameters)
         {
             return new LogEventInfo(logLevel, loggerName, formatProvider, message, parameters, null);
         }
@@ -494,7 +495,8 @@ namespace NLog
         /// <param name="message">The message.</param>
         /// <param name="parameters">The parameters.</param>
         /// <returns>Instance of <see cref="LogEventInfo"/>.</returns>
-        public static LogEventInfo Create(LogLevel logLevel, string loggerName, Exception exception, IFormatProvider formatProvider, [Localizable(false)] string message, object[] parameters)
+        [MessageTemplateFormatMethod("message")]
+        public static LogEventInfo Create(LogLevel logLevel, string loggerName, Exception exception, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object[] parameters)
         {
             return new LogEventInfo(logLevel, loggerName, formatProvider, message, parameters, exception);
         }

--- a/src/NLog/Logger-V1Compat.cs
+++ b/src/NLog/Logger-V1Compat.cs
@@ -35,6 +35,7 @@ namespace NLog
 {
     using System;
     using System.ComponentModel;
+    using JetBrains.Annotations;
 
     /// <content>
     /// Auto-generated Logger members for binary compatibility with NLog 1.0.
@@ -65,7 +66,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Log(LogLevel level, IFormatProvider formatProvider, object value) 
+        public void Log(LogLevel level, IFormatProvider formatProvider, object value)
         {
             if (IsEnabled(level))
             {
@@ -82,7 +83,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, string message, object arg1, object arg2)
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsEnabled(level))
             {
@@ -100,7 +101,7 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, string message, object arg1, object arg2, object arg3)
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsEnabled(level))
             {
@@ -117,11 +118,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, IFormatProvider formatProvider, string message, bool argument)
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -132,8 +133,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Log(LogLevel level, string message, bool argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
+        {
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument });
@@ -149,11 +151,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, IFormatProvider formatProvider, string message, char argument)
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -164,8 +166,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Log(LogLevel level, string message, char argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
+        {
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument });
@@ -181,11 +184,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, IFormatProvider formatProvider, string message, byte argument)
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -196,8 +199,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Log(LogLevel level, string message, byte argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
+        {
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument });
@@ -213,11 +217,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, IFormatProvider formatProvider, string message, string argument)
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -228,8 +232,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Log(LogLevel level, string message, string argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
+        {
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument });
@@ -249,7 +254,7 @@ namespace NLog
         {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -260,42 +265,11 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Log(LogLevel level, string message, int argument) 
-        { 
-            if (IsEnabled(level))
-            {
-                WriteToTargets(level, message, new object[] { argument });
-            }
-        }
-
-        /// <summary>
-        /// Writes the diagnostic message at the specified level using the specified value as a parameter and formatting it with the supplied format provider.
-        /// </summary>
-        /// <param name="level">The log level.</param>
-        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
-        /// <param name="message">A <see langword="string" /> containing one format item.</param>
-        /// <param name="argument">The argument to format.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, IFormatProvider formatProvider, string message, long argument)
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
-            }
-        }
-
-        /// <summary>
-        /// Writes the diagnostic message at the specified level using the specified value as a parameter.
-        /// </summary>
-        /// <param name="level">The log level.</param>
-        /// <param name="message">A <see langword="string" /> containing one format item.</param>
-        /// <param name="argument">The argument to format.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Log(LogLevel level, string message, long argument) 
-        { 
-            if (IsEnabled(level))
-            {
                 WriteToTargets(level, message, new object[] { argument });
             }
         }
@@ -309,11 +283,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, IFormatProvider formatProvider, string message, float argument)
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -324,42 +298,11 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Log(LogLevel level, string message, float argument) 
-        { 
-            if (IsEnabled(level))
-            {
-                WriteToTargets(level, message, new object[] { argument });
-            }
-        }
-
-        /// <summary>
-        /// Writes the diagnostic message at the specified level using the specified value as a parameter and formatting it with the supplied format provider.
-        /// </summary>
-        /// <param name="level">The log level.</param>
-        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
-        /// <param name="message">A <see langword="string" /> containing one format item.</param>
-        /// <param name="argument">The argument to format.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, IFormatProvider formatProvider, string message, double argument)
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
-            }
-        }
-
-        /// <summary>
-        /// Writes the diagnostic message at the specified level using the specified value as a parameter.
-        /// </summary>
-        /// <param name="level">The log level.</param>
-        /// <param name="message">A <see langword="string" /> containing one format item.</param>
-        /// <param name="argument">The argument to format.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Log(LogLevel level, string message, double argument) 
-        { 
-            if (IsEnabled(level))
-            {
                 WriteToTargets(level, message, new object[] { argument });
             }
         }
@@ -373,11 +316,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, IFormatProvider formatProvider, string message, decimal argument)
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -388,28 +331,29 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Log(LogLevel level, string message, decimal argument) 
-        { 
-            if (IsEnabled(level))
-            {
-                WriteToTargets(level, message, new object[] { argument });
-            }
-        }
-
-        /// <summary>
-        /// Writes the diagnostic message at the specified level using the specified value as a parameter and formatting it with the supplied format provider.
-        /// </summary>
-        /// <param name="level">The log level.</param>
-        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
-        /// <param name="message">A <see langword="string" /> containing one format item.</param>
-        /// <param name="argument">The argument to format.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, IFormatProvider formatProvider, string message, object argument)
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(level, message, new object[] { argument });
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message at the specified level using the specified value as a parameter and formatting it with the supplied format provider.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
+        {
+            if (IsEnabled(level))
+            {
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -420,8 +364,75 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Log(LogLevel level, string message, object argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
+        {
+            if (IsEnabled(level))
+            {
+                WriteToTargets(level, message, new object[] { argument });
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message at the specified level using the specified value as a parameter and formatting it with the supplied format provider.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
+        {
+            if (IsEnabled(level))
+            {
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message at the specified level using the specified value as a parameter.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
+        {
+            if (IsEnabled(level))
+            {
+                WriteToTargets(level, message, new object[] { argument });
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message at the specified level using the specified value as a parameter and formatting it with the supplied format provider.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
+        {
+            if (IsEnabled(level))
+            {
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message at the specified level using the specified value as a parameter.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
+        {
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument });
@@ -438,11 +449,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, IFormatProvider formatProvider, string message, sbyte argument)
-        { 
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -455,8 +466,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, string message, sbyte argument)
-        { 
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument });
@@ -473,11 +484,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, IFormatProvider formatProvider, string message, uint argument)
-        { 
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -490,8 +501,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, string message, uint argument)
-        { 
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument });
@@ -508,11 +519,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, IFormatProvider formatProvider, string message, ulong argument)
-        { 
+        public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsEnabled(level))
             {
-                WriteToTargets(level, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -525,8 +536,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, string message, ulong argument)
-        { 
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument });
@@ -556,7 +567,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Trace(IFormatProvider formatProvider, object value) 
+        public void Trace(IFormatProvider formatProvider, object value)
         {
             if (IsTraceEnabled)
             {
@@ -572,7 +583,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(string message, object arg1, object arg2)
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsTraceEnabled)
             {
@@ -589,7 +600,7 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(string message, object arg1, object arg2, object arg3)
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsTraceEnabled)
             {
@@ -605,11 +616,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(IFormatProvider formatProvider, string message, bool argument)
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -619,8 +630,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Trace(string message, bool argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
+        {
             if (IsTraceEnabled)
             {
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument });
@@ -635,11 +647,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(IFormatProvider formatProvider, string message, char argument)
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -649,8 +661,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Trace(string message, char argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, char argument)
+        {
             if (IsTraceEnabled)
             {
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument });
@@ -665,11 +678,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(IFormatProvider formatProvider, string message, byte argument)
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -679,8 +692,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Trace(string message, byte argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
+        {
             if (IsTraceEnabled)
             {
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument });
@@ -695,11 +709,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(IFormatProvider formatProvider, string message, string argument)
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -709,8 +723,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Trace(string message, string argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, string argument)
+        {
             if (IsTraceEnabled)
             {
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument });
@@ -729,7 +744,7 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -739,40 +754,11 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Trace(string message, int argument) 
-        { 
-            if (IsTraceEnabled)
-            {
-                WriteToTargets(LogLevel.Trace, message, new object[] { argument });
-            }
-        }
-
-        /// <summary>
-        /// Writes the diagnostic message at the <c>Trace</c> level using the specified value as a parameter and formatting it with the supplied format provider.
-        /// </summary>
-        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
-        /// <param name="message">A <see langword="string" /> containing one format item.</param>
-        /// <param name="argument">The argument to format.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(IFormatProvider formatProvider, string message, long argument)
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
-            }
-        }
-
-        /// <summary>
-        /// Writes the diagnostic message at the <c>Trace</c> level using the specified value as a parameter.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> containing one format item.</param>
-        /// <param name="argument">The argument to format.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Trace(string message, long argument) 
-        { 
-            if (IsTraceEnabled)
-            {
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument });
             }
         }
@@ -785,11 +771,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(IFormatProvider formatProvider, string message, float argument)
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -799,40 +785,11 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Trace(string message, float argument) 
-        { 
-            if (IsTraceEnabled)
-            {
-                WriteToTargets(LogLevel.Trace, message, new object[] { argument });
-            }
-        }
-
-        /// <summary>
-        /// Writes the diagnostic message at the <c>Trace</c> level using the specified value as a parameter and formatting it with the supplied format provider.
-        /// </summary>
-        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
-        /// <param name="message">A <see langword="string" /> containing one format item.</param>
-        /// <param name="argument">The argument to format.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(IFormatProvider formatProvider, string message, double argument)
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
-            }
-        }
-
-        /// <summary>
-        /// Writes the diagnostic message at the <c>Trace</c> level using the specified value as a parameter.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> containing one format item.</param>
-        /// <param name="argument">The argument to format.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Trace(string message, double argument) 
-        { 
-            if (IsTraceEnabled)
-            {
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument });
             }
         }
@@ -845,11 +802,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(IFormatProvider formatProvider, string message, decimal argument)
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -859,27 +816,28 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Trace(string message, decimal argument) 
-        { 
-            if (IsTraceEnabled)
-            {
-                WriteToTargets(LogLevel.Trace, message, new object[] { argument });
-            }
-        }
-
-        /// <summary>
-        /// Writes the diagnostic message at the <c>Trace</c> level using the specified value as a parameter and formatting it with the supplied format provider.
-        /// </summary>
-        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
-        /// <param name="message">A <see langword="string" /> containing one format item.</param>
-        /// <param name="argument">The argument to format.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(IFormatProvider formatProvider, string message, object argument)
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Trace, message, new object[] { argument });
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified value as a parameter and formatting it with the supplied format provider.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MessageTemplateFormatMethod("message")]
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
+        {
+            if (IsTraceEnabled)
+            {
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -889,8 +847,71 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Trace(string message, object argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, double argument)
+        {
+            if (IsTraceEnabled)
+            {
+                WriteToTargets(LogLevel.Trace, message, new object[] { argument });
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified value as a parameter and formatting it with the supplied format provider.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MessageTemplateFormatMethod("message")]
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
+        {
+            if (IsTraceEnabled)
+            {
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified value as a parameter.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MessageTemplateFormatMethod("message")]
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
+        {
+            if (IsTraceEnabled)
+            {
+                WriteToTargets(LogLevel.Trace, message, new object[] { argument });
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified value as a parameter and formatting it with the supplied format provider.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MessageTemplateFormatMethod("message")]
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
+        {
+            if (IsTraceEnabled)
+            {
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified value as a parameter.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MessageTemplateFormatMethod("message")]
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, object argument)
+        {
             if (IsTraceEnabled)
             {
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument });
@@ -906,11 +927,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(IFormatProvider formatProvider, string message, sbyte argument)
-        { 
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -922,8 +943,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(string message, sbyte argument)
-        { 
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsTraceEnabled)
             {
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument });
@@ -939,11 +960,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(IFormatProvider formatProvider, string message, uint argument)
-        { 
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -955,8 +976,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(string message, uint argument)
-        { 
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsTraceEnabled)
             {
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument });
@@ -972,11 +993,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(IFormatProvider formatProvider, string message, ulong argument)
-        { 
+        public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsTraceEnabled)
             {
-                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -988,8 +1009,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Trace(string message, ulong argument)
-        { 
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsTraceEnabled)
             {
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument });
@@ -1019,7 +1040,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Debug(IFormatProvider formatProvider, object value) 
+        public void Debug(IFormatProvider formatProvider, object value)
         {
             if (IsDebugEnabled)
             {
@@ -1035,7 +1056,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(string message, object arg1, object arg2)
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsDebugEnabled)
             {
@@ -1052,7 +1073,7 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(string message, object arg1, object arg2, object arg3)
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsDebugEnabled)
             {
@@ -1068,11 +1089,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, bool argument)
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1082,8 +1103,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Debug(string message, bool argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1098,11 +1120,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, char argument)
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1112,8 +1134,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Debug(string message, char argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, char argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1128,11 +1151,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, byte argument)
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1142,8 +1165,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Debug(string message, byte argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1158,11 +1182,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, string argument)
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1172,8 +1196,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Debug(string message, string argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, string argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1188,11 +1213,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, int argument)
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1202,8 +1227,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Debug(string message, int argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, int argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1218,11 +1244,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, long argument)
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1232,8 +1258,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Debug(string message, long argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, long argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1248,11 +1275,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, float argument)
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1262,8 +1289,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Debug(string message, float argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, float argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1278,11 +1306,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, double argument)
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1292,8 +1320,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Debug(string message, double argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, double argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1308,11 +1337,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, decimal argument)
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1322,8 +1351,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Debug(string message, decimal argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1338,11 +1368,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, object argument)
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1352,8 +1382,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Debug(string message, object argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, object argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1369,11 +1400,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, sbyte argument)
-        { 
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1385,8 +1416,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(string message, sbyte argument)
-        { 
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1402,11 +1433,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, uint argument)
-        { 
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1418,8 +1449,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(string message, uint argument)
-        { 
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1435,11 +1466,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(IFormatProvider formatProvider, string message, ulong argument)
-        { 
+        public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1451,8 +1482,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Debug(string message, ulong argument)
-        { 
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsDebugEnabled)
             {
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
@@ -1482,7 +1513,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Info(IFormatProvider formatProvider, object value) 
+        public void Info(IFormatProvider formatProvider, object value)
         {
             if (IsInfoEnabled)
             {
@@ -1498,7 +1529,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(string message, object arg1, object arg2)
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsInfoEnabled)
             {
@@ -1515,7 +1546,7 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(string message, object arg1, object arg2, object arg3)
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsInfoEnabled)
             {
@@ -1531,11 +1562,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, bool argument)
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1545,8 +1576,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Info(string message, bool argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1561,11 +1593,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, char argument)
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1575,8 +1607,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Info(string message, char argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, char argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1591,11 +1624,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, byte argument)
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1605,8 +1638,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Info(string message, byte argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1621,11 +1655,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, string argument)
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1635,8 +1669,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Info(string message, string argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, string argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1651,11 +1686,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, int argument)
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1665,8 +1700,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Info(string message, int argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, int argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1681,11 +1717,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, long argument)
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1695,8 +1731,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Info(string message, long argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, long argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1711,11 +1748,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, float argument)
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1725,8 +1762,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Info(string message, float argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, float argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1741,11 +1779,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, double argument)
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1755,8 +1793,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Info(string message, double argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, double argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1771,11 +1810,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, decimal argument)
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1785,8 +1824,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Info(string message, decimal argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1801,11 +1841,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, object argument)
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1815,8 +1855,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Info(string message, object argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, object argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1832,11 +1873,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, sbyte argument)
-        { 
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1848,8 +1889,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(string message, sbyte argument)
-        { 
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1865,11 +1906,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, uint argument)
-        { 
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1881,8 +1922,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(string message, uint argument)
-        { 
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1898,11 +1939,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(IFormatProvider formatProvider, string message, ulong argument)
-        { 
+        public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -1914,8 +1955,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Info(string message, ulong argument)
-        { 
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsInfoEnabled)
             {
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
@@ -1945,7 +1986,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Warn(IFormatProvider formatProvider, object value) 
+        public void Warn(IFormatProvider formatProvider, object value)
         {
             if (IsWarnEnabled)
             {
@@ -1961,7 +2002,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(string message, object arg1, object arg2)
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsWarnEnabled)
             {
@@ -1978,7 +2019,7 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(string message, object arg1, object arg2, object arg3)
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsWarnEnabled)
             {
@@ -1994,11 +2035,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, bool argument)
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2008,8 +2049,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Warn(string message, bool argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2024,11 +2066,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, char argument)
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2038,8 +2080,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Warn(string message, char argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, char argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2054,11 +2097,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, byte argument)
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2068,8 +2111,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Warn(string message, byte argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2084,11 +2128,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, string argument)
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2098,8 +2142,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Warn(string message, string argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, string argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2114,11 +2159,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, int argument)
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2128,8 +2173,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Warn(string message, int argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, int argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2144,11 +2190,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, long argument)
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2158,8 +2204,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Warn(string message, long argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, long argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2174,11 +2221,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, float argument)
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2188,8 +2235,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Warn(string message, float argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, float argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2204,11 +2252,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, double argument)
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2218,8 +2266,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Warn(string message, double argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, double argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2234,11 +2283,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, decimal argument)
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2248,8 +2297,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Warn(string message, decimal argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2264,11 +2314,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, object argument)
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2278,8 +2328,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Warn(string message, object argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, object argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2295,11 +2346,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, sbyte argument)
-        { 
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2311,8 +2362,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(string message, sbyte argument)
-        { 
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2328,11 +2379,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, uint argument)
-        { 
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2344,8 +2395,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(string message, uint argument)
-        { 
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2361,11 +2412,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(IFormatProvider formatProvider, string message, ulong argument)
-        { 
+        public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2377,8 +2428,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Warn(string message, ulong argument)
-        { 
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsWarnEnabled)
             {
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
@@ -2408,7 +2459,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Error(IFormatProvider formatProvider, object value) 
+        public void Error(IFormatProvider formatProvider, object value)
         {
             if (IsErrorEnabled)
             {
@@ -2424,7 +2475,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(string message, object arg1, object arg2)
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsErrorEnabled)
             {
@@ -2441,7 +2492,7 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(string message, object arg1, object arg2, object arg3)
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsErrorEnabled)
             {
@@ -2457,11 +2508,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, bool argument)
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2471,8 +2522,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Error(string message, bool argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2487,11 +2539,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, char argument)
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2501,8 +2553,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Error(string message, char argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, char argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2517,11 +2570,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, byte argument)
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2531,8 +2584,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Error(string message, byte argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2547,11 +2601,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, string argument)
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2561,8 +2615,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Error(string message, string argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, string argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2577,11 +2632,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, int argument)
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2591,8 +2646,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Error(string message, int argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, int argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2607,11 +2663,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, long argument)
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2621,8 +2677,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Error(string message, long argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, long argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2637,11 +2694,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, float argument)
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2651,8 +2708,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Error(string message, float argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, float argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2667,11 +2725,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, double argument)
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2681,8 +2739,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Error(string message, double argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, double argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2697,11 +2756,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, decimal argument)
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2711,8 +2770,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Error(string message, decimal argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2727,11 +2787,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, object argument)
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2741,8 +2801,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Error(string message, object argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, object argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2758,11 +2819,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, sbyte argument)
-        { 
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2774,8 +2835,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(string message, sbyte argument)
-        { 
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2791,11 +2852,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, uint argument)
-        { 
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2807,8 +2868,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(string message, uint argument)
-        { 
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2824,11 +2885,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(IFormatProvider formatProvider, string message, ulong argument)
-        { 
+        public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2840,8 +2901,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Error(string message, ulong argument)
-        { 
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsErrorEnabled)
             {
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
@@ -2871,7 +2932,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Fatal(IFormatProvider formatProvider, object value) 
+        public void Fatal(IFormatProvider formatProvider, object value)
         {
             if (IsFatalEnabled)
             {
@@ -2887,7 +2948,7 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(string message, object arg1, object arg2)
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsFatalEnabled)
             {
@@ -2904,7 +2965,7 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(string message, object arg1, object arg2, object arg3)
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsFatalEnabled)
             {
@@ -2920,11 +2981,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, bool argument)
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2934,8 +2995,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Fatal(string message, bool argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -2950,11 +3012,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, char argument)
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2964,8 +3026,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Fatal(string message, char argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, char argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -2980,11 +3043,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, byte argument)
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -2994,8 +3057,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Fatal(string message, byte argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -3010,11 +3074,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, string argument)
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -3024,8 +3088,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Fatal(string message, string argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, string argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -3040,11 +3105,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, int argument)
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -3054,8 +3119,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Fatal(string message, int argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, int argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -3070,11 +3136,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, long argument)
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -3084,8 +3150,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Fatal(string message, long argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, long argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -3100,11 +3167,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, float argument)
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -3114,8 +3181,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Fatal(string message, float argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, float argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -3130,11 +3198,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, double argument)
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -3144,8 +3212,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Fatal(string message, double argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, double argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -3160,11 +3229,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, decimal argument)
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -3174,8 +3243,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Fatal(string message, decimal argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -3190,11 +3260,11 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, object argument)
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -3204,8 +3274,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Fatal(string message, object argument) 
-        { 
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, object argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -3221,11 +3292,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, sbyte argument)
-        { 
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -3237,8 +3308,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(string message, sbyte argument)
-        { 
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -3254,11 +3325,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, uint argument)
-        { 
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -3270,8 +3341,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(string message, uint argument)
-        { 
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, uint argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -3287,11 +3358,11 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(IFormatProvider formatProvider, string message, ulong argument)
-        { 
+        public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument }); 
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
             }
         }
 
@@ -3303,8 +3374,8 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-        public void Fatal(string message, ulong argument)
-        { 
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
+        {
             if (IsFatalEnabled)
             {
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
@@ -3354,7 +3425,7 @@ namespace NLog
         /// <inheritdoc/>
         [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void  InfoException([Localizable(false)] string message, Exception exception)
+        public void InfoException([Localizable(false)] string message, Exception exception)
         {
             Info(exception, message);
         }
@@ -3367,7 +3438,7 @@ namespace NLog
         /// <inheritdoc/>
         [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void  WarnException([Localizable(false)] string message, Exception exception)
+        public void WarnException([Localizable(false)] string message, Exception exception)
         {
             Warn(exception, message);
         }


### PR DESCRIPTION
Followup to #4757. Looks like Resharper recognize NLog-Logger-methods without help from these attributes, but like consistency.