### PR TITLE
LogEventInfo - IsLogEventMutableSafe better use of _formattedMessage as hint

### DIFF
--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -626,7 +626,10 @@ namespace NLog
 
         internal bool IsLogEventMutableSafe()
         {
-            if (Exception != null || _formattedMessage != null)
+            if (Exception != null)
+                return false;
+
+            if (_formattedMessage != null && _parameters?.Length > 0)
                 return false;
 
             var properties = CreateOrUpdatePropertiesInternal(false);


### PR DESCRIPTION
LogEvent can still be immutable, even when `_formattedMessage` is set. See also #5319

Still allow deferring of layout-rendering to background-thread, when using NLog.Extensions.Logging