### PR TITLE
ObjectReflectionCache - Skip serializing System.Net.IPAddress

### DIFF
--- a/src/NLog/Internal/AsyncOperationCounter.cs
+++ b/src/NLog/Internal/AsyncOperationCounter.cs
@@ -58,12 +58,13 @@ namespace NLog.Internal
         /// </summary>
         /// <param name="exception">Exception coming from the completed operation [optional]</param>
         public void CompleteOperation(Exception exception)
-        { 
+        {
+            System.Threading.Interlocked.Decrement(ref _pendingOperationCounter);
+
             if (_pendingCompletionList.Count > 0)
             {
                 lock (_pendingCompletionList)
                 {
-                    System.Threading.Interlocked.Decrement(ref _pendingOperationCounter);
                     var nodeNext = _pendingCompletionList.First;
                     while (nodeNext != null)
                     {
@@ -72,10 +73,6 @@ namespace NLog.Internal
                         nodeValue(exception);  // Will modify _pendingCompletionList
                     }
                 }
-            }
-            else
-            {
-                System.Threading.Interlocked.Decrement(ref _pendingOperationCounter);
             }
         }
 

--- a/src/NLog/Internal/Reflection/ObjectReflectionCache.cs
+++ b/src/NLog/Internal/Reflection/ObjectReflectionCache.cs
@@ -243,8 +243,8 @@ namespace NLog.Internal
             if (typeof(System.IO.Stream).IsAssignableFrom(objectType))
                 return true;    // Skip serializing properties that often throws exceptions
 
-            if (typeof(System.Globalization.CultureInfo).IsAssignableFrom(objectType))
-                return true;    // Skip serializing CultureInfo details
+            if (typeof(System.Net.IPAddress).IsAssignableFrom(objectType))
+                return true;    // Skip serializing properties that often throws exceptions
 
             return false;
         }

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -1089,7 +1089,7 @@ namespace NLog.UnitTests.Layouts
             logEventInfo.Properties["RequestId"] = expectedValue;
 
             var actualValue = jsonLayout.Render(logEventInfo);           
-            Assert.Equal($"{{ \"BadObject\": {{\"Recursive\":[\"Hello\"], \"WeirdProperty\":\"System.Action\", \"CultureProperty\":\"\"}}, \"RequestId\": \"{expectedValue}\" }}", actualValue);
+            Assert.Equal($"{{ \"BadObject\": {{\"Recursive\":[\"Hello\"], \"WeirdProperty\":\"System.Action\"}}, \"RequestId\": \"{expectedValue}\" }}", actualValue);
         }
 
         class BadObject
@@ -1099,8 +1099,6 @@ namespace NLog.UnitTests.Layouts
             public IEnumerable<string> EvilProperty => throw new NotSupportedException();
 
             public System.Action WeirdProperty { get; } = new System.Action(() => throw new NotSupportedException());
-
-            public System.IFormatProvider CultureProperty { get; } = System.Globalization.CultureInfo.InvariantCulture;
         }
 
         class EvilObject : IFormattable

--- a/tests/NLog.UnitTests/Targets/Wrappers/AutoFlushTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AutoFlushTargetWrapperTests.cs
@@ -97,14 +97,14 @@ namespace NLog.UnitTests.Targets.Wrappers
 
             wrapper.WriteAsyncLogEvent(logEvent.WithContinuation(continuation));
 
-            continuationHit.WaitOne();
+            Assert.True(continuationHit.WaitOne(5000));
             Assert.Null(lastException);
             Assert.Equal(1, myTarget.FlushCount);
             Assert.Equal(1, myTarget.WriteCount);
 
             continuationHit.Reset();
             wrapper.WriteAsyncLogEvent(logEvent.WithContinuation(continuation));
-            continuationHit.WaitOne();
+            Assert.True(continuationHit.WaitOne(5000));
             Assert.Null(lastException);
             Assert.Equal(2, myTarget.WriteCount);
             Assert.Equal(2, myTarget.FlushCount);
@@ -136,7 +136,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             Assert.Null(lastException);
             wrapper.Flush(continuation);
             Assert.Null(lastException);
-            continuationHit.WaitOne();
+            Assert.True(continuationHit.WaitOne(5000));
             Assert.Null(lastException);
             wrapper.Flush(ex => { });   // Executed right away
             Assert.Null(lastException);
@@ -167,7 +167,7 @@ namespace NLog.UnitTests.Targets.Wrappers
 
             wrapper.WriteAsyncLogEvent(logEvent.WithContinuation(continuation));
 
-            continuationHit.WaitOne();
+            Assert.True(continuationHit.WaitOne(5000));
             Assert.NotNull(lastException);
             Assert.IsType<InvalidOperationException>(lastException);
 
@@ -178,7 +178,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             continuationHit.Reset();
             lastException = null;
             wrapper.WriteAsyncLogEvent(logEvent.WithContinuation(continuation));
-            continuationHit.WaitOne();
+            Assert.True(continuationHit.WaitOne(5000));
             Assert.NotNull(lastException);
             Assert.IsType<InvalidOperationException>(lastException);
             Assert.Equal(0, myTarget.FlushCount);


### PR DESCRIPTION
Microsoft ASP.NET like to log System.Net.IPAddress-objects, but its properties throws exception depending on IPv4 or IPv6.