### PR TITLE
FileTarget - SetCreationTimeUtc only when IsArchivingEnabled

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -207,7 +207,7 @@ namespace NLog.Internal.FileAppenders
             try
             {
                 var fileStream = TryCreateFileStream(allowFileSharedWriting, overrideBufferSize);
-                fixWindowFileSystemTunnelingCapabilities = !fileAlreadyExisted && (CreateFileParameters.FileOpenRetryCount > 0 || PlatformDetector.IsWin32);
+                fixWindowFileSystemTunnelingCapabilities = !fileAlreadyExisted && CreateFileParameters.IsArchivingEnabled && (CreateFileParameters.FileOpenRetryCount > 0 || PlatformDetector.IsWin32);
                 return fileStream;
             }
             catch (DirectoryNotFoundException)


### PR DESCRIPTION
Followup to #5381 (Only apply fix for Windows Tunnelling when NLog depends on File.CreationTimeUtc when IsArchivingEnabled = true)

Avoid overhead from calling exotic file-api-methods, that might not be supported on limited-platforms (unless using exotic NLog FileTarget features)