### PR TITLE
Improve InternalLogger output when testing candidate config file locations

### DIFF
--- a/src/NLog/Config/LoggingConfigurationFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationFileLoader.cs
@@ -95,6 +95,10 @@ namespace NLog.Config
                     config = LoadXmlLoggingConfigurationFile(logFactory, configFile);
                     return true;    // File exists, and maybe the config is valid, stop search
                 }
+                else
+                {
+                    InternalLogger.Debug("No file exists for candidate config file location: {0}", configFile);
+                }
             }
             catch (IOException ex)
             {

--- a/src/NLog/Internal/AssemblyHelpers.cs
+++ b/src/NLog/Internal/AssemblyHelpers.cs
@@ -142,7 +142,7 @@ namespace NLog.Internal
                 if (string.IsNullOrEmpty(assembly.Location))
                 {
                     // Assembly with no actual location should be skipped (Avoid PlatformNotSupportedException)
-                    InternalLogger.Warn("Ignoring assembly location because location is empty: {0}", fullName);
+                    InternalLogger.Debug("Ignoring assembly location because location is empty: {0}", fullName);
                     return string.Empty;
                 }
 #endif
@@ -150,21 +150,21 @@ namespace NLog.Internal
                 Uri assemblyCodeBase;
                 if (!Uri.TryCreate(assembly.CodeBase, UriKind.RelativeOrAbsolute, out assemblyCodeBase))
                 {
-                    InternalLogger.Warn("Ignoring assembly location because code base is unknown: '{0}' ({1})", assembly.CodeBase, fullName);
+                    InternalLogger.Debug("Ignoring assembly location because code base is unknown: '{0}' ({1})", assembly.CodeBase, fullName);
                     return string.Empty;
                 }
 
                 var assemblyLocation = Path.GetDirectoryName(assemblyCodeBase.LocalPath);
                 if (string.IsNullOrEmpty(assemblyLocation))
                 {
-                    InternalLogger.Warn("Ignoring assembly location because it is not a valid directory: '{0}' ({1})", assemblyCodeBase.LocalPath, fullName);
+                    InternalLogger.Debug("Ignoring assembly location because it is not a valid directory: '{0}' ({1})", assemblyCodeBase.LocalPath, fullName);
                     return string.Empty;
                 }
 
                 DirectoryInfo directoryInfo = new DirectoryInfo(assemblyLocation);
                 if (!directoryInfo.Exists)
                 {
-                    InternalLogger.Warn("Ignoring assembly location because directory doesn't exists: '{0}' ({1})", assemblyLocation, fullName);
+                    InternalLogger.Debug("Ignoring assembly location because directory doesn't exists: '{0}' ({1})", assemblyLocation, fullName);
                     return string.Empty;
                 }
 


### PR DESCRIPTION
Not warning when meeting assembly with empty `Location`- or `CodeBase`-property.