### PR TITLE
Refactor ConditionBasedFilter when filter to use ternary operator

### DIFF
--- a/src/NLog/Filters/ConditionBasedFilter.cs
+++ b/src/NLog/Filters/ConditionBasedFilter.cs
@@ -58,8 +58,8 @@ namespace NLog.Filters
         /// <inheritdoc/>
         protected override FilterResult Check(LogEventInfo logEvent)
         {
-            bool isConditionTrue = Condition.Evaluate(logEvent) == ConditionExpression.BoxedTrue;
-            return isConditionTrue ? Action : FilterDefaultAction;
+            object val = Condition.Evaluate(logEvent);
+            return ConditionExpression.BoxedTrue.Equals(val) ? Action : FilterDefaultAction;
         }
     }
 }

--- a/src/NLog/Filters/ConditionBasedFilter.cs
+++ b/src/NLog/Filters/ConditionBasedFilter.cs
@@ -58,13 +58,8 @@ namespace NLog.Filters
         /// <inheritdoc/>
         protected override FilterResult Check(LogEventInfo logEvent)
         {
-            object val = Condition.Evaluate(logEvent);
-            if (ConditionExpression.BoxedTrue.Equals(val))
-            {
-                return Action;
-            }
-
-            return FilterDefaultAction;
+            bool isConditionTrue = Condition.Evaluate(logEvent) == ConditionExpression.BoxedTrue;
+            return isConditionTrue ? Action : FilterDefaultAction;
         }
     }
 }


### PR DESCRIPTION
In the refactored code, we directly compare the result of Condition.Evaluate(logEvent) with ConditionExpression.BoxedTrue to determine if the condition is true. Instead of assigning the result to val, we directly use the comparison result to determine the path of execution. This simplifies the code by removing the need for the if statement and condenses it into a single return statement.