### PR TITLE
Log4JXmlEventLayoutRenderer - IncludeEventProperties default = true

### DIFF
--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -227,7 +227,7 @@ namespace NLog.LayoutRenderers
         /// Gets or sets the option to include all properties from the log events
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
-        public bool IncludeEventProperties { get; set; }
+        public bool IncludeEventProperties { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the stack separator for log4j:NDC in output from <see cref="ScopeContext"/> nested context.

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -72,6 +72,7 @@ namespace NLog.Targets
         public NLogViewerTarget()
         {
             IncludeNLogData = true;
+            IncludeEventProperties = false; // Already included when IncludeNLogData = true
         }
 
         /// <summary>


### PR DESCRIPTION
Better defaults for Log4J-XML where event-properties are included by default in log4net.

But exclude NLogViewer-target since it is special, and has its own standards.