### PR TITLE
Marked ConfigurationItemFactory.CreateInstance obsolete

### DIFF
--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -8,6 +8,14 @@ if (-Not $LastExitCode -eq 0)
 
 if ($isWindows -or $Env:WinDir)
 {
+	dotnet publish .\tests\TestTrimPublish --configuration release
+	if (-Not $LastExitCode -eq 0)
+		{ exit $LastExitCode }
+
+	.\tests\TestTrimPublish\bin\release\net7.0\win-x64\TestTrimPublish.exe
+	if (-Not $LastExitCode -eq 0)
+		{ exit $LastExitCode }
+
 	dotnet test ./tests/NLog.UnitTests/ --framework net461 --configuration release --no-restore
 	if (-Not $LastExitCode -eq 0)
 		{ exit $LastExitCode }

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -12,7 +12,7 @@ if ($isWindows -or $Env:WinDir)
 	if (-Not $LastExitCode -eq 0)
 		{ exit $LastExitCode }
 
-	.\tests\TestTrimPublish\bin\release\net7.0\win-x64\TestTrimPublish.exe
+	.\tests\TestTrimPublish\bin\release\net6.0\win-x64\publish\TestTrimPublish.exe
 	if (-Not $LastExitCode -eq 0)
 		{ exit $LastExitCode }
 

--- a/src/NLog.sln
+++ b/src/NLog.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30413.136
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33627.172
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog", "NLog\NLog.csproj", "{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}"
 EndProject
@@ -43,6 +43,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.Database", "NLog.Database\NLog.Database.csproj", "{7D3A19CB-9BE0-4611-8464-6C49D4FE0106}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.Database.Tests", "..\tests\NLog.Database.Tests\NLog.Database.Tests.csproj", "{35EB0745-C37C-4E42-86C5-481A7D773E2E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestTrimPublish", "..\tests\TestTrimPublish\TestTrimPublish.csproj", "{058FBDB2-4C9C-45F6-BE9E-088AD019C77A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -98,6 +100,10 @@ Global
 		{35EB0745-C37C-4E42-86C5-481A7D773E2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{35EB0745-C37C-4E42-86C5-481A7D773E2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35EB0745-C37C-4E42-86C5-481A7D773E2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{058FBDB2-4C9C-45F6-BE9E-088AD019C77A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{058FBDB2-4C9C-45F6-BE9E-088AD019C77A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{058FBDB2-4C9C-45F6-BE9E-088AD019C77A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{058FBDB2-4C9C-45F6-BE9E-088AD019C77A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -113,6 +119,7 @@ Global
 		{FDABA8A6-80EE-4FBA-A5AA-2EB972DC4F17} = {194AB4BD-C817-4C59-A86C-49D89B8C3A64}
 		{7D3A19CB-9BE0-4611-8464-6C49D4FE0106} = {194AB4BD-C817-4C59-A86C-49D89B8C3A64}
 		{35EB0745-C37C-4E42-86C5-481A7D773E2E} = {194AB4BD-C817-4C59-A86C-49D89B8C3A64}
+		{058FBDB2-4C9C-45F6-BE9E-088AD019C77A} = {8CCD7CF7-F30B-414A-B7FE-1B49411E4EFD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6B4C8E9F-1E2F-4AB3-993A-8776CFA08DC0}

--- a/src/NLog/Conditions/Parsing/ConditionParser.cs
+++ b/src/NLog/Conditions/Parsing/ConditionParser.cs
@@ -132,8 +132,10 @@ namespace NLog.Conditions
 
             try
             {
-                var methodInfo = _configurationItemFactory.ConditionMethods.CreateInstance(functionName);
-                var methodDelegate = _configurationItemFactory.ConditionMethodDelegates.CreateInstance(functionName);
+#pragma warning disable CS0618 // Type or member is obsolete
+                var methodInfo = _configurationItemFactory.ConditionMethodFactory.CreateMethodInfo(functionName);
+#pragma warning restore CS0618 // Type or member is obsolete
+                var methodDelegate = _configurationItemFactory.ConditionMethodFactory.CreateInstance(functionName);
                 return new ConditionMethodExpression(functionName, methodInfo, methodDelegate, par);
             }
             catch (Exception exception)

--- a/src/NLog/Config/AssemblyExtensionLoader.cs
+++ b/src/NLog/Config/AssemblyExtensionLoader.cs
@@ -1,0 +1,386 @@
+﻿// 
+// Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+namespace NLog.Config
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using NLog.Common;
+    using NLog.Internal;
+
+    [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
+    internal class AssemblyExtensionLoader : IAssemblyExtensionLoader
+    {
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming - Allow extension loading from config", "IL2072")]
+        public void LoadTypeFromName(ConfigurationItemFactory factory, string typeName, string itemNamePrefix)
+        {
+            var configType = PropertyTypeConverter.ConvertToType(typeName, true);
+            factory.RegisterType(configType, itemNamePrefix);
+        }
+
+        public void LoadAssemblyFromName(ConfigurationItemFactory factory, string assemblyName, string itemNamePrefix)
+        {
+            var loadedAssemblies = factory.ScanLoadedAssemblies();
+            if (loadedAssemblies.Count > 1)
+            {
+                foreach (var assembly in loadedAssemblies)
+                {
+                    if (string.Equals(assembly.GetName().Name, assemblyName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        InternalLogger.Debug("Skipped Auto loading assembly name: {0}", assemblyName);
+                        return;
+                    }
+                }
+            }
+
+            InternalLogger.Info("Auto loading assembly name: {0}", assemblyName);
+            Assembly extensionAssembly = LoadAssemblyFromName(assemblyName);
+            InternalLogger.LogAssemblyVersion(extensionAssembly);
+            factory.RegisterItemsFromAssembly(extensionAssembly, itemNamePrefix);
+            InternalLogger.Info("Auto loading assembly name: {0} succeeded!", assemblyName);
+        }
+
+        public void LoadAssemblyFromPath(ConfigurationItemFactory factory, string assemblyPath, string baseDirectory, string itemNamePrefix)
+        {
+#if !NETSTANDARD1_3
+            InternalLogger.Info("Auto loading assembly file: {0}", assemblyPath);
+            var extensionAssembly = LoadAssemblyFromPath(assemblyPath, baseDirectory);
+            InternalLogger.LogAssemblyVersion(extensionAssembly);
+            factory.RegisterItemsFromAssembly(extensionAssembly, itemNamePrefix);
+            InternalLogger.Info("Auto loading assembly file: {0} succeeded!", assemblyPath);
+#else
+            // Nothing to do for Sonar Cube
+#endif
+        }
+
+        public void ScanForAutoLoadExtensions(ConfigurationItemFactory factory)
+        {
+#if !NETSTANDARD1_3
+            try
+            {
+                var nlogAssembly = typeof(LogFactory).GetAssembly();
+                var assemblyLocation = string.Empty;
+                var extensionDlls = ArrayHelper.Empty<string>();
+                var fileLocations = GetAutoLoadingFileLocations();
+                foreach (var fileLocation in fileLocations)
+                {
+                    if (string.IsNullOrEmpty(fileLocation.Key))
+                        continue;
+
+                    if (string.IsNullOrEmpty(assemblyLocation))
+                        assemblyLocation = fileLocation.Key;
+
+                    extensionDlls = GetNLogExtensionFiles(fileLocation.Key);
+                    if (extensionDlls.Length > 0)
+                    {
+                        assemblyLocation = fileLocation.Key;
+                        break;
+                    }
+                }
+
+                InternalLogger.Debug("Start auto loading, location: {0}", assemblyLocation);
+                var alreadyRegistered = LoadNLogExtensionAssemblies(factory, nlogAssembly, extensionDlls);
+                RegisterAppDomainAssemblies(factory, nlogAssembly, alreadyRegistered);
+            }
+            catch (System.Security.SecurityException ex)
+            {
+                InternalLogger.Warn(ex, "Seems that we do not have permission");
+                if (ex.MustBeRethrown())
+                {
+                    throw;
+                }
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                InternalLogger.Warn(ex, "Seems that we do not have permission");
+                if (ex.MustBeRethrown())
+                {
+                    throw;
+                }
+            }
+            InternalLogger.Debug("Auto loading done");
+#else
+            // Nothing to do for Sonar Cube
+#endif
+        }
+
+#if !NETSTANDARD1_3
+        private static HashSet<string> LoadNLogExtensionAssemblies(ConfigurationItemFactory factory, Assembly nlogAssembly, string[] extensionDlls)
+        {
+            HashSet<string> alreadyRegistered = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    nlogAssembly.FullName
+                };
+
+            foreach (var extensionDll in extensionDlls)
+            {
+                InternalLogger.Info("Auto loading assembly file: {0}", extensionDll);
+
+                try
+                {
+                    var extensionAssembly = LoadAssemblyFromPath(extensionDll);
+                    InternalLogger.LogAssemblyVersion(extensionAssembly);
+                    factory.RegisterItemsFromAssembly(extensionAssembly);
+                    alreadyRegistered.Add(extensionAssembly.FullName);
+
+                    InternalLogger.Info("Auto loading assembly file: {0} succeeded!", extensionDll);
+                }
+                catch (Exception ex)
+                {
+                    if (ex.MustBeRethrownImmediately())
+                    {
+                        throw;
+                    }
+
+                    InternalLogger.Warn(ex, "Auto loading assembly file: {0} failed! Skipping this file.", extensionDll);
+                    if (ex.MustBeRethrown())
+                    {
+                        throw;
+                    }
+                }
+            }
+
+            return alreadyRegistered;
+        }
+
+        private static void RegisterAppDomainAssemblies(ConfigurationItemFactory factory, Assembly nlogAssembly, HashSet<string> alreadyRegistered)
+        {
+            alreadyRegistered.Add(nlogAssembly.FullName);
+
+#if !NETSTANDARD1_5
+            var allAssemblies = LogFactory.DefaultAppEnvironment.GetAppDomainRuntimeAssemblies();
+#else
+            var allAssemblies = new [] { nlogAssembly };
+#endif
+            foreach (var assembly in allAssemblies)
+            {
+                if (assembly.FullName.StartsWith("NLog.", StringComparison.OrdinalIgnoreCase) && !alreadyRegistered.Contains(assembly.FullName))
+                {
+                    factory.RegisterItemsFromAssembly(assembly);
+                }
+
+                if (IncludeAsHiddenAssembly(assembly.FullName))
+                {
+                    LogManager.AddHiddenAssembly(assembly);
+                }
+            }
+        }
+
+        private static bool IncludeAsHiddenAssembly(string assemblyFullName)
+        {
+            if (assemblyFullName.StartsWith("NLog.Extensions.Logging,", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (assemblyFullName.StartsWith("NLog.Web,", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (assemblyFullName.StartsWith("NLog.Web.AspNetCore,", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (assemblyFullName.StartsWith("Microsoft.Extensions.Logging,", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (assemblyFullName.StartsWith("Microsoft.Extensions.Logging.Abstractions,", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (assemblyFullName.StartsWith("Microsoft.Extensions.Logging.Filter,", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (assemblyFullName.StartsWith("Microsoft.Logging,", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            return false;
+        }
+
+        internal static IEnumerable<KeyValuePair<string, string>> GetAutoLoadingFileLocations()
+        {
+            var nlogAssembly = typeof(LogFactory).GetAssembly();
+            var nlogAssemblyLocation = PathHelpers.TrimDirectorySeparators(AssemblyHelpers.GetAssemblyFileLocation(nlogAssembly));
+            InternalLogger.Debug("Auto loading based on NLog-Assembly found location: {0}", nlogAssemblyLocation);
+            if (!string.IsNullOrEmpty(nlogAssemblyLocation))
+                yield return new KeyValuePair<string, string>(nlogAssemblyLocation, nameof(nlogAssemblyLocation));
+
+            var entryAssemblyLocation = PathHelpers.TrimDirectorySeparators(LogFactory.DefaultAppEnvironment.EntryAssemblyLocation);
+            InternalLogger.Debug("Auto loading based on GetEntryAssembly-Assembly found location: {0}", entryAssemblyLocation);
+            if (!string.IsNullOrEmpty(entryAssemblyLocation) && !string.Equals(entryAssemblyLocation, nlogAssemblyLocation, StringComparison.OrdinalIgnoreCase))
+                yield return new KeyValuePair<string, string>(entryAssemblyLocation, nameof(entryAssemblyLocation));
+
+            var baseDirectory = PathHelpers.TrimDirectorySeparators(LogFactory.DefaultAppEnvironment.AppDomainBaseDirectory);
+            InternalLogger.Debug("Auto loading based on AppDomain-BaseDirectory found location: {0}", baseDirectory);
+            if (!string.IsNullOrEmpty(baseDirectory) && !string.Equals(baseDirectory, nlogAssemblyLocation, StringComparison.OrdinalIgnoreCase))
+                yield return new KeyValuePair<string, string>(baseDirectory, nameof(baseDirectory));
+        }
+
+        private static string[] GetNLogExtensionFiles(string assemblyLocation)
+        {
+            try
+            {
+                InternalLogger.Debug("Search for auto loading files in location: {0}", assemblyLocation);
+                if (string.IsNullOrEmpty(assemblyLocation))
+                {
+                    return ArrayHelper.Empty<string>();
+                }
+
+                var extensionDlls = System.IO.Directory.GetFiles(assemblyLocation, "NLog*.dll")
+                .Select(System.IO.Path.GetFileName)
+                .Where(x => !x.Equals("NLog.dll", StringComparison.OrdinalIgnoreCase))
+                .Where(x => !x.Equals("NLog.UnitTests.dll", StringComparison.OrdinalIgnoreCase))
+                .Select(x => System.IO.Path.Combine(assemblyLocation, x));
+                return extensionDlls.ToArray();
+            }
+            catch (System.IO.DirectoryNotFoundException ex)
+            {
+                InternalLogger.Warn(ex, "Skipping auto loading location because assembly directory does not exist: {0}", assemblyLocation);
+                if (ex.MustBeRethrown())
+                {
+                    throw;
+                }
+                return ArrayHelper.Empty<string>();
+            }
+            catch (System.Security.SecurityException ex)
+            {
+                InternalLogger.Warn(ex, "Skipping auto loading location because access not allowed to assembly directory: {0}", assemblyLocation);
+                if (ex.MustBeRethrown())
+                {
+                    throw;
+                }
+                return ArrayHelper.Empty<string>();
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                InternalLogger.Warn(ex, "Skipping auto loading location because access not allowed to assembly directory: {0}", assemblyLocation);
+                if (ex.MustBeRethrown())
+                {
+                    throw;
+                }
+                return ArrayHelper.Empty<string>();
+            }
+        }
+#endif
+
+#if !NETSTANDARD1_3
+        /// <summary>
+        /// Load from url
+        /// </summary>
+        /// <param name="assemblyFileName">file or path, including .dll</param>
+        /// <param name="baseDirectory">basepath, optional</param>
+        /// <returns></returns>
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming - Allow extension loading from config", "IL2026")]
+        [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
+        private static Assembly LoadAssemblyFromPath(string assemblyFileName, string baseDirectory = null)
+        {
+            string fullFileName = baseDirectory is null ? assemblyFileName : System.IO.Path.Combine(baseDirectory, assemblyFileName);
+
+            InternalLogger.Info("Loading assembly file: {0}", fullFileName);
+#if NETSTANDARD1_5
+            try
+            {
+                var assemblyName = System.Runtime.Loader.AssemblyLoadContext.GetAssemblyName(fullFileName);
+                return Assembly.Load(assemblyName);
+            }
+            catch (Exception ex)
+            {
+                // this doesn't usually work
+                InternalLogger.Warn(ex, "Fallback to AssemblyLoadContext.Default.LoadFromAssemblyPath for file: {0}", fullFileName);
+                return System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromAssemblyPath(fullFileName);
+            }
+#else
+            Assembly asm = Assembly.LoadFrom(fullFileName);
+            return asm;
+#endif
+        }
+#endif
+
+        /// <summary>
+        /// Load from url
+        /// </summary>
+        private static Assembly LoadAssemblyFromName(string assemblyName)
+        {
+            InternalLogger.Info("Loading assembly: {0}", assemblyName);
+
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            try
+            {
+                Assembly assembly = Assembly.Load(assemblyName);
+                return assembly;
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                var name = new AssemblyName(assemblyName);
+                InternalLogger.Trace("Try find '{0}' in current domain", assemblyName);
+                var loadedAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(domainAssembly => IsAssemblyMatch(name, domainAssembly.GetName()));
+                if (loadedAssembly != null)
+                {
+                    InternalLogger.Trace("Found '{0}' in current domain", assemblyName);
+                    return loadedAssembly;
+                }
+
+                InternalLogger.Trace("Haven't found' '{0}' in current domain", assemblyName);
+                throw;
+            }
+#else
+            var name = new AssemblyName(assemblyName);
+            return Assembly.Load(name);
+#endif
+        }
+
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+        private static bool IsAssemblyMatch(AssemblyName expected, AssemblyName actual)
+        {
+            if (expected.Name != actual.Name)
+                return false;
+            if (expected.Version != null && expected.Version != actual.Version)
+                return false;
+            if (expected.CultureInfo != null && expected.CultureInfo.Name != actual.CultureInfo.Name)
+                return false;
+
+            var expectedKeyToken = expected.GetPublicKeyToken();
+            var correctToken = expectedKeyToken is null || expectedKeyToken.SequenceEqual(actual.GetPublicKeyToken());
+            return correctToken;
+        }
+#endif
+    }
+
+    internal interface IAssemblyExtensionLoader
+    {
+        void ScanForAutoLoadExtensions(ConfigurationItemFactory factory);
+
+        void LoadAssemblyFromPath(ConfigurationItemFactory factory, string assemblyPath, string baseDirectory, string itemNamePrefix);
+
+        void LoadAssemblyFromName(ConfigurationItemFactory factory, string assemblyName, string itemNamePrefix);
+
+        void LoadTypeFromName(ConfigurationItemFactory factory, string typeName, string itemNamePrefix);
+    }
+}

--- a/src/NLog/Config/AssemblyExtensionTypes.cs
+++ b/src/NLog/Config/AssemblyExtensionTypes.cs
@@ -1,0 +1,247 @@
+// 
+// Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    /// <summary>
+    /// Provides logging interface and utility functions.
+    /// </summary>
+    internal static class AssemblyExtensionTypes
+    {
+        public static void RegisterTypes(ConfigurationItemFactory factory)
+        {
+            #pragma warning disable CS0618 // Type or member is obsolete
+            factory.RegisterType<NLog.Config.LoggingRule>();
+            factory.FilterFactory.RegisterType<NLog.Filters.ConditionBasedFilter>("when");
+            factory.FilterFactory.RegisterType<NLog.Filters.WhenContainsFilter>("whenContains");
+            factory.FilterFactory.RegisterType<NLog.Filters.WhenEqualFilter>("whenEqual");
+            factory.FilterFactory.RegisterType<NLog.Filters.WhenNotContainsFilter>("whenNotContains");
+            factory.FilterFactory.RegisterType<NLog.Filters.WhenNotEqualFilter>("whenNotEqual");
+            factory.FilterFactory.RegisterType<NLog.Filters.WhenRepeatedFilter>("whenRepeated");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.AllEventPropertiesLayoutRenderer>("all-event-properties");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.AppDomainLayoutRenderer>("appdomain");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.AppSettingLayoutRenderer2>("appsetting");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.AssemblyVersionLayoutRenderer>("assembly-version");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.BaseDirLayoutRenderer>("basedir");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.CallSiteFileNameLayoutRenderer>("callsite-filename");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.CallSiteLayoutRenderer>("callsite");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.CallSiteLineNumberLayoutRenderer>("callsite-linenumber");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.CounterLayoutRenderer>("counter");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.CurrentDirLayoutRenderer>("currentdir");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.DateLayoutRenderer>("date");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.DbNullLayoutRenderer>("db-null");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.DirectorySeparatorLayoutRenderer>("dir-separator");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.EnvironmentLayoutRenderer>("environment");
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.EnvironmentUserLayoutRenderer>("environment-user");
+#endif
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.EventContextLayoutRenderer>("event-context");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.EventPropertiesLayoutRenderer>("event-properties");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ExceptionLayoutRenderer>("exception");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.FileContentsLayoutRenderer>("file-contents");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.GarbageCollectorInfoLayoutRenderer>("gc");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.GdcLayoutRenderer>("gdc");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.GuidLayoutRenderer>("guid");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.HostNameLayoutRenderer>("hostname");
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.IdentityLayoutRenderer>("identity");
+#endif
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.InstallContextLayoutRenderer>("install-context");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.LevelLayoutRenderer>("level");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.LiteralLayoutRenderer>("literal");
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.LocalIpAddressLayoutRenderer>("local-ip");
+#endif
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Log4JXmlEventLayoutRenderer>("log4jxmlevent");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.LoggerNameLayoutRenderer>("logger");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.LongDateLayoutRenderer>("longdate");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.MachineNameLayoutRenderer>("machinename");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.MdcLayoutRenderer>("mdc");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.MdlcLayoutRenderer>("mdlc");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.MessageLayoutRenderer>("message");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.NdcLayoutRenderer>("ndc");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.NdlcLayoutRenderer>("ndlc");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.NdlcTimingLayoutRenderer>("ndlctiming");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.NewLineLayoutRenderer>("newline");
+#if !NETSTANDARD1_3
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.NLogDirLayoutRenderer>("nlogdir");
+#endif
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.PerformanceCounterLayoutRenderer>("performancecounter");
+#if !NETSTANDARD1_3
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessDirLayoutRenderer>("processdir");
+#endif
+#if !NETSTANDARD1_3
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessIdLayoutRenderer>("processid");
+#endif
+#if !NETSTANDARD1_3
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessInfoLayoutRenderer>("processinfo");
+#endif
+#if !NETSTANDARD1_3
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessNameLayoutRenderer>("processname");
+#endif
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessTimeLayoutRenderer>("processtime");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.QueryPerformanceCounterLayoutRenderer>("qpc");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.RegistryLayoutRenderer>("registry");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.SequenceIdLayoutRenderer>("sequenceid");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ShortDateLayoutRenderer>("shortdate");
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.SpecialFolderLayoutRenderer>("specialfolder");
+#endif
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.StackTraceLayoutRenderer>("stacktrace");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.TempDirLayoutRenderer>("tempdir");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ThreadIdLayoutRenderer>("threadid");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ThreadNameLayoutRenderer>("threadname");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.TicksLayoutRenderer>("ticks");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.TimeLayoutRenderer>("time");
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.TraceActivityIdLayoutRenderer>("activityid");
+#endif
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.VariableLayoutRenderer>("var");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.WindowsIdentityLayoutRenderer>("windows-identity");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.CachedLayoutRendererWrapper>("cached");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.CachedLayoutRendererWrapper>("Cached");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.CachedLayoutRendererWrapper>("ClearCache");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.CachedLayoutRendererWrapper>("CachedSeconds");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.FileSystemNormalizeLayoutRendererWrapper>("filesystem-normalize");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.FileSystemNormalizeLayoutRendererWrapper>("FSNormalize");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.JsonEncodeLayoutRendererWrapper>("json-encode");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.JsonEncodeLayoutRendererWrapper>("JsonEncode");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.LeftLayoutRendererWrapper>("left");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.LeftLayoutRendererWrapper>("Truncate");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.LowercaseLayoutRendererWrapper>("lowercase");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.LowercaseLayoutRendererWrapper>("Lowercase");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.NoRawValueLayoutRendererWrapper>("norawvalue");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.NoRawValueLayoutRendererWrapper>("NoRawValue");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.ObjectPathRendererWrapper>("Object-Path");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.ObjectPathRendererWrapper>("ObjectPath");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.OnExceptionLayoutRendererWrapper>("onexception");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.OnHasPropertiesLayoutRendererWrapper>("onhasproperties");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.PaddingLayoutRendererWrapper>("pad");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.PaddingLayoutRendererWrapper>("Padding");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.PaddingLayoutRendererWrapper>("PadCharacter");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.PaddingLayoutRendererWrapper>("FixedLength");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.PaddingLayoutRendererWrapper>("AlignmentOnTruncation");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.ReplaceLayoutRendererWrapper>("replace");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.ReplaceNewLinesLayoutRendererWrapper>("replace-newlines");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.ReplaceNewLinesLayoutRendererWrapper>("ReplaceNewLines");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.RightLayoutRendererWrapper>("right");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.Rot13LayoutRendererWrapper>("rot13");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.SubstringLayoutRendererWrapper>("substring");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.TrimWhiteSpaceLayoutRendererWrapper>("trim-whitespace");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.TrimWhiteSpaceLayoutRendererWrapper>("TrimWhiteSpace");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.UppercaseLayoutRendererWrapper>("uppercase");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.UppercaseLayoutRendererWrapper>("Uppercase");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.UrlEncodeLayoutRendererWrapper>("url-encode");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.WhenEmptyLayoutRendererWrapper>("whenEmpty");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.WhenEmptyLayoutRendererWrapper>("WhenEmpty");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.WhenLayoutRendererWrapper>("when");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.WhenLayoutRendererWrapper>("When");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.WrapLineLayoutRendererWrapper>("wrapline");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.WrapLineLayoutRendererWrapper>("WrapLine");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.XmlEncodeLayoutRendererWrapper>("xml-encode");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.XmlEncodeLayoutRendererWrapper>("XmlEncode");
+            factory.LayoutFactory.RegisterType<NLog.Layouts.CompoundLayout>("CompoundLayout");
+            factory.RegisterType<NLog.Layouts.CsvColumn>();
+            factory.LayoutFactory.RegisterType<NLog.Layouts.CsvLayout>("CsvLayout");
+            factory.RegisterType<NLog.Layouts.JsonAttribute>();
+            factory.LayoutFactory.RegisterType<NLog.Layouts.JsonLayout>("JsonLayout");
+            factory.LayoutFactory.RegisterType<NLog.Layouts.LayoutWithHeaderAndFooter>("LayoutWithHeaderAndFooter");
+            factory.LayoutFactory.RegisterType<NLog.Layouts.Log4JXmlEventLayout>("Log4JXmlEventLayout");
+            factory.LayoutFactory.RegisterType<NLog.Layouts.SimpleLayout>("SimpleLayout");
+            factory.RegisterType<NLog.Layouts.XmlAttribute>();
+            factory.LayoutFactory.RegisterType<NLog.Layouts.XmlLayout>("XmlLayout");
+            factory.TargetFactory.RegisterType<NLog.Targets.ChainsawTarget>("Chainsaw");
+#if !NETSTANDARD1_3
+            factory.TargetFactory.RegisterType<NLog.Targets.ColoredConsoleTarget>("ColoredConsole");
+#endif
+#if !NETSTANDARD1_3
+            factory.RegisterType<NLog.Targets.ConsoleRowHighlightingRule>();
+#endif
+#if !NETSTANDARD1_3
+            factory.TargetFactory.RegisterType<NLog.Targets.ConsoleTarget>("Console");
+#endif
+#if !NETSTANDARD1_3
+            factory.RegisterType<NLog.Targets.ConsoleWordHighlightingRule>();
+#endif
+            factory.RegisterType<NLog.Targets.DatabaseCommandInfo>();
+            factory.RegisterType<NLog.Targets.DatabaseObjectPropertyInfo>();
+            factory.RegisterType<NLog.Targets.DatabaseParameterInfo>();
+            factory.TargetFactory.RegisterType<NLog.Targets.DatabaseTarget>("Database");
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            factory.TargetFactory.RegisterType<NLog.Targets.DebuggerTarget>("Debugger");
+#endif
+            factory.TargetFactory.RegisterType<NLog.Targets.DebugTarget>("Debug");
+#if !NETSTANDARD
+            factory.TargetFactory.RegisterType<NLog.Targets.EventLogTarget>("EventLog");
+#endif
+            factory.TargetFactory.RegisterType<NLog.Targets.FileTarget>("File");
+            factory.TargetFactory.RegisterType<NLog.Targets.LogReceiverWebServiceTarget>("LogReceiverService");
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            factory.TargetFactory.RegisterType<NLog.Targets.MailTarget>("Mail");
+#endif
+            factory.TargetFactory.RegisterType<NLog.Targets.MemoryTarget>("Memory");
+            factory.RegisterType<NLog.Targets.MethodCallParameter>();
+            factory.TargetFactory.RegisterType<NLog.Targets.MethodCallTarget>("MethodCall");
+            factory.TargetFactory.RegisterType<NLog.Targets.NetworkTarget>("Network");
+            factory.RegisterType<NLog.Targets.NLogViewerParameterInfo>();
+            factory.TargetFactory.RegisterType<NLog.Targets.NLogViewerTarget>("NLogViewer");
+            factory.TargetFactory.RegisterType<NLog.Targets.NullTarget>("Null");
+            factory.TargetFactory.RegisterType<NLog.Targets.OutputDebugStringTarget>("OutputDebugString");
+            factory.TargetFactory.RegisterType<NLog.Targets.PerformanceCounterTarget>("PerfCounter");
+            factory.RegisterType<NLog.Targets.TargetPropertyWithContext>();
+#if !NETSTANDARD1_3
+            factory.TargetFactory.RegisterType<NLog.Targets.TraceTarget>("Trace");
+#endif
+            factory.TargetFactory.RegisterType<NLog.Targets.WebServiceTarget>("WebService");
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.AsyncTargetWrapper>("AsyncWrapper");
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.AutoFlushTargetWrapper>("AutoFlushWrapper");
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.BufferingTargetWrapper>("BufferingWrapper");
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.FallbackGroupTarget>("FallbackGroup");
+            factory.RegisterType<NLog.Targets.Wrappers.FilteringRule>();
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.FilteringTargetWrapper>("FilteringWrapper");
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.ImpersonatingTargetWrapper>("ImpersonatingWrapper");
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.LimitingTargetWrapper>("LimitingWrapper");
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.PostFilteringTargetWrapper>("PostFilteringWrapper");
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.RandomizeGroupTarget>("RandomizeGroup");
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.RepeatingTargetWrapper>("RepeatingWrapper");
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.RetryingTargetWrapper>("RetryingWrapper");
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.RoundRobinGroupTarget>("RoundRobinGroup");
+            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.SplitGroupTarget>("SplitGroup");
+            factory.TimeSourceFactory.RegisterType<NLog.Time.AccurateLocalTimeSource>("AccurateLocal");
+            factory.TimeSourceFactory.RegisterType<NLog.Time.AccurateUtcTimeSource>("AccurateUTC");
+            factory.TimeSourceFactory.RegisterType<NLog.Time.FastLocalTimeSource>("FastLocal");
+            factory.TimeSourceFactory.RegisterType<NLog.Time.FastUtcTimeSource>("FastUTC");
+            #pragma warning restore CS0618 // Type or member is obsolete
+        }
+    }
+}

--- a/src/NLog/Config/AssemblyExtensionTypes.cs
+++ b/src/NLog/Config/AssemblyExtensionTypes.cs
@@ -50,7 +50,9 @@ namespace NLog.Config
             factory.FilterFactory.RegisterType<NLog.Filters.WhenRepeatedFilter>("whenRepeated");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.AllEventPropertiesLayoutRenderer>("all-event-properties");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.AppDomainLayoutRenderer>("appdomain");
-            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.AppSettingLayoutRenderer2>("appsetting");
+#if !NETSTANDARD
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.AppSettingLayoutRenderer>("appsetting");
+#endif
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.AssemblyVersionLayoutRenderer>("assembly-version");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.BaseDirLayoutRenderer>("basedir");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.CallSiteFileNameLayoutRenderer>("callsite-filename");
@@ -65,8 +67,11 @@ namespace NLog.Config
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.EnvironmentUserLayoutRenderer>("environment-user");
 #endif
-            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.EventContextLayoutRenderer>("event-context");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.EventPropertiesLayoutRenderer>("event-properties");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.EventPropertiesLayoutRenderer>("event-property");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.EventPropertiesLayoutRenderer>("event-context");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ExceptionDataLayoutRenderer>("exceptiondata");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ExceptionDataLayoutRenderer>("exception-data");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ExceptionLayoutRenderer>("exception");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.FileContentsLayoutRenderer>("file-contents");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.GarbageCollectorInfoLayoutRenderer>("gc");
@@ -78,11 +83,13 @@ namespace NLog.Config
 #endif
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.InstallContextLayoutRenderer>("install-context");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.LevelLayoutRenderer>("level");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.LevelLayoutRenderer>("loglevel");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.LiteralLayoutRenderer>("literal");
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.LocalIpAddressLayoutRenderer>("local-ip");
 #endif
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Log4JXmlEventLayoutRenderer>("log4jxmlevent");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.LoggerNameLayoutRenderer>("loggername");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.LoggerNameLayoutRenderer>("logger");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.LongDateLayoutRenderer>("longdate");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.MachineNameLayoutRenderer>("machinename");
@@ -96,7 +103,6 @@ namespace NLog.Config
 #if !NETSTANDARD1_3
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.NLogDirLayoutRenderer>("nlogdir");
 #endif
-            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.PerformanceCounterLayoutRenderer>("performancecounter");
 #if !NETSTANDARD1_3
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessDirLayoutRenderer>("processdir");
 #endif
@@ -110,12 +116,23 @@ namespace NLog.Config
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessNameLayoutRenderer>("processname");
 #endif
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessTimeLayoutRenderer>("processtime");
-            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.QueryPerformanceCounterLayoutRenderer>("qpc");
-            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.RegistryLayoutRenderer>("registry");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ScopeContextIndentLayoutRenderer>("scopeindent");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ScopeContextNestedStatesLayoutRenderer>("scopenested");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ScopeContextPropertyLayoutRenderer>("scopeproperty");
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ScopeContextTimingLayoutRenderer>("scopetiming");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.SequenceIdLayoutRenderer>("sequenceid");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.ShortDateLayoutRenderer>("shortdate");
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.SpecialFolderApplicationDataLayoutRenderer>("userApplicationDataDir");
+#endif
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.SpecialFolderCommonApplicationDataLayoutRenderer>("commonApplicationDataDir");
+#endif
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.SpecialFolderLayoutRenderer>("specialfolder");
+#endif
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.SpecialFolderLocalApplicationDataLayoutRenderer>("userLocalApplicationDataDir");
 #endif
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.StackTraceLayoutRenderer>("stacktrace");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.TempDirLayoutRenderer>("tempdir");
@@ -127,7 +144,6 @@ namespace NLog.Config
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.TraceActivityIdLayoutRenderer>("activityid");
 #endif
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.VariableLayoutRenderer>("var");
-            factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.WindowsIdentityLayoutRenderer>("windows-identity");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.CachedLayoutRendererWrapper>("cached");
             factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.CachedLayoutRendererWrapper>("Cached");
             factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.CachedLayoutRendererWrapper>("ClearCache");
@@ -140,6 +156,7 @@ namespace NLog.Config
             factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.LeftLayoutRendererWrapper>("Truncate");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.LowercaseLayoutRendererWrapper>("lowercase");
             factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.LowercaseLayoutRendererWrapper>("Lowercase");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.LowercaseLayoutRendererWrapper>("ToLower");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.NoRawValueLayoutRendererWrapper>("norawvalue");
             factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.NoRawValueLayoutRendererWrapper>("NoRawValue");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.ObjectPathRendererWrapper>("Object-Path");
@@ -161,6 +178,7 @@ namespace NLog.Config
             factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.TrimWhiteSpaceLayoutRendererWrapper>("TrimWhiteSpace");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.UppercaseLayoutRendererWrapper>("uppercase");
             factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.UppercaseLayoutRendererWrapper>("Uppercase");
+            factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.UppercaseLayoutRendererWrapper>("ToUpper");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.UrlEncodeLayoutRendererWrapper>("url-encode");
             factory.LayoutRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.WhenEmptyLayoutRendererWrapper>("whenEmpty");
             factory.AmbientRendererFactory.RegisterType<NLog.LayoutRenderers.Wrappers.WhenEmptyLayoutRendererWrapper>("WhenEmpty");
@@ -173,11 +191,13 @@ namespace NLog.Config
             factory.LayoutFactory.RegisterType<NLog.Layouts.CompoundLayout>("CompoundLayout");
             factory.RegisterType<NLog.Layouts.CsvColumn>();
             factory.LayoutFactory.RegisterType<NLog.Layouts.CsvLayout>("CsvLayout");
+            factory.LayoutFactory.RegisterType<NLog.Layouts.JsonArrayLayout>("JsonArrayLayout");
             factory.RegisterType<NLog.Layouts.JsonAttribute>();
             factory.LayoutFactory.RegisterType<NLog.Layouts.JsonLayout>("JsonLayout");
             factory.LayoutFactory.RegisterType<NLog.Layouts.LayoutWithHeaderAndFooter>("LayoutWithHeaderAndFooter");
             factory.LayoutFactory.RegisterType<NLog.Layouts.Log4JXmlEventLayout>("Log4JXmlEventLayout");
             factory.LayoutFactory.RegisterType<NLog.Layouts.SimpleLayout>("SimpleLayout");
+            factory.RegisterType<NLog.Layouts.ValueTypeLayoutInfo>();
             factory.RegisterType<NLog.Layouts.XmlAttribute>();
             factory.LayoutFactory.RegisterType<NLog.Layouts.XmlLayout>("XmlLayout");
             factory.TargetFactory.RegisterType<NLog.Targets.ChainsawTarget>("Chainsaw");
@@ -193,21 +213,20 @@ namespace NLog.Config
 #if !NETSTANDARD1_3
             factory.RegisterType<NLog.Targets.ConsoleWordHighlightingRule>();
 #endif
-            factory.RegisterType<NLog.Targets.DatabaseCommandInfo>();
-            factory.RegisterType<NLog.Targets.DatabaseObjectPropertyInfo>();
-            factory.RegisterType<NLog.Targets.DatabaseParameterInfo>();
-            factory.TargetFactory.RegisterType<NLog.Targets.DatabaseTarget>("Database");
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
             factory.TargetFactory.RegisterType<NLog.Targets.DebuggerTarget>("Debugger");
 #endif
+            factory.TargetFactory.RegisterType<NLog.Targets.DebugSystemTarget>("DebugSystem");
             factory.TargetFactory.RegisterType<NLog.Targets.DebugTarget>("Debug");
 #if !NETSTANDARD
             factory.TargetFactory.RegisterType<NLog.Targets.EventLogTarget>("EventLog");
 #endif
             factory.TargetFactory.RegisterType<NLog.Targets.FileTarget>("File");
-            factory.TargetFactory.RegisterType<NLog.Targets.LogReceiverWebServiceTarget>("LogReceiverService");
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
             factory.TargetFactory.RegisterType<NLog.Targets.MailTarget>("Mail");
+            factory.TargetFactory.RegisterType<NLog.Targets.MailTarget>("Email");
+            factory.TargetFactory.RegisterType<NLog.Targets.MailTarget>("Smtp");
+            factory.TargetFactory.RegisterType<NLog.Targets.MailTarget>("SmtpClient");
 #endif
             factory.TargetFactory.RegisterType<NLog.Targets.MemoryTarget>("Memory");
             factory.RegisterType<NLog.Targets.MethodCallParameter>();
@@ -216,11 +235,10 @@ namespace NLog.Config
             factory.RegisterType<NLog.Targets.NLogViewerParameterInfo>();
             factory.TargetFactory.RegisterType<NLog.Targets.NLogViewerTarget>("NLogViewer");
             factory.TargetFactory.RegisterType<NLog.Targets.NullTarget>("Null");
-            factory.TargetFactory.RegisterType<NLog.Targets.OutputDebugStringTarget>("OutputDebugString");
-            factory.TargetFactory.RegisterType<NLog.Targets.PerformanceCounterTarget>("PerfCounter");
             factory.RegisterType<NLog.Targets.TargetPropertyWithContext>();
 #if !NETSTANDARD1_3
             factory.TargetFactory.RegisterType<NLog.Targets.TraceTarget>("Trace");
+            factory.TargetFactory.RegisterType<NLog.Targets.TraceTarget>("TraceSystem");
 #endif
             factory.TargetFactory.RegisterType<NLog.Targets.WebServiceTarget>("WebService");
             factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.AsyncTargetWrapper>("AsyncWrapper");
@@ -229,7 +247,6 @@ namespace NLog.Config
             factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.FallbackGroupTarget>("FallbackGroup");
             factory.RegisterType<NLog.Targets.Wrappers.FilteringRule>();
             factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.FilteringTargetWrapper>("FilteringWrapper");
-            factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.ImpersonatingTargetWrapper>("ImpersonatingWrapper");
             factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.LimitingTargetWrapper>("LimitingWrapper");
             factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.PostFilteringTargetWrapper>("PostFilteringWrapper");
             factory.TargetFactory.RegisterType<NLog.Targets.Wrappers.RandomizeGroupTarget>("RandomizeGroup");

--- a/src/NLog/Config/AssemblyExtensionTypes.tt
+++ b/src/NLog/Config/AssemblyExtensionTypes.tt
@@ -7,7 +7,6 @@
 <#@ import namespace="System.Text" #>
 <#@ output extension=".cs" #>
 <# 
-    //Generation of overloads of all six levels
     //T4 templates are built in Visual Studio. See https://msdn.microsoft.com/en-us/library/bb126445.aspx
 #>// 
 // Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen

--- a/src/NLog/Config/AssemblyExtensionTypes.tt
+++ b/src/NLog/Config/AssemblyExtensionTypes.tt
@@ -1,0 +1,201 @@
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ assembly name="$(TargetDir)NLog.dll" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Reflection" #>
+<#@ import namespace="System.Text" #>
+<#@ output extension=".cs" #>
+<# 
+    //Generation of overloads of all six levels
+    //T4 templates are built in Visual Studio. See https://msdn.microsoft.com/en-us/library/bb126445.aspx
+#>// 
+// Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Config
+{
+    /// <summary>
+    /// Provides logging interface and utility functions.
+    /// </summary>
+    internal static class AssemblyExtensionTypes
+    {
+        public static void RegisterTypes(ConfigurationItemFactory factory)
+        {
+            #pragma warning disable CS0618 // Type or member is obsolete
+<#
+    var types  = typeof(NLog.LogFactory).Assembly.GetTypes().OrderBy(t => t.ToString());
+
+    var netFramework = new string[]
+    {
+        "NLog.LayoutRenderers.AppSettingLayoutRenderer",
+        "NLog.Targets.EventLogTarget",
+    };
+    var netStandard2 = new string[]
+    {
+        "NLog.Targets.MailTarget",
+        "NLog.Targets.DebuggerTarget",
+        "NLog.LayoutRenderers.EnvironmentUserLayoutRenderer",
+        "NLog.LayoutRenderers.IdentityLayoutRenderer",
+        "NLog.LayoutRenderers.LocalIpAddressLayoutRenderer",
+        "NLog.LayoutRenderers.SpecialFolderApplicationDataLayoutRenderer",
+        "NLog.LayoutRenderers.SpecialFolderCommonApplicationDataLayoutRenderer",
+        "NLog.LayoutRenderers.SpecialFolderLayoutRenderer",
+        "NLog.LayoutRenderers.SpecialFolderLocalApplicationDataLayoutRenderer",
+        "NLog.LayoutRenderers.TraceActivityIdLayoutRenderer",
+        "NLog.LayoutRenderers.TraceActivityIdLayoutRenderer", 
+    };
+    var netStandard15 = new string[]
+    {
+        "NLog.LayoutRenderers.NLogDirLayoutRenderer",
+        "NLog.LayoutRenderers.ProcessDirLayoutRenderer",
+        "NLog.LayoutRenderers.ProcessIdLayoutRenderer",
+        "NLog.LayoutRenderers.ProcessInfoLayoutRenderer",
+        "NLog.LayoutRenderers.ProcessNameLayoutRenderer",
+        "NLog.Targets.ColoredConsoleTarget",
+        "NLog.Targets.ConsoleRowHighlightingRule",
+        "NLog.Targets.ConsoleWordHighlightingRule",
+        "NLog.Targets.ConsoleTarget",
+        "NLog.Targets.TraceTarget",
+    };
+
+    foreach(var type in types)
+    {
+        if (type.IsAbstract || type.IsPrimitive || !type.IsPublic)
+            continue;
+
+        if (netFramework.Contains(type.ToString()))
+        {
+#>
+#if !NETSTANDARD
+<#
+        }
+        else if (netStandard2.Contains(type.ToString()))
+        {
+#>
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+<#
+        }
+        else if (netStandard15.Contains(type.ToString()))
+        {
+#>
+#if !NETSTANDARD1_3
+<#
+        }
+
+        if (typeof(NLog.Targets.Target).IsAssignableFrom(type))
+        {
+            var targetAttributes = type.GetCustomAttributes<NLog.Targets.TargetAttribute>(false);
+            foreach (var targetAlias in targetAttributes)
+            {
+                var targetAliasName = targetAlias.Name;
+#>
+            factory.TargetFactory.RegisterType<<#= type #>>("<#= targetAliasName #>");
+<#
+            }
+        }
+        else if (typeof(NLog.Layouts.Layout).IsAssignableFrom(type))
+        {
+            var layoutAttributes = type.GetCustomAttributes<NLog.Layouts.LayoutAttribute>(false);
+            foreach (var layoutAlias in layoutAttributes)
+            {
+                var layoutAliasName = layoutAlias.Name;
+#>
+            factory.LayoutFactory.RegisterType<<#= type #>>("<#= layoutAliasName #>");
+<#
+            }
+        }
+        else if (typeof(NLog.LayoutRenderers.LayoutRenderer).IsAssignableFrom(type))
+        {
+            var layoutAttributes = type.GetCustomAttributes<NLog.LayoutRenderers.LayoutRendererAttribute>(false);
+            foreach (var layoutAlias in layoutAttributes)
+            {
+                var layoutAliasName = layoutAlias.Name;
+#>
+            factory.LayoutRendererFactory.RegisterType<<#= type #>>("<#= layoutAliasName #>");
+<#
+            }
+
+            var ambientAttributes = type.GetCustomAttributes<NLog.LayoutRenderers.AmbientPropertyAttribute>(false);
+            foreach (var layoutAlias in ambientAttributes)
+            {
+                var layoutAliasName = layoutAlias.Name;
+#>
+            factory.AmbientRendererFactory.RegisterType<<#= type #>>("<#= layoutAliasName #>");
+<#
+            }
+        }
+        else if (typeof(NLog.Filters.Filter).IsAssignableFrom(type))
+        {
+            var filterAttributes = type.GetCustomAttributes<NLog.Filters.FilterAttribute>(false);
+            foreach (var filterAlias in filterAttributes)
+            {
+                var filterName = filterAlias.Name;
+#>
+            factory.FilterFactory.RegisterType<<#= type #>>("<#= filterName #>");
+<#
+            }
+        }
+        else if (typeof(NLog.Time.TimeSource).IsAssignableFrom(type))
+        {
+            var timeSourceAttribute = type.GetCustomAttributes<NLog.Time.TimeSourceAttribute>(false);
+            foreach (var timeAlias in timeSourceAttribute)
+            {
+                var timeSourceName = timeAlias.Name;
+#>
+            factory.TimeSourceFactory.RegisterType<<#= type #>>("<#= timeSourceName #>");
+<#
+            }
+        }
+        else
+        {
+            var configAttribute = type.GetCustomAttributes<NLog.Config.NLogConfigurationItemAttribute>(false);
+            if (configAttribute?.Any() == true)
+            {
+#>
+            factory.RegisterType<<#= type #>>();
+<#
+            }
+        }
+
+        if (netFramework.Contains(type.ToString()) || netStandard2.Contains(type.ToString()) || netStandard15.Contains(type.ToString()))
+        {
+#>
+#endif
+<#
+        }
+    }
+#>
+            #pragma warning restore CS0618 // Type or member is obsolete
+        }
+    }
+}

--- a/src/NLog/Config/AssemblyLoadingEventArgs.cs
+++ b/src/NLog/Config/AssemblyLoadingEventArgs.cs
@@ -40,6 +40,7 @@ namespace NLog.Config
     /// <summary>
     /// An assembly is trying to load. 
     /// </summary>
+    [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
     public class AssemblyLoadingEventArgs : CancelEventArgs
     {
         /// <summary>

--- a/src/NLog/Config/ConfigurationItemCreator.cs
+++ b/src/NLog/Config/ConfigurationItemCreator.cs
@@ -40,5 +40,6 @@ namespace NLog.Config
     /// </summary>
     /// <param name="itemType">Type of the item.</param>
     /// <returns>Created object of the specified type.</returns>
+    [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
     public delegate object ConfigurationItemCreator(Type itemType);
 }

--- a/src/NLog/Config/IFactory.cs
+++ b/src/NLog/Config/IFactory.cs
@@ -34,6 +34,7 @@
 namespace NLog.Config
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
     /// Provides means to populate factories of named items (such as targets, layouts, layout renderers, etc.).
@@ -42,8 +43,15 @@ namespace NLog.Config
     {
         void Clear();
 
+        [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
         void ScanTypes(Type[] types, string assemblyName, string itemNamePrefix);
 
-        void RegisterType(Type type, string itemNamePrefix);
+        void RegisterType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] Type type, string itemNamePrefix);
+    }
+
+    internal interface IFactory<TBaseType> : IFactory where TBaseType : class
+    {
+        bool TryCreateInstance(string typeAlias, out TBaseType result);
+        void RegisterType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] TType>(string typeAlias) where TType : TBaseType, new();
     }
 }

--- a/src/NLog/Config/IFactory.cs
+++ b/src/NLog/Config/IFactory.cs
@@ -37,7 +37,7 @@ namespace NLog.Config
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
-    /// Provides means to populate factories of named items (such as targets, layouts, layout renderers, etc.).
+    /// Factory of named items (such as <see cref="Targets.Target"/>, <see cref="Layouts.Layout"/>, <see cref="LayoutRenderers.LayoutRenderer"/>, etc.).
     /// </summary>
     internal interface IFactory
     {
@@ -49,9 +49,18 @@ namespace NLog.Config
         void RegisterType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] Type type, string itemNamePrefix);
     }
 
-    internal interface IFactory<TBaseType> : IFactory where TBaseType : class
+    /// <summary>
+    /// Factory of named items (such as <see cref="Targets.Target"/>, <see cref="Layouts.Layout"/>, <see cref="LayoutRenderers.LayoutRenderer"/>, etc.).
+    /// </summary>
+    public interface IFactory<TBaseType> where TBaseType : class
     {
-        bool TryCreateInstance(string typeAlias, out TBaseType result);
+        /// <summary>
+        /// Registers type-creation from type-alias
+        /// </summary>
         void RegisterType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] TType>(string typeAlias) where TType : TBaseType, new();
+        /// <summary>
+        /// Create type-instance from type-alias
+        /// </summary>
+        bool TryCreateInstance(string typeAlias, out TBaseType result);
     }
 }

--- a/src/NLog/Config/INamedItemFactory.cs
+++ b/src/NLog/Config/INamedItemFactory.cs
@@ -40,6 +40,7 @@ namespace NLog.Config
     /// </summary>
     /// <typeparam name="TInstanceType">Base type for each item instance.</typeparam>
     /// <typeparam name="TDefinitionType">Item definition type (typically <see cref="System.Type"/>).</typeparam>
+    [Obsolete("Instead use NLog.LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
     public interface INamedItemFactory<TInstanceType, TDefinitionType>
         where TInstanceType : class
     {
@@ -56,7 +57,6 @@ namespace NLog.Config
         /// <param name="itemName">Name of the item.</param>
         /// <param name="result">Reference to a variable which will store the item definition.</param>
         /// <returns>Item definition.</returns>
-        [Obsolete("Use TryCreateInstance instead. Marked obsolete with NLog v5.2")]
         bool TryGetDefinition(string itemName, out TDefinitionType result);
 
         /// <summary>

--- a/src/NLog/Config/INamedItemFactory.cs
+++ b/src/NLog/Config/INamedItemFactory.cs
@@ -33,13 +33,13 @@
 
 namespace NLog.Config
 {
-    using System.Reflection;
+    using System;
 
     /// <summary>
     /// Represents a factory of named items (such as targets, layouts, layout renderers, etc.).
     /// </summary>
     /// <typeparam name="TInstanceType">Base type for each item instance.</typeparam>
-    /// <typeparam name="TDefinitionType">Item definition type (typically <see cref="System.Type"/> or <see cref="MethodInfo"/>).</typeparam>
+    /// <typeparam name="TDefinitionType">Item definition type (typically <see cref="System.Type"/>).</typeparam>
     public interface INamedItemFactory<TInstanceType, TDefinitionType>
         where TInstanceType : class
     {
@@ -56,6 +56,7 @@ namespace NLog.Config
         /// <param name="itemName">Name of the item.</param>
         /// <param name="result">Reference to a variable which will store the item definition.</param>
         /// <returns>Item definition.</returns>
+        [Obsolete("Use TryCreateInstance instead. Marked obsolete with NLog v5.2")]
         bool TryGetDefinition(string itemName, out TDefinitionType result);
 
         /// <summary>

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -732,7 +732,7 @@ namespace NLog.Config
                 roots.Add(target);
             }
 
-            _configItems = ObjectGraphScanner.FindReachableObjects<object>(true, roots.ToArray());
+            _configItems = ObjectGraphScanner.FindReachableObjects<object>(ConfigurationItemFactory.Default, true, roots.ToArray());
 
             InternalLogger.Info("Validating config: {0}", this);
 
@@ -743,7 +743,7 @@ namespace NLog.Config
                     if (o is ISupportsInitialize)
                         continue;   // Target + Layout + LayoutRenderer validate on Initialize()
 
-                    PropertyHelper.CheckRequiredParameters(o);
+                    PropertyHelper.CheckRequiredParameters(ConfigurationItemFactory.Default, o);
                 }
                 catch (Exception ex)
                 {

--- a/src/NLog/Config/LoggingConfigurationFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationFileLoader.cs
@@ -76,7 +76,9 @@ namespace NLog.Config
         
         private LoggingConfiguration TryLoadFromFilePaths(LogFactory logFactory, string filename)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var configFileNames = logFactory.GetCandidateConfigFilePaths(filename);
+#pragma warning restore CS0618 // Type or member is obsolete
             foreach (string configFile in configFileNames)
             {
                 if (TryLoadLoggingConfiguration(logFactory, configFile, out var config))

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -1298,7 +1298,8 @@ namespace NLog.Config
                     }
                 }
 
-                if (!factory.TryCreateInstance(typeName, out newInstance) || newInstance is null)
+                newInstance = factory.CreateInstance(typeName);
+                if (newInstance is null)
                 {
                     throw new NLogConfigurationException($"Factory returned null for {typeof(T).Name} of type: {typeName}");
                 }

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -194,7 +194,7 @@ namespace NLog.Config
 
             if (autoLoadExtensions)
             {
-                ConfigurationItemFactory.ScanForAutoLoadExtensions(LogFactory);
+                ConfigurationItemFactory.Default.AssemblyLoader.ScanForAutoLoadExtensions(ConfigurationItemFactory.Default);
             }
 
             _serviceRepository.RegisterMessageTemplateParser(parseMessageTemplates);
@@ -343,16 +343,16 @@ namespace NLog.Config
 #endif
                 if (!StringHelpers.IsNullOrWhiteSpace(assemblyName))
                 {
-                    ParseExtensionWithAssembly(assemblyName, prefix);
+                    ParseExtensionWithAssemblyName(assemblyName?.Trim(), prefix);
                 }
             }
         }
 
-        private void RegisterExtension(string type, string itemNamePrefix)
+        private void RegisterExtension(string typeName, string itemNamePrefix)
         {
             try
             {
-                ConfigurationItemFactory.Default.RegisterType(Type.GetType(type, true), itemNamePrefix);
+                ConfigurationItemFactory.Default.AssemblyLoader.LoadTypeFromName(ConfigurationItemFactory.Default, typeName, itemNamePrefix);
             }
             catch (Exception exception)
             {
@@ -360,7 +360,7 @@ namespace NLog.Config
                     throw;
 
                 var configException =
-                    new NLogConfigurationException("Error loading extensions: " + type, exception);
+                    new NLogConfigurationException("Error loading extensions: " + typeName, exception);
                 if (MustThrowConfigException(configException))
                     throw configException;
             }
@@ -371,8 +371,7 @@ namespace NLog.Config
         {
             try
             {
-                Assembly asm = AssemblyHelpers.LoadFromPath(assemblyFile, baseDirectory);
-                ConfigurationItemFactory.Default.RegisterItemsFromAssembly(asm, prefix);
+                ConfigurationItemFactory.Default.AssemblyLoader.LoadAssemblyFromPath(ConfigurationItemFactory.Default, assemblyFile, baseDirectory, prefix);
             }
             catch (Exception exception)
             {
@@ -387,12 +386,18 @@ namespace NLog.Config
         }
 #endif
 
-        private void ParseExtensionWithAssembly(string assemblyName, string prefix)
+        private bool RegisterExtensionFromAssemblyName(string assemblyName, string originalTypeName)
+        {
+            InternalLogger.Debug("Loading Assembly-Name '{0}' for type: {1}", assemblyName, originalTypeName);
+            return ParseExtensionWithAssemblyName(assemblyName, string.Empty);
+        }
+
+        private bool ParseExtensionWithAssemblyName(string assemblyName, string prefix)
         {
             try
             {
-                Assembly asm = AssemblyHelpers.LoadFromName(assemblyName);
-                ConfigurationItemFactory.Default.RegisterItemsFromAssembly(asm, prefix);
+                ConfigurationItemFactory.Default.AssemblyLoader.LoadAssemblyFromName(ConfigurationItemFactory.Default, assemblyName, prefix);
+                return true;
             }
             catch (Exception exception)
             {
@@ -404,6 +409,8 @@ namespace NLog.Config
                 if (MustThrowConfigException(configException))
                     throw configException;
             }
+
+            return false;
         }
 
         private void ParseVariableElement(ValidatedConfigurationElement variableElement)
@@ -480,7 +487,7 @@ namespace NLog.Config
             if (!AssertNonEmptyValue(timeSourceType, "type", timeElement.Name, string.Empty))
                 return;
 
-            TimeSource newTimeSource = FactoryCreateInstance(timeSourceType, ConfigurationItemFactory.Default.TimeSources);
+            TimeSource newTimeSource = FactoryCreateInstance(timeSourceType, ConfigurationItemFactory.Default.TimeSourceFactory);
             if (newTimeSource != null)
             {
                 ConfigureFromAttributesAndElements(newTimeSource, timeElement);
@@ -775,8 +782,8 @@ namespace NLog.Config
             foreach (var filterElement in filtersElement.ValidChildren)
             {
                 var filterType = filterElement.GetOptionalValue("type", null) ?? filterElement.Name;
-                Filter filter = FactoryCreateInstance(filterType, ConfigurationItemFactory.Default.Filters);
-                ConfigureFromAttributesAndElements(filter, filterElement, true);
+                Filter filter = FactoryCreateInstance(filterType, ConfigurationItemFactory.Default.FilterFactory);
+                ConfigureFromAttributesAndElements(filter, filterElement);
                 rule.Filters.Add(filter);
             }
         }
@@ -897,7 +904,7 @@ namespace NLog.Config
 
         private Target CreateTargetType(string targetTypeName)
         {
-            return FactoryCreateInstance(targetTypeName, ConfigurationItemFactory.Default.Targets);
+            return FactoryCreateInstance(targetTypeName, ConfigurationItemFactory.Default.TargetFactory);
         }
 
         private void ParseTargetElement(Target target, ValidatedConfigurationElement targetElement, Dictionary<string, ValidatedConfigurationElement> typeNameToDefaultTargetParameters = null)
@@ -912,7 +919,7 @@ namespace NLog.Config
             var compound = target as CompoundTargetBase;
             var wrapper = target as WrapperTargetBase;
 
-            ConfigureObjectFromAttributes(target, targetElement, true);
+            ConfigureObjectFromAttributes(target, targetElement);
 
             foreach (var childElement in targetElement.ValidChildren)
             {
@@ -1042,7 +1049,7 @@ namespace NLog.Config
             return false;
         }
 
-        private void ConfigureObjectFromAttributes(object targetObject, ValidatedConfigurationElement element, bool ignoreType)
+        private void ConfigureObjectFromAttributes<T>(T targetObject, ValidatedConfigurationElement element, bool ignoreType = true) where T : class
         {
             foreach (var kvp in element.ValueLookup)
             {
@@ -1058,21 +1065,31 @@ namespace NLog.Config
             }
         }
 
-        private void SetPropertyValueFromString(object targetObject, string propertyName, string propertyValue, ValidatedConfigurationElement element)
+        private void SetPropertyValueFromString<T>(T targetObject, string propertyName, string propertyValue, ValidatedConfigurationElement element) where T : class
         {
             try
             {
+                if (targetObject is null)
+                {
+                    throw new NLogConfigurationException($"'{typeof(T).Name}' is null, and cannot assign property '{propertyName}'='{propertyValue}'");
+                }
+                
+                if (!PropertyHelper.TryGetPropertyInfo(ConfigurationItemFactory.Default, targetObject, propertyName, out var propertyInfo))
+                {
+                    throw new NLogConfigurationException($"'{targetObject?.GetType()?.Name}' cannot assign unknown property '{propertyName}'='{propertyValue}'");
+                }
+
                 var propertyValueExpanded = ExpandSimpleVariables(propertyValue, out var matchingVariableName);
                 if (matchingVariableName != null && TryLookupDynamicVariable(matchingVariableName, out var matchingLayout))
                 {
-                    if (PropertyHelper.TryGetPropertyInfo(targetObject, propertyName, out var propInfo) && propInfo.PropertyType.IsAssignableFrom(matchingLayout.GetType()))
+                    if (propertyInfo.PropertyType.IsAssignableFrom(matchingLayout.GetType()))
                     {
-                        PropertyHelper.SetPropertyValueForObject(targetObject, matchingLayout, propInfo);
+                        PropertyHelper.SetPropertyValueForObject(targetObject, matchingLayout, propertyInfo);
                         return;
                     }
                 }
 
-                PropertyHelper.SetPropertyFromString(targetObject, propertyName, propertyValueExpanded, ConfigurationItemFactory.Default);
+                PropertyHelper.SetPropertyFromString(targetObject, propertyInfo, propertyValueExpanded, ConfigurationItemFactory.Default);
             }
             catch (NLogConfigurationException ex)
             {
@@ -1090,34 +1107,43 @@ namespace NLog.Config
             }
         }
 
-        private void SetPropertyValuesFromElement(object o, ValidatedConfigurationElement childElement, ILoggingConfigurationElement parentElement)
+        private void SetPropertyValuesFromElement<T>(T targetObject, ValidatedConfigurationElement childElement, ILoggingConfigurationElement parentElement) where T : class
         {
-            if (!PropertyHelper.TryGetPropertyInfo(o, childElement.Name, out var propInfo))
+            if (targetObject is null)
             {
-                var configException = new NLogConfigurationException($"'{o?.GetType()?.Name}' cannot assign unknown property '{childElement.Name}' in section '{parentElement.Name}'");
+                var configException = new NLogConfigurationException($"'{typeof(T).Name}' is null, and cannot assign property '{childElement.Name}' in section '{parentElement.Name}'");
+                if (MustThrowConfigException(configException))
+                    throw configException;
+
+                return;
+            }
+            
+            if (!PropertyHelper.TryGetPropertyInfo(ConfigurationItemFactory.Default, targetObject, childElement.Name, out var propInfo))
+            {
+                var configException = new NLogConfigurationException($"'{targetObject?.GetType()?.Name}' cannot assign unknown property '{childElement.Name}' in section '{parentElement.Name}'");
                 if (MustThrowConfigException(configException))
                     throw configException;
 
                 return;
             }
 
-            if (AddArrayItemFromElement(o, propInfo, childElement))
+            if (AddArrayItemFromElement(targetObject, propInfo, childElement))
             {
                 return;
             }
 
-            if (SetLayoutFromElement(o, propInfo, childElement))
+            if (SetLayoutFromElement(targetObject, propInfo, childElement))
             {
                 return;
             }
 
-            if (SetFilterFromElement(o, propInfo, childElement))
+            if (SetFilterFromElement(targetObject, propInfo, childElement))
             {
                 return;
             }
 
-            object item = propInfo.GetValue(o, null);
-            ConfigureFromAttributesAndElements(item, childElement);
+            object propertyValue = propInfo.GetValue(targetObject, null);
+            ConfigureFromAttributesAndElements(propertyValue, childElement);
         }
 
         private bool AddArrayItemFromElement(object o, PropertyInfo propInfo, ValidatedConfigurationElement element)
@@ -1210,7 +1236,7 @@ namespace NLog.Config
                 }
             }
 
-            var layoutInstance = FactoryCreateInstance(expandedClassType, ConfigurationItemFactory.Default.Layouts);
+            var layoutInstance = FactoryCreateInstance(expandedClassType, ConfigurationItemFactory.Default.LayoutFactory);
             if (layoutInstance != null)
             {
                 ConfigureFromAttributesAndElements(layoutInstance, element);
@@ -1222,7 +1248,7 @@ namespace NLog.Config
 
         private Filter TryCreateFilterInstance(ValidatedConfigurationElement element, Type type)
         {
-            var filter = TryCreateInstance(element, type, ConfigurationItemFactory.Default.Filters);
+            var filter = TryCreateInstance(element, type, ConfigurationItemFactory.Default.FilterFactory);
             if (filter != null)
             {
                 ConfigureFromAttributesAndElements(filter, element);
@@ -1232,7 +1258,7 @@ namespace NLog.Config
             return null;
         }
 
-        private T TryCreateInstance<T>(ValidatedConfigurationElement element, Type type, INamedItemFactory<T, Type> factory)
+        private T TryCreateInstance<T>(ValidatedConfigurationElement element, Type type, IFactory<T> factory)
             where T : class
         {
             // Check if correct type
@@ -1247,27 +1273,34 @@ namespace NLog.Config
             return FactoryCreateInstance(classType, factory);
         }
 
-        private T FactoryCreateInstance<T>(string classType, INamedItemFactory<T, Type> factory) where T : class
+        private T FactoryCreateInstance<T>(string typeName, IFactory<T> factory) where T : class
         {
             T newInstance = null;
 
             try
             {
-                classType = ExpandSimpleVariables(classType);
-                if (classType.Contains(','))
+                typeName = ExpandSimpleVariables(typeName);
+                if (typeName.Contains(','))
                 {
                     // Possible specification of assembly-name detected
-                    if (factory.TryCreateInstance(classType, out newInstance) && newInstance != null)
+                    var shortName = typeName.Substring(0, typeName.IndexOf(',')).Trim();
+                    if (factory.TryCreateInstance(shortName, out newInstance) && newInstance != null)
                         return newInstance;
 
-                    // Attempt to load the assembly name extracted from the prefix
-                    classType = RegisterExtensionFromAssemblyName(classType);
+                    var assemblyName = typeName.Substring(typeName.IndexOf(',') + 1).Trim();
+                    if (!string.IsNullOrEmpty(assemblyName))
+                    {
+                        // Attempt to load the assembly name extracted from the prefix
+                        if (RegisterExtensionFromAssemblyName(assemblyName, typeName))
+                        {
+                            typeName = shortName;
+                        }
+                    }
                 }
 
-                newInstance = factory.CreateInstance(classType);
-                if (newInstance is null)
+                if (!factory.TryCreateInstance(typeName, out newInstance) || newInstance is null)
                 {
-                    throw new NLogConfigurationException($"Factory returned null for {typeof(T).Name} of type: {classType}");
+                    throw new NLogConfigurationException($"Factory returned null for {typeof(T).Name} of type: {typeName}");
                 }
             }
             catch (NLogConfigurationException configException)
@@ -1280,7 +1313,7 @@ namespace NLog.Config
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
-                var configException = new NLogConfigurationException($"Failed to create {typeof(T).Name} of type: {classType}", ex);
+                var configException = new NLogConfigurationException($"Failed to create {typeof(T).Name} of type: {typeName}", ex);
                 if (MustThrowConfigException(configException))
                     throw configException;
             }
@@ -1288,30 +1321,9 @@ namespace NLog.Config
             return newInstance;
         }
 
-        private string RegisterExtensionFromAssemblyName(string classType)
+        private void ConfigureFromAttributesAndElements<T>(T targetObject, ValidatedConfigurationElement element) where T : class
         {
-            var assemblyName = classType.Substring(classType.IndexOf(',') + 1).Trim();
-            if (!string.IsNullOrEmpty(assemblyName))
-            {
-                try
-                {
-                    InternalLogger.Debug("Loading Assembly-Name '{0}' for type: {1}", assemblyName, classType);
-                    ParseExtensionWithAssembly(assemblyName, string.Empty);
-                    return classType.Substring(0, classType.IndexOf(',')).Trim() + ", " + assemblyName; // uniform format
-                }
-                catch (Exception ex)
-                {
-                    if (ex.MustBeRethrownImmediately())
-                        throw;
-                }
-            }
-
-            return classType;
-        }
-
-        private void ConfigureFromAttributesAndElements(object targetObject, ValidatedConfigurationElement element, bool ignoreTypeProperty = true)
-        {
-            ConfigureObjectFromAttributes(targetObject, element, ignoreTypeProperty);
+            ConfigureObjectFromAttributes(targetObject, element);
 
             foreach (var childElement in element.ValidChildren)
             {

--- a/src/NLog/Config/LoggingConfigurationWatchableFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationWatchableFileLoader.cs
@@ -188,7 +188,9 @@ namespace NLog.Config
                     }
 #endif
                     InternalLogger.Warn(exception, "NLog configuration failed to reload");
+#pragma warning disable CS0618 // Type or member is obsolete
                     _logFactory?.NotifyConfigurationReloaded(new LoggingConfigurationReloadedEventArgs(false, exception));
+#pragma warning restore CS0618 // Type or member is obsolete
                     return;
                 }
 
@@ -198,7 +200,9 @@ namespace NLog.Config
 
                     _logFactory.Configuration = newConfig;  // Triggers LogFactory to call Activated(...) that adds file-watch again
 
+#pragma warning disable CS0618 // Type or member is obsolete
                     _logFactory?.NotifyConfigurationReloaded(new LoggingConfigurationReloadedEventArgs(true));
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
                 catch (Exception exception)
                 {
@@ -210,7 +214,9 @@ namespace NLog.Config
 #endif
                     InternalLogger.Warn(exception, "NLog configuration reloaded, failed to be assigned");
                     _watcher.Watch(oldConfig.FileNamesToWatch);
+#pragma warning disable CS0618 // Type or member is obsolete
                     _logFactory?.NotifyConfigurationReloaded(new LoggingConfigurationReloadedEventArgs(false, exception));
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }
         }

--- a/src/NLog/Config/MethodFactory.cs
+++ b/src/NLog/Config/MethodFactory.cs
@@ -212,6 +212,7 @@ namespace NLog.Config
         /// <param name="itemName">The method name.</param>
         /// <param name="result">The result.</param>
         /// <returns>A value of <c>true</c> if the method was found, <c>false</c> otherwise.</returns>
+        [Obsolete("Use TryCreateInstance instead that resolves delegate. Marked obsolete with NLog v5.2")]
         public bool TryCreateInstance(string itemName, out MethodInfo result)
         {
             return TryGetDefinition(itemName, out result);
@@ -253,6 +254,7 @@ namespace NLog.Config
         /// </summary>
         /// <param name="itemName">Method name.</param>
         /// <returns>MethodInfo object.</returns>
+        [Obsolete("Use TryCreateInstance instead that resolves delegate. Marked obsolete with NLog v5.2")]
         MethodInfo INamedItemFactory<MethodInfo, MethodInfo>.CreateInstance(string itemName)
         {
             if (TryCreateInstance(itemName, out MethodInfo result))
@@ -284,6 +286,7 @@ namespace NLog.Config
         /// <param name="itemName">The method name.</param>
         /// <param name="result">The result.</param>
         /// <returns>A value of <c>true</c> if the method was found, <c>false</c> otherwise.</returns>
+        [Obsolete("Use TryCreateInstance instead that resolves delegate. Marked obsolete with NLog v5.2")]
         public bool TryGetDefinition(string itemName, out MethodInfo result)
         {
             lock (_nameToMethodInfo)

--- a/src/NLog/Config/MethodFactory.cs
+++ b/src/NLog/Config/MethodFactory.cs
@@ -35,27 +35,32 @@ namespace NLog.Config
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Reflection;
     using NLog.Common;
+    using NLog.Conditions;
     using NLog.Internal;
 
     /// <summary>
     /// Factory for locating methods.
     /// </summary>
-    internal class MethodFactory : INamedItemFactory<MethodInfo, MethodInfo>, INamedItemFactory<ReflectionHelpers.LateBoundMethod, MethodInfo>, IFactory
+    internal class MethodFactory :
+#pragma warning disable CS0618 // Type or member is obsolete
+        INamedItemFactory<MethodInfo, MethodInfo>,
+        INamedItemFactory<ReflectionHelpers.LateBoundMethod, MethodInfo>,
+#pragma warning restore CS0618 // Type or member is obsolete
+        IFactory
     {
         private readonly Dictionary<string, MethodInfo> _nameToMethodInfo = new Dictionary<string, MethodInfo>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, ReflectionHelpers.LateBoundMethod> _nameToLateBoundMethod = new Dictionary<string, ReflectionHelpers.LateBoundMethod>(StringComparer.OrdinalIgnoreCase);
-        private readonly Func<Type, IList<KeyValuePair<string, MethodInfo>>> _methodExtractor;
         private readonly MethodFactory _globalDefaultFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MethodFactory"/> class.
         /// </summary>
-        public MethodFactory(MethodFactory globalDefaultFactory, Func<Type, IList<KeyValuePair<string, MethodInfo>>> methodExtractor)
+        public MethodFactory(MethodFactory globalDefaultFactory)
         {
             _globalDefaultFactory = globalDefaultFactory;
-            _methodExtractor = methodExtractor;
         }
 
         /// <summary>
@@ -66,6 +71,9 @@ namespace NLog.Config
         /// <param name="types">The types to scan.</param>
         /// <param name="assemblyName">The assembly name for the type.</param>
         /// <param name="itemNamePrefix">The item name prefix.</param>
+        [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
+        [UnconditionalSuppressMessage("Trimming - Ignore since obsolete", "IL2072")]
+        [UnconditionalSuppressMessage("Trimming - Ignore since obsolete", "IL2062")]
         public void ScanTypes(Type[] types, string assemblyName, string itemNamePrefix)
         {
             foreach (Type t in types)
@@ -94,9 +102,21 @@ namespace NLog.Config
         /// </summary>
         /// <param name="type">The type to register.</param>
         /// <param name="itemNamePrefix">The item name prefix.</param>
-        public void RegisterType(Type type, string itemNamePrefix)
+        public void RegisterType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] Type type, string itemNamePrefix)
         {
-            RegisterType(type, string.Empty, itemNamePrefix);
+            var extractedMethods = ExtractClassMethods<ConditionMethodsAttribute, ConditionMethodAttribute>(type);
+            for (int i = 0; i < extractedMethods.Count; ++i)
+            {
+                RegisterDefinition(extractedMethods[i].Key, extractedMethods[i].Value, string.Empty, string.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Registers the definition of a single method.
+        /// </summary>
+        public void RegisterDefinition(string itemName, MethodInfo itemDefinition)
+        {
+            RegisterDefinition(itemName, itemDefinition, string.Empty, string.Empty);
         }
 
         /// <summary>
@@ -105,9 +125,10 @@ namespace NLog.Config
         /// <param name="type">The type to register.</param>
         /// <param name="assemblyName">The assembly name for the type.</param>
         /// <param name="itemNamePrefix">The item name prefix.</param>
-        public void RegisterType(Type type, string assemblyName, string itemNamePrefix)
+        [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
+        public void RegisterType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type, string assemblyName, string itemNamePrefix)
         {
-            var extractedMethods = _methodExtractor(type);
+            var extractedMethods = ExtractClassMethods<ConditionMethodsAttribute, ConditionMethodAttribute>(type);
             if (extractedMethods?.Count > 0)
             {
                 for (int i = 0; i < extractedMethods.Count; ++i)
@@ -124,7 +145,7 @@ namespace NLog.Config
         /// <typeparam name="TMethodAttributeType">Include methods that are marked with this attribute</typeparam>
         /// <param name="type">Class Type to scan</param>
         /// <returns>Collection of methods with their symbolic names</returns>
-        public static IList<KeyValuePair<string, MethodInfo>> ExtractClassMethods<TClassAttributeType, TMethodAttributeType>(Type type) 
+        public static IList<KeyValuePair<string, MethodInfo>> ExtractClassMethods<TClassAttributeType, TMethodAttributeType>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type) 
             where TClassAttributeType : Attribute
             where TMethodAttributeType : NameBaseAttribute
         {
@@ -161,7 +182,8 @@ namespace NLog.Config
         /// </summary>
         /// <param name="itemName">The method name.</param>
         /// <param name="itemDefinition">The method info.</param>
-        public void RegisterDefinition(string itemName, MethodInfo itemDefinition)
+        [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
+        void INamedItemFactory<MethodInfo, MethodInfo>.RegisterDefinition(string itemName, MethodInfo itemDefinition)
         {
             RegisterDefinition(itemName, itemDefinition, string.Empty, string.Empty);
         }
@@ -212,7 +234,7 @@ namespace NLog.Config
         /// <param name="itemName">The method name.</param>
         /// <param name="result">The result.</param>
         /// <returns>A value of <c>true</c> if the method was found, <c>false</c> otherwise.</returns>
-        [Obsolete("Use TryCreateInstance instead that resolves delegate. Marked obsolete with NLog v5.2")]
+        [Obsolete("Use TryCreateInstance instead. Marked obsolete with NLog v5.2")]
         public bool TryCreateInstance(string itemName, out MethodInfo result)
         {
             return TryGetDefinition(itemName, out result);
@@ -254,8 +276,14 @@ namespace NLog.Config
         /// </summary>
         /// <param name="itemName">Method name.</param>
         /// <returns>MethodInfo object.</returns>
-        [Obsolete("Use TryCreateInstance instead that resolves delegate. Marked obsolete with NLog v5.2")]
+        [Obsolete("Use TryCreateInstance instead. Marked obsolete with NLog v5.2")]
         MethodInfo INamedItemFactory<MethodInfo, MethodInfo>.CreateInstance(string itemName)
+        {
+            return CreateMethodInfo(itemName);
+        }
+
+        [Obsolete("Use TryCreateInstance instead. Marked obsolete with NLog v5.2")]
+        internal MethodInfo CreateMethodInfo(string itemName)
         {
             if (TryCreateInstance(itemName, out MethodInfo result))
             {
@@ -286,7 +314,7 @@ namespace NLog.Config
         /// <param name="itemName">The method name.</param>
         /// <param name="result">The result.</param>
         /// <returns>A value of <c>true</c> if the method was found, <c>false</c> otherwise.</returns>
-        [Obsolete("Use TryCreateInstance instead that resolves delegate. Marked obsolete with NLog v5.2")]
+        [Obsolete("Use TryCreateInstance instead. Marked obsolete with NLog v5.2")]
         public bool TryGetDefinition(string itemName, out MethodInfo result)
         {
             lock (_nameToMethodInfo)
@@ -298,6 +326,12 @@ namespace NLog.Config
             }
 
             return _globalDefaultFactory?.TryGetDefinition(itemName, out result) ?? false;
+        }
+
+        [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
+        void INamedItemFactory<ReflectionHelpers.LateBoundMethod, MethodInfo>.RegisterDefinition(string itemName, System.Reflection.MethodInfo itemDefinition)
+        {
+            RegisterDefinition(itemName, itemDefinition, string.Empty, string.Empty);
         }
     }
 }

--- a/src/NLog/Config/SimpleConfigurator.cs
+++ b/src/NLog/Config/SimpleConfigurator.cs
@@ -42,6 +42,7 @@ namespace NLog.Config
     /// 
     /// Warning, these methods will overwrite the current config.
     /// </summary>
+    [Obsolete("Use LogManager.Setup().LoadConfiguration() instead. Marked obsolete on NLog 5.2")]
     public static class SimpleConfigurator
     {
 #if !NETSTANDARD1_3
@@ -49,6 +50,7 @@ namespace NLog.Config
         /// Configures NLog for console logging so that all messages above and including
         /// the <see cref="NLog.LogLevel.Info"/> level are output to the console.
         /// </summary>
+        [Obsolete("Use LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteToConsole()) instead. Marked obsolete on NLog 5.2")]
         public static void ConfigureForConsoleLogging()
         {
             ConfigureForConsoleLogging(LogLevel.Info);
@@ -59,6 +61,7 @@ namespace NLog.Config
         /// the specified level are output to the console.
         /// </summary>
         /// <param name="minLevel">The minimal logging level.</param>
+        [Obsolete("Use LogManager.Setup().LoadConfiguration(c => c.ForLogger(minLevel).WriteToConsole()) instead. Marked obsolete on NLog 5.2")]
         public static void ConfigureForConsoleLogging(LogLevel minLevel)
         {
             ConsoleTarget consoleTarget = new ConsoleTarget();
@@ -74,6 +77,7 @@ namespace NLog.Config
         /// above and including the <see cref="NLog.LogLevel.Info"/> level are output.
         /// </summary>
         /// <param name="target">The target to log all messages to.</param>
+        [Obsolete("Use LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(target)) instead. Marked obsolete on NLog 5.2")]
         public static void ConfigureForTargetLogging(Target target)
         {
             Guard.ThrowIfNull(target);
@@ -86,6 +90,7 @@ namespace NLog.Config
         /// </summary>
         /// <param name="target">The target to log all messages to.</param>
         /// <param name="minLevel">The minimal logging level.</param>
+        [Obsolete("Use LogManager.Setup().LoadConfiguration(c => c.ForLogger(minLevel).WriteTo(target)) instead. Marked obsolete on NLog 5.2")]
         public static void ConfigureForTargetLogging(Target target, LogLevel minLevel)
         {
             Guard.ThrowIfNull(target);
@@ -99,6 +104,7 @@ namespace NLog.Config
         /// the <see cref="NLog.LogLevel.Info"/> level are written to the specified file.
         /// </summary>
         /// <param name="fileName">Log file name.</param>
+        [Obsolete("Use LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteToFile(fileName)) instead. Marked obsolete on NLog 5.2")]
         public static void ConfigureForFileLogging(string fileName)
         {
             ConfigureForFileLogging(fileName, LogLevel.Info);
@@ -110,6 +116,7 @@ namespace NLog.Config
         /// </summary>
         /// <param name="fileName">Log file name.</param>
         /// <param name="minLevel">The minimal logging level.</param>
+        [Obsolete("Use LogManager.Setup().LoadConfiguration(c => c.ForLogger(minLevel).WriteToFile(fileName)) instead. Marked obsolete on NLog 5.2")]
         public static void ConfigureForFileLogging(string fileName, LogLevel minLevel)
         {
             FileTarget target = new FileTarget();

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -275,6 +275,7 @@ namespace NLog.Config
         /// Get file paths (including filename) for the possible NLog config files. 
         /// </summary>
         /// <returns>The file paths to the possible config file</returns>
+        [Obsolete("Replaced by LogManager.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         public static IEnumerable<string> GetCandidateConfigFilePaths()
         {
             return LogManager.LogFactory.GetCandidateConfigFilePaths();
@@ -284,6 +285,7 @@ namespace NLog.Config
         /// Overwrite the paths (including filename) for the possible NLog config files.
         /// </summary>
         /// <param name="filePaths">The file paths to the possible config file</param>
+        [Obsolete("Replaced by LogManager.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         public static void SetCandidateConfigFilePaths(IEnumerable<string> filePaths)
         {
             LogManager.LogFactory.SetCandidateConfigFilePaths(filePaths);
@@ -292,6 +294,7 @@ namespace NLog.Config
         /// <summary>
         /// Clear the candidate file paths and return to the defaults.
         /// </summary>
+        [Obsolete("Replaced by LogManager.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         public static void ResetCandidateConfigFilePath()
         {
             LogManager.LogFactory.ResetCandidateConfigFilePath();

--- a/src/NLog/Internal/AppEnvironmentWrapper.cs
+++ b/src/NLog/Internal/AppEnvironmentWrapper.cs
@@ -126,7 +126,9 @@ namespace NLog.Internal.Fakeables
                 return Path.GetDirectoryName(entryLocation);
             }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             return AssemblyHelpers.GetAssemblyFileLocation(entryAssembly);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         private static string LookupEntryAssemblyFileName()

--- a/src/NLog/Internal/AssemblyMetadataAttribute.cs
+++ b/src/NLog/Internal/AssemblyMetadataAttribute.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,41 +31,15 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.LayoutRenderers
+#if NET35
+namespace System.Reflection
 {
-    /// <summary>
-    /// Gets or sets the property of System.GC to retrieve.
-    /// </summary>
-    public enum GarbageCollectorProperty
+    [AttributeUsage(AttributeTargets.Assembly)]
+    internal sealed class AssemblyMetadataAttribute : Attribute
     {
-        /// <summary>
-        /// Total memory allocated.
-        /// </summary>
-        TotalMemory,
-
-        /// <summary>
-        /// Total memory allocated (perform full garbage collection first).
-        /// </summary>
-        TotalMemoryForceCollection,
-
-        /// <summary>
-        /// Gets the number of Gen0 collections.
-        /// </summary>
-        CollectionCount0,
-
-        /// <summary>
-        /// Gets the number of Gen1 collections.
-        /// </summary>
-        CollectionCount1,
-
-        /// <summary>
-        /// Gets the number of Gen2 collections.
-        /// </summary>
-        CollectionCount2,
-
-        /// <summary>
-        /// Maximum generation number supported by GC.
-        /// </summary>
-        MaxGeneration,
+        public AssemblyMetadataAttribute(string key, string value)
+        {
+        }
     }
 }
+#endif

--- a/src/NLog/Internal/CallSiteInformation.cs
+++ b/src/NLog/Internal/CallSiteInformation.cs
@@ -102,7 +102,7 @@ namespace NLog.Internal
         public MethodBase GetCallerStackFrameMethod(int skipFrames)
         {
             StackFrame frame = StackTrace?.GetFrame(UserStackFrameNumber + skipFrames);
-            return frame?.GetMethod();
+            return StackTraceUsageUtils.GetStackMethod(frame);
         }
 
         public string GetCallerClassName(MethodBase method, bool includeNameSpace, bool cleanAsyncMoveNext, bool cleanAnonymousDelegates)
@@ -218,10 +218,12 @@ namespace NLog.Internal
                 if (SkipAssembly(stackFrame))
                     continue;
 
-                if (stackFrame.GetMethod()?.Name == "MoveNext" && stackFrames.Length > i)
+                var stackMethod = StackTraceUsageUtils.GetStackMethod(stackFrame);
+                if (stackMethod?.Name == "MoveNext" && stackFrames.Length > i)
                 {
                     var nextStackFrame = stackFrames[i + 1];
-                    var declaringType = nextStackFrame.GetMethod()?.DeclaringType;
+                    var nextStackMethod = StackTraceUsageUtils.GetStackMethod(nextStackFrame);
+                    var declaringType = nextStackMethod?.DeclaringType;
                     if (declaringType?.Namespace == "System.Runtime.CompilerServices" || declaringType == typeof(System.Threading.ExecutionContext))
                     {
                         //async, search further
@@ -254,7 +256,7 @@ namespace NLog.Internal
         /// <returns></returns>
         private static bool IsLoggerType(StackFrame frame, Type loggerType)
         {
-            var method = frame.GetMethod();
+            var method = StackTraceUsageUtils.GetStackMethod(frame);
             Type declaringType = method?.DeclaringType;
             var isLoggerType = declaringType != null && (loggerType == declaringType || declaringType.IsSubclassOf(loggerType) || loggerType.IsAssignableFrom(declaringType));
             return isLoggerType;

--- a/src/NLog/Internal/DynamicallyAccessedMemberTypes.cs
+++ b/src/NLog/Internal/DynamicallyAccessedMemberTypes.cs
@@ -1,0 +1,230 @@
+﻿// 
+// Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
+        AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+        Inherited = false)]
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    /// <summary>
+    /// Specifies the types of members that are dynamically accessed.
+    ///
+    /// This enumeration has a <see cref="FlagsAttribute"/> attribute that allows a
+    /// bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        /// <summary>
+        /// Specifies no members.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies the default, parameterless public constructor.
+        /// </summary>
+        PublicParameterlessConstructor = 0x0001,
+
+        /// <summary>
+        /// Specifies all public constructors.
+        /// </summary>
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+
+        /// <summary>
+        /// Specifies all non-public constructors.
+        /// </summary>
+        NonPublicConstructors = 0x0004,
+
+        /// <summary>
+        /// Specifies all public methods.
+        /// </summary>
+        PublicMethods = 0x0008,
+
+        /// <summary>
+        /// Specifies all non-public methods.
+        /// </summary>
+        NonPublicMethods = 0x0010,
+
+        /// <summary>
+        /// Specifies all public fields.
+        /// </summary>
+        PublicFields = 0x0020,
+
+        /// <summary>
+        /// Specifies all non-public fields.
+        /// </summary>
+        NonPublicFields = 0x0040,
+
+        /// <summary>
+        /// Specifies all public nested types.
+        /// </summary>
+        PublicNestedTypes = 0x0080,
+
+        /// <summary>
+        /// Specifies all non-public nested types.
+        /// </summary>
+        NonPublicNestedTypes = 0x0100,
+
+        /// <summary>
+        /// Specifies all public properties.
+        /// </summary>
+        PublicProperties = 0x0200,
+
+        /// <summary>
+        /// Specifies all non-public properties.
+        /// </summary>
+        NonPublicProperties = 0x0400,
+
+        /// <summary>
+        /// Specifies all public events.
+        /// </summary>
+        PublicEvents = 0x0800,
+
+        /// <summary>
+        /// Specifies all non-public events.
+        /// </summary>
+        NonPublicEvents = 0x1000,
+
+        /// <summary>
+        /// Specifies all interfaces implemented by the type.
+        /// </summary>
+        Interfaces = 0x2000,
+
+        /// <summary>
+        /// Specifies all members.
+        /// </summary>
+        All = ~None
+    }
+
+    /// <summary>
+    /// Suppresses reporting of a specific rule violation, allowing multiple suppressions on a
+    /// single code artifact.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="UnconditionalSuppressMessageAttribute"/> is different than
+    /// <see cref="SuppressMessageAttribute"/> in that it doesn't have a
+    /// <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    internal sealed class UnconditionalSuppressMessageAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
+        /// class, specifying the category of the tool and the identifier for an analysis rule.
+        /// </summary>
+        /// <param name="category">The category for the attribute.</param>
+        /// <param name="checkId">The identifier of the analysis rule the attribute applies to.</param>
+        public UnconditionalSuppressMessageAttribute(string category, string checkId)
+        {
+            Category = category;
+            CheckId = checkId;
+        }
+
+        /// <summary>
+        /// Gets the category identifying the classification of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Category"/> property describes the tool or tool analysis category
+        /// for which a message suppression attribute applies.
+        /// </remarks>
+        public string Category { get; }
+
+        /// <summary>
+        /// Gets the identifier of the analysis tool rule to be suppressed.
+        /// </summary>
+        /// <remarks>
+        /// Concatenated together, the <see cref="Category"/> and <see cref="CheckId"/>
+        /// properties form a unique check identifier.
+        /// </remarks>
+        public string CheckId { get; }
+
+        /// <summary>
+        /// Gets or sets the scope of the code that is relevant for the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The Scope property is an optional argument that specifies the metadata scope for which
+        /// the attribute is relevant.
+        /// </remarks>
+        public string Scope { get; set; }
+
+        /// <summary>
+        /// Gets or sets a fully qualified path that represents the target of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Target"/> property is an optional argument identifying the analysis target
+        /// of the attribute. An example value is "System.IO.Stream.ctor():System.Void".
+        /// Because it is fully qualified, it can be long, particularly for targets such as parameters.
+        /// The analysis tool user interface should be capable of automatically formatting the parameter.
+        /// </remarks>
+        public string Target { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional argument expanding on exclusion criteria.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="MessageId "/> property is an optional argument that specifies additional
+        /// exclusion where the literal metadata target is not sufficiently precise. For example,
+        /// the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
+        /// and it may be desirable to suppress a violation against a statement in the method that will
+        /// give a rule violation, but not against all statements in the method.
+        /// </remarks>
+        public string MessageId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the justification for suppressing the code analysis message.
+        /// </summary>
+        public string Justification { get; set; }
+    }
+}
+

--- a/src/NLog/Internal/FactoryHelper.cs
+++ b/src/NLog/Internal/FactoryHelper.cs
@@ -34,13 +34,14 @@
 namespace NLog.Internal
 {
     using System;
+    using NLog.Config;
 
     /// <summary>
     /// Object construction helper.
     /// </summary>
     internal static class FactoryHelper
     {
-        internal static object CreateInstance(Type t)
+        internal static readonly ConfigurationItemCreator CreateInstance = (t) =>
         {
             try
             {
@@ -50,6 +51,6 @@ namespace NLog.Internal
             {
                 throw new NLogConfigurationException($"Cannot access the constructor of type: {t.FullName}. Is the required permission granted?", exception);
             }
-        }
+        };
     }
 }

--- a/src/NLog/Internal/FactoryHelper.cs
+++ b/src/NLog/Internal/FactoryHelper.cs
@@ -39,18 +39,22 @@ namespace NLog.Internal
     /// <summary>
     /// Object construction helper.
     /// </summary>
+    [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
     internal static class FactoryHelper
     {
-        internal static readonly ConfigurationItemCreator CreateInstance = (t) =>
+        internal static readonly ConfigurationItemCreator CreateInstance = DefaultCreateInstance;
+
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming - Ignore since obsolete", "IL2067")]
+        private static object DefaultCreateInstance(Type type)
         {
             try
             {
-                return Activator.CreateInstance(t);
+                return Activator.CreateInstance(type);
             }
             catch (MissingMethodException exception)
             {
-                throw new NLogConfigurationException($"Cannot access the constructor of type: {t.FullName}. Is the required permission granted?", exception);
+                throw new NLogConfigurationException($"Cannot access the constructor of type: {type.FullName}. Is the required permission granted?", exception);
             }
-        };
+        }
     }
 }

--- a/src/NLog/Internal/Reflection/ObjectGraphScanner.cs
+++ b/src/NLog/Internal/Reflection/ObjectGraphScanner.cs
@@ -89,12 +89,6 @@ namespace NLog.Internal
                 return;
             }
 
-            var type = targetObject.GetType();
-            if (InternalLogger.IsTraceEnabled)
-            {
-                InternalLogger.Trace("{0}Scanning {1} '{2}'", new string(' ', level), type.Name, targetObject);
-            }
-
             if (targetObject is T t)
             {
                 result.Add(t);
@@ -102,6 +96,12 @@ namespace NLog.Internal
                 {
                     return;
                 }
+            }
+
+            var type = targetObject.GetType();
+            if (InternalLogger.IsTraceEnabled)
+            {
+                InternalLogger.Trace("{0}Scanning {1} '{2}'", new string(' ', level), type.Name, targetObject);
             }
 
             foreach (var configProp in PropertyHelper.GetAllConfigItemProperties(configFactory, type))

--- a/src/NLog/Internal/Reflection/ObjectGraphScanner.cs
+++ b/src/NLog/Internal/Reflection/ObjectGraphScanner.cs
@@ -53,10 +53,11 @@ namespace NLog.Internal
         /// from any of the given root objects when traversing the object graph over public properties.
         /// </summary>
         /// <typeparam name="T">Type of the objects to return.</typeparam>
+        /// <param name="configFactory">Configuration Reflection Helper</param>
         /// <param name="aggressiveSearch">Also search the properties of the wanted objects.</param>
         /// <param name="rootObjects">The root objects.</param>
         /// <returns>Ordered list of objects implementing T.</returns>
-        public static List<T> FindReachableObjects<T>(bool aggressiveSearch, params object[] rootObjects)
+        public static List<T> FindReachableObjects<T>(ConfigurationItemFactory configFactory, bool aggressiveSearch, params object[] rootObjects)
             where T : class
         {
             if (InternalLogger.IsTraceEnabled)
@@ -67,36 +68,34 @@ namespace NLog.Internal
             var visitedObjects = new HashSet<object>(SingleItemOptimizedHashSet<object>.ReferenceEqualityComparer.Default);
             foreach (var rootObject in rootObjects)
             {
-                if (IncludeConfigurationItem(rootObject))
+                if (PropertyHelper.IsConfigurationItemType(configFactory, rootObject?.GetType()))
                 {
-                    ScanProperties(aggressiveSearch, result, rootObject, 0, visitedObjects);
+                    ScanProperties(configFactory, aggressiveSearch, rootObject, result, 0, visitedObjects);
                 }
             }
             return result;
         }
 
-        /// <remarks>ISet is not there in .net35, so using HashSet</remarks>
-        private static void ScanProperties<T>(bool aggressiveSearch, List<T> result, object o, int level, HashSet<object> visitedObjects)
+        private static void ScanProperties<T>(ConfigurationItemFactory configFactory, bool aggressiveSearch, object targetObject, List<T> result, int level, HashSet<object> visitedObjects)
             where T : class
         {
-            if (o is null)
+            if (targetObject is null)
             {
                 return;
             }
 
-            if (visitedObjects.Contains(o))
+            if (visitedObjects.Contains(targetObject))
             {
                 return;
             }
 
-            var type = o.GetType();
-
+            var type = targetObject.GetType();
             if (InternalLogger.IsTraceEnabled)
             {
-                InternalLogger.Trace("{0}Scanning {1} '{2}'", new string(' ', level), type.Name, o);
+                InternalLogger.Trace("{0}Scanning {1} '{2}'", new string(' ', level), type.Name, targetObject);
             }
 
-            if (o is T t)
+            if (targetObject is T t)
             {
                 result.Add(t);
                 if (!aggressiveSearch)
@@ -105,68 +104,73 @@ namespace NLog.Internal
                 }
             }
 
-            foreach (var configProp in PropertyHelper.GetAllConfigItemProperties(type))
+            foreach (var configProp in PropertyHelper.GetAllConfigItemProperties(configFactory, type))
             {
                 if (string.IsNullOrEmpty(configProp.Key))
                     continue;   // Ignore default values
 
-                var propInfo = configProp.Value;
-                if (PropertyHelper.IsSimplePropertyType(propInfo.PropertyType))
+                if (!PropertyHelper.IsConfigurationItemType(configFactory, configProp.Value.PropertyType))
                     continue;
 
-                var propValue = propInfo.GetValue(o, null);
+                var propInfo = configProp.Value;
+                var propValue = propInfo.GetValue(targetObject, null);
                 if (propValue is null)
                     continue;
 
-                visitedObjects.Add(o);
-                ScanPropertyForObject(propInfo, propValue, aggressiveSearch, result, level, visitedObjects);
+                visitedObjects.Add(targetObject);
+                ScanPropertyForObject(configFactory, aggressiveSearch, propValue, propInfo, result, level, visitedObjects);
             }
         }
 
-        private static void ScanPropertyForObject<T>(PropertyInfo prop, object propValue, bool aggressiveSearch, List<T> result, int level, HashSet<object> visitedObjects) where T : class
+        private static void ScanPropertyForObject<T>(ConfigurationItemFactory configFactory, bool aggressiveSearch, object propValue, PropertyInfo prop, List<T> result, int level, HashSet<object> visitedObjects) where T : class
         {
             if (InternalLogger.IsTraceEnabled)
             {
-                InternalLogger.Trace("{0}Scanning Property {1} '{2}' {3}", new string(' ', level + 1), prop.Name, propValue.ToString(), prop.PropertyType.Namespace);
+                InternalLogger.Trace("{0}Scanning Property {1} '{2}' {3}", new string(' ', level + 1), prop.Name, propValue, prop.PropertyType);
             }
 
             if (propValue is IEnumerable enumerable)
             {
-                var list = ConvertEnumerableToList(enumerable);
-                if (list.Count > 0 && !visitedObjects.Contains(list))
+                var propListValue = ConvertEnumerableToList(enumerable, visitedObjects);
+                if (propListValue.Count > 0)
                 {
-                    visitedObjects.Add(list);
-                    ScanPropertiesList(list, aggressiveSearch, result, level + 1, visitedObjects);
+                    ScanPropertiesList(configFactory, aggressiveSearch, propListValue, result, level + 1, visitedObjects);
                 }
             }
             else
             {
-                // .NET native doesn't always allow reflection of System-types (Ex. Encoding)
-                if (IncludeConfigurationItem(propValue, prop.PropertyType))
-                {
-                    ScanProperties(aggressiveSearch, result, propValue, level + 1, visitedObjects);
-                }
+                ScanProperties(configFactory, aggressiveSearch, propValue, result, level + 1, visitedObjects);
             }
         }
 
-        private static void ScanPropertiesList<T>(IList list, bool aggressiveSearch, List<T> result, int level, HashSet<object> visitedObjects) where T : class
+        private static void ScanPropertiesList<T>(ConfigurationItemFactory configFactory, bool aggressiveSearch, IList list, List<T> result, int level, HashSet<object> visitedObjects) where T : class
         {
-            for (int i = 0; i < list.Count; i++)
+            var firstElement = list[0];
+            if (firstElement is null || PropertyHelper.IsConfigurationItemType(configFactory, firstElement.GetType()))
             {
-                var element = list[i];
-                if (IncludeConfigurationItem(element))
+                ScanProperties(configFactory, aggressiveSearch, firstElement, result, level, visitedObjects);
+
+                for (int i = 1; i < list.Count; i++)
                 {
-                    ScanProperties(aggressiveSearch, result, element, level, visitedObjects);
+                    var element = list[i];
+                    ScanProperties(configFactory, aggressiveSearch, element, result, level, visitedObjects);
                 }
             }
         }
 
-        private static IList ConvertEnumerableToList(IEnumerable enumerable)
+        private static IList ConvertEnumerableToList(IEnumerable enumerable, HashSet<object> visitedObjects)
         {
             if (enumerable is ICollection collection && collection.Count == 0)
             {
                 return ArrayHelper.Empty<object>();
             }
+
+            if (visitedObjects.Contains(enumerable))
+            {
+                return ArrayHelper.Empty<object>();
+            }
+
+            visitedObjects.Add(enumerable);
 
             if (enumerable is IList list)
             {
@@ -190,22 +194,6 @@ namespace NLog.Internal
             //new list to prevent: Collection was modified after the enumerator was instantiated.
             //note .Cast is tread-unsafe! But at least it isn't a ICollection / IList
             return enumerable.Cast<object>().ToList();
-        }
-
-        private static bool IncludeConfigurationItem(object item, Type propertyType = null)
-        {
-            propertyType = propertyType ?? item?.GetType();
-            if (propertyType is null)
-                return false;
-
-            if (PropertyHelper.IsConfigurationItemType(propertyType))
-                return true;
-
-            var itemType = item?.GetType();
-            if (itemType != null && itemType != propertyType && PropertyHelper.IsConfigurationItemType(itemType))
-                return true;
-
-            return false;
         }
     }
 }

--- a/src/NLog/Internal/Reflection/ReflectionHelpers.cs
+++ b/src/NLog/Internal/Reflection/ReflectionHelpers.cs
@@ -40,42 +40,12 @@ namespace NLog.Internal
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
-    using NLog.Common;
 
     /// <summary>
     /// Reflection helpers.
     /// </summary>
     internal static class ReflectionHelpers
     {
-        /// <summary>
-        /// Gets all usable exported types from the given assembly.
-        /// </summary>
-        /// <param name="assembly">Assembly to scan.</param>
-        /// <returns>Usable types from the given assembly.</returns>
-        /// <remarks>Types which cannot be loaded are skipped.</remarks>
-        public static Type[] SafeGetTypes(this Assembly assembly)
-        {
-            try
-            {
-                return assembly.GetTypes();
-            }
-            catch (ReflectionTypeLoadException typeLoadException)
-            {
-                var result = typeLoadException.Types?.Where(t => t != null)?.ToArray() ?? ArrayHelper.Empty<Type>();
-                InternalLogger.Warn(typeLoadException, "Loaded {0} valid types from Assembly: {1}", result.Length, assembly.FullName);
-                foreach (var ex in typeLoadException.LoaderExceptions ?? ArrayHelper.Empty<Exception>())
-                {
-                    InternalLogger.Warn(ex, "Type load exception.");
-                }
-                return result;
-            }
-            catch (Exception ex)
-            {
-                InternalLogger.Warn(ex, "Failed to load types from Assembly: {0}", assembly.FullName);
-                return ArrayHelper.Empty<Type>();
-            }
-        }
-
         /// <summary>
         /// Is this a static class?
         /// </summary>
@@ -319,7 +289,7 @@ namespace NLog.Internal
 
         public static bool IsValidPublicProperty(this PropertyInfo p)
         {
-            return p.CanRead && p.GetIndexParameters().Length == 0 && p.GetGetMethod() != null;
+            return p?.CanRead == true && p.GetIndexParameters().Length == 0 && p.GetGetMethod() != null;
         }
 
         public static object GetPropertyValue(this PropertyInfo p, object instance)

--- a/src/NLog/Internal/Reflection/ReflectionHelpers.cs
+++ b/src/NLog/Internal/Reflection/ReflectionHelpers.cs
@@ -289,7 +289,7 @@ namespace NLog.Internal
 
         public static bool IsValidPublicProperty(this PropertyInfo p)
         {
-            return p?.CanRead == true && p.GetIndexParameters().Length == 0 && p.GetGetMethod() != null;
+            return p != null && p.CanRead && p.GetIndexParameters().Length == 0 && p.GetGetMethod() != null;
         }
 
         public static object GetPropertyValue(this PropertyInfo p, object instance)

--- a/src/NLog/Internal/StackTraceUsageUtils.cs
+++ b/src/NLog/Internal/StackTraceUsageUtils.cs
@@ -154,6 +154,12 @@ namespace NLog.Internal
             return className;
         }
 
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming - Allow callsite logic", "IL2026")]
+        public static MethodBase GetStackMethod(StackFrame stackFrame)
+        {
+            return stackFrame?.GetMethod();
+        }
+
         /// <summary>
         /// Gets the fully qualified name of the class invoking the calling method, including the 
         /// namespace but not the assembly.    
@@ -209,7 +215,10 @@ namespace NLog.Internal
                 var stackTrace = new StackTrace(false);
                 className = GetClassFullName(stackTrace);
                 if (string.IsNullOrEmpty(className))
-                    className = stackFrame.GetMethod()?.Name ?? string.Empty;
+                {
+                    var method = StackTraceUsageUtils.GetStackMethod(stackFrame);
+                    className = method?.Name ?? string.Empty;
+                }                    
             }
             return className;
         }
@@ -234,7 +243,7 @@ namespace NLog.Internal
         /// <returns>Valid assembly, or null if assembly was internal</returns>
         public static Assembly LookupAssemblyFromStackFrame(StackFrame stackFrame)
         {
-            var method = stackFrame.GetMethod();
+            var method = StackTraceUsageUtils.GetStackMethod(stackFrame);
             if (method is null)
             {
                 return null;
@@ -267,7 +276,7 @@ namespace NLog.Internal
         /// <returns>Valid class name, or empty string if assembly was internal</returns>
         public static string LookupClassNameFromStackFrame(StackFrame stackFrame)
         {
-            var method = stackFrame.GetMethod();
+            var method = StackTraceUsageUtils.GetStackMethod(stackFrame);
             if (method != null && LookupAssemblyFromStackFrame(stackFrame) != null)
             {
                 string className = GetStackFrameMethodClassName(method, true, true, true);

--- a/src/NLog/LayoutRenderers/ApplicationEnvironment/GarbageCollectorInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ApplicationEnvironment/GarbageCollectorInfoLayoutRenderer.cs
@@ -31,8 +31,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if !MONO
-
 namespace NLog.LayoutRenderers
 {
     using System;
@@ -96,5 +94,3 @@ namespace NLog.LayoutRenderers
         }
     }
 }
-
-#endif

--- a/src/NLog/LayoutRenderers/CallSite/StackTraceLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSite/StackTraceLayoutRenderer.cs
@@ -175,8 +175,7 @@ namespace NLog.LayoutRenderers
             bool first = true;
             for (int i = 0; i < stackFrameList.Count; ++i)
             {
-                StackFrame f = stackFrameList[i];
-                var method = f.GetMethod();
+                var method = StackTraceUsageUtils.GetStackMethod(stackFrameList[i]);
                 if (method is null)
                 {
                     continue;   // Net Native can have StackFrames without managed methods
@@ -211,8 +210,7 @@ namespace NLog.LayoutRenderers
             bool first = true;
             for (int i = 0; i < stackFrameList.Count; ++i)
             {
-                StackFrame f = stackFrameList[i];
-                var method = f.GetMethod();
+                var method = StackTraceUsageUtils.GetStackMethod(stackFrameList[i]);
                 if (method is null)
                 {
                     continue;   // Net Native can have StackFrames without managed methods

--- a/src/NLog/LayoutRenderers/Directories/NLogDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Directories/NLogDirLayoutRenderer.cs
@@ -90,9 +90,15 @@ namespace NLog.LayoutRenderers
         {
             var nlogAssembly = typeof(LogFactory).GetAssembly();
             if (!string.IsNullOrEmpty(nlogAssembly.Location))
+            {
                 return Path.GetDirectoryName(nlogAssembly.Location);
+            }
             else
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
                 return AssemblyHelpers.GetAssemblyFileLocation(nlogAssembly) ?? string.Empty;
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
         }
     }
 }

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -364,6 +364,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> to append the rendered data to.</param>
         /// <param name="ex">The Exception whose method name should be appended.</param>        
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming - Allow callsite logic", "IL2026")]
         protected virtual void AppendMethod(StringBuilder sb, Exception ex)
         {
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -257,7 +257,7 @@ namespace NLog.LayoutRenderers
         {
             Guard.ThrowIfNull(layoutRendererType);
             Guard.ThrowIfNullOrEmpty(name);
-            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterDefinition(name, layoutRendererType);
+            ConfigurationItemFactory.Default.GetLayoutRendererFactory().RegisterDefinition(name, layoutRendererType);
         }
 
         /// <summary>
@@ -293,7 +293,7 @@ namespace NLog.LayoutRenderers
         public static void Register(FuncLayoutRenderer layoutRenderer)
         {
             Guard.ThrowIfNull(layoutRenderer);
-            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterFuncLayout(layoutRenderer.LayoutRendererName, layoutRenderer);
+            ConfigurationItemFactory.Default.GetLayoutRendererFactory().RegisterFuncLayout(layoutRenderer.LayoutRendererName, layoutRenderer);
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -34,6 +34,7 @@
 namespace NLog.LayoutRenderers
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Text;
     using NLog.Common;
@@ -127,7 +128,7 @@ namespace NLog.LayoutRenderers
         {
             try
             {
-                PropertyHelper.CheckRequiredParameters(this);
+                PropertyHelper.CheckRequiredParameters(ConfigurationItemFactory.Default, this);
                 InitializeLayoutRenderer();
             }
             catch (Exception ex)
@@ -237,7 +238,8 @@ namespace NLog.LayoutRenderers
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
         /// <typeparam name="T">Type of the layout renderer.</typeparam>
         /// <param name="name">The layout-renderer type-alias for use in NLog configuration - without '${ }'</param>
-        public static void Register<T>(string name)
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
+        public static void Register<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] T>(string name)
             where T : LayoutRenderer
         {
             var layoutRendererType = typeof(T);
@@ -250,13 +252,12 @@ namespace NLog.LayoutRenderers
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
         /// <param name="layoutRendererType"> Type of the layout renderer.</param>
         /// <param name="name">The layout-renderer type-alias for use in NLog configuration - without '${ }'</param>
-        public static void Register(string name, Type layoutRendererType)
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
+        public static void Register(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] Type layoutRendererType)
         {
             Guard.ThrowIfNull(layoutRendererType);
             Guard.ThrowIfNullOrEmpty(name);
-
-            ConfigurationItemFactory.Default.LayoutRenderers
-                .RegisterDefinition(name, layoutRendererType);
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterDefinition(name, layoutRendererType);
         }
 
         /// <summary>
@@ -264,6 +265,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <param name="name">The layout-renderer type-alias for use in NLog configuration - without '${ }'</param>
         /// <param name="func">Callback that returns the value for the layout renderer.</param>
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
         public static void Register(string name, Func<LogEventInfo, object> func)
         {
             Guard.ThrowIfNull(func);
@@ -275,6 +277,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <param name="name">The layout-renderer type-alias for use in NLog configuration - without '${ }'</param>
         /// <param name="func">Callback that returns the value for the layout renderer.</param>
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
         public static void Register(string name, Func<LogEventInfo, LoggingConfiguration, object> func)
         {
             Guard.ThrowIfNull(func);
@@ -286,10 +289,11 @@ namespace NLog.LayoutRenderers
         /// Register a custom layout renderer with a callback function <paramref name="layoutRenderer"/>. The callback receives the logEvent and the current configuration.
         /// </summary>
         /// <param name="layoutRenderer">Renderer with callback func</param>
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
         public static void Register(FuncLayoutRenderer layoutRenderer)
         {
             Guard.ThrowIfNull(layoutRenderer);
-            ConfigurationItemFactory.Default.GetLayoutRenderers().RegisterFuncLayout(layoutRenderer.LayoutRendererName, layoutRenderer);
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterFuncLayout(layoutRenderer.LayoutRendererName, layoutRenderer);
         }
 
         /// <summary>

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -442,7 +442,7 @@ namespace NLog.Layouts
         [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
         public static void Register(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] Type layoutType)
         {
-            ConfigurationItemFactory.Default.LayoutFactory.RegisterDefinition(name, layoutType);
+            ConfigurationItemFactory.Default.GetLayoutFactory().RegisterDefinition(name, layoutType);
         }
 
         /// <summary>

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -36,13 +36,14 @@ namespace NLog.Layouts
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Text;
+    using JetBrains.Annotations;
     using NLog.Config;
     using NLog.Internal;
     using NLog.Common;
     using NLog.Targets;
-    using JetBrains.Annotations;
 
     /// <summary>
     /// Abstract interface that layouts must implement.
@@ -334,7 +335,7 @@ namespace NLog.Layouts
 
                     _scannedForObjects = false;
 
-                    PropertyHelper.CheckRequiredParameters(this);
+                    PropertyHelper.CheckRequiredParameters(ConfigurationItemFactory.Default, this);
 
                     InitializeLayout();
 
@@ -353,7 +354,7 @@ namespace NLog.Layouts
 
         internal void PerformObjectScanning()
         {
-            var objectGraphScannerList = ObjectGraphScanner.FindReachableObjects<IRenderable>(true, this);
+            var objectGraphScannerList = ObjectGraphScanner.FindReachableObjects<IRenderable>(ConfigurationItemFactory.Default, true, this);
             var objectGraphTypes = new HashSet<Type>(objectGraphScannerList.Select(o => o.GetType()));
             objectGraphTypes.Remove(typeof(SimpleLayout));
             objectGraphTypes.Remove(typeof(NLog.LayoutRenderers.LiteralLayoutRenderer));
@@ -424,7 +425,8 @@ namespace NLog.Layouts
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
         /// <typeparam name="T"> Type of the Layout.</typeparam>
         /// <param name="name"> Name of the Layout.</param>
-        public static void Register<T>(string name)
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
+        public static void Register<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] T>(string name)
             where T : Layout
         {
             var layoutRendererType = typeof(T);
@@ -437,10 +439,10 @@ namespace NLog.Layouts
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
         /// <param name="layoutType"> Type of the Layout.</param>
         /// <param name="name"> Name of the Layout.</param>
-        public static void Register(string name, Type layoutType)
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
+        public static void Register(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] Type layoutType)
         {
-            ConfigurationItemFactory.Default.Layouts
-                .RegisterDefinition(name, layoutType);
+            ConfigurationItemFactory.Default.LayoutFactory.RegisterDefinition(name, layoutType);
         }
 
         /// <summary>

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -122,7 +122,7 @@ namespace NLog.Layouts
                     AddLiteral(literalBuf, result);
 
                     LayoutRenderer newLayoutRenderer = ParseLayoutRenderer(configurationItemFactory, sr, throwConfigExceptions);
-                    if (CanBeConvertedToLiteral(newLayoutRenderer))
+                    if (CanBeConvertedToLiteral(configurationItemFactory, newLayoutRenderer))
                     {
                         newLayoutRenderer = ConvertToLiteral(newLayoutRenderer);
                     }
@@ -446,10 +446,10 @@ namespace NLog.Layouts
                     parameterName = parameterName.Trim();
                     LayoutRenderer parameterTarget = layoutRenderer;
 
-                    if (!PropertyHelper.TryGetPropertyInfo(layoutRenderer, parameterName, out var propertyInfo))
+                    if (!PropertyHelper.TryGetPropertyInfo(configurationItemFactory, layoutRenderer, parameterName, out var propertyInfo))
                     {
                         parameterTarget = LookupAmbientProperty(parameterName, configurationItemFactory, ref wrappers, ref orderedWrappers);
-                        if (parameterTarget is null || !PropertyHelper.TryGetPropertyInfo(parameterTarget, parameterName, out propertyInfo))
+                        if (parameterTarget is null || !PropertyHelper.TryGetPropertyInfo(configurationItemFactory, parameterTarget, parameterName, out propertyInfo))
                         {
                             parameterTarget = layoutRenderer;
                             propertyInfo = null;
@@ -561,7 +561,7 @@ namespace NLog.Layouts
 
         private static LayoutRenderer LookupAmbientProperty(string propertyName, ConfigurationItemFactory configurationItemFactory, ref Dictionary<Type, LayoutRenderer> wrappers, ref List<LayoutRenderer> orderedWrappers)
         {
-            if (configurationItemFactory.AmbientProperties.TryCreateInstance(propertyName, out var wrapperInstance))
+            if (configurationItemFactory.AmbientRendererFactory.TryCreateInstance(propertyName, out var wrapperInstance))
             {
                 wrappers = wrappers ?? new Dictionary<Type, LayoutRenderer>();
                 orderedWrappers = orderedWrappers ?? new List<LayoutRenderer>();
@@ -583,7 +583,7 @@ namespace NLog.Layouts
             LayoutRenderer layoutRenderer;
             try
             {
-                layoutRenderer = configurationItemFactory.LayoutRenderers.CreateInstance(typeName);
+                layoutRenderer = configurationItemFactory.LayoutRendererFactory.CreateInstance(typeName);
             }
             catch (Exception ex)
             {
@@ -603,7 +603,7 @@ namespace NLog.Layouts
         {
             // what we've just read is not a parameterName, but a value
             // assign it to a default property (denoted by empty string)
-            if (PropertyHelper.TryGetPropertyInfo(layoutRenderer, string.Empty, out var propertyInfo))
+            if (PropertyHelper.TryGetPropertyInfo(configurationItemFactory, layoutRenderer, string.Empty, out var propertyInfo))
             {
                 if (!typeof(Layout).IsAssignableFrom(propertyInfo.PropertyType) && value.IndexOf('\\') >= 0)
                 {
@@ -631,7 +631,7 @@ namespace NLog.Layouts
             {
                 var newRenderer = (WrapperLayoutRendererBase)orderedWrappers[i];
                 InternalLogger.Trace("Wrapping {0} with {1}", lr.GetType(), newRenderer.GetType());
-                if (CanBeConvertedToLiteral(lr))
+                if (CanBeConvertedToLiteral(configurationItemFactory, lr))
                 {
                     lr = ConvertToLiteral(lr);
                 }
@@ -643,9 +643,9 @@ namespace NLog.Layouts
             return lr;
         }
 
-        private static bool CanBeConvertedToLiteral(LayoutRenderer lr)
+        private static bool CanBeConvertedToLiteral(ConfigurationItemFactory configurationItemFactory, LayoutRenderer lr)
         {
-            foreach (IRenderable renderable in ObjectGraphScanner.FindReachableObjects<IRenderable>(true, lr))
+            foreach (IRenderable renderable in ObjectGraphScanner.FindReachableObjects<IRenderable>(configurationItemFactory, true, lr))
             {
                 var renderType = renderable.GetType();
                 if (renderType == typeof(SimpleLayout))

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -561,15 +561,16 @@ namespace NLog.Layouts
 
         private static LayoutRenderer LookupAmbientProperty(string propertyName, ConfigurationItemFactory configurationItemFactory, ref Dictionary<Type, LayoutRenderer> wrappers, ref List<LayoutRenderer> orderedWrappers)
         {
-            if (configurationItemFactory.AmbientProperties.TryGetDefinition(propertyName, out var wrapperType))
+            if (configurationItemFactory.AmbientProperties.TryCreateInstance(propertyName, out var wrapperInstance))
             {
                 wrappers = wrappers ?? new Dictionary<Type, LayoutRenderer>();
                 orderedWrappers = orderedWrappers ?? new List<LayoutRenderer>();
+                var wrapperType = wrapperInstance.GetType();
                 if (!wrappers.TryGetValue(wrapperType, out var wrapperRenderer))
                 {
-                    wrapperRenderer = configurationItemFactory.AmbientProperties.CreateInstance(propertyName);
-                    wrappers[wrapperType] = wrapperRenderer;
-                    orderedWrappers.Add(wrapperRenderer);
+                    wrappers[wrapperType] = wrapperInstance;
+                    orderedWrappers.Add(wrapperInstance);
+                    wrapperRenderer = wrapperInstance;
                 }
                 return wrapperRenderer;
             }

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -282,8 +282,7 @@ namespace NLog.Layouts
 
         private string RenderStringValue(LogEventInfo logEvent, StringBuilder stringBuilder, string previousStringValue)
         {
-            SimpleLayout simpleLayout = _innerLayout as SimpleLayout;
-            if (simpleLayout?.IsSimpleStringText == true)
+            if (_innerLayout is SimpleLayout simpleLayout && simpleLayout.IsSimpleStringText)
             {
                 return simpleLayout.Render(logEvent);
             }

--- a/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
+++ b/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
@@ -250,7 +250,7 @@ namespace NLog.Layouts
 
         private object CreateTypedDefaultValue()
         {
-            if (_typedDefaultValue?.IsFixed == true)
+            if (_typedDefaultValue != null && _typedDefaultValue.IsFixed)
                 return _typedDefaultValue.FixedObjectValue;
 
             if (_defaultValue is null)

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -36,6 +36,7 @@ namespace NLog
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;
@@ -79,6 +80,7 @@ namespace NLog
         /// <summary>
         /// Occurs when logging <see cref="Configuration" /> gets reloaded.
         /// </summary>
+        [Obsolete("Replaced by ConfigurationChanged. Marked obsolete on NLog 5.2")]
         public static event EventHandler<LoggingConfigurationReloadedEventArgs> ConfigurationReloaded
         {
             add => factory.ConfigurationReloaded += value;
@@ -162,6 +164,7 @@ namespace NLog
         /// </summary>
         /// <param name="configFile">Configuration file to be read</param>
         /// <returns>LogFactory instance for fluent interface</returns>
+        [Obsolete("Replaced by LogManager.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         public static LogFactory LoadConfiguration(string configFile)
         {
             factory.LoadConfiguration(configFile);
@@ -228,7 +231,8 @@ namespace NLog
         /// Make sure you're not doing this in a loop.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static Logger GetCurrentClassLogger(Type loggerType)
+        [Obsolete("Replaced by LogFactory.GetCurrentClassLogger<T>(). Marked obsolete on NLog 5.2")]
+        public static Logger GetCurrentClassLogger([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type loggerType)
         {
             return factory.GetLogger(StackTraceUsageUtils.GetClassFullName(), loggerType);
         }
@@ -261,7 +265,8 @@ namespace NLog
         /// <param name="loggerType">The logger class. This class must inherit from <see cref="Logger" />.</param>
         /// <returns>The logger of type <paramref name="loggerType"/>. Multiple calls to <c>GetLogger</c> with the same argument aren't guaranteed to return the same logger reference.</returns>
         /// <remarks>The generic way for this method is <see cref="NLog.LogFactory{loggerType}.GetLogger(string)"/></remarks>
-        public static Logger GetLogger(string name, Type loggerType)
+        [Obsolete("Replaced by LogFactory.GetLogger<T>(). Marked obsolete on NLog 5.2")]
+        public static Logger GetLogger(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type loggerType)
         {
             return factory.GetLogger(name, loggerType);
         }

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -810,7 +810,7 @@ namespace NLog
 
         private Logger CreateChildLogger()
         {
-            Logger newLogger = Factory.CreateNewLogger(GetType()) ?? new Logger();
+            Logger newLogger = (Logger)MemberwiseClone();
             newLogger.Initialize(Name, _targetsByLevel, Factory);
             newLogger._contextProperties = CreateContextPropertiesDictionary(_contextProperties);
             newLogger._contextLogger = _contextLogger;  // Use the GetTargetsForLevel() of the parent Logger

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -58,6 +58,9 @@ For all config options and platform support, check https://nlog-project.org/conf
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsTrimmable>true</IsTrimmable>
+    <TrimMode>copyused</TrimMode>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
@@ -170,6 +173,10 @@ For all config options and platform support, check https://nlog-project.org/conf
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>InternalLogger-generated.cs</LastGenOutput>
     </None>
+    <None Update="Config\AssemblyExtensionTypes.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AssemblyExtensionTypes.cs</LastGenOutput>
+    </None>
     <None Update="Logger-generated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Logger-generated.cs</LastGenOutput>
@@ -185,6 +192,11 @@ For all config options and platform support, check https://nlog-project.org/conf
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>InternalLogger-generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Config\AssemblyExtensionTypes.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AssemblyExtensionTypes.tt</DependentUpon>
     </Compile>
     <Compile Update="Logger-generated.cs">
       <DesignTime>True</DesignTime>

--- a/src/NLog/SetupBuilderExtensions.cs
+++ b/src/NLog/SetupBuilderExtensions.cs
@@ -154,7 +154,28 @@ namespace NLog
         /// <param name="optional">Whether to allow application to run when NLog config is not available</param>
         public static ISetupBuilder LoadConfigurationFromFile(this ISetupBuilder setupBuilder, IEnumerable<string> candidateFilePaths, bool optional = true)
         {
-            setupBuilder.LogFactory.SetCandidateConfigFilePaths(candidateFilePaths);
+#pragma warning disable CS0618 // Type or member is obsolete
+            if (candidateFilePaths is null)
+            {
+                setupBuilder.LogFactory.ResetCandidateConfigFilePath();
+            }
+            else if (optional)
+            {
+                var originalFilePaths = setupBuilder.LogFactory.GetCandidateConfigFilePaths();
+                var uniqueFilePaths = new HashSet<string>(candidateFilePaths, StringComparer.OrdinalIgnoreCase);
+                var orderedFilePaths = new List<string>(candidateFilePaths);
+                foreach (var filePath in originalFilePaths)
+                {
+                    if (uniqueFilePaths.Add(filePath))
+                        orderedFilePaths.Add(filePath);
+                }
+                setupBuilder.LogFactory.SetCandidateConfigFilePaths(orderedFilePaths);
+            }
+            else
+            {
+                setupBuilder.LogFactory.SetCandidateConfigFilePaths(candidateFilePaths);
+            }
+#pragma warning restore CS0618 // Type or member is obsolete
             return setupBuilder.LoadConfigurationFromFile(default(string), optional);
         }
 

--- a/src/NLog/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog/SetupExtensionsBuilderExtensions.cs
@@ -138,7 +138,7 @@ namespace NLog
                     typeAlias += "Wrapper";
                 }
             }
-            ConfigurationItemFactory.Default.TargetFactory.RegisterType<T>(typeAlias, factory);
+            ConfigurationItemFactory.Default.GetTargetFactory().RegisterType<T>(typeAlias, factory);
             return setupBuilder;
         }
 
@@ -154,7 +154,7 @@ namespace NLog
                 throw new ArgumentException("Missing NLog Target type-alias", nameof(name));
             if (!typeof(Target).IsAssignableFrom(targetType))
                 throw new ArgumentException("Not of type NLog Target", nameof(targetType));
-            ConfigurationItemFactory.Default.TargetFactory.RegisterDefinition(name, targetType);
+            ConfigurationItemFactory.Default.GetTargetFactory().RegisterDefinition(name, targetType);
             return setupBuilder;
         }
 
@@ -181,7 +181,7 @@ namespace NLog
             where T : Layout
         {
             typeAlias = string.IsNullOrEmpty(typeAlias) ? ResolveTypeAlias<T, LayoutAttribute>(ArrayHelper.Empty<string>()) : typeAlias;
-            ConfigurationItemFactory.Default.LayoutFactory.RegisterType<T>(typeAlias, factory);
+            ConfigurationItemFactory.Default.GetLayoutFactory().RegisterType<T>(typeAlias, factory);
             return setupBuilder;
         }
 
@@ -197,7 +197,7 @@ namespace NLog
                 throw new ArgumentException("Missing NLog Layout type-alias", nameof(typeAlias));
             if (!typeof(Layout).IsAssignableFrom(layoutType))
                 throw new ArgumentException("Not of type NLog Layout", nameof(layoutType));
-            ConfigurationItemFactory.Default.LayoutFactory.RegisterDefinition(typeAlias, layoutType);
+            ConfigurationItemFactory.Default.GetLayoutFactory().RegisterDefinition(typeAlias, layoutType);
             return setupBuilder;
         }
 
@@ -224,7 +224,7 @@ namespace NLog
             where T : LayoutRenderer
         {
             typeAlias = string.IsNullOrEmpty(typeAlias) ? ResolveTypeAlias<T, LayoutRendererAttribute>("LayoutRendererWrapper", "LayoutRenderer") : typeAlias;
-            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType<T>(typeAlias, factory);
+            ConfigurationItemFactory.Default.GetLayoutRendererFactory().RegisterType<T>(typeAlias, factory);
             return setupBuilder;
         }
 
@@ -265,7 +265,7 @@ namespace NLog
                 throw new ArgumentException("Missing NLog LayoutRenderer type-alias", nameof(name));
             if (!typeof(LayoutRenderer).IsAssignableFrom(layoutRendererType))
                 throw new ArgumentException("Not of type NLog LayoutRenderer", nameof(layoutRendererType));
-            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterDefinition(name, layoutRendererType);
+            ConfigurationItemFactory.Default.GetLayoutRendererFactory().RegisterDefinition(name, layoutRendererType);
             return setupBuilder;
         }
 
@@ -313,7 +313,17 @@ namespace NLog
         public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder setupBuilder, string name, Func<LogEventInfo, LoggingConfiguration, object> layoutMethod, LayoutRenderOptions options)
         {
             FuncLayoutRenderer layoutRenderer = Layout.CreateFuncLayoutRenderer(layoutMethod, options, name);
-            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterFuncLayout(name, layoutRenderer);
+            return setupBuilder.RegisterLayoutRenderer(layoutRenderer);
+        }
+
+        /// <summary>
+        /// Register a custom NLog LayoutRenderer with a callback function
+        /// </summary>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
+        /// <param name="layoutRenderer">LayoutRenderer instance with type-alias and callback-method.</param>
+        public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder setupBuilder, FuncLayoutRenderer layoutRenderer)
+        {
+            ConfigurationItemFactory.Default.GetLayoutRendererFactory().RegisterFuncLayout(layoutRenderer.LayoutRendererName, layoutRenderer);
             return setupBuilder;
         }
 

--- a/src/NLog/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog/SetupExtensionsBuilderExtensions.cs
@@ -99,11 +99,33 @@ namespace NLog
         /// <typeparam name="T">Type of the Target.</typeparam>
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="name">The target type-alias for use in NLog configuration. Will extract from class-attribute when unassigned.</param>
-        public static ISetupExtensionsBuilder RegisterTarget<T>(this ISetupExtensionsBuilder setupBuilder, string name = null) where T : Target
+        public static ISetupExtensionsBuilder RegisterTarget<T>(this ISetupExtensionsBuilder setupBuilder, string name = null)
+            where T : Target, new()
         {
-            var targetType = typeof(T);
-            name = string.IsNullOrEmpty(name) ? (targetType.GetFirstCustomAttribute<TargetAttribute>()?.Name ?? typeof(T).Name) : name;
-            return RegisterTarget(setupBuilder, name, targetType);
+            return RegisterTarget<T>(setupBuilder, () => new T(), name);
+        }
+
+        /// <summary>
+        /// Register a custom NLog Target.
+        /// </summary>
+        /// <typeparam name="T">Type of the Target.</typeparam>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
+        /// <param name="factory">The factory method for creating instance of NLog Target</param>
+        /// <param name="typeAlias">The target type-alias for use in NLog configuration. Will extract from class-attribute when unassigned.</param>
+        public static ISetupExtensionsBuilder RegisterTarget<T>(this ISetupExtensionsBuilder setupBuilder, Func<T> factory, string typeAlias = null)
+            where T : Target
+        {
+            typeAlias = string.IsNullOrEmpty(typeAlias) ? typeof(T).GetFirstCustomAttribute<TargetAttribute>()?.Name : typeAlias;
+            if (string.IsNullOrEmpty(typeAlias))
+            {
+                typeAlias = ResolveTypeAlias<T>("TargetWrapper", "Target");
+                if (typeof(NLog.Targets.Wrappers.WrapperTargetBase).IsAssignableFrom(typeof(T)) && !typeAlias.EndsWith("Wrapper", StringComparison.OrdinalIgnoreCase))
+                {
+                    typeAlias += "Wrapper";
+                }
+            }
+            ConfigurationItemFactory.Default.GetTargetFactory().RegisterDefinition<T>(typeAlias, () => factory(), string.Empty);
+            return setupBuilder;
         }
 
         /// <summary>
@@ -129,11 +151,24 @@ namespace NLog
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="typeAlias">The layout type-alias for use in NLog configuration. Will extract from class-attribute when unassigned.</param>
         public static ISetupExtensionsBuilder RegisterLayout<T>(this ISetupExtensionsBuilder setupBuilder, string typeAlias = null)
+            where T : Layout, new()
+        {
+            return RegisterLayout<T>(setupBuilder, () => new T(), typeAlias);
+        }
+
+        /// <summary>
+        /// Register a custom NLog Layout.
+        /// </summary>
+        /// <typeparam name="T">Type of the layout renderer.</typeparam>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
+        /// <param name="factory">The factory method for creating instance of NLog Layout</param>
+        /// <param name="typeAlias">The layout type-alias for use in NLog configuration. Will extract from class-attribute when unassigned.</param>
+        public static ISetupExtensionsBuilder RegisterLayout<T>(this ISetupExtensionsBuilder setupBuilder, Func<T> factory, string typeAlias = null)
             where T : Layout
         {
-            var layoutRendererType = typeof(T);
-            typeAlias = string.IsNullOrEmpty(typeAlias) ? (layoutRendererType.GetFirstCustomAttribute<LayoutAttribute>()?.Name ?? typeof(T).Name) : typeAlias;
-            return RegisterLayout(setupBuilder, typeAlias, layoutRendererType);
+            typeAlias = string.IsNullOrEmpty(typeAlias) ? ResolveTypeAlias<T, LayoutAttribute>(ArrayHelper.Empty<string>()) : typeAlias;
+            ConfigurationItemFactory.Default.GetLayoutFactory().RegisterDefinition<T>(typeAlias, () => factory(), string.Empty);
+            return setupBuilder;
         }
 
         /// <summary>
@@ -159,11 +194,49 @@ namespace NLog
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="name">The layout-renderer type-alias for use in NLog configuration - without '${ }'. Will extract from class-attribute when unassigned.</param>
         public static ISetupExtensionsBuilder RegisterLayoutRenderer<T>(this ISetupExtensionsBuilder setupBuilder, string name = null)
+            where T : LayoutRenderer, new()
+        {
+            return RegisterLayoutRenderer<T>(setupBuilder, () => new T(), name);
+        }
+
+        /// <summary>
+        /// Register a custom NLog LayoutRenderer.
+        /// </summary>
+        /// <typeparam name="T">Type of the layout renderer.</typeparam>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
+        /// <param name="factory">The factory method for creating instance of NLog LayoutRenderer</param>
+        /// <param name="typeAlias">The layout-renderer type-alias for use in NLog configuration - without '${ }'. Will extract from class-attribute when unassigned.</param>
+        public static ISetupExtensionsBuilder RegisterLayoutRenderer<T>(this ISetupExtensionsBuilder setupBuilder, Func<T> factory, string typeAlias = null)
             where T : LayoutRenderer
         {
-            var layoutRendererType = typeof(T);
-            name = string.IsNullOrEmpty(name) ? (layoutRendererType.GetFirstCustomAttribute<LayoutRendererAttribute>()?.Name ?? typeof(T).Name) : name;
-            return RegisterLayoutRenderer(setupBuilder, name, layoutRendererType);
+            typeAlias = string.IsNullOrEmpty(typeAlias) ? ResolveTypeAlias<T, LayoutRendererAttribute>("LayoutRendererWrapper", "LayoutRenderer") : typeAlias;
+            ConfigurationItemFactory.Default.GetLayoutRenderers().RegisterDefinition<T>(typeAlias, () => factory(), string.Empty);
+            return setupBuilder;
+        }
+
+        private static string ResolveTypeAlias<T, TNameAttribute>(params string[] trimEndings) where TNameAttribute : NameBaseAttribute
+        {
+            var typeAlias = typeof(T).GetFirstCustomAttribute<TNameAttribute>()?.Name;
+            if (!string.IsNullOrEmpty(typeAlias))
+                return typeAlias;
+
+            return ResolveTypeAlias<T>(trimEndings);
+        }
+
+        private static string ResolveTypeAlias<T>(params string[] trimEndings)
+        {
+            var typeAlias = typeof(T).Name;
+
+            foreach (var ending in trimEndings)
+            {
+                int endingPosition = typeAlias.IndexOf(ending, StringComparison.OrdinalIgnoreCase);
+                if (endingPosition > 0)
+                {
+                    return typeAlias.Substring(endingPosition);
+                }
+            }
+
+            return typeAlias;
         }
 
         /// <summary>

--- a/src/NLog/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog/SetupExtensionsBuilderExtensions.cs
@@ -41,6 +41,7 @@ namespace NLog
     using NLog.Layouts;
     using NLog.LayoutRenderers;
     using NLog.Targets;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
     /// Extension methods to setup NLog extensions, so they are known when loading NLog LoggingConfiguration
@@ -70,7 +71,7 @@ namespace NLog
         /// </remarks>
         public static ISetupExtensionsBuilder AutoLoadExtensions(this ISetupExtensionsBuilder setupBuilder)
         {
-            ConfigurationItemFactory.ScanForAutoLoadExtensions(setupBuilder.LogFactory);
+            ConfigurationItemFactory.Default.AssemblyLoader.ScanForAutoLoadExtensions(ConfigurationItemFactory.Default);
             return setupBuilder;
         }
 
@@ -79,7 +80,9 @@ namespace NLog
         /// </summary>
         public static ISetupExtensionsBuilder RegisterAssembly(this ISetupExtensionsBuilder setupBuilder, Assembly assembly)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             ConfigurationItemFactory.Default.RegisterItemsFromAssembly(assembly);
+#pragma warning restore CS0618 // Type or member is obsolete
             return setupBuilder;
         }
 
@@ -88,8 +91,19 @@ namespace NLog
         /// </summary>
         public static ISetupExtensionsBuilder RegisterAssembly(this ISetupExtensionsBuilder setupBuilder, string assemblyName)
         {
-            Assembly assembly = AssemblyHelpers.LoadFromName(assemblyName);
-            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(assembly);
+            ConfigurationItemFactory.Default.AssemblyLoader.LoadAssemblyFromName(ConfigurationItemFactory.Default, assemblyName, string.Empty);
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Register a custom NLog Configuration Type.
+        /// </summary>
+        /// <typeparam name="T">Type of the NLog configuration item</typeparam>
+        /// <param name="setupBuilder">Fluent interface parameter.</param>
+        public static ISetupExtensionsBuilder RegisterType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] T>(this ISetupExtensionsBuilder setupBuilder)
+            where T : class, new()
+        {
+            ConfigurationItemFactory.Default.RegisterType<T>();
             return setupBuilder;
         }
 
@@ -99,7 +113,7 @@ namespace NLog
         /// <typeparam name="T">Type of the Target.</typeparam>
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="name">The target type-alias for use in NLog configuration. Will extract from class-attribute when unassigned.</param>
-        public static ISetupExtensionsBuilder RegisterTarget<T>(this ISetupExtensionsBuilder setupBuilder, string name = null)
+        public static ISetupExtensionsBuilder RegisterTarget<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] T>(this ISetupExtensionsBuilder setupBuilder, string name = null)
             where T : Target, new()
         {
             return RegisterTarget<T>(setupBuilder, () => new T(), name);
@@ -112,7 +126,7 @@ namespace NLog
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="factory">The factory method for creating instance of NLog Target</param>
         /// <param name="typeAlias">The target type-alias for use in NLog configuration. Will extract from class-attribute when unassigned.</param>
-        public static ISetupExtensionsBuilder RegisterTarget<T>(this ISetupExtensionsBuilder setupBuilder, Func<T> factory, string typeAlias = null)
+        public static ISetupExtensionsBuilder RegisterTarget<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] T>(this ISetupExtensionsBuilder setupBuilder, Func<T> factory, string typeAlias = null)
             where T : Target
         {
             typeAlias = string.IsNullOrEmpty(typeAlias) ? typeof(T).GetFirstCustomAttribute<TargetAttribute>()?.Name : typeAlias;
@@ -124,7 +138,7 @@ namespace NLog
                     typeAlias += "Wrapper";
                 }
             }
-            ConfigurationItemFactory.Default.GetTargetFactory().RegisterDefinition<T>(typeAlias, () => factory(), string.Empty);
+            ConfigurationItemFactory.Default.TargetFactory.RegisterType<T>(typeAlias, factory);
             return setupBuilder;
         }
 
@@ -134,13 +148,13 @@ namespace NLog
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="name">Type name of the Target</param>
         /// <param name="targetType">The target type-alias for use in NLog configuration</param>
-        public static ISetupExtensionsBuilder RegisterTarget(this ISetupExtensionsBuilder setupBuilder, string name, Type targetType)
+        public static ISetupExtensionsBuilder RegisterTarget(this ISetupExtensionsBuilder setupBuilder, string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] Type targetType)
         {
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentException("Missing NLog Target type-alias", nameof(name));
             if (!typeof(Target).IsAssignableFrom(targetType))
                 throw new ArgumentException("Not of type NLog Target", nameof(targetType));
-            ConfigurationItemFactory.Default.Targets.RegisterDefinition(name, targetType);
+            ConfigurationItemFactory.Default.TargetFactory.RegisterDefinition(name, targetType);
             return setupBuilder;
         }
 
@@ -150,7 +164,7 @@ namespace NLog
         /// <typeparam name="T">Type of the layout renderer.</typeparam>
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="typeAlias">The layout type-alias for use in NLog configuration. Will extract from class-attribute when unassigned.</param>
-        public static ISetupExtensionsBuilder RegisterLayout<T>(this ISetupExtensionsBuilder setupBuilder, string typeAlias = null)
+        public static ISetupExtensionsBuilder RegisterLayout<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] T>(this ISetupExtensionsBuilder setupBuilder, string typeAlias = null)
             where T : Layout, new()
         {
             return RegisterLayout<T>(setupBuilder, () => new T(), typeAlias);
@@ -163,11 +177,11 @@ namespace NLog
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="factory">The factory method for creating instance of NLog Layout</param>
         /// <param name="typeAlias">The layout type-alias for use in NLog configuration. Will extract from class-attribute when unassigned.</param>
-        public static ISetupExtensionsBuilder RegisterLayout<T>(this ISetupExtensionsBuilder setupBuilder, Func<T> factory, string typeAlias = null)
+        public static ISetupExtensionsBuilder RegisterLayout<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] T>(this ISetupExtensionsBuilder setupBuilder, Func<T> factory, string typeAlias = null)
             where T : Layout
         {
             typeAlias = string.IsNullOrEmpty(typeAlias) ? ResolveTypeAlias<T, LayoutAttribute>(ArrayHelper.Empty<string>()) : typeAlias;
-            ConfigurationItemFactory.Default.GetLayoutFactory().RegisterDefinition<T>(typeAlias, () => factory(), string.Empty);
+            ConfigurationItemFactory.Default.LayoutFactory.RegisterType<T>(typeAlias, factory);
             return setupBuilder;
         }
 
@@ -177,13 +191,13 @@ namespace NLog
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="layoutType">Type of the layout.</param>
         /// <param name="typeAlias">The layout type-alias for use in NLog configuration</param>
-        public static ISetupExtensionsBuilder RegisterLayout(this ISetupExtensionsBuilder setupBuilder, string typeAlias, Type layoutType)
+        public static ISetupExtensionsBuilder RegisterLayout(this ISetupExtensionsBuilder setupBuilder, string typeAlias, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] Type layoutType)
         {
             if (string.IsNullOrEmpty(typeAlias))
                 throw new ArgumentException("Missing NLog Layout type-alias", nameof(typeAlias));
             if (!typeof(Layout).IsAssignableFrom(layoutType))
                 throw new ArgumentException("Not of type NLog Layout", nameof(layoutType));
-            ConfigurationItemFactory.Default.Layouts.RegisterDefinition(typeAlias, layoutType);
+            ConfigurationItemFactory.Default.LayoutFactory.RegisterDefinition(typeAlias, layoutType);
             return setupBuilder;
         }
 
@@ -193,7 +207,7 @@ namespace NLog
         /// <typeparam name="T">Type of the layout renderer.</typeparam>
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="name">The layout-renderer type-alias for use in NLog configuration - without '${ }'. Will extract from class-attribute when unassigned.</param>
-        public static ISetupExtensionsBuilder RegisterLayoutRenderer<T>(this ISetupExtensionsBuilder setupBuilder, string name = null)
+        public static ISetupExtensionsBuilder RegisterLayoutRenderer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] T>(this ISetupExtensionsBuilder setupBuilder, string name = null)
             where T : LayoutRenderer, new()
         {
             return RegisterLayoutRenderer<T>(setupBuilder, () => new T(), name);
@@ -206,11 +220,11 @@ namespace NLog
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="factory">The factory method for creating instance of NLog LayoutRenderer</param>
         /// <param name="typeAlias">The layout-renderer type-alias for use in NLog configuration - without '${ }'. Will extract from class-attribute when unassigned.</param>
-        public static ISetupExtensionsBuilder RegisterLayoutRenderer<T>(this ISetupExtensionsBuilder setupBuilder, Func<T> factory, string typeAlias = null)
+        public static ISetupExtensionsBuilder RegisterLayoutRenderer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] T>(this ISetupExtensionsBuilder setupBuilder, Func<T> factory, string typeAlias = null)
             where T : LayoutRenderer
         {
             typeAlias = string.IsNullOrEmpty(typeAlias) ? ResolveTypeAlias<T, LayoutRendererAttribute>("LayoutRendererWrapper", "LayoutRenderer") : typeAlias;
-            ConfigurationItemFactory.Default.GetLayoutRenderers().RegisterDefinition<T>(typeAlias, () => factory(), string.Empty);
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType<T>(typeAlias, factory);
             return setupBuilder;
         }
 
@@ -245,13 +259,13 @@ namespace NLog
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="layoutRendererType">Type of the layout renderer.</param>
         /// <param name="name">The layout-renderer type-alias for use in NLog configuration - without '${ }'</param>
-        public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder setupBuilder, string name, Type layoutRendererType)
+        public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder setupBuilder, string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] Type layoutRendererType)
         {
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentException("Missing NLog LayoutRenderer type-alias", nameof(name));
             if (!typeof(LayoutRenderer).IsAssignableFrom(layoutRendererType))
                 throw new ArgumentException("Not of type NLog LayoutRenderer", nameof(layoutRendererType));
-            ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition(name, layoutRendererType);
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterDefinition(name, layoutRendererType);
             return setupBuilder;
         }
 
@@ -299,7 +313,7 @@ namespace NLog
         public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder setupBuilder, string name, Func<LogEventInfo, LoggingConfiguration, object> layoutMethod, LayoutRenderOptions options)
         {
             FuncLayoutRenderer layoutRenderer = Layout.CreateFuncLayoutRenderer(layoutMethod, options, name);
-            ConfigurationItemFactory.Default.GetLayoutRenderers().RegisterFuncLayout(name, layoutRenderer);
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterFuncLayout(name, layoutRenderer);
             return setupBuilder;
         }
 
@@ -315,7 +329,7 @@ namespace NLog
             if (!conditionMethod.IsStatic)
                 throw new ArgumentException($"{conditionMethod.Name} must be static", nameof(conditionMethod));
 
-            ConfigurationItemFactory.Default.ConditionMethods.RegisterDefinition(name, conditionMethod);
+            ConfigurationItemFactory.Default.ConditionMethodFactory.RegisterDefinition(name, conditionMethod);
             return setupBuilder;
         }
 
@@ -347,7 +361,7 @@ namespace NLog
 
         private static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, Delegate conditionMethod, ReflectionHelpers.LateBoundMethod lateBoundMethod)
         {
-            ConfigurationItemFactory.Default.ConditionMethodDelegates.RegisterDefinition(name, conditionMethod.GetDelegateInfo(), lateBoundMethod);
+            ConfigurationItemFactory.Default.ConditionMethodFactory.RegisterDefinition(name, conditionMethod.GetDelegateInfo(), lateBoundMethod);
             return setupBuilder;
         }
 

--- a/src/NLog/SetupLoadConfigurationExtensions.cs
+++ b/src/NLog/SetupLoadConfigurationExtensions.cs
@@ -85,6 +85,29 @@ namespace NLog
         /// Defines <see cref="LoggingRule" /> for redirecting output from matching <see cref="Logger"/> to wanted targets.
         /// </summary>
         /// <param name="configBuilder">Fluent interface parameter.</param>
+        /// <param name="finalMinLevel">Restrict minimum LogLevel for <see cref="Logger"/> names that matches this rule</param>
+        /// <param name="loggerNamePattern">Logger name pattern to check which <see cref="Logger"/> names matches this rule</param>
+        /// <param name="ruleName">Rule identifier to allow rule lookup</param>
+        public static ISetupConfigurationLoggingRuleBuilder ForLogger(this ISetupLoadConfigurationBuilder configBuilder, LogLevel finalMinLevel, string loggerNamePattern = "*", string ruleName = null)
+        {
+            var ruleBuilder = new SetupConfigurationLoggingRuleBuilder(configBuilder.LogFactory, configBuilder.Configuration, loggerNamePattern, ruleName);
+            if (finalMinLevel != null)
+            {
+                ruleBuilder.LoggingRule.EnableLoggingForLevels(finalMinLevel, LogLevel.MaxLevel);
+                ruleBuilder.LoggingRule.FinalMinLevel = finalMinLevel;
+            }
+            else
+            {
+                ruleBuilder.LoggingRule.EnableLoggingForLevels(LogLevel.MinLevel, LogLevel.MaxLevel);
+            }                
+            return ruleBuilder;
+        }
+
+
+        /// <summary>
+        /// Defines <see cref="LoggingRule" /> for redirecting output from matching <see cref="Logger"/> to wanted targets.
+        /// </summary>
+        /// <param name="configBuilder">Fluent interface parameter.</param>
         /// <param name="targetName">Override the name for the target created</param>
         public static ISetupConfigurationTargetBuilder ForTarget(this ISetupLoadConfigurationBuilder configBuilder, string targetName = null)
         {

--- a/src/NLog/Targets/ConsoleRowHighlightingRule.cs
+++ b/src/NLog/Targets/ConsoleRowHighlightingRule.cs
@@ -31,6 +31,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+#if !NETSTANDARD1_3
+
 namespace NLog.Targets
 {
     using NLog.Conditions;
@@ -103,3 +105,5 @@ namespace NLog.Targets
         }
     }
 }
+
+#endif

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -36,6 +36,7 @@ namespace NLog.Targets
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using JetBrains.Annotations;
     using NLog.Common;
@@ -425,7 +426,7 @@ namespace NLog.Targets
                 {
                     try
                     {
-                        PropertyHelper.CheckRequiredParameters(this);
+                        PropertyHelper.CheckRequiredParameters(ConfigurationItemFactory.Default, this);
 
                         InitializeTarget();
                         _initializeException = null;
@@ -523,7 +524,7 @@ namespace NLog.Targets
 
         private void FindAllLayouts()
         {
-            _allLayouts = ObjectGraphScanner.FindReachableObjects<Layout>(false, this).ToArray();
+            _allLayouts = ObjectGraphScanner.FindReachableObjects<Layout>(ConfigurationItemFactory.Default, false, this).ToArray();
             InternalLogger.Trace("{0} has {1} layouts", this, _allLayouts.Length);
             _allLayoutsAreThreadAgnostic = _allLayouts.All(layout => layout.ThreadAgnostic);
             _oneLayoutIsMutableUnsafe = _allLayoutsAreThreadAgnostic && _allLayouts.Any(layout => layout.MutableUnsafe);
@@ -779,7 +780,8 @@ namespace NLog.Targets
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
         /// <typeparam name="T">Type of the Target.</typeparam>
         /// <param name="name">The target type-alias for use in NLog configuration</param>
-        public static void Register<T>(string name)
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
+        public static void Register<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] T>(string name)
             where T : Target
         {
             var layoutRendererType = typeof(T);
@@ -792,9 +794,10 @@ namespace NLog.Targets
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
         /// <param name="targetType">Type of the Target.</param>
         /// <param name="name">The target type-alias for use in NLog configuration</param>
-        public static void Register(string name, Type targetType)
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
+        public static void Register(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] Type targetType)
         {
-            ConfigurationItemFactory.Default.Targets.RegisterDefinition(name, targetType);
+            ConfigurationItemFactory.Default.TargetFactory.RegisterDefinition(name, targetType);
         }
     }
 }

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -797,7 +797,7 @@ namespace NLog.Targets
         [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
         public static void Register(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] Type targetType)
         {
-            ConfigurationItemFactory.Default.TargetFactory.RegisterDefinition(name, targetType);
+            ConfigurationItemFactory.Default.GetTargetFactory().RegisterDefinition(name, targetType);
         }
     }
 }

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -256,7 +256,22 @@ namespace NLog.UnitTests
                 if (appDomainFixedOutputAttribute != null)
                 {
                     var threadAgnosticAttribute = type.GetCustomAttribute<ThreadAgnosticAttribute>();
-                    Assert.True(!(threadAgnosticAttribute is null), $"{type.ToString()} should also have ThreadAgnostic");
+                    Assert.True(!(threadAgnosticAttribute is null), $"{type.ToString()} should also have [ThreadAgnostic]");
+                }
+            }
+        }
+
+        [Fact]
+        public void WrapperLayoutRenderer_EnsureThreadAgnostic()
+        {
+            foreach (Type type in allTypes)
+            {
+                if (typeof(NLog.LayoutRenderers.Wrappers.WrapperLayoutRendererBase).IsAssignableFrom(type))
+                {
+                    if (type.IsAbstract || !type.IsPublic)
+                        continue;   // skip non-concrete types, enumerations, and private nested types
+
+                    Assert.True(type.IsDefined(typeof(ThreadAgnosticAttribute), true), $"{type.ToString()} is missing [ThreadAgnostic] attribute.");
                 }
             }
         }
@@ -314,6 +329,93 @@ namespace NLog.UnitTests
                                 Assert.Equal(typeAlias + "LayoutRenderer", type.Name, StringComparer.OrdinalIgnoreCase);
                             }
                         }
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void ValidateConfigurationItemFactory()
+        {
+            ConfigurationItemFactory.Default = null;    // Reset
+            
+            foreach (Type type in allTypes)
+            {
+                if (!type.IsPublic || !type.IsClass || type.IsAbstract)
+                    continue;
+
+                if (typeof(NLog.Targets.Target).IsAssignableFrom(type))
+                {
+                    var configAttribs = type.GetCustomAttributes<NLog.Targets.TargetAttribute>();
+                    Assert.NotEmpty(configAttribs);
+
+                    foreach (var configName in configAttribs)
+                    {
+                        Assert.True(ConfigurationItemFactory.Default.TargetFactory.TryCreateInstance(configName.Name, out var _));
+                    }
+                }
+                else if (typeof(NLog.Layouts.Layout).IsAssignableFrom(type))
+                {
+                    if (type.IsGenericType && type.GetGenericTypeDefinition().Equals(typeof(NLog.Layouts.Layout<>)))
+                        continue;
+
+                    if (type == typeof(NLog.Layouts.XmlElement))
+                        continue;
+
+                    var configAttribs = type.GetCustomAttributes<NLog.Layouts.LayoutAttribute>();
+                    Assert.NotEmpty(configAttribs);
+
+                    foreach (var configName in configAttribs)
+                    {
+                        Assert.True(ConfigurationItemFactory.Default.LayoutFactory.TryCreateInstance(configName.Name, out var _));
+                    }
+                }
+                else if (typeof(NLog.LayoutRenderers.LayoutRenderer).IsAssignableFrom(type))
+                {
+                    if (type == typeof(NLog.LayoutRenderers.FuncLayoutRenderer) || type == typeof(NLog.LayoutRenderers.FuncThreadAgnosticLayoutRenderer))
+                        continue;
+
+                    var configAttribs = type.GetCustomAttributes<NLog.LayoutRenderers.LayoutRendererAttribute>();
+                    Assert.NotEmpty(configAttribs);
+
+                    foreach (var configName in configAttribs)
+                    {
+                        Assert.True(ConfigurationItemFactory.Default.LayoutRendererFactory.TryCreateInstance(configName.Name, out var _));
+                    }
+
+                    if (typeof(NLog.LayoutRenderers.Wrappers.WrapperLayoutRendererBase).IsAssignableFrom(type))
+                    {
+                        var wrapperAttribs = type.GetCustomAttributes<NLog.LayoutRenderers.AmbientPropertyAttribute>();
+                        if (wrapperAttribs?.Any() == true)
+                        {
+                            foreach (var ambientName in wrapperAttribs)
+                            {
+                                Assert.True(ConfigurationItemFactory.Default.AmbientRendererFactory.TryCreateInstance(ambientName.Name, out var _));
+                            }
+                        }
+                    }
+                }
+                else if (typeof(NLog.Filters.Filter).IsAssignableFrom(type))
+                {
+                    if (type == typeof(NLog.Filters.WhenMethodFilter))
+                        continue;
+
+                    var configAttribs = type.GetCustomAttributes<NLog.Filters.FilterAttribute>();
+                    Assert.NotEmpty(configAttribs);
+
+                    foreach (var configName in configAttribs)
+                    {
+                        Assert.True(ConfigurationItemFactory.Default.FilterFactory.TryCreateInstance(configName.Name, out var _));
+                    }
+                }
+                else if (typeof(NLog.Time.TimeSource).IsAssignableFrom(type))
+                {
+                    var configAttribs = type.GetCustomAttributes<NLog.Time.TimeSourceAttribute>();
+                    Assert.NotEmpty(configAttribs);
+
+                    foreach (var configName in configAttribs)
+                    {
+                        Assert.True(ConfigurationItemFactory.Default.TimeSourceFactory.TryCreateInstance(configName.Name, out var _));
                     }
                 }
             }

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -338,7 +338,9 @@ namespace NLog.UnitTests
         public void ValidateConfigurationItemFactory()
         {
             ConfigurationItemFactory.Default = null;    // Reset
-            
+
+            var missingTypes = new List<string>();
+
             foreach (Type type in allTypes)
             {
                 if (!type.IsPublic || !type.IsClass || type.IsAbstract)
@@ -346,12 +348,21 @@ namespace NLog.UnitTests
 
                 if (typeof(NLog.Targets.Target).IsAssignableFrom(type))
                 {
-                    var configAttribs = type.GetCustomAttributes<NLog.Targets.TargetAttribute>();
+                    var configAttribs = type.GetCustomAttributes<NLog.Targets.TargetAttribute>(false);
                     Assert.NotEmpty(configAttribs);
 
                     foreach (var configName in configAttribs)
                     {
-                        Assert.True(ConfigurationItemFactory.Default.TargetFactory.TryCreateInstance(configName.Name, out var _));
+                        if (!ConfigurationItemFactory.Default.TargetFactory.TryCreateInstance(configName.Name, out var target))
+                        {
+                            Console.WriteLine(configName.Name);
+                            missingTypes.Add(configName.Name);
+                        }
+                        else if (type != target.GetType())
+                        {
+                            Console.WriteLine(type.Name);
+                            missingTypes.Add(type.Name);
+                        }
                     }
                 }
                 else if (typeof(NLog.Layouts.Layout).IsAssignableFrom(type))
@@ -362,12 +373,21 @@ namespace NLog.UnitTests
                     if (type == typeof(NLog.Layouts.XmlElement))
                         continue;
 
-                    var configAttribs = type.GetCustomAttributes<NLog.Layouts.LayoutAttribute>();
+                    var configAttribs = type.GetCustomAttributes<NLog.Layouts.LayoutAttribute>(false);
                     Assert.NotEmpty(configAttribs);
 
                     foreach (var configName in configAttribs)
                     {
-                        Assert.True(ConfigurationItemFactory.Default.LayoutFactory.TryCreateInstance(configName.Name, out var _));
+                        if (!ConfigurationItemFactory.Default.LayoutFactory.TryCreateInstance(configName.Name, out var layout))
+                        {
+                            Console.WriteLine(configName.Name);
+                            missingTypes.Add(configName.Name);
+                        }
+                        else if (type != layout.GetType())
+                        {
+                            Console.WriteLine(type.Name);
+                            missingTypes.Add(type.Name);
+                        }
                     }
                 }
                 else if (typeof(NLog.LayoutRenderers.LayoutRenderer).IsAssignableFrom(type))
@@ -375,22 +395,40 @@ namespace NLog.UnitTests
                     if (type == typeof(NLog.LayoutRenderers.FuncLayoutRenderer) || type == typeof(NLog.LayoutRenderers.FuncThreadAgnosticLayoutRenderer))
                         continue;
 
-                    var configAttribs = type.GetCustomAttributes<NLog.LayoutRenderers.LayoutRendererAttribute>();
+                    var configAttribs = type.GetCustomAttributes<NLog.LayoutRenderers.LayoutRendererAttribute>(false);
                     Assert.NotEmpty(configAttribs);
 
                     foreach (var configName in configAttribs)
                     {
-                        Assert.True(ConfigurationItemFactory.Default.LayoutRendererFactory.TryCreateInstance(configName.Name, out var _));
+                        if (!ConfigurationItemFactory.Default.LayoutRendererFactory.TryCreateInstance(configName.Name, out var layoutRenderer))
+                        {
+                            Console.WriteLine(configName.Name);
+                            missingTypes.Add(configName.Name);
+                        }
+                        else if (type != layoutRenderer.GetType())
+                        {
+                            Console.WriteLine(type.Name);
+                            missingTypes.Add(type.Name);
+                        }
                     }
 
                     if (typeof(NLog.LayoutRenderers.Wrappers.WrapperLayoutRendererBase).IsAssignableFrom(type))
                     {
-                        var wrapperAttribs = type.GetCustomAttributes<NLog.LayoutRenderers.AmbientPropertyAttribute>();
+                        var wrapperAttribs = type.GetCustomAttributes<NLog.LayoutRenderers.AmbientPropertyAttribute>(false);
                         if (wrapperAttribs?.Any() == true)
                         {
                             foreach (var ambientName in wrapperAttribs)
                             {
-                                Assert.True(ConfigurationItemFactory.Default.AmbientRendererFactory.TryCreateInstance(ambientName.Name, out var _));
+                                if (!ConfigurationItemFactory.Default.AmbientRendererFactory.TryCreateInstance(ambientName.Name, out var layoutRenderer))
+                                {
+                                    Console.WriteLine(ambientName.Name);
+                                    missingTypes.Add(ambientName.Name);
+                                }
+                                else if (type != layoutRenderer.GetType())
+                                {
+                                    Console.WriteLine(type.Name);
+                                    missingTypes.Add(type.Name);
+                                }
                             }
                         }
                     }
@@ -400,25 +438,45 @@ namespace NLog.UnitTests
                     if (type == typeof(NLog.Filters.WhenMethodFilter))
                         continue;
 
-                    var configAttribs = type.GetCustomAttributes<NLog.Filters.FilterAttribute>();
+                    var configAttribs = type.GetCustomAttributes<NLog.Filters.FilterAttribute>(false);
                     Assert.NotEmpty(configAttribs);
 
                     foreach (var configName in configAttribs)
                     {
-                        Assert.True(ConfigurationItemFactory.Default.FilterFactory.TryCreateInstance(configName.Name, out var _));
+                        if (!ConfigurationItemFactory.Default.FilterFactory.TryCreateInstance(configName.Name, out var filter))
+                        {
+                            Console.WriteLine(configName.Name);
+                            missingTypes.Add(configName.Name);
+                        }
+                        else if (type != filter.GetType())
+                        {
+                            Console.WriteLine(type.Name);
+                            missingTypes.Add(type.Name);
+                        }
                     }
                 }
                 else if (typeof(NLog.Time.TimeSource).IsAssignableFrom(type))
                 {
-                    var configAttribs = type.GetCustomAttributes<NLog.Time.TimeSourceAttribute>();
+                    var configAttribs = type.GetCustomAttributes<NLog.Time.TimeSourceAttribute>(false);
                     Assert.NotEmpty(configAttribs);
 
                     foreach (var configName in configAttribs)
                     {
-                        Assert.True(ConfigurationItemFactory.Default.TimeSourceFactory.TryCreateInstance(configName.Name, out var _));
+                        if (!ConfigurationItemFactory.Default.TimeSourceFactory.TryCreateInstance(configName.Name, out var timeSource))
+                        {
+                            Console.WriteLine(configName.Name);
+                            missingTypes.Add(configName.Name);
+                        }
+                        else if (type != timeSource.GetType())
+                        {
+                            Console.WriteLine(type.Name);
+                            missingTypes.Add(type.Name);
+                        }
                     }
                 }
             }
+
+            Assert.Empty(missingTypes);
         }
     }
 }

--- a/tests/NLog.UnitTests/Conditions/ConditionEvaluatorTests.cs
+++ b/tests/NLog.UnitTests/Conditions/ConditionEvaluatorTests.cs
@@ -342,15 +342,15 @@ namespace NLog.UnitTests.Conditions
         private static ConfigurationItemFactory SetupConditionMethods()
         {
             var factories = new ConfigurationItemFactory();
-            factories.ConditionMethods.RegisterDefinition("GetGuid", typeof(MyConditionMethods).GetMethod("GetGuid"));
-            factories.ConditionMethods.RegisterDefinition("ToInt16", typeof(MyConditionMethods).GetMethod("ToInt16"));
-            factories.ConditionMethods.RegisterDefinition("ToInt32", typeof(MyConditionMethods).GetMethod("ToInt32"));
-            factories.ConditionMethods.RegisterDefinition("ToInt64", typeof(MyConditionMethods).GetMethod("ToInt64"));
-            factories.ConditionMethods.RegisterDefinition("ToDouble", typeof(MyConditionMethods).GetMethod("ToDouble"));
-            factories.ConditionMethods.RegisterDefinition("ToSingle", typeof(MyConditionMethods).GetMethod("ToSingle"));
-            factories.ConditionMethods.RegisterDefinition("ToDateTime", typeof(MyConditionMethods).GetMethod("ToDateTime"));
-            factories.ConditionMethods.RegisterDefinition("ToDecimal", typeof(MyConditionMethods).GetMethod("ToDecimal"));
-            factories.ConditionMethods.RegisterDefinition("IsValid", typeof(MyConditionMethods).GetMethod("IsValid"));
+            factories.ConditionMethodFactory.RegisterDefinition("GetGuid", typeof(MyConditionMethods).GetMethod("GetGuid"));
+            factories.ConditionMethodFactory.RegisterDefinition("ToInt16", typeof(MyConditionMethods).GetMethod("ToInt16"));
+            factories.ConditionMethodFactory.RegisterDefinition("ToInt32", typeof(MyConditionMethods).GetMethod("ToInt32"));
+            factories.ConditionMethodFactory.RegisterDefinition("ToInt64", typeof(MyConditionMethods).GetMethod("ToInt64"));
+            factories.ConditionMethodFactory.RegisterDefinition("ToDouble", typeof(MyConditionMethods).GetMethod("ToDouble"));
+            factories.ConditionMethodFactory.RegisterDefinition("ToSingle", typeof(MyConditionMethods).GetMethod("ToSingle"));
+            factories.ConditionMethodFactory.RegisterDefinition("ToDateTime", typeof(MyConditionMethods).GetMethod("ToDateTime"));
+            factories.ConditionMethodFactory.RegisterDefinition("ToDecimal", typeof(MyConditionMethods).GetMethod("ToDecimal"));
+            factories.ConditionMethodFactory.RegisterDefinition("IsValid", typeof(MyConditionMethods).GetMethod("IsValid"));
             return factories;
         }
 

--- a/tests/NLog.UnitTests/Conditions/ConditionParserTests.cs
+++ b/tests/NLog.UnitTests/Conditions/ConditionParserTests.cs
@@ -206,7 +206,7 @@ namespace NLog.UnitTests.Conditions
         public void CustomNLogFactoriesTest()
         {
             var configurationItemFactory = new ConfigurationItemFactory();
-            configurationItemFactory.LayoutRendererFactory.RegisterDefinition("foo", typeof(FooLayoutRenderer));
+            configurationItemFactory.LayoutRendererFactory.RegisterType<FooLayoutRenderer>("foo");
             configurationItemFactory.ConditionMethodFactory.RegisterDefinition("check", typeof(MyConditionMethods).GetMethod("CheckIt"));
 
             ConditionParser.ParseExpression("check('${foo}')", configurationItemFactory);
@@ -216,7 +216,7 @@ namespace NLog.UnitTests.Conditions
         public void MethodNameWithUnderscores()
         {
             var configurationItemFactory = new ConfigurationItemFactory();
-            configurationItemFactory.LayoutRendererFactory.RegisterDefinition("foo", typeof(FooLayoutRenderer));
+            configurationItemFactory.LayoutRendererFactory.RegisterType<FooLayoutRenderer>("foo");
             configurationItemFactory.ConditionMethodFactory.RegisterDefinition("__check__", typeof(MyConditionMethods).GetMethod("CheckIt"));
 
             ConditionParser.ParseExpression("__check__('${foo}')", configurationItemFactory);

--- a/tests/NLog.UnitTests/Conditions/ConditionParserTests.cs
+++ b/tests/NLog.UnitTests/Conditions/ConditionParserTests.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.UnitTests.Conditions
 {
+    using System;
     using NLog.Internal;
     using NLog.Conditions;
     using NLog.Config;
@@ -205,8 +206,8 @@ namespace NLog.UnitTests.Conditions
         public void CustomNLogFactoriesTest()
         {
             var configurationItemFactory = new ConfigurationItemFactory();
-            configurationItemFactory.LayoutRenderers.RegisterDefinition("foo", typeof(FooLayoutRenderer));
-            configurationItemFactory.ConditionMethods.RegisterDefinition("check", typeof(MyConditionMethods).GetMethod("CheckIt"));
+            configurationItemFactory.LayoutRendererFactory.RegisterDefinition("foo", typeof(FooLayoutRenderer));
+            configurationItemFactory.ConditionMethodFactory.RegisterDefinition("check", typeof(MyConditionMethods).GetMethod("CheckIt"));
 
             ConditionParser.ParseExpression("check('${foo}')", configurationItemFactory);
         }
@@ -215,8 +216,8 @@ namespace NLog.UnitTests.Conditions
         public void MethodNameWithUnderscores()
         {
             var configurationItemFactory = new ConfigurationItemFactory();
-            configurationItemFactory.LayoutRenderers.RegisterDefinition("foo", typeof(FooLayoutRenderer));
-            configurationItemFactory.ConditionMethods.RegisterDefinition("__check__", typeof(MyConditionMethods).GetMethod("CheckIt"));
+            configurationItemFactory.LayoutRendererFactory.RegisterDefinition("foo", typeof(FooLayoutRenderer));
+            configurationItemFactory.ConditionMethodFactory.RegisterDefinition("__check__", typeof(MyConditionMethods).GetMethod("CheckIt"));
 
             ConditionParser.ParseExpression("__check__('${foo}')", configurationItemFactory);
         }

--- a/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
@@ -42,6 +42,7 @@ namespace NLog.UnitTests.Config
     public class ConfigurationItemFactoryTests : NLogTestBase
     {
         [Fact]
+        [Obsolete("Instead override type-creation by calling RegisterDefinition with delegate. Marked obsolete with NLog v5.2")]
         public void ConfigurationItemFactoryDefaultTest()
         {
             var itemFactory = new ConfigurationItemFactory();
@@ -66,6 +67,7 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        [Obsolete("Instead override type-creation by calling RegisterDefinition with delegate. Marked obsolete with NLog v5.2")]
         public void ConfigurationItemFactoryUsesSuppliedDelegateToResolveObject()
         {
             var cif = new ConfigurationItemFactory();

--- a/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigurationItemFactoryTests.cs
@@ -42,7 +42,23 @@ namespace NLog.UnitTests.Config
     public class ConfigurationItemFactoryTests : NLogTestBase
     {
         [Fact]
-        [Obsolete("Instead override type-creation by calling RegisterDefinition with delegate. Marked obsolete with NLog v5.2")]
+        public void ConfigurationItemFactoryTargetTest()
+        {
+            var itemFactory = new ConfigurationItemFactory();
+            itemFactory.TargetFactory.RegisterType(nameof(MemoryTarget), () => new MemoryTarget());
+            Assert.IsType<MemoryTarget>(itemFactory.TargetFactory.CreateInstance(nameof(MemoryTarget)));
+        }
+
+        [Fact]
+        public void ConfigurationItemFactoryFailsTest()
+        {
+            var itemFactory = new ConfigurationItemFactory();
+            var ex = Assert.ThrowsAny<Exception>(() => itemFactory.TargetFactory.CreateInstance("Memory-Target") as MemoryTarget);
+            Assert.Contains("Memory-Target", ex.Message);
+        }
+
+        [Fact]
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
         public void ConfigurationItemFactoryDefaultTest()
         {
             var itemFactory = new ConfigurationItemFactory();
@@ -50,51 +66,27 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
         public void ConfigurationItemFactorySimpleTest()
         {
-            var cif = new ConfigurationItemFactory();
-            cif.RegisterType(typeof(DebugTarget), string.Empty);
-            var target = cif.Targets.CreateInstance("Debug") as DebugTarget;
+            var itemFactory = new ConfigurationItemFactory();
+            itemFactory.RegisterType(typeof(DebugTarget), string.Empty);
+            var target = itemFactory.TargetFactory.CreateInstance("Debug") as DebugTarget;
             Assert.NotNull(target);
         }
 
         [Fact]
-        public void ConfigurationItemFactoryFailsTest()
-        {
-            var cif = new ConfigurationItemFactory();
-            var ex = Assert.ThrowsAny<Exception>(() => cif.Targets.CreateInstance("Debug-Target") as DebugTarget);
-            Assert.Contains("Debug-Target", ex.Message);
-        }
-
-        [Fact]
-        [Obsolete("Instead override type-creation by calling RegisterDefinition with delegate. Marked obsolete with NLog v5.2")]
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
         public void ConfigurationItemFactoryUsesSuppliedDelegateToResolveObject()
         {
-            var cif = new ConfigurationItemFactory();
-            cif.RegisterType(typeof(DebugTarget), string.Empty);
+            var itemFactory = new ConfigurationItemFactory();
+            itemFactory.RegisterType(typeof(DebugTarget), string.Empty);
             List<Type> resolvedTypes = new List<Type>();
-            cif.CreateInstance = t => { resolvedTypes.Add(t); return Activator.CreateInstance(t); };
-            Target target = cif.Targets.CreateInstance("Debug");
+            itemFactory.CreateInstance = t => { resolvedTypes.Add(t); return Activator.CreateInstance(t); };
+            Target target = itemFactory.TargetFactory.CreateInstance("Debug");
             Assert.NotNull(target);
             Assert.Single(resolvedTypes);
             Assert.Equal(typeof(DebugTarget), resolvedTypes[0]);
         }
-
-#if !NETSTANDARD && !MONO
-
-        [Fact]
-        public void ExtendedLayoutRendererTest()
-        {
-            var layoutRenderers = ConfigurationItemFactory.Default.LayoutRenderers;
-
-            AssertInstance(layoutRenderers, "appsetting", "AppSettingLayoutRenderer", "AppSettingLayoutRenderer2");
-        }
-
-        private static void AssertInstance<T1, T2>(INamedItemFactory<T1, T2> targets, string itemName, params string[] expectedTypeNames)
-            where T1 : class
-        {
-            Assert.Contains(targets.CreateInstance(itemName).GetType().Name, expectedTypeNames);
-        }
-#endif
     }
 }

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -250,7 +250,7 @@ namespace NLog.UnitTests.Config
         {
             Assert.NotNull(typeof(FooLayout));
             var configurationItemFactory = new ConfigurationItemFactory();
-            configurationItemFactory.LayoutFactory.RegisterNamedType("foo", typeof(FooLayout).ToString() + "," + typeof(FooLayout).Assembly.GetName().Name);
+            configurationItemFactory.GetLayoutFactory().RegisterNamedType("foo", typeof(FooLayout).ToString() + "," + typeof(FooLayout).Assembly.GetName().Name);
             Assert.NotNull(configurationItemFactory.LayoutFactory.CreateInstance("foo"));
         }
 
@@ -610,9 +610,9 @@ namespace NLog.UnitTests.Config
             var configFactory = new ConfigurationItemFactory(assembly);
 
             // Act
-            var foundDefinition = configFactory.TargetFactory.TryGetDefinition(input, out var outputDefinition);
+            var foundDefinition = configFactory.GetTargetFactory().TryGetDefinition(input, out var outputDefinition);
             var foundInstance = configFactory.TargetFactory.TryCreateInstance(input, out var outputInstance);
-            var instance = (foundDefinition || foundInstance || expected != null) ? configFactory.TargetFactory.CreateInstance(input) : null;
+            var instance = (foundDefinition || foundInstance || expected != null) ? configFactory.GetTargetFactory().CreateInstance(input) : null;
 
             // Assert
             Assert.Equal(expected != null, foundInstance);

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -245,6 +245,15 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        public void RegisterNamedTypeLessTest()
+        {
+            Assert.NotNull(typeof(FooLayout));
+            var configurationItemFactory = new ConfigurationItemFactory();
+            ((Factory<Layout, LayoutAttribute>)configurationItemFactory.Layouts).RegisterNamedType("foo", typeof(FooLayout).ToString() + "," + typeof(FooLayout).Assembly.GetName().Name);
+            Assert.NotNull(configurationItemFactory.Layouts.CreateInstance("foo"));
+        }
+
+        [Fact]
         public void ExtensionTest_extensions_not_top_and_used()
         {
             Assert.NotNull(typeof(FooLayout));
@@ -597,7 +606,9 @@ namespace NLog.UnitTests.Config
             var configFactory = new ConfigurationItemFactory(assembly);
 
             // Act
+#pragma warning disable CS0618 // Type or member is obsolete
             var foundDefinition = configFactory.Targets.TryGetDefinition(input, out var outputDefinition);
+#pragma warning restore CS0618 // Type or member is obsolete
             var foundInstance = configFactory.Targets.TryCreateInstance(input, out var outputInstance);
             var instance = (foundDefinition || foundInstance || expected != null) ? configFactory.Targets.CreateInstance(input) : null;
 

--- a/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
+++ b/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
@@ -393,7 +393,7 @@ namespace NLog.UnitTests.Config
             </nlog>", null, logFactory);
             logFactory.GetLogger("Hello").Info("World");
 
-            ConfigurationItemFactory.Default.GetLayoutRenderers().TryCreateInstance("mylayout", out var layoutRenderer);
+            ConfigurationItemFactory.Default.LayoutRendererFactory.TryCreateInstance("mylayout", out var layoutRenderer);
             var layout = new SimpleLayout(new LayoutRenderer[] { layoutRenderer }, "mylayout", ConfigurationItemFactory.Default);
             layout.Render(LogEventInfo.CreateNullEvent());
 
@@ -421,7 +421,7 @@ namespace NLog.UnitTests.Config
             </nlog>", null, logFactory);
             logFactory.GetLogger("Hello").Info("World");
 
-            ConfigurationItemFactory.Default.GetLayoutRenderers().TryCreateInstance("mylayout", out var layoutRenderer);
+            ConfigurationItemFactory.Default.LayoutRendererFactory.TryCreateInstance("mylayout", out var layoutRenderer);
             var layout = new SimpleLayout(new LayoutRenderer[] { layoutRenderer }, "mylayout", ConfigurationItemFactory.Default);
             layout.Render(LogEventInfo.CreateNullEvent());
 

--- a/tests/NLog.UnitTests/Config/ReloadTests.cs
+++ b/tests/NLog.UnitTests/Config/ReloadTests.cs
@@ -98,9 +98,15 @@ namespace NLog.UnitTests.Config
         private static void SetLogManagerConfiguration(bool useExplicitFileLoading, string configFilePath)
         {
             if (useExplicitFileLoading)
+            {
                 LogManager.Configuration = new XmlLoggingConfiguration(configFilePath);
+            }
             else
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
                 LogManager.LogFactory.SetCandidateConfigFilePaths(new string[] { configFilePath });
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
         }
 
         [Theory]
@@ -574,6 +580,7 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        [Obsolete("Replaced by ConfigurationChanged. Marked obsolete on NLog 5.2")]
         public void TestKeepVariablesOnReload()
         {
             string config = @"<nlog autoReload='true' keepVariablesOnReload='true'>
@@ -634,6 +641,7 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        [Obsolete("Replaced by ConfigurationChanged. Marked obsolete on NLog 5.2")]
         public void TestResetVariablesOnReload()
         {
             string config = @"<nlog autoReload='true' keepVariablesOnReload='false'>
@@ -688,6 +696,7 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        [Obsolete("Replaced by ConfigurationChanged. Marked obsolete on NLog 5.2")]
         public void ReloadConfigOnTimer_When_No_Exception_Raises_ConfigurationReloadedEvent()
         {
             var called = false;
@@ -708,6 +717,7 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        [Obsolete("Replaced by LogFactory.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         public void TestReloadingInvalidConfiguration()
         {
             var validXmlConfig = @"<nlog>
@@ -754,6 +764,7 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        [Obsolete("Replaced by LogFactory.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         public void TestThrowExceptionWhenInvalidXml()
         {
             var invalidXmlConfig = @"<nlog throwExceptions='true' internalLogLevel='debug' internalLogLevel='error'>
@@ -800,21 +811,20 @@ namespace NLog.UnitTests.Config
             }
         }
 
-
         private class ConfigurationReloadWaiter : IDisposable
         {
             private ManualResetEvent counterEvent = new ManualResetEvent(false);
 
             public ConfigurationReloadWaiter()
             {
-                LogManager.ConfigurationReloaded += SignalCounterEvent(counterEvent);
+                LogManager.ConfigurationChanged += SignalCounterEvent(counterEvent);
             }
 
             public bool DidReload => counterEvent.WaitOne(0);
 
             public void Dispose()
             {
-                LogManager.ConfigurationReloaded -= SignalCounterEvent(counterEvent);
+                LogManager.ConfigurationChanged -= SignalCounterEvent(counterEvent);
             }
 
             public void WaitForReload()
@@ -822,7 +832,7 @@ namespace NLog.UnitTests.Config
                 counterEvent.WaitOne(3000);
             }
 
-            private static EventHandler<LoggingConfigurationReloadedEventArgs> SignalCounterEvent(ManualResetEvent counterEvent)
+            private static EventHandler<LoggingConfigurationChangedEventArgs> SignalCounterEvent(ManualResetEvent counterEvent)
             {
                 return (sender, e) =>
                 {

--- a/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
@@ -821,10 +821,9 @@ namespace NLog.UnitTests.Config
 
             try
             {
-                var config = XmlLoggingConfiguration.CreateFromXmlString("<nlog internalLogFile='" + tempFileName + @"' internalLogLevel='Warn'>
-                    <extensions>
-                        <add assembly='NLog.UnitTests'/> 
-                    </extensions>
+                var logFactory = new LogFactory().Setup()
+                    .SetupExtensions(ext => ext.RegisterTarget<Targets.Mocks.MockTargetWrapper >())
+                    .LoadConfigurationFromXml("<nlog internalLogFile='" + tempFileName + @"' internalLogLevel='Warn'>
                     <targets async='true'>
                         <target name='d1' type='Debug' />
                         <target name='d2' type='MockWrapper'>
@@ -840,9 +839,6 @@ namespace NLog.UnitTests.Config
                     </rules>
                 </nlog>");
 
-                var logFactory = new LogFactory();
-                logFactory.Configuration = config;
-
                 AssertFileNotContains(tempFileName, "Unused target detected. Add a rule for this target to the configuration. TargetName: d2", Encoding.UTF8);
 
                 AssertFileNotContains(tempFileName, "Unused target detected. Add a rule for this target to the configuration. TargetName: d3", Encoding.UTF8);
@@ -851,7 +847,6 @@ namespace NLog.UnitTests.Config
 
                 AssertFileContains(tempFileName, "Unused target detected. Add a rule for this target to the configuration. TargetName: d5", Encoding.UTF8);
             }
-
             finally
             {
                 NLog.Common.InternalLogger.Reset();
@@ -1035,7 +1030,7 @@ namespace NLog.UnitTests.Config
 
         private static void AssertLogLevelEnabled(ILogger logger, LogLevel expectedLogLevel)
         {
-            AssertLogLevelEnabled(logger, new[] {expectedLogLevel });
+            AssertLogLevelEnabled(logger, new[] { expectedLogLevel });
         }
 
         private static void AssertLogLevelEnabled(ILogger logger, LogLevel[] expectedLogLevels)
@@ -1044,9 +1039,9 @@ namespace NLog.UnitTests.Config
             {
                 var logLevel = LogLevel.FromOrdinal(i);
                 if (expectedLogLevels.Contains(logLevel))
-                    Assert.True(logger.IsEnabled(logLevel),$"{logLevel} expected as true");
+                    Assert.True(logger.IsEnabled(logLevel), $"{logLevel} expected as true");
                 else
-                    Assert.False(logger.IsEnabled(logLevel),$"{logLevel} expected as false");
+                    Assert.False(logger.IsEnabled(logLevel), $"{logLevel} expected as false");
             }
         }
     }

--- a/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
+++ b/tests/NLog.UnitTests/ConfigFileLocatorTests.cs
@@ -62,6 +62,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Replaced by LogFactory.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         public void GetCandidateConfigTest()
         {
             var candidateConfigFilePaths = XmlLoggingConfiguration.GetCandidateConfigFilePaths();
@@ -71,6 +72,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Replaced by LogFactory.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         public void GetCandidateConfigTest_list_is_readonly()
         {
             Assert.Throws<NotSupportedException>(() =>
@@ -84,6 +86,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Replaced by LogFactory.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         public void SetCandidateConfigTest()
         {
             var list = new List<string> { "c:\\global\\temp.config" };
@@ -95,6 +98,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Replaced by LogFactory.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         public void ResetCandidateConfigTest()
         {
             var countBefore = XmlLoggingConfiguration.GetCandidateConfigFilePaths().Count();

--- a/tests/NLog.UnitTests/GetLoggerTests.cs
+++ b/tests/NLog.UnitTests/GetLoggerTests.cs
@@ -56,6 +56,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Replaced by GetLogger<T>(). Marked obsolete on NLog 5.2")]
         public void TypedGetLoggerTest()
         {
             LogFactory lf = new LogFactory();
@@ -77,6 +78,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Replaced by GetCurrentClassLogger<T>(). Marked obsolete on NLog 5.2")]
         public void TypedGetCurrentClassLoggerTest()
         {
             LogFactory lf = new LogFactory();
@@ -135,6 +137,7 @@ namespace NLog.UnitTests
 
 
         [Fact]
+        [Obsolete("Replaced by GetCurrentClassLogger<T>(). Marked obsolete on NLog 5.2")]
         public void InvalidLoggerConfiguration_NotThrowsThrowExceptions_NotThrows()
         {
             using (new NoThrowNLogExceptions())
@@ -144,19 +147,14 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Replaced by GetCurrentClassLogger<T>(). Marked obsolete on NLog 5.2")]
         public void InvalidLoggerConfiguration_ThrowsThrowExceptions_Throws()
         {
             LogManager.ThrowExceptions = true;
-            InvalidLoggerConfiguration_ThrowsNLogResolveException();
-        }
-
-        private void InvalidLoggerConfiguration_ThrowsNLogResolveException()
-        {
-            Assert.Throws<NLogDependencyResolveException>(() =>
+            Assert.Throws<NLogRuntimeException>(() =>
             {
                 LogManager.GetCurrentClassLogger(typeof(InvalidLogger));
             });
-
         }
 
         public class MyLogger : Logger

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSite/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSite/CallSiteTests.cs
@@ -1087,7 +1087,7 @@ namespace NLog.UnitTests.LayoutRenderers
                 </rules>
             </nlog>").LogFactory;
 
-            var logger = logFactory.GetLogger("mylogger", typeof(MyLogger));
+            var logger = logFactory.GetLogger<MyLogger>("mylogger");
 
             Assert.True(logger is MyLogger, "logger isn't MyLogger");
             logger.Debug("msg");
@@ -1105,7 +1105,7 @@ namespace NLog.UnitTests.LayoutRenderers
                 </rules>
             </nlog>").LogFactory;
 
-            MyLogger logger = logFactory.GetLogger("mylogger", typeof(MyLogger)) as MyLogger;
+            MyLogger logger = logFactory.GetLogger<MyLogger>("mylogger");
 
             Assert.NotNull(logger);
             logger.Debug("msg");
@@ -1123,7 +1123,7 @@ namespace NLog.UnitTests.LayoutRenderers
                 </rules>
             </nlog>").LogFactory;
 
-            Logger logger = logFactory.GetLogger("mylogger", typeof(MyLogger)) as Logger;
+            Logger logger = logFactory.GetLogger<MyLogger>("mylogger");
 
             Assert.NotNull(logger);
             logger.Debug("msg");

--- a/tests/NLog.UnitTests/LayoutRenderers/FuncLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/FuncLayoutRendererTests.cs
@@ -62,28 +62,27 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
-        [Obsolete("Instead override type-creation by calling NLog.LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
-        public void RegisterCustomFuncLayoutRendererTest_Legacy()
+        public void RegisterCustomFuncLayoutRendererTestOldStyle()
         {
             // Arrange
             var funcLayoutRenderer = new MyFuncLayoutRenderer("the-answer-new");
 
             // Act
-            LayoutRenderer.Register(funcLayoutRenderer);
-
-            LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"<nlog throwExceptions='true'>
+            var logFactory = new LogFactory().Setup()
+                .SetupExtensions(ext => ext.RegisterLayoutRenderer(funcLayoutRenderer))
+                .LoadConfigurationFromXml(@"<nlog throwExceptions='true'>
                 <targets>
                     <target name='debug' type='Debug' layout= 'TheAnswer=${the-answer-new:Format=D3}' /></targets>
                 <rules>
                     <logger name='*' minlevel='Debug' writeTo='debug' />
                 </rules>
-            </nlog>");
+            </nlog>").LogFactory;
 
-            var logger = LogManager.GetCurrentClassLogger();
+            var logger = logFactory.GetCurrentClassLogger();
             logger.Debug("test1");
 
             // Assert
-            AssertDebugLastMessage("debug", "TheAnswer=042");
+            AssertDebugLastMessage("debug", "TheAnswer=042", logFactory);
         }
 
         private class MyFuncLayoutRenderer : FuncLayoutRenderer
@@ -91,7 +90,6 @@ namespace NLog.UnitTests.LayoutRenderers
             public MyFuncLayoutRenderer() : base(string.Empty)
             {
             }
-
 
             public MyFuncLayoutRenderer(string layoutRendererName) : base(layoutRendererName)
             {

--- a/tests/NLog.UnitTests/LayoutRenderers/FuncLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/FuncLayoutRendererTests.cs
@@ -31,6 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using System;
 using NLog.LayoutRenderers;
 using NLog.Config;
 using Xunit;
@@ -41,6 +42,28 @@ namespace NLog.UnitTests.LayoutRenderers
     {
         [Fact]
         public void RegisterCustomFuncLayoutRendererTest()
+        {
+            // Arrange
+            var logFactory = new LogFactory().Setup().SetupExtensions(ext => ext.RegisterLayoutRenderer<MyFuncLayoutRenderer>("the-answer-new"))
+                .LoadConfigurationFromXml(@"<nlog throwExceptions='true'>
+                <targets>
+                    <target name='debug' type='Debug' layout= 'TheAnswer=${the-answer-new:Format=D3}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>").LogFactory;
+
+            // Act
+            var logger = logFactory.GetCurrentClassLogger();
+            logger.Debug("test1");
+
+            // Assert
+            AssertDebugLastMessage("debug", "TheAnswer=042", logFactory);
+        }
+
+        [Fact]
+        [Obsolete("Instead override type-creation by calling NLog.LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
+        public void RegisterCustomFuncLayoutRendererTest_Legacy()
         {
             // Arrange
             var funcLayoutRenderer = new MyFuncLayoutRenderer("the-answer-new");
@@ -65,7 +88,11 @@ namespace NLog.UnitTests.LayoutRenderers
 
         private class MyFuncLayoutRenderer : FuncLayoutRenderer
         {
-            /// <inheritdoc/>
+            public MyFuncLayoutRenderer() : base(string.Empty)
+            {
+            }
+
+
             public MyFuncLayoutRenderer(string layoutRendererName) : base(layoutRendererName)
             {
             }

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -31,12 +31,12 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-using NLog.Layouts;
-using Xunit;
-
 namespace NLog.UnitTests.Layouts
 {
+    using System;
+    using NLog.Layouts;
+    using Xunit;
+
     public class LayoutTypedTests : NLogTestBase
     {
         [Fact]
@@ -1002,6 +1002,19 @@ namespace NLog.UnitTests.Layouts
 
         [Fact]
         public void LayoutRendererSupportTypedLayout()
+        {
+            var cif = new NLog.Config.ConfigurationItemFactory();
+            cif.LayoutRendererFactory.RegisterType(nameof(LayoutTypedTestLayoutRenderer), () => new LayoutTypedTestLayoutRenderer());
+
+            Layout l = new SimpleLayout("${LayoutTypedTestLayoutRenderer:IntProperty=42}", cif);
+            l.Initialize(null);
+            var result = l.Render(LogEventInfo.CreateNullEvent());
+            Assert.Equal("42", result);
+        }
+
+        [Fact]
+        [Obsolete("Instead override type-creation by calling NLog.LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
+        public void LayoutRendererSupportTypedLayout_Legacy()
         {
             var cif = new NLog.Config.ConfigurationItemFactory();
             cif.RegisterType(typeof(LayoutTypedTestLayoutRenderer), string.Empty);

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -1004,7 +1004,7 @@ namespace NLog.UnitTests.Layouts
         public void LayoutRendererSupportTypedLayout()
         {
             var cif = new NLog.Config.ConfigurationItemFactory();
-            cif.LayoutRendererFactory.RegisterType(nameof(LayoutTypedTestLayoutRenderer), () => new LayoutTypedTestLayoutRenderer());
+            cif.LayoutRendererFactory.RegisterType<LayoutTypedTestLayoutRenderer>(nameof(LayoutTypedTestLayoutRenderer));
 
             Layout l = new SimpleLayout("${LayoutTypedTestLayoutRenderer:IntProperty=42}", cif);
             l.Initialize(null);

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
@@ -61,7 +61,7 @@ namespace NLog.UnitTests.Layouts
             using (new NoThrowNLogExceptions())
             {
                 ConfigurationItemFactory configurationItemFactory = new ConfigurationItemFactory();
-                configurationItemFactory.LayoutRenderers.RegisterDefinition("throwsException", typeof(ThrowsExceptionRenderer));
+                configurationItemFactory.LayoutRendererFactory.RegisterType("throwsException", () => new ThrowsExceptionRenderer());
 
                 SimpleLayout l = new SimpleLayout("xx${throwsException}yy", configurationItemFactory);
                 string output = l.Render(LogEventInfo.CreateNullEvent());
@@ -101,7 +101,7 @@ namespace NLog.UnitTests.Layouts
                         using (new NoThrowNLogExceptions())
                         {
                             ConfigurationItemFactory configurationItemFactory = new ConfigurationItemFactory();
-                            configurationItemFactory.LayoutRenderers.RegisterDefinition("throwsException", typeof(ThrowsExceptionRenderer));
+                            configurationItemFactory.LayoutRendererFactory.RegisterType("throwsException", () => new ThrowsExceptionRenderer());
 
                             SimpleLayout l = new SimpleLayout("xx${throwsException:msg1}yy${throwsException:msg2}zz", configurationItemFactory);
                             string output = l.Render(LogEventInfo.CreateNullEvent());

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
@@ -61,7 +61,7 @@ namespace NLog.UnitTests.Layouts
             using (new NoThrowNLogExceptions())
             {
                 ConfigurationItemFactory configurationItemFactory = new ConfigurationItemFactory();
-                configurationItemFactory.LayoutRendererFactory.RegisterType("throwsException", () => new ThrowsExceptionRenderer());
+                configurationItemFactory.LayoutRendererFactory.RegisterType<ThrowsExceptionRenderer>("throwsException");
 
                 SimpleLayout l = new SimpleLayout("xx${throwsException}yy", configurationItemFactory);
                 string output = l.Render(LogEventInfo.CreateNullEvent());
@@ -101,7 +101,7 @@ namespace NLog.UnitTests.Layouts
                         using (new NoThrowNLogExceptions())
                         {
                             ConfigurationItemFactory configurationItemFactory = new ConfigurationItemFactory();
-                            configurationItemFactory.LayoutRendererFactory.RegisterType("throwsException", () => new ThrowsExceptionRenderer());
+                            configurationItemFactory.LayoutRendererFactory.RegisterType<ThrowsExceptionRenderer>("throwsException");
 
                             SimpleLayout l = new SimpleLayout("xx${throwsException:msg1}yy${throwsException:msg2}zz", configurationItemFactory);
                             string output = l.Render(LogEventInfo.CreateNullEvent());

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -31,23 +31,20 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using NLog.Config;
-using NLog.Filters;
-
 namespace NLog.UnitTests.Layouts
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Text;
+    using NLog.Config;
+    using NLog.Filters;
     using NLog.LayoutRenderers;
     using NLog.LayoutRenderers.Wrappers;
     using NLog.Layouts;
     using NLog.Targets;
-    using System;
     using Xunit;
-    using static Config.TargetConfigurationTests;
 
     public class SimpleLayoutParserTests : NLogTestBase
     {
@@ -555,7 +552,7 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void InvalidLayoutWithExistingRenderer_WillThrowIfExceptionThrowingIsOn()
         {
-            ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition("layoutrenderer-with-list", typeof(LayoutRendererWithListParam));
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType("layoutrenderer-with-list", () => new LayoutRendererWithListParam());
             LogManager.ThrowConfigExceptions = true;
             Assert.Throws<NLogConfigurationException>(() =>
             {
@@ -567,7 +564,7 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void UnknownPropertyInLayout_WillThrowIfExceptionThrowingIsOn()
         {
-            ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition("layoutrenderer-with-list", typeof(LayoutRendererWithListParam));
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType("layoutrenderer-with-list", () => new LayoutRendererWithListParam());
             LogManager.ThrowConfigExceptions = true;
 
             Assert.Throws<NLogConfigurationException>(() =>
@@ -616,7 +613,7 @@ namespace NLog.UnitTests.Layouts
 #endif
         public void LayoutWithListParamTest(string input, string propname, string expected)
         {
-            ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition("layoutrenderer-with-list", typeof(LayoutRendererWithListParam));
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType("layoutrenderer-with-list", () => new LayoutRendererWithListParam());
             SimpleLayout l = $@"${{layoutrenderer-with-list:{propname}={input}}}";
 
             var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
@@ -633,7 +630,7 @@ namespace NLog.UnitTests.Layouts
             //note flags enum already supported
 
             //can;t convert empty to int
-            ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition("layoutrenderer-with-list", typeof(LayoutRendererWithListParam));
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType("layoutrenderer-with-list", () => new LayoutRendererWithListParam());
             Assert.Throws<NLogConfigurationException>(() =>
             {
                 SimpleLayout l = $@"${{layoutrenderer-with-list:{propname}={input}}}";
@@ -655,7 +652,21 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
-        void FuncLayoutRendererRegisterTest1()
+        public void FuncLayoutRendererRegisterTest1()
+        {
+            var theAnswer = "42";
+
+            var logFactory = new LogFactory().Setup().SetupExtensions(ext => ext.RegisterLayoutRenderer("the-answer", (evt) => theAnswer))
+                .LoadConfiguration(builder => builder.ForLogger().WriteTo(new DebugTarget() { Name = "Debug", Layout = "${the-answer}" })).LogFactory;
+
+            logFactory.GetCurrentClassLogger().Info("Hello World");
+
+            AssertDebugLastMessage("Debug", theAnswer, logFactory);
+        }
+
+        [Fact]
+        [Obsolete("Instead override type-creation by calling NLog.LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
+        public void FuncLayoutRendererRegisterTest1_Legacy()
         {
             LayoutRenderer.Register("the-answer", (info) => "42");
             Layout l = "${the-answer}";
@@ -664,7 +675,7 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
-        void FuncLayoutRendererFluentMethod_ThreadAgnostic_Test()
+        public void FuncLayoutRendererFluentMethod_ThreadAgnostic_Test()
         {
             // Arrange
             var layout = Layout.FromMethod(l => "42", LayoutRenderOptions.ThreadAgnostic);
@@ -676,7 +687,7 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
-        void FuncLayoutRendererFluentMethod_Test()
+        public void FuncLayoutRendererFluentMethod_Test()
         {
             // Arrange
             var layout = Layout.FromMethod(l => "42", LayoutRenderOptions.None);
@@ -688,14 +699,33 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
-        void FuncLayoutRendererFluentMethod_NullThrows_Test()
+        public void FuncLayoutRendererFluentMethod_NullThrows_Test()
         {
             // Arrange
             Assert.Throws<ArgumentNullException>(() => Layout.FromMethod(null));
         }
 
         [Fact]
-        void FuncLayoutRendererRegisterTest1WithXML()
+        public void FuncLayoutRendererRegisterTest1WithXML()
+        {
+            var logFactory = new LogFactory().Setup().SetupExtensions(ext => ext.RegisterLayoutRenderer("the-answer", (evt) => 42))
+                .LoadConfigurationFromXml(
+@"<nlog throwExceptions='true'>          
+                <targets>
+                    <target name='debug' type='Debug' layout= 'TheAnswer=${the-answer:Format=D3}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>").LogFactory;
+
+            logFactory.GetCurrentClassLogger().Info("test1");
+
+            AssertDebugLastMessage("debug", "TheAnswer=042", logFactory);
+        }
+
+        [Fact]
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
+        public void FuncLayoutRendererRegisterTest1WithXML_Legacy()
         {
             LayoutRenderer.Register("the-answer", (info) => 42);
 
@@ -715,7 +745,19 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
-        void FuncLayoutRendererRegisterTest2()
+        public void FuncLayoutRendererRegisterTest2()
+        {
+            var logFactory = new LogFactory().Setup().SetupExtensions(ext => ext.RegisterLayoutRenderer("message-length", (evt) => evt.Message.Length))
+                .LoadConfiguration(builder => builder.ForLogger().WriteTo(new DebugTarget() { Name = "Debug", Layout = "${message-length" })).LogFactory;
+
+            logFactory.GetCurrentClassLogger().Info("1234567890");
+
+            AssertDebugLastMessage("Debug", "10", logFactory);
+        }
+
+        [Fact]
+        [Obsolete("Instead use LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
+        public void FuncLayoutRendererRegisterTest2_Legacy()
         {
             LayoutRenderer.Register("message-length", (info) => info.Message.Length);
             Layout l = "${message-length}";
@@ -724,13 +766,13 @@ namespace NLog.UnitTests.Layouts
         }
 
         [Fact]
-        void SimpleLayout_FromString_ThrowConfigExceptions()
+        public void SimpleLayout_FromString_ThrowConfigExceptions()
         {
             Assert.Throws<NLogConfigurationException>(() => Layout.FromString("${evil}", true));
         }
 
         [Fact]
-        void SimpleLayout_FromString_NoThrowConfigExceptions()
+        public void SimpleLayout_FromString_NoThrowConfigExceptions()
         {
             Assert.NotNull(Layout.FromString("${evil}", false));
         }
@@ -855,7 +897,7 @@ namespace NLog.UnitTests.Layouts
 
             public List<FilterResult> Enums { get; set; }
 
-            public List<MyFlagsEnum> FlagEnums { get; set; }
+            public List<Config.TargetConfigurationTests.MyFlagsEnum> FlagEnums { get; set; }
 
             public List<int> Numbers { get; set; }
 

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutParserTests.cs
@@ -552,7 +552,7 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void InvalidLayoutWithExistingRenderer_WillThrowIfExceptionThrowingIsOn()
         {
-            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType("layoutrenderer-with-list", () => new LayoutRendererWithListParam());
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType<LayoutRendererWithListParam>("layoutrenderer-with-list");
             LogManager.ThrowConfigExceptions = true;
             Assert.Throws<NLogConfigurationException>(() =>
             {
@@ -564,7 +564,7 @@ namespace NLog.UnitTests.Layouts
         [Fact]
         public void UnknownPropertyInLayout_WillThrowIfExceptionThrowingIsOn()
         {
-            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType("layoutrenderer-with-list", () => new LayoutRendererWithListParam());
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType<LayoutRendererWithListParam>("layoutrenderer-with-list");
             LogManager.ThrowConfigExceptions = true;
 
             Assert.Throws<NLogConfigurationException>(() =>
@@ -613,7 +613,7 @@ namespace NLog.UnitTests.Layouts
 #endif
         public void LayoutWithListParamTest(string input, string propname, string expected)
         {
-            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType("layoutrenderer-with-list", () => new LayoutRendererWithListParam());
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType<LayoutRendererWithListParam>("layoutrenderer-with-list");
             SimpleLayout l = $@"${{layoutrenderer-with-list:{propname}={input}}}";
 
             var le = LogEventInfo.Create(LogLevel.Info, "logger", "message");
@@ -630,7 +630,7 @@ namespace NLog.UnitTests.Layouts
             //note flags enum already supported
 
             //can;t convert empty to int
-            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType("layoutrenderer-with-list", () => new LayoutRendererWithListParam());
+            ConfigurationItemFactory.Default.LayoutRendererFactory.RegisterType<LayoutRendererWithListParam>("layoutrenderer-with-list");
             Assert.Throws<NLogConfigurationException>(() =>
             {
                 SimpleLayout l = $@"${{layoutrenderer-with-list:{propname}={input}}}";

--- a/tests/NLog.UnitTests/Layouts/ThreadAgnosticTests.cs
+++ b/tests/NLog.UnitTests/Layouts/ThreadAgnosticTests.cs
@@ -43,24 +43,6 @@ namespace NLog.UnitTests.Layouts
     public class ThreadAgnosticTests : NLogTestBase
     {
         [Fact]
-        public void ThreadAgnosticAttributeTest()
-        {
-            foreach (var t in ReflectionHelpers.SafeGetTypes(typeof(Layout).Assembly))
-            {
-                if (t.Namespace == typeof(WrapperLayoutRendererBase).Namespace)
-                {
-                    if (t.IsAbstract || t.IsEnum || t.IsNestedPrivate)
-                    {
-                        // skip non-concrete types, enumerations, and private nested types
-                        continue;
-                    }
-
-                    Assert.True(t.IsDefined(typeof(ThreadAgnosticAttribute), true), "Type " + t + " is missing [ThreadAgnostic] attribute.");
-                }
-            }
-        }
-
-        [Fact]
         public void ThreadAgnosticTest()
         {
             Layout l = new SimpleLayout("${message}");
@@ -178,8 +160,7 @@ namespace NLog.UnitTests.Layouts
         public void CustomNotAgnosticTests()
         {
             var cif = new ConfigurationItemFactory();
-            cif.RegisterType(typeof(CustomRendererNonAgnostic), string.Empty);
-
+            cif.LayoutRendererFactory.RegisterType("customNotAgnostic", () => new CustomRendererNonAgnostic());
             Layout l = new SimpleLayout("${customNotAgnostic}", cif);
 
             l.Initialize(null);
@@ -190,7 +171,7 @@ namespace NLog.UnitTests.Layouts
         public void CustomAgnosticTests()
         {
             var cif = new ConfigurationItemFactory();
-            cif.RegisterType(typeof(CustomRendererAgnostic), string.Empty);
+            cif.LayoutRendererFactory.RegisterType("customAgnostic", () => new CustomRendererAgnostic());
 
             Layout l = new SimpleLayout("${customAgnostic}", cif);
 

--- a/tests/NLog.UnitTests/Layouts/ThreadAgnosticTests.cs
+++ b/tests/NLog.UnitTests/Layouts/ThreadAgnosticTests.cs
@@ -160,7 +160,7 @@ namespace NLog.UnitTests.Layouts
         public void CustomNotAgnosticTests()
         {
             var cif = new ConfigurationItemFactory();
-            cif.LayoutRendererFactory.RegisterType("customNotAgnostic", () => new CustomRendererNonAgnostic());
+            cif.LayoutRendererFactory.RegisterType<CustomRendererNonAgnostic>("customNotAgnostic");
             Layout l = new SimpleLayout("${customNotAgnostic}", cif);
 
             l.Initialize(null);
@@ -171,7 +171,7 @@ namespace NLog.UnitTests.Layouts
         public void CustomAgnosticTests()
         {
             var cif = new ConfigurationItemFactory();
-            cif.LayoutRendererFactory.RegisterType("customAgnostic", () => new CustomRendererAgnostic());
+            cif.LayoutRendererFactory.RegisterType<CustomRendererAgnostic>("customAgnostic");
 
             Layout l = new SimpleLayout("${customAgnostic}", cif);
 

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -110,6 +110,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Replaced by LogFactory.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         public void Configuration_InaccessibleNLog_doesNotThrowException()
         {
             string tempDirectory = null;
@@ -138,6 +139,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Replaced by LogFactory.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         public void LoadConfiguration_InaccessibleNLog_throwException()
         {
             string tempDirectory = null;
@@ -170,6 +172,7 @@ namespace NLog.UnitTests
             return new FileStream(configFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
         }
 
+        [Obsolete("Replaced by LogFactory.Setup().LoadConfigurationFromFile(). Marked obsolete on NLog 5.2")]
         private static LogFactory CreateEmptyNLogFile(out string tempDirectory, out string filePath)
         {
             tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -57,7 +57,9 @@ namespace NLog.UnitTests
             //reset before every test
             LogManager.ThrowExceptions = false; // Ignore any errors triggered by closing existing config
             LogManager.Configuration = null;    // Will close any existing config
+#pragma warning disable CS0618 // Type or member is obsolete
             LogManager.LogFactory.ResetCandidateConfigFilePath();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             InternalLogger.Reset();
             InternalLogger.LogLevel = LogLevel.Off;

--- a/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ConcurrentFileTargetTests.cs
@@ -80,19 +80,22 @@ namespace NLog.UnitTests.Targets
             switch (modes[0])
             {
                 case "async":
-                    SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(ft, 100, AsyncTargetWrapperOverflowAction.Grow) { Name = name, TimeToSleepBetweenBatches = 10 }, LogLevel.Debug);
+                    var asyncTarget = new AsyncTargetWrapper(ft, 100, AsyncTargetWrapperOverflowAction.Grow) { Name = name, TimeToSleepBetweenBatches = 10 };
+                    LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(asyncTarget));
                     break;
 
                 case "buffered":
-                    SimpleConfigurator.ConfigureForTargetLogging(new BufferingTargetWrapper(ft, 100) { Name = name }, LogLevel.Debug);
+                    var bufferTarget = new BufferingTargetWrapper(ft, 100) { Name = name };
+                    LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(bufferTarget));
                     break;
 
                 case "buffered_timed_flush":
-                    SimpleConfigurator.ConfigureForTargetLogging(new BufferingTargetWrapper(ft, 100, 10) { Name = name }, LogLevel.Debug);
+                    var bufferFlushTarget = new BufferingTargetWrapper(ft, 100, 10) { Name = name };
+                    LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(bufferFlushTarget));
                     break;
 
                 default:
-                    SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                    LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(ft));
                     break;
             }
         }

--- a/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
@@ -478,7 +478,8 @@ namespace NLog.UnitTests.Targets
             var target = CreateEventLogTarget("NLog.UnitTests" + Guid.NewGuid().ToString("N"), EventLogTargetOverflowAction.Split, maxMessageLength);
             target.Layout = new SimpleLayout("${message}");
             target.Source = new SimpleLayout("${event-properties:item=DynamicSource}");
-            SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
+
+            LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(target));
 
             var logger = LogManager.GetLogger("WriteEventLogEntry");
 
@@ -515,7 +516,7 @@ namespace NLog.UnitTests.Targets
             var target = CreateEventLogTarget("NLog.UnitTests" + Guid.NewGuid().ToString("N"), EventLogTargetOverflowAction.Truncate, 5000);
             target.EventId = eventId;
             target.Category = (short)category;
-            SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
+            LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(target));
             var logger = LogManager.GetLogger("WriteEventLogEntry");
             logger.Log(LogLevel.Error, "Simple Test Message");
             var eventLog = new EventLog(target.Log);
@@ -540,7 +541,7 @@ namespace NLog.UnitTests.Targets
             var target = CreateEventLogTarget("NLog.UnitTests" + Guid.NewGuid().ToString("N"), EventLogTargetOverflowAction.Truncate, 5000);
             target.EventId = "${event-properties:EventId}";
             target.Category = "${event-properties:Category}";
-            SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
+            LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(target));
             var logger = LogManager.GetLogger("WriteEventLogEntry");
             LogEventInfo theEvent = new LogEventInfo(LogLevel.Error, "TestLoggerName", "Simple Message");
             theEvent.Properties["EventId"] = eventId;
@@ -572,7 +573,7 @@ namespace NLog.UnitTests.Targets
             var target = new EventLogTarget(eventLogMock, null);
             InitializeEventLogTarget(target, sourceName, overflowAction, maxMessageLength, entryType);
 
-            SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
+            LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(target));
 
             var logger = LogManager.GetLogger("WriteEventLogEntry");
             logger.Log(logLevel, logMessage);

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -124,7 +124,7 @@ namespace NLog.UnitTests.Targets
                     ForceMutexConcurrentWrites = forceMutexConcurrentWrites,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -186,7 +186,7 @@ namespace NLog.UnitTests.Targets
                             ArchiveAboveSize = archiveSameFolder ? 1000000 : 0,
                         };
 
-                        SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                        LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                         logger.Debug("aaa");
 
@@ -274,7 +274,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${level} ${message}",
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -306,7 +306,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${level} ${message}",
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("aaa");
 
@@ -350,7 +350,7 @@ namespace NLog.UnitTests.Targets
                         ForceMutexConcurrentWrites = forceMutexConcurrentWrites,
                     };
 
-                    SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                    LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                     for (int i = 0; i < 300; i++)
                     {
@@ -412,7 +412,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 1,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 for (int i = 0; i < 12; ++i)
                 {
                     for (int j = 0; j < 31; ++j)
@@ -520,7 +520,7 @@ namespace NLog.UnitTests.Targets
                         MaxArchiveDays = maxArchiveDays ? 5 * 30 : 0
                     };
 
-                    SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                    LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                     logger.Debug($"{i.ToString()}{i.ToString()}{i.ToString()}");
                     LogManager.Configuration = null;    // Flush
 
@@ -603,7 +603,7 @@ namespace NLog.UnitTests.Targets
                         ArchiveAboveSize = 120, // Only 2 LogEvents per file
                         MaxArchiveFiles = 1,
                     };
-                    SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                    LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                     if (i == 0)
                     {
@@ -651,7 +651,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${level} ${message}"
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -672,7 +672,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${level} ${message}"
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -692,7 +692,7 @@ namespace NLog.UnitTests.Targets
                     DeleteOldFileOnStartup = true
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 logger.Debug("aaa");
                 logger.Info("bbb");
                 logger.Warn("ccc");
@@ -777,7 +777,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${level} ${message}"
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -797,7 +797,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${level} ${message}"
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -826,7 +826,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 1
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 logger.Debug("ddd");
                 logger.Info("eee");
                 logger.Warn("fff");
@@ -881,14 +881,14 @@ namespace NLog.UnitTests.Targets
             try
             {
                 // No archive on startup (ignoring threshold)
-                SimpleConfigurator.ConfigureForTargetLogging(CreateTestTarget(1000));
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(CreateTestTarget(1000)));
                 logger.Info("aaa");
-                LogManager.Flush();
+                LogManager.Shutdown();
                 AssertFileContents(logFile, "Info aaa\n", Encoding.UTF8);
                 Assert.False(File.Exists(archiveTempName));
 
                 // Archive on startup with small threshold -> Must be archived
-                SimpleConfigurator.ConfigureForTargetLogging(CreateTestTarget(3));
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(CreateTestTarget(3)));
                 logger.Info("ccc");
                 LogManager.Flush();
                 AssertFileContents(logFile, "Info ccc\n", Encoding.UTF8);
@@ -929,14 +929,14 @@ namespace NLog.UnitTests.Targets
             try
             {
                 // No archive on startup (ignoring threshold)
-                SimpleConfigurator.ConfigureForTargetLogging(CreateTestTarget(1000));
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(CreateTestTarget(1000)));
                 logger.Info("aaa");
-                LogManager.Flush();
+                LogManager.Shutdown();
                 AssertFileContents(logFile, "Info aaa\n", Encoding.UTF8);
                 Assert.False(File.Exists(archiveTempName));
 
                 NLog.LogManager.ThrowExceptions = false;
-                SimpleConfigurator.ConfigureForTargetLogging(CreateTestTarget(3));
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(CreateTestTarget(3)));
 
                 using (var fileStream = new FileStream(logFile, FileMode.Open, FileAccess.Write, FileShare.None))
                 {
@@ -992,7 +992,7 @@ namespace NLog.UnitTests.Targets
                 if (useFooter)
                     fileTarget.Footer = footer;
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 string headerPart = useHeader ? header + LineEndingMode.LF.NewLineCharacters : string.Empty;
                 string footerPart = useFooter ? footer + LineEndingMode.LF.NewLineCharacters : string.Empty;
@@ -1072,7 +1072,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${level} ${message}"
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -1112,7 +1112,7 @@ namespace NLog.UnitTests.Targets
                     OpenFileFlushTimeout = autoFlushTimeout,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -1164,7 +1164,7 @@ namespace NLog.UnitTests.Targets
                     ArchiveNumbering = ArchiveNumberingMode.Sequence
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 // we emit 5 * 25 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
@@ -1228,7 +1228,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 0
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 // we emit 5 * 25 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 4 archives
@@ -1293,7 +1293,7 @@ namespace NLog.UnitTests.Targets
                     ArchiveNumbering = ArchiveNumberingMode.Date
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 //e.g. 20150804
                 var archiveFileName = DateTime.Now.ToString("yyyyMMdd");
@@ -1368,7 +1368,8 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = maxArchiveFiles
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
+
                 //writing 19 times 10 bytes (9 char + linefeed) will result in 3 archive files and 1 current file
                 for (var i = 0; i < 19; ++i)
                 {
@@ -1387,7 +1388,7 @@ namespace NLog.UnitTests.Targets
                 Assert.Equal(maxArchiveFiles, files.Count());
 
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 //writing just one line of 11 bytes will trigger the cleanup of old archived files
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest file
                 logger.Debug("1234567890");
@@ -1435,7 +1436,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = maxArchiveFiles
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 for (var i = 0; i < 4; ++i)
                 {
                     logger.Debug("123456789");
@@ -1450,7 +1451,7 @@ namespace NLog.UnitTests.Targets
                 Assert.Equal(maxArchiveFiles + 1, files.Count());
 
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 //writing 50ms later will trigger the cleanup of old archived files
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest file
                 Thread.Sleep(50);
@@ -1542,7 +1543,7 @@ namespace NLog.UnitTests.Targets
                     Header = "header",
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("123456789");
                 DateTime previousWriteTime = timeSource.Time;
@@ -1596,7 +1597,7 @@ namespace NLog.UnitTests.Targets
                 foreach (var file in files)
                     AssertFileContentsStartsWith(file, "header", Encoding.UTF8);
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 //writing one line on a new day will trigger the cleanup of old archived files
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest file
                 timeSource.AddToLocalTime(TimeSpan.FromDays(1));
@@ -1693,7 +1694,7 @@ namespace NLog.UnitTests.Targets
                     ForceMutexConcurrentWrites = forceMutexConcurrentWrites,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("123456789");
                 LogManager.Flush();
@@ -1775,7 +1776,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${date:format=O}|${message}",
                 };
                 string archiveDateFormat = fileTarget.ArchiveDateFormat;
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("1234567890");
                 timeSource.AddToLocalTime(TimeSpan.FromMinutes(1));
@@ -1970,7 +1971,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 0
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 //writing 19 times 10 bytes (9 char + linefeed) will result in 3 archive files and 1 current file
                 for (var i = 0; i < 19; ++i)
                 {
@@ -1990,7 +1991,7 @@ namespace NLog.UnitTests.Targets
 
                 Assert.Equal(3, fileCount);
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 //create 1 new file for archive
                 logger.Debug("1234567890");
                 LogManager.Configuration = null;
@@ -2033,7 +2034,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 5
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 //writing 29 times 10 bytes (9 char + linefeed) will result in 3 archive files and 1 current file
                 for (var i = 0; i < 29; ++i)
                 {
@@ -2052,7 +2053,7 @@ namespace NLog.UnitTests.Targets
 
                 //alter the MaxArchivedFiles
                 fileTarget.MaxArchiveFiles = 2;
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 //writing just one line of 11 bytes will trigger the cleanup of old archived files
                 //as stated by the MaxArchiveFiles property, but will only delete the oldest files
                 logger.Debug("1234567890");
@@ -2102,7 +2103,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 2,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 // Writing 16 times 10 bytes = 160 bytes = 3 files
                 for (var i = 0; i < 16; ++i)
@@ -2141,7 +2142,7 @@ namespace NLog.UnitTests.Targets
                 const string footer = "Footerline";
 
                 string archiveFolder = Path.Combine(tempPath, "archive");
-                var ft = new FileTarget
+                var fileTarget = new FileTarget
                 {
                     FileName = logFile,
                     ArchiveFileName = Path.Combine(archiveFolder, "{####}.txt"),
@@ -2154,7 +2155,7 @@ namespace NLog.UnitTests.Targets
                     WriteFooterOnArchivingOnly = writeFooterOnArchivingOnly
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(ft, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 // Writing 16 times 10 bytes = 160 bytes = 3 files
                 for (var i = 0; i < 16; ++i)
@@ -2164,7 +2165,7 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;    // Flush
 
-                string expectedEnding = footer + ft.LineEnding.NewLineCharacters;
+                string expectedEnding = footer + fileTarget.LineEnding.NewLineCharacters;
                 if (writeFooterOnArchivingOnly)
                     Assert.False(File.ReadAllText(logFile).EndsWith(expectedEnding), "Footer was unexpectedly written to log file.");
                 else
@@ -2233,7 +2234,7 @@ namespace NLog.UnitTests.Targets
                 if (specifyArchiveFileName)
                     fileTarget.ArchiveFileName = Path.Combine(tempPath, "archive", "{####}." + archiveExtension);
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 // we emit 5 * 25 * (3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
@@ -2312,7 +2313,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 0
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 // we emit 5 * 25 * (3 x aaa + \n) bytes
                 // so that we should get a full file + 4 archives
@@ -2377,7 +2378,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${message}"
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger(LogLevel.Debug).WriteTo(fileTarget));
 
                 var times = 25;
                 for (var i = 0; i < times; ++i)
@@ -2429,7 +2430,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${message}"
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(new BufferingTargetWrapper(fileTarget, 10), LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger(LogLevel.Debug).WriteTo(new BufferingTargetWrapper(fileTarget, 10)));
 
                 var times = 25;
                 for (var i = 0; i < times; ++i)
@@ -2486,11 +2487,7 @@ namespace NLog.UnitTests.Targets
                 // in logging threads.
                 var threadID = Thread.CurrentThread.ManagedThreadId.ToString();
 
-                SimpleConfigurator.ConfigureForTargetLogging(new AsyncTargetWrapper(fileTarget, 10, AsyncTargetWrapperOverflowAction.Grow)
-                {
-                    Name = "AsyncMultiFileWrite_wrapper",
-                    TimeToSleepBetweenBatches = 1,
-                }, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger(LogLevel.Debug).WriteTo(fileTarget).WithAsync());
 
                 var times = 25;
                 for (var i = 0; i < times; ++i)
@@ -2603,7 +2600,7 @@ namespace NLog.UnitTests.Targets
                 }
 #endif
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 // we emit 5 * 25 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 3 archives
@@ -2681,7 +2678,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 1000,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 for (var i = 0; i < 25; ++i)
                 {
@@ -2722,7 +2719,7 @@ namespace NLog.UnitTests.Targets
                     OpenFileCacheTimeout = 0
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Fatal);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Fatal("aaa");
 
@@ -2760,7 +2757,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 5
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 //Creates 5 archive files.
                 for (int i = 0; i <= 5; i++)
@@ -2808,7 +2805,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 10   // Get past the optimization to avoid deleting old files.
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 string existingFile = archiveFileLayout.Replace("{#}", "notadate");
                 Directory.CreateDirectory(Path.GetDirectoryName(logFile));
@@ -2847,7 +2844,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 1,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 // we emit 2 * 25 *(aaa + \n) bytes
                 // so that we should get a full file + 1 archives
@@ -2912,7 +2909,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 2,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 // we emit 3 * 25 *(aaa + \n) bytes
                 // so that we should get a full file + 2 archives
@@ -2994,7 +2991,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 2,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 // we emit 2 * 25 *(aaa + \n) bytes
                 // so that we should get a full file + 1 archive
@@ -3054,7 +3051,7 @@ namespace NLog.UnitTests.Targets
                     ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 ArchiveFileNameHelper helper = new ArchiveFileNameHelper(Path.Combine(tempPath, "archive"), DateTime.Now.ToString(fileTarget.ArchiveDateFormat), archiveExtension);
 
@@ -3117,7 +3114,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = maxArchiveFiles,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 var logger1 = LogManager.GetLogger("log");
                 var logger2 = LogManager.GetLogger("log-other");
 
@@ -3184,7 +3181,7 @@ namespace NLog.UnitTests.Targets
 
                 // Verify that archieve-cleanup after startup handles same folder archive correctly
                 fileTarget.ArchiveAboveSize = 200;
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 logger1.Info("Bye");
                 logger2.Info("Bye");
                 Assert.Equal(12, Directory.GetFiles(tempPath).Length);
@@ -3212,7 +3209,7 @@ namespace NLog.UnitTests.Targets
             var logFile1 = Path.Combine(tempPath, "Log{0}.txt");
             try
             {
-                var fileTarget1 = new FileTarget
+                var fileTarget = new FileTarget
                 {
                     FileName = string.Format(logFile1, ""),
                     ArchiveAboveSize = 100,
@@ -3222,7 +3219,7 @@ namespace NLog.UnitTests.Targets
                     Encoding = Encoding.ASCII,
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget1, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 Generate100BytesLog('a');
                 Generate100BytesLog('b');
@@ -3349,7 +3346,7 @@ namespace NLog.UnitTests.Targets
                 ArchiveNumbering = archiveNumbering,
                 ArchiveAboveSize = logFileMaxSize
             };
-            SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+            LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
             for (int currentSequenceNumber = 0; currentSequenceNumber < count; currentSequenceNumber++)
                 logger.Debug("Test {0}", currentSequenceNumber);
 
@@ -3927,7 +3924,7 @@ namespace NLog.UnitTests.Targets
                     OpenFileCacheTimeout = 0
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -3957,7 +3954,7 @@ namespace NLog.UnitTests.Targets
                     OpenFileCacheTimeout = 0
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("aaa");
                 logger.Info("bbb");
@@ -3992,7 +3989,7 @@ namespace NLog.UnitTests.Targets
                     MaxArchiveFiles = 0
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
                 logfile = Path.GetFullPath(logfile);
                 // we emit 5 * 25 *(3 x aaa + \n) bytes
                 // so that we should get a full file + 4 archives
@@ -4381,7 +4378,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${message}",
                 };
 
-                SimpleConfigurator.ConfigureForTargetLogging(fileTarget, LogLevel.Debug);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 var logger = LogManager.GetLogger(nameof(ShouldNotArchiveWhenMeetingOldLogEventTimestamps));
                 logger.Info("123");

--- a/tests/TestTrimPublish/Program.cs
+++ b/tests/TestTrimPublish/Program.cs
@@ -17,10 +17,10 @@ try
     </nlog>
     ").GetCurrentClassLogger();
 
-    logger.Debug("Start");
+    logger.Debug("Almost ready");
     logger.Info("Success");
-
     NLog.LogManager.Shutdown();
+    logger.Debug("Almost done");
 }
 finally
 {

--- a/tests/TestTrimPublish/Program.cs
+++ b/tests/TestTrimPublish/Program.cs
@@ -1,0 +1,37 @@
+﻿using NLog;
+
+var consoleWriter = new StringWriter();
+var orgConsole = System.Console.Out;
+try
+{
+    System.Console.SetOut(consoleWriter);
+
+    var logger = NLog.LogManager.Setup().LoadConfigurationFromXml(@"
+    <nlog>
+      <targets>
+        <target type='console' name='console' layout='${threadid}|${message}' />
+      </targets>
+      <rules>
+        <logger name='*' minLevel='Info' writeTo='console' />
+      </rules>
+    </nlog>
+    ").GetCurrentClassLogger();
+
+    logger.Debug("Start");
+    logger.Info("Success");
+
+    NLog.LogManager.Shutdown();
+}
+finally
+{
+    System.Console.SetOut(orgConsole);
+}
+
+var result = consoleWriter.ToString();
+
+Console.WriteLine(result);
+
+if (result == $"{Environment.CurrentManagedThreadId}|Success{System.Environment.NewLine}")
+    return 0;
+else
+    return -1;

--- a/tests/TestTrimPublish/TestTrimPublish.csproj
+++ b/tests/TestTrimPublish/TestTrimPublish.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishTrimmed>true</PublishTrimmed>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NLog\NLog.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
See also #5190

`ConfigurationItemFactory` must mark all dynamic type-loading as obsolete, and instead redirect to new LogFactory.Setup()-extension-methods. The extension-methods to perform assembly-loading will then be extracted to seperate nuget-package with NLog v6.

Still missing some pieces:
- [x] Verify that triming will work without warnings when using factory-delegate, instead of `Activator.CreateInstance`
- [x] Change to use the new static registration, instead of dynamic scanning of NLog-assembly.
- [x] Implement unit-test that asserts that static-registration is done correctly for all relevant types.
- [x] Step 2 that makes reflection free property-assignment possible.
- [x] Mark all the old registration-methods for extensions as obsolete, and redirect to using factory-delegates (Using NLog v5 for guiding users to NLog v6)
- [x] Mark all the old file-loading-methods as obsolete and redirect to `NLog.LogManager.Setup().LoadConfigurationFromFile()`
    - Also `XmlLoggingConfiguration.CreateFromXmlString` as `XmlLoggingConfiguration` with include-file-support will disappear
    - Also `LoggingConfiguration.FileNamesToWatch` as only relevant for `XmlLoggingConfiguration`