### PR TITLE
FileTarget - Rename option to WriteHeaderWhenInitialFileNotEmpty

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -486,13 +486,15 @@ namespace NLog.Targets
             set => _archiveOldFileOnStartup = value;
         }
         private bool? _archiveOldFileOnStartup;
-        
+
         /// <summary>
-        /// Gets or sets whether to write the Header on initial creation of file appender.
-        /// Independent of file is empty or not.
-        /// Alternative use <see cref="ArchiveOldFileOnStartup"/> to ensure each application session has its own individual log-file.
+        /// Gets or sets whether to write the Header on initial creation of file appender, even if the file is not empty.
+        /// Default value is <see langword="false"/>, which means only write header when initial file is empty (Ex. ensures valid CSV files)
         /// </summary>
-        public bool WriteHeaderOnInitialFileOpen { get; set; }
+        /// <remarks>
+        /// Alternative use <see cref="ArchiveOldFileOnStartup"/> to ensure each application session gets individual log-file.
+        /// </remarks>
+        public bool WriteHeaderWhenInitialFileNotEmpty { get; set; }
 
         /// <summary>
         /// Gets or sets a value of the file size threshold to archive old log file on startup.
@@ -2511,7 +2513,7 @@ namespace NLog.Targets
                     appender.Write(preamble, 0, preamble.Length);
             }
             
-            if (Header != null && (isNewOrEmptyFile || WriteHeaderOnInitialFileOpen))
+            if (Header != null && (isNewOrEmptyFile || WriteHeaderWhenInitialFileNotEmpty))
             {
                 InternalLogger.Trace("{0}: Write header", this);
                 ArraySegment<byte> headerBytes = GetLayoutBytes(Header);

--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -2241,7 +2241,7 @@ namespace NLog.UnitTests.Targets
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void WriteHeaderOnStartupTest(bool writeHeaderOnInitialFileOpen)
+        public void WriteHeaderOnStartupTest(bool writeHeaderWhenInitialFileNotEmpty)
         {
             var logFile = Path.GetTempFileName() + ".txt";
             try
@@ -2256,7 +2256,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${message}",
                     Header = header,
                     WriteBom = true,
-                    WriteHeaderOnInitialFileOpen = true
+                    WriteHeaderWhenInitialFileNotEmpty = true
                 };
 
                 LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
@@ -2279,7 +2279,7 @@ namespace NLog.UnitTests.Targets
                     Layout = "${message}",
                     Header = header,
                     WriteBom = true,
-                    WriteHeaderOnInitialFileOpen = writeHeaderOnInitialFileOpen
+                    WriteHeaderWhenInitialFileNotEmpty = writeHeaderWhenInitialFileNotEmpty
                 };
 
                 LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
@@ -2290,7 +2290,7 @@ namespace NLog.UnitTests.Targets
 
                 LogManager.Configuration = null;    // Flush
                 
-                if (writeHeaderOnInitialFileOpen)
+                if (writeHeaderWhenInitialFileNotEmpty)
                     AssertFileContents(logFile, headerPart + logPart + headerPart + logPart, Encoding.UTF8, addBom: true);
                 else
                     AssertFileContents(logFile, headerPart + logPart + logPart, Encoding.UTF8, addBom: true);


### PR DESCRIPTION
Rename option WriteHeaderOnInitialFileOpen to WriteHeaderWhenInitialFileNotEmpty

Followup to  #5407 since I'm not completely satisfied with my own suggested option-name.