### PR TITLE
Max StackTraceUsage should be computed using bitwise OR

### DIFF
--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -377,7 +377,7 @@ namespace NLog.Layouts
 
             // determine the max StackTraceUsage, to decide if Logger needs to capture callsite
             StackTraceUsage = StackTraceUsage.None;    // In case this Layout should implement IUsesStackTrace
-            StackTraceUsage = objectGraphScannerList.OfType<IUsesStackTrace>().DefaultIfEmpty().Max(item => item?.StackTraceUsage ?? StackTraceUsage.None);
+            StackTraceUsage = objectGraphScannerList.OfType<IUsesStackTrace>().DefaultIfEmpty().Aggregate(StackTraceUsage.None, (usage, item) => usage | item?.StackTraceUsage ?? StackTraceUsage.None);
 
             _scannedForObjects = true;
         }


### PR DESCRIPTION
The `StackTraceUsage` of a layout is currently using `Max` to compute the maximum value. This is buggy when individual `StackTraceUsage` values have overlapping bits.