### PR TITLE
NLogConfigurationException constructor with string.Format marked obsolete

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -341,7 +341,7 @@ namespace NLog.Config
             var target = FindTargetByName(targetName);
             if (target is null)
             {
-                throw new NLogConfigurationException("Target '{0}' not found", targetName);
+                throw new NLogConfigurationException($"Target '{targetName}' not found");
             }
 
             AddRuleForOneLevel(level, target, loggerNamePattern, false);

--- a/src/NLog/Config/LoggingConfigurationElementExtensions.cs
+++ b/src/NLog/Config/LoggingConfigurationElementExtensions.cs
@@ -104,7 +104,7 @@ namespace NLog.Config
             }
             catch (Exception exception)
             {
-                var configException = new NLogConfigurationException(exception, $"'{attributeName}' hasn't a valid boolean value '{value}'. {defaultValue} will be used");
+                var configException = new NLogConfigurationException($"'{attributeName}' hasn't a valid boolean value '{value}'. {defaultValue} will be used", exception);
                 if (configException.MustBeRethrown())
                 {
                     throw configException;

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -290,7 +290,7 @@ namespace NLog.Config
                 if (exception.MustBeRethrownImmediately())
                     throw;
 
-                var configException = new NLogConfigurationException(exception, $"Property '{propertyName}' assigned invalid LogLevel value '{propertyValue}'. Fallback to '{fallbackValue}'");
+                var configException = new NLogConfigurationException($"Property '{propertyName}' assigned invalid LogLevel value '{propertyValue}'. Fallback to '{fallbackValue}'", exception);
                 if (MustThrowConfigException(configException))
                     throw configException;
 
@@ -1069,7 +1069,7 @@ namespace NLog.Config
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
-                var configException = new NLogConfigurationException(ex, $"Error when setting value '{propertyValue}' for property '{propertyName}' on {targetObject?.GetType()} in section '{element.Name}'");
+                var configException = new NLogConfigurationException($"Error when setting value '{propertyValue}' for property '{propertyName}' on {targetObject?.GetType()} in section '{element.Name}'", ex);
                 if (MustThrowConfigException(configException))
                     throw;
             }
@@ -1372,7 +1372,7 @@ namespace NLog.Config
                 if (exception.MustBeRethrownImmediately())
                     throw;
 
-                var configException = new NLogConfigurationException(exception, $"'{propertyName}' hasn't a valid boolean value '{value}'. {defaultValue} will be used");
+                var configException = new NLogConfigurationException($"'{propertyName}' hasn't a valid boolean value '{value}'. {defaultValue} will be used", exception);
                 if (MustThrowConfigException(configException))
                     throw configException;
                 return defaultValue;

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -364,7 +364,7 @@ namespace NLog.Config
                     throw;
                 }
 
-                var configurationException = new NLogConfigurationException(exception, "Exception when loading configuration {0}", fileName);
+                var configurationException = new NLogConfigurationException($"Exception when loading configuration {fileName}", exception);
                 InternalLogger.Error(exception, configurationException.Message);
                 if (!ignoreErrors && (LogFactory.ThrowConfigExceptions ?? LogFactory.ThrowExceptions || configurationException.MustBeRethrown()))
                     throw configurationException;
@@ -530,7 +530,7 @@ namespace NLog.Config
                     throw;
                 }
 
-                var configurationException = new NLogConfigurationException(exception, "Error when including '{0}'.", newFileName);
+                var configurationException = new NLogConfigurationException($"Error when including '{newFileName}'.", exception);
                 InternalLogger.Error(exception, configurationException.Message);
                 if (!ignoreErrors)
                     throw configurationException;

--- a/src/NLog/Internal/Reflection/PropertyHelper.cs
+++ b/src/NLog/Internal/Reflection/PropertyHelper.cs
@@ -408,13 +408,13 @@ namespace NLog.Internal
                 //no support for array
                 if (collectionObject is null)
                 {
-                    throw new NLogConfigurationException("Cannot create instance of {0} for value {1}", collectionType.ToString(), valueRaw);
+                    throw new NLogConfigurationException($"Cannot create instance of {collectionType.ToString()} for value {valueRaw}");
                 }
 
                 collectionAddMethod = collectionObject.GetType().GetMethod("Add", BindingFlags.Instance | BindingFlags.Public);
                 if (collectionAddMethod is null)
                 {
-                    throw new NLogConfigurationException("Add method on type {0} for value {1} not found", collectionType.ToString(), valueRaw);
+                    throw new NLogConfigurationException($"Add method on type {collectionType.ToString()} for value {valueRaw} not found");
                 }
 
                 return true;

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -563,7 +563,7 @@ namespace NLog.Layouts
             }
             catch (Exception ex)
             {
-                var configException = new NLogConfigurationException(ex, $"Error parsing layout {typeName}");
+                var configException = new NLogConfigurationException($"Error parsing layout {typeName}", ex);
                 if (throwConfigExceptions ?? configException.MustBeRethrown())
                 {
                     throw configException;

--- a/src/NLog/NLogConfigurationException.cs
+++ b/src/NLog/NLogConfigurationException.cs
@@ -65,6 +65,7 @@ namespace NLog
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="messageParameters">Parameters for the message</param>
+        [Obsolete("Instead use string interpolation. Marked obsolete with NLog 5.0")]
         [StringFormatMethod("message")]
         public NLogConfigurationException(string message, params object[] messageParameters)
             : base(string.Format(message, messageParameters))
@@ -76,17 +77,8 @@ namespace NLog
         /// </summary>
         /// <param name="innerException">The inner exception.</param>
         /// <param name="message">The message.</param>
-        public NLogConfigurationException(Exception innerException, string message)
-            : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NLogRuntimeException" /> class.
-        /// </summary>
-        /// <param name="innerException">The inner exception.</param>
-        /// <param name="message">The message.</param>
         /// <param name="messageParameters">Parameters for the message</param>
+        [Obsolete("Instead use string interpolation. Marked obsolete with NLog 5.0")]
         [StringFormatMethod("message")]
         public NLogConfigurationException(Exception innerException, string message, params object[] messageParameters)
             : base(string.Format(message, messageParameters), innerException)

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -526,12 +526,12 @@ namespace NLog.Targets
         {
             if (!UseSystemNetMailSettings && DeliveryMethod == SmtpDeliveryMethod.Network && SmtpServer is null)
             {
-                throw new NLogConfigurationException("The MailTarget's '{0}' properties are not set - but needed because useSystemNetMailSettings=false and DeliveryMethod=Network. The email message will not be sent.", "SmtpServer");
+                throw new NLogConfigurationException($"The MailTarget's '{nameof(SmtpServer)}' properties are not set - but needed because useSystemNetMailSettings=false and DeliveryMethod=Network. The email message will not be sent.");
             }
 
             if (!UseSystemNetMailSettings && DeliveryMethod == SmtpDeliveryMethod.SpecifiedPickupDirectory && PickupDirectoryLocation is null)
             {
-                throw new NLogConfigurationException("The MailTarget's '{0}' properties are not set - but needed because useSystemNetMailSettings=false and DeliveryMethod=SpecifiedPickupDirectory. The email message will not be sent.", "PickupDirectoryLocation");
+                throw new NLogConfigurationException($"The MailTarget's '{nameof(PickupDirectoryLocation)}' properties are not set - but needed because useSystemNetMailSettings=false and DeliveryMethod=SpecifiedPickupDirectory. The email message will not be sent.");
             }
         }
 


### PR DESCRIPTION
Now `NLogConfigurationException` matches `ArgumentException`-constructors.

See also #4805