### PR TITLE
integrate and refactor ThrowIfNull- fixes #5055

### DIFF
--- a/src/NLog/Internal/Guard.cs
+++ b/src/NLog/Internal/Guard.cs
@@ -1,0 +1,69 @@
+//
+// Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of Jaroslaw Kowalski nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    sealed class CallerArgumentExpressionAttribute : Attribute
+    {
+        public CallerArgumentExpressionAttribute(string param)
+        {
+            Param = param;
+        }
+
+        public string Param { get; }
+    }
+}
+#endif
+
+namespace NLog.Internal
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    internal static class Guard
+    {
+        internal static T ThrowIfNull<T>(
+            T arg,
+            [CallerArgumentExpression("arg")] string param = "")
+            where T : class
+        {
+            if (arg is null)
+            {
+                throw new ArgumentNullException(param);
+            }
+
+            return arg;
+        }
+    }
+}

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -128,9 +128,7 @@ namespace NLog
         /// <returns>New Logger object that automatically appends specified properties</returns>
         public Logger WithProperties(IEnumerable<KeyValuePair<string, object>> properties)
         {
-            if (properties == null)
-                throw new ArgumentNullException(nameof(properties));
-
+            Guard.ThrowIfNull(properties);
             Logger newLogger = CreateChildLogger();
             foreach (KeyValuePair<string, object> property in properties)
             {
@@ -315,11 +313,7 @@ namespace NLog
         {
             if (IsEnabled(level))
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
-
+                Guard.ThrowIfNull(messageFunc);
                 WriteToTargets(level, messageFunc());
             }
         }


### PR DESCRIPTION
This PR introduces a backward compatible way to use `ThrowIfNull` to check if the given argument is null and
throw an exception or simply return the value of the argument. 

This is a draft PR to get initial feedback. It implements a backward compatible attribute that's used on .NET 5 and lower. The checks are an example how it could be used in the Logger.cs class.

An idea that came: maybe the `Guard` class could be extended to also integrate more checks like `ThrowIfNullOrEmpty` for e.g. strings?

**R=**@snakefoot?
**Refs**: #5055