### PR TITLE
Update unit-test-projects to net6

### DIFF
--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -2,7 +2,7 @@ dotnet restore ./tests/NLog.UnitTests/
 if (-Not $LastExitCode -eq 0)
 	{ exit $LastExitCode }
 
-dotnet test ./tests/NLog.UnitTests/ --framework netcoreapp3.1 --configuration release --no-restore
+dotnet test ./tests/NLog.UnitTests/ --framework net6.0 --configuration release --no-restore
 if (-Not $LastExitCode -eq 0)
 	{ exit $LastExitCode }
 
@@ -51,7 +51,7 @@ if ($isWindows -or $Env:WinDir)
 }
 else
 {
-	dotnet test ./tests/NLog.Database.Tests/ --framework netcoreapp3.1 --configuration release
+	dotnet test ./tests/NLog.Database.Tests/ --framework net6.0 --configuration release
 	if (-Not $LastExitCode -eq 0)
 		{ exit $LastExitCode }
 

--- a/tests/NLog.Database.Tests/NLog.Database.Tests.csproj
+++ b/tests/NLog.Database.Tests/NLog.Database.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
@@ -9,10 +9,10 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 
-    <DebugType Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">Full</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
   
@@ -25,25 +25,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.SQLite" />
     <Reference Include="System.Transactions" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.114.3" />
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.115.5" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.5" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.17" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />  <!-- Help Microsoft.Data.Sqlite -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.6" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.20" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />  <!-- Help Microsoft.Data.SqlClient -->
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NLog.UnitTests/Conditions/ConditionEvaluatorTests.cs
+++ b/tests/NLog.UnitTests/Conditions/ConditionEvaluatorTests.cs
@@ -329,11 +329,8 @@ namespace NLog.UnitTests.Conditions
             Assert.Same(inner, ex1.InnerException);
         }
 
-#if NETSTANDARD
-        [Fact(Skip = "NetStandard does not mark InvalidOperationException as Serializable")]
-#else
+#if !NET6_0_OR_GREATER
         [Fact]
-#endif
         public void ExceptionTest4()
         {
             var inner = new InvalidOperationException("f");
@@ -347,6 +344,7 @@ namespace NLog.UnitTests.Conditions
             Assert.Equal("msg", ex2.Message);
             Assert.Equal("f", ex2.InnerException.Message);
         }
+#endif
 
         [Fact]
         public void ExceptionTest11()
@@ -371,11 +369,8 @@ namespace NLog.UnitTests.Conditions
             Assert.Same(inner, ex1.InnerException);
         }
 
-#if NETSTANDARD
-        [Fact(Skip = "NetStandard does not mark InvalidOperationException as Serializable")]
-#else
+#if !NET6_0_OR_GREATER
         [Fact]
-#endif
         public void ExceptionTest14()
         {
             var inner = new InvalidOperationException("f");
@@ -389,6 +384,7 @@ namespace NLog.UnitTests.Conditions
             Assert.Equal("msg", ex2.Message);
             Assert.Equal("f", ex2.InnerException.Message);
         }
+#endif
 
         private static ConfigurationItemFactory SetupConditionMethods()
         {

--- a/tests/NLog.UnitTests/Config/ExtensionTests.cs
+++ b/tests/NLog.UnitTests/Config/ExtensionTests.cs
@@ -48,10 +48,10 @@ namespace NLog.UnitTests.Config
 
     public class ExtensionTests : NLogTestBase
     {
-        private readonly string extensionAssemblyName1 = "SampleExtensions";
-        private readonly string extensionAssemblyFullPath1 = Path.GetFullPath("SampleExtensions.dll");
+        private readonly static string extensionAssemblyName1 = "SampleExtensions";
+        private readonly static string extensionAssemblyFullPath1 = Path.GetFullPath("SampleExtensions.dll");
 
-        private string GetExtensionAssemblyFullPath()
+        private static string GetExtensionAssemblyFullPath()
         {
 #if NETSTANDARD
             Assert.NotNull(typeof(FooLayout));
@@ -682,9 +682,9 @@ namespace NLog.UnitTests.Config
             var testsDirectory = configurationDirectory.Parent.Parent.Parent;
             var manuallyLoadedAssemblyPath = Path.Combine(testsDirectory.FullName, "ManuallyLoadedExtension", "bin", configurationDirectory.Name,
 #if NETSTANDARD
-                    "netstandard2.0",
+                "netstandard2.0",
 #elif NET35 || NET40 || NET45
-                    "net461",
+                "net461",
 #else
                 nlogDirectory.Name,
 #endif

--- a/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
+++ b/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
@@ -615,7 +615,9 @@ namespace NLog.UnitTests.Config
             var logFactory = new LogFactory();
             logFactory.Setup().SetupExtensions(s => s.RegisterConditionMethod("hasParameters", evt => evt.Parameters?.Length > 0));
             logFactory.Setup().SetupExtensions(s => s.RegisterConditionMethod("isProduction", () => false));
+#pragma warning disable CS0618 // Type or member is obsolete
             logFactory.Setup().SetupExtensions(s => s.RegisterConditionMethod("isValid", typeof(Conditions.ConditionEvaluatorTests.MyConditionMethods).GetMethod(nameof(Conditions.ConditionEvaluatorTests.MyConditionMethods.IsValid))));
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Act
             logFactory.Configuration = new XmlLoggingConfiguration(@"<nlog throwExceptions='true'>

--- a/tests/NLog.UnitTests/Internal/NetworkSenders/HttpNetworkSenderTests.cs
+++ b/tests/NLog.UnitTests/Internal/NetworkSenders/HttpNetworkSenderTests.cs
@@ -49,6 +49,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
         /// Test <see cref="HttpNetworkSender"/> via <see cref="NetworkTarget"/>
         /// </summary>
         [Fact]
+        [Obsolete("WebRequest is obsolete. Use HttpClient instead.")]
         public void HttpNetworkSenderViaNetworkTargetTest()
         {
             // Arrange
@@ -92,6 +93,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
         }
 
         [Fact]
+        [Obsolete("WebRequest is obsolete. Use HttpClient instead.")]
         public void HttpNetworkSenderViaNetworkTargetRecoveryTest()
         {
             // Arrange
@@ -136,7 +138,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             mock.Dispose();
         }
 
-
+        [Obsolete("WebRequest is obsolete. Use HttpClient instead.")]
         private static INetworkSenderFactory CreateNetworkSenderFactoryMock(WebRequestMock webRequestMock)
         {
             var networkSenderFactoryMock = Substitute.For<INetworkSenderFactory>();

--- a/tests/NLog.UnitTests/LayoutRenderers/Contexts/EventPropertiesTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Contexts/EventPropertiesTests.cs
@@ -145,9 +145,9 @@ namespace NLog.UnitTests.LayoutRenderers
 
             Layout layout = "${event-properties:prop1:culture=nl-NL}";
             LogEventInfo logEvent = LogEventInfo.Create(LogLevel.Info, "logger1", "message1");
-            logEvent.Properties["prop1"] = new DateTime(2020, 2, 21, 23, 1, 0);
+            logEvent.Properties["prop1"] = new DateTime(2020, 11, 21, 23, 1, 0);
 
-            Assert.Equal("21-2-2020 23:01:00", layout.Render(logEvent));
+            Assert.Equal("21-11-2020 23:01:00", layout.Render(logEvent));
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/Mocks/WebRequestFactoryMock.cs
+++ b/tests/NLog.UnitTests/Mocks/WebRequestFactoryMock.cs
@@ -37,6 +37,7 @@ using NLog.Internal.NetworkSenders;
 
 namespace NLog.UnitTests.Mocks
 {
+    [Obsolete("WebRequest is obsolete. Use HttpClient instead.")]
     class WebRequestFactoryMock : IWebRequestFactory
     {
         private readonly WebRequestMock _mock;

--- a/tests/NLog.UnitTests/Mocks/WebRequestMock.cs
+++ b/tests/NLog.UnitTests/Mocks/WebRequestMock.cs
@@ -38,7 +38,8 @@ using NSubstitute;
 
 namespace NLog.UnitTests.Mocks
 {
-    public class WebRequestMock : WebRequest, IDisposable
+    [Obsolete("WebRequest is obsolete. Use HttpClient instead.")]
+    public sealed class WebRequestMock : WebRequest, IDisposable
     {
         public Uri RequestedAddress { get; set; }
 
@@ -61,7 +62,7 @@ namespace NLog.UnitTests.Mocks
                 RequestStream.Position = 0;
                 RequestStream.SetLength(0);
                 System.Threading.Thread.Sleep(50);
-                throw new ArgumentNullException("You are doomed");
+                throw new InvalidDataException("You are doomed");
             }
 
             var responseStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("new response 1"));

--- a/tests/NLog.UnitTests/NLog.UnitTests.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.csproj
@@ -1,16 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net461;net6.0</TargetFrameworks>
 
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 
-    <DebugType Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">Full</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TestTargetFramework)' != '' ">
@@ -18,15 +18,15 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' AND '$(TestTargetFramework)' == 'net35' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net6.0' AND '$(TestTargetFramework)' == 'net35' ">
     <DefineConstants>$(DefineConstants);NET35</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' AND '$(TestTargetFramework)' == 'net45' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net6.0' AND '$(TestTargetFramework)' == 'net45' ">
     <DefineConstants>$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
   
@@ -35,7 +35,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" /> <!-- Because of OWIN + NetCoreApp3.1 -->
     <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
@@ -43,7 +42,7 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.6.3" Condition="'$(OS)' != 'Windows_NT'" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -57,10 +56,11 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="DotNetZip.Reduced" Version="1.9.1.8" />
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.9" />
-    <PackageReference Include="Microsoft.Owin" version="4.2.2" /> <!-- Waiting for updated OwinSelfHost -->
+    <PackageReference Include="Microsoft.Owin" version="4.2.2" />   <!-- Waiting for updated OwinSelfHost -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" /> <!-- Waiting for updated OwinSelfHost -->
   </ItemGroup>
  
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' AND '$(TestTargetFramework)' != '' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' AND '$(TestTargetFramework)' != '' ">
     <Reference Include="NLog">
       <HintPath>../../src/NLog/bin/$(Configuration)/$(TestTargetFramework)/NLog.dll</HintPath>
       <Private>True</Private>

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -624,7 +624,7 @@ namespace NLog.UnitTests.Targets
                 // See that opening closing 
                 AssertFileContents(logFile, "name;level;message\nNLog.UnitTests.Targets.FileTargetTests;Debug;aaa\nNLog.UnitTests.Targets.FileTargetTests;Debug;aaa\n", Encoding.UTF8);
 
-                Assert.NotEqual(3, Directory.GetFiles(tempDir).Count());   // See that archive cleanup worked
+                Assert.NotEqual(3, Directory.GetFiles(tempDir).Length);   // See that archive cleanup worked
 
                 LogManager.Configuration = null;    // Close
             }
@@ -2790,7 +2790,7 @@ namespace NLog.UnitTests.Targets
                 Assert.True(File.Exists(logFile));
 
                 //Five archive files, plus the log file itself.
-                Assert.True(tempDirectory.GetFiles(archiveFileMask).Count() == 5 + 1);
+                Assert.True(tempDirectory.GetFiles(archiveFileMask).Length == 5 + 1);
             }
             finally
             {
@@ -3570,7 +3570,7 @@ namespace NLog.UnitTests.Targets
         /// <param name="expectedArchiveFiles">expected count of archived files</param>
         /// <param name="dateFormat">date format</param>
         /// <param name="changeCreationAndWriteTime">change file creation/last write date</param>
-        private void TestMaxArchiveFilesWithDate(int maxArchiveFilesConfig, int expectedArchiveFiles, string dateFormat, bool changeCreationAndWriteTime)
+        private static void TestMaxArchiveFilesWithDate(int maxArchiveFilesConfig, int expectedArchiveFiles, string dateFormat, bool changeCreationAndWriteTime)
         {
             string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             string archivePath = Path.Combine(tempDir, "archive");
@@ -3665,7 +3665,7 @@ namespace NLog.UnitTests.Targets
         /// <param name="expectedArchiveFiles">Expected number of archive files after archiving has occured.</param>
         /// <param name="dateFormat">string to be used for formatting log file names</param>
         /// <param name="changeCreationAndWriteTime"></param>
-        private void HandleArchiveFilesMultipleContextMultipleTargetsTest(
+        private static void HandleArchiveFilesMultipleContextMultipleTargetsTest(
             int maxArchiveFilesConfig, int expectedArchiveFiles, string dateFormat, bool changeCreationAndWriteTime)
         {
             string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -3807,7 +3807,7 @@ namespace NLog.UnitTests.Targets
         /// <param name="expectedArchiveFiles">Expected number of archive files after archiving has occured.</param>
         /// <param name="dateFormat">string to be used for formatting log file names</param>
         /// <param name="changeCreationAndWriteTime"></param>
-        private void HandleArchiveFilesMultipleContextSingleTargetsTest(
+        private static void HandleArchiveFilesMultipleContextSingleTargetsTest(
             int maxArchiveFilesConfig, int expectedArchiveFiles, string dateFormat, bool changeCreationAndWriteTime)
         {
             string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -4064,7 +4064,7 @@ namespace NLog.UnitTests.Targets
             var invalidChars = Path.GetInvalidFileNameChars();
             var invalidFileName = Path.DirectorySeparatorChar.ToString();
             var expectedFileName = "";
-            for (int i = 0; i < invalidChars.Count(); i++)
+            for (int i = 0; i < invalidChars.Length; i++)
             {
                 var invalidChar = invalidChars[i];
                 if (invalidChar == Path.DirectorySeparatorChar || invalidChar == Path.AltDirectorySeparatorChar)
@@ -4107,7 +4107,9 @@ namespace NLog.UnitTests.Targets
         [InlineData("UTF-16BE", true)]
         [InlineData("UTF-32", true)]
         [InlineData("UTF-32BE", true)]
+#if !NET6_0_OR_GREATER
         [InlineData("UTF-7", false)]
+#endif
         [InlineData("UTF-8", false)]
         [InlineData("ASCII", false)]
         public void TestInitialBomValue(string encodingName, bool expected)

--- a/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/WebServiceTargetTests.cs
@@ -110,7 +110,7 @@ namespace NLog.UnitTests.Targets
             WebserviceTest_httppost_utf8("includeBOM='false'", false);
         }
 
-        private void WebserviceTest_httppost_utf8(string bomAttr, bool includeBom)
+        private static void WebserviceTest_httppost_utf8(string bomAttr, bool includeBom)
         {
             var logFactory = new LogFactory().Setup()
                                              .SetupExtensions(ext => ext.RegisterAssembly(typeof(WebServiceTarget).Assembly))
@@ -142,7 +142,9 @@ namespace NLog.UnitTests.Targets
             Assert.Equal("utf-8", target.Encoding.WebName);
 
             //async call with mockup stream
+#pragma warning disable SYSLIB0014 // Type or member is obsolete
             var webRequest = System.Net.WebRequest.Create("http://www.test.com");
+#pragma warning restore SYSLIB0014 // Type or member is obsolete
             var httpWebRequest = (HttpWebRequest)webRequest;
             var streamMock = new StreamMock();
 

--- a/tests/NLog.WindowsRegistry.Tests/NLog.WindowsRegistry.Tests.csproj
+++ b/tests/NLog.WindowsRegistry.Tests/NLog.WindowsRegistry.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
     <AssemblyOriginatorKeyFile>NLogTests.snk</AssemblyOriginatorKeyFile>
@@ -9,18 +9,17 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 
-    <DebugType Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">Full</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" Condition=" '$(TargetFramework)' == 'netcoreapp3.1' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NLog.WindowsRegistry.Tests/RegistryTests.cs
+++ b/tests/NLog.WindowsRegistry.Tests/RegistryTests.cs
@@ -37,6 +37,9 @@ namespace NLog.WindowsRegistry.Tests
     using Microsoft.Win32;
     using Xunit;
 
+#if NETSTANDARD
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
     public sealed class RegistryTests : IDisposable
     {
         private const string TestKey = @"Software\NLogTest";


### PR DESCRIPTION
To fix Azure DevOps that complains about NetCoreApp3.1

`Testhost process for source(s) 'D:\a\1\s\tests\NLog.Database.Tests\bin\Release\netcoreapp3.1\NLog.Database.Tests.dll' exited with error: You must install or update .NET to run this application.`