### PR TITLE
LoggingConfigurationParser should alert when LoggingRule filters are bad

### DIFF
--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -84,7 +84,7 @@ namespace NLog.UnitTests.Config
     <rules>
       <logger name='*' writeTo='t'>
         <filters>
-           <whenFoo x='44' action='Ignore' />
+           <whenFoo x='44' action='Log' />
         </filters>
       </logger>
     </rules>
@@ -174,7 +174,7 @@ namespace NLog.UnitTests.Config
     <rules>
       <logger name='*' writeTo='t'>
         <filters>
-           <myprefix.whenFoo x='44' action='Ignore' />
+           <myprefix.whenFoo x='44' action='Log' />
         </filters>
       </logger>
     </rules>
@@ -222,7 +222,7 @@ namespace NLog.UnitTests.Config
     <rules>
       <logger name='*' writeTo='t'>
         <filters>
-           <whenFoo x='44' action='Ignore' />
+           <whenFoo x='44' action='Log' />
         </filters>
       </logger>
     </rules>
@@ -264,7 +264,7 @@ namespace NLog.UnitTests.Config
     <rules>
       <logger name='*' writeTo='t'>
         <filters>
-           <whenFoo x='44' action='Ignore' />
+           <whenFoo x='44' action='Log' />
         </filters>
       </logger>
     </rules>

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -256,7 +256,7 @@ namespace NLog.UnitTests.Config
                     </targets>
                     <rules>
                         <logger name='*' minlevel='debug' appendto='debug' filterDefaultAction='ignore'>
-                            <filters>
+                            <filters defaultAction='log'>
                                 <whenContains />
                             </filters>
                         </logger>


### PR DESCRIPTION
Discovered that not every company have a NLog Janitor on their payroll.

Better help the NLog-users that care about their NLog LoggingConfiguration being correct. Instead of just failing silently, and causing NLog 5.0 upgrade to be a failure.

Followup to the breaking change #3359