### PR TITLE
ConfigurationItemFactory - Revert so MethodFactory continues to scan non-public classes

### DIFF
--- a/src/NLog/Config/MethodFactory.cs
+++ b/src/NLog/Config/MethodFactory.cs
@@ -72,7 +72,7 @@ namespace NLog.Config
             {
                 try
                 {
-                    if (t.IsClass() && t.IsPublic())
+                    if (t.IsClass())
                     {
                         RegisterType(t, assemblyName, itemNamePrefix);
                     }


### PR DESCRIPTION
To avoid breaking change from #5115