### PR TITLE
Support SpecialFolder ApplicationDataDir for internalLogFile when parsing nlog.config

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -254,6 +254,14 @@ namespace NLog.Config
                 if (ContainsSubStringIgnoreCase(internalLogFile, "${processdir}", out string processDirToken))
                     internalLogFile = internalLogFile.Replace(processDirToken, System.IO.Path.GetDirectoryName(LogFactory.CurrentAppEnvironment.CurrentProcessFilePath) + System.IO.Path.DirectorySeparatorChar.ToString());
 #endif
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+                if (ContainsSubStringIgnoreCase(internalLogFile, "${applicationDataDir}", out string appDataDirToken))
+                    internalLogFile = internalLogFile.Replace(appDataDirToken, Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + System.IO.Path.DirectorySeparatorChar.ToString());
+                if (ContainsSubStringIgnoreCase(internalLogFile, "${commonApplicationDataDir}", out string commonAppDataDirToken))
+                    internalLogFile = internalLogFile.Replace(commonAppDataDirToken, Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData) + System.IO.Path.DirectorySeparatorChar.ToString());
+                if (ContainsSubStringIgnoreCase(internalLogFile, "${localApplicationDataDir}", out string localapplicationdatadir))
+                    internalLogFile = internalLogFile.Replace(localapplicationdatadir, Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + System.IO.Path.DirectorySeparatorChar.ToString());
+#endif
                 if (internalLogFile.IndexOf('%') >= 0)
                     internalLogFile = Environment.ExpandEnvironmentVariables(internalLogFile);
                 return internalLogFile;

--- a/src/NLog/LayoutRenderers/Directories/SpecialFolderApplicationDataLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Directories/SpecialFolderApplicationDataLayoutRenderer.cs
@@ -1,0 +1,56 @@
+﻿// 
+// Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+
+namespace NLog.LayoutRenderers
+{
+    using System;
+
+    /// <summary>
+    /// System special folder path from <see cref="Environment.SpecialFolder.ApplicationData"/>
+    /// </summary>
+    [LayoutRenderer("applicationDataDir")]
+    public class SpecialFolderApplicationDataLayoutRenderer : SpecialFolderLayoutRenderer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpecialFolderApplicationDataLayoutRenderer" /> class.
+        /// </summary>
+        public SpecialFolderApplicationDataLayoutRenderer()
+        {
+            Folder = Environment.SpecialFolder.ApplicationData;
+        }
+    }
+}
+
+#endif

--- a/src/NLog/LayoutRenderers/Directories/SpecialFolderCommonApplicationDataLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Directories/SpecialFolderCommonApplicationDataLayoutRenderer.cs
@@ -1,0 +1,56 @@
+﻿// 
+// Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+
+namespace NLog.LayoutRenderers
+{
+    using System;
+
+    /// <summary>
+    /// System special folder path from <see cref="Environment.SpecialFolder.CommonApplicationData"/>
+    /// </summary>
+    [LayoutRenderer("commonApplicationDataDir")]
+    public class SpecialFolderCommonApplicationDataLayoutRenderer : SpecialFolderLayoutRenderer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpecialFolderCommonApplicationDataLayoutRenderer" /> class.
+        /// </summary>
+        public SpecialFolderCommonApplicationDataLayoutRenderer()
+        {
+            Folder = Environment.SpecialFolder.CommonApplicationData;
+        }
+    }
+}
+
+#endif

--- a/src/NLog/LayoutRenderers/Directories/SpecialFolderLocalApplicationDataLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Directories/SpecialFolderLocalApplicationDataLayoutRenderer.cs
@@ -1,0 +1,56 @@
+﻿// 
+// Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+
+namespace NLog.LayoutRenderers
+{
+    using System;
+
+    /// <summary>
+    /// System special folder path from <see cref="Environment.SpecialFolder.LocalApplicationData"/>
+    /// </summary>
+    [LayoutRenderer("localApplicationDataDir")]
+    public class SpecialFolderLocalApplicationDataLayoutRenderer : SpecialFolderLayoutRenderer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpecialFolderLocalApplicationDataLayoutRenderer" /> class.
+        /// </summary>
+        public SpecialFolderLocalApplicationDataLayoutRenderer()
+        {
+            Folder = Environment.SpecialFolder.LocalApplicationData;
+        }
+    }
+}
+
+#endif

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -117,6 +117,29 @@ namespace NLog.UnitTests.Config
             }
 #endif
 
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            using (new InternalLoggerScope(true))
+            {
+                var xml = "<nlog internalLogFile='${ApplicationDataDir}test.txt'></nlog>";
+                var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+                Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), InternalLogger.LogFile);
+            }
+
+            using (new InternalLoggerScope(true))
+            {
+                var xml = "<nlog internalLogFile='${CommonApplicationDataDir}test.txt'></nlog>";
+                var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+                Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), InternalLogger.LogFile);
+            }
+
+            using (new InternalLoggerScope(true))
+            {
+                var xml = "<nlog internalLogFile='${LocalApplicationDataDir}test.txt'></nlog>";
+                var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+                Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), InternalLogger.LogFile);
+            }
+#endif
+
             using (new InternalLoggerScope(true))
             {
                 var userName = Environment.GetEnvironmentVariable("USERNAME") ?? string.Empty;

--- a/tests/NLog.UnitTests/LayoutRenderers/Directories/SpecialFolderTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Directories/SpecialFolderTests.cs
@@ -73,6 +73,24 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             AssertLayoutRendererOutput($"${{specialfolder:folder={sysDirString}:dir=aaa:file=bbb.txt}}", Path.Combine(sysDir, "aaa", "bbb.txt"));
         }
+
+        [Fact]
+        public void SpecialFolderApplicationDataTest()
+        {
+            AssertLayoutRendererOutput("${ApplicationDataDir}", Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+        }
+
+        [Fact]
+        public void SpecialFolderCommonApplicationDataTest()
+        {
+            AssertLayoutRendererOutput("${CommonApplicationDataDir}", Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData));
+        }
+
+        [Fact]
+        public void SpecialFolderLocalApplicationDataTest()
+        {
+            AssertLayoutRendererOutput("${LocalApplicationDataDir}", Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+        }
     }
 #endif
 }


### PR DESCRIPTION
Trying to resolve #4861

Introduces support for these symbol-types (both for internalLogFile and normal layouts):
- `${applicationDataDir}`
- `${commonApplicationDataDir}`
- `${localApplicationDataDir}`