### PR TITLE
Added required null checks

### DIFF
--- a/src/NLog/Config/ServiceRepositoryInternal.cs
+++ b/src/NLog/Config/ServiceRepositoryInternal.cs
@@ -142,7 +142,7 @@ namespace NLog.Config
             {
                 seenTypes = seenTypes ?? new HashSet<Type>();
                 var parameterValues = CreateCtorParameterValues(constructorParameters, seenTypes);
-                return compiledConstructor.Ctor(parameterValues);
+                return compiledConstructor?.Ctor(parameterValues);
             }
         }
 

--- a/src/NLog/Internal/Collections/PropertiesDictionary.cs
+++ b/src/NLog/Internal/Collections/PropertiesDictionary.cs
@@ -142,7 +142,7 @@ namespace NLog.Internal
                 var eventProperties = _eventProperties;
                 if (eventProperties is null)
                 {
-                    eventProperties = _eventProperties = new Dictionary<object, PropertyValue>(newMessageProperties.Count, PropertyKeyComparer.Default);
+                    eventProperties = _eventProperties = new Dictionary<object, PropertyValue>(newMessageProperties?.Count ?? 0, PropertyKeyComparer.Default);
                 }
 
                 if (oldMessageProperties != null && eventProperties.Count > 0)

--- a/src/NLog/Internal/FormatHelper.cs
+++ b/src/NLog/Internal/FormatHelper.cs
@@ -88,7 +88,7 @@ namespace NLog.Internal
             }
             else
             {
-                return value.ToString() ?? string.Empty;
+                return value?.ToString() ?? string.Empty;
             }
         }
     }


### PR DESCRIPTION
Thanks for NLog, it's very helpful tool! I think this changes can helps.

* 30820cf3248df86a13dd8d059b7deaa3b4fc6b6e There is not enough null check,  are above we are already use null check for compiledConstructor variable.
* d44ba4cfe7072f160ad0233fa9735d31067f96e1 Potential NullReferenceException, because below these changes, we are already have the null check. Right [here](https://github.com/NLog/NLog/blob/dev/src/NLog/Internal/Collections/PropertiesDictionary.cs#L153)
* c9299ec69e0dd36729a9579a470b9a28231d13d8 There is not enough null check,  are above we are already use null check for value variable.