### PR TITLE
Add variables element to NLog.xsd and extend schema tests

### DIFF
--- a/Test-XmlFile.ps1
+++ b/Test-XmlFile.ps1
@@ -52,6 +52,19 @@ function Test-XmlFile
 
 # Needs absolute paths. Will throw a error if one of the files is not found
 $pwd = get-location;
+$testFilesDir = "$pwd\examples\targets\Configuration File"
+$xsdFilePath = "$pwd\src\NLog\bin\Release\NLog.xsd"
+$excludedTests = ("MessageBox","RichTextBox","FormControl","PerfCounter","OutputDebugString","MSMQ","Database")
+
+$ret = $true
+Get-ChildItem -Path $testFilesDir -Directory -Exclude $excludedTests | Get-ChildItem -Recurse -File -Filter NLog.config | % {
+    $testOutcome = Test-XmlFile $xsdFilePath $_.FullName
+    if (-Not $testOutcome) { 
+        $ret = $false
+    }
+}
+return $ret
 
 # Returns true if valid
-return Test-XmlFile "$pwd\src\NLog\bin\Release\NLog.xsd" "$pwd\examples\targets\Configuration File\Null\NLog.config"
+#return Test-XmlFile "$pwd\src\NLog\bin\Release\NLog.xsd" "$pwd\examples\targets\Configuration File\Null\NLog.config"
+#return Test-XmlFile "$pwd\src\NLog\bin\Release\NLog.xsd" "$pwd\examples\targets\Configuration File\Variables\NLog.config"

--- a/Test-XmlFile.ps1
+++ b/Test-XmlFile.ps1
@@ -55,7 +55,7 @@ $pwd = get-location;
 $testFilesDir = "$pwd\examples\targets\Configuration File"
 $xsdFilePath = "$pwd\src\NLog\bin\Release\NLog.xsd"
 $excludedTests = ("MessageBox","RichTextBox","FormControl","PerfCounter","OutputDebugString","MSMQ","Database")
-
+# Returns true if all selected tests in examples directory are valid
 $ret = $true
 Get-ChildItem -Path $testFilesDir -Directory -Exclude $excludedTests | Get-ChildItem -Recurse -File -Filter NLog.config | % {
     $testOutcome = Test-XmlFile $xsdFilePath $_.FullName
@@ -64,7 +64,3 @@ Get-ChildItem -Path $testFilesDir -Directory -Exclude $excludedTests | Get-Child
     }
 }
 return $ret
-
-# Returns true if valid
-#return Test-XmlFile "$pwd\src\NLog\bin\Release\NLog.xsd" "$pwd\examples\targets\Configuration File\Null\NLog.config"
-#return Test-XmlFile "$pwd\src\NLog\bin\Release\NLog.xsd" "$pwd\examples\targets\Configuration File\Variables\NLog.config"

--- a/examples/targets/Configuration File/File/CSV/NLog.config
+++ b/examples/targets/Configuration File/File/CSV/NLog.config
@@ -3,7 +3,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <targets>
         <target name="csv" xsi:type="File" fileName="${basedir}/file.csv">
-            <layout xsi:type="CSVLayout">
+            <layout xsi:type="CsvLayout">
                 <column name="time" layout="${longdate}" />
                 <column name="message" layout="${message}" />
                 <column name="logger" layout="${logger}"/>

--- a/examples/targets/Configuration File/Null/NLog.config
+++ b/examples/targets/Configuration File/Null/NLog.config
@@ -4,7 +4,7 @@
     <targets>
         <target name="n" xsi:type="Null" layout="${message}" formatMessage="true" />
     </targets>
-
+	
     <rules>
         <logger name="*" minlevel="Debug" writeTo="n" />
     </rules>

--- a/examples/targets/Configuration File/Variables/NLog.config
+++ b/examples/targets/Configuration File/Variables/NLog.config
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      
+    <extensions>
+        <add assembly="NLog.Extensions.Logging"/> <!-- enable MicrosoftConsoleLayout -->
+    </extensions>
+
+    <variables>
+        <variable name="MaiL.Host" value="localhost"/>
+        <variable name="Mail.To" value="jaak@jkowalski.net"/>
+    </variables>
+    
+    <variable name="CommonLayout">
+        <layout xsi:type="JsonLayout" includeEventProperties="true">
+            <attribute name="area" layout="${gdc:item=area}" />
+        </layout>
+    </variable>
+      
+      
+    <targets>
+        <target name="mail" xsi:type="Mail"
+            smtpServer="${Mail.Host}" 
+            from="jaak@jkowalski.net"
+            to="${Mail.To}"
+            subject="test subject" 
+            layout="${CommonLayout}"/>
+    </targets>
+
+    <rules>
+        <logger name="*" minlevel="Debug" writeTo="mail" />
+    </rules>
+</nlog>

--- a/examples/targets/Configuration File/WebService/NLog.config
+++ b/examples/targets/Configuration File/WebService/NLog.config
@@ -4,9 +4,9 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <targets>
         <target name="ws" xsi:type="WebService" namespace="http://www.nlog-project.org/example" protocol="Soap11" methodName="HelloWorld" url="http://localhost:2648/Service1.asmx">
-            <parameter name="n1" type="System.String" layout="${message}"/>
-            <parameter name="n2" type="System.String" layout="${logger}"/>
-            <parameter name="n3" type="System.String" layout="${level}"/>
+            <parameter name="n1" parameterType="System.String" layout="${message}"/>
+            <parameter name="n2" parameterType="System.String" layout="${logger}"/>
+            <parameter name="n3" parameterType="System.String" layout="${level}"/>
         </target>
     </targets>
 

--- a/tools/MakeNLogXSD/TemplateXSD.xml
+++ b/tools/MakeNLogXSD/TemplateXSD.xml
@@ -12,6 +12,7 @@
       <xs:element name="extensions" type="NLogExtensions" />
       <xs:element name="include" type="NLogInclude" />
       <xs:element name="variable" type="NLogVariable" />
+      <xs:element name="variables" type="NLogVariables" />
       <xs:element name="targets" type="NLogTargets" />
       <xs:element name="rules" type="NLogRules" />
       <xs:element name="time" type="TimeSource" />
@@ -263,6 +264,12 @@
         <xs:documentation>Variable value.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="NLogVariables">
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="variable" type="NLogVariable" />
+    </xs:sequence>
   </xs:complexType>
 
   <xs:simpleType name="NLogTargetIDList">

--- a/tools/MakeNLogXSD/TemplateXSD.xml
+++ b/tools/MakeNLogXSD/TemplateXSD.xml
@@ -253,6 +253,11 @@
           <xs:documentation>Variable value. Note, the 'value' attribute has precedence over this one.</xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout">
+        <xs:annotation>
+          <xs:documentation>Layout type variable value. Note, the 'value' attribute has precedence over this one.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
     </xs:choice>
     <xs:attribute name="name" type="xs:string" use="required">
       <xs:annotation>


### PR DESCRIPTION
This PR resolves #5201 and extends testing engine to process multiple example directories (vs. single Null directory as before).