### PR TITLE
MessageLayoutRenderer - Skip Flatten when simple AggregateException

### DIFF
--- a/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
@@ -118,6 +118,8 @@ namespace NLog.LayoutRenderers
                 {
                     return aggregateException.InnerExceptions[0];
                 }
+
+                return aggregateException;  // Matches ${exception} default behavior
             }
 #endif
             return exception;


### PR DESCRIPTION
Revert breaking change introduced with #5299