### PR TITLE
Improve loading of nlog-config with .NET6 single file publish

### DIFF
--- a/src/NLog/Config/LoggingConfigurationFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationFileLoader.cs
@@ -307,7 +307,7 @@ namespace NLog.Config
 
                 if (PathHelpers.IsTempDir(entryAssemblyLocation, _appEnvironment.UserTempFilePath))
                 {
-                    // Handle Single File Published on NetCore 3.1 and loading side-by-side exe.nlog (Not relevant for Net5.0)
+                    // Handle Single File Published on NetCore 3.1 and loading side-by-side exe.nlog (Not relevant for Net5.0 and newer)
                     string processFilePath = _appEnvironment.CurrentProcessFilePath;
                     if (!string.IsNullOrEmpty(processFilePath))
                     {
@@ -320,10 +320,12 @@ namespace NLog.Config
                     string assemblyFileName = _appEnvironment.EntryAssemblyFileName;
                     if (!string.IsNullOrEmpty(assemblyFileName))
                     {
-                        // Handle unpublished .NET Core Application
                         var assemblyBaseName = Path.GetFileNameWithoutExtension(assemblyFileName);
                         if (!string.IsNullOrEmpty(assemblyBaseName))
+                        {
+                            // Handle unpublished .NET Core Application, where assembly-filename has dll-extension
                             yield return Path.Combine(entryAssemblyLocation, assemblyBaseName + ".exe.nlog");
+                        }
 
                         yield return Path.Combine(entryAssemblyLocation, assemblyFileName + ".nlog");
                     }

--- a/src/NLog/Internal/AppEnvironmentWrapper.cs
+++ b/src/NLog/Internal/AppEnvironmentWrapper.cs
@@ -126,7 +126,19 @@ namespace NLog.Internal.Fakeables
         {
             try
             {
-                return Path.GetFileName(System.Reflection.Assembly.GetEntryAssembly()?.Location ?? string.Empty);
+                var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
+                var assemblyLocation = entryAssembly?.Location;
+                if (!string.IsNullOrEmpty(assemblyLocation))
+                {
+                    return Path.GetFileName(assemblyLocation);
+                }
+                
+                // Fallback to the Assembly-Name when unable to extract FileName from Location
+                var assemblyName = entryAssembly?.GetName()?.Name;
+                if (!string.IsNullOrEmpty(assemblyName))
+                    return assemblyName + ".dll";
+                else
+                    return string.Empty;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Trying to resolve #4818, where `System.Reflection.Assembly.GetEntryAssembly()` has empty `Location`-property on .NET6