### PR TITLE
ConfigurationItemFactory - Fix NullReferenceException when skipping already loaded assembly

### DIFF
--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -48,8 +48,8 @@ namespace NLog.UnitTests.Config
 
     public class ExtensionTests : NLogTestBase
     {
-        private string extensionAssemblyName1 = "SampleExtensions";
-        private string extensionAssemblyFullPath1 = Path.GetFullPath("SampleExtensions.dll");
+        private readonly string extensionAssemblyName1 = "SampleExtensions";
+        private readonly string extensionAssemblyFullPath1 = Path.GetFullPath("SampleExtensions.dll");
 
         private string GetExtensionAssemblyFullPath()
         {


### PR DESCRIPTION
Resolves  #5277. Fixing bug introduced with #5257

Also changed `MustBeRethrownImmediately` to `MustBeRethrown` so unit-test on build-server will detect such issues in the future.