### PR TITLE
🚧 Fix ReplaceNewLinesLayoutRendererWrapper handling of new lines in the replacement string. Fixes 5079.

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -65,8 +65,12 @@ namespace NLog.LayoutRenderers.Wrappers
                 var containsNewLines = builder.IndexOf('\n', orgLength) >= 0;
                 if (containsNewLines)
                 {
-                    builder.Replace(WindowsNewLine, UnixNewLine, orgLength, builder.Length - orgLength);
-                    builder.Replace(UnixNewLine, Replacement, orgLength, builder.Length - orgLength);
+                    string str = builder.ToString(orgLength, builder.Length - orgLength)
+                                        .Replace(WindowsNewLine, UnixNewLine)
+                                        .Replace(UnixNewLine, Replacement);
+
+                    builder.Length = orgLength;
+                    builder.Append(str);
                 }
             }
         }

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -65,12 +65,8 @@ namespace NLog.LayoutRenderers.Wrappers
                 var containsNewLines = builder.IndexOf('\n', orgLength) >= 0;
                 if (containsNewLines)
                 {
-                    string str = builder.ToString(orgLength, builder.Length - orgLength)
-                                        .Replace(WindowsNewLine, UnixNewLine)
-                                        .Replace(UnixNewLine, Replacement);
-
-                    builder.Length = orgLength;
-                    builder.Append(str);
+                    builder.Replace(WindowsNewLine, UnixNewLine, orgLength, builder.Length - orgLength);
+                    builder.Replace(UnixNewLine, Replacement, orgLength, builder.Length - orgLength);
                 }
             }
         }

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -66,7 +66,7 @@ namespace NLog.LayoutRenderers.Wrappers
                 if (containsNewLines)
                 {
                     string str = builder.ToString(orgLength, builder.Length - orgLength)
-                                        .Replace(WindowsNewLine, Replacement)
+                                        .Replace(WindowsNewLine, UnixNewLine)
                                         .Replace(UnixNewLine, Replacement);
 
                     builder.Length = orgLength;


### PR DESCRIPTION
A fix for #5079, ensure all newlines char are Unix before actually replace them.
_The proof that using any other intermediate char is at least inefficient is let to the reader._