### PR TITLE
LogEventInfo-constructor to skip Parameters-array allocation (unit test)

### DIFF
--- a/src/NLog/Layouts/CSV/CsvQuotingMode.cs
+++ b/src/NLog/Layouts/CSV/CsvQuotingMode.cs
@@ -39,7 +39,7 @@ namespace NLog.Layouts
     public enum CsvQuotingMode
     {
         /// <summary>
-        /// Quote all column (Fast)
+        /// Quote Always (Fast)
         /// </summary>
         All,
 

--- a/tests/NLog.UnitTests/LogMessageFormatterTests.cs
+++ b/tests/NLog.UnitTests/LogMessageFormatterTests.cs
@@ -33,7 +33,9 @@
 
 namespace NLog.UnitTests
 {
+    using System.Text;
     using NLog.MessageTemplates;
+    using NLog.Targets;
     using Xunit;
 
     public class LogMessageFormatterTests : NLogTestBase
@@ -85,36 +87,55 @@ namespace NLog.UnitTests
         [Fact]
         public void ExtensionsLoggingPreFormatTest()
         {
-            LogEventInfo logEventInfo = new LogEventInfo(LogLevel.Info, "MyLogger", "Login request from John for BestApplicationEver", "Login request from {Username} for {Application}", new[]
+            LogEventInfo logEventInfo1 = new LogEventInfo(LogLevel.Info, "MyLogger", "Login request from John for BestApplicationEver", "Login request from {Username} for {Application}", new[]
             {
                 new MessageTemplateParameter("Username", "John", null, CaptureType.Normal),
                 new MessageTemplateParameter("Application", "BestApplicationEver", null, CaptureType.Normal)
             });
 
+            LogEventInfo logEventInfo2 = new LogEventInfo(LogLevel.Info, "MyLogger", "Login request from John for BestApplicationEver", "Login request from {Username} for {Application}", new[]
+{
+                new MessageTemplateParameter("Username", "John", null, CaptureType.Normal),
+                new MessageTemplateParameter("Application", new StringBuilder("BestApplicationEver", 32), null, CaptureType.Normal)
+            });
+
             var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
                 <nlog throwExceptions='true'>
                     <targets>
-                        <target name='debug' type='Debug'  >
-                                <layout type='JsonLayout' IncludeAllProperties='true'>
-                                    <attribute name='LogMessage' layout='${message:raw=true}' />
-                                </layout>
+                        <target name='buffer' type='BufferingWrapper'>
+                            <target name='debug' type='Debug'  >
+                                    <layout type='JsonLayout' IncludeAllProperties='true' maxRecursionLimit='0'>
+                                        <attribute name='LogMessage' layout='${message:raw=true}' />
+                                    </layout>
+                            </target>
                         </target>
                     </targets>
                     <rules>
-                        <logger name='*' levels='Info' writeTo='debug' />
+                        <logger name='*' levels='Info' writeTo='buffer' />
                     </rules>
                 </nlog>").LogFactory;
 
+            var debugTarget = logFactory.Configuration.FindTargetByName<DebugTarget>("debug");
             var logger = logFactory.GetLogger("A");
-            logger.Log(logEventInfo);
+
+            logger.Log(logEventInfo2);
+            logFactory.Flush();
+            var result2 = debugTarget.Layout.Render(logEventInfo2);
+            Assert.Same(result2, debugTarget.LastMessage);
+
+            logger.Log(logEventInfo1);
+            logFactory.Flush();
+            var result1 = debugTarget.Layout.Render(logEventInfo1);
+            Assert.NotSame(result1, debugTarget.LastMessage);
+
             logFactory.AssertDebugLastMessage("{ \"LogMessage\": \"Login request from {Username} for {Application}\", \"Username\": \"John\", \"Application\": \"BestApplicationEver\" }");
 
-            Assert.Equal("Login request from John for BestApplicationEver", logEventInfo.FormattedMessage);
+            Assert.Equal("Login request from John for BestApplicationEver", logEventInfo1.FormattedMessage);
 
-            AssertContainsInDictionary(logEventInfo.Properties, "Username", "John");
-            AssertContainsInDictionary(logEventInfo.Properties, "Application", "BestApplicationEver");
-            Assert.Contains(new MessageTemplateParameter("Username", "John", null, CaptureType.Normal), logEventInfo.MessageTemplateParameters);
-            Assert.Contains(new MessageTemplateParameter("Application", "BestApplicationEver", null, CaptureType.Normal), logEventInfo.MessageTemplateParameters);
+            AssertContainsInDictionary(logEventInfo1.Properties, "Username", "John");
+            AssertContainsInDictionary(logEventInfo1.Properties, "Application", "BestApplicationEver");
+            Assert.Contains(new MessageTemplateParameter("Username", "John", null, CaptureType.Normal), logEventInfo1.MessageTemplateParameters);
+            Assert.Contains(new MessageTemplateParameter("Application", "BestApplicationEver", null, CaptureType.Normal), logEventInfo1.MessageTemplateParameters);
         }
 
         [Fact]


### PR DESCRIPTION
Followup to #5354 and #5319