### PR TITLE
ConcurrentRequestQueue - Reduced SpinCount to 15, before monitor wait

### DIFF
--- a/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
+++ b/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
@@ -160,7 +160,7 @@ namespace NLog.Targets.Wrappers
             long currentCount = 0;
             bool firstYield = true;
             SpinWait spinWait = new SpinWait();
-            for (int i = 0; i <= 20; ++i)
+            for (int i = 0; i < 15; ++i)
             {
                 if (spinWait.NextSpinWillYield)
                 {


### PR DESCRIPTION
Double performance in synthetic benchmarks, when using OverflowAction=Block