### PR TITLE
LoggingConfigurationParser - Support for using assembly-name as type-alias-prefix

### DIFF
--- a/src/NLog/Config/Factory.cs
+++ b/src/NLog/Config/Factory.cs
@@ -159,11 +159,15 @@ namespace NLog.Config
             GetTypeDelegate typeLookup = () => itemDefinition;
             itemName = NormalizeName(itemName);
             _items[itemNamePrefix + itemName] = typeLookup;
-            if (!string.IsNullOrEmpty(assemblyName))
+            if (!string.IsNullOrEmpty(assemblyName) && !string.Equals(assemblyName, "nlog", StringComparison.OrdinalIgnoreCase))
             {
                 _items[itemName + ", " + assemblyName] = typeLookup;
                 _items[itemDefinition.Name + ", " + assemblyName] = typeLookup;
                 _items[itemDefinition.ToString() + ", " + assemblyName] = typeLookup;
+
+                _items[assemblyName + ":" + itemName] = typeLookup;
+                _items[assemblyName + ":" + itemDefinition.Name] = typeLookup;
+                _items[assemblyName + ":" + itemDefinition.ToString()] = typeLookup;
             }
         }
 
@@ -288,6 +292,14 @@ namespace NLog.Config
             {
                 var left = itemName.Substring(0, commaIndex).Replace("-", string.Empty);
                 var right = itemName.Substring(commaIndex);
+                return left + right;
+            }
+
+            var colonIndex = itemName.IndexOf(':');
+            if (colonIndex >= 0)
+            {
+                var right = itemName.Substring(colonIndex).Replace("-", string.Empty);
+                var left = itemName.Substring(0, colonIndex);
                 return left + right;
             }
 

--- a/src/NLog/Config/LoggingConfigurationElementExtensions.cs
+++ b/src/NLog/Config/LoggingConfigurationElementExtensions.cs
@@ -117,31 +117,7 @@ namespace NLog.Config
         public static string GetConfigItemTypeAttribute(this ILoggingConfigurationElement element, string sectionNameForRequiredValue = null)
         {
             var typeAttributeValue = sectionNameForRequiredValue != null ? element.GetRequiredValue("type", sectionNameForRequiredValue) : element.GetOptionalValue("type", null);
-            return StripOptionalNamespacePrefix(typeAttributeValue)?.Trim();
-        }
-
-        /// <summary>
-        /// Remove the namespace (before :)
-        /// </summary>
-        /// <example>
-        /// x:a, will be a
-        /// </example>
-        /// <param name="attributeValue"></param>
-        /// <returns></returns>
-        private static string StripOptionalNamespacePrefix(string attributeValue)
-        {
-            if (attributeValue is null)
-            {
-                return null;
-            }
-
-            int p = attributeValue.IndexOf(':');
-            if (p < 0)
-            {
-                return attributeValue;
-            }
-
-            return attributeValue.Substring(p + 1);
+            return typeAttributeValue?.Trim();
         }
     }
 }

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -405,10 +405,31 @@ namespace NLog.UnitTests.Config
         [Fact]
         public void ExtensionTypeWithAssemblyNameCanLoad()
         {
+            ConfigurationItemFactory.Default = null;
+
             var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
 <nlog throwExceptions='true'>
 <targets>
-    <target name='t' type='AutoLoadTarget,  NLogAutoLoadExtension' />
+    <target name='t' type='AutoLoadTarget ,  NLogAutoLoadExtension' />
+</targets>
+<rules>
+    <logger name='*' writeTo='t' />
+</rules>
+</nlog>").LogFactory;
+
+            var autoLoadedTarget = logFactory.Configuration.FindTargetByName("t");
+            Assert.Equal("NLogAutloadExtension.AutoLoadTarget", autoLoadedTarget.GetType().ToString());
+        }
+
+        [Fact]
+        public void ExtensionTypeWithAssemblyNameCanLoad_XmlPrefix()
+        {
+            ConfigurationItemFactory.Default = null;
+
+            var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
+<nlog throwExceptions='true'>
+<targets>
+    <target name='t' type='NLogAutoLoadExtension:AutoLoadTarget' />
 </targets>
 <rules>
     <logger name='*' writeTo='t' />
@@ -586,6 +607,7 @@ namespace NLog.UnitTests.Config
         [InlineData("", null)]
         [InlineData("ManuallyLoadedTarget", "ManuallyLoadedExtension.ManuallyLoadedTarget")]
         [InlineData("ManuallyLoaded-Target", "ManuallyLoadedExtension.ManuallyLoadedTarget")]
+        [InlineData("Manually-Loaded-Extension:ManuallyLoadedTarget", "ManuallyLoadedExtension.ManuallyLoadedTarget")]
         [InlineData("ManuallyLoadedTarget, Manually-Loaded-Extension", "ManuallyLoadedExtension.ManuallyLoadedTarget")]
         [InlineData("ManuallyLoaded-Target, Manually-Loaded-Extension", "ManuallyLoadedExtension.ManuallyLoadedTarget")]
         [InlineData(", Manually-Loaded-Extension", null)] // border case


### PR DESCRIPTION
Trying to resolve  #4978, so one can do this (Assembly-name in QName-prefix):

```xml
<target xsi:type="NLog.Targets.Syslog:Syslog" name="cee-udp">
```

See also: https://en.wikipedia.org/wiki/QName

Not happy about having multiple ways of specifying assembly-name in the type-alias, but also not happy about breaking xml-schema-validation on purpose (Though NLog-config-variables also doesn't work that well with xml-schema-validation. Ex. `minLevel="${var:defaultLevel}"`).

Before NLog always ignored/stripped any prefix in type-name, but with this change then NLog will include the prefix when loading types. And will try to load assembly-name matching the prefix. Maybe this is for NLog 5.1 ? (Not sure of the original purpose of the prefix, and why it was ignored/skipped)