### PR TITLE
Refactor - Apply ThrowIfNull and ThrowIfNullOrEmpty

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -83,7 +83,7 @@ namespace NLog.Config
         internal ConfigurationItemFactory(ServiceRepository serviceRepository, ConfigurationItemFactory globalDefaultFactory, params Assembly[] assemblies)
         {
             CreateInstance = FactoryHelper.CreateInstance;
-            _serviceRepository = serviceRepository ?? throw new ArgumentNullException(nameof(serviceRepository));
+            _serviceRepository = Guard.ThrowIfNull(serviceRepository);
             _targets = new Factory<Target, TargetAttribute>(this, globalDefaultFactory?._targets);
             _filters = new Factory<Filter, FilterAttribute>(this, globalDefaultFactory?._filters);
             _layoutRenderers = new LayoutRendererFactory(this, globalDefaultFactory?._layoutRenderers);

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -213,7 +213,7 @@ namespace NLog.Config
         /// <exception cref="ArgumentNullException">when <paramref name="target"/> is <see langword="null"/></exception>
         public void AddTarget([NotNull] Target target)
         {
-            if (target is null) { throw new ArgumentNullException(nameof(target)); }
+            Guard.ThrowIfNull(target);
 
             InternalLogger.Debug("Adding target {0}(Name={1})", target.GetType(), target.Name);
 
@@ -231,8 +231,8 @@ namespace NLog.Config
         /// <exception cref="ArgumentNullException">when <paramref name="target"/> is <see langword="null"/></exception>
         public void AddTarget(string name, [NotNull] Target target)
         {
-            if (name is null) { throw new ArgumentNullException(nameof(name)); }
-            if (target is null) { throw new ArgumentNullException(nameof(target)); }
+            Guard.ThrowIfNull(name);
+            Guard.ThrowIfNull(target);
 
             InternalLogger.Debug("Adding target {0}(Name={1})", target.GetType(), string.IsNullOrEmpty(name) ? target.Name : name);
 
@@ -317,7 +317,7 @@ namespace NLog.Config
         /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
         public void AddRule(LogLevel minLevel, LogLevel maxLevel, Target target, string loggerNamePattern = "*")
         {
-            if (target is null) { throw new ArgumentNullException(nameof(target)); }
+            Guard.ThrowIfNull(target);
             AddRule(minLevel, maxLevel, target, loggerNamePattern, false);
         }
 
@@ -331,7 +331,7 @@ namespace NLog.Config
         /// <param name="final">Gets or sets a value indicating whether to quit processing any further rule when this one matches.</param>
         public void AddRule(LogLevel minLevel, LogLevel maxLevel, Target target, string loggerNamePattern, bool final)
         {
-            if (target is null) { throw new ArgumentNullException(nameof(target)); }
+            Guard.ThrowIfNull(target);
             AddLoggingRulesThreadSafe(new LoggingRule(loggerNamePattern, minLevel, maxLevel, target) { Final = final });
             AddTargetThreadSafe(target);
         }
@@ -370,7 +370,7 @@ namespace NLog.Config
         /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
         public void AddRuleForOneLevel(LogLevel level, Target target, string loggerNamePattern = "*")
         {
-            if (target is null) { throw new ArgumentNullException(nameof(target)); }
+            Guard.ThrowIfNull(target);
             AddRuleForOneLevel(level, target, loggerNamePattern, false);
         }
 
@@ -383,7 +383,7 @@ namespace NLog.Config
         /// <param name="final">Gets or sets a value indicating whether to quit processing any further rule when this one matches.</param>
         public void AddRuleForOneLevel(LogLevel level, Target target, string loggerNamePattern, bool final)
         {
-            if (target is null) { throw new ArgumentNullException(nameof(target)); }
+            Guard.ThrowIfNull(target);
             var loggingRule = new LoggingRule(loggerNamePattern, target) { Final = final };
             loggingRule.EnableLoggingForLevel(level);
             AddLoggingRulesThreadSafe(loggingRule);
@@ -413,7 +413,7 @@ namespace NLog.Config
         /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
         public void AddRuleForAllLevels(Target target, string loggerNamePattern = "*")
         {
-            if (target is null) { throw new ArgumentNullException(nameof(target)); }
+            Guard.ThrowIfNull(target);
             AddRuleForAllLevels(target, loggerNamePattern, false);
         }
 
@@ -425,7 +425,7 @@ namespace NLog.Config
         /// <param name="final">Gets or sets a value indicating whether to quit processing any further rule when this one matches.</param>
         public void AddRuleForAllLevels(Target target, string loggerNamePattern, bool final)
         {
-            if (target is null) { throw new ArgumentNullException(nameof(target)); }
+            Guard.ThrowIfNull(target);
             var loggingRule = new LoggingRule(loggerNamePattern, target) { Final = final };
             loggingRule.EnableLoggingForLevels(LogLevel.MinLevel, LogLevel.MaxLevel);
             AddLoggingRulesThreadSafe(loggingRule);
@@ -577,10 +577,7 @@ namespace NLog.Config
         /// </remarks>
         public void Install(InstallationContext installationContext)
         {
-            if (installationContext is null)
-            {
-                throw new ArgumentNullException(nameof(installationContext));
-            }
+            Guard.ThrowIfNull(installationContext);
 
             InitializeAll();
             var configItemsList = GetInstallableItems();
@@ -615,10 +612,7 @@ namespace NLog.Config
         /// </remarks>
         public void Uninstall(InstallationContext installationContext)
         {
-            if (installationContext is null)
-            {
-                throw new ArgumentNullException(nameof(installationContext));
-            }
+            Guard.ThrowIfNull(installationContext);
 
             InitializeAll();
 

--- a/src/NLog/Config/NLogDependencyResolveException.cs
+++ b/src/NLog/Config/NLogDependencyResolveException.cs
@@ -33,6 +33,7 @@
 
 using System;
 using JetBrains.Annotations;
+using NLog.Internal;
 
 namespace NLog.Config
 {
@@ -51,7 +52,7 @@ namespace NLog.Config
         /// </summary>
         public NLogDependencyResolveException(string message, [NotNull] Type serviceType) : base(CreateFullMessage(serviceType, message))
         {
-            ServiceType = serviceType ?? throw new ArgumentNullException(nameof(serviceType));
+            ServiceType = Guard.ThrowIfNull(serviceType);
         }
 
         /// <summary>
@@ -59,7 +60,7 @@ namespace NLog.Config
         /// </summary>
         public NLogDependencyResolveException(string message, Exception innerException, [NotNull] Type serviceType) : base(CreateFullMessage(serviceType, message), innerException)
         {
-            ServiceType = serviceType ?? throw new ArgumentNullException(nameof(serviceType));
+            ServiceType = Guard.ThrowIfNull(serviceType);
         }
 
         private static string CreateFullMessage(Type typeToResolve, string message) => $"Cannot resolve the type: '{typeToResolve.Name}'. {message}".Trim();

--- a/src/NLog/Config/ServiceRepositoryExtensions.cs
+++ b/src/NLog/Config/ServiceRepositoryExtensions.cs
@@ -140,10 +140,7 @@ namespace NLog.Config
         /// </summary>
         internal static ServiceRepository RegisterValueFormatter(this ServiceRepository serviceRepository, [NotNull] IValueFormatter valueFormatter)
         {
-            if (valueFormatter is null)
-            {
-                throw new ArgumentNullException(nameof(valueFormatter));
-            }
+            Guard.ThrowIfNull(valueFormatter);
 
             serviceRepository.RegisterSingleton(valueFormatter);
             return serviceRepository;
@@ -151,10 +148,7 @@ namespace NLog.Config
 
         internal static ServiceRepository RegisterJsonConverter(this ServiceRepository serviceRepository, [NotNull] IJsonConverter jsonConverter)
         {
-            if (jsonConverter is null)
-            {
-                throw new ArgumentNullException(nameof(jsonConverter));
-            }
+            Guard.ThrowIfNull(jsonConverter);
 
             serviceRepository.RegisterSingleton(jsonConverter);
             return serviceRepository;
@@ -162,10 +156,7 @@ namespace NLog.Config
 
         internal static ServiceRepository RegisterPropertyTypeConverter(this ServiceRepository serviceRepository, [NotNull] IPropertyTypeConverter converter)
         {
-            if (converter is null)
-            {
-                throw new ArgumentNullException(nameof(converter));
-            }
+            Guard.ThrowIfNull(converter);
 
             serviceRepository.RegisterSingleton(converter);
             return serviceRepository;
@@ -173,10 +164,7 @@ namespace NLog.Config
 
         internal static ServiceRepository RegisterObjectTypeTransformer(this ServiceRepository serviceRepository, [NotNull] IObjectTypeTransformer transformer)
         {
-            if (transformer is null)
-            {
-                throw new ArgumentNullException(nameof(transformer));
-            }
+            Guard.ThrowIfNull(transformer);
 
             serviceRepository.RegisterSingleton(transformer);
             return serviceRepository;

--- a/src/NLog/Config/ServiceRepositoryInternal.cs
+++ b/src/NLog/Config/ServiceRepositoryInternal.cs
@@ -64,10 +64,8 @@ namespace NLog.Config
 
         public override void RegisterService(Type type, object instance)
         {
-            if (type is null)
-                throw new ArgumentNullException(nameof(type));
-            if (instance is null)
-                throw new ArgumentNullException(nameof(instance));
+            Guard.ThrowIfNull(type);
+            Guard.ThrowIfNull(instance);
 
             lock (_lockObject)
             {
@@ -95,8 +93,7 @@ namespace NLog.Config
 
         private object DefaultResolveInstance(Type itemType, HashSet<Type> seenTypes)
         {
-            if (itemType is null)
-                throw new ArgumentNullException(nameof(itemType));
+            Guard.ThrowIfNull(itemType);
 
             ConfigurationItemCreator objectResolver = null;
             CompiledConstructor compiledConstructor = null;
@@ -223,7 +220,7 @@ namespace NLog.Config
 
             public CompiledConstructor([NotNull] ReflectionHelpers.LateBoundConstructor ctor, ParameterInfo[] parameters = null)
             {
-                Ctor = ctor ?? throw new ArgumentNullException(nameof(ctor));
+                Ctor = Guard.ThrowIfNull(ctor);
                 Parameters = parameters;
             }
         }

--- a/src/NLog/Config/SimpleConfigurator.cs
+++ b/src/NLog/Config/SimpleConfigurator.cs
@@ -34,6 +34,7 @@
 namespace NLog.Config
 {
     using System;
+    using NLog.Internal;
     using NLog.Targets;
 
     /// <summary>
@@ -75,7 +76,7 @@ namespace NLog.Config
         /// <param name="target">The target to log all messages to.</param>
         public static void ConfigureForTargetLogging(Target target)
         {
-            if (target is null) { throw new ArgumentNullException(nameof(target)); }
+            Guard.ThrowIfNull(target);
             ConfigureForTargetLogging(target, LogLevel.Info);
         }
 
@@ -87,7 +88,7 @@ namespace NLog.Config
         /// <param name="minLevel">The minimal logging level.</param>
         public static void ConfigureForTargetLogging(Target target, LogLevel minLevel)
         {
-            if (target is null) { throw new ArgumentNullException(nameof(target)); }
+            Guard.ThrowIfNull(target);
             LoggingConfiguration config = new LoggingConfiguration();
             config.AddRule(minLevel, LogLevel.MaxLevel, target, "*");
             LogManager.Configuration = config;

--- a/src/NLog/Filters/WhenMethodFilter.cs
+++ b/src/NLog/Filters/WhenMethodFilter.cs
@@ -33,6 +33,7 @@
 
 namespace NLog.Filters
 {
+    using NLog.Internal;
     using System;
 
     /// <summary>
@@ -47,8 +48,8 @@ namespace NLog.Filters
         /// </summary>
         public WhenMethodFilter(Func<LogEventInfo, FilterResult> filterMethod)
         {
-            if (filterMethod is null)
-                throw new ArgumentNullException(nameof(filterMethod));
+            Guard.ThrowIfNull(filterMethod);
+
             _filterMethod = filterMethod;
         }
 

--- a/src/NLog/Fluent/LogBuilder.cs
+++ b/src/NLog/Fluent/LogBuilder.cs
@@ -37,6 +37,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
+using NLog.Internal;
 
 namespace NLog.Fluent
 {
@@ -67,10 +68,8 @@ namespace NLog.Fluent
         [CLSCompliant(false)]
         public LogBuilder(ILogger logger, LogLevel logLevel)
         {
-            if (logger is null)
-                throw new ArgumentNullException(nameof(logger));
-            if (logLevel is null)
-                throw new ArgumentNullException(nameof(logLevel));
+            Guard.ThrowIfNull(logger);
+            Guard.ThrowIfNull(logLevel);
 
             _logger = logger;
             _logEvent = new LogEventInfo() { LoggerName = logger.Name, Level = logLevel };
@@ -99,8 +98,7 @@ namespace NLog.Fluent
         /// <returns>current <see cref="LogBuilder"/> for chaining calls.</returns>
         public LogBuilder Level(LogLevel logLevel)
         {
-            if (logLevel is null)
-                throw new ArgumentNullException(nameof(logLevel));
+            Guard.ThrowIfNull(logLevel);
 
             _logEvent.Level = logLevel;
             return this;
@@ -235,8 +233,7 @@ namespace NLog.Fluent
         /// <returns>current <see cref="LogBuilder"/> for chaining calls.</returns>
         public LogBuilder Property(object name, object value)
         {
-            if (name is null)
-                throw new ArgumentNullException(nameof(name));
+            Guard.ThrowIfNull(name);
 
             _logEvent.Properties[name] = value;
             return this;
@@ -249,8 +246,7 @@ namespace NLog.Fluent
         /// <returns>current <see cref="LogBuilder"/> for chaining calls.</returns>
         public LogBuilder Properties(IDictionary properties)
         {
-            if (properties is null)
-                throw new ArgumentNullException(nameof(properties));
+            Guard.ThrowIfNull(properties);
 
             foreach (var key in properties.Keys)
             {

--- a/src/NLog/ILoggerExtensions.cs
+++ b/src/NLog/ILoggerExtensions.cs
@@ -40,6 +40,7 @@ namespace NLog
     using System.Threading.Tasks;
 #endif
     using JetBrains.Annotations;
+    using NLog.Internal;
 
     /// <summary>
     /// Extensions for NLog <see cref="ILogger"/>.
@@ -489,10 +490,7 @@ namespace NLog
         {
             if (logger.IsTraceEnabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 logger.Trace(exception, messageFunc());
             }
@@ -508,10 +506,7 @@ namespace NLog
         {
             if (logger.IsDebugEnabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 logger.Debug(exception, messageFunc());
             }
@@ -527,10 +522,7 @@ namespace NLog
         {
             if (logger.IsInfoEnabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 logger.Info(exception, messageFunc());
             }
@@ -546,10 +538,7 @@ namespace NLog
         {
             if (logger.IsWarnEnabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 logger.Warn(exception, messageFunc());
             }
@@ -565,10 +554,7 @@ namespace NLog
         {
             if (logger.IsErrorEnabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 logger.Error(exception, messageFunc());
             }
@@ -584,10 +570,7 @@ namespace NLog
         {
             if (logger.IsFatalEnabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 logger.Fatal(exception, messageFunc());
             }

--- a/src/NLog/Internal/Collections/PropertiesDictionary.cs
+++ b/src/NLog/Internal/Collections/PropertiesDictionary.cs
@@ -283,8 +283,7 @@ namespace NLog.Internal
         /// <inheritDoc/>
         public void CopyTo(KeyValuePair<object, object>[] array, int arrayIndex)
         {
-            if (array is null)
-                throw new ArgumentNullException(nameof(array));
+            Guard.ThrowIfNull(array);
             if (arrayIndex < 0)
                 throw new ArgumentOutOfRangeException(nameof(arrayIndex));
 
@@ -682,8 +681,7 @@ namespace NLog.Internal
             /// <inheritDoc/>
             public void CopyTo(object[] array, int arrayIndex)
             {
-                if (array is null)
-                    throw new ArgumentNullException(nameof(array));
+                Guard.ThrowIfNull(array);
                 if (arrayIndex < 0)
                     throw new ArgumentOutOfRangeException(nameof(arrayIndex));
 

--- a/src/NLog/Internal/Guard.cs
+++ b/src/NLog/Internal/Guard.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,52 +31,48 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.Targets
+#if !NETCOREAPP3_1_OR_GREATER
+namespace System.Runtime.CompilerServices
 {
-    using NLog.Internal;
-    using System;
-
-    /// <summary>
-    /// A descriptor for an archive created with the DateAndSequence numbering mode.
-    /// </summary>
-    internal class DateAndSequenceArchive
+    [AttributeUsage(AttributeTargets.Parameter)]
+    sealed class CallerArgumentExpressionAttribute : Attribute
     {
-        private readonly string _dateFormat;
-
-        /// <summary>
-        /// The full name of the archive file.
-        /// </summary>
-        public string FileName { get; }
-
-        /// <summary>
-        /// The parsed date contained in the file name.
-        /// </summary>
-        public DateTime Date { get; }
-
-        /// <summary>
-        /// The parsed sequence number contained in the file name.
-        /// </summary>
-        public int Sequence { get; }
-
-        /// <summary>
-        /// Determines whether <paramref name="date"/> produces the same string as the current instance's date once formatted with the current instance's date format.
-        /// </summary>
-        /// <param name="date">The date to compare the current object's date to.</param>
-        /// <returns><c>True</c> if the formatted dates are equal, otherwise <c>False</c>.</returns>
-        public bool HasSameFormattedDate(DateTime date)
+        public CallerArgumentExpressionAttribute(string param)
         {
-            return string.Equals(date.ToString(_dateFormat), Date.ToString(_dateFormat), StringComparison.Ordinal);
+            Param = param;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DateAndSequenceArchive"/> class.
-        /// </summary>
-        public DateAndSequenceArchive(string fileName, DateTime date, string dateFormat, int sequence)
+        public string Param { get; }
+    }
+}
+#endif
+
+namespace NLog.Internal
+{
+    using System;
+    using System.Runtime.CompilerServices;
+
+    internal static class Guard
+    {
+        internal static T ThrowIfNull<T>(
+            T arg,
+            [CallerArgumentExpression("arg")] string param = "")
+            where T : class
         {
-            FileName = Guard.ThrowIfNull(fileName);
-            _dateFormat = Guard.ThrowIfNull(dateFormat);
-            Date = date;
-            Sequence = sequence;
+            if (arg is null)
+                throw new ArgumentNullException(string.IsNullOrEmpty(param) ? typeof(T).Name : param);
+
+            return arg;
+        }
+
+        internal static string ThrowIfNullOrEmpty(
+            string arg,
+            [CallerArgumentExpression("arg")] string param = "")
+        {
+            if (string.IsNullOrEmpty(arg))
+                throw new ArgumentNullException(string.IsNullOrEmpty(param) ? nameof(arg) : param);
+
+            return arg;
         }
     }
 }

--- a/src/NLog/Internal/Strings/StringHelpers.cs
+++ b/src/NLog/Internal/Strings/StringHelpers.cs
@@ -91,15 +91,8 @@ namespace NLog.Internal
         /// <returns>The same reference of nothing has been replaced.</returns>
         public static string Replace([NotNull] string str, [NotNull] string oldValue, string newValue, StringComparison comparison)
         {
-            if (str is null)
-            {
-                throw new ArgumentNullException(nameof(str));
-            }
-
-            if (oldValue is null)
-            {
-                throw new ArgumentNullException(nameof(oldValue));
-            }
+            Guard.ThrowIfNull(str);
+            Guard.ThrowIfNull(oldValue);
 
             if (str.Length == 0)
             {

--- a/src/NLog/LayoutRenderers/FuncLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/FuncLayoutRenderer.cs
@@ -62,7 +62,7 @@ namespace NLog.LayoutRenderers
         /// <param name="renderMethod">Method that renders the layout.</param>
         public FuncLayoutRenderer(string layoutRendererName, Func<LogEventInfo, LoggingConfiguration, object> renderMethod)
         {
-            _renderMethod = renderMethod ?? throw new ArgumentNullException(nameof(renderMethod));
+            _renderMethod = Guard.ThrowIfNull(renderMethod);
             LayoutRendererName = layoutRendererName;
         }
 

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -252,8 +252,9 @@ namespace NLog.LayoutRenderers
         /// <param name="name">The layout-renderer type-alias for use in NLog configuration - without '${ }'</param>
         public static void Register(string name, Type layoutRendererType)
         {
-            if (layoutRendererType is null) throw new ArgumentNullException(nameof(layoutRendererType));
-            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
+            Guard.ThrowIfNull(layoutRendererType);
+            Guard.ThrowIfNullOrEmpty(name);
+
             ConfigurationItemFactory.Default.LayoutRenderers
                 .RegisterDefinition(name, layoutRendererType);
         }
@@ -265,7 +266,7 @@ namespace NLog.LayoutRenderers
         /// <param name="func">Callback that returns the value for the layout renderer.</param>
         public static void Register(string name, Func<LogEventInfo, object> func)
         {
-            if (func is null) throw new ArgumentNullException(nameof(func));
+            Guard.ThrowIfNull(func);
             Register(name, (info, configuration) => func(info));
         }
 
@@ -276,7 +277,7 @@ namespace NLog.LayoutRenderers
         /// <param name="func">Callback that returns the value for the layout renderer.</param>
         public static void Register(string name, Func<LogEventInfo, LoggingConfiguration, object> func)
         {
-            if (func is null) throw new ArgumentNullException(nameof(func));
+            Guard.ThrowIfNull(func);
             var layoutRenderer = new FuncLayoutRenderer(name, func);
             Register(layoutRenderer);
         }
@@ -287,7 +288,7 @@ namespace NLog.LayoutRenderers
         /// <param name="layoutRenderer">Renderer with callback func</param>
         public static void Register(FuncLayoutRenderer layoutRenderer)
         {
-            if (layoutRenderer is null) throw new ArgumentNullException(nameof(layoutRenderer));
+            Guard.ThrowIfNull(layoutRenderer);
             ConfigurationItemFactory.Default.GetLayoutRenderers().RegisterFuncLayout(layoutRenderer.LayoutRendererName, layoutRenderer);
         }
 

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -144,8 +144,7 @@ namespace NLog.Layouts
         /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
         public static Layout FromMethod(Func<LogEventInfo, object> layoutMethod, LayoutRenderOptions options = LayoutRenderOptions.None)
         {
-            if (layoutMethod is null)
-                throw new ArgumentNullException(nameof(layoutMethod));
+            Guard.ThrowIfNull(layoutMethod);
 
 #if !NETSTANDARD1_3 && !NETSTANDARD1_5
             var name = $"{layoutMethod.Method?.DeclaringType?.ToString()}.{layoutMethod.Method?.Name}";

--- a/src/NLog/LogEventBuilder.cs
+++ b/src/NLog/LogEventBuilder.cs
@@ -36,6 +36,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
+using NLog.Internal;
 
 namespace NLog
 {
@@ -54,7 +55,7 @@ namespace NLog
         /// <param name="logger">The <see cref="NLog.Logger"/> to send the log event.</param>
         public LogEventBuilder([NotNull] ILogger logger)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _logger = Guard.ThrowIfNull(logger);
             _logEvent = new LogEventInfo() { LoggerName = _logger.Name };
         }
 
@@ -65,10 +66,9 @@ namespace NLog
         /// <param name="logLevel">The log level. LogEvent is only created when <see cref="LogLevel"/> is enabled for <paramref name="logger"/></param>
         public LogEventBuilder([NotNull] ILogger logger, [NotNull] LogLevel logLevel)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _logger = Guard.ThrowIfNull(logger);
 
-            if (logLevel is null)
-                throw new ArgumentNullException(nameof(logLevel));
+            Guard.ThrowIfNull(logLevel);
 
             if (logger.IsEnabled(logLevel))
             {
@@ -99,8 +99,7 @@ namespace NLog
         /// <param name="propertyValue">The value of the context property.</param>
         public LogEventBuilder Property<T>([NotNull] string propertyName, T propertyValue)
         {
-            if (propertyName is null)
-                throw new ArgumentNullException(nameof(propertyName));
+            Guard.ThrowIfNull(propertyName);
 
             if (_logEvent is null)
                 return this;
@@ -115,8 +114,7 @@ namespace NLog
         /// <param name="properties">The properties to set.</param>
         public LogEventBuilder Properties([NotNull] IEnumerable<KeyValuePair<string, object>> properties)
         {
-            if (properties is null)
-                throw new ArgumentNullException(nameof(properties));
+            Guard.ThrowIfNull(properties);
 
             if (_logEvent is null)
                 return this;

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -431,8 +431,7 @@ namespace NLog
         /// </summary>
         public LogFactory Setup(Action<ISetupBuilder> setupBuilder)
         {
-            if (setupBuilder is null)
-                throw new ArgumentNullException(nameof(setupBuilder));
+            Guard.ThrowIfNull(setupBuilder);
             setupBuilder(new SetupBuilder(this));
             return this;
         }

--- a/src/NLog/LogLevel.cs
+++ b/src/NLog/LogLevel.cs
@@ -33,6 +33,7 @@
 
 namespace NLog
 {
+    using NLog.Internal;
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
@@ -280,10 +281,7 @@ namespace NLog
         /// <returns>The enumeration value.</returns>
         public static LogLevel FromString(string levelName)
         {
-            if (levelName is null)
-            {
-                throw new ArgumentNullException(nameof(levelName));
-            }
+            Guard.ThrowIfNull(levelName);
 
             if (levelName.Equals("Trace", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/NLog/Logger-generated.cs
+++ b/src/NLog/Logger-generated.cs
@@ -36,6 +36,7 @@ namespace NLog
     using System;
     using System.ComponentModel;
     using JetBrains.Annotations;
+    using NLog.Internal;
 
     /// <summary>
     /// Provides logging interface and utility functions.
@@ -137,10 +138,7 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 WriteToTargets(LogLevel.Trace, messageFunc());
             }
@@ -378,10 +376,7 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 WriteToTargets(LogLevel.Debug, messageFunc());
             }
@@ -619,10 +614,7 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 WriteToTargets(LogLevel.Info, messageFunc());
             }
@@ -860,10 +852,7 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 WriteToTargets(LogLevel.Warn, messageFunc());
             }
@@ -1101,10 +1090,7 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 WriteToTargets(LogLevel.Error, messageFunc());
             }
@@ -1342,10 +1328,7 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 WriteToTargets(LogLevel.Fatal, messageFunc());
             }

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -128,8 +128,7 @@ namespace NLog
         /// <returns>New Logger object that automatically appends specified properties</returns>
         public Logger WithProperties(IEnumerable<KeyValuePair<string, object>> properties)
         {
-            if (properties == null)
-                throw new ArgumentNullException(nameof(properties));
+            Guard.ThrowIfNull(properties);
 
             Logger newLogger = CreateChildLogger();
             foreach (KeyValuePair<string, object> property in properties)
@@ -315,10 +314,7 @@ namespace NLog
         {
             if (IsEnabled(level))
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
+                Guard.ThrowIfNull(messageFunc);
 
                 WriteToTargets(level, messageFunc());
             }

--- a/src/NLog/MessageTemplates/MessageTemplateParameter.cs
+++ b/src/NLog/MessageTemplates/MessageTemplateParameter.cs
@@ -33,6 +33,7 @@
 
 using System;
 using JetBrains.Annotations;
+using NLog.Internal;
 
 namespace NLog.MessageTemplates
 {
@@ -104,7 +105,7 @@ namespace NLog.MessageTemplates
         /// <param name="format">Parameter Format</param>
         internal MessageTemplateParameter([NotNull] string name, object value, string format)
         {
-            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Name = Guard.ThrowIfNull(name);
             Value = value;
             Format = format;
             CaptureType = CaptureType.Normal;
@@ -119,7 +120,7 @@ namespace NLog.MessageTemplates
         /// <param name="captureType">Parameter CaptureType</param>
         public MessageTemplateParameter([NotNull] string name, object value, string format, CaptureType captureType)
         {
-            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Name = Guard.ThrowIfNull(name);
             Value = value;
             Format = format;
             CaptureType = captureType;

--- a/src/NLog/MessageTemplates/TemplateEnumerator.cs
+++ b/src/NLog/MessageTemplates/TemplateEnumerator.cs
@@ -31,6 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
+using NLog.Internal;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -61,7 +62,7 @@ namespace NLog.MessageTemplates
         /// <returns>Template, never null</returns>
         public TemplateEnumerator(string template)
         {
-            _template = template ?? throw new ArgumentNullException(nameof(template));
+            _template = Guard.ThrowIfNull(template);
             _length = _template.Length;
             _position = 0;
             _literalLength = 0;

--- a/src/NLog/NullLogger.cs
+++ b/src/NLog/NullLogger.cs
@@ -34,7 +34,6 @@
 namespace NLog
 {
     using Internal;
-    using System;
 
     /// <summary>
     /// It works as a normal <see cref="Logger" /> but it discards all messages which an application requests 
@@ -50,10 +49,7 @@ namespace NLog
         /// <param name="factory">The factory class to be used for the creation of this logger.</param>
         public NullLogger(LogFactory factory)
         {
-            if (factory is null)
-            {
-                throw new ArgumentNullException(nameof(factory));
-            }
+            Guard.ThrowIfNull(factory);
 
             Initialize(string.Empty, TargetWithFilterChain.NoTargetsByLevel, factory);
         }

--- a/src/NLog/SetupBuilderExtensions.cs
+++ b/src/NLog/SetupBuilderExtensions.cs
@@ -175,8 +175,8 @@ namespace NLog
         /// <param name="resourceName">Name of the manifest resource for NLog config XML</param>
         public static ISetupBuilder LoadConfigurationFromAssemblyResource(this ISetupBuilder setupBuilder, System.Reflection.Assembly applicationAssembly, string resourceName = "NLog.config")
         {
-            if (applicationAssembly is null) throw new ArgumentNullException(nameof(applicationAssembly));
-            if (string.IsNullOrEmpty(resourceName)) throw new ArgumentNullException(nameof(resourceName));
+            Guard.ThrowIfNull(applicationAssembly);
+            Guard.ThrowIfNullOrEmpty(resourceName);
 
             var resourcePaths = applicationAssembly.GetManifestResourceNames().Where(x => x.EndsWith(resourceName, StringComparison.OrdinalIgnoreCase)).ToList();
             if (resourcePaths.Count == 1)

--- a/src/NLog/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog/SetupExtensionsBuilderExtensions.cs
@@ -238,8 +238,7 @@ namespace NLog
         /// <param name="conditionMethod">MethodInfo extracted by reflection - typeof(MyClass).GetMethod("MyFunc", BindingFlags.Static).</param>
         public static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, MethodInfo conditionMethod)
         {
-            if (conditionMethod is null)
-                throw new ArgumentNullException(nameof(conditionMethod));
+            Guard.ThrowIfNull(conditionMethod);
             if (!conditionMethod.IsStatic)
                 throw new ArgumentException($"{conditionMethod.Name} must be static", nameof(conditionMethod));
 
@@ -255,8 +254,7 @@ namespace NLog
         /// <param name="conditionMethod">Lambda method.</param>
         public static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, Func<LogEventInfo, object> conditionMethod)
         {
-            if (conditionMethod is null)
-                throw new ArgumentNullException(nameof(conditionMethod));
+            Guard.ThrowIfNull(conditionMethod);
             ReflectionHelpers.LateBoundMethod lateBound = (target, args) => conditionMethod((LogEventInfo)args[0]);
             return RegisterConditionMethod(setupBuilder, name, conditionMethod, lateBound);
         }
@@ -269,8 +267,7 @@ namespace NLog
         /// <param name="conditionMethod">Lambda method.</param>
         public static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, Func<object> conditionMethod)
         {
-            if (conditionMethod is null)
-                throw new ArgumentNullException(nameof(conditionMethod));
+            Guard.ThrowIfNull(conditionMethod);
             ReflectionHelpers.LateBoundMethod lateBound = (target, args) => conditionMethod();
             return RegisterConditionMethod(setupBuilder, name, conditionMethod, lateBound);
         }
@@ -289,8 +286,7 @@ namespace NLog
         /// <param name="singletonService">Implementation of interface.</param>
         public static ISetupExtensionsBuilder RegisterSingletonService<T>(this ISetupExtensionsBuilder setupBuilder, T singletonService) where T : class
         {
-            if (singletonService is null)
-                throw new ArgumentNullException(nameof(singletonService));
+            Guard.ThrowIfNull(singletonService);
             setupBuilder.LogFactory.ServiceRepository.RegisterSingleton<T>(singletonService);
             return setupBuilder;
         }
@@ -303,10 +299,9 @@ namespace NLog
         /// <param name="singletonService">Implementation of interface.</param>
         public static ISetupExtensionsBuilder RegisterSingletonService(this ISetupExtensionsBuilder setupBuilder, Type interfaceType, object singletonService)
         {
-            if (interfaceType is null)
-                throw new ArgumentNullException(nameof(interfaceType));
-            if (singletonService is null)
-                throw new ArgumentNullException(nameof(singletonService));
+            Guard.ThrowIfNull(interfaceType);
+            Guard.ThrowIfNull(singletonService);
+
             if (!interfaceType.IsAssignableFrom(singletonService.GetType()))
                 throw new ArgumentException("Service instance not matching type", nameof(singletonService));
             setupBuilder.LogFactory.ServiceRepository.RegisterService(interfaceType, singletonService);
@@ -320,8 +315,7 @@ namespace NLog
         /// <param name="serviceProvider">External dependency injection repository</param>
         public static ISetupExtensionsBuilder RegisterServiceProvider(this ISetupExtensionsBuilder setupBuilder, IServiceProvider serviceProvider)
         {
-            if (serviceProvider is null)
-                throw new ArgumentNullException(nameof(serviceProvider));
+            Guard.ThrowIfNull(serviceProvider);
 
             setupBuilder.LogFactory.ServiceRepository.RegisterSingleton(serviceProvider);
             return setupBuilder;

--- a/src/NLog/SetupLoadConfigurationExtensions.cs
+++ b/src/NLog/SetupLoadConfigurationExtensions.cs
@@ -99,8 +99,7 @@ namespace NLog
         /// <param name="minLevel">Minimum level that this rule matches</param>
         public static ISetupConfigurationLoggingRuleBuilder FilterMinLevel(this ISetupConfigurationLoggingRuleBuilder configBuilder, LogLevel minLevel)
         {
-            if (minLevel is null)
-                throw new ArgumentNullException(nameof(minLevel));
+            Guard.ThrowIfNull(minLevel);
 
             configBuilder.LoggingRule.DisableLoggingForLevels(LogLevel.MinLevel, LogLevel.MaxLevel);
             configBuilder.LoggingRule.EnableLoggingForLevels(minLevel, LogLevel.MaxLevel);
@@ -114,8 +113,7 @@ namespace NLog
         /// <param name="maxLevel">Maximum level that this rule matches</param>
         public static ISetupConfigurationLoggingRuleBuilder FilterMaxLevel(this ISetupConfigurationLoggingRuleBuilder configBuilder, LogLevel maxLevel)
         {
-            if (maxLevel is null)
-                throw new ArgumentNullException(nameof(maxLevel));
+            Guard.ThrowIfNull(maxLevel);
 
             configBuilder.LoggingRule.DisableLoggingForLevels(LogLevel.MinLevel, LogLevel.MaxLevel);
             configBuilder.LoggingRule.EnableLoggingForLevels(LogLevel.MinLevel, maxLevel);
@@ -129,8 +127,7 @@ namespace NLog
         /// <param name="logLevel">Single loglevel that this rule matches</param>
         public static ISetupConfigurationLoggingRuleBuilder FilterLevel(this ISetupConfigurationLoggingRuleBuilder configBuilder, LogLevel logLevel)
         {
-            if (logLevel is null)
-                throw new ArgumentNullException(nameof(logLevel));
+            Guard.ThrowIfNull(logLevel);
 
             if (configBuilder.LoggingRule.IsLoggingEnabledForLevel(logLevel))
             {
@@ -164,8 +161,7 @@ namespace NLog
         /// <param name="filterDefaultAction">Default action if none of the filters match</param>
         public static ISetupConfigurationLoggingRuleBuilder FilterDynamic(this ISetupConfigurationLoggingRuleBuilder configBuilder, Filter filter, FilterResult? filterDefaultAction = null)
         {
-            if (filter is null)
-                throw new ArgumentNullException(nameof(filter));
+            Guard.ThrowIfNull(filter);
 
             configBuilder.LoggingRule.Filters.Add(filter);
             if (filterDefaultAction.HasValue)
@@ -184,8 +180,7 @@ namespace NLog
         /// <param name="filterDefaultAction">Default action if none of the filters match</param>
         public static ISetupConfigurationLoggingRuleBuilder FilterDynamic(this ISetupConfigurationLoggingRuleBuilder configBuilder, Func<LogEventInfo, FilterResult> filterMethod, FilterResult? filterDefaultAction = null)
         {
-            if (filterMethod is null)
-                throw new ArgumentNullException(nameof(filterMethod));
+            Guard.ThrowIfNull(filterMethod);
 
             return configBuilder.FilterDynamic(new WhenMethodFilter(filterMethod), filterDefaultAction);
         }
@@ -415,8 +410,7 @@ namespace NLog
         /// <param name="layouts">Layouts to render object[]-args before calling <paramref name="logEventAction"/></param>
         public static ISetupConfigurationTargetBuilder WriteToMethodCall(this ISetupConfigurationTargetBuilder configBuilder, Action<LogEventInfo, object[]> logEventAction, Layout[] layouts = null)
         {
-            if (logEventAction is null)
-                throw new ArgumentNullException(nameof(logEventAction));
+            Guard.ThrowIfNull(logEventAction);
 
             var methodTarget = new MethodCallTarget(string.Empty, logEventAction);
             if (layouts?.Length > 0)
@@ -506,8 +500,7 @@ namespace NLog
         /// <param name="maxArchiveDays">Maximum days of archive files that should be kept.</param>
         public static ISetupConfigurationTargetBuilder WriteToFile(this ISetupConfigurationTargetBuilder configBuilder, Layout fileName, Layout layout = null, System.Text.Encoding encoding = null, LineEndingMode lineEnding = null, bool keepFileOpen = true, bool concurrentWrites = false, long archiveAboveSize = 0, int maxArchiveFiles = 0, int maxArchiveDays = 0)
         {
-            if (fileName is null)
-                throw new ArgumentNullException(nameof(fileName));
+            Guard.ThrowIfNull(fileName);
 
             var fileTarget = new FileTarget();
             fileTarget.FileName = fileName;
@@ -532,8 +525,7 @@ namespace NLog
         /// <param name="wrapperFactory">Factory method for creating target-wrapper</param>
         public static ISetupConfigurationTargetBuilder WithWrapper(this ISetupConfigurationTargetBuilder configBuilder, Func<Target, Target> wrapperFactory)
         {
-            if (wrapperFactory is null)
-                throw new ArgumentNullException(nameof(wrapperFactory));
+            Guard.ThrowIfNull(wrapperFactory);
 
             var targets = configBuilder.Targets;
 
@@ -659,8 +651,7 @@ namespace NLog
         /// <param name="returnToFirstOnSuccess">Whether to return to the first target after any successful write</param>
         public static ISetupConfigurationTargetBuilder WithFallback(this ISetupConfigurationTargetBuilder configBuilder, Target fallbackTarget, bool returnToFirstOnSuccess = true)
         {
-            if (fallbackTarget is null)
-                throw new ArgumentNullException(nameof(fallbackTarget));
+            Guard.ThrowIfNull(fallbackTarget);
 
             if (string.IsNullOrEmpty(fallbackTarget.Name))
                 fallbackTarget.Name = EnsureUniqueTargetName(configBuilder.Configuration, fallbackTarget, "_Fallback");

--- a/src/NLog/SetupSerializationBuilderExtensions.cs
+++ b/src/NLog/SetupSerializationBuilderExtensions.cs
@@ -36,6 +36,7 @@ namespace NLog
     using System;
     using System.Reflection;
     using NLog.Config;
+    using NLog.Internal;
 
     /// <summary>
     /// Extension methods to setup NLog extensions, so they are known when loading NLog LoggingConfiguration
@@ -65,8 +66,7 @@ namespace NLog
         /// </summary>
         public static ISetupSerializationBuilder RegisterObjectTransformation<T>(this ISetupSerializationBuilder setupBuilder, Func<T, object> transformer)
         {
-            if (transformer is null)
-                throw new ArgumentNullException(nameof(transformer));
+            Guard.ThrowIfNull(transformer);
 
             var original = setupBuilder.LogFactory.ServiceRepository.GetService<IObjectTypeTransformer>();
             setupBuilder.LogFactory.ServiceRepository.RegisterObjectTypeTransformer(new ObjectTypeTransformation<T>(transformer, original));
@@ -78,10 +78,8 @@ namespace NLog
         /// </summary>
         public static ISetupSerializationBuilder RegisterObjectTransformation(this ISetupSerializationBuilder setupBuilder, Type objectType, Func<object, object> transformer)
         {
-            if (objectType is null)
-                throw new ArgumentNullException(nameof(objectType));
-            if (transformer is null)
-                throw new ArgumentNullException(nameof(transformer));
+            Guard.ThrowIfNull(objectType);
+            Guard.ThrowIfNull(transformer);
 
             var original = setupBuilder.LogFactory.ServiceRepository.GetService<IObjectTypeTransformer>();
             setupBuilder.LogFactory.ServiceRepository.RegisterObjectTypeTransformer(new ObjectTypeTransformation(objectType, transformer, original));

--- a/src/NLog/Targets/LineEndingMode.cs
+++ b/src/NLog/Targets/LineEndingMode.cs
@@ -113,7 +113,7 @@ namespace NLog.Targets
         /// <exception cref="ArgumentOutOfRangeException">There is no line ending mode with the specified name.</exception>
         public static LineEndingMode FromString([NotNull] string name)
         {
-            if (name is null) throw new ArgumentNullException(nameof(name));
+            Guard.ThrowIfNull(name);
 
             if (name.Equals(CRLF.Name, StringComparison.OrdinalIgnoreCase)) return CRLF;
             if (name.Equals(LF.Name, StringComparison.OrdinalIgnoreCase)) return LF;

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -179,10 +179,7 @@ namespace NLog.Targets
         /// <param name="asyncContinuation">The asynchronous continuation.</param>
         public void Flush(AsyncContinuation asyncContinuation)
         {
-            if (asyncContinuation is null)
-            {
-                throw new ArgumentNullException(nameof(asyncContinuation));
-            }
+            Guard.ThrowIfNull(asyncContinuation);
 
             asyncContinuation = AsyncHelpers.PreventMultipleCalls(asyncContinuation);
 

--- a/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
@@ -38,6 +38,7 @@ namespace NLog.UnitTests.Config
     using System.Text;
     using JetBrains.Annotations;
     using NLog.Config;
+    using NLog.Internal;
     using NLog.Targets;
     using Xunit;
 
@@ -261,7 +262,7 @@ namespace NLog.UnitTests.Config
         {
             public TargetWithInjection([NotNull] IJsonConverter jsonConverter)
             {
-                JsonConverter = jsonConverter ?? throw new ArgumentNullException(nameof(jsonConverter));
+                JsonConverter = Guard.ThrowIfNull(jsonConverter);
             }
 
             public IJsonConverter JsonConverter { get; }
@@ -274,7 +275,7 @@ namespace NLog.UnitTests.Config
             /// <inheritdoc/>
             public TargetWithNestedInjection([NotNull] ClassWithInjection helper)
             {
-                Helper = helper ?? throw new ArgumentNullException(nameof(helper));
+                Helper = Guard.ThrowIfNull(helper);
             }
         }
 

--- a/tests/NLog.UnitTests/Internal/GuardTests.cs
+++ b/tests/NLog.UnitTests/Internal/GuardTests.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -31,52 +31,56 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-namespace NLog.Targets
+using NLog.Internal;
+using System;
+using Xunit;
+
+namespace NLog.UnitTests.Internal
 {
-    using NLog.Internal;
-    using System;
-
-    /// <summary>
-    /// A descriptor for an archive created with the DateAndSequence numbering mode.
-    /// </summary>
-    internal class DateAndSequenceArchive
+    public class GuardTests
     {
-        private readonly string _dateFormat;
-
-        /// <summary>
-        /// The full name of the archive file.
-        /// </summary>
-        public string FileName { get; }
-
-        /// <summary>
-        /// The parsed date contained in the file name.
-        /// </summary>
-        public DateTime Date { get; }
-
-        /// <summary>
-        /// The parsed sequence number contained in the file name.
-        /// </summary>
-        public int Sequence { get; }
-
-        /// <summary>
-        /// Determines whether <paramref name="date"/> produces the same string as the current instance's date once formatted with the current instance's date format.
-        /// </summary>
-        /// <param name="date">The date to compare the current object's date to.</param>
-        /// <returns><c>True</c> if the formatted dates are equal, otherwise <c>False</c>.</returns>
-        public bool HasSameFormattedDate(DateTime date)
+        [Fact]
+        public void ThrowIfNull_WhenArgumentIsNull_ThrowArgumentNullException()
         {
-            return string.Equals(date.ToString(_dateFormat), Date.ToString(_dateFormat), StringComparison.Ordinal);
+            object argument = null;
+
+            Assert.Throws<ArgumentNullException>(() => Guard.ThrowIfNull(argument));
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DateAndSequenceArchive"/> class.
-        /// </summary>
-        public DateAndSequenceArchive(string fileName, DateTime date, string dateFormat, int sequence)
+        [Fact]
+        public void ThrowIfNull_WhenArgumentIsNotNull_ReturnArgument()
         {
-            FileName = Guard.ThrowIfNull(fileName);
-            _dateFormat = Guard.ThrowIfNull(dateFormat);
-            Date = date;
-            Sequence = sequence;
+            var argument = "test";
+
+            var result = Guard.ThrowIfNull(argument);
+
+            Assert.Equal(argument, result);
+        }
+
+        [Fact]
+        public void ThrowIfNullOrEmpty_WhenArgumentIsNull_ThrowArgumentNullException()
+        {
+            string argument = null;
+
+            Assert.Throws<ArgumentNullException>(() => Guard.ThrowIfNullOrEmpty(argument));
+        }
+
+        [Fact]
+        public void ThrowIfNullOrEmpty_WhenArgumentIsEmpty_ThrowArgumentNullException()
+        {
+            var argument = string.Empty;
+
+            Assert.Throws<ArgumentNullException>(() => Guard.ThrowIfNullOrEmpty(argument));
+        }
+
+        [Fact]
+        public void ThrowIfNullOrEmpty_WhenArgumentIsValid_ReturnArgument()
+        {
+            var argument = "test";
+
+            var result = Guard.ThrowIfNull(argument);
+
+            Assert.Equal(argument, result);
         }
     }
 }

--- a/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/EventLogTargetTests.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-#if  !MONO && !NETSTANDARD
+#if !MONO && !NETSTANDARD
 
 namespace NLog.UnitTests.Targets
 {
@@ -41,6 +41,7 @@ namespace NLog.UnitTests.Targets
     using System.Linq;
     using System.Diagnostics;
     using NLog.Config;
+    using NLog.Internal;
     using NLog.Layouts;
     using NLog.Targets;
     using Xunit;
@@ -682,10 +683,10 @@ namespace NLog.UnitTests.Targets
                 Func<string, string, string> logNameFromSourceNameFunction,
                 Action<EventSourceCreationData> createEventSourceFunction)
             {
-                DeleteEventSourceFunction = deleteEventSourceFunction ?? throw new ArgumentNullException(nameof(deleteEventSourceFunction));
-                SourceExistsFunction = sourceExistsFunction ?? throw new ArgumentNullException(nameof(sourceExistsFunction));
-                LogNameFromSourceNameFunction = logNameFromSourceNameFunction ?? throw new ArgumentNullException(nameof(logNameFromSourceNameFunction));
-                CreateEventSourceFunction = createEventSourceFunction ?? throw new ArgumentNullException(nameof(createEventSourceFunction));
+                DeleteEventSourceFunction = Guard.ThrowIfNull(deleteEventSourceFunction);
+                SourceExistsFunction = Guard.ThrowIfNull(sourceExistsFunction);
+                LogNameFromSourceNameFunction = Guard.ThrowIfNull(logNameFromSourceNameFunction);
+                CreateEventSourceFunction = Guard.ThrowIfNull(createEventSourceFunction);
             }
 
             private Action<string, string> DeleteEventSourceFunction { get; }

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -47,6 +47,7 @@ using System.Web.Http;
 using System.Web.Http.Dependencies;
 using Microsoft.Owin.Hosting;
 using Owin;
+using NLog.Internal;
 #endif
 using NLog.Targets;
 using Xunit;
@@ -724,10 +725,7 @@ namespace NLog.UnitTests.Targets
             public void Post([FromBody] ComplexType complexType)
             {
                 //this is working. 
-                if (complexType is null)
-                {
-                    throw new ArgumentNullException(nameof(complexType));
-                }
+                Guard.ThrowIfNull(complexType);
                 Context.ReceivedLogsPostParam1.Add(complexType.Param1);
 
                 if (Context.CountdownEvent != null)
@@ -911,10 +909,7 @@ namespace NLog.UnitTests.Targets
             [HttpPost]
             public void Json(LogMeController.ComplexType complexType)
             {
-                if (complexType is null)
-                {
-                    throw new ArgumentNullException(nameof(complexType));
-                }
+                Guard.ThrowIfNull(complexType);
 
                 processRequest(complexType);
             }
@@ -940,10 +935,7 @@ namespace NLog.UnitTests.Targets
             [HttpPost]
             public void Xml(LogMeController.ComplexType complexType)
             {
-                if (complexType is null)
-                {
-                    throw new ArgumentNullException(nameof(complexType));
-                }
+                Guard.ThrowIfNull(complexType);
 
                 processRequest(complexType);
             }


### PR DESCRIPTION
Resolves #5055 

# Changes

Added `Guard` class with two methods
```csharp
static T ThrowIfNull<T>(T arg, [CallerArgumentExpression("arg")] string param = "")
static string ThrowIfNullOrEmpty(string arg, [CallerArgumentExpression("arg")] string param = "")
```
and replaced all occurrences of

```csharp
if (arg is null)
    throw new ArgumentNullException(nameof(arg));

// and

if (string.IsNullOrEmpty(arg))
    throw new ArgumentNullException(nameof(arg));
```

# Remarks

This is the only line that we use the `message` parameter of `ArgumentNullException` so I didn't wanted to include it in the `Guard` methods
https://github.com/NLog/NLog/blob/589ee8b1398665c1810660c5434d0226b0ccf09f/src/NLog/LogFactory.cs#L1074

This check is in a different assembly so I didn't added the refence to the `Guard`. I don't know if it would be ok.
https://github.com/NLog/NLog/blob/589ee8b1398665c1810660c5434d0226b0ccf09f/tests/PackageLoaderTestAssembly/NLogPackageLoaders.cs#L74