### PR TITLE
LogFactory - Avoid loading candidate NLog-config files for every Logger created

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -310,6 +310,7 @@ namespace NLog
                             _configLoaded = true;
                         }
                     }
+
                     OnConfigurationChanged(new LoggingConfigurationChangedEventArgs(value, oldConfig));
                 }
             }
@@ -445,8 +446,8 @@ namespace NLog
         /// Gets the logger with the full name of the current class, so namespace and class name.
         /// </summary>
         /// <returns>The logger.</returns>
-        /// <remarks>This is a slow-running method. 
-        /// Make sure you're not doing this in a loop.</remarks>
+        /// <remarks>This method introduces performance hit, because of StackTrace capture.
+        /// Make sure you are not calling this method in a loop.</remarks>
         [MethodImpl(MethodImplOptions.NoInlining)]
         public Logger GetCurrentClassLogger()
         {
@@ -465,8 +466,8 @@ namespace NLog
         /// </summary>
         /// <returns>The logger with type <typeparamref name="T"/>.</returns>
         /// <typeparam name="T">Type of the logger</typeparam>
-        /// <remarks>This is a slow-running method. 
-        /// Make sure you're not doing this in a loop.</remarks>
+        /// <remarks>This method introduces performance hit, because of StackTrace capture.
+        /// Make sure you are not calling this method in a loop.</remarks>
         [MethodImpl(MethodImplOptions.NoInlining)]
         public T GetCurrentClassLogger<T>() where T : Logger, new()
         {
@@ -485,8 +486,8 @@ namespace NLog
         /// </summary>
         /// <param name="loggerType">The type of the logger to create. The type must inherit from <see cref="Logger"/></param>
         /// <returns>The logger of type <paramref name="loggerType"/>.</returns>
-        /// <remarks>This is a slow-running method. Make sure you are not calling this method in a 
-        /// loop.</remarks>
+        /// <remarks>This method introduces performance hit, because of StackTrace capture.
+        /// Make sure you are not calling this method in a loop.</remarks>
         [MethodImpl(MethodImplOptions.NoInlining)]
         public Logger GetCurrentClassLogger(Type loggerType)
         {
@@ -1216,7 +1217,8 @@ namespace NLog
                     newLogger = new Logger();
                 }
 
-                newLogger.Initialize(name, GetLoggerConfiguration(name, Configuration), this);
+                var config = _config ?? (_loggerCache.Count == 0 ? Configuration : null);   // Only force load NLog-config with first logger
+                newLogger.Initialize(name, GetLoggerConfiguration(name, config), this);
                 _loggerCache.InsertOrUpdate(cacheKey, newLogger);
                 return newLogger;
             }

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -365,10 +365,22 @@ namespace NLog.UnitTests
         protected string RunAndCaptureInternalLog(SyncAction action, LogLevel internalLogLevel)
         {
             var stringWriter = new Logger();
-            InternalLogger.LogWriter = stringWriter;
-            InternalLogger.LogLevel = LogLevel.Trace;
-            InternalLogger.IncludeTimestamp = false;
-            action();
+            var orgWriter = InternalLogger.LogWriter;
+            var orgTimestamp = InternalLogger.IncludeTimestamp;
+            var orgLevel = InternalLogger.LogLevel;
+            try
+            {
+                InternalLogger.LogWriter = stringWriter;
+                InternalLogger.IncludeTimestamp = false;
+                InternalLogger.LogLevel = internalLogLevel;
+                action();
+            }
+            finally
+            {
+                InternalLogger.LogWriter = orgWriter;
+                InternalLogger.IncludeTimestamp = orgTimestamp;
+                InternalLogger.LogLevel = orgLevel;
+            }
 
             return stringWriter.ToString();
         }


### PR DESCRIPTION
NLog should not introduce a performance-hit during application-startup when not able to load `NLog.config` (Or no NLog.config available). The performance-hit would depend on the number of unique Logger-objects that are created.

Before it would attempt to scan all NLog-config-candidate-file-locations for every unique Logger-object created by the application (until NLog-config has been loaded). Now it will only do the auto-scan on the initial Logger-creation.

One could consider creating a fluent `Setup()`-extension-method that starts file-watchers for all candidate-locations, that stays active until a valid NLog-configuration is loaded.