### PR TITLE
Emit LogEventDropped event from NetworkTarget

### DIFF
--- a/src/NLog/Targets/NetworkLogEventDroppedEventArgs.cs
+++ b/src/NLog/Targets/NetworkLogEventDroppedEventArgs.cs
@@ -40,20 +40,17 @@ namespace NLog.Targets
     /// </summary>
     public class NetworkLogEventDroppedEventArgs : EventArgs
     {
-        /// <summary>
-        /// Provides a value to use with events that do not have event data.
-        /// </summary>
+        /// <inheritdoc cref="NetworkLogEventDroppedReason.MaxMessageSizeOverflow"/>
         internal static readonly NetworkLogEventDroppedEventArgs MaxMessageSizeOverflow = new NetworkLogEventDroppedEventArgs(NetworkLogEventDroppedReason.MaxMessageSizeOverflow);
 
-        /// <summary>
-        /// Provides a value to use with events that do not have event data.
-        /// </summary>
+        /// <inheritdoc cref="NetworkLogEventDroppedReason.MaxConnectionsOverflow"/>
         internal static readonly NetworkLogEventDroppedEventArgs MaxConnectionsOverflow = new NetworkLogEventDroppedEventArgs(NetworkLogEventDroppedReason.MaxConnectionsOverflow);
 
-        /// <summary>
-        /// Provides a value to use with events that do not have event data.
-        /// </summary>
+        /// <inheritdoc cref="NetworkLogEventDroppedReason.MaxQueueOverflow"/>
         internal static readonly NetworkLogEventDroppedEventArgs MaxQueueOverflow = new NetworkLogEventDroppedEventArgs(NetworkLogEventDroppedReason.MaxQueueOverflow);
+
+        /// <inheritdoc cref="NetworkLogEventDroppedReason.NetworkError"/>
+        internal static readonly NetworkLogEventDroppedEventArgs NetworkErrorDetected = new NetworkLogEventDroppedEventArgs(NetworkLogEventDroppedReason.NetworkError);
 
         /// <summary>
         /// Creates new instance of NetworkTargetLogEventDroppedEventArgs

--- a/src/NLog/Targets/NetworkLogEventDroppedReason.cs
+++ b/src/NLog/Targets/NetworkLogEventDroppedReason.cs
@@ -49,6 +49,10 @@ namespace NLog.Targets
         /// <summary>
         /// Discarded LogEvent because attempted to open more than <see cref="NetworkTarget.MaxConnections"/> connections
         /// </summary>
-        MaxConnectionsOverflow
+        MaxConnectionsOverflow,
+        /// <summary>
+        /// Discarded LogEvent because of network communication error
+        /// </summary>
+        NetworkError
     }
 }

--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -337,6 +337,7 @@ namespace NLog.Targets
             catch (Exception ex)
             {
                 InternalLogger.Error(ex, "{0}: Failed to create sender to address: '{1}'", this, address);
+                OnLogEventDropped(this, NetworkLogEventDroppedEventArgs.NetworkErrorDetected);
                 throw;
             }
 
@@ -348,6 +349,7 @@ namespace NLog.Targets
                     if (ex != null)
                     {
                         InternalLogger.Error(ex, "{0}: Error when sending.", this);
+                        OnLogEventDropped(this, NetworkLogEventDroppedEventArgs.NetworkErrorDetected);
                         ReleaseCachedConnection(senderNode);
                     }
 
@@ -400,6 +402,7 @@ namespace NLog.Targets
                 catch (Exception ex)
                 {
                     InternalLogger.Error(ex, "{0}: Failed to create sender to address: '{1}'", this, address);
+                    OnLogEventDropped(this, NetworkLogEventDroppedEventArgs.NetworkErrorDetected);
                     throw;
                 }
 
@@ -423,6 +426,7 @@ namespace NLog.Targets
                     if (ex != null)
                     {
                         InternalLogger.Error(ex, "{0}: Error when sending.", this);
+                        OnLogEventDropped(this, NetworkLogEventDroppedEventArgs.NetworkErrorDetected);
                     }
 
                     sender.Close(ex2 => { });

--- a/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
@@ -459,7 +459,7 @@ namespace NLog.UnitTests.Targets
             Assert.True(result.IndexOf("2: send 0 5") != -1);
             Assert.True(result.IndexOf("2: close") != -1);
 
-            Assert.Equal(1, droppedLogs);
+            Assert.Equal(2, droppedLogs);
         }
 
         [Fact]
@@ -477,6 +477,21 @@ namespace NLog.UnitTests.Targets
             target.Layout = "${message}";
             target.KeepConnection = true;
             target.OnOverflow = NetworkTargetOverflowAction.Discard;
+
+            int droppedLogsDueToSendFailure = 0;
+            int droppedLogsOther = 0;
+            target.LogEventDropped += (sender, args) =>
+            {
+                if (args.Reason == NetworkLogEventDroppedReason.NetworkError)
+                {
+                    droppedLogsDueToSendFailure++;
+                }
+                else
+                {
+                    droppedLogsOther++;
+                }
+            };
+
             target.Initialize(null);
 
             var exceptions = new List<Exception>();
@@ -526,6 +541,9 @@ namespace NLog.UnitTests.Targets
             Assert.True(result.IndexOf("4: send 0 7") != -1);
             Assert.True(result.IndexOf("4: send 0 5") != -1);
             Assert.True(result.IndexOf("4: close") != -1);
+
+            Assert.Equal(3, droppedLogsDueToSendFailure);
+            Assert.Equal(0, droppedLogsOther);
         }
 
         [Fact]


### PR DESCRIPTION
 when failed to establish or write to network connection

Current implementation did not cover most basic scenario - when network connection cannot be established.

Related to #5084
