### PR TITLE
Include error-message from inner-exception when layout contains unknown layoutrenderer

### DIFF
--- a/src/NLog/Config/Factory.cs
+++ b/src/NLog/Config/Factory.cs
@@ -253,6 +253,10 @@ namespace NLog.Config
             {
                 message += ". Extension NLog.Database not included?";
             }
+            else if (normalName?.StartsWith("eventlog", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                message += ". Extension NLog.WindowsEventLog not included?";
+            }
             else if (normalName?.StartsWith("windowsidentity", StringComparison.OrdinalIgnoreCase) == true)
             {
                 message += ". Extension NLog.WindowsIdentity not included?";

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -586,7 +586,7 @@ namespace NLog.Layouts
             }
             catch (Exception ex)
             {
-                var configException = new NLogConfigurationException($"Failed to parse layout containing type: {typeName}", ex);
+                var configException = new NLogConfigurationException($"Failed to parse layout containing type: {typeName} - {ex.Message}", ex);
                 if (throwConfigExceptions ?? configException.MustBeRethrown())
                 {
                     throw configException;


### PR DESCRIPTION
Before:
```
Error: Failed to parse layout containing type: aspnet-request-url
```
After:
```
Error: Failed to parse layout containing type: aspnet-request-url - LayoutRenderer type-alias is unknown: 'aspnet-request-url'. Extension NLog.Web.AspNetCore not included?
```
See also  #5072