### PR TITLE
ConfigurationItemFactory - Skip assembly-loading should also check prefix-option

### DIFF
--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -162,8 +162,14 @@ namespace NLog.Config
         /// Gets the ambient property factory.
         /// </summary>
         public IFactory<LayoutRenderer> AmbientRendererFactory => _ambientProperties;
-        internal IFactory<Filter> FilterFactory => _filters;
-        internal IFactory<TimeSource> TimeSourceFactory => _timeSources;
+        /// <summary>
+        /// Gets the <see cref="Filter"/> factory.
+        /// </summary>
+        public IFactory<Filter> FilterFactory => _filters;
+        /// <summary>
+        /// Gets the <see cref="TimeSource"/> factory.
+        /// </summary>
+        public IFactory<TimeSource> TimeSourceFactory => _timeSources;
         internal MethodFactory ConditionMethodFactory => _conditionMethods;
 
         internal Factory<Target, TargetAttribute> GetTargetFactory() => _targets;

--- a/src/NLog/Config/LoggingConfigurationFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationFileLoader.cs
@@ -117,10 +117,7 @@ namespace NLog.Config
             catch (Exception ex)
             {
                 InternalLogger.Error(ex, "Failed loading from config file location: {0}", configFile);
-                if (logFactory.ThrowConfigExceptions ?? logFactory.ThrowExceptions)
-                    throw;
-
-                if (ex.MustBeRethrown())
+                if ((logFactory.ThrowConfigExceptions ?? logFactory.ThrowExceptions) || ex.MustBeRethrown())
                     throw;
             }
 

--- a/src/NLog/Internal/ExceptionHelper.cs
+++ b/src/NLog/Internal/ExceptionHelper.cs
@@ -89,11 +89,14 @@ namespace NLog.Internal
             }
 
             var isConfigError = exception is NLogConfigurationException;
+            var logFactory = loggerContext?.LogFactory;
+            var throwExceptionsAll = logFactory?.ThrowExceptions == true || LogManager.ThrowExceptions;
+            var shallRethrow = isConfigError ? (logFactory?.ThrowConfigExceptions ?? LogManager.ThrowConfigExceptions ?? throwExceptionsAll) : throwExceptionsAll;
 
             //we throw always configuration exceptions (historical)
             if (!exception.IsLoggedToInternalLogger())
             {
-                var level = isConfigError ? LogLevel.Warn : LogLevel.Error;
+                var level = shallRethrow ? LogLevel.Error : LogLevel.Warn;
                 if (loggerContext != null)
                 {
                     if (string.IsNullOrEmpty(callerMemberName))
@@ -102,12 +105,11 @@ namespace NLog.Internal
                         InternalLogger.Log(exception, level, "{0}: Exception in {1}", loggerContext, callerMemberName);
                 }
                 else
+                {
                     InternalLogger.Log(exception, level, "Error has been raised.");
+                }
             }
 
-            var logFactory = loggerContext?.LogFactory;
-            var throwExceptionsAll = logFactory?.ThrowExceptions == true || LogManager.ThrowExceptions;
-            var shallRethrow = isConfigError ? (logFactory?.ThrowConfigExceptions ?? LogManager.ThrowConfigExceptions ?? throwExceptionsAll) : throwExceptionsAll;
             return shallRethrow;
         }
 

--- a/tests/NLog.UnitTests/Internal/ExceptionHelperTests.cs
+++ b/tests/NLog.UnitTests/Internal/ExceptionHelperTests.cs
@@ -104,7 +104,7 @@ namespace NLog.UnitTests.Internal
         [Theory]
         [InlineData("Error has been raised.", typeof(ArgumentException), false, "Error")]
         [InlineData("Error has been raised.", typeof(ArgumentException), true, "Warn")]
-        [InlineData("Error has been raised.", typeof(NLogConfigurationException), false, "Warn")]
+        [InlineData("Error has been raised.", typeof(NLogConfigurationException), false, "Error")]
         [InlineData("Error has been raised.", typeof(NLogConfigurationException), true, "Warn")]
         [InlineData("", typeof(ArgumentException), true, "Warn")]
         [InlineData("", typeof(NLogConfigurationException), true, "Warn")]


### PR DESCRIPTION
Resolves #5256 - Bug introduced with NLog v5.2 by #5190 

NLog v5.2 introduced an optimization to skip assembly-reflection, when already loaded the recommended way, but it failed to recognize the use of custom assembly-prefix