### PR TITLE
Reverted AppDomain BaseDirectory as fallback when loading nlog.dll.nlog

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -506,11 +506,16 @@ namespace NLog.Common
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
                 var fileVersionInfo = !string.IsNullOrEmpty(assembly.Location) ?
                     System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location) : null;
+                var globalAssemblyCache = false;
+#if !NETSTANDARD
+                if (assembly.GlobalAssemblyCache)
+                    globalAssemblyCache = true;
+#endif
                 Info("{0}. File version: {1}. Product version: {2}. GlobalAssemblyCache: {3}",
                     assembly.FullName,
                     fileVersionInfo?.FileVersion,
                     fileVersionInfo?.ProductVersion,
-                    assembly.GlobalAssemblyCache);
+                    globalAssemblyCache);
 #else
                 Info(assembly.FullName);
 #endif

--- a/src/NLog/Config/LoggingConfigurationFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationFileLoader.cs
@@ -273,21 +273,22 @@ namespace NLog.Config
 
         private string LookupNLogAssemblyLocation()
         {
-            var nlogAssembly = typeof(LogFactory).GetAssembly();
 #if !NETSTANDARD1_3
+            var nlogAssembly = typeof(LogFactory).GetAssembly();
             // Get path to NLog.dll.nlog only if the assembly is not in the GAC
             var nlogAssemblyLocation = nlogAssembly.Location;
             if (!string.IsNullOrEmpty(nlogAssemblyLocation))
             {
 #if !NETSTANDARD
-                if (!nlogAssembly.GlobalAssemblyCache)
-#endif
+                if (nlogAssembly.GlobalAssemblyCache)
                 {
-                    return nlogAssemblyLocation;
+                    return null;
                 }
+#endif
+                return nlogAssemblyLocation;
             }
 #endif
-            return Path.Combine(_appEnvironment.AppDomainBaseDirectory, nlogAssembly.GetName().Name + ".dll");
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
nlog.dll.nlog is super exotic, so lets keep it that way. Now reverted  #4843