### PR TITLE
NetworkTarget - Support Compress = GZip for UDP with GELF to GrayLog

### DIFF
--- a/src/NLog/Targets/NetworkTargetCompressionType.cs
+++ b/src/NLog/Targets/NetworkTargetCompressionType.cs
@@ -1,0 +1,54 @@
+﻿// 
+// Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+namespace NLog.Targets
+{
+    /// <summary>
+    /// Type of compression for protocol payload
+    /// </summary>
+    public enum NetworkTargetCompressionType
+    {
+        /// <summary>
+        /// No compression
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// GZip optimal compression
+        /// </summary>
+        GZip = 1,
+        /// <summary>
+        /// GZip fastest compression
+        /// </summary>
+        GZipFast = 2,
+    }
+}


### PR DESCRIPTION
Better UDP-support for https://www.nuget.org/packages/NLog.GelfLayout

And GZip can also be used with Log4jXml over UDP (If supported by the Log4j-viewer-client)