### PR TITLE
FileTarget - FilePathLayout with fixed-filename can translate to absolute path

### DIFF
--- a/src/NLog/Internal/AppDomains/FakeAppDomain.cs
+++ b/src/NLog/Internal/AppDomains/FakeAppDomain.cs
@@ -47,7 +47,7 @@ namespace NLog.Internal.Fakeables
         private readonly System.Runtime.Loader.AssemblyLoadContext _defaultContext;
 #endif
 
-        /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref="FakeAppDomain" /> class.</summary>
         public FakeAppDomain()
         {
             BaseDirectory = AppContext.BaseDirectory;

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -250,6 +250,7 @@ namespace NLog.Targets
                 {
                     _fileNameKind = value;
                     _fullFileName = CreateFileNameLayout(FileName);
+                    _fullArchiveFileName = CreateFileNameLayout(ArchiveFileName);
                     ResetFileAppenders("FileNameKind Changed");
                 }
             }

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
@@ -658,7 +658,6 @@ namespace NLog.UnitTests.Targets
 
         protected class TestObject
         {
-            /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
             public TestObject(string name)
             {
                 Name = name;
@@ -687,7 +686,6 @@ namespace NLog.UnitTests.Targets
 
         private class ObjectWithExceptionAndPrivateSetter
         {
-            /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
             public ObjectWithExceptionAndPrivateSetter(string name)
             {
                 Name = name;


### PR DESCRIPTION
Fixed absolute-path is faster than "dynamic" relative-path.