### PR TITLE
MailTarget - Added support for SmtpClient UseDefaultCredentials

### DIFF
--- a/src/NLog/Internal/ISmtpClient.cs
+++ b/src/NLog/Internal/ISmtpClient.cs
@@ -84,6 +84,11 @@ namespace NLog.Internal
         /// Gets or sets the folder where applications save mail messages to be processed by the local SMTP server.
         /// </summary>
         string PickupDirectoryLocation { get; set; }
+
+        /// <summary>
+        /// Authenticate using the default network credentials of the currently logged on user
+        /// </summary>
+        bool UseDefaultCredentials { get; set; }
     }
 }
 

--- a/src/NLog/Targets/MailTarget.cs
+++ b/src/NLog/Targets/MailTarget.cs
@@ -302,6 +302,11 @@ namespace NLog.Targets
         public bool ReplaceNewlineWithBrTagInHtml { get; set; }
 
         /// <summary>
+        /// Authenticate using the default network credentials of the currently logged on user
+        /// </summary>
+        public bool UseDefaultCredentials { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating the SMTP client timeout.
         /// </summary>
         /// <remarks>Warning: zero is not infinite waiting</remarks>
@@ -483,6 +488,10 @@ namespace NLog.Targets
 
                     InternalLogger.Trace("{0}:   Using basic authentication: Username='{1}' Password='{2}'", this, username, new string('*', password.Length));
                     client.Credentials = new NetworkCredential(username, password);
+                }
+                else if (UseDefaultCredentials)
+                {
+                    client.UseDefaultCredentials = true;
                 }
             }
             

--- a/tests/NLog.UnitTests/Targets/MailTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MailTargetTests.cs
@@ -920,6 +920,7 @@ namespace NLog.UnitTests.Targets
             public int Timeout { get; set; }
             public string PickupDirectoryLocation { get; set; }
 
+            public bool UseDefaultCredentials { get; set; }
 
             public ICredentialsByHost Credentials { get; set; }
             public bool EnableSsl { get; set; }


### PR DESCRIPTION
See also: https://docs.microsoft.com/en-us/dotnet/api/system.net.mail.smtpclient.usedefaultcredentials