### PR TITLE
SandCastle Docs should always use nuget-packages

### DIFF
--- a/src/Docs/BuildDoc.cmd
+++ b/src/Docs/BuildDoc.cmd
@@ -2,7 +2,6 @@
 
 set BuildVersion=5.0
 
-msbuild /t:restore,build %~dp0\..\NLog.sln /p:Configuration=Release /verbosity:minimal
 msbuild /t:restore,build %~dp0\dll_to_doc /p:RestorePackagesConfig=true /p:Configuration=Release /verbosity:minimal
 msbuild /t:restore %~dp0NLog.shfbproj /p:Configuration=Release /verbosity:minimal
 msbuild %~dp0NLog.shfbproj /p:Configuration=Release /p:Framework=%FRAMEWORK% /p:AssemblyName=NLog /p:BuildVersion=%BuildVersion%

--- a/src/Docs/NLog.shfbproj
+++ b/src/Docs/NLog.shfbproj
@@ -28,22 +28,22 @@
     <OutputPath>Doc\</OutputPath>
     <HtmlHelpName>NLog</HtmlHelpName>
     <DocumentationSources>
-      <DocumentationSource sourceFile="..\NLog\bin\Release\net45\NLog.dll" platform=".NET Framework 4.5" />
-      <DocumentationSource sourceFile="..\NLog\bin\Release\net45\NLog.xml" platform=".NET Framework 4.5" />
-      <DocumentationSource sourceFile="..\NLog.Database\bin\Release\netstandard2.0\NLog.Database.dll" />
-      <DocumentationSource sourceFile="..\NLog.Database\bin\Release\netstandard2.0\NLog.Database.xml" />
-      <DocumentationSource sourceFile="..\NLog.OutputDebugString\bin\Release\netstandard2.0\NLog.OutputDebugString.dll" />
-      <DocumentationSource sourceFile="..\NLog.OutputDebugString\bin\Release\netstandard2.0\NLog.OutputDebugString.xml" />
-      <DocumentationSource sourceFile="..\NLog.MSMQ\bin\Release\net45\NLog.MSMQ.dll" />
-      <DocumentationSource sourceFile="..\NLog.MSMQ\bin\Release\net45\NLog.MSMQ.xml" />
-      <DocumentationSource sourceFile="..\NLog.PerformanceCounter\bin\Release\netstandard2.0\NLog.PerformanceCounter.dll" />
-      <DocumentationSource sourceFile="..\NLog.PerformanceCounter\bin\Release\netstandard2.0\NLog.PerformanceCounter.xml" />
-      <DocumentationSource sourceFile="..\NLog.Wcf\bin\Release\netstandard2.0\NLog.Wcf.dll" />
-      <DocumentationSource sourceFile="..\NLog.Wcf\bin\Release\netstandard2.0\NLog.Wcf.xml" />
-      <DocumentationSource sourceFile="..\NLog.WindowsIdentity\bin\Release\netstandard2.0\NLog.WindowsIdentity.dll" />
-      <DocumentationSource sourceFile="..\NLog.WindowsIdentity\bin\Release\netstandard2.0\NLog.WindowsIdentity.xml" />
-      <DocumentationSource sourceFile="..\NLog.WindowsRegistry\bin\Release\netstandard2.0\NLog.WindowsRegistry.dll" />
-      <DocumentationSource sourceFile="..\NLog.WindowsRegistry\bin\Release\netstandard2.0\NLog.WindowsRegistry.xml" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.dll" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.xml" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.Database.dll" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.Database.xml" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.OutputDebugString.dll" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.OutputDebugString.xml" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.MSMQ.dll" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.MSMQ.xml" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.PerformanceCounter.dll" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.PerformanceCounter.xml" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.Wcf.dll" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.Wcf.xml" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.WindowsIdentity.dll" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.WindowsIdentity.xml" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.WindowsRegistry.dll" />
+      <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.WindowsRegistry.xml" />
       <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.Windows.Forms.dll" />
       <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.Windows.Forms.xml" />
       <DocumentationSource sourceFile="dll_to_doc\bin\Release\NLog.Extensions.Logging.dll" />
@@ -70,12 +70,12 @@
     <ComponentConfigurations>
       <ComponentConfig id="Code Block Component" enabled="True">
         <component id="Code Block Component">
-  <basePath value="{@HtmlEncProjectFolder}..\..\" />
-  <outputPaths>{@HelpFormatOutputPaths}</outputPaths>
-  <allowMissingSource value="true" />
-  <removeRegionMarkers value="false" />
-  <colorizer syntaxFile="{@CoreComponentsFolder}Colorizer\highlight.xml" styleFile="{@CoreComponentsFolder}Colorizer\highlight.xsl" stylesheet="{@CoreComponentsFolder}Colorizer\highlight.css" scriptFile="{@CoreComponentsFolder}Colorizer\highlight.js" disabled="{@DisableCodeBlockComponent}" language="cs" tabSize="0" numberLines="true" outlining="true" keepSeeTags="true" defaultTitle="true" />
-</component>
+          <basePath value="{@HtmlEncProjectFolder}..\..\" />
+          <outputPaths>{@HelpFormatOutputPaths}</outputPaths>
+          <allowMissingSource value="true" />
+          <removeRegionMarkers value="false" />
+          <colorizer syntaxFile="{@CoreComponentsFolder}Colorizer\highlight.xml" styleFile="{@CoreComponentsFolder}Colorizer\highlight.xsl" stylesheet="{@CoreComponentsFolder}Colorizer\highlight.css" scriptFile="{@CoreComponentsFolder}Colorizer\highlight.js" disabled="{@DisableCodeBlockComponent}" language="cs" tabSize="0" numberLines="true" outlining="true" keepSeeTags="true" defaultTitle="true" />
+        </component>
       </ComponentConfig>
     </ComponentConfigurations>
     <ApiFilter>
@@ -164,8 +164,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EWSoftware.SHFB" Version="2019.9.15" />
-    <PackageReference Include="EWSoftware.SHFB.NETFramework" Version="4.8.0" />
+    <PackageReference Include="EWSoftware.SHFB" Version="2022.2.6" />
+    <PackageReference Include="EWSoftware.SHFB.NETFramework" Version="4.8.0.2" />
   </ItemGroup>
   <!-- Import the common build targets during NuGet restore because before the packages are being installed, $(SHFBROOT) is not set yet -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition="'$(MSBuildRestoreSessionId)' != ''" />

--- a/src/Docs/README.md
+++ b/src/Docs/README.md
@@ -2,10 +2,9 @@
 Generated docs for https://nlog-project.org/documentation/
 
 ## How to run
-1. Install [Sandcastle Help File Builder (SHFB) ](https://github.com/EWSoftware/SHFB), tested it with [v2022.2.6.0](https://github.com/EWSoftware/SHFB/releases/tag/v2022.2.6.0)
 1. Perhaps update the year. Search for `2004-` for in [NLog.shfbproj](NLog.shfbproj).
-1. Start *Developer Command Prompt for VS 2022*
-1. Run [BuildDoc.cmd](BuildDoc.cmd)
-1. Copy the Doc folder to the documentation folder of nlog.github.io
-1. Remove unneeded files: .config, .aspx. .php, WebKI.xml, WebTOC.xml and LastBuild.log
+2. Start *Developer Command Prompt for VS 2022*
+3. Run [BuildDoc.cmd](BuildDoc.cmd)
+4. Copy the Doc folder to the documentation folder of nlog.github.io
+5. Remove unneeded files: .config, .aspx. .php, WebKI.xml, WebTOC.xml and LastBuild.log
 

--- a/src/Docs/dll_to_doc/dll_to_doc.csproj
+++ b/src/Docs/dll_to_doc/dll_to_doc.csproj
@@ -35,6 +35,12 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.5.0.0\lib\net46\NLog.dll</HintPath>
+    </Reference>
+    <Reference Include="NLog.Database, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.Database.5.0.0\lib\net46\NLog.Database.dll</HintPath>
+    </Reference>
     <Reference Include="NLog.DiagnosticSource, Version=1.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>packages\NLog.DiagnosticSource.1.2.0\lib\net45\NLog.DiagnosticSource.dll</HintPath>
     </Reference>
@@ -47,8 +53,20 @@
     <Reference Include="NLog.MailKit, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>packages\NLog.MailKit.4.1.0\lib\netstandard2.0\NLog.MailKit.dll</HintPath>
     </Reference>
+    <Reference Include="NLog.MSMQ, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.MSMQ.5.0.0\lib\net46\NLog.MSMQ.dll</HintPath>
+    </Reference>
+    <Reference Include="NLog.OutputDebugString, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.OutputDebugString.5.0.0\lib\net46\NLog.OutputDebugString.dll</HintPath>
+    </Reference>
     <Reference Include="NLog.Owin.Logging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>packages\NLog.Owin.Logging.1.1.0\lib\net45\NLog.Owin.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="NLog.PerformanceCounter, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.PerformanceCounter.5.0.0\lib\net46\NLog.PerformanceCounter.dll</HintPath>
+    </Reference>
+    <Reference Include="NLog.Wcf, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.Wcf.5.0.0\lib\net46\NLog.Wcf.dll</HintPath>
     </Reference>
     <Reference Include="NLog.Web, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>packages\NLog.Web.5.0.0\lib\net46\NLog.Web.dll</HintPath>
@@ -57,11 +75,25 @@
       <HintPath>packages\NLog.Web.AspNetCore.5.0.0\lib\net461\NLog.Web.AspNetCore.dll</HintPath>
     </Reference>
     <Reference Include="NLog.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>packages\NLog.Windows.Forms.4.5.0\lib\net35\NLog.Windows.Forms.dll</HintPath>
+      <HintPath>packages\NLog.Windows.Forms.4.6.0\lib\net35\NLog.Windows.Forms.dll</HintPath>
+    </Reference>
+    <Reference Include="NLog.WindowsIdentity, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.WindowsIdentity.5.0.0\lib\net46\NLog.WindowsIdentity.dll</HintPath>
+    </Reference>
+    <Reference Include="NLog.WindowsRegistry, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.WindowsRegistry.5.0.0\lib\net46\NLog.WindowsRegistry.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Messaging" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Docs/dll_to_doc/packages.config
+++ b/src/Docs/dll_to_doc/packages.config
@@ -1,12 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NLog" version="5.0.0" targetFramework="net472" />
+  <package id="NLog.Database" version="5.0.0" targetFramework="net472" />
   <package id="NLog.DiagnosticSource" version="1.2.0" targetFramework="net472" />
   <package id="NLog.Extensions.Hosting" version="5.0.0" targetFramework="net472" />
   <package id="NLog.Extensions.Logging" version="5.0.0" targetFramework="net472" />
   <package id="NLog.MailKit" version="4.1.0" targetFramework="net472" />
+  <package id="NLog.MSMQ" version="5.0.0" targetFramework="net472" />
+  <package id="NLog.OutputDebugString" version="5.0.0" targetFramework="net472" />
   <package id="NLog.Owin.Logging" version="1.1.0" targetFramework="net472" />
+  <package id="NLog.PerformanceCounter" version="5.0.0" targetFramework="net472" />
+  <package id="NLog.Wcf" version="5.0.0" targetFramework="net472" />
   <package id="NLog.Web" version="5.0.0" targetFramework="net472" />
   <package id="NLog.Web.AspNetCore" version="5.0.0" targetFramework="net472" />
-  <package id="NLog.Windows.Forms" version="4.5.0" targetFramework="net472" />
+  <package id="NLog.Windows.Forms" version="4.6.0" targetFramework="net472" />
+  <package id="NLog.WindowsIdentity" version="5.0.0" targetFramework="net472" />
+  <package id="NLog.WindowsRegistry" version="5.0.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
- Changed from building local NLog.dlls to always using dll_to_doc-nuget-project.
- Removed advice about `Install [Sandcastle Help File Builder]` since `NLog.shfbproj` will download it automatically
