### PR TITLE
AsyncTaskTarget - Dynamic wait time after TaskTimeoutSeconds has expired

### DIFF
--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -783,7 +783,7 @@ namespace NLog.Targets
 
                     if (previousTask != null)
                     {
-                        if (!WaitTaskIsCompleted(previousTask, TimeSpan.FromMilliseconds(150)))
+                        if (!WaitTaskIsCompleted(previousTask, TimeSpan.FromSeconds(TaskTimeoutSeconds / 10.0)))
                         {
                             InternalLogger.Debug("{0}: WriteAsyncTask had timeout. Task did not cancel properly: {1}.", this, previousTask.Status);
                         }


### PR DESCRIPTION
If having 150 secs timeout (default), then it will now wait additional 15 secs after signal cancellation (Instead of always 150 ms)