### PR TITLE
AsyncTargetWrapper - keep fast instant timer on wroteFullBatchSize

### DIFF
--- a/src/NLog/Internal/ExceptionHelper.cs
+++ b/src/NLog/Internal/ExceptionHelper.cs
@@ -150,6 +150,10 @@ namespace NLog.Internal
             {
                 return true;
             }
+            if (exception is ArgumentOutOfRangeException)
+            {
+                return true;
+            }
             if (exception is DivideByZeroException)
             {
                 return true;


### PR DESCRIPTION
But revert back to holding writer-lock when lazy scheduling background writer thread.