### PR TITLE
AppDomainWrapper - Unhandled exception on Linux without  ICU package

### DIFF
--- a/src/NLog/Internal/AppDomains/AppDomainWrapper.cs
+++ b/src/NLog/Internal/AppDomains/AppDomainWrapper.cs
@@ -67,6 +67,16 @@ namespace NLog.Internal.Fakeables
 
             try
             {
+                FriendlyName = appDomain.FriendlyName;
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Warn(ex, "AppDomain.FriendlyName Failed");
+                FriendlyName = GetFriendlyNameFromEntryAssembly() ?? GetFriendlyNameFromProcessName() ?? string.Empty;
+            }
+
+            try
+            {
                 ConfigurationFile = LookupConfigurationFile(appDomain);
             }
             catch (Exception ex)
@@ -85,7 +95,6 @@ namespace NLog.Internal.Fakeables
                 PrivateBinPath = ArrayHelper.Empty<string>();
             }
 
-            FriendlyName = appDomain.FriendlyName;
             Id = appDomain.Id;
         }
 
@@ -113,6 +122,32 @@ namespace NLog.Internal.Fakeables
 #else
             return ArrayHelper.Empty<string>();
 #endif
+        }
+
+        private static string GetFriendlyNameFromEntryAssembly()
+        {
+            try
+            {
+                string assemblyName = Assembly.GetEntryAssembly()?.GetName()?.Name;
+                return string.IsNullOrEmpty(assemblyName) ? null : assemblyName;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string GetFriendlyNameFromProcessName()
+        {
+            try
+            {
+                string processName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+                return string.IsNullOrEmpty(processName) ? null : processName;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Should probably be fixed in dotnet-runtime, but until then NLog should not throw unhandled exceptions.
```

Process terminated. Couldn't find a valid ICU package installed on the system. Please install libicu using your package manager and try again. Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. Please see https://aka.ms/dotnet-missing-libicu for more information.
   at System.Environment.FailFast(System.String)
   at System.Globalization.GlobalizationMode+Settings..cctor()
   at System.Globalization.CultureData.CreateCultureWithInvariantData()
   at System.Globalization.CultureData.get_Invariant()
   at System.Globalization.CultureInfo..cctor()
   at System.Globalization.CultureInfo.get_CachedCulturesByName()
   at System.Globalization.CultureInfo.GetCultureInfo(System.String)
   at System.Reflection.RuntimeAssembly.GetLocale()
   at System.Reflection.RuntimeAssembly.GetName(Boolean)
   at System.Reflection.Assembly.GetName()
   at System.AppDomain.get_FriendlyName()
   at NLog.Internal.Fakeables.AppDomainWrapper..ctor(System.AppDomain)
   at NLog.LogFactory.get_DefaultAppEnvironment()
   at NLog.LogFactory..cctor()
   at NLog.LogFactory..ctor()
   at NLog.LogManager..cctor()
   at NLog.LogManager.GetCurrentClassLogger()
```