### PR TITLE
Reduced embedded resource ILLink.Descriptors.xml to only NLog to avoid IL2007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Date format: (year/month/day)
 
 ### Version 5.0.3 (2022/09/01)
 
+**Fixes**
+- [#5051](https://github.com/NLog/NLog/pull/5051) Added embedded resource with ILLink.Descriptors.xml to skip AOT (#5051) (@snakefoot)
+
+### Version 5.0.3 (2022/09/01)
+
 **Improvements**
 - [#5034](https://github.com/NLog/NLog/pull/5034) Added embedded resource with ILLink.Descriptors.xml to skip AOT (#5034) (@snakefoot)
 - [#5035](https://github.com/NLog/NLog/pull/5035) Layout Typed that can handle LogEventInfo is null (#5035) (@snakefoot)

--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,7 @@
 # creates NuGet package at \artifacts
 dotnet --version
 
-$versionPrefix = "5.0.3"
+$versionPrefix = "5.0.4"
 $versionSuffix = ""
 $versionFile = $versionPrefix + "." + ${env:APPVEYOR_BUILD_NUMBER}
 $versionProduct = $versionPrefix;

--- a/src/NLog/ILLink.Descriptors.xml
+++ b/src/NLog/ILLink.Descriptors.xml
@@ -1,18 +1,3 @@
 <linker>
   <assembly fullname="NLog" preserve="all" />
-  <assembly fullname="NLog.Targets.AppCenter" preserve="all" />
-  <assembly fullname="NLog.Targets.MauiLog" preserve="all" />
-  <assembly fullname="NLog.Database" preserve="all" />
-  <assembly fullname="NLog.DiagnosticSource" preserve="all" />
-  <assembly fullname="NLog.Extensions.Logging" preserve="all" />
-  <assembly fullname="NLog.Etw" preserve="all" />
-  <assembly fullname="NLog.MailKit" preserve="all" />
-  <assembly fullname="NLog.MSMQ" preserve="all" />
-  <assembly fullname="NLog.OutputDebugString" preserve="all" />
-  <assembly fullname="NLog.PerformanceCounter" preserve="all" />
-  <assembly fullname="NLog.WindowsEventLog" preserve="all" />
-  <assembly fullname="NLog.WindowsIdentity" preserve="all" />
-  <assembly fullname="NLog.Windows.Forms" preserve="all" />
-  <assembly fullname="NLog.Wcf" preserve="all" />
-  <assembly fullname="NLog.Web.AspNetCore" preserve="all" />
 </linker>

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -29,6 +29,7 @@ For ASP.NET Core, check: https://www.nuget.org/packages/NLog.Web.AspNetCore
     <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
+- Fixed embedded resource with ILLink.Descriptors.xml to avoid IL2007 (#5051) (@snakefoot)
 - Added embedded resource with ILLink.Descriptors.xml to skip AOT (#5034) (@snakefoot)
 - Layout Typed that can handle LogEventInfo is null (#5035) (@snakefoot)
 - JsonLayout - Fix output for Attributes with IncludeEmptyValue=false and Encode=false (#5036) (@snakefoot)


### PR DESCRIPTION
Followup to #5034 (Removing friends) to resolve #5050

```
Error: resource ILLink.Descriptors.xml in NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c(15,4): error IL2007: Could not resolve assembly 'NLog.Windows.Forms'.
```