### PR TITLE
ConfigurationItemFactory - Include ConditionMethods in registration

### DIFF
--- a/src/NLog/Conditions/Parsing/ConditionParser.cs
+++ b/src/NLog/Conditions/Parsing/ConditionParser.cs
@@ -113,13 +113,13 @@ namespace NLog.Conditions
             return expression;
         }
 
-        private ConditionMethodExpression ParsePredicate(string functionName)
+        private ConditionMethodExpression ParseMethodPredicate(string functionName)
         {
-            var par = new List<ConditionExpression>();
+            var inputParameters = new List<ConditionExpression>();
 
             while (!_tokenizer.IsEOF() && _tokenizer.TokenType != ConditionTokenType.RightParen)
             {
-                par.Add(ParseExpression());
+                inputParameters.Add(ParseExpression());
                 if (_tokenizer.TokenType != ConditionTokenType.Comma)
                 {
                     break;
@@ -132,11 +132,7 @@ namespace NLog.Conditions
 
             try
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                var methodInfo = _configurationItemFactory.ConditionMethodFactory.CreateMethodInfo(functionName);
-#pragma warning restore CS0618 // Type or member is obsolete
-                var methodDelegate = _configurationItemFactory.ConditionMethodFactory.CreateInstance(functionName);
-                return new ConditionMethodExpression(functionName, methodInfo, methodDelegate, par);
+                return CreateMethodExpression(functionName, inputParameters);
             }
             catch (Exception exception)
             {
@@ -149,6 +145,44 @@ namespace NLog.Conditions
 
                 throw new ConditionParseException($"Cannot resolve function '{functionName}'", exception);
             }
+        }
+
+        private ConditionMethodExpression CreateMethodExpression(string functionName, List<ConditionExpression> inputParameters)
+        {
+            // Attempt to lookup functionName that can handle the provided number of input-parameters
+            if (inputParameters.Count == 0)
+            {
+                Func<LogEventInfo, object> method = _configurationItemFactory.ConditionMethodFactory.TryCreateInstanceWithNoParameters(functionName);
+                if (method != null)
+                    return ConditionMethodExpression.CreateMethodNoParameters(functionName, method);
+            }
+            else if (inputParameters.Count == 1)
+            {
+                Func<LogEventInfo, object, object> method = _configurationItemFactory.ConditionMethodFactory.TryCreateInstanceWithOneParameter(functionName);
+                if (method != null)
+                    return ConditionMethodExpression.CreateMethodOneParameter(functionName, method, inputParameters);
+            }
+            else if (inputParameters.Count == 2)
+            {
+                Func<LogEventInfo, object, object, object> method = _configurationItemFactory.ConditionMethodFactory.TryCreateInstanceWithTwoParameters(functionName);
+                if (method != null)
+                    return ConditionMethodExpression.CreateMethodTwoParameters(functionName, method, inputParameters);
+            }
+            else if (inputParameters.Count == 3)
+            {
+                Func<LogEventInfo, object, object, object, object> method = _configurationItemFactory.ConditionMethodFactory.TryCreateInstanceWithThreeParameters(functionName);
+                if (method != null)
+                    return ConditionMethodExpression.CreateMethodThreeParameters(functionName, method, inputParameters);
+            }
+
+            Func<object[], object> manyParameterMethod = _configurationItemFactory.ConditionMethodFactory.TryCreateInstanceWithManyParameters(functionName, out var manyParameterMinCount, out var manyParameterMaxCount, out var manyParameterWithLogEvent);
+            if (manyParameterMethod is null)
+                throw new ConditionParseException($"Unknown condition method '{functionName}'");
+            if (manyParameterMinCount > inputParameters.Count)
+                throw new ConditionParseException($"Condition method '{functionName}' requires minimum {manyParameterMinCount} parameters, but passed {inputParameters.Count}.");
+            if (manyParameterMaxCount < inputParameters.Count)
+                throw new ConditionParseException($"Condition method '{functionName}' requires maximum {manyParameterMaxCount} parameters, but passed {inputParameters.Count}.");
+            return ConditionMethodExpression.CreateMethodManyParameters(functionName, manyParameterMethod, inputParameters, manyParameterWithLogEvent);
         }
 
         private ConditionExpression ParseLiteralExpression()
@@ -200,8 +234,8 @@ namespace NLog.Conditions
                 {
                     _tokenizer.GetNextToken();
 
-                    ConditionMethodExpression predicateExpression = ParsePredicate(keyword);
-                    return predicateExpression;
+                    var conditionMethodExpression = ParseMethodPredicate(keyword);
+                    return conditionMethodExpression;
                 }
             }
 

--- a/src/NLog/Config/AssemblyExtensionTypes.cs
+++ b/src/NLog/Config/AssemblyExtensionTypes.cs
@@ -272,6 +272,19 @@ namespace NLog.Config
             factory.TimeSourceFactory.RegisterType<NLog.Time.AccurateUtcTimeSource>("AccurateUTC");
             factory.TimeSourceFactory.RegisterType<NLog.Time.FastLocalTimeSource>("FastLocal");
             factory.TimeSourceFactory.RegisterType<NLog.Time.FastUtcTimeSource>("FastUTC");
+            factory.ConditionMethodFactory.RegisterOneParameter("length", (logEvent,arg1) => NLog.Conditions.ConditionMethods.Length(arg1?.ToString()));
+            factory.ConditionMethodFactory.RegisterTwoParameters("equals", (logEvent,arg1,arg2) => NLog.Conditions.ConditionMethods.Equals2(arg1?.ToString(), arg2?.ToString()));
+            factory.ConditionMethodFactory.RegisterTwoParameters("strequals", (logEvent,arg1,arg2) => NLog.Conditions.ConditionMethods.Equals2(arg1?.ToString(), arg2?.ToString()));
+            factory.ConditionMethodFactory.RegisterThreeParameters("strequals", (logEvent,arg1,arg2,arg3) => NLog.Conditions.ConditionMethods.Equals2(arg1?.ToString(), arg2?.ToString(), arg3 is bool ignoreCase ? ignoreCase : true));
+            factory.ConditionMethodFactory.RegisterTwoParameters("contains", (logEvent,arg1,arg2) => NLog.Conditions.ConditionMethods.Contains(arg1?.ToString(), arg2?.ToString()));
+            factory.ConditionMethodFactory.RegisterThreeParameters("contains", (logEvent,arg1,arg2,arg3) => NLog.Conditions.ConditionMethods.Contains(arg1?.ToString(), arg2?.ToString(), arg3 is bool ignoreCase ? ignoreCase : true));
+            factory.ConditionMethodFactory.RegisterTwoParameters("starts-with", (logEvent,arg1,arg2) => NLog.Conditions.ConditionMethods.StartsWith(arg1?.ToString(), arg2?.ToString()));
+            factory.ConditionMethodFactory.RegisterThreeParameters("starts-with", (logEvent,arg1,arg2,arg3) => NLog.Conditions.ConditionMethods.StartsWith(arg1?.ToString(), arg2?.ToString(), arg3 is bool ignoreCase ? ignoreCase : true));
+            factory.ConditionMethodFactory.RegisterTwoParameters("ends-with", (logEvent,arg1,arg2) => NLog.Conditions.ConditionMethods.EndsWith(arg1?.ToString(), arg2?.ToString()));
+            factory.ConditionMethodFactory.RegisterThreeParameters("ends-with", (logEvent,arg1,arg2,arg3) => NLog.Conditions.ConditionMethods.EndsWith(arg1?.ToString(), arg2?.ToString(), arg3 is bool ignoreCase ? ignoreCase : true));
+            factory.ConditionMethodFactory.RegisterTwoParameters("regex-matches", (logEvent,arg1,arg2) => NLog.Conditions.ConditionMethods.RegexMatches(arg1?.ToString(), arg2?.ToString()));
+            factory.ConditionMethodFactory.RegisterThreeParameters("regex-matches", (logEvent,arg1,arg2,arg3) => NLog.Conditions.ConditionMethods.RegexMatches(arg1?.ToString(), arg2?.ToString(), arg3?.ToString() ?? string.Empty));
+
             #pragma warning restore CS0618 // Type or member is obsolete
         }
     }

--- a/src/NLog/Config/AssemblyExtensionTypes.tt
+++ b/src/NLog/Config/AssemblyExtensionTypes.tt
@@ -204,6 +204,19 @@ namespace NLog.Config
         }
     }
 #>
+            factory.ConditionMethodFactory.RegisterOneParameter("length", (logEvent,arg1) => NLog.Conditions.ConditionMethods.Length(arg1?.ToString()));
+            factory.ConditionMethodFactory.RegisterTwoParameters("equals", (logEvent,arg1,arg2) => NLog.Conditions.ConditionMethods.Equals2(arg1?.ToString(), arg2?.ToString()));
+            factory.ConditionMethodFactory.RegisterTwoParameters("strequals", (logEvent,arg1,arg2) => NLog.Conditions.ConditionMethods.Equals2(arg1?.ToString(), arg2?.ToString()));
+            factory.ConditionMethodFactory.RegisterThreeParameters("strequals", (logEvent,arg1,arg2,arg3) => NLog.Conditions.ConditionMethods.Equals2(arg1?.ToString(), arg2?.ToString(), arg3 is bool ignoreCase ? ignoreCase : true));
+            factory.ConditionMethodFactory.RegisterTwoParameters("contains", (logEvent,arg1,arg2) => NLog.Conditions.ConditionMethods.Contains(arg1?.ToString(), arg2?.ToString()));
+            factory.ConditionMethodFactory.RegisterThreeParameters("contains", (logEvent,arg1,arg2,arg3) => NLog.Conditions.ConditionMethods.Contains(arg1?.ToString(), arg2?.ToString(), arg3 is bool ignoreCase ? ignoreCase : true));
+            factory.ConditionMethodFactory.RegisterTwoParameters("starts-with", (logEvent,arg1,arg2) => NLog.Conditions.ConditionMethods.StartsWith(arg1?.ToString(), arg2?.ToString()));
+            factory.ConditionMethodFactory.RegisterThreeParameters("starts-with", (logEvent,arg1,arg2,arg3) => NLog.Conditions.ConditionMethods.StartsWith(arg1?.ToString(), arg2?.ToString(), arg3 is bool ignoreCase ? ignoreCase : true));
+            factory.ConditionMethodFactory.RegisterTwoParameters("ends-with", (logEvent,arg1,arg2) => NLog.Conditions.ConditionMethods.EndsWith(arg1?.ToString(), arg2?.ToString()));
+            factory.ConditionMethodFactory.RegisterThreeParameters("ends-with", (logEvent,arg1,arg2,arg3) => NLog.Conditions.ConditionMethods.EndsWith(arg1?.ToString(), arg2?.ToString(), arg3 is bool ignoreCase ? ignoreCase : true));
+            factory.ConditionMethodFactory.RegisterTwoParameters("regex-matches", (logEvent,arg1,arg2) => NLog.Conditions.ConditionMethods.RegexMatches(arg1?.ToString(), arg2?.ToString()));
+            factory.ConditionMethodFactory.RegisterThreeParameters("regex-matches", (logEvent,arg1,arg2,arg3) => NLog.Conditions.ConditionMethods.RegexMatches(arg1?.ToString(), arg2?.ToString(), arg3?.ToString()));
+
             #pragma warning restore CS0618 // Type or member is obsolete
         }
     }

--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -578,7 +578,6 @@ namespace NLog.Config
             lock (SyncRoot)
             {
                 AssemblyExtensionTypes.RegisterTypes(factory);
-                factory.ConditionMethodFactory.RegisterType(typeof(NLog.Conditions.ConditionMethods), string.Empty);
 #pragma warning disable CS0618 // Type or member is obsolete
                 factory.RegisterExternalItems();
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/NLog/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog/SetupExtensionsBuilderExtensions.cs
@@ -333,6 +333,7 @@ namespace NLog
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="name">Name of the condition filter method</param>
         /// <param name="conditionMethod">MethodInfo extracted by reflection - typeof(MyClass).GetMethod("MyFunc", BindingFlags.Static).</param>
+        [Obsolete("Instead use RegisterConditionMethod with delegate, as type reflection will be moved out. Marked obsolete with NLog v5.2")]
         public static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, MethodInfo conditionMethod)
         {
             Guard.ThrowIfNull(conditionMethod);
@@ -352,8 +353,8 @@ namespace NLog
         public static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, Func<LogEventInfo, object> conditionMethod)
         {
             Guard.ThrowIfNull(conditionMethod);
-            ReflectionHelpers.LateBoundMethod lateBound = (target, args) => conditionMethod((LogEventInfo)args[0]);
-            return RegisterConditionMethod(setupBuilder, name, conditionMethod, lateBound);
+            ConfigurationItemFactory.Default.ConditionMethodFactory.RegisterNoParameters(name, (logEvent) => conditionMethod(logEvent));
+            return setupBuilder;
         }
 
         /// <summary>
@@ -365,13 +366,7 @@ namespace NLog
         public static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, Func<object> conditionMethod)
         {
             Guard.ThrowIfNull(conditionMethod);
-            ReflectionHelpers.LateBoundMethod lateBound = (target, args) => conditionMethod();
-            return RegisterConditionMethod(setupBuilder, name, conditionMethod, lateBound);
-        }
-
-        private static ISetupExtensionsBuilder RegisterConditionMethod(this ISetupExtensionsBuilder setupBuilder, string name, Delegate conditionMethod, ReflectionHelpers.LateBoundMethod lateBoundMethod)
-        {
-            ConfigurationItemFactory.Default.ConditionMethodFactory.RegisterDefinition(name, conditionMethod.GetDelegateInfo(), lateBoundMethod);
+            ConfigurationItemFactory.Default.ConditionMethodFactory.RegisterNoParameters(name, (logEvent) => conditionMethod());
             return setupBuilder;
         }
 

--- a/src/NLog/SetupLoadConfigurationExtensions.cs
+++ b/src/NLog/SetupLoadConfigurationExtensions.cs
@@ -637,10 +637,9 @@ namespace NLog
             return configBuilder.WithWrapper(t =>
             {
                 var targetWrapper = new AutoFlushTargetWrapper() { WrappedTarget = t };
-                var methodInfo = conditionMethod.GetDelegateInfo();
-                ReflectionHelpers.LateBoundMethod lateBound = (target, args) => conditionMethod((LogEventInfo)args[0]);
-                var conditionExpression = new Conditions.ConditionMethodExpression(methodInfo.Name, methodInfo, lateBound, ArrayHelper.Empty<Conditions.ConditionExpression>());
-                targetWrapper.Condition = conditionExpression;
+
+                var autoFlushCondition = Conditions.ConditionMethodExpression.CreateMethodNoParameters("AutoFlush", (logEvent) => conditionMethod(logEvent) ? Conditions.ConditionExpression.BoxedTrue : Conditions.ConditionExpression.BoxedFalse);
+                targetWrapper.Condition = autoFlushCondition;
                 if (flushOnConditionOnly.HasValue)
                     targetWrapper.FlushOnConditionOnly = flushOnConditionOnly.Value;
                 return targetWrapper;

--- a/tests/NLog.UnitTests/Conditions/ConditionParserTests.cs
+++ b/tests/NLog.UnitTests/Conditions/ConditionParserTests.cs
@@ -197,9 +197,9 @@ namespace NLog.UnitTests.Conditions
         {
             var result = ConditionParser.ParseExpression("starts-with(logger, 'x${message}')") as ConditionMethodExpression;
             Assert.NotNull(result);
+            Assert.Equal("starts-with", result.MethodName);
             Assert.Equal("starts-with(logger, 'x${message}')", result.ToString());
-            Assert.Equal("StartsWith", result.MethodInfo.Name);
-            Assert.Equal(typeof(ConditionMethods), result.MethodInfo.DeclaringType);
+            Assert.Equal(2, result.MethodParameters.Count);
         }
 
         [Fact]


### PR DESCRIPTION
Resolves #5260

Replaced expression-tree-compilation with direct method calls. Discovered that expression-tree-compilation doesn't work well with `PublishAOT` (Because dynamic compiler is not available). See also [Improve performance with Expression Trees](https://github.com/NLog/NLog/pull/1779#issuecomment-262397937)