### PR TITLE
AssemblyVersionLayoutRenderer - Support override of Default value

### DIFF
--- a/src/NLog/LayoutRenderers/ApplicationEnvironment/AssemblyVersionType.cs
+++ b/src/NLog/LayoutRenderers/ApplicationEnvironment/AssemblyVersionType.cs
@@ -49,7 +49,7 @@ namespace NLog.LayoutRenderers
         File,
 
         /// <summary>
-        /// Gets additional version information.
+        /// Gets the product version, extracted from the additional version information.
         /// </summary>
         Informational
     }

--- a/tests/NLog.UnitTests/LayoutRenderers/ApplicationEnvironment/AssemblyVersionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ApplicationEnvironment/AssemblyVersionTests.cs
@@ -64,10 +64,28 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
+        public void EntryAssemblyVersionDefaultTest()
+        {
+            var assembly = Assembly.GetEntryAssembly();
+            var assemblyVersion = assembly is null
+                ? "1.2.3.4"
+                : assembly.GetName().Version.ToString();
+            AssertLayoutRendererOutput("${assembly-version:default=1.2.3.4}", assemblyVersion);
+        }
+
+        [Fact]
         public void AssemblyNameVersionTest()
         {
             AssertLayoutRendererOutput("${assembly-version:NLogAutoLoadExtension}", "2.0.0.0");
         }
+
+        [Fact]
+        public void AssemblyNameUnknownVersionTest()
+        {
+            using (new NoThrowNLogExceptions())
+                AssertLayoutRendererOutput("${assembly-version:FooBar:default=1.2.3.4}", "1.2.3.4");
+        }
+
 
         [Fact]
         public void AssemblyNameVersionTypeTest()


### PR DESCRIPTION
When specifying Default-value, then it will only attempt to load assembly-version once.