### PR TITLE
WrapperTarget - Derive Name from wrappedTarget

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -103,7 +103,7 @@ namespace NLog.Targets.Wrappers
         public AsyncTargetWrapper(string name, Target wrappedTarget)
             : this(wrappedTarget)
         {
-            Name = name;
+            Name = name ?? Name;
         }
 
         /// <summary>
@@ -123,6 +123,8 @@ namespace NLog.Targets.Wrappers
         /// <param name="overflowAction">The action to be taken when the queue overflows.</param>
         public AsyncTargetWrapper(Target wrappedTarget, int queueLimit, AsyncTargetWrapperOverflowAction overflowAction)
         {
+            Name = string.IsNullOrEmpty(wrappedTarget?.Name) ? Name : (wrappedTarget.Name + "_wrapped");
+            WrappedTarget = wrappedTarget;
 #if NETSTANDARD2_0
             // NetStandard20 includes many optimizations for ConcurrentQueue:
             //  - See: https://blogs.msdn.microsoft.com/dotnet/2017/06/07/performance-improvements-in-net-core/
@@ -132,7 +134,6 @@ namespace NLog.Targets.Wrappers
 #else
             _requestQueue = new AsyncRequestQueue(10000, AsyncTargetWrapperOverflowAction.Discard);
 #endif
-            WrappedTarget = wrappedTarget;
             QueueLimit = queueLimit;
             OverflowAction = overflowAction;
         }

--- a/src/NLog/Targets/Wrappers/AutoFlushTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AutoFlushTargetWrapper.cs
@@ -103,7 +103,7 @@ namespace NLog.Targets.Wrappers
         public AutoFlushTargetWrapper(string name, Target wrappedTarget)
             : this(wrappedTarget)
         {
-            Name = name;
+            Name = name ?? Name;
         }
 
         /// <summary>
@@ -112,6 +112,7 @@ namespace NLog.Targets.Wrappers
         /// <param name="wrappedTarget">The wrapped target.</param>
         public AutoFlushTargetWrapper(Target wrappedTarget)
         {
+            Name = string.IsNullOrEmpty(wrappedTarget?.Name) ? Name : (wrappedTarget.Name + "_wrapped");
             WrappedTarget = wrappedTarget;
         }
 

--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -69,7 +69,7 @@ namespace NLog.Targets.Wrappers
         public BufferingTargetWrapper(string name, Target wrappedTarget)
             : this(wrappedTarget)
         {
-            Name = name;
+            Name = name ?? Name;
         }
 
         /// <summary>
@@ -111,6 +111,7 @@ namespace NLog.Targets.Wrappers
         /// <param name="overflowAction">The action to take when the buffer overflows.</param>
         public BufferingTargetWrapper(Target wrappedTarget, int bufferSize, int flushTimeout, BufferingTargetWrapperOverflowAction overflowAction)
         {
+            Name = string.IsNullOrEmpty(wrappedTarget?.Name) ? Name : (wrappedTarget.Name + "_wrapped");
             WrappedTarget = wrappedTarget;
             BufferSize = bufferSize;
             FlushTimeout = flushTimeout;

--- a/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
@@ -80,7 +80,7 @@ namespace NLog.Targets.Wrappers
         public FilteringTargetWrapper(string name, Target wrappedTarget, ConditionExpression condition)
             : this(wrappedTarget, condition)
         {
-            Name = name;
+            Name = name ?? Name;
         }
 
         /// <summary>
@@ -90,6 +90,7 @@ namespace NLog.Targets.Wrappers
         /// <param name="condition">The condition.</param>
         public FilteringTargetWrapper(Target wrappedTarget, ConditionExpression condition)
         {
+            Name = string.IsNullOrEmpty(wrappedTarget?.Name) ? Name : (wrappedTarget.Name + "_wrapped");
             WrappedTarget = wrappedTarget;
             Condition = condition;
         }

--- a/src/NLog/Targets/Wrappers/GroupByTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/GroupByTargetWrapper.cs
@@ -70,7 +70,7 @@ namespace NLog.Targets.Wrappers
         /// </summary>
         /// <param name="wrappedTarget">The wrapped target.</param>
         public GroupByTargetWrapper(Target wrappedTarget)
-            : this(null, wrappedTarget)
+            : this(string.IsNullOrEmpty(wrappedTarget?.Name) ? null : (wrappedTarget.Name + "_wrapped"), wrappedTarget)
         {
         }
 

--- a/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
@@ -65,7 +65,7 @@ namespace NLog.Targets.Wrappers
         public LimitingTargetWrapper(string name, Target wrappedTarget) 
             : this(wrappedTarget, 1000, TimeSpan.FromHours(1))
         {
-            Name = name;
+            Name = name ?? Name;
         }
 
         /// <summary>
@@ -85,9 +85,10 @@ namespace NLog.Targets.Wrappers
         /// <param name="interval">Interval in which the maximum number of messages can be written.</param>
         public LimitingTargetWrapper(Target wrappedTarget, int messageLimit, TimeSpan interval)
         {
+            Name = string.IsNullOrEmpty(wrappedTarget?.Name) ? Name : (wrappedTarget.Name + "_wrapped");
+            WrappedTarget = wrappedTarget;
             MessageLimit = messageLimit;
             Interval = interval;
-            WrappedTarget = wrappedTarget;
         }
 
         /// <summary>

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -84,7 +84,7 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the <see cref="PostFilteringTargetWrapper" /> class.
         /// </summary>
         public PostFilteringTargetWrapper(Target wrappedTarget)
-            : this(null, wrappedTarget)
+            : this(string.IsNullOrEmpty(wrappedTarget?.Name) ? null : (wrappedTarget.Name + "_wrapped"), wrappedTarget)
         {
         }
 
@@ -95,7 +95,7 @@ namespace NLog.Targets.Wrappers
         /// <param name="wrappedTarget">The wrapped target.</param>
         public PostFilteringTargetWrapper(string name, Target wrappedTarget)
         {
-            Name = name;
+            Name = name ?? Name;
             WrappedTarget = wrappedTarget;
         }
 

--- a/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/RetryingTargetWrapper.cs
@@ -80,7 +80,7 @@ namespace NLog.Targets.Wrappers
         public RetryingTargetWrapper(string name, Target wrappedTarget, int retryCount, int retryDelayMilliseconds)
             : this(wrappedTarget, retryCount, retryDelayMilliseconds)
         {
-            Name = name;
+            Name = name ?? Name;
         }
 
         /// <summary>
@@ -91,6 +91,7 @@ namespace NLog.Targets.Wrappers
         /// <param name="retryDelayMilliseconds">The retry delay milliseconds.</param>
         public RetryingTargetWrapper(Target wrappedTarget, int retryCount, int retryDelayMilliseconds)
         {
+            Name = string.IsNullOrEmpty(wrappedTarget?.Name) ? Name : (wrappedTarget.Name + "_wrapped");
             WrappedTarget = wrappedTarget;
             RetryCount = retryCount;
             RetryDelayMilliseconds = retryDelayMilliseconds;


### PR DESCRIPTION
Make it easier to built configuration from code, when not using fluent API

Exception is thrown when adding target to NLog configuration without name.