### PR TITLE
FileTarget - SetCreationTimeUtc always when running on Windows

### DIFF
--- a/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/BaseFileAppender.cs
@@ -202,12 +202,12 @@ namespace NLog.Internal.FileAppenders
         private FileStream TryCreateDirectoryFileStream(bool allowFileSharedWriting, int overrideBufferSize)
         {
             bool fileAlreadyExisted = UpdateCreationTime();
-            bool fixWindowFileSystemTunnelingCapabilities = false;
+            bool fixWindowsFileSystemTunneling = false;
 
             try
             {
                 var fileStream = TryCreateFileStream(allowFileSharedWriting, overrideBufferSize);
-                fixWindowFileSystemTunnelingCapabilities = !fileAlreadyExisted && CreateFileParameters.IsArchivingEnabled && (CreateFileParameters.FileOpenRetryCount > 0 || PlatformDetector.IsWin32);
+                fixWindowsFileSystemTunneling = !fileAlreadyExisted && (CreateFileParameters.IsArchivingEnabled || PlatformDetector.IsWin32);
                 return fileStream;
             }
             catch (DirectoryNotFoundException)
@@ -236,11 +236,11 @@ namespace NLog.Internal.FileAppenders
             }
             finally
             {
-                if (fixWindowFileSystemTunnelingCapabilities)
+                if (fixWindowsFileSystemTunneling)
                 {
                     try
                     {
-                        // Set the file's creation time to avoid being thwarted by Windows' Tunneling capabilities (https://support.microsoft.com/en-us/kb/172190).
+                        // Set the file's creation time to avoid being thwarted by Windows FileSystem Tunneling capabilities (https://support.microsoft.com/en-us/kb/172190).
                         File.SetCreationTimeUtc(FileName, CreationTimeUtc);
                     }
                     catch (Exception ex)


### PR DESCRIPTION
Followup to #5382 and #5381

If user deletes a log-file on Windows, and NLog immediately starts a new file (with same name), then the new file should not inherit creation-file-stamp from the just deleted file.