### PR TITLE
JsonLayout - Support minimal thread context capture from inner layouts

### DIFF
--- a/src/NLog/Layouts/CSV/CsvLayout.cs
+++ b/src/NLog/Layouts/CSV/CsvLayout.cs
@@ -35,6 +35,7 @@ namespace NLog.Layouts
 {
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Linq;
     using System.Text;
     using NLog.Config;
     using NLog.Internal;
@@ -57,6 +58,7 @@ namespace NLog.Layouts
         private string _actualColumnDelimiter;
         private string _doubleQuoteChar;
         private char[] _quotableCharacters;
+        private Layout[] _precalculateLayouts = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CsvLayout"/> class.
@@ -149,11 +151,19 @@ namespace NLog.Layouts
 
             _quotableCharacters = (QuoteChar + "\r\n" + _actualColumnDelimiter).ToCharArray();
             _doubleQuoteChar = QuoteChar + QuoteChar;
+            _precalculateLayouts = ResolveLayoutPrecalculation(Columns.Select(cln => cln.Layout));
+        }
+
+        /// <inheritdoc/>
+        protected override void CloseLayout()
+        {
+            _precalculateLayouts = null;
+            base.CloseLayout();
         }
 
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
-            PrecalculateBuilderInternal(logEvent, target);
+            PrecalculateBuilderInternal(logEvent, target, _precalculateLayouts);
         }
 
         /// <inheritdoc/>

--- a/src/NLog/Layouts/CompoundLayout.cs
+++ b/src/NLog/Layouts/CompoundLayout.cs
@@ -50,6 +50,8 @@ namespace NLog.Layouts
     [AppDomainFixedOutput]
     public class CompoundLayout : Layout
     {
+        private Layout[] _precalculateLayouts = null;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CompoundLayout"/> class.
         /// </summary>
@@ -68,14 +70,17 @@ namespace NLog.Layouts
         /// <inheritdoc/>
         protected override void InitializeLayout()
         {
-            base.InitializeLayout();
             foreach (var layout in Layouts)
                 layout.Initialize(LoggingConfiguration);
+
+            base.InitializeLayout();
+
+            _precalculateLayouts = ResolveLayoutPrecalculation(Layouts);
         }
 
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
-            PrecalculateBuilderInternal(logEvent, target);
+            PrecalculateBuilderInternal(logEvent, target, _precalculateLayouts);
         }
 
         /// <inheritdoc/>
@@ -99,6 +104,7 @@ namespace NLog.Layouts
         /// <inheritdoc/>
         protected override void CloseLayout()
         {
+            _precalculateLayouts = null;
             foreach (var layout in Layouts)
                 layout.Close();
             base.CloseLayout();

--- a/src/NLog/Layouts/JSON/JsonArrayLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonArrayLayout.cs
@@ -48,6 +48,8 @@ namespace NLog.Layouts
     [ThreadAgnostic]
     public class JsonArrayLayout : Layout
     {
+        private Layout[] _precalculateLayouts = null;
+
         private IJsonConverter JsonConverter
         {
             get => _jsonConverter ?? (_jsonConverter = ResolveService<IJsonConverter>());
@@ -75,15 +77,23 @@ namespace NLog.Layouts
         public bool RenderEmptyObject { get; set; } = true;
 
         /// <inheritdoc/>
+        protected override void InitializeLayout()
+        {
+            base.InitializeLayout();
+            _precalculateLayouts = ResolveLayoutPrecalculation(Items);
+        }
+
+        /// <inheritdoc/>
         protected override void CloseLayout()
         {
             JsonConverter = null;
+            _precalculateLayouts = null;
             base.CloseLayout();
         }
 
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
-            PrecalculateBuilderInternal(logEvent, target);
+            PrecalculateBuilderInternal(logEvent, target, _precalculateLayouts);
         }
 
         /// <inheritdoc/>

--- a/src/NLog/Layouts/JSON/JsonLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonLayout.cs
@@ -36,6 +36,7 @@ namespace NLog.Layouts
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
+    using System.Linq;
     using System.Text;
     using NLog.Config;
 
@@ -51,6 +52,7 @@ namespace NLog.Layouts
     public class JsonLayout : Layout
     {
         private const int SpacesPerIndent = 2;
+        private Layout[] _precalculateLayouts = null;
 
         private LimitRecursionJsonConvert JsonConverter
         {
@@ -221,6 +223,8 @@ namespace NLog.Layouts
                 MutableUnsafe = true;
             }
 
+            _precalculateLayouts = (IncludeScopeProperties || IncludeEventProperties) ? null : ResolveLayoutPrecalculation(Attributes.Select(atr => atr.Layout));
+
             if (_escapeForwardSlashInternal.HasValue && Attributes?.Count > 0)
             {
                 foreach (var attribute in Attributes)
@@ -252,12 +256,13 @@ namespace NLog.Layouts
         {
             JsonConverter = null;
             ValueFormatter = null;
+            _precalculateLayouts = null;
             base.CloseLayout();
         }
 
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
-            PrecalculateBuilderInternal(logEvent, target);
+            PrecalculateBuilderInternal(logEvent, target, _precalculateLayouts);
         }
 
         /// <inheritdoc/>

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -198,7 +198,7 @@ namespace NLog.Layouts
 
         internal override void PrecalculateBuilder(LogEventInfo logEvent, StringBuilder target)
         {
-            PrecalculateBuilderInternal(logEvent, target);
+            PrecalculateBuilderInternal(logEvent, target, null);
         }
 
         /// <inheritdoc/>

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -312,7 +312,7 @@ namespace NLog.Layouts
         {
             if (!IsLogEventMutableSafe(logEvent))
             {
-                PrecalculateBuilderInternal(logEvent, target);
+                PrecalculateBuilderInternal(logEvent, target, null);
             }
         }
 


### PR DESCRIPTION
And allow deferring full layout rendering to backkground thread, by only capturing thread-context for the individual parts, instead of doing precalculate of the entire output-result.

Reducing the overhead for the application-thread when logging, along with reducing memory-allocations.