### PR TITLE
Added PublishReadyToRun to TestTrimPublish

### DIFF
--- a/tests/TestTrimPublish/TestTrimPublish.csproj
+++ b/tests/TestTrimPublish/TestTrimPublish.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <PublishTrimmed>true</PublishTrimmed>
     <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>true</PublishReadyToRun>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
NLog supports [PublishTrimmed](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained) and [PublishReadyToRun](https://learn.microsoft.com/en-us/dotnet/core/deploying/ready-to-run) and [PublishSingleFile](https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/)