### PR TITLE
ChainsawTarget - IncludeEventProperties = true since IncludeNLogData = false

### DIFF
--- a/src/NLog/Targets/ChainsawTarget.cs
+++ b/src/NLog/Targets/ChainsawTarget.cs
@@ -60,6 +60,7 @@ namespace NLog.Targets
         public ChainsawTarget()
         {
             IncludeNLogData = false;
+            IncludeEventProperties = true;
         }
 
         /// <summary>


### PR DESCRIPTION
Better defaults. Followup to #4891