### PR TITLE
ScopeContext - Replace rescursive lookup with enumeration

### DIFF
--- a/src/NLog/Internal/ScopeContextPropertyEnumerator.cs
+++ b/src/NLog/Internal/ScopeContextPropertyEnumerator.cs
@@ -80,17 +80,6 @@ namespace NLog.Internal
         }
 
 #if !NET35 && !NET40
-        public static Dictionary<string, object> CloneScopePropertiesToDictionary(IReadOnlyCollection<KeyValuePair<string, TValue>> parentContext, int initialCapacity)
-        {
-            var propertyCount = parentContext.Count;
-            var scopeProperties = new Dictionary<string, object>(propertyCount + initialCapacity, ScopeContext.DefaultComparer);
-            if (propertyCount > 0)
-            {
-                CopyScopePropertiesToDictionary(parentContext, scopeProperties);
-            }
-            return scopeProperties;
-        }
-
         public static void CopyScopePropertiesToDictionary(IReadOnlyCollection<KeyValuePair<string, TValue>> parentContext, Dictionary<string, object> scopeDictionary)
         {
             using (var propertyEnumerator = new ScopeContextPropertyEnumerator<TValue>(parentContext))

--- a/src/NLog/LayoutRenderers/Contexts/ScopeContextIndentLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/ScopeContextIndentLayoutRenderer.cs
@@ -55,8 +55,8 @@ namespace NLog.LayoutRenderers
         {
             string indent = null;
 
-            var messages = ScopeContext.GetAllNestedStates();
-            for (int i = 0; i < messages.Length; ++i)
+            var messages = ScopeContext.GetAllNestedStateList();
+            for (int i = 0; i < messages.Count; ++i)
             {
                 indent = indent ?? Indent?.Render(logEvent) ?? string.Empty;
                 builder.Append(indent);

--- a/src/NLog/LayoutRenderers/Contexts/ScopeContextNestedStatesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/ScopeContextNestedStatesLayoutRenderer.cs
@@ -89,26 +89,26 @@ namespace NLog.LayoutRenderers
                 return;
             }
 
-            var messages = ScopeContext.GetAllNestedStates();
-            if (messages.Length == 0)
+            var messages = ScopeContext.GetAllNestedStateList();
+            if (messages.Count == 0)
                 return;
 
             int startPos = 0;
-            int endPos = messages.Length;
+            int endPos = messages.Count;
 
             if (TopFrames != -1)
             {
-                endPos = Math.Min(TopFrames, messages.Length);
+                endPos = Math.Min(TopFrames, messages.Count);
             }
             else if (BottomFrames != -1)
             {
-                startPos = messages.Length - Math.Min(BottomFrames, messages.Length);
+                startPos = messages.Count - Math.Min(BottomFrames, messages.Count);
             }
 
             AppendNestedStates(builder, messages, startPos, endPos, logEvent);
         }
 
-        private void AppendNestedStates(StringBuilder builder, object[] messages, int startPos, int endPos, LogEventInfo logEvent)
+        private void AppendNestedStates(StringBuilder builder, IList<object> messages, int startPos, int endPos, LogEventInfo logEvent)
         {
             bool formatAsJson = MessageTemplates.ValueFormatter.FormatAsJson.Equals(Format, StringComparison.Ordinal);
             var formatProvider = GetFormatProvider(logEvent, Culture);

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -674,12 +674,12 @@ namespace NLog.Targets
         /// <returns>Collection with <see cref="ScopeContext"/> stack items if any, else null</returns>
         protected virtual IList<object> CaptureScopeContextNested(LogEventInfo logEvent)
         {
-            var stack = ScopeContext.GetAllNestedStates();
-            if (stack.Length == 0)
+            var stack = ScopeContext.GetAllNestedStateList();
+            if (stack.Count == 0)
                 return stack;
 
             IList<object> filteredStack = null;
-            for (int i = 0; i < stack.Length; ++i)
+            for (int i = 0; i < stack.Count; ++i)
             {
                 var ndcValue = stack[i];
                 if (SerializeScopeContextNestedState(logEvent, ndcValue, out var serializedValue))
@@ -693,7 +693,7 @@ namespace NLog.Targets
                 {
                     if (filteredStack is null)
                     {
-                        filteredStack = new List<object>(stack.Length);
+                        filteredStack = new List<object>(stack.Count);
                         for (int j = 0; j < i; ++j)
                             filteredStack.Add(stack[j]);
                     }


### PR DESCRIPTION
Resolve #5171 

ScopeContext is optimized to have minimal overhead, until making actual property-lookup. To also make the property-lookup very fast, then it would use recursion to build the lookup-dictionary with minimal allocation (resolve initial-capacity). But recursion can lead to stackoverflow, so better to be a little slower than to be dead.