### PR TITLE
FileTarget - Recover from file-deleted when same archive-folder

### DIFF
--- a/src/NLog/Internal/Files/MultiFileWatcher.cs
+++ b/src/NLog/Internal/Files/MultiFileWatcher.cs
@@ -131,7 +131,7 @@ namespace NLog.Internal
                 directory = Path.GetFullPath(directory);
                 if (!Directory.Exists(directory))
                 {
-                    InternalLogger.Warn("Cannot watch file {0} for non-existing directory: {1}", fileName, directory);
+                    InternalLogger.Warn("Cannot watch file '{0}' for non-existing directory: {1}", fileName, directory);
                     return;
                 }
 

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1980,7 +1980,7 @@ namespace NLog.Targets
             if (!initializedNewFile && _initializedFiles.Remove(archiveFileName))
             {
                 // Register current filename needs re-initialization
-                InternalLogger.Debug("{0}: Invalidates appender for archive file '{1}' since it no longer exists", this, archiveFileName);
+                InternalLogger.Debug("{0}: Invalidate appender as archive file no longer exists: '{1}'", this, archiveFileName);
                 _fileAppenderCache.InvalidateAppender(archiveFileName)?.Dispose();
             }
 


### PR DESCRIPTION
Resolves #5203

Skip optimization to ignore certain file-operations when happening in the archive-folder-destination-folder, when using `concurrentWrites="true"` (because it conflicts with same folder-archive-situations).

Since `concurrentWrites="false"` is the new default with NLog v5, then I'm not that worried about removing these specials optimizations for `concurrentWrites="true"`, when conflicting with same-folder-archive-logic (that was approved with NLog v4.5)