### PR TITLE
Support SpecialFolder UserApplicationDataDir for internalLogFile when parsing nlog.config

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -255,11 +255,11 @@ namespace NLog.Config
                     internalLogFile = internalLogFile.Replace(processDirToken, System.IO.Path.GetDirectoryName(LogFactory.CurrentAppEnvironment.CurrentProcessFilePath) + System.IO.Path.DirectorySeparatorChar.ToString());
 #endif
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
-                if (ContainsSubStringIgnoreCase(internalLogFile, "${applicationDataDir}", out string appDataDirToken))
-                    internalLogFile = internalLogFile.Replace(appDataDirToken, Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + System.IO.Path.DirectorySeparatorChar.ToString());
                 if (ContainsSubStringIgnoreCase(internalLogFile, "${commonApplicationDataDir}", out string commonAppDataDirToken))
                     internalLogFile = internalLogFile.Replace(commonAppDataDirToken, Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData) + System.IO.Path.DirectorySeparatorChar.ToString());
-                if (ContainsSubStringIgnoreCase(internalLogFile, "${localApplicationDataDir}", out string localapplicationdatadir))
+                if (ContainsSubStringIgnoreCase(internalLogFile, "${userApplicationDataDir}", out string appDataDirToken))
+                    internalLogFile = internalLogFile.Replace(appDataDirToken, Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + System.IO.Path.DirectorySeparatorChar.ToString());
+                if (ContainsSubStringIgnoreCase(internalLogFile, "${userLocalApplicationDataDir}", out string localapplicationdatadir))
                     internalLogFile = internalLogFile.Replace(localapplicationdatadir, Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + System.IO.Path.DirectorySeparatorChar.ToString());
 #endif
                 if (internalLogFile.IndexOf('%') >= 0)

--- a/src/NLog/LayoutRenderers/Directories/SpecialFolderApplicationDataLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Directories/SpecialFolderApplicationDataLayoutRenderer.cs
@@ -40,7 +40,7 @@ namespace NLog.LayoutRenderers
     /// <summary>
     /// System special folder path from <see cref="Environment.SpecialFolder.ApplicationData"/>
     /// </summary>
-    [LayoutRenderer("applicationDataDir")]
+    [LayoutRenderer("userApplicationDataDir")]
     public class SpecialFolderApplicationDataLayoutRenderer : SpecialFolderLayoutRenderer
     {
         /// <summary>

--- a/src/NLog/LayoutRenderers/Directories/SpecialFolderLocalApplicationDataLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Directories/SpecialFolderLocalApplicationDataLayoutRenderer.cs
@@ -40,7 +40,7 @@ namespace NLog.LayoutRenderers
     /// <summary>
     /// System special folder path from <see cref="Environment.SpecialFolder.LocalApplicationData"/>
     /// </summary>
-    [LayoutRenderer("localApplicationDataDir")]
+    [LayoutRenderer("userLocalApplicationDataDir")]
     public class SpecialFolderLocalApplicationDataLayoutRenderer : SpecialFolderLayoutRenderer
     {
         /// <summary>

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -120,13 +120,6 @@ namespace NLog.UnitTests.Config
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
             using (new InternalLoggerScope(true))
             {
-                var xml = "<nlog internalLogFile='${ApplicationDataDir}test.txt'></nlog>";
-                var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
-                Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), InternalLogger.LogFile);
-            }
-
-            using (new InternalLoggerScope(true))
-            {
                 var xml = "<nlog internalLogFile='${CommonApplicationDataDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
                 Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), InternalLogger.LogFile);
@@ -134,7 +127,14 @@ namespace NLog.UnitTests.Config
 
             using (new InternalLoggerScope(true))
             {
-                var xml = "<nlog internalLogFile='${LocalApplicationDataDir}test.txt'></nlog>";
+                var xml = "<nlog internalLogFile='${UserApplicationDataDir}test.txt'></nlog>";
+                var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+                Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), InternalLogger.LogFile);
+            }
+
+            using (new InternalLoggerScope(true))
+            {
+                var xml = "<nlog internalLogFile='${UserLocalApplicationDataDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
                 Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), InternalLogger.LogFile);
             }

--- a/tests/NLog.UnitTests/LayoutRenderers/Directories/SpecialFolderTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Directories/SpecialFolderTests.cs
@@ -75,21 +75,21 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
-        public void SpecialFolderApplicationDataTest()
-        {
-            AssertLayoutRendererOutput("${ApplicationDataDir}", Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
-        }
-
-        [Fact]
         public void SpecialFolderCommonApplicationDataTest()
         {
             AssertLayoutRendererOutput("${CommonApplicationDataDir}", Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData));
         }
 
         [Fact]
-        public void SpecialFolderLocalApplicationDataTest()
+        public void SpecialFolderUserApplicationDataTest()
         {
-            AssertLayoutRendererOutput("${LocalApplicationDataDir}", Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+            AssertLayoutRendererOutput("${UserApplicationDataDir}", Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+        }
+
+        [Fact]
+        public void SpecialFolderUserLocalApplicationDataTest()
+        {
+            AssertLayoutRendererOutput("${UserLocalApplicationDataDir}", Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
         }
     }
 #endif


### PR DESCRIPTION
Followup to #4863

Decided that `ApplicationDataDir` was too generic. One might think it would be the directory of the running application.