### PR TITLE
NetworkTarget - Skip connection when above max message size

### DIFF
--- a/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/NetworkTargetTests.cs
@@ -459,7 +459,7 @@ namespace NLog.UnitTests.Targets
             Assert.True(result.IndexOf("2: send 0 5") != -1);
             Assert.True(result.IndexOf("2: close") != -1);
 
-            Assert.Equal(2, droppedLogs);
+            Assert.Equal(1, droppedLogs);
         }
 
         [Fact]


### PR DESCRIPTION
When going to discard payload because larger than MaxMessageSize, then no need to etablish connection.

There is a minor breaking as it will no longer make connection-handshake when payload above max-message-size, or when payload is zero bytes.