### PR TITLE
Remove irrelevant StructuredMessageTemplateAttribute

### DIFF
--- a/src/NLog/Abstractions/ILogger.cs
+++ b/src/NLog/Abstractions/ILogger.cs
@@ -296,14 +296,14 @@ namespace NLog
         /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
         [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        void DebugException([Localizable(false)][StructuredMessageTemplate] string message, Exception exception);
+        void DebugException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Debug</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
-        void Debug(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message);
+        void Debug(Exception exception, [Localizable(false)] string message);
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Debug</c> level.
@@ -961,7 +961,7 @@ namespace NLog
         /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
         [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        void FatalException([Localizable(false)][StructuredMessageTemplate] string message, Exception exception);
+        void FatalException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Fatal</c> level.


### PR DESCRIPTION
I found that some overloads in `ILogger` have the `[StructuredMessageTemplate]` but they don't actually treat the input as a structured message, instead treating it like a regular string. This leads to false-positives in R# and irrelevant syntax highlighting. I believe these attributes shouldn't be here, as they are only applied to the `Debug` level ([search link](https://github.com/search?q=repo%3ANLog%2FNLog%20%2F%5C%5BStructuredMessageTemplate%5C%5D%5B%5E%2C%5D*%5C%29%2F%20&type=code)) (and `Fatal` for obsolete version of the method). Note that these methods also don't have `[MessageTemplateFormatMethod]`.

<img width="611" alt="Screenshot 2023-06-26 at 11 44 07" src="https://github.com/NLog/NLog/assets/13440397/f78c1809-2d66-422e-825b-a590970639ac">
