### PR TITLE
TargetWithContext - Fixed ScopeContext capture when multiple wrappers

### DIFF
--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -943,7 +943,7 @@ namespace NLog.Targets
 
                 private void CaptureContext(LogEventInfo logEvent)
                 {
-                    if (IsActive)
+                    if (IsActive && !logEvent.TryGetCachedLayoutValue(this, out var _))
                     {
                         var scopeContextProperties = _owner.CaptureScopeContextProperties(logEvent, null);
                         logEvent.AddCachedLayoutValue(this, scopeContextProperties);
@@ -975,7 +975,7 @@ namespace NLog.Targets
 
                 private void CaptureContext(LogEventInfo logEvent)
                 {
-                    if (IsActive)
+                    if (IsActive && !logEvent.TryGetCachedLayoutValue(this, out var _))
                     {
                         var nestedContext = _owner.CaptureScopeContextNested(logEvent);
                         logEvent.AddCachedLayoutValue(this, nestedContext);


### PR DESCRIPTION
Avoid issue where the second-wrapper overwrites the precalculate-capture from the first-wrapper.

See also: https://stackoverflow.com/questions/76314302/asynctasktarget-cannot-get-scope-properties-but-targetwithcontext-can