### PR TITLE
PlatformDetector.IsMono is only for legacy .NET Framework

### DIFF
--- a/src/NLog/Internal/PlatformDetector.cs
+++ b/src/NLog/Internal/PlatformDetector.cs
@@ -40,28 +40,29 @@ namespace NLog.Internal
     /// </summary>
     internal static class PlatformDetector
     {
-        private static readonly RuntimeOS currentOS = GetCurrentRuntimeOS();
-
         /// <summary>
         /// Gets the current runtime OS.
         /// </summary>
-        public static RuntimeOS CurrentOS => currentOS;
+        public static RuntimeOS CurrentOS => _currentOS ?? (_currentOS = GetCurrentRuntimeOS()).Value;
+        private static RuntimeOS? _currentOS;
 
         /// <summary>
         /// Gets a value indicating whether current OS is Win32-based (desktop or mobile).
         /// </summary>
-        public static bool IsWin32 => currentOS == RuntimeOS.Windows || currentOS == RuntimeOS.WindowsNT;
+        public static bool IsWin32 => CurrentOS == RuntimeOS.Windows || CurrentOS == RuntimeOS.WindowsNT;
 
         /// <summary>
         /// Gets a value indicating whether current OS is Unix-based.
         /// </summary>
-        public static bool IsUnix => currentOS == RuntimeOS.Linux || currentOS == RuntimeOS.MacOSX;
+        public static bool IsUnix => CurrentOS == RuntimeOS.Linux || CurrentOS == RuntimeOS.MacOSX;
 
+#if !NETSTANDARD
         /// <summary>
         /// Gets a value indicating whether current runtime is Mono-based
         /// </summary>
         public static bool IsMono => _isMono ?? (_isMono = Type.GetType("Mono.Runtime") != null).Value;
         private static bool? _isMono;
+#endif
 
         private static RuntimeOS GetCurrentRuntimeOS()
         {

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -1423,11 +1423,11 @@ namespace NLog
                 //Exception: System.AppDomainUnloadedException
                 //Message: Attempted to access an unloaded AppDomain.
                 InternalLogger.Info("AppDomain Shutting down. LogFactory closing...");
-                // Finalizer thread has about 2 secs on Windows-platform, before being terminated
-                // MONO (and friends) have a hard time with spinning up flush threads/timers during domain unload
+                // Domain-Unload has to complete in about 2 secs on Windows-platform, before being terminated.
+                // Other platforms like Linux will fail when trying to spin up new threads at domain unload.
                 var flushTimeout =
-#if !NETSTANDARD1_3 && !MONO
-                    PlatformDetector.IsWin32 && !PlatformDetector.IsMono ? TimeSpan.FromMilliseconds(1500) :
+#if !NETSTANDARD1_3
+                    PlatformDetector.IsWin32 ? TimeSpan.FromMilliseconds(1500) :
 #endif
                     TimeSpan.Zero;
                 Close(flushTimeout);

--- a/src/NLog/Targets/ConsoleTargetHelper.cs
+++ b/src/NLog/Targets/ConsoleTargetHelper.cs
@@ -50,8 +50,10 @@ namespace NLog.Targets
             {
                 if (!Environment.UserInteractive)
                 {
+#if !NETSTANDARD
                     if (Internal.PlatformDetector.IsMono && Console.In is StreamReader)
                         return true;    // Extra bonus check for Mono, that doesn't support Environment.UserInteractive
+#endif
 
                     reason = "Environment.UserInteractive = False";
                     return false;

--- a/tests/NLog.UnitTests/Internal/PlatformDetectorTests.cs
+++ b/tests/NLog.UnitTests/Internal/PlatformDetectorTests.cs
@@ -38,6 +38,7 @@ namespace NLog.UnitTests.Internal
 {
     public class PlatformDetectorTests
     {
+#if !NETSTANDARD
         [Fact]
         public void IsMonoTest()
         {
@@ -47,6 +48,7 @@ namespace NLog.UnitTests.Internal
             Assert.False(PlatformDetector.IsMono);
 #endif
         }
+#endif
 
         [Fact]
         public void GetCurrentOSTest()


### PR DESCRIPTION
Skip resolving `Type.GetType("Mono.Runtime")` when running on modern platform. Avoid triggering `AppDomain.TypeResolve`-events and extra noise.