### PR TITLE
Report NLog version on initial configuration assignment

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -208,7 +208,7 @@ namespace NLog.Config
         private ICollection<KeyValuePair<string, string>> CreateUniqueSortedListFromConfig(ILoggingConfigurationElement nlogConfig)
         {
             var dict = ValidatedConfigurationElement.Create(nlogConfig, LogFactory).ValueLookup;
-            if (dict.Count == 0)
+            if (dict.Count <= 1)
                 return dict;
 
             var sortedList = new List<KeyValuePair<string, string>>(dict.Count);

--- a/src/NLog/Config/ServiceRepositoryExtensions.cs
+++ b/src/NLog/Config/ServiceRepositoryExtensions.cs
@@ -174,18 +174,18 @@ namespace NLog.Config
         {
             if (messageTemplateParser == false)
             {
-                NLog.Common.InternalLogger.Info("Message Template String Format always enabled");
+                NLog.Common.InternalLogger.Debug("Message Template String Format always enabled");
                 serviceRepository.RegisterSingleton<ILogMessageFormatter>(LogMessageStringFormatter.Default);
             }
             else if (messageTemplateParser == true)
             {
-                NLog.Common.InternalLogger.Info("Message Template Format always enabled");
+                NLog.Common.InternalLogger.Debug("Message Template Format always enabled");
                 serviceRepository.RegisterSingleton<ILogMessageFormatter>(new LogMessageTemplateFormatter(serviceRepository, true, false));
             }
             else
             {
                 //null = auto
-                NLog.Common.InternalLogger.Info("Message Template Auto Format enabled");
+                NLog.Common.InternalLogger.Debug("Message Template Auto Format enabled");
                 serviceRepository.RegisterSingleton<ILogMessageFormatter>(new LogMessageTemplateFormatter(serviceRepository, false, false));
             }
             return serviceRepository;

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -268,11 +268,11 @@ namespace NLog
                     {
                         try
                         {
+                            LogConfigurationInitialized();
                             _config = config;
                             _configLoader.Activated(this, _config);
                             _config.Dump();
                             ReconfigExistingLoggers();
-                            LogConfigurationInitialized();
                         }
                         finally
                         {
@@ -307,6 +307,8 @@ namespace NLog
                     {
                         try
                         {
+                            if (oldConfig is null)
+                                LogConfigurationInitialized();
                             _configLoader.Activated(this, _config);
                             _config.Dump();
                             ReconfigExistingLoggers();
@@ -403,6 +405,9 @@ namespace NLog
 
         internal static void LogConfigurationInitialized()
         {
+            if (!InternalLogger.IsInfoEnabled)
+                return;
+
             InternalLogger.Info("Configuration initialized.");
             try
             {
@@ -413,7 +418,6 @@ namespace NLog
                 InternalLogger.Debug(ex, "Not running in full trust");
             }
         }
-
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting 
         /// unmanaged resources.


### PR DESCRIPTION
Skip resolving assembly version, unless InternalLogger is enabled.