### PR TITLE
Revert Xamarin PreserveAttribute with default values

### DIFF
--- a/src/NLog/Internal/Xamarin/PreserveAttribute.cs
+++ b/src/NLog/Internal/Xamarin/PreserveAttribute.cs
@@ -47,7 +47,7 @@ namespace NLog.Internal.Xamarin
         /// <summary>
         /// Ensures that all members of this type are preserved
         /// </summary>
-        public bool AllMembers { get; set; }
+        public bool AllMembers { get; set; } = true;
         /// <summary>
         /// Flags the method as a method to preserve during linking if the container class is pulled in.
         /// </summary>

--- a/src/NLog/Properties/AssemblyInfo.cs
+++ b/src/NLog/Properties/AssemblyInfo.cs
@@ -38,7 +38,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using NLog.Internal.Xamarin;
 
-[assembly: Preserve(AllMembers = true)]    // Automatic --linkskip=NLog
+[assembly: Preserve]    // Automatic --linkskip=NLog
 [assembly: AssemblyCulture("")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
This reverts commit 68094dcff219149fd906e82aa2d81633ee251bd9.

The PreserveAttribute also works for Unity 3D, where it doesn't have attributes.