### PR TITLE
NetworkTarget - Reduce memory allocations in UdpNetworkSender

### DIFF
--- a/src/NLog/Internal/NetworkSenders/NetworkSenderFactory.cs
+++ b/src/NLog/Internal/NetworkSenders/NetworkSenderFactory.cs
@@ -47,24 +47,6 @@ namespace NLog.Internal.NetworkSenders
         /// <inheritdoc/>
         public NetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime)
         {
-            if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
-            {
-                return new HttpNetworkSender(url)
-                {
-                    MaxQueueSize = maxQueueSize,
-                    OnQueueOverflow = onQueueOverflow,
-                };
-            }
-
-            if (url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
-            {
-                return new HttpNetworkSender(url)
-                {
-                    MaxQueueSize = maxQueueSize,
-                    OnQueueOverflow = onQueueOverflow,
-                };
-            }
-
             if (url.StartsWith("tcp://", StringComparison.OrdinalIgnoreCase))
             {
                 return new TcpNetworkSender(url, AddressFamily.Unspecified)
@@ -125,6 +107,24 @@ namespace NLog.Internal.NetworkSenders
                     MaxQueueSize = maxQueueSize,
                     OnQueueOverflow = onQueueOverflow,
                     MaxMessageSize = maxMessageSize,
+                };
+            }
+
+            if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+            {
+                return new HttpNetworkSender(url)
+                {
+                    MaxQueueSize = maxQueueSize,
+                    OnQueueOverflow = onQueueOverflow,
+                };
+            }
+
+            if (url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                return new HttpNetworkSender(url)
+                {
+                    MaxQueueSize = maxQueueSize,
+                    OnQueueOverflow = onQueueOverflow,
                 };
             }
 

--- a/src/NLog/Internal/NetworkSenders/TcpNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/TcpNetworkSender.cs
@@ -163,7 +163,8 @@ namespace NLog.Internal.NetworkSenders
         {
             var uri = new Uri(Address);
             var args = new MySocketAsyncEventArgs();
-            args.RemoteEndPoint = ParseEndpointAddress(uri, AddressFamily);
+            var ipAddress = ResolveIpAddress(uri, AddressFamily);
+            args.RemoteEndPoint = new System.Net.IPEndPoint(ipAddress, uri.Port);
             args.Completed += _socketOperationCompletedAsync;
             args.UserToken = null;
 
@@ -303,12 +304,13 @@ namespace NLog.Internal.NetworkSenders
             }
         }
 
-        public override void CheckSocket()
+        public override ISocket CheckSocket()
         {
             if (_socket is null)
             {
                 DoInitialize();
             }
+            return _socket;
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Internal/NetworkSenders/TcpNetworkSenderTests.cs
+++ b/tests/NLog.UnitTests/Internal/NetworkSenders/TcpNetworkSenderTests.cs
@@ -84,12 +84,12 @@ namespace NLog.UnitTests.Internal.NetworkSenders
                 Assert.True(mre.WaitOne(10000), "Network Flush not completed");
 
                 var actual = sender.Log.ToString();
-                Assert.True(actual.IndexOf("Parse endpoint address tcp://hostname:123/ Unspecified") != -1);
-                Assert.True(actual.IndexOf("create socket 10000 Stream Tcp") != -1);
-                Assert.True(actual.IndexOf("connect async to {mock end point: tcp://hostname:123/}") != -1);
-                Assert.True(actual.IndexOf("send async 0 1 'q'") != -1);
-                Assert.True(actual.IndexOf("send async 0 2 'qu'") != -1);
-                Assert.True(actual.IndexOf("send async 0 4 'quic'") != -1);
+                Assert.Contains("Parse endpoint address tcp://hostname:123/ Unspecified", actual);
+                Assert.Contains("create socket InterNetwork Stream Tcp", actual);
+                Assert.Contains("connect async to 0.0.0.0:123", actual);
+                Assert.Contains("send async 0 1 'q'", actual);
+                Assert.Contains("send async 0 2 'qu'", actual);
+                Assert.Contains("send async 0 4 'quic'", actual);
 
                 mre.Reset();
                 for (int i = 1; i < 8; i *= 2)
@@ -114,17 +114,17 @@ namespace NLog.UnitTests.Internal.NetworkSenders
                 Assert.True(mre.WaitOne(10000), "Network Close not completed");
 
                 actual = sender.Log.ToString();
-                
-                Assert.True(actual.IndexOf("Parse endpoint address tcp://hostname:123/ Unspecified") != -1);
-                Assert.True(actual.IndexOf("create socket 10000 Stream Tcp") != -1);
-                Assert.True(actual.IndexOf("connect async to {mock end point: tcp://hostname:123/}") != -1);
-                Assert.True(actual.IndexOf("send async 0 1 'q'") != -1);
-                Assert.True(actual.IndexOf("send async 0 2 'qu'") != -1);
-                Assert.True(actual.IndexOf("send async 0 4 'quic'") != -1);
-                Assert.True(actual.IndexOf("send async 0 1 'q'") != -1);
-                Assert.True(actual.IndexOf("send async 0 2 'qu'") != -1);
-                Assert.True(actual.IndexOf("send async 0 4 'quic'") != -1);
-                Assert.True(actual.IndexOf("close") != -1);
+
+                Assert.Contains("Parse endpoint address tcp://hostname:123/ Unspecified", actual);
+                Assert.Contains("create socket InterNetwork Stream Tcp", actual);
+                Assert.Contains("connect async to 0.0.0.0:123", actual);
+                Assert.Contains("send async 0 1 'q'", actual);
+                Assert.Contains("send async 0 2 'qu'", actual);
+                Assert.Contains("send async 0 4 'quic'", actual);
+                Assert.Contains("send async 0 1 'q'", actual);
+                Assert.Contains("send async 0 2 'qu'", actual);
+                Assert.Contains("send async 0 4 'quic'", actual);
+                Assert.Contains("close", actual);
 
                 foreach (var ex in exceptions)
                 {
@@ -181,10 +181,10 @@ namespace NLog.UnitTests.Internal.NetworkSenders
 
             var actual = sender.Log.ToString();
 
-            Assert.True(actual.IndexOf("Parse endpoint address tcp://hostname:123/ Unspecified") != -1);
-            Assert.True(actual.IndexOf("create socket 10000 Stream Tcp") != -1);
-            Assert.True(actual.IndexOf("connect async to {mock end point: tcp://hostname:123/}") != -1);
-            Assert.True(actual.IndexOf("failed") != -1);
+            Assert.Contains("Parse endpoint address tcp://hostname:123/ Unspecified", actual);
+            Assert.Contains("create socket InterNetwork Stream Tcp", actual);
+            Assert.Contains("connect async to 0.0.0.0:123", actual);
+            Assert.Contains("failed", actual);
 
             foreach (var ex in exceptions)
             {
@@ -233,14 +233,14 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             Assert.True(mre.WaitOne(10000), "Network Flush not completed");
 
             var actual = sender.Log.ToString();
-            Assert.True(actual.IndexOf("Parse endpoint address tcp://hostname:123/ Unspecified") != -1);
-            Assert.True(actual.IndexOf("create socket 10000 Stream Tcp") != -1);
-            Assert.True(actual.IndexOf("connect async to {mock end point: tcp://hostname:123/}") != -1);
-            Assert.True(actual.IndexOf("send async 0 1 'q'") != -1);
-            Assert.True(actual.IndexOf("send async 0 2 'qu'") != -1);
-            Assert.True(actual.IndexOf("send async 0 3 'qui'") != -1);
-            Assert.True(actual.IndexOf("failed") != -1);
-            Assert.True(actual.IndexOf("close") != -1);
+            Assert.Contains("Parse endpoint address tcp://hostname:123/ Unspecified", actual);
+            Assert.Contains("create socket InterNetwork Stream Tcp", actual);
+            Assert.Contains("connect async to 0.0.0.0:123", actual);
+            Assert.Contains("send async 0 1 'q'", actual);
+            Assert.Contains("send async 0 2 'qu'", actual);
+            Assert.Contains("send async 0 3 'qui'", actual);
+            Assert.Contains("failed", actual);
+            Assert.Contains("close", actual);
 
             for (int i = 0; i < exceptions.Length; ++i)
             {
@@ -270,10 +270,10 @@ namespace NLog.UnitTests.Internal.NetworkSenders
                 return new MockSocket(addressFamily, socketType, protocolType, this);
             }
 
-            protected override EndPoint ParseEndpointAddress(Uri uri, AddressFamily addressFamily)
+            protected override IPAddress ResolveIpAddress(Uri uri, AddressFamily addressFamily)
             {
                 Log.WriteLine("Parse endpoint address {0} {1}", uri, addressFamily);
-                return new MockEndPoint(uri);
+                return IPAddress.Any;
             }
 
             public int ConnectFailure { get; set; }
@@ -376,23 +376,6 @@ namespace NLog.UnitTests.Internal.NetworkSenders
                     log.WriteLine("sendto async {0} {1} '{2}' {3}", args.Offset, args.Count, Encoding.UTF8.GetString(args.Buffer, args.Offset, args.Count), args.RemoteEndPoint);
                     return InvokeCallback(args);
                 }
-            }
-        }
-
-        internal class MockEndPoint : EndPoint
-        {
-            private readonly Uri uri;
-
-            public MockEndPoint(Uri uri)
-            {
-                this.uri = uri;
-            }
-
-            public override AddressFamily AddressFamily => (AddressFamily)10000;
-
-            public override string ToString()
-            {
-                return "{mock end point: " + uri + "}";
             }
         }
     }

--- a/tests/NLog.UnitTests/Internal/NetworkSenders/UdpNetworkSenderTests.cs
+++ b/tests/NLog.UnitTests/Internal/NetworkSenders/UdpNetworkSenderTests.cs
@@ -42,7 +42,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
     public class UdpNetworkSenderTests
     {
         [Theory]
-        [InlineData("udp://randomurl:8080", false)]
+        [InlineData("udp://127.0.0.1:8080", false)]
         [InlineData("udp://255.255.255.255:8080", true)]
         public void CreateSocket_HandlesBroadcast(string url, bool broadcastEnabled)
         {
@@ -50,7 +50,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             var sender = new UdpNetworkSender(url, AddressFamily.InterNetwork);
 
             // act
-            var socket = sender.CreateSocket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            var socket = sender.CheckSocket();
 
             // assert
             Assert.Equal(broadcastEnabled, ((SocketProxy)socket).UnderlyingSocket.EnableBroadcast);

--- a/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
@@ -747,7 +747,7 @@ namespace NLog.UnitTests.Targets
         {
             var target = new NetworkTarget()
             {
-                Address = "tcp4://127.0.0.1:33415",
+                Address = "tcp4://localhost:33415",
                 Layout = "${message}\n",
                 KeepConnection = true,
             };


### PR DESCRIPTION
IPv4 Broadcast-address detection without allocating extra Uri-object and doing IPAddress.ToString()