### PR TITLE
Use correct legacy NLogConfigurationException constructor

### DIFF
--- a/src/NLog/Config/LoggingConfigurationElementExtensions.cs
+++ b/src/NLog/Config/LoggingConfigurationElementExtensions.cs
@@ -112,7 +112,7 @@ namespace NLog.Config
             }
             catch (Exception exception)
             {
-                var configException = new NLogConfigurationException(exception, $"'{attributeName}' hasn't a valid boolean value '{value}'. {defaultValue} will be used");
+                var configException = new NLogConfigurationException($"'{attributeName}' hasn't a valid boolean value '{value}'. {defaultValue} will be used", exception);
                 if (configException.MustBeRethrown())
                 {
                     throw configException;

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -286,9 +286,8 @@ namespace NLog.Config
                 if (exception.MustBeRethrownImmediately())
                     throw;
 
-                const string message = "attribute '{0}': '{1}' isn't valid LogLevel. {2} will be used.";
                 var configException =
-                    new NLogConfigurationException(exception, message, attributeName, attributeValue, @default);
+                    new NLogConfigurationException($"attribute '{attributeName}': '{attributeValue}' isn't valid LogLevel. {@default} will be used.", exception);
                 if (MustThrowConfigException(configException))
                     throw configException;
 
@@ -1058,7 +1057,7 @@ namespace NLog.Config
                     if (ex.MustBeRethrownImmediately())
                         throw;
 
-                    var configException = new NLogConfigurationException(ex, $"Error when setting value '{childValue}' for property '{childName}' on element '{element}'");
+                    var configException = new NLogConfigurationException($"Error when setting value '{childValue}' for property '{childName}' on element '{element}'", ex);
                     if (MustThrowConfigException(configException))
                         throw;
                 }
@@ -1291,7 +1290,7 @@ namespace NLog.Config
                 if (exception.MustBeRethrownImmediately())
                     throw;
 
-                var configException = new NLogConfigurationException(exception, $"'{propertyName}' hasn't a valid boolean value '{value}'. {defaultValue} will be used");
+                var configException = new NLogConfigurationException($"'{propertyName}' hasn't a valid boolean value '{value}'. {defaultValue} will be used", exception);
                 if (MustThrowConfigException(configException))
                     throw configException;
                 return defaultValue;


### PR DESCRIPTION
Avoid issue with string.Format parsing. Fixed bug introduced with NLog 4.7.9 in #4369