### PR TITLE
Updated embedded resource with ILLink.Descriptors.xml

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -596,13 +596,15 @@ namespace NLog.Config
         private void RegisterExternalItems()
         {
 #if !NET35 && !NET40
+            _layouts.RegisterNamedType("microsoftconsolejsonlayout", "NLog.Extensions.Logging.MicrosoftConsoleJsonLayout, NLog.Extensions.Logging");
             _layoutRenderers.RegisterNamedType("configsetting", "NLog.Extensions.Logging.ConfigSettingLayoutRenderer, NLog.Extensions.Logging");
             _layoutRenderers.RegisterNamedType("microsoftconsolelayout", "NLog.Extensions.Logging.MicrosoftConsoleLayoutRenderer, NLog.Extensions.Logging");
-            _layoutRenderers.RegisterNamedType("microsoftconsolejsonlayout", "NLog.Extensions.Logging.MicrosoftConsoleJsonLayout, NLog.Extensions.Logging");
 #endif
             _layoutRenderers.RegisterNamedType("performancecounter", "NLog.LayoutRenderers.PerformanceCounterLayoutRenderer, NLog.PerformanceCounter");
             _layoutRenderers.RegisterNamedType("registry", "NLog.LayoutRenderers.RegistryLayoutRenderer, NLog.WindowsRegistry");
             _layoutRenderers.RegisterNamedType("windows-identity", "NLog.LayoutRenderers.WindowsIdentityLayoutRenderer, NLog.WindowsIdentity");
+            _layoutRenderers.RegisterNamedType("activity", "NLog.LayoutRenderers.ActivityTraceLayoutRenderer, NLog.DiagnosticSource");
+            _targets.RegisterNamedType("diagnosticlistener", "NLog.Targets.DiagnosticListenerTarget, NLog.DiagnosticSource");
             _targets.RegisterNamedType("database", "NLog.Targets.DatabaseTarget, NLog.Database");
 #if NETSTANDARD
             _targets.RegisterNamedType("eventlog", "NLog.Targets.EventLogTarget, NLog.WindowsEventLog");

--- a/src/NLog/ILLink.Descriptors.xml
+++ b/src/NLog/ILLink.Descriptors.xml
@@ -1,7 +1,7 @@
 <linker>
   <assembly fullname="NLog" preserve="all" />
   <assembly fullname="NLog.Targets.AppCenter" preserve="all" />
-  <assembly fullname="NLog.Targets.Xamarin" preserve="all" />
+  <assembly fullname="NLog.Targets.MauiLog" preserve="all" />
   <assembly fullname="NLog.Database" preserve="all" />
   <assembly fullname="NLog.DiagnosticSource" preserve="all" />
   <assembly fullname="NLog.Extensions.Logging" preserve="all" />


### PR DESCRIPTION
Changed NLog.Targets.Xamarin to NLog.Targets.MauiLog

Since Xamarin will reach end-of-life at May 1, 2024 
