### PR TITLE
Remove net45 as default target-platform but keep in build-script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -27,20 +27,18 @@ msbuild /t:Restore,Pack .\src\NLog\ /p:targetFrameworks='"net46;net45;net35;nets
 if (-Not $LastExitCode -eq 0)
 	{ exit $LastExitCode }
 
-function create-package($packageName)
+function create-package($packageName, $targetFrameworks)
 {
-
 	$path = ".\src\$packageName\"
-	msbuild /t:Restore,Pack $path /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:ContinuousIntegrationBuild=true /p:EmbedUntrackedSources=true /p:PackageOutputPath=..\..\artifacts /verbosity:minimal  /maxcpucount
+	msbuild /t:Restore,Pack $path /p:targetFrameworks=$targetFrameworks /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:ContinuousIntegrationBuild=true /p:EmbedUntrackedSources=true /p:PackageOutputPath=..\..\artifacts /verbosity:minimal  /maxcpucount
 	if (-Not $LastExitCode -eq 0)
 		{ exit $LastExitCode }
-
 }
 
-create-package('NLog.Database')
-create-package('NLog.OutputDebugString')
-create-package('NLog.WindowsEventLog')
-create-package('NLog.WindowsRegistry')
+create-package 'NLog.Database' '"net35;net45;net46;netstandard1.3;netstandard1.5;netstandard2.0"'
+create-package 'NLog.OutputDebugString' '"net35;net45;net46;netstandard2.0"'
+create-package 'NLog.WindowsEventLog' '"netstandard2.0"'
+create-package 'NLog.WindowsRegistry' '"net35;net45;net46;netstandard2.0"'
 
 msbuild /t:xsd /t:NuGetSchemaPackage .\src\NLog.proj /p:Configuration=Release /p:BuildNetFX45=true /p:BuildVersion=$versionProduct /p:Configuration=Release /p:BuildLabelOverride=NONE /verbosity:minimal
 

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -51,16 +51,6 @@ else
     if (-Not $LastExitCode -eq 0)
 	    { exit $LastExitCode }
 
-    dotnet msbuild /t:Build /p:targetFramework=net45 /p:Configuration=Release /p:DebugType=Full /p:monobuild=1 ./src/NLog/
-    if (-Not $LastExitCode -eq 0)
-	    { exit $LastExitCode }
-    dotnet msbuild /t:Build /p:targetFramework=net461 /p:Configuration=Release /p:DebugType=Full /p:monobuild=1 /p:TestTargetFramework=net45 tests/NLog.UnitTests
-    if (-Not $LastExitCode -eq 0)
-	    { exit $LastExitCode }
-	dotnet vstest ./tests/NLog.UnitTests/bin/Release/net45/NLog.UnitTests.dll
-    if (-Not $LastExitCode -eq 0)
-	    { exit $LastExitCode }
-
 	dotnet test ./tests/NLog.Database.Tests/ --framework netcoreapp3.1 --configuration release
 	if (-Not $LastExitCode -eq 0)
 		{ exit $LastExitCode }

--- a/src/NLog.Database/NLog.Database.csproj
+++ b/src/NLog.Database/NLog.Database.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <TargetFrameworks>net46;net45;net35;netstandard1.3;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net46;netstandard1.3;netstandard1.5;netstandard2.0</TargetFrameworks>
 
     <Title>NLog Database Target</Title>
     <Company>NLog</Company>

--- a/src/NLog.OutputDebugString/NLog.OutputDebugString.csproj
+++ b/src/NLog.OutputDebugString/NLog.OutputDebugString.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net45;net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net46;netstandard2.0</TargetFrameworks>
 
     <Title>NLog.OutputDebugString</Title>
     <Company>NLog</Company>

--- a/src/NLog.WindowsRegistry/NLog.WindowsRegistry.csproj
+++ b/src/NLog.WindowsRegistry/NLog.WindowsRegistry.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net45;net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net46;netstandard2.0</TargetFrameworks>
 
     <Title>NLog Windows Registry</Title>
     <Company>NLog</Company>

--- a/src/NLog.WindowsRegistry/RegistryLayoutRenderer.cs
+++ b/src/NLog.WindowsRegistry/RegistryLayoutRenderer.cs
@@ -158,7 +158,7 @@ namespace NLog.LayoutRenderers
             builder.Append(value);
         }
 
-        private class ParseResult
+        private sealed class ParseResult
         {
             public string SubKey { get; set; }
 

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net46;net45;net35;netstandard1.3;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net35;net46;netstandard1.3;netstandard1.5;netstandard2.0</TargetFrameworks>
 
     <Title>NLog for .NET Framework and .NET Standard</Title>
     <Company>NLog</Company>

--- a/tests/ManuallyLoadedExtension/ManuallyLoadedExtension.csproj
+++ b/tests/ManuallyLoadedExtension/ManuallyLoadedExtension.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AssemblyName>Manually-Loaded-Extension</AssemblyName>
   </PropertyGroup>
 

--- a/tests/NLog.WindowsRegistry.Tests/NLog.WindowsRegistry.Tests.csproj
+++ b/tests/NLog.WindowsRegistry.Tests/NLog.WindowsRegistry.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>

--- a/tests/NLogAutoLoadExtension/NLogAutoLoadExtension.csproj
+++ b/tests/NLogAutoLoadExtension/NLogAutoLoadExtension.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <TargetFrameworks>net461;netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
 
     <InformationalVersion>2.0.0.2</InformationalVersion>
 

--- a/tests/PackageLoaderTestAssembly/PackageLoaderTestAssembly.csproj
+++ b/tests/PackageLoaderTestAssembly/PackageLoaderTestAssembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/SampleExtensions/SampleExtensions.csproj
+++ b/tests/SampleExtensions/SampleExtensions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <TargetFrameworks>net461;netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
 
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>


### PR DESCRIPTION
Similar to the NLog-UnitTest-project that doesn't match the test-platforms used on the build-server.

Resolves #5008