### PR TITLE
Improve loading of nlog-config with .NET6 single file publish

### DIFF
--- a/src/NLog/Internal/Fakeables/AppEnvironmentWrapper.cs
+++ b/src/NLog/Internal/Fakeables/AppEnvironmentWrapper.cs
@@ -99,7 +99,19 @@ namespace NLog.Internal.Fakeables
         {
             try
             {
-                return Path.GetFileName(System.Reflection.Assembly.GetEntryAssembly()?.Location ?? string.Empty);
+                var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
+                var assemblyLocation = entryAssembly?.Location;
+                if (!string.IsNullOrEmpty(assemblyLocation))
+                {
+                    return Path.GetFileName(assemblyLocation);
+                }
+
+                // Fallback to the Assembly-Name when unable to extract FileName from Location
+                var assemblyName = entryAssembly?.GetName()?.Name;
+                if (!string.IsNullOrEmpty(assemblyName))
+                    return assemblyName + ".dll";
+                else
+                    return string.Empty;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Trying to resolve #4818 for NLog 4.7.15. See also #4819