### PR TITLE
Skip checking ExcludeProperties when empty, to avoid string GetHashCode

### DIFF
--- a/src/NLog/Layouts/JSON/JsonLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonLayout.cs
@@ -310,6 +310,7 @@ namespace NLog.Layouts
 
             if (IncludeScopeProperties)
             {
+                bool checkExcludeProperties = ExcludeProperties.Count > 0;
                 using (var scopeEnumerator = ScopeContext.GetAllPropertiesEnumerator())
                 {
                     while (scopeEnumerator.MoveNext())
@@ -318,7 +319,7 @@ namespace NLog.Layouts
                         if (string.IsNullOrEmpty(scopeProperty.Key))
                             continue;
 
-                        if (ExcludeProperties.Contains(scopeProperty.Key))
+                        if (checkExcludeProperties && ExcludeProperties.Contains(scopeProperty.Key))
                             continue;
 
                         AppendJsonPropertyValue(scopeProperty.Key, scopeProperty.Value, null, null, MessageTemplates.CaptureType.Unknown, sb, sb.Length == orgLength);
@@ -328,13 +329,14 @@ namespace NLog.Layouts
 
             if (IncludeEventProperties && logEvent.HasProperties)
             {
+                bool checkExcludeProperties = ExcludeProperties.Count > 0;
                 IEnumerable<MessageTemplates.MessageTemplateParameter> propertiesList = logEvent.CreateOrUpdatePropertiesInternal(true);
                 foreach (var prop in propertiesList)
                 {
                     if (string.IsNullOrEmpty(prop.Name))
                         continue;
 
-                    if (ExcludeProperties.Contains(prop.Name))
+                    if (checkExcludeProperties && ExcludeProperties.Contains(prop.Name))
                         continue;
 
                     AppendJsonPropertyValue(prop.Name, prop.Value, prop.Format, logEvent.FormatProvider, prop.CaptureType, sb, sb.Length == orgLength);

--- a/src/NLog/Layouts/XML/XmlElementBase.cs
+++ b/src/NLog/Layouts/XML/XmlElementBase.cs
@@ -360,6 +360,7 @@ namespace NLog.Layouts
         {
             if (IncludeScopeProperties)
             {
+                bool checkExcludeProperties = ExcludeProperties.Count > 0;
                 using (var scopeEnumerator = ScopeContext.GetAllPropertiesEnumerator())
                 {
                     while (scopeEnumerator.MoveNext())
@@ -368,7 +369,7 @@ namespace NLog.Layouts
                         if (string.IsNullOrEmpty(scopeProperty.Key))
                             continue;
 
-                        if (ExcludeProperties.Contains(scopeProperty.Key))
+                        if (checkExcludeProperties && ExcludeProperties.Contains(scopeProperty.Key))
                             continue;
 
                         AppendXmlPropertyValue(scopeProperty.Key, scopeProperty.Value, sb, orgLength);
@@ -376,7 +377,7 @@ namespace NLog.Layouts
                 }
             }
 
-            if (IncludeEventProperties && logEventInfo.HasProperties)
+            if (IncludeEventProperties)
             {
                 AppendLogEventProperties(logEventInfo, sb, orgLength);
             }
@@ -384,13 +385,17 @@ namespace NLog.Layouts
 
         private void AppendLogEventProperties(LogEventInfo logEventInfo, StringBuilder sb, int orgLength)
         {
+            if (!logEventInfo.HasProperties)
+                return;
+
+            bool checkExcludeProperties = ExcludeProperties.Count > 0;
             IEnumerable<MessageTemplates.MessageTemplateParameter> propertiesList = logEventInfo.CreateOrUpdatePropertiesInternal(true);
             foreach (var prop in propertiesList)
             {
                 if (string.IsNullOrEmpty(prop.Name))
                     continue;
 
-                if (ExcludeProperties.Contains(prop.Name))
+                if (checkExcludeProperties && ExcludeProperties.Contains(prop.Name))
                     continue;
 
                 var propertyValue = prop.Value;

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -247,13 +247,17 @@ namespace NLog.Targets
                 // TODO Make Dictionary-Lazy-adapter for PropertiesDictionary to skip extra Dictionary-allocation
                 combinedProperties = combinedProperties ?? CreateNewDictionary(logEvent.Properties.Count + (ContextProperties?.Count ?? 0));
                 bool checkForDuplicates = combinedProperties.Count > 0;
+                bool checkExcludeProperties = ExcludeProperties.Count > 0;
                 foreach (var property in logEvent.Properties)
                 {
-                    string propertyKey = property.Key.ToString();
-                    if (string.IsNullOrEmpty(propertyKey) || ExcludeProperties.Contains(propertyKey))
+                    string propertyName = property.Key.ToString();
+                    if (string.IsNullOrEmpty(propertyName))
                         continue;
 
-                    AddContextProperty(logEvent, propertyKey, property.Value, checkForDuplicates, combinedProperties);
+                    if (checkExcludeProperties && ExcludeProperties.Contains(propertyName))
+                        continue;
+
+                    AddContextProperty(logEvent, propertyName, property.Value, checkForDuplicates, combinedProperties);
                 }
             }
             combinedProperties = GetContextProperties(logEvent, combinedProperties);
@@ -303,16 +307,16 @@ namespace NLog.Targets
             return true;
         }
 
-        private void AddContextProperty(LogEventInfo logEvent, string itemName, object itemValue, bool checkForDuplicates, IDictionary<string, object> combinedProperties)
+        private void AddContextProperty(LogEventInfo logEvent, string propertyName, object propertyValue, bool checkForDuplicates, IDictionary<string, object> combinedProperties)
         {
-            if (checkForDuplicates && combinedProperties.ContainsKey(itemName))
+            if (checkForDuplicates && combinedProperties.ContainsKey(propertyName))
             {
-                itemName = GenerateUniqueItemName(logEvent, itemName, itemValue, combinedProperties);
-                if (itemName is null)
+                propertyName = GenerateUniqueItemName(logEvent, propertyName, propertyValue, combinedProperties);
+                if (propertyName is null)
                     return;
             }
 
-            combinedProperties[itemName] = itemValue;
+            combinedProperties[propertyName] = propertyValue;
         }
 
         /// <summary>
@@ -460,9 +464,13 @@ namespace NLog.Targets
 
             contextProperties = contextProperties ?? CreateNewDictionary(globalNames.Count);
             bool checkForDuplicates = contextProperties.Count > 0;
+            bool checkExcludeProperties = ExcludeProperties.Count > 0;
             foreach (string propertyName in globalNames)
             {
-                if (string.IsNullOrEmpty(propertyName) || ExcludeProperties.Contains(propertyName))
+                if (string.IsNullOrEmpty(propertyName))
+                    continue;
+
+                if (checkExcludeProperties && ExcludeProperties.Contains(propertyName))
                     continue;
 
                 var propertyValue = GlobalDiagnosticsContext.GetObject(propertyName);
@@ -547,22 +555,23 @@ namespace NLog.Targets
             using (var scopeEnumerator = ScopeContext.GetAllPropertiesEnumerator())
             {
                 bool checkForDuplicates = contextProperties?.Count > 0;
+                bool checkExcludeProperties = ExcludeProperties.Count > 0;
                 while (scopeEnumerator.MoveNext())
                 {
                     var scopeProperty = scopeEnumerator.Current;
-                    var name = scopeProperty.Key;
-                    if (string.IsNullOrEmpty(name))
+                    var propertyName = scopeProperty.Key;
+                    if (string.IsNullOrEmpty(propertyName))
                         continue;
 
-                    if (ExcludeProperties.Contains(name))
+                    if (checkExcludeProperties && ExcludeProperties.Contains(propertyName))
                         continue;
 
                     contextProperties = contextProperties ?? CreateNewDictionary(0);
 
-                    object value = scopeProperty.Value;
-                    if (SerializeScopeContextProperty(logEvent, name, value, out var serializedValue))
+                    object propertyValue = scopeProperty.Value;
+                    if (SerializeScopeContextProperty(logEvent, propertyName, propertyValue, out var serializedValue))
                     {
-                        AddContextProperty(logEvent, name, serializedValue, checkForDuplicates, contextProperties);
+                        AddContextProperty(logEvent, propertyName, serializedValue, checkForDuplicates, contextProperties);
                     }
                 }
             }


### PR DESCRIPTION
ExcludeProperties `HashSet.Contains(string)` resolves `string.GetHashCode` even if HashSet is empty.