### PR TITLE
EventLogTarget - Bump default MaxMessageLength to 30000 to match Win2008

### DIFF
--- a/src/NLog/Targets/EventLogTarget.cs
+++ b/src/NLog/Targets/EventLogTarget.cs
@@ -65,7 +65,8 @@ namespace NLog.Targets
         /// <summary>
         /// Max size in characters (limitation of the EventLog API).
         /// </summary>
-        internal const int EventLogMaxMessageLength = 16384;
+        /// <seealso href="https://docs.microsoft.com/en-gb/windows/win32/api/winbase/nf-winbase-reporteventw"/>
+        internal const int EventLogMaxMessageLength = 30000;
 
         private readonly IEventLogWrapper _eventLogWrapper;
 


### PR DESCRIPTION
See also: https://docs.microsoft.com/en-gb/windows/win32/api/winbase/nf-winbase-reporteventw

> Each string is limited to 31,839 characters.

> Prior to Windows Vista:  Each string is limited to 32K characters.