### PR TITLE
Translate ConditionParseException into NLogConfigurationException

### DIFF
--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -74,7 +74,13 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void UnknownLayoutRendererProperty()
         {
-            Assert.Throws<NLogConfigurationException>(() => new SimpleLayout("'${message:unknown_item=${unknown-value}}'"));
+            Assert.Throws<NLogConfigurationException>(() => new SimpleLayout("${message:unknown_item=${unknown-value}}"));
+        }
+
+        [Fact]
+        public void UnknownConditionLayoutRenderer()
+        {
+            Assert.Throws<NLogConfigurationException>(() => new SimpleLayout("${when:when=Levl==LogLevel.Info:inner=Unknown}"));
         }
 
         [Fact]


### PR DESCRIPTION
When using `throwConfigExceptions="true"`, then failure to parse ConditionExpressions should not be ignored.
