### PR TITLE
LogManager.ReconfigExistingLoggers with reduced memory allocation

### DIFF
--- a/src/NLog/Internal/TargetWithFilterChain.cs
+++ b/src/NLog/Internal/TargetWithFilterChain.cs
@@ -117,17 +117,15 @@ namespace NLog.Internal
             return stackTraceUsage;
         }
 
-        static internal TargetWithFilterChain[] BuildLoggerConfiguration(string loggerName, LoggingConfiguration configuration, LogLevel globalLogLevel)
+        static internal TargetWithFilterChain[] BuildLoggerConfiguration(string loggerName, List<LoggingRule> loggingRules, LogLevel globalLogLevel)
         {
-            if (configuration is null || LogLevel.Off.Equals(globalLogLevel))
+            if (loggingRules is null || loggingRules.Count == 0 || LogLevel.Off.Equals(globalLogLevel))
                 return TargetWithFilterChain.NoTargetsByLevel;
 
             TargetWithFilterChain[] targetsByLevel = TargetWithFilterChain.CreateLoggingConfiguration();
             TargetWithFilterChain[] lastTargetsByLevel = TargetWithFilterChain.CreateLoggingConfiguration();
             bool[] suppressedLevels = new bool[LogLevel.MaxLevel.Ordinal + 1];
 
-            //no "System.InvalidOperationException: Collection was modified"
-            var loggingRules = configuration.GetLoggingRulesThreadSafe();
             bool targetsFound = GetTargetsByLevelForLogger(loggerName, loggingRules, globalLogLevel, targetsByLevel, lastTargetsByLevel, suppressedLevels);
             return targetsFound ? targetsByLevel : TargetWithFilterChain.NoTargetsByLevel;
         }

--- a/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
@@ -500,7 +500,7 @@ namespace NLog.UnitTests.Config
                 </rules>
             </nlog>").LogFactory;
 
-            var loggerConfig = logFactory.BuildLoggerConfiguration("AAA", logFactory.Configuration);
+            var loggerConfig = logFactory.BuildLoggerConfiguration("AAA", logFactory.Configuration?.GetLoggingRulesThreadSafe());
             var targets = loggerConfig[LogLevel.Warn.Ordinal];
             Assert.Equal("d1", targets.Target.Name);
             Assert.Equal("d2", targets.NextInChain.Target.Name);


### PR DESCRIPTION
Only call `GetLoggingRulesThreadSafe()` once, instead for every Logger-instance