### PR TITLE
Updated unit-tests to work with Azure.DevOps-build-pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 
 script:
   # Run tests
-  - dotnet test tests/NLog.UnitTests --configuration Release --framework netcoreapp2.0
+  - dotnet test tests/NLog.UnitTests --configuration Release --framework netcoreapp2.1
 
   - dotnet msbuild /t:Restore /p:targetframework=net452 /p:monobuild=1 src/NLog
   - dotnet msbuild /t:Restore /p:targetframework=net452 /p:monobuild=1 tests/NLog.UnitTests

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -29,7 +29,7 @@ msbuild /t:Restore,Build /p:Configuration=Release /p:DebugType=Full .\tests\NLog
 if (-Not $LastExitCode -eq 0)
 	{ exit $LastExitCode }
 
-dotnet test .\tests\NLog.UnitTests\  --configuration release --framework netcoreapp2.0 --no-build
+dotnet test .\tests\NLog.UnitTests\  --configuration release --framework netcoreapp2.1 --no-build
 if (-Not $LastExitCode -eq 0)
 	{ exit $LastExitCode }
 

--- a/src/NLog.sln
+++ b/src/NLog.sln
@@ -42,6 +42,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\appveyor.yml = ..\appveyor.yml
 		..\build.ps1 = ..\build.ps1
 		..\CHANGELOG.md = ..\CHANGELOG.md
+		..\run-tests.ps1 = ..\run-tests.ps1
 	EndProjectSection
 EndProject
 Global

--- a/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ExceptionTests.cs
@@ -41,6 +41,7 @@ namespace NLog.UnitTests.LayoutRenderers
     using NLog.Internal;
     using Xunit;
     using NLog.Config;
+    using Xunit.Sdk;
 
     public class ExceptionTests : NLogTestBase
     {
@@ -461,8 +462,8 @@ namespace NLog.UnitTests.LayoutRenderers
             // Obsolete method requires testing until completely removed.
             logger.ErrorException("msg", ex);
             var lastMessage1 = GetDebugLastMessage("debug1");
-            Assert.StartsWith("{\"Type\":\"System.ApplicationException\", \"Message\":\"Wrapper2\"", lastMessage1);
-            Assert.Contains("\"InnerException\":{\"Type\":\"System.ArgumentException\", \"Message\":\"Wrapper1\"", lastMessage1);
+            Assert.StartsWith("{\"Type\":\"System.ApplicationException\", ", lastMessage1);
+            Assert.Contains("\"InnerException\":{\"Type\":\"System.ArgumentException\", ", lastMessage1);
             Assert.Contains("\"ParamName\":\"exceptionMessage\"", lastMessage1);
             Assert.Contains("1Really_Bad_Boy_", lastMessage1);
 
@@ -470,10 +471,10 @@ namespace NLog.UnitTests.LayoutRenderers
 
             logger.Error(ex, "msg");
             var lastMessage2 = GetDebugLastMessage("debug1");
-            Assert.StartsWith("{\"Type\":\"System.ApplicationException\", \"Message\":\"Wrapper2\"", lastMessage2);
-            Assert.Contains("\"InnerException\":{\"Type\":\"System.ArgumentException\", \"Message\":\"Wrapper1\"", lastMessage2);
+            Assert.StartsWith("{\"Type\":\"System.ApplicationException\", ", lastMessage2);
+            Assert.Contains("\"InnerException\":{\"Type\":\"System.ArgumentException\", ", lastMessage2);
             Assert.Contains("\"ParamName\":\"exceptionMessage\"", lastMessage2);
-            Assert.Contains("1Really_Bad_Boy_", lastMessage1);
+            Assert.Contains("1Really_Bad_Boy_", lastMessage2);
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/LayoutRenderers/ProcessNameLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ProcessNameLayoutRendererTests.cs
@@ -56,7 +56,7 @@ namespace NLog.UnitTests.LayoutRenderers
             var lower = actual.ToLower();
 
             //lowercase
-            var allowedProcessNames = new List<string> {"vstest.executionengine", "xunit", "mono-sgen", "dotnet", "testhost.x86", "testhost.x64" };
+            var allowedProcessNames = new List<string> {"vstest.executionengine", "xunit", "mono-sgen", "dotnet", "testhost.x86", "testhost.x64", "testhost.net452" };
 
             Assert.True(allowedProcessNames.Any(p => lower.Contains(p)),
                 $"validating processname failed. Please add (if correct) '{actual}' to 'allowedProcessNames'");

--- a/tests/NLog.UnitTests/NLog.UnitTests.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' And '$(APPVEYOR)' == '' ">net452;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' And '$(APPVEYOR)' != '' ">net452;netcoreapp2.1</TargetFrameworks>
 
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -33,7 +34,7 @@
     <DefineConstants>$(DefineConstants);NET4_0;DYNAMIC_OBJECT</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);NETSTANDARD;NET4_5;DYNAMIC_OBJECT</DefineConstants>
   </PropertyGroup>
 
@@ -53,7 +54,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0" />

--- a/tests/NLog.UnitTests/Targets/Wrappers/AutoFlushTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AutoFlushTargetWrapperTests.cs
@@ -99,14 +99,14 @@ namespace NLog.UnitTests.Targets.Wrappers
 
             wrapper.WriteAsyncLogEvent(logEvent.WithContinuation(continuation));
 
-            continuationHit.WaitOne();
+            Assert.True(continuationHit.WaitOne(5000));
             Assert.Null(lastException);
             Assert.Equal(1, myTarget.FlushCount);
             Assert.Equal(1, myTarget.WriteCount);
 
             continuationHit.Reset();
             wrapper.WriteAsyncLogEvent(logEvent.WithContinuation(continuation));
-            continuationHit.WaitOne();
+            Assert.True(continuationHit.WaitOne(5000));
             Assert.Null(lastException);
             Assert.Equal(2, myTarget.WriteCount);
             Assert.Equal(2, myTarget.FlushCount);
@@ -138,7 +138,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             Assert.Null(lastException);
             wrapper.Flush(continuation);
             Assert.Null(lastException);
-            continuationHit.WaitOne();
+            Assert.True(continuationHit.WaitOne(5000));
             Assert.Null(lastException);
             wrapper.Flush(ex => { });   // Executed right away
             Assert.Null(lastException);
@@ -169,7 +169,7 @@ namespace NLog.UnitTests.Targets.Wrappers
 
             wrapper.WriteAsyncLogEvent(logEvent.WithContinuation(continuation));
 
-            continuationHit.WaitOne();
+            Assert.True(continuationHit.WaitOne(5000));
             Assert.NotNull(lastException);
             Assert.IsType<InvalidOperationException>(lastException);
 
@@ -180,7 +180,7 @@ namespace NLog.UnitTests.Targets.Wrappers
             continuationHit.Reset();
             lastException = null;
             wrapper.WriteAsyncLogEvent(logEvent.WithContinuation(continuation));
-            continuationHit.WaitOne();
+            Assert.True(continuationHit.WaitOne(5000));
             Assert.NotNull(lastException);
             Assert.IsType<InvalidOperationException>(lastException);
             Assert.Equal(0, myTarget.FlushCount);


### PR DESCRIPTION
Must stay on VS2017 on AppVeyor to produce Silverlight/WindowsPhone-builds.