### PR TITLE
dotnet list package --vulnerable --include-transitive

### DIFF
--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -49,6 +49,13 @@ if ($isWindows -or $Env:WinDir)
 	dotnet vstest ./tests/NLog.UnitTests/bin/Release/net45/NLog.UnitTests.dll
 	if (-Not $LastExitCode -eq 0)
 		{ exit $LastExitCode }
+
+	dotnet list ./src package --vulnerable --include-transitive | findstr /S /c:"has the following vulnerable packages"
+	if (-Not $LastExitCode -eq 1)
+	{
+		dotnet list ./src package --vulnerable --include-transitive
+		exit 1
+	}
 }
 else
 {

--- a/tests/NLog.UnitTests/NLog.UnitTests.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" /> <!-- Because of NSubstitute + Castle.Core-->
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.1' ">

--- a/tests/NLog.WindowsIdentity.Tests/NLog.WindowsIdentity.Tests.csproj
+++ b/tests/NLog.WindowsIdentity.Tests/NLog.WindowsIdentity.Tests.csproj
@@ -25,7 +25,8 @@
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="5.0.0" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="5.0.1" />
   </ItemGroup> 
 
   <ItemGroup>


### PR DESCRIPTION
Followup to #4882 + #4881

Sadly enough there is no exit-code: https://github.com/NuGet/Home/issues/11315 + https://github.com/dotnet/sdk/issues/16852 (yet)