### PR TITLE
FileTarget - First acquire file-handle to compress before creating zip-file

### DIFF
--- a/src/NLog/Targets/ZipArchiveFileCompressor.cs
+++ b/src/NLog/Targets/ZipArchiveFileCompressor.cs
@@ -57,9 +57,9 @@ namespace NLog.Targets
 
         public void CompressFile(string fileName, string archiveFileName, string entryName)
         {
+            using (var originalFileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             using (var archiveStream = new FileStream(archiveFileName, FileMode.Create))
             using (var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create))
-            using (var originalFileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite ))
             {
                 var zipArchiveEntry = archive.CreateEntry(entryName);
                 using (var destination = zipArchiveEntry.Open())


### PR DESCRIPTION
Trying to resolve #4860 so not creating lots of zip-files when unable to acquire file-handle