### PR TITLE
Improve logging when using relative NLog.config file-path

### DIFF
--- a/src/NLog/Config/LoggingConfigurationFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationFileLoader.cs
@@ -128,7 +128,7 @@ namespace NLog.Config
 
         private LoggingConfiguration LoadXmlLoggingConfigurationFile(LogFactory logFactory, string configFile)
         {
-            InternalLogger.Debug("Loading config from {0}", configFile);
+            InternalLogger.Debug("Reading config from XML file: {0}", configFile);
 
             using (var xmlReader = _appEnvironment.LoadXmlFile(configFile))
             {

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -341,12 +341,12 @@ namespace NLog.Config
             try
             {
                 InitializeSucceeded = null;
-                _originalFileName = fileName;
+                _originalFileName = string.IsNullOrEmpty(fileName) ? fileName : GetFileLookupKey(fileName);
                 reader.MoveToContent();
                 var content = new NLogXmlElement(reader);
-                if (!string.IsNullOrEmpty(fileName))
+                if (!string.IsNullOrEmpty(_originalFileName))
                 {
-                    InternalLogger.Info("Configuring from an XML element in {0}...", fileName);
+                    InternalLogger.Info("Loading config from XML file: {0}", _originalFileName);
                     ParseTopLevel(content, fileName, autoReloadDefault: false);
                 }
                 else


### PR DESCRIPTION
```
2022-04-20 21:18:22.5494 Debug No file exists at candidate config file location: C:\Windows\SysWOW64\WindowsPowerShell\v1.0\NLog.config
2022-04-20 21:18:22.5494 Debug Reading config from XML file: NLog.config
2022-04-20 21:18:22.5494 Info Loading config from XML file: C:\Users\MyUser\source\repos\NLog\src\NLog.config
```