### PR TITLE
NLogTraceListener - Align Filter-behavior for all Write-methods

### DIFF
--- a/src/NLog/NLogTraceListener.cs
+++ b/src/NLog/NLogTraceListener.cs
@@ -169,7 +169,16 @@ namespace NLog
         /// <param name="message">A message to write.</param>
         public override void Write(string message)
         {
-            ProcessLogEventInfo(DefaultLogLevel, null, message, null, null, TraceEventType.Resume, null);
+            WriteInternal(message);
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, writes the specified message to the listener you create in the derived class.
+        /// </summary>
+        /// <param name="o">A message payload to write.</param>
+        public override void Write(object o)
+        {
+            WriteInternal(o);
         }
 
         /// <summary>
@@ -178,7 +187,39 @@ namespace NLog
         /// <param name="message">A message to write.</param>
         public override void WriteLine(string message)
         {
-            ProcessLogEventInfo(DefaultLogLevel, null, message, null, null, TraceEventType.Resume, null);
+            WriteInternal(message);
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, writes the specified message to the listener you create in the derived class.
+        /// </summary>
+        /// <param name="o">A message payload to write.</param>
+        public override void WriteLine(object o)
+        {
+            WriteInternal(o);
+        }
+
+        private void WriteInternal(string message)
+        {
+            if (Filter != null && !Filter.ShouldTrace(null, String.Empty, TraceEventType.Verbose, 0, message, null, null, null))
+                return;
+
+            ProcessLogEventInfo(DefaultLogLevel, null, message, null, null, TraceEventType.Verbose, null);
+        }
+
+        private void WriteInternal(object o)
+        {
+            if (Filter != null && !Filter.ShouldTrace(null, string.Empty, TraceEventType.Verbose, 0, string.Empty, null, o, null))
+                return;
+
+            if (o is null || o is IConvertible)
+            {
+                ProcessLogEventInfo(DefaultLogLevel, null, o?.ToString() ?? string.Empty, null, null, TraceEventType.Verbose, null);
+            }
+            else
+            {
+                ProcessLogEventInfo(DefaultLogLevel, null, "{0}", new[] { o }, null, TraceEventType.Verbose, null);
+            }
         }
 
         /// <summary>
@@ -408,21 +449,30 @@ namespace NLog
             var ev = new LogEventInfo();
             ev.LoggerName = logger.Name;
             ev.Level = logLevel;
-            if (eventType.HasValue)
+            if (eventType.HasValue && eventType != TraceEventType.Verbose)
             {
                 ev.Properties.Add("EventType", eventType.Value);
             }
 
-            if (relatedActivityId.HasValue)
+            if (relatedActivityId.HasValue && relatedActivityId != Guid.Empty)
             {
                 ev.Properties.Add("RelatedActivityID", relatedActivityId.Value);
             }
 
             ev.Message = message;
             ev.Parameters = arguments;
+            if (arguments?.Length == 1 && arguments[0] is Exception exception)
+            {
+                ev.Exception = exception;
+                if (message == "{0}")
+                {
+                    ev.FormatProvider = ExceptionMessageFormatProvider.Instance;
+                }
+            }
+
             ev.Level = _forceLogLevel ?? logLevel;
 
-            if (eventId.HasValue)
+            if (eventId.HasValue && eventId != 0)
             {
                 ev.Properties.Add("EventID", eventId.Value);
             }
@@ -432,7 +482,7 @@ namespace NLog
                 ev.SetStackTrace(stackTrace, userFrameIndex);
             }
 
-            logger.Log(ev);
+            logger.Log(typeof(System.Diagnostics.Trace), ev);
         }
 
         private Logger GetLogger(string loggerName, StackTrace stackTrace, out int userFrameIndex)

--- a/src/NLog/NLogTraceListener.cs
+++ b/src/NLog/NLogTraceListener.cs
@@ -46,6 +46,10 @@ namespace NLog
     /// <summary>
     /// TraceListener which routes all messages through NLog.
     /// </summary>
+    /// <remarks>
+    /// <a href="https://github.com/NLog/NLog/wiki/NLog-Trace-Listener-for-System-Diagnostics-Trace">See NLog Wiki</a>
+    /// </remarks>
+    /// <seealso href="https://github.com/NLog/NLog/wiki/NLog-Trace-Listener-for-System-Diagnostics-Trace">Documentation on NLog Wiki</seealso>
     public class NLogTraceListener : TraceListener
     {
         private LogFactory _logFactory;

--- a/tests/NLog.UnitTests/NLogTraceListenerTests.cs
+++ b/tests/NLog.UnitTests/NLogTraceListenerTests.cs
@@ -65,7 +65,7 @@ namespace NLog.UnitTests
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}' /></targets>
                     <rules>
                         <logger name='*' minlevel='Debug' writeTo='debug' />
                     </rules>
@@ -75,16 +75,16 @@ namespace NLog.UnitTests
             Trace.Listeners.Add(new NLogTraceListener { Name = "Logger1" });
 
             Trace.Write("Hello");
-            AssertDebugLastMessage("debug", "Logger1 Debug Hello");
+            AssertDebugLastMessage("debug", "Logger1 Debug Hello  ");
 
             Trace.Write("Hello", "Cat1");
-            AssertDebugLastMessage("debug", "Logger1 Debug Cat1: Hello");
+            AssertDebugLastMessage("debug", "Logger1 Debug Cat1: Hello  ");
 
             Trace.Write(3.1415);
-            AssertDebugLastMessage("debug", $"Logger1 Debug {3.1415}");
+            AssertDebugLastMessage("debug", $"Logger1 Debug {3.1415}  ");
 
             Trace.Write(3.1415, "Cat2");
-            AssertDebugLastMessage("debug", $"Logger1 Debug Cat2: {3.1415}");
+            AssertDebugLastMessage("debug", $"Logger1 Debug Cat2: {3.1415}  ");
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace NLog.UnitTests
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}' /></targets>
                     <rules>
                         <logger name='*' minlevel='Debug' writeTo='debug' />
                     </rules>
@@ -102,16 +102,16 @@ namespace NLog.UnitTests
             Trace.Listeners.Add(new NLogTraceListener { Name = "Logger1" });
 
             Trace.WriteLine("Hello");
-            AssertDebugLastMessage("debug", "Logger1 Debug Hello");
+            AssertDebugLastMessage("debug", "Logger1 Debug Hello  ");
 
             Trace.WriteLine("Hello", "Cat1");
-            AssertDebugLastMessage("debug", "Logger1 Debug Cat1: Hello");
+            AssertDebugLastMessage("debug", "Logger1 Debug Cat1: Hello  ");
 
             Trace.WriteLine(3.1415);
-            AssertDebugLastMessage("debug", $"Logger1 Debug {3.1415}");
+            AssertDebugLastMessage("debug", $"Logger1 Debug {3.1415}  ");
 
             Trace.WriteLine(3.1415, "Cat2");
-            AssertDebugLastMessage("debug", $"Logger1 Debug Cat2: {3.1415}");
+            AssertDebugLastMessage("debug", $"Logger1 Debug Cat2: {3.1415}  ");
         }
 
         [Fact]
@@ -119,7 +119,7 @@ namespace NLog.UnitTests
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}' /></targets>
                     <rules>
                         <logger name='*' minlevel='Trace' writeTo='debug' />
                     </rules>
@@ -129,7 +129,7 @@ namespace NLog.UnitTests
             Trace.Listeners.Add(new NLogTraceListener { Name = "Logger1", DefaultLogLevel = LogLevel.Trace });
 
             Trace.Write("Hello");
-            AssertDebugLastMessage("debug", "Logger1 Trace Hello");
+            AssertDebugLastMessage("debug", "Logger1 Trace Hello  ");
         }
 
         [Fact]
@@ -152,7 +152,7 @@ namespace NLog.UnitTests
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}' /></targets>
                     <rules>
                         <logger name='*' minlevel='Debug' writeTo='debug' />
                     </rules>
@@ -162,10 +162,10 @@ namespace NLog.UnitTests
             Trace.Listeners.Add(new NLogTraceListener { Name = "Logger1" });
 
             Trace.Fail("Message");
-            AssertDebugLastMessage("debug", "Logger1 Error Message");
+            AssertDebugLastMessage("debug", "Logger1 Error Message  Error");
 
             Trace.Fail("Message", "Detailed Message");
-            AssertDebugLastMessage("debug", "Logger1 Error Message Detailed Message");
+            AssertDebugLastMessage("debug", "Logger1 Error Message Detailed Message  Error");
         }
 
         [Fact]
@@ -173,7 +173,7 @@ namespace NLog.UnitTests
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}' /></targets>
                     <rules>
                         <logger name='*' minlevel='Debug' writeTo='debug' />
                     </rules>
@@ -183,7 +183,7 @@ namespace NLog.UnitTests
             Trace.Listeners.Add(new NLogTraceListener { Name = "Logger1", AutoLoggerName = true });
 
             Trace.Write("Hello");
-            AssertDebugLastMessage("debug", GetType().FullName + " Debug Hello");
+            AssertDebugLastMessage("debug", GetType().FullName + " Debug Hello  ");
         }
 
         [Fact]
@@ -191,7 +191,7 @@ namespace NLog.UnitTests
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-context:EventID}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}' /></targets>
                     <rules>
                         <logger name='*' minlevel='Trace' writeTo='debug' />
                     </rules>
@@ -201,10 +201,10 @@ namespace NLog.UnitTests
             ts.Listeners.Add(new NLogTraceListener { Name = "Logger1", DefaultLogLevel = LogLevel.Trace });
 
             ts.TraceData(TraceEventType.Critical, 123, 42);
-            AssertDebugLastMessage("debug", "MySource1 Fatal 42 123");
+            AssertDebugLastMessage("debug", "MySource1 Fatal 42 123 Critical");
 
             ts.TraceData(TraceEventType.Critical, 145, 42, 3.14, "foo");
-            AssertDebugLastMessage("debug", $"MySource1 Fatal 42, {3.14.ToString(CultureInfo.CurrentCulture)}, foo 145");
+            AssertDebugLastMessage("debug", $"MySource1 Fatal 42, {3.14.ToString(CultureInfo.CurrentCulture)}, foo 145 Critical");
         }
 
 #if MONO
@@ -216,7 +216,7 @@ namespace NLog.UnitTests
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-context:EventID}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}' /></targets>
                     <rules>
                         <logger name='*' minlevel='Trace' writeTo='debug' />
                     </rules>
@@ -226,10 +226,10 @@ namespace NLog.UnitTests
             ts.Listeners.Add(new NLogTraceListener { Name = "Logger1", DefaultLogLevel = LogLevel.Trace });
             
             ts.TraceInformation("Quick brown fox");
-            AssertDebugLastMessage("debug", "MySource1 Info Quick brown fox 0");
+            AssertDebugLastMessage("debug", "MySource1 Info Quick brown fox  Information");
 
             ts.TraceInformation("Mary had {0} lamb", "a little");
-            AssertDebugLastMessage("debug", "MySource1 Info Mary had a little lamb 0");
+            AssertDebugLastMessage("debug", "MySource1 Info Mary had a little lamb  Information");
         }
 
         [Fact]
@@ -237,7 +237,7 @@ namespace NLog.UnitTests
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-context:EventID}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}' /></targets>
                     <rules>
                         <logger name='*' minlevel='Trace' writeTo='debug' />
                     </rules>
@@ -247,28 +247,28 @@ namespace NLog.UnitTests
             ts.Listeners.Add(new NLogTraceListener { Name = "Logger1", DefaultLogLevel = LogLevel.Trace });
 
             ts.TraceEvent(TraceEventType.Information, 123, "Quick brown {0} jumps over the lazy {1}.", "fox", "dog");
-            AssertDebugLastMessage("debug", "MySource1 Info Quick brown fox jumps over the lazy dog. 123");
+            AssertDebugLastMessage("debug", "MySource1 Info Quick brown fox jumps over the lazy dog. 123 Information");
 
             ts.TraceEvent(TraceEventType.Information, 123);
-            AssertDebugLastMessage("debug", "MySource1 Info  123");
+            AssertDebugLastMessage("debug", "MySource1 Info  123 Information");
 
             ts.TraceEvent(TraceEventType.Verbose, 145, "Bar");
-            AssertDebugLastMessage("debug", "MySource1 Trace Bar 145");
+            AssertDebugLastMessage("debug", "MySource1 Trace Bar 145 ");
 
             ts.TraceEvent(TraceEventType.Error, 145, "Foo");
-            AssertDebugLastMessage("debug", "MySource1 Error Foo 145");
+            AssertDebugLastMessage("debug", "MySource1 Error Foo 145 Error");
 
             ts.TraceEvent(TraceEventType.Suspend, 145, "Bar");
-            AssertDebugLastMessage("debug", "MySource1 Debug Bar 145");
+            AssertDebugLastMessage("debug", "MySource1 Debug Bar 145 Suspend");
 
             ts.TraceEvent(TraceEventType.Resume, 145, "Foo");
-            AssertDebugLastMessage("debug", "MySource1 Debug Foo 145");
+            AssertDebugLastMessage("debug", "MySource1 Debug Foo 145 Resume");
 
             ts.TraceEvent(TraceEventType.Warning, 145, "Bar");
-            AssertDebugLastMessage("debug", "MySource1 Warn Bar 145");
+            AssertDebugLastMessage("debug", "MySource1 Warn Bar 145 Warning");
 
             ts.TraceEvent(TraceEventType.Critical, 145, "Foo");
-            AssertDebugLastMessage("debug", "MySource1 Fatal Foo 145");
+            AssertDebugLastMessage("debug", "MySource1 Fatal Foo 145 Critical");
         }
 
 #if MONO
@@ -280,7 +280,7 @@ namespace NLog.UnitTests
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-context:EventID}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}' /></targets>
                     <rules>
                         <logger name='*' minlevel='Trace' writeTo='debug' />
                     </rules>
@@ -291,10 +291,10 @@ namespace NLog.UnitTests
 
             // force all logs to be Warn, DefaultLogLevel has no effect on TraceSource
             ts.TraceInformation("Quick brown fox");
-            AssertDebugLastMessage("debug", "MySource1 Warn Quick brown fox 0");
+            AssertDebugLastMessage("debug", "MySource1 Warn Quick brown fox  Information");
 
             ts.TraceInformation("Mary had {0} lamb", "a little");
-            AssertDebugLastMessage("debug", "MySource1 Warn Mary had a little lamb 0");
+            AssertDebugLastMessage("debug", "MySource1 Warn Mary had a little lamb  Information");
         }
 
         [Fact]
@@ -302,7 +302,7 @@ namespace NLog.UnitTests
         {
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-context:EventID}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}' /></targets>
                     <rules>
                         <logger name='*' minlevel='Trace' writeTo='debug' />
                     </rules>
@@ -313,19 +313,85 @@ namespace NLog.UnitTests
 
             // force all logs to be Warn, DefaultLogLevel has no effect on TraceSource
             ts.TraceEvent(TraceEventType.Error, 0, "Quick brown fox");
-            AssertDebugLastMessage("debug", "MySource1 Warn Quick brown fox 0");
+            AssertDebugLastMessage("debug", "MySource1 Warn Quick brown fox  Error");
 
             ts.TraceInformation("Mary had {0} lamb", "a little");
-            AssertDebugLastMessage("debug", "MySource1 Warn Quick brown fox 0");
+            AssertDebugLastMessage("debug", "MySource1 Warn Quick brown fox  Error");
         }
 #endif
+
+        [Fact]
+        public void GlobalAllFilterTraceTest()
+        {
+            try
+            {
+                Trace.Listeners.Clear();
+                Trace.Listeners.Add(new NLogTraceListener { Name = "Logger1", Filter = new EventTypeFilter(SourceLevels.Verbose) });
+
+                LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+                <nlog>
+                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}' /></targets>
+                    <rules>
+                        <logger name='*' minlevel='Trace' writeTo='debug' />
+                    </rules>
+                </nlog>");
+
+                Trace.WriteLine("Quick brown fox");
+                AssertDebugLastMessage("debug", "Logger1 Debug Quick brown fox  ");
+                Trace.WriteLine(new ArgumentException("Mary had a little lamb"));
+                AssertDebugLastMessage("debug", "Logger1 Debug System.ArgumentException: Mary had a little lamb  ");
+                Trace.Write("Quick brown fox");
+                AssertDebugLastMessage("debug", "Logger1 Debug Quick brown fox  ");
+                Trace.Write(new ArgumentException("Mary had a little lamb"));
+                AssertDebugLastMessage("debug", "Logger1 Debug System.ArgumentException: Mary had a little lamb  ");
+                Trace.Flush();
+            }
+            finally
+            {
+                Trace.Listeners.Clear();
+            }
+        }
+
+        [Fact]
+        public void GlobalInfoFilterTraceTest()
+        {
+            try
+            {
+                Trace.Listeners.Clear();
+                Trace.Listeners.Add(new NLogTraceListener { Name = "Logger1", Filter = new EventTypeFilter(SourceLevels.Information) });
+
+                LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(@"
+                <nlog>
+                    <targets><target name='debug' type='Debug' layout='${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}' /></targets>
+                    <rules>
+                        <logger name='*' minlevel='Trace' writeTo='debug' />
+                    </rules>
+                </nlog>");
+
+                Trace.TraceInformation("Mary had a little lamb");
+                AssertDebugLastMessageContains("debug", "Mary had a little lamb  Information");
+                Trace.WriteLine("Quick brown fox");
+                AssertDebugLastMessageContains("debug", "Mary had a little lamb  Information");
+                Trace.WriteLine(new ArgumentException("Mary had a little lamb"));
+                AssertDebugLastMessageContains("debug", "Mary had a little lamb  Information");
+                Trace.Write("Quick brown fox");
+                AssertDebugLastMessageContains("debug", "Mary had a little lamb  Information");
+                Trace.Write(new ArgumentException("Mary had a little lamb"));
+                AssertDebugLastMessageContains("debug", "Mary had a little lamb  Information");
+                Trace.Flush();
+            }
+            finally
+            {
+                Trace.Listeners.Clear();
+            }
+        }
 
         [Fact]
         public void TraceTargetWriteLineTest()
         {
             var logger = new LogFactory().Setup().LoadConfiguration(builder =>
             {
-                builder.ForLogger().WriteToTrace(layout: "${logger} ${level} ${message}", rawWrite: true);
+                builder.ForLogger().WriteToTrace(layout: "${logger} ${level} ${message} ${event-properties:EventID} ${event-properties:EventType}", rawWrite: true);
             }).GetLogger("MySource1");
 
             var sw = new System.IO.StringWriter();
@@ -340,7 +406,7 @@ namespace NLog.UnitTests
                         continue;
                     logger.Log(logLevel, "Quick brown fox");
                     Trace.Flush();
-                    Assert.Equal($"MySource1 {logLevel} Quick brown fox" + Environment.NewLine, sw.GetStringBuilder().ToString());
+                    Assert.Equal($"MySource1 {logLevel} Quick brown fox  " + Environment.NewLine, sw.GetStringBuilder().ToString());
                     sw.GetStringBuilder().Length = 0;
                 }
                 
@@ -360,7 +426,7 @@ namespace NLog.UnitTests
             LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString($@"
                 <nlog>
                     <targets>
-                        <target name='trace' type='Trace' layout='${{logger}} ${{level}} ${{message}}' enableTraceFail='{enableTraceFail}' />
+                        <target name='trace' type='Trace' layout='${{logger}} ${{level}} ${{message}} ${{event-properties:EventID}} ${{event-properties:EventType}}' enableTraceFail='{enableTraceFail}' />
                     </targets>
                     <rules>
                         <logger name='*' minlevel='Trace' writeTo='trace' />
@@ -384,12 +450,12 @@ namespace NLog.UnitTests
                     if (logLevel == LogLevel.Fatal)
                     {
                         if (enableTraceFail)
-                            Assert.Equal($"Fail: {logger.Name} Fatal Quick brown fox" + Environment.NewLine, sw.GetStringBuilder().ToString());
+                            Assert.Equal($"Fail: {logger.Name} Fatal Quick brown fox  " + Environment.NewLine, sw.GetStringBuilder().ToString());
                         else
-                            Assert.NotEqual($"Fail: {logger.Name} Fatal Quick brown fox" + Environment.NewLine, sw.GetStringBuilder().ToString());
+                            Assert.NotEqual($"Fail: {logger.Name} Fatal Quick brown fox  " + Environment.NewLine, sw.GetStringBuilder().ToString());
                     }
                     
-                    Assert.Contains($"{logger.Name} {logLevel} Quick brown fox" + Environment.NewLine, sw.GetStringBuilder().ToString());
+                    Assert.Contains($"{logger.Name} {logLevel} Quick brown fox  " + Environment.NewLine, sw.GetStringBuilder().ToString());
                     sw.GetStringBuilder().Length = 0;
                 }
             }


### PR DESCRIPTION
- [x] Waiting for NLog v5.3

Skip allocation of the `LogEventInfo.Properties`-dictionary, when `TraceEventType.Verbose`.

Align Filter-behavior for all Write-methods to match default TraceListener-implementation:
- Write(string message)
- Write(object o)
- WriteLine(string message)
- WriteLine(object o)