### PR TITLE
Implemented dynamic archive directory creation

### DIFF
--- a/src/NLog/Targets/FileArchiveModes/FileArchiveModeDate.cs
+++ b/src/NLog/Targets/FileArchiveModes/FileArchiveModeDate.cs
@@ -35,6 +35,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace NLog.Targets.FileArchiveModes
 {
@@ -50,7 +51,7 @@ namespace NLog.Targets.FileArchiveModes
         private readonly string _archiveDateFormat;
 
         public FileArchiveModeDate(string archiveDateFormat, bool isArchiveCleanupEnabled)
-            :base(isArchiveCleanupEnabled)
+            : base(isArchiveCleanupEnabled)
         {
             _archiveDateFormat = archiveDateFormat;
         }
@@ -86,7 +87,7 @@ namespace NLog.Targets.FileArchiveModes
         public override DateAndSequenceArchive GenerateArchiveFileName(string archiveFilePath, DateTime archiveDate, List<DateAndSequenceArchive> existingArchiveFiles)
         {
             FileNameTemplate archiveFileNameTemplate = GenerateFileNameTemplate(archiveFilePath);
-            string dirName = Path.GetDirectoryName(archiveFilePath);
+            string dirName = Regex.Replace(Path.GetDirectoryName(archiveFilePath), @"\{#+\}", archiveDate.ToString(_archiveDateFormat));
             archiveFilePath = Path.Combine(dirName, archiveFileNameTemplate.ReplacePattern("*").Replace("*", archiveDate.ToString(_archiveDateFormat)));
             archiveFilePath = Path.GetFullPath(archiveFilePath);    // Rebuild to fix non-standard path-format
             return new DateAndSequenceArchive(archiveFilePath, archiveDate, _archiveDateFormat, 0);

--- a/src/NLog/Targets/FileArchiveModes/FileArchiveModeDateAndSequence.cs
+++ b/src/NLog/Targets/FileArchiveModes/FileArchiveModeDateAndSequence.cs
@@ -35,6 +35,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text.RegularExpressions;
 using NLog.Common;
 
 namespace NLog.Targets.FileArchiveModes
@@ -52,7 +53,7 @@ namespace NLog.Targets.FileArchiveModes
         private readonly string _archiveDateFormat;
 
         public FileArchiveModeDateAndSequence(string archiveDateFormat, bool archiveCleanupEnabled)
-            :base(archiveCleanupEnabled)
+            : base(archiveCleanupEnabled)
         {
             _archiveDateFormat = archiveDateFormat;
         }
@@ -89,7 +90,7 @@ namespace NLog.Targets.FileArchiveModes
             string paddedSequence = nextSequenceNumber.ToString().PadLeft(minSequenceLength, '0');
             string archiveFileNameWithoutPath = archiveFileNameTemplate.ReplacePattern("*").Replace("*",
                 $"{archiveDate.ToString(_archiveDateFormat)}.{paddedSequence}");
-            string dirName = Path.GetDirectoryName(archiveFilePath);
+            string dirName = Regex.Replace(Path.GetDirectoryName(archiveFilePath), @"\{#+\}", archiveDate.ToString(_archiveDateFormat));
             archiveFilePath = Path.Combine(dirName, archiveFileNameWithoutPath);
             archiveFilePath = Path.GetFullPath(archiveFilePath);    // Rebuild to fix non-standard path-format
             return new DateAndSequenceArchive(archiveFilePath, archiveDate, _archiveDateFormat, nextSequenceNumber);

--- a/src/NLog/Targets/FileArchiveModes/FileArchiveModeSequence.cs
+++ b/src/NLog/Targets/FileArchiveModes/FileArchiveModeSequence.cs
@@ -35,6 +35,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text.RegularExpressions;
 using NLog.Internal;
 
 namespace NLog.Targets.FileArchiveModes
@@ -50,7 +51,7 @@ namespace NLog.Targets.FileArchiveModes
         private readonly string _archiveDateFormat;
 
         public FileArchiveModeSequence(string archiveDateFormat, bool isArchiveCleanupEnabled)
-            :base(isArchiveCleanupEnabled)
+            : base(isArchiveCleanupEnabled)
         {
             _archiveDateFormat = archiveDateFormat;
         }
@@ -75,7 +76,7 @@ namespace NLog.Targets.FileArchiveModes
             {
                 return null;
             }
-            
+
             var creationTimeUtc = archiveFile.LookupValidFileCreationTimeUtc();
             var creationTime = creationTimeUtc > DateTime.MinValue ? NLog.Time.TimeSource.Current.FromSystemTime(creationTimeUtc) : DateTime.MinValue;
             return new DateAndSequenceArchive(archiveFile.FullName, creationTime, string.Empty, num);
@@ -91,7 +92,7 @@ namespace NLog.Targets.FileArchiveModes
 
             int minSequenceLength = archiveFileNameTemplate.EndAt - archiveFileNameTemplate.BeginAt - 2;
             string paddedSequence = nextSequenceNumber.ToString().PadLeft(minSequenceLength, '0');
-            string dirName = Path.GetDirectoryName(archiveFilePath);
+            string dirName = Regex.Replace(Path.GetDirectoryName(archiveFilePath), @"\{#+\}", archiveDate.ToString(_archiveDateFormat));
             archiveFilePath = Path.Combine(dirName, archiveFileNameTemplate.ReplacePattern("*").Replace("*", paddedSequence));
             archiveFilePath = Path.GetFullPath(archiveFilePath);    // Rebuild to fix non-standard path-format
             return new DateAndSequenceArchive(archiveFilePath, archiveDate, _archiveDateFormat, nextSequenceNumber);


### PR DESCRIPTION
Dynamic archive was only able to create dynamic file names. Directory names were not affected.

For example, with `archiveFileName="Logs/Archive/archived-{#}/file.log"` the created directory's name was `archived-{#}`.

Based on this issue:
https://stackoverflow.com/questions/77366618/subtract-from-date-in-nlog-configuration/77368855#77368855

Note: I did not implement this in FileArchiveModeDynamicSequence, because I'm not familiar with that mode and it looked different to the others.