### PR TITLE
JsonLayout - Support minimal thread context capture from inner layouts

### DIFF
--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -406,7 +406,7 @@ namespace NLog.Layouts
                 }
             }
 
-            if (layoutCount <= 1 || layoutCount == precalculateSimpleLayoutCount || precalculateSimpleLayoutCount > 5 || (precalculateLayoutCount - precalculateSimpleLayoutCount) > 2)
+            if (layoutCount <= 1 || precalculateLayoutCount > 4 || (precalculateLayoutCount - precalculateSimpleLayoutCount) > 2 || (layoutCount - precalculateSimpleLayoutCount) <= 1)
             {
                 return null;
             }


### PR DESCRIPTION
Followup to #5337 (Trying to balance when it makes sense to perform minimal capture, skip when minimal is almost everything)