### PR TITLE
NLogConfigurationException - Improve styling of error-message when failing to assign property

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -1069,7 +1069,7 @@ namespace NLog.Config
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
-                var configException = new NLogConfigurationException($"Error when setting value '{propertyValue}' for property '{propertyName}' on {targetObject?.GetType()} in section '{element.Name}'", ex);
+                var configException = new NLogConfigurationException($"'{targetObject?.GetType()?.Name}' cannot assign property '{propertyName}'='{propertyValue}' in section '{element.Name}'. Error: {ex.Message}", ex);
                 if (MustThrowConfigException(configException))
                     throw;
             }
@@ -1090,7 +1090,7 @@ namespace NLog.Config
         {
             if (!PropertyHelper.TryGetPropertyInfo(o, childElement.Name, out var propInfo))
             {
-                var configException = new NLogConfigurationException($"Unknown property '{childElement.Name}' for '{o?.GetType()}' in section '{parentElement.Name}'");
+                var configException = new NLogConfigurationException($"'{o?.GetType()?.Name}' cannot assign unknown property '{childElement.Name}' in section '{parentElement.Name}'");
                 if (MustThrowConfigException(configException))
                     throw configException;
 

--- a/src/NLog/Internal/Reflection/PropertyHelper.cs
+++ b/src/NLog/Internal/Reflection/PropertyHelper.cs
@@ -96,7 +96,7 @@ namespace NLog.Internal
 
             if (!TryGetPropertyInfo(objType, propertyName, out var propInfo))
             {
-                throw new NLogConfigurationException($"Unknown property '{propertyName}'='{value}' for '{objType.Name}'");
+                throw new NLogConfigurationException($"'{objType?.Name}' cannot assign unknown property '{propertyName}'='{value}'");
             }
 
             SetPropertyFromString(obj, propertyName, value, propInfo, configurationItemFactory);
@@ -112,7 +112,7 @@ namespace NLog.Internal
                 {
                     if (propInfo.IsDefined(_arrayParameterAttribute.GetType(), false))
                     {
-                        throw new NotSupportedException($"Property {propertyName} on {obj.GetType().Name} is an array, and cannot be assigned a scalar value: '{value}'.");
+                        throw new NotSupportedException($"'{obj?.GetType()?.Name}' cannot assign property '{propertyName}', because property of type array and not scalar value: '{value}'.");
                     }
 
                     propertyType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
@@ -128,7 +128,7 @@ namespace NLog.Internal
             }
             catch (TargetInvocationException ex)
             {
-                throw new NLogConfigurationException($"Error when setting property '{propInfo.Name}'='{value}' on {obj.GetType().Name}", ex.InnerException);
+                throw new NLogConfigurationException($"'{obj?.GetType()?.Name}' cannot assign property '{propInfo.Name}'='{value}'", ex.InnerException ?? ex);
             }
             catch (Exception exception)
             {
@@ -137,7 +137,7 @@ namespace NLog.Internal
                     throw;
                 }
 
-                throw new NLogConfigurationException($"Error when setting property '{propInfo.Name}'='{value}' on {obj.GetType().Name}", exception);
+                throw new NLogConfigurationException($"'{obj?.GetType()?.Name}' cannot assign property '{propInfo.Name}'='{value}'. Error={exception.Message}", exception);
             }
         }
 

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -461,7 +461,7 @@ namespace NLog.Layouts
                         var value = ParseParameterValue(stringReader);
                         if (!string.IsNullOrEmpty(parameterName) || !StringHelpers.IsNullOrWhiteSpace(value))
                         {
-                            var configException = new NLogConfigurationException($"Unknown property '{parameterName}=' for ${{{typeName}}} ({layoutRenderer?.GetType()})");
+                            var configException = new NLogConfigurationException($"${{{typeName}}} cannot assign unknown property '{parameterName}='");
                             if (throwConfigExceptions ?? configException.MustBeRethrown())
                             {
                                 throw configException;
@@ -522,7 +522,7 @@ namespace NLog.Layouts
         {
             if (parameterName?.Equals(previousParameterName, StringComparison.OrdinalIgnoreCase) == true)
             {
-                var configException = new NLogConfigurationException($"Same property '{parameterName}' assigned twice for {layoutRenderer?.GetType()} ");
+                var configException = new NLogConfigurationException($"'{layoutRenderer?.GetType()?.Name}' has same property '{parameterName}=' assigned twice");
                 if (throwConfigExceptions ?? configException.MustBeRethrown())
                 {
                     throw configException;
@@ -590,7 +590,7 @@ namespace NLog.Layouts
             }
             else
             {
-                var configException = new NLogConfigurationException($"{layoutRenderer.GetType()} has no default property to assign value {value}");
+                var configException = new NLogConfigurationException($"'{layoutRenderer?.GetType()?.Name}' has no default property to assign value {value}");
                 if (throwConfigExceptions ?? configException.MustBeRethrown())
                 {
                     throw configException;

--- a/tests/NLog.UnitTests/Internal/Reflection/PropertyHelperTests.cs
+++ b/tests/NLog.UnitTests/Internal/Reflection/PropertyHelperTests.cs
@@ -62,7 +62,7 @@ namespace NLog.UnitTests.Internal.Reflection
             // Assert
             Assert.IsType<NLogConfigurationException>(ex.InnerException);
             Assert.IsType<NotSupportedException>(ex.InnerException.InnerException);
-            Assert.Contains("is an array, and cannot be assigned a scalar value", ex.InnerException.InnerException.Message);
+            Assert.Contains("because property of type array and not scalar value", ex.InnerException.InnerException.Message);
         }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -72,6 +72,18 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void UnknownLayoutRendererProperty()
+        {
+            Assert.Throws<NLogConfigurationException>(() => new SimpleLayout("'${message:unknown_item=${unknown-value}}'"));
+        }
+
+        [Fact]
+        public void UnknownLayoutRendererPropertyValue()
+        {
+            Assert.Throws<NLogConfigurationException>(() => new SimpleLayout("'${message:withexception=${unknown-value}}'"));
+        }
+
+        [Fact]
         public void SingleParamTest()
         {
             SimpleLayout l = "${event-property:item=AAA}";


### PR DESCRIPTION
Move the property-value at the end, because the value can be "long". 