### PR TITLE
Fixed missing initialization of layout-parameters for ConditionMethodExpression

### DIFF
--- a/src/NLog/Conditions/Expressions/ConditionMethodExpression.cs
+++ b/src/NLog/Conditions/Expressions/ConditionMethodExpression.cs
@@ -114,6 +114,11 @@ namespace NLog.Conditions
         /// </summary>
         public MethodInfo MethodInfo { get; }
 
+        /// <summary>
+        /// Gets the method parameters
+        /// </summary>
+        public IList<ConditionExpression> MethodParameters => _methodParameters;
+
         private static object[] CreateMethodDefaultParameters(ParameterInfo[] formalParameters, ConditionExpression[] methodParameters, int parameterOffset)
         {
             var defaultParameterCount = formalParameters.Length - methodParameters.Length - parameterOffset;

--- a/tests/NLog.UnitTests/Filters/ConditionBasedFilterTests.cs
+++ b/tests/NLog.UnitTests/Filters/ConditionBasedFilterTests.cs
@@ -46,11 +46,12 @@ namespace NLog.UnitTests.Filters
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug'>
                    <filters defaultAction='log'>
-                        <when condition=""contains(message,'zzz')"" action='Ignore' />
+                        <when condition=""contains(message, '${var:environment}')"" action='Ignore' />
                     </filters>
                     </logger>
                 </rules>
             </nlog>").LogFactory;
+            logFactory.Configuration.Variables["environment"] = "zzz";  // Veriy that method-parameters are scanned and initialized with active config
 
             var logger = logFactory.GetLogger("A");
             logger.Debug("a");


### PR DESCRIPTION
Resolves  #4832

See also: https://stackoverflow.com/questions/71422784/net-core-nlog-filter-when-condition-with-equals-not-working

Bug introduced with #3787 (NLog 4.7)