### PR TITLE
Replaced MutableUnsafeAttribute with ThreadAgnosticImmutableAttribute

### DIFF
--- a/src/NLog/Config/ThreadAgnosticImmutableAttribute.cs
+++ b/src/NLog/Config/ThreadAgnosticImmutableAttribute.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 // 
 // All rights reserved.
@@ -34,17 +34,19 @@
 namespace NLog.Config
 {
     using System;
-    using System.ComponentModel;
 
     /// <summary>
-    /// Marks the layout or layout renderer depends on mutable objects from the LogEvent
+    /// Marks the layout or layout renderer as thread independent - it producing correct results 
+    /// regardless of the thread it's running on.
     /// 
-    /// This can be <see cref="LogEventInfo.Properties"/> or <see cref="LogEventInfo.Exception"/>
+    /// Layout or layout-renderer depends on <see cref="LogEventInfo.Properties"/> or <see cref="LogEventInfo.Exception"/>,
+    /// and requires that LogEvent-state is recognized as immutable.
     /// </summary>
-    [Obsolete("Marked obsolete on NLog 5.3, instead use ThreadAgnosticImmutableAttribute")]
+    /// <remarks>
+    /// Must be used in combination with <see cref="ThreadAgnosticAttribute"/>, else it will have no effect
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Class)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public sealed class MutableUnsafeAttribute : Attribute
+    public sealed class ThreadAgnosticImmutableAttribute : Attribute
     {
     }
 }

--- a/src/NLog/Internal/Files/FilePathLayout.cs
+++ b/src/NLog/Internal/Files/FilePathLayout.cs
@@ -146,7 +146,7 @@ namespace NLog.Internal
             }
             else
             {
-                if (!_layout.ThreadAgnostic || _layout.MutableUnsafe)
+                if (!_layout.ThreadAgnostic || _layout.ThreadAgnosticImmutable)
                 {
                     object cachedResult;
                     if (logEvent.TryGetCachedLayoutValue(_layout, out cachedResult))

--- a/src/NLog/LayoutRenderers/Contexts/AllEventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/AllEventPropertiesLayoutRenderer.cs
@@ -45,7 +45,7 @@ namespace NLog.LayoutRenderers
     /// </summary>
     [LayoutRenderer("all-event-properties")]
     [ThreadAgnostic]
-    [MutableUnsafe]
+    [ThreadAgnosticImmutable]
     public class AllEventPropertiesLayoutRenderer : LayoutRenderer
     {
         private string _format;

--- a/src/NLog/LayoutRenderers/Contexts/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/EventPropertiesLayoutRenderer.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("event-property")]
     [LayoutRenderer("event-context")]
     [ThreadAgnostic]
-    [MutableUnsafe]
+    [ThreadAgnosticImmutable]
     public class EventPropertiesLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
     {
         private ObjectReflectionCache ObjectReflectionCache => _objectReflectionCache ?? (_objectReflectionCache = new ObjectReflectionCache(LoggingConfiguration.GetServiceProvider()));

--- a/src/NLog/LayoutRenderers/ExceptionDataLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionDataLayoutRenderer.cs
@@ -46,7 +46,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("exceptiondata")]
     [LayoutRenderer("exception-data")]
     [ThreadAgnostic]
-    [MutableUnsafe]
+    [ThreadAgnosticImmutable]
     public class ExceptionDataLayoutRenderer : LayoutRenderer
     {
         /// <summary>

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -51,7 +51,6 @@ namespace NLog.LayoutRenderers
     /// XML event description compatible with log4j, Chainsaw and NLogViewer.
     /// </summary>
     [LayoutRenderer("log4jxmlevent")]
-    [MutableUnsafe]
     public class Log4JXmlEventLayoutRenderer : LayoutRenderer, IUsesStackTrace, IIncludeContext
     {
         private static readonly DateTime log4jDateBase = new DateTime(1970, 1, 1);

--- a/src/NLog/Layouts/JSON/JsonLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonLayout.cs
@@ -226,7 +226,7 @@ namespace NLog.Layouts
             }
             if (IncludeEventProperties)
             {
-                MutableUnsafe = true;
+                ThreadAgnosticImmutable = true;
             }
 
             _precalculateLayouts = (IncludeScopeProperties || IncludeEventProperties) ? null : ResolveLayoutPrecalculation(Attributes.Select(atr => atr.Layout));

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -329,7 +329,7 @@ namespace NLog.Layouts
 
                     if (ThreadAgnostic)
                     {
-                        if (MutableUnsafe)
+                        if (ThreadAgnosticImmutable)
                         {
                             // If raw value doesn't have the ability to mutate, then we can skip precalculate
                             var success = _rawValueRenderer.TryGetRawValue(logEvent, out var value);
@@ -361,7 +361,7 @@ namespace NLog.Layouts
                 }
             }
 
-            return ThreadAgnostic && !MutableUnsafe;
+            return ThreadAgnostic && !ThreadAgnosticImmutable;
         }
 
         private static bool IsObjectValueMutableSafe(object value)
@@ -381,7 +381,7 @@ namespace NLog.Layouts
                         Initialize(LoggingConfiguration);
                     }
 
-                    if ((!ThreadAgnostic || MutableUnsafe) && logEvent.TryGetCachedLayoutValue(this, out _))
+                    if ((!ThreadAgnostic || ThreadAgnosticImmutable) && logEvent.TryGetCachedLayoutValue(this, out _))
                     {
                         rawValue = null;
                         return false;    // Raw-Value has been precalculated, so not available

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -164,7 +164,7 @@ namespace NLog.Layouts
             base.InitializeLayout();
             _innerLayout?.Initialize(LoggingConfiguration ?? _innerLayout.LoggingConfiguration);
             ThreadAgnostic = _innerLayout?.ThreadAgnostic ?? true;
-            MutableUnsafe = _innerLayout?.MutableUnsafe ?? false;
+            ThreadAgnosticImmutable = _innerLayout?.ThreadAgnosticImmutable ?? false;
             StackTraceUsage = _innerLayout?.StackTraceUsage ?? StackTraceUsage.None;
             _valueTypeConverter = null;
             _previousStringValue = null;
@@ -195,7 +195,7 @@ namespace NLog.Layouts
 
         private void PrecalculateInnerLayout(LogEventInfo logEvent, StringBuilder target)
         {
-            if (IsFixed || (_innerLayout.ThreadAgnostic && !_innerLayout.MutableUnsafe))
+            if (IsFixed || (_innerLayout.ThreadAgnostic && !_innerLayout.ThreadAgnosticImmutable))
                 return;
 
             if (TryRenderObjectValue(logEvent, target, out var cachedValue))

--- a/src/NLog/Layouts/XML/XmlElementBase.cs
+++ b/src/NLog/Layouts/XML/XmlElementBase.cs
@@ -231,7 +231,7 @@ namespace NLog.Layouts
                 ThreadAgnostic = false;
 
             if (IncludeEventProperties)
-                MutableUnsafe = true;
+                ThreadAgnosticImmutable = true;
 
             if (Attributes.Count > 1)
             {

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -624,7 +624,7 @@ namespace NLog
             return Convert.GetTypeCode(value) != TypeCode.Object;
         }
 
-        internal bool IsLogEventMutableSafe()
+        internal bool IsLogEventThreadAgnosticImmutable()
         {
             if (Exception != null)
                 return false;

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -896,7 +896,7 @@ namespace NLog.Targets
                 if (IncludeScopeProperties || IncludeScopeNested)
                     ThreadAgnostic = false;
                 if (IncludeEventProperties)
-                    MutableUnsafe = true;   // TODO Need to convert Properties to an immutable state
+                    ThreadAgnosticImmutable = true;   // TODO Need to convert Properties to an immutable state
             }
 
             public override string ToString()
@@ -906,7 +906,7 @@ namespace NLog.Targets
 
             public override void Precalculate(LogEventInfo logEvent)
             {
-                if (!(TargetLayout?.ThreadAgnostic ?? true) || (TargetLayout?.MutableUnsafe ?? false))
+                if (TargetLayout?.ThreadAgnostic == false || TargetLayout?.ThreadAgnosticImmutable == true)
                 {
                     TargetLayout.Precalculate(logEvent);
                     if (logEvent.TryGetCachedLayoutValue(TargetLayout, out var cachedLayout))
@@ -921,7 +921,7 @@ namespace NLog.Targets
 
             internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
             {
-                if (!(TargetLayout?.ThreadAgnostic ?? true) || (TargetLayout?.MutableUnsafe ?? false))
+                if (TargetLayout?.ThreadAgnostic == false || TargetLayout?.ThreadAgnosticImmutable == true)
                 {
                     TargetLayout.PrecalculateBuilder(logEvent, target);
                     if (logEvent.TryGetCachedLayoutValue(TargetLayout, out var cachedLayout))


### PR DESCRIPTION
- [x] Waiting for NLog v5.3

I don't like the word "unsafe", and since the attribute is just a restriction of the original `ThreadAgnosticAttribute`, then I think `[ThreadAgnosticImmutable]` is better (Only ThreadAgnostic when LogEvent-state is immutable)