### PR TITLE
Layout Typed should fail when unable to parse fixed value

### DIFF
--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -223,12 +223,12 @@ namespace NLog.Layouts
         /// <inheritdoc/>
         public override string ToString()
         {
-            if (string.IsNullOrEmpty(Text) && _layoutRenderers.Length > 0)
+            if (string.IsNullOrEmpty(Text) && !IsFixedText && _layoutRenderers.Length > 0)
             {
                 return ToStringWithNestedItems(_layoutRenderers, r => r.ToString());
             }
 
-            return Text;
+            return Text ?? _fixedText ?? string.Empty;
         }
 
         internal void SetLayoutRenderers(LayoutRenderer[] layoutRenderers, string text)

--- a/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
+++ b/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
@@ -35,6 +35,7 @@ using System;
 using System.Globalization;
 using System.Reflection;
 using NLog.Config;
+using NLog.Internal;
 
 namespace NLog.Layouts
 {
@@ -225,9 +226,13 @@ namespace NLog.Layouts
             }
             catch (TargetInvocationException ex)
             {
-                if (ex.InnerException != null)
+                if (ex.InnerException is null)
+                    throw;
+
+                if (ex.InnerException.MustBeRethrown())
                     throw ex.InnerException;
-                throw;
+
+                return _innerLayout;
             }
         }
 

--- a/tests/NLog.Database.Tests/DatabaseTargetTests.cs
+++ b/tests/NLog.Database.Tests/DatabaseTargetTests.cs
@@ -1287,11 +1287,11 @@ Dispose()
                 DBProvider = typeof(MockDbConnection).AssemblyQualifiedName,
                 CommandText = "command1",
             };
-            databaseTarget.ConnectionProperties.Add(new DatabaseObjectPropertyInfo() { Name = "AccessToken", Layout = "abc", PropertyType = typeof(int) });
+            databaseTarget.ConnectionProperties.Add(new DatabaseObjectPropertyInfo() { Name = "AccessToken", Layout = "${eventProperty:accessToken}", PropertyType = typeof(int) });
             var logFactory = new LogFactory().Setup().LoadConfiguration(cfg => cfg.Configuration.AddRuleForAllLevels(databaseTarget)).LogFactory;
 
             // Act + Assert
-            Assert.Throws<InvalidCastException>(() => logFactory.GetCurrentClassLogger().Info("Hello"));
+            Assert.Throws<InvalidCastException>(() => logFactory.GetCurrentClassLogger().WithProperty("accessToken", "abc").Info("Hello"));
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -59,6 +59,22 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
+        public void LayoutFixedInvalidIntTest()
+        {
+            Layout<int> layout;
+            Assert.Throws<NLogConfigurationException>(() => layout = "abc");
+        }
+
+        [Fact]
+        public void LayoutFixedEmptyIntTest()
+        {
+            Layout<int> layout = "";
+            var result = layout.RenderValue(LogEventInfo.CreateNullEvent());
+            Assert.Equal(0, result);
+            Assert.Equal("", layout.ToString());
+        }
+
+        [Fact]
         public void LayoutFixedNullableIntValueTest()
         {
             // Arrange
@@ -76,6 +92,22 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(5, layout);
             Assert.NotEqual(0, layout);
             Assert.NotEqual(default(int?), layout);
+        }
+
+        [Fact]
+        public void LayoutFixedInvalidNullableIntTest()
+        {
+            Layout<int?> layout;
+            Assert.Throws<NLogConfigurationException>(() => layout = "abc");
+        }
+
+        [Fact]
+        public void LayoutFixedEmptyNullableIntTest()
+        {
+            Layout<int?> layout = "";
+            var result = layout.RenderValue(LogEventInfo.CreateNullEvent());
+            Assert.Null(result);
+            Assert.Equal("", layout.ToString());
         }
 
         [Fact]
@@ -145,6 +177,22 @@ namespace NLog.UnitTests.Layouts
             Assert.Same(layout.FixedValue, layout.FixedValue);
             Assert.Equal("null", layout.ToString());
             Assert.NotEqual(new Uri("//other"), layout);
+        }
+
+        [Fact]
+        public void LayoutFixedInvalidUrlTest()
+        {
+            Layout<Uri> layout;
+            Assert.Throws<NLogConfigurationException>(() => layout = "!!!");
+        }
+
+        [Fact]
+        public void LayoutFixedEmptyUrlTest()
+        {
+            Layout<int?> layout = "";
+            var result = layout.RenderValue(LogEventInfo.CreateNullEvent());
+            Assert.Null(result);
+            Assert.Equal("", layout.ToString());
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
@@ -87,6 +87,9 @@ namespace NLog.UnitTests.Layouts
 
             var l2 = new SimpleLayout(new LayoutRenderer[0], "someFakeText", ConfigurationItemFactory.Default);
             Assert.Equal("someFakeText", l2.ToString());
+
+            var l3 = new SimpleLayout("");
+            Assert.Equal("", l3.ToString());
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
@@ -626,7 +626,8 @@ namespace NLog.UnitTests.Targets
 
             if (entryType != null)
             {
-                target.EntryType = new Layout<EventLogEntryType>(entryType);
+                using (new NoThrowNLogExceptions())
+                    target.EntryType = new Layout<EventLogEntryType>(entryType);
             }
 
             return target;

--- a/tests/NLog.UnitTests/Targets/MailTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MailTargetTests.cs
@@ -520,14 +520,17 @@ namespace NLog.UnitTests.Targets
                 To = "bar@foo.com",
                 Subject = "Hello from NLog",
                 SmtpServer = "server1",
-                Priority = "invalidPriority"
+                Priority = "${scopeproperty:scopePriority}"
             };
             var logFactory = new LogFactory().Setup().LoadConfiguration(cfg =>
             {
                 cfg.Configuration.AddRuleForAllLevels(mmt);
             }).LogFactory;
 
-            logFactory.GetLogger("MyLogger").Info("log message 1");
+            using (logFactory.GetCurrentClassLogger().PushScopeProperty("scopePriority", "InvalidPriority"))
+            {
+                logFactory.GetLogger("MyLogger").Info("log message 1");
+            }
 
             var messageSent = mmt.CreatedMocks[0].MessagesSent[0];
             Assert.Equal(MailPriority.Normal, messageSent.Priority);


### PR DESCRIPTION
Better user-experience when using fixed-values for typed `Layout<T>`. Getting the parse-exception upfront during config-initialization, and not late after starting logging.

Followup to #4306