### PR TITLE
FileTarget - Mark GetFormattedMessage as obsolete and redirect to RenderFormattedMessage

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1130,6 +1130,7 @@ namespace NLog.Targets
         /// </summary>
         /// <param name="logEvent">The log event to be formatted.</param>
         /// <returns>A string representation of the log event.</returns>
+        [Obsolete("No longer used and replaced by RenderFormattedMessage. Marked obsolete on NLog 5.0")]
         protected virtual string GetFormattedMessage(LogEventInfo logEvent)
         {
             return Layout.Render(logEvent);
@@ -1140,7 +1141,7 @@ namespace NLog.Targets
         /// </summary>
         /// <param name="logEvent">Log event.</param>
         /// <returns>Array of bytes that are ready to be written.</returns>
-        [Obsolete("No longer used and replaced by RenderFormattedMessageToStream. Marked obsolete on NLog 5.0")]
+        [Obsolete("No longer used and replaced by RenderFormattedMessage. Marked obsolete on NLog 5.0")]
         protected virtual byte[] GetBytesToWrite(LogEventInfo logEvent)
         {
             string text = GetFormattedMessage(logEvent);
@@ -1157,7 +1158,7 @@ namespace NLog.Targets
         /// </summary>
         /// <param name="value">The byte array.</param>
         /// <returns>The modified byte array. The function can do the modification in-place.</returns>
-        [Obsolete("No longer used and replaced by RenderFormattedMessageToStream. Marked obsolete on NLog 5.0")]
+        [Obsolete("No longer used and replaced by TransformStream. Marked obsolete on NLog 5.0")]
         protected virtual byte[] TransformBytes(byte[] value)
         {
             return value;


### PR DESCRIPTION
`GetFormattedMessage` should have been obsoleted with NLog 4.4.2 (Since it was stopped being used). See also #1799 + #4253

One can replace this:

```c#
        protected override string GetFormattedMessage(LogEventInfo logEvent)
        {
            return CleanseLogMessage.Cleanse(Layout.Render(logEvent));
        }
```

With this:

```c#
        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
        {
            Layout.Render(logEvent, target);
            var result = CleanseLogMessage.Cleanse(target.ToString());
            target.Clear();
            target.Append(result);
        }
```