### PR TITLE
NLogConfigurationException - Skip string.Format when no args

### DIFF
--- a/src/NLog/NLogConfigurationException.cs
+++ b/src/NLog/NLogConfigurationException.cs
@@ -31,11 +31,10 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using JetBrains.Annotations;
-
 namespace NLog
 {
     using System;
+    using JetBrains.Annotations;
 
     /// <summary>
     /// Exception thrown during NLog configuration.
@@ -69,6 +68,16 @@ namespace NLog
         [StringFormatMethod("message")]
         public NLogConfigurationException(string message, params object[] messageParameters)
             : base(string.Format(message, messageParameters))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NLogRuntimeException" /> class.
+        /// </summary>
+        /// <param name="innerException">The inner exception.</param>
+        /// <param name="message">The message.</param>
+        public NLogConfigurationException(Exception innerException, string message)
+            : base(message, innerException)
         {
         }
 

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -66,6 +66,12 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void UnknownLayoutRenderer()
+        {
+            Assert.Throws<NLogConfigurationException>(() => new SimpleLayout("'${{unknown-type}}'"));
+        }
+
+        [Fact]
         public void SingleParamTest()
         {
             SimpleLayout l = "${event-property:item=AAA}";
@@ -441,8 +447,6 @@ namespace NLog.UnitTests.Layouts
             var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
             Assert.Equal("Log_{#}.log", l.Render(le));
         }
-
-
 
         [Fact]
         public void InnerLayoutWithHashTest_need_escape()


### PR DESCRIPTION
Fixed bug introduced with NLog 4.7.9 in #4369 (Bug is only triggered when using invalid NLog.config).

See also https://stackoverflow.com/questions/71254198/nlog-input-string-was-not-in-a-correct-format-using-windows-identity