### PR TITLE
DateLayoutRenderer - Optimize for ISO-8601 format

### DIFF
--- a/src/NLog/Internal/Strings/StringBuilderExt.cs
+++ b/src/NLog/Internal/Strings/StringBuilderExt.cs
@@ -148,7 +148,7 @@ namespace NLog.Internal
         /// <summary>
         /// Convert DateTime into UTC and format to yyyy-MM-ddTHH:mm:ss.fffffffZ - ISO 8601 Compliant Date Format (Round-Trip-Time)
         /// </summary>
-        public static void AppendXmlDateTimeUtcRoundTrip(this StringBuilder builder, DateTime dateTime)
+        public static void AppendXmlDateTimeUtcRoundTrip(this StringBuilder builder, DateTime dateTime, bool forceFraction = false)
         {
             if (dateTime.Kind == DateTimeKind.Unspecified)
                 dateTime = new DateTime(dateTime.Ticks, DateTimeKind.Utc);
@@ -166,16 +166,20 @@ namespace NLog.Internal
             builder.Append(':');
             builder.Append2DigitsZeroPadded(dateTime.Second);
             int fraction = (int)(dateTime.Ticks % 10000000);
-            if (fraction > 0)
+            if (fraction > 0 || forceFraction)
             {
                 builder.Append('.');
 
-                // Remove trailing zeros
                 int max_digit_count = 7;
-                while (fraction % 10 == 0)
+
+                if (!forceFraction)
                 {
-                    --max_digit_count;
-                    fraction /= 10;
+                    // Remove trailing zeros
+                    while (fraction % 10 == 0)
+                    {
+                        --max_digit_count;
+                        fraction /= 10;
+                    }
                 }
 
                 // Append the remaining fraction

--- a/tests/NLog.UnitTests/Internal/Strings/StringBuilderExtTests.cs
+++ b/tests/NLog.UnitTests/Internal/Strings/StringBuilderExtTests.cs
@@ -105,6 +105,18 @@ namespace NLog.UnitTests.Internal
             Assert.Equal(System.Xml.XmlConvert.ToString(input, System.Xml.XmlDateTimeSerializationMode.Utc), sb.ToString());
         }
 
+        [Theory]
+        [MemberData(nameof(TestAppendXsdDateTimeRoundTripCases))]
+        void TestAppendXmlDateTimeRoundTripUtcToString(DateTime input)
+        {
+            input = new DateTime(input.Ticks, DateTimeKind.Utc);
+            StringBuilder sb = new StringBuilder();
+            StringBuilderExt.AppendXmlDateTimeUtcRoundTrip(sb, input, forceFraction: true);
+            Assert.Equal(input.ToString("O",System.Globalization.CultureInfo.InvariantCulture), sb.ToString());
+            Assert.Equal(input.ToString("o", System.Globalization.CultureInfo.InvariantCulture), sb.ToString());
+            Assert.Equal(input.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", System.Globalization.CultureInfo.InvariantCulture), sb.ToString());
+        }
+
         public static IEnumerable<object[]> TestAppendXsdDateTimeRoundTripCases()
         {
             yield return new object[] { DateTime.MinValue };

--- a/tests/NLog.UnitTests/LayoutRenderers/DateTime/DateTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/DateTime/DateTests.cs
@@ -60,6 +60,20 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
+        public void Iso8601Test()
+        {
+            var dateLayoutRenderer = new DateLayoutRenderer();
+            dateLayoutRenderer.UniversalTime = true;
+            dateLayoutRenderer.Format = "o";
+            dateLayoutRenderer.Culture = CultureInfo.InvariantCulture;
+
+            var logEvent = new LogEventInfo(LogLevel.Info, "logger", "msg");
+            var result = dateLayoutRenderer.Render(logEvent);
+
+            Assert.Equal(logEvent.TimeStamp.ToUniversalTime().ToString(dateLayoutRenderer.Format, dateLayoutRenderer.Culture), result);
+        }
+
+        [Fact]
         public void TimeZoneTest()
         {
             var dateLayoutRenderer = new DateLayoutRenderer();


### PR DESCRIPTION
`yyyy-MM-ddTHH:mm:ss.fffffffZ` - ISO 8601 Compliant Date Format (Round-Trip-Time)