### PR TITLE
Added IncludeEventProperties + IncludeScopeProperties for NLog v4

### DIFF
--- a/src/NLog/IIncludeContext.cs
+++ b/src/NLog/IIncludeContext.cs
@@ -54,9 +54,20 @@ namespace NLog
         /// Gets or sets the option to include all properties from the log events
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
+        bool IncludeEventProperties { get; set; }
+
+        /// <summary>
+        /// Gets or sets the option to include all properties from the log events
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
         bool IncludeAllProperties { get; set; }
 
 #if !SILVERLIGHT
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        bool IncludeScopeProperties { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
@@ -69,7 +80,6 @@ namespace NLog
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
         bool IncludeNdlc { get; set; }
-
 #endif
     }
 }

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -176,6 +176,12 @@ namespace NLog.LayoutRenderers
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
+        public bool IncludeScopeProperties { get => IncludeMdlc; set => IncludeMdlc = value; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
         public bool IncludeMdlc { get; set; }
 
         /// <summary>
@@ -194,6 +200,12 @@ namespace NLog.LayoutRenderers
             set => _ndlcLayoutRenderer.Separator = value;
         }
 #endif
+
+        /// <summary>
+        /// Gets or sets the option to include all properties from the log events
+        /// </summary>
+        /// <docgen category='JSON Output' order='10' />
+        public bool IncludeEventProperties { get => IncludeAllProperties; set => IncludeAllProperties = value; }
 
         /// <summary>
         /// Gets or sets the option to include all properties from the log events

--- a/src/NLog/Layouts/JsonLayout.cs
+++ b/src/NLog/Layouts/JsonLayout.cs
@@ -141,6 +141,13 @@ namespace NLog.Layouts
         /// <docgen category='JSON Output' order='10' />
         [DefaultValue(false)]
         public bool IncludeMdlc { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
+        /// </summary>
+        /// <docgen category='JSON Output' order='10' />
+        [DefaultValue(false)]
+        public bool IncludeScopeProperties { get => IncludeMdlc; set => IncludeMdlc = value; }
 #endif
 
         /// <summary>
@@ -149,6 +156,13 @@ namespace NLog.Layouts
         /// <docgen category='JSON Output' order='10' />
         [DefaultValue(false)]
         public bool IncludeAllProperties { get; set; }
+
+        /// <summary>
+        /// Gets or sets the option to include all properties from the log event (as JSON)
+        /// </summary>
+        /// <docgen category='JSON Output' order='10' />
+        [DefaultValue(false)]
+        public bool IncludeEventProperties { get => IncludeAllProperties; set => IncludeAllProperties = value; }
 
         /// <summary>
         /// Gets or sets the option to exclude null/empty properties from the log event (as JSON)

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -88,6 +88,16 @@ namespace NLog.Layouts
         /// Gets or sets the option to include all properties from the log events
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
+        public bool IncludeEventProperties
+        {
+            get => Renderer.IncludeEventProperties;
+            set => Renderer.IncludeEventProperties = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the option to include all properties from the log events
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
         public bool IncludeAllProperties
         {
             get => Renderer.IncludeAllProperties;
@@ -105,6 +115,16 @@ namespace NLog.Layouts
         }
 
 #if !SILVERLIGHT
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeScopeProperties
+        {
+            get => Renderer.IncludeScopeProperties;
+            set => Renderer.IncludeScopeProperties = value;
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>

--- a/src/NLog/Layouts/XmlElementBase.cs
+++ b/src/NLog/Layouts/XmlElementBase.cs
@@ -122,6 +122,13 @@ namespace NLog.Layouts
         /// <docgen category='LogEvent Properties XML Options' order='10' />
         [DefaultValue(false)]
         public bool IncludeMdlc { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
+        /// </summary>
+        /// <docgen category='LogEvent Properties XML Options' order='10' />
+        [DefaultValue(false)]
+        public bool IncludeScopeProperties { get => IncludeMdlc; set => IncludeMdlc = value; }
 #endif
 
         /// <summary>
@@ -130,6 +137,13 @@ namespace NLog.Layouts
         /// <docgen category='LogEvent Properties XML Options' order='10' />
         [DefaultValue(false)]
         public bool IncludeAllProperties { get; set; }
+
+        /// <summary>
+        /// Gets or sets the option to include all properties from the log event (as XML)
+        /// </summary>
+        /// <docgen category='LogEvent Properties XML Options' order='10' />
+        [DefaultValue(false)]
+        public bool IncludeEventProperties { get => IncludeAllProperties; set => IncludeAllProperties = value; }
 
         /// <summary>
         /// List of property names to exclude when <see cref="IncludeAllProperties"/> is true

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -164,6 +164,16 @@ namespace NLog.Targets
         /// Gets or sets a value indicating whether to include <see cref="MappedDiagnosticsLogicalContext"/> dictionary contents.
         /// </summary>
         /// <docgen category='Payload Options' order='10' />
+        public bool IncludeScopeProperties
+        {
+            get => Renderer.IncludeScopeProperties;
+            set => Renderer.IncludeScopeProperties = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include <see cref="MappedDiagnosticsLogicalContext"/> dictionary contents.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
         public bool IncludeMdlc
         {
             get => Renderer.IncludeMdlc;
@@ -199,6 +209,16 @@ namespace NLog.Targets
         {
             get => Renderer.IncludeAllProperties;
             set => Renderer.IncludeAllProperties = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the option to include all properties from the log events
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeEventProperties
+        {
+            get => Renderer.IncludeEventProperties;
+            set => Renderer.IncludeEventProperties = value;
         }
 
         /// <summary>

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -65,7 +65,7 @@ namespace NLog.Targets
         bool IIncludeContext.IncludeAllProperties { get => IncludeEventProperties; set => IncludeEventProperties = value; }
 
         /// <docgen category='Layout Options' order='10' />
-        public bool IncludeEventProperties { get => _contextLayout.IncludeAllProperties; set => _contextLayout.IncludeAllProperties = value; }
+        public bool IncludeEventProperties { get => _contextLayout.IncludeEventProperties; set => _contextLayout.IncludeEventProperties = value; }
 
         /// <inheritdoc/>
         /// <docgen category='Layout Options' order='10' />
@@ -76,6 +76,10 @@ namespace NLog.Targets
         public bool IncludeNdc { get => _contextLayout.IncludeNdc; set => _contextLayout.IncludeNdc = value; }
 
 #if !SILVERLIGHT
+        /// <inheritdoc/>
+        /// <docgen category='Layout Options' order='10' />
+        public bool IncludeScopeProperties { get => _contextLayout.IncludeScopeProperties; set => _contextLayout.IncludeScopeProperties = value; }
+
         /// <inheritdoc/>
         /// <docgen category='Layout Options' order='10' />
         public bool IncludeMdlc { get => _contextLayout.IncludeMdlc; set => _contextLayout.IncludeMdlc = value; }
@@ -679,6 +683,7 @@ namespace NLog.Targets
 #endif
 
             public bool IncludeAllProperties { get; set; }
+            public bool IncludeEventProperties { get => IncludeAllProperties; set => IncludeAllProperties = value; }
             public bool IncludeCallSite { get; set; }
             public bool IncludeCallSiteStackTrace { get; set; }
 
@@ -688,6 +693,7 @@ namespace NLog.Targets
 #if !SILVERLIGHT
             public bool IncludeMdlc { get => MdlcLayout.IsActive; set => MdlcLayout.IsActive = value; }
             public bool IncludeNdlc { get => NdlcLayout.IsActive; set => NdlcLayout.IsActive = value; }
+            public bool IncludeScopeProperties { get => IncludeMdlc; set => IncludeMdlc = value; }
 #endif
 
             StackTraceUsage IUsesStackTrace.StackTraceUsage


### PR DESCRIPTION
To reduce friction when using examples for NLog v5 with NLog v4.

See also: https://stackoverflow.com/questions/71049928/nlog-jsonlayout-does-not-include-logevent-properties