### PR TITLE
Improved XML docs for MDC, MDLC, NDC, NDLC about being replaced by ScopeContext

### DIFF
--- a/src/NLog/Abstractions/ILogger.cs
+++ b/src/NLog/Abstractions/ILogger.cs
@@ -123,7 +123,7 @@ namespace NLog
         void Trace(LogMessageGenerator messageFunc);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// Obsolete and replaced by <see cref="Trace(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Trace</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
@@ -182,7 +182,7 @@ namespace NLog
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// Obsolete and replaced by <see cref="Trace(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Trace</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
@@ -289,7 +289,7 @@ namespace NLog
         void Debug(LogMessageGenerator messageFunc);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// Obsolete and replaced by <see cref="Debug(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Debug</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
@@ -348,7 +348,7 @@ namespace NLog
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// Obsolete and replaced by <see cref="Debug(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Debug</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
@@ -455,7 +455,7 @@ namespace NLog
         void Info(LogMessageGenerator messageFunc);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// Obsolete and replaced by <see cref="Info(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Info</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
@@ -514,7 +514,7 @@ namespace NLog
         void Info([Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// Obsolete and replaced by <see cref="Info(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Info</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
@@ -621,7 +621,7 @@ namespace NLog
         void Warn(LogMessageGenerator messageFunc);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// Obsolete and replaced by <see cref="Warn(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Warn</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
@@ -680,7 +680,7 @@ namespace NLog
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// Obsolete and replaced by <see cref="Warn(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Warn</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
@@ -787,7 +787,7 @@ namespace NLog
         void Error(LogMessageGenerator messageFunc);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// Obsolete and replaced by <see cref="Error(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Error</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
@@ -847,7 +847,7 @@ namespace NLog
         void Error([Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// Obsolete and replaced by <see cref="Error(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Error</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
@@ -954,7 +954,7 @@ namespace NLog
         void Fatal(LogMessageGenerator messageFunc);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// Obsolete and replaced by <see cref="Fatal(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Fatal</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>
@@ -1013,7 +1013,7 @@ namespace NLog
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// Obsolete and replaced by <see cref="Fatal(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Fatal</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
         /// <param name="exception">An exception to be logged.</param>

--- a/src/NLog/Abstractions/ILoggerBase.cs
+++ b/src/NLog/Abstractions/ILoggerBase.cs
@@ -113,7 +113,7 @@ namespace NLog
         void Log(LogLevel level, LogMessageGenerator messageFunc);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the specified level.
+        /// Obsolete and replaced by <see cref="Log(LogLevel, Exception, string, object[])"/> - Writes the diagnostic message and exception at the specified level.
         /// </summary>
         /// <param name="level">The log level.</param>
         /// <param name="message">A <see langword="string" /> to be written.</param>
@@ -171,7 +171,7 @@ namespace NLog
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
 
         /// <summary>
-        /// Writes the diagnostic message and exception at the specified level.
+        /// Obsolete and replaced by <see cref="Log(LogLevel, Exception, string, object[])"/> - Writes the diagnostic message and exception at the specified level.
         /// </summary>
         /// <param name="level">The log level.</param>
         /// <param name="message">A <see langword="string" /> to be written.</param>

--- a/src/NLog/Config/AssemblyLoadingEventArgs.cs
+++ b/src/NLog/Config/AssemblyLoadingEventArgs.cs
@@ -38,7 +38,8 @@ using System.Reflection;
 namespace NLog.Config
 {
     /// <summary>
-    /// An assembly is trying to load. 
+    /// Obsolete since dynamic assembly loading is not compatible with publish as trimmed application.
+    /// Event notification about trying to load assembly with NLog extensions.
     /// </summary>
     [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
     public class AssemblyLoadingEventArgs : CancelEventArgs

--- a/src/NLog/Config/ConfigurationItemCreator.cs
+++ b/src/NLog/Config/ConfigurationItemCreator.cs
@@ -36,6 +36,7 @@ namespace NLog.Config
     using System;
 
     /// <summary>
+    /// Obsolete since dynamic tyope loading is not compatible with publish as trimmed application.
     /// Constructs a new instance the configuration item (target, layout, layout renderer, etc.) given its type.
     /// </summary>
     /// <param name="itemType">Type of the item.</param>

--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -85,7 +85,8 @@ namespace NLog.Config
         }
 
         /// <summary>
-        /// Called before the assembly will be loaded.
+        /// Obsolete since dynamic assembly loading is not compatible with publish as trimmed application.
+        /// Called before the assembly with NLog extensions is being loaded.
         /// </summary>
         [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -100,6 +101,7 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete since dynamic assembly loading is not compatible with publish as trimmed application.
         /// Initializes a new instance of the <see cref="ConfigurationItemFactory"/> class.
         /// </summary>
         /// <param name="assemblies">The assemblies to scan for named items.</param>
@@ -188,6 +190,7 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NLog.SetupBuilderExtensions.SetupExtensions"/> with NLog v5.2.
         /// Gets or sets the creator delegate used to instantiate configuration objects.
         /// </summary>
         /// <remarks>
@@ -198,6 +201,7 @@ namespace NLog.Config
         public ConfigurationItemCreator CreateInstance { get; set; } = FactoryHelper.CreateInstance;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NLog.SetupBuilderExtensions.SetupExtensions"/> with NLog v5.2.
         /// Gets the <see cref="Target"/> factory.
         /// </summary>
         /// <value>The target factory.</value>
@@ -206,6 +210,7 @@ namespace NLog.Config
         public INamedItemFactory<Target, Type> Targets => _targets;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NLog.SetupBuilderExtensions.SetupExtensions"/> with NLog v5.2.
         /// Gets the <see cref="Layout"/> factory.
         /// </summary>
         /// <value>The layout factory.</value>
@@ -214,6 +219,7 @@ namespace NLog.Config
         public INamedItemFactory<Layout, Type> Layouts => _layouts;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NLog.SetupBuilderExtensions.SetupExtensions"/> with NLog v5.2.
         /// Gets the <see cref="LayoutRenderer"/> factory.
         /// </summary>
         /// <value>The layout renderer factory.</value>
@@ -222,6 +228,7 @@ namespace NLog.Config
         public INamedItemFactory<LayoutRenderer, Type> LayoutRenderers => _layoutRenderers;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NLog.SetupBuilderExtensions.SetupExtensions"/> with NLog v5.2.
         /// Gets the ambient property factory.
         /// </summary>
         /// <value>The ambient property factory.</value>
@@ -230,6 +237,7 @@ namespace NLog.Config
         public INamedItemFactory<LayoutRenderer, Type> AmbientProperties => _ambientProperties;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NLog.SetupBuilderExtensions.SetupExtensions"/> with NLog v5.2.
         /// Gets the <see cref="Filter"/> factory.
         /// </summary>
         /// <value>The filter factory.</value>
@@ -238,6 +246,7 @@ namespace NLog.Config
         public INamedItemFactory<Filter, Type> Filters => _filters;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NLog.SetupBuilderExtensions.SetupExtensions"/> with NLog v5.2.
         /// Gets the time source factory.
         /// </summary>
         /// <value>The time source factory.</value>
@@ -246,6 +255,7 @@ namespace NLog.Config
         public INamedItemFactory<TimeSource, Type> TimeSources => _timeSources;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NLog.SetupBuilderExtensions.SetupExtensions"/> with NLog v5.2.
         /// Gets the condition method factory.
         /// </summary>
         /// <value>The condition method factory.</value>
@@ -254,6 +264,7 @@ namespace NLog.Config
         public INamedItemFactory<MethodInfo, MethodInfo> ConditionMethods => _conditionMethods;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NLog.SetupSerializationBuilderExtensions.RegisterJsonConverter"/> with NLog v5.2.
         /// Gets or sets the JSON serializer to use with <see cref="JsonLayout"/>
         /// </summary>
         [Obsolete("Instead use NLog.LogManager.Setup().SetupSerialization(s => s.RegisterJsonConverter()) or ResolveService<IJsonConverter>(). Marked obsolete on NLog 5.0")]
@@ -265,6 +276,7 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NLog.SetupSerializationBuilderExtensions.RegisterValueFormatter"/> with NLog v5.2.
         /// Gets or sets the string serializer to use with <see cref="LogEventInfo.MessageTemplateParameters"/>
         /// </summary>
         [Obsolete("Instead use NLog.LogManager.Setup().SetupSerialization(s => s.RegisterValueFormatter()) or ResolveService<IValueFormatter>(). Marked obsolete on NLog 5.0")]
@@ -276,6 +288,7 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NLog.SetupBuilderExtensions.SetupExtensions"/> with NLog v5.2.
         /// Gets or sets the parameter converter to use with <see cref="TargetWithContext"/> or <see cref="Layout{T}"/>
         /// </summary>
         [Obsolete("Instead use LogFactory.ServiceRepository.RegisterService(). Marked obsolete on NLog 5.0")]
@@ -301,6 +314,7 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete since dynamic assembly loading is not compatible with publish as trimmed application.
         /// Registers named items from the assembly.
         /// </summary>
         /// <param name="assembly">The assembly.</param>
@@ -312,6 +326,7 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete since dynamic assembly loading is not compatible with publish as trimmed application.
         /// Registers named items from the assembly.
         /// </summary>
         /// <param name="assembly">The assembly.</param>
@@ -358,6 +373,7 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete since dynamic assembly loading is not compatible with publish as trimmed application.
         /// Call Preload for NLogPackageLoader
         /// </summary>
         /// <remarks>
@@ -450,6 +466,7 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete since dynamic type loading is not compatible with publish as trimmed application.
         /// Registers the type.
         /// </summary>
         /// <param name="type">The type to register.</param>

--- a/src/NLog/Config/INamedItemFactory.cs
+++ b/src/NLog/Config/INamedItemFactory.cs
@@ -36,6 +36,7 @@ namespace NLog.Config
     using System;
 
     /// <summary>
+    /// Obsolete since dynamic type loading is not compatible with publish as trimmed application. Replaced by <see cref="IFactory{TBaseType}"/>.
     /// Represents a factory of named items (such as targets, layouts, layout renderers, etc.).
     /// </summary>
     /// <typeparam name="TInstanceType">Base type for each item instance.</typeparam>

--- a/src/NLog/Config/LoggingConfigurationChangedEventArgs.cs
+++ b/src/NLog/Config/LoggingConfigurationChangedEventArgs.cs
@@ -60,6 +60,9 @@ namespace NLog.Config
         /// <summary>
         /// Gets the new configuration.
         /// </summary>
+        /// <remarks>
+        /// New value can be <c>null</c> when unloading configuration during shutdown.
+        /// </remarks>
         /// <value>The new configuration.</value>
         public LoggingConfiguration ActivatedConfiguration { get; }
     }

--- a/src/NLog/Config/LoggingConfigurationReloadedEventArgs.cs
+++ b/src/NLog/Config/LoggingConfigurationReloadedEventArgs.cs
@@ -38,7 +38,7 @@ namespace NLog.Config
     using System;
 
     /// <summary>
-    /// Arguments for <see cref="LogFactory.ConfigurationReloaded"/>.
+    /// Obsolete and replaced by <see cref="LoggingConfigurationChangedEventArgs"/> and <see cref="LogFactory.ConfigurationChanged"/> with NLog v5.2.
     /// </summary>
     [Obsolete("Replaced by ConfigurationChanged, but check args.ActivatedConfiguration != null. Marked obsolete on NLog 5.2")]
     public class LoggingConfigurationReloadedEventArgs : EventArgs

--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -193,7 +193,9 @@ namespace NLog.Config
         }
 
         /// <summary>
-        /// Default action if none of the filters match
+        /// Obsolete and replaced by <see cref="FilterDefaultAction"/> with NLog v5.
+        /// 
+        /// Default action when filters not matching
         /// </summary>
         /// <remarks>
         /// NLog v4.6 introduced the setting with default value <see cref="FilterResult.Neutral"/>. 

--- a/src/NLog/Config/SimpleConfigurator.cs
+++ b/src/NLog/Config/SimpleConfigurator.cs
@@ -38,6 +38,8 @@ namespace NLog.Config
     using NLog.Targets;
 
     /// <summary>
+    /// Obsolete and replaced by <see cref="LogManager.Setup()"/> with NLog v5.2.
+    /// 
     /// Provides simple programmatic configuration API used for trivial logging cases.
     /// 
     /// Warning, these methods will overwrite the current config.
@@ -47,6 +49,8 @@ namespace NLog.Config
     {
 #if !NETSTANDARD1_3
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> and <see cref="NLog.SetupLoadConfigurationExtensions.WriteToConsole"/> with NLog v5.2.
+        /// 
         /// Configures NLog for console logging so that all messages above and including
         /// the <see cref="NLog.LogLevel.Info"/> level are output to the console.
         /// </summary>
@@ -57,6 +61,8 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> and <see cref="NLog.SetupLoadConfigurationExtensions.WriteToConsole"/> with NLog v5.2.
+        /// 
         /// Configures NLog for console logging so that all messages above and including
         /// the specified level are output to the console.
         /// </summary>
@@ -73,6 +79,8 @@ namespace NLog.Config
 #endif
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> with NLog v5.2.
+        /// 
         /// Configures NLog for to log to the specified target so that all messages 
         /// above and including the <see cref="NLog.LogLevel.Info"/> level are output.
         /// </summary>
@@ -85,6 +93,8 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> with NLog v5.2.
+        /// 
         /// Configures NLog for to log to the specified target so that all messages 
         /// above and including the specified level are output.
         /// </summary>
@@ -100,6 +110,8 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> and <see cref="NLog.SetupLoadConfigurationExtensions.WriteToFile"/> with NLog v5.2.
+        /// 
         /// Configures NLog for file logging so that all messages above and including
         /// the <see cref="NLog.LogLevel.Info"/> level are written to the specified file.
         /// </summary>
@@ -111,6 +123,8 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> and <see cref="NLog.SetupLoadConfigurationExtensions.WriteToFile"/> with NLog v5.2.
+        /// 
         /// Configures NLog for file logging so that all messages above and including
         /// the specified level are written to the specified file.
         /// </summary>

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -87,6 +87,8 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="XmlLoggingConfiguration(string)"/> with NLog v4.7.
+        /// 
         /// Initializes a new instance of the <see cref="XmlLoggingConfiguration" /> class.
         /// </summary>
         /// <param name="fileName">Configuration file to be read.</param>
@@ -98,6 +100,8 @@ namespace NLog.Config
         { }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="XmlLoggingConfiguration(string, LogFactory)"/> with NLog v4.7.
+        /// 
         /// Initializes a new instance of the <see cref="XmlLoggingConfiguration" /> class.
         /// </summary>
         /// <param name="fileName">Configuration file to be read.</param>
@@ -143,6 +147,8 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="XmlLoggingConfiguration(XmlReader, string)"/> with NLog v4.7.
+        /// 
         /// Initializes a new instance of the <see cref="XmlLoggingConfiguration" /> class.
         /// </summary>
         /// <param name="reader"><see cref="XmlReader"/> containing the configuration section.</param>
@@ -155,6 +161,8 @@ namespace NLog.Config
         { }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="XmlLoggingConfiguration(XmlReader, string, LogFactory)"/> with NLog v4.7.
+        /// 
         /// Initializes a new instance of the <see cref="XmlLoggingConfiguration" /> class.
         /// </summary>
         /// <param name="reader"><see cref="XmlReader"/> containing the configuration section.</param>

--- a/src/NLog/Contexts/MappedDiagnosticsContext.cs
+++ b/src/NLog/Contexts/MappedDiagnosticsContext.cs
@@ -39,8 +39,10 @@ namespace NLog
     using NLog.Internal;
 
     /// <summary>
-    /// Mapped Diagnostics Context - a thread-local structure that keeps a dictionary
-    /// of strings and provides methods to output them in layouts. 
+    /// Obsolete and replaced by <see cref="ScopeContext"/> with NLog v5.
+    /// 
+    /// Mapped Diagnostics Context (MDC) is a dictionary of keys and values.
+    /// Stores the dictionary in the thread-local static variable, and provides methods to output dictionary values in layouts.
     /// </summary>
     [Obsolete("Replaced by ScopeContext.PushProperty or Logger.PushScopeProperty using ${scopeproperty}. Marked obsolete on NLog 5.0")]
     public static class MappedDiagnosticsContext

--- a/src/NLog/Contexts/MappedDiagnosticsLogicalContext.cs
+++ b/src/NLog/Contexts/MappedDiagnosticsLogicalContext.cs
@@ -38,9 +38,11 @@ namespace NLog
     using NLog.Internal;
 
     /// <summary>
-    /// Async version of Mapped Diagnostics Context - a logical context structure that keeps a dictionary
-    /// of strings and provides methods to output them in layouts.  Allows for maintaining state across
-    /// asynchronous tasks and call contexts.
+    /// Obsolete and replaced by <see cref="ScopeContext"/> with NLog v5.
+    /// 
+    /// Mapped Diagnostics Logical Context (MDLC) is a dictionary of keys and values.
+    /// Stores the dictionary in the logical thread callcontext, and provides methods to output dictionary values in layouts.
+    /// Allows for maintaining state across asynchronous tasks and call contexts.
     /// </summary>
     /// <remarks>
     /// Ideally, these changes should be incorporated as a new version of the MappedDiagnosticsContext class in the original

--- a/src/NLog/Contexts/NestedDiagnosticsContext.cs
+++ b/src/NLog/Contexts/NestedDiagnosticsContext.cs
@@ -38,8 +38,10 @@ namespace NLog
     using NLog.Internal;
 
     /// <summary>
-    /// Nested Diagnostics Context - a thread-local structure that keeps a stack
-    /// of strings and provides methods to output them in layouts
+    /// Obsolete and replaced by <see cref="ScopeContext"/> with NLog v5.
+    /// 
+    /// Nested Diagnostics Context (NDC) is a stack of nested values.
+    /// Stores the stack in the thread-local static variable, and provides methods to output the values in layouts.
     /// </summary>
     [Obsolete("Replaced by ScopeContext.PushNestedState or Logger.PushScopeNested using ${scopenested}. Marked obsolete on NLog 5.0")]
     public static class NestedDiagnosticsContext

--- a/src/NLog/Contexts/NestedDiagnosticsLogicalContext.cs
+++ b/src/NLog/Contexts/NestedDiagnosticsLogicalContext.cs
@@ -39,8 +39,10 @@ namespace NLog
     using NLog.Internal;
 
     /// <summary>
-    /// Async version of <see cref="NestedDiagnosticsContext" /> - a logical context structure that keeps a stack
-    /// Allows for maintaining scope across asynchronous tasks and call contexts.
+    /// Obsolete and replaced by <see cref="ScopeContext"/> with NLog v5.
+    /// 
+    /// Nested Diagnostics Logical Context (NDLC) is a stack of nested values.
+    /// Stores the stack in the logical thread callcontexte, and provides methods to output the values in layouts.
     /// </summary>
     [Obsolete("Replaced by ScopeContext.PushNestedState or Logger.PushScopeNested using ${scopenested}. Marked obsolete on NLog 5.0")]
     public static class NestedDiagnosticsLogicalContext

--- a/src/NLog/Fluent/Log.cs
+++ b/src/NLog/Fluent/Log.cs
@@ -49,6 +49,8 @@ namespace NLog.Fluent
         private static readonly ILogger _logger = LogManager.GetCurrentClassLogger();
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForLogEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event with the specified <see cref="LogLevel" />.
         /// </summary>
         /// <param name="logLevel">The log level.</param>
@@ -61,6 +63,8 @@ namespace NLog.Fluent
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForTraceEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event at the <c>Trace</c> level.
         /// </summary>
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is the file path at the time of compile.</param>
@@ -72,6 +76,8 @@ namespace NLog.Fluent
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForDebugEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event at the <c>Debug</c> level.
         /// </summary>
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is the file path at the time of compile.</param>
@@ -83,6 +89,8 @@ namespace NLog.Fluent
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForInfoEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event at the <c>Info</c> level.
         /// </summary>
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is the file path at the time of compile.</param>
@@ -94,6 +102,8 @@ namespace NLog.Fluent
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForWarnEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event at the <c>Warn</c> level.
         /// </summary>
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is the file path at the time of compile.</param>
@@ -105,6 +115,8 @@ namespace NLog.Fluent
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForErrorEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event at the <c>Error</c> level.
         /// </summary>
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is the file path at the time of compile.</param>
@@ -116,6 +128,8 @@ namespace NLog.Fluent
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForFatalEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event at the <c>Fatal</c> level.
         /// </summary>
         /// <param name="callerFilePath">The full path of the source file that contains the caller. This is the file path at the time of compile.</param>

--- a/src/NLog/Fluent/LogBuilder.cs
+++ b/src/NLog/Fluent/LogBuilder.cs
@@ -42,6 +42,8 @@ using NLog.Internal;
 namespace NLog.Fluent
 {
     /// <summary>
+    /// Obsolete and replaced by <see cref="LogEventBuilder"/> with NLog v5.
+    /// 
     /// A fluent class to build log events for NLog.
     /// </summary>
     [Obsolete("Obsoleted since it allocates unnecessary. Instead use ILogger.ForLogEvent and LogEventBuilder. Obsoleted in NLog 5.0")]

--- a/src/NLog/Fluent/LoggerExtensions.cs
+++ b/src/NLog/Fluent/LoggerExtensions.cs
@@ -40,6 +40,8 @@ namespace NLog.Fluent
     public static class LoggerExtensions
     {
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForLogEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event with the specified <see cref="LogLevel"/>.
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
@@ -54,6 +56,8 @@ namespace NLog.Fluent
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForTraceEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event at the <c>Trace</c> level.
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
@@ -65,8 +69,10 @@ namespace NLog.Fluent
             var builder = new LogBuilder(logger, LogLevel.Trace);
             return builder;
         }
-        
+
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForDebugEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event at the <c>Debug</c> level.
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
@@ -78,8 +84,10 @@ namespace NLog.Fluent
             var builder = new LogBuilder(logger, LogLevel.Debug);
             return builder;
         }
-        
+
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForInfoEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event at the <c>Info</c> level.
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
@@ -91,8 +99,10 @@ namespace NLog.Fluent
             var builder = new LogBuilder(logger, LogLevel.Info);
             return builder;
         }
-        
+
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForWarnEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event at the <c>Warn</c> level.
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
@@ -104,8 +114,10 @@ namespace NLog.Fluent
             var builder = new LogBuilder(logger, LogLevel.Warn);
             return builder;
         }
-        
+
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForErrorEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event at the <c>Error</c> level.
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
@@ -117,8 +129,10 @@ namespace NLog.Fluent
             var builder = new LogBuilder(logger, LogLevel.Error);
             return builder;
         }
-        
+
         /// <summary>
+        /// Obsolete and replaced by <see cref="ILoggerExtensions.ForFatalEvent"/> with NLog v5.
+        /// 
         /// Starts building a log event at the <c>Fatal</c> level.
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>

--- a/src/NLog/LayoutRenderers/ApplicationEnvironment/AppSettingLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ApplicationEnvironment/AppSettingLayoutRenderer.cs
@@ -65,6 +65,8 @@ namespace NLog.LayoutRenderers
         public string Item { get; set; }
 
         ///<summary>
+        /// Obsolete and replaced by <see cref="Item"/> with NLog v4.6.
+        /// 
         /// The AppSetting item-name
         ///</summary>
         [Obsolete("Allows easier conversion from NLog.Extended. Instead use Item-property. Marked obsolete in NLog 4.6")]

--- a/src/NLog/LayoutRenderers/Contexts/MdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/MdcLayoutRenderer.cs
@@ -39,7 +39,8 @@ namespace NLog.LayoutRenderers
     using NLog.Internal;
 
     /// <summary>
-    /// Render a Mapped Diagnostic Context item, See <see cref="MappedDiagnosticsContext"/>
+    /// Obsolete and replaced by <see cref="ScopeContextPropertyLayoutRenderer"/> with NLog v5.
+    /// Render Mapped Diagnostics Logical (MDC) from <see cref="MappedDiagnosticsContext"/>
     /// </summary>
     [LayoutRenderer("mdc")]
     [Obsolete("Replaced by ScopeContextPropertyLayoutRenderer ${scopeproperty}. Marked obsolete on NLog 5.0")]

--- a/src/NLog/LayoutRenderers/Contexts/MdlcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/MdlcLayoutRenderer.cs
@@ -39,8 +39,8 @@ namespace NLog.LayoutRenderers
     using NLog.Internal;
 
     /// <summary>
-    /// Render a Mapped Diagnostic Logical Context item (based on CallContext).
-    /// See <see cref="MappedDiagnosticsLogicalContext"/>
+    /// Obsolete and replaced by <see cref="ScopeContextPropertyLayoutRenderer"/> with NLog v5.
+    /// Render Mapped Diagnostics Logical Context (MDLC) from <see cref="MappedDiagnosticsLogicalContext"/>
     /// </summary>
     [LayoutRenderer("mdlc")]
     [Obsolete("Replaced by ScopeContextPropertyLayoutRenderer ${scopeproperty}. Marked obsolete on NLog 5.0")]

--- a/src/NLog/LayoutRenderers/Contexts/NdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/NdcLayoutRenderer.cs
@@ -37,8 +37,8 @@ namespace NLog.LayoutRenderers
     using System.Text;
 
     /// <summary>
-    /// Render a Nested Diagnostic Context item.
-    /// See <see cref="NestedDiagnosticsContext"/>
+    /// Obsolete and replaced by <see cref="ScopeContextNestedStatesLayoutRenderer"/> with NLog v5.
+    /// Render Nested Diagnostic Context (NDC) from <see cref="NestedDiagnosticsContext"/>
     /// </summary>
     [LayoutRenderer("ndc")]
     [Obsolete("Replaced by ScopeContextNestedStatesLayoutRenderer ${scopenested}. Marked obsolete on NLog 5.0")]

--- a/src/NLog/LayoutRenderers/Contexts/NdlcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/NdlcLayoutRenderer.cs
@@ -37,8 +37,8 @@ namespace NLog.LayoutRenderers
     using System.Text;
 
     /// <summary>
-    /// Render a Nested Diagnostic Logical Context item (Async scope)
-    /// See <see cref="NestedDiagnosticsLogicalContext"/>
+    /// Obsolete and replaced by <see cref="ScopeContextNestedStatesLayoutRenderer"/> with NLog v5.
+    /// Render Nested Diagnostic Context (NDLC) from <see cref="NestedDiagnosticsLogicalContext"/>
     /// </summary>
     [LayoutRenderer("ndlc")]
     [Obsolete("Replaced by ScopeContextNestedStatesLayoutRenderer ${scopenested}. Marked obsolete on NLog 5.0")]

--- a/src/NLog/LayoutRenderers/Contexts/NdlcTimingLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Contexts/NdlcTimingLayoutRenderer.cs
@@ -37,7 +37,8 @@ namespace NLog.LayoutRenderers
     using System.Text;
 
     /// <summary>
-    /// <see cref="NestedDiagnosticsLogicalContext"/> Timing Renderer (Async scope)
+    /// Obsolete and replaced by <see cref="ScopeContextTimingLayoutRenderer"/> with NLog v5.
+    /// Render Nested Diagnostic Context (NDLC) timings from <see cref="NestedDiagnosticsLogicalContext"/>
     /// </summary>
     [LayoutRenderer("ndlctiming")]
     [Obsolete("Replaced by ScopeContextTimingLayoutRenderer ${scopetiming}. Marked obsolete on NLog 5.0")]

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -234,6 +234,8 @@ namespace NLog.LayoutRenderers
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> with NLog v5.2.
+        /// 
         /// Register a custom layout renderer.
         /// </summary>
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
@@ -249,6 +251,8 @@ namespace NLog.LayoutRenderers
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> with NLog v5.2
+        /// 
         /// Register a custom layout renderer.
         /// </summary>
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
@@ -264,6 +268,8 @@ namespace NLog.LayoutRenderers
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> with NLog v5.2
+        /// 
         /// Register a custom layout renderer with a callback function <paramref name="func"/>. The callback receives the logEvent.
         /// </summary>
         /// <param name="name">The layout-renderer type-alias for use in NLog configuration - without '${ }'</param>
@@ -277,6 +283,8 @@ namespace NLog.LayoutRenderers
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> with NLog v5.2
+        /// 
         /// Register a custom layout renderer with a callback function <paramref name="func"/>. The callback receives the logEvent and the current configuration.
         /// </summary>
         /// <param name="name">The layout-renderer type-alias for use in NLog configuration - without '${ }'</param>
@@ -291,6 +299,8 @@ namespace NLog.LayoutRenderers
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> with NLog v5.2
+        /// 
         /// Register a custom layout renderer with a callback function <paramref name="layoutRenderer"/>. The callback receives the logEvent and the current configuration.
         /// </summary>
         /// <param name="layoutRenderer">Renderer with callback func</param>

--- a/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/Log4JXmlEventLayoutRenderer.cs
@@ -156,6 +156,8 @@ namespace NLog.LayoutRenderers
         public bool IncludeSourceInfo { get; set; }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeProperties"/> with NLog v5.
+        /// 
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsContext"/> dictionary.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -165,6 +167,8 @@ namespace NLog.LayoutRenderers
         private bool? _includeMdc;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeProperties"/> with NLog v5.
+        /// 
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -174,6 +178,8 @@ namespace NLog.LayoutRenderers
         private bool? _includeMdlc;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeNdc"/> with NLog v5.
+        /// 
         /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsLogicalContext"/> stack.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -214,6 +220,8 @@ namespace NLog.LayoutRenderers
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NdcItemSeparator"/> with NLog v5.
+        /// 
         /// Gets or sets the stack separator for log4j:NDC in output from <see cref="ScopeContext"/> nested context.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -222,6 +230,8 @@ namespace NLog.LayoutRenderers
         public string NdlcItemSeparator { get => ScopeNestedSeparator; set => ScopeNestedSeparator = value; }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeEventProperties"/> with NLog v5.
+        /// 
         /// Gets or sets the option to include all properties from the log events
         /// </summary>
         /// <docgen category='Layout Options' order='10' />

--- a/src/NLog/Layouts/JSON/JsonLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonLayout.cs
@@ -148,6 +148,8 @@ namespace NLog.Layouts
         private bool? _includeScopeProperties;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeEventProperties"/> with NLog v5.
+        /// 
         /// Gets or sets the option to include all properties from the log event (as JSON)
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -156,6 +158,8 @@ namespace NLog.Layouts
         public bool IncludeAllProperties { get => IncludeEventProperties; set => IncludeEventProperties = value; }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeProperties"/> with NLog v5.
+        /// 
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsContext"/> dictionary.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -165,6 +169,8 @@ namespace NLog.Layouts
         private bool? _includeMdc;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeProperties"/> with NLog v5.
+        /// 
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -452,6 +452,8 @@ namespace NLog.Layouts
         protected abstract string GetFormattedMessage(LogEventInfo logEvent);
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> with NLog v5.2.
+        /// 
         /// Register a custom Layout.
         /// </summary>
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
@@ -467,6 +469,8 @@ namespace NLog.Layouts
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> with NLog v5.2.
+        /// 
         /// Register a custom Layout.
         /// </summary>
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>

--- a/src/NLog/Layouts/Log4JXmlEventLayout.cs
+++ b/src/NLog/Layouts/Log4JXmlEventLayout.cs
@@ -109,6 +109,8 @@ namespace NLog.Layouts
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeEventProperties"/> with NLog v5.
+        /// 
         /// Gets or sets the option to include all properties from the log events
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -117,6 +119,8 @@ namespace NLog.Layouts
         public bool IncludeAllProperties { get => IncludeEventProperties; set => IncludeEventProperties = value; }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeProperties"/> with NLog v5.
+        /// 
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsContext"/> dictionary.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -131,6 +135,8 @@ namespace NLog.Layouts
         public bool IncludeNdc { get => Renderer.IncludeNdc; set => Renderer.IncludeNdc = value; }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeProperties"/> with NLog v5.
+        /// 
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -139,6 +145,8 @@ namespace NLog.Layouts
         public bool IncludeMdlc { get => Renderer.IncludeMdlc; set => Renderer.IncludeMdlc = value; }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeNdc"/> with NLog v5.
+        /// 
         /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsLogicalContext"/> stack.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />

--- a/src/NLog/Layouts/XML/XmlElementBase.cs
+++ b/src/NLog/Layouts/XML/XmlElementBase.cs
@@ -116,6 +116,8 @@ namespace NLog.Layouts
         private bool? _includeScopeProperties;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeProperties"/> with NLog v5.
+        /// 
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsContext"/> dictionary.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -125,6 +127,8 @@ namespace NLog.Layouts
         private bool? _includeMdc;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeProperties"/> with NLog v5.
+        /// 
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -134,6 +138,8 @@ namespace NLog.Layouts
         private bool? _includeMdlc;
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeEventProperties"/> with NLog v5.
+        /// 
         /// Gets or sets the option to include all properties from the log event (as XML)
         /// </summary>
         /// <docgen category='Layout Options' order='10' />

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -87,12 +87,16 @@ namespace NLog
         private readonly ILoggingConfigurationLoader _configLoader;
 
         /// <summary>
-        /// Occurs when logging <see cref="Configuration" /> changes.
+        /// Occurs when logging <see cref="Configuration" /> changes. Both when assigned to new config or config unloaded.
         /// </summary>
+        /// <remarks>
+        /// Note <see cref="LoggingConfigurationChangedEventArgs.ActivatedConfiguration"/> can be <c>null</c> when unloading configuration at shutdown.
+        /// </remarks>
         public event EventHandler<LoggingConfigurationChangedEventArgs> ConfigurationChanged;
 
 #if !NETSTANDARD1_3
         /// <summary>
+        /// Obsolete and replaced by <see cref="ConfigurationChanged"/> with NLog v5.2.
         /// Occurs when logging <see cref="Configuration" /> gets reloaded.
         /// </summary>
         [Obsolete("Replaced by ConfigurationChanged, but check args.ActivatedConfiguration != null. Marked obsolete on NLog 5.2")]
@@ -542,6 +546,7 @@ namespace NLog
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="GetLogger{T}(string)"/> with NLog v5.2.
         /// Gets the specified named logger.
         /// Use <paramref name="loggerType"/> to create instance of a custom <see cref="Logger"/>.
         /// If you haven't defined your own <see cref="Logger"/> class, then use the overload without the loggerType.

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -68,8 +68,11 @@ namespace NLog
         public static LogFactory LogFactory => factory;
 
         /// <summary>
-        /// Occurs when logging <see cref="Configuration" /> changes.
+        /// Occurs when logging <see cref="Configuration" /> changes. Both when assigned to new config or config unloaded.
         /// </summary>
+        /// <remarks>
+        /// Note <see cref="LoggingConfigurationChangedEventArgs.ActivatedConfiguration"/> can be <c>null</c> when unloading configuration at shutdown.
+        /// </remarks>
         public static event EventHandler<LoggingConfigurationChangedEventArgs> ConfigurationChanged
         {
             add => factory.ConfigurationChanged += value;
@@ -78,6 +81,7 @@ namespace NLog
 
 #if !NETSTANDARD1_3
         /// <summary>
+        /// Obsolete and replaced by <see cref="ConfigurationChanged"/> with NLog v5.2.
         /// Occurs when logging <see cref="Configuration" /> gets reloaded.
         /// </summary>
         [Obsolete("Replaced by ConfigurationChanged, but check args.ActivatedConfiguration != null. Marked obsolete on NLog 5.2")]
@@ -161,7 +165,8 @@ namespace NLog
         }
 
         /// <summary>
-        /// Loads logging configuration from file (Currently only XML configuration files supported)
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> and <see cref="SetupBuilderExtensions.LoadConfigurationFromFile(ISetupBuilder, string, bool)"/> with NLog v5.2.
+        /// Loads logging configuration from file (Only XML configuration files supported)
         /// </summary>
         /// <param name="configFile">Configuration file to be read</param>
         /// <returns>LogFactory instance for fluent interface</returns>
@@ -223,6 +228,7 @@ namespace NLog
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogFactory.GetCurrentClassLogger{T}()"/> with NLog v5.2.
         /// Gets a custom logger with the full name of the current class, so namespace and class name.
         /// Use <paramref name="loggerType"/> to create instance of a custom <see cref="Logger"/>.
         /// If you haven't defined your own <see cref="Logger"/> class, then use the overload without the loggerType.
@@ -260,8 +266,8 @@ namespace NLog
         }
 
         /// <summary>
-        /// Gets the specified named custom logger.
-        /// Use <paramref name="loggerType"/> to create instance of a custom <see cref="Logger"/>.
+        /// Obsolete and replaced by <see cref="LogFactory.GetLogger{T}(string)"/> with NLog v5.2.
+        /// Gets the specified named custom <see cref="Logger"/> using the parameter <paramref name="loggerType"/> for creating instance.
         /// If you haven't defined your own <see cref="Logger"/> class, then use the overload without the loggerType.
         /// </summary>
         /// <param name="name">Name of the logger.</param>
@@ -352,6 +358,7 @@ namespace NLog
         }
 
         /// <summary>
+        /// Obsolete and replaced by by <see cref="SuspendLogging"/> with NLog v5.
         /// Suspends the logging, and returns object for using-scope so scope-exit calls <see cref="EnableLogging"/>
         /// </summary>
         /// <remarks>
@@ -368,6 +375,7 @@ namespace NLog
         }
 
         /// <summary>
+        /// Obsolete and replaced by disposing the scope returned from <see cref="SuspendLogging"/> with NLog v5.
         /// Resumes logging if having called <see cref="DisableLogging"/>.
         /// </summary>
         /// <remarks>

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -139,6 +139,8 @@ namespace NLog
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="WithProperty"/> that prevents unexpected side-effects in Logger-state.
+        /// 
         /// Updates the specified context property for the current logger. The logger will append it for all log events.
         ///
         /// With <see cref="Properties"/> property, all properties can be enumerated (or updated). 

--- a/src/NLog/NLogConfigurationException.cs
+++ b/src/NLog/NLogConfigurationException.cs
@@ -62,6 +62,7 @@ namespace NLog
         }
 
         /// <summary>
+        /// Obsolete and replaced by using normal string-interpolation with <see cref="NLogConfigurationException(string)"/> in NLog v5.
         /// Initializes a new instance of the <see cref="NLogConfigurationException" /> class.
         /// </summary>
         /// <param name="message">The message.</param>
@@ -75,6 +76,7 @@ namespace NLog
         }
 
         /// <summary>
+        /// Obsolete and replaced by using normal string-interpolation with <see cref="NLogConfigurationException(string)"/> in NLog v5.
         /// Initializes a new instance of the <see cref="NLogConfigurationException" /> class.
         /// </summary>
         /// <param name="innerException">The inner exception.</param>

--- a/src/NLog/NLogRuntimeException.cs
+++ b/src/NLog/NLogRuntimeException.cs
@@ -63,6 +63,7 @@ namespace NLog
         }
 
         /// <summary>
+        /// Obsolete and replaced by using normal string-interpolation with <see cref="NLogRuntimeException(string)"/> in NLog v5.
         /// Initializes a new instance of the <see cref="NLogRuntimeException" /> class.
         /// </summary>
         /// <param name="message">The message.</param>

--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -109,6 +109,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="StdErr"/> with NLog v5.
         /// Gets or sets a value indicating whether the error stream (stderr) should be used instead of the output stream (stdout).
         /// </summary>
         /// <docgen category='Console Options' order='10' />

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -85,6 +85,7 @@ namespace NLog.Targets
         private readonly ReusableBufferCreator _reusableEncodingBuffer = new ReusableBufferCreator(16 * 1024);
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="StdErr"/> with NLog v5.
         /// Gets or sets a value indicating whether to send the log messages to the standard error instead of the standard output.
         /// </summary>
         /// <docgen category='Console Options' order='10' />

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1133,6 +1133,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="RenderFormattedMessage"/> with NLog v5.
         /// Formats the log event for write.
         /// </summary>
         /// <param name="logEvent">The log event to be formatted.</param>
@@ -1145,6 +1146,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="RenderFormattedMessage"/> with NLog v5.
         /// Gets the bytes to be written to the file.
         /// </summary>
         /// <param name="logEvent">Log event.</param>
@@ -1163,6 +1165,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="TransformStream"/> with NLog v5.
         /// Modifies the specified byte array before it gets sent to a file.
         /// </summary>
         /// <param name="value">The byte array.</param>

--- a/src/NLog/Targets/MethodCallParameter.cs
+++ b/src/NLog/Targets/MethodCallParameter.cs
@@ -103,6 +103,7 @@ namespace NLog.Targets
         public Layout Layout { get => _layoutInfo.Layout; set => _layoutInfo.Layout = value; }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="ParameterType"/> with NLog v4.6.
         /// Gets or sets the type of the parameter. Obsolete alias for <see cref="ParameterType"/>
         /// </summary>
         /// <docgen category='Parameter Options' order='50' />

--- a/src/NLog/Targets/NLogViewerTarget.cs
+++ b/src/NLog/Targets/NLogViewerTarget.cs
@@ -128,6 +128,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeProperties"/> with NLog v5.
         /// Gets or sets a value indicating whether to include <see cref="MappedDiagnosticsContext"/> dictionary contents.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -174,6 +175,7 @@ namespace NLog.Targets
         public string ScopeNestedSeparator { get => Renderer.ScopeNestedSeparator; set => Renderer.ScopeNestedSeparator = value; }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeEventProperties"/> with NLog v5.
         /// Gets or sets the option to include all properties from the log events
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -182,6 +184,7 @@ namespace NLog.Targets
         public bool IncludeAllProperties { get => IncludeEventProperties; set => IncludeEventProperties = value; }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeProperties"/> with NLog v5.
         /// Gets or sets a value indicating whether to include <see cref="MappedDiagnosticsLogicalContext"/> dictionary contents.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -190,6 +193,7 @@ namespace NLog.Targets
         public bool IncludeMdlc { get => Renderer.IncludeMdlc; set => Renderer.IncludeMdlc = value; }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeNdc"/> with NLog v5.
         /// Gets or sets a value indicating whether to include contents of the <see cref="NestedDiagnosticsLogicalContext"/> stack.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
@@ -198,6 +202,7 @@ namespace NLog.Targets
         public bool IncludeNdlc { get => Renderer.IncludeNdlc; set => Renderer.IncludeNdlc = value; }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="NdcItemSeparator"/> with NLog v5.
         /// Gets or sets the stack separator for log4j:NDC in output from <see cref="ScopeContext"/> nested context.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />

--- a/src/NLog/Targets/NetworkTargetConnectionsOverflowAction.cs
+++ b/src/NLog/Targets/NetworkTargetConnectionsOverflowAction.cs
@@ -47,6 +47,7 @@ namespace NLog.Targets
         Grow = 0,
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="Grow"/> with NLog v5.
         /// Just allow it.
         /// </summary>
         [Obsolete("Replaced by Grow. Marked obsolete on NLog 5.0")]
@@ -59,6 +60,7 @@ namespace NLog.Targets
         Discard = 1,
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="Discard"/> with NLog v5.
         /// Discard the connection item.
         /// </summary>
         [Obsolete("Replaced by Discard. Marked obsolete on NLog 5.0")]

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -771,6 +771,8 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> with NLog v5.2.
+        /// 
         /// Register a custom Target.
         /// </summary>
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>
@@ -786,6 +788,8 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="LogManager.Setup()"/> with NLog v5.2.
+        /// 
         /// Register a custom Target.
         /// </summary>
         /// <remarks>Short-cut for registering to default <see cref="ConfigurationItemFactory"/></remarks>

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -108,25 +108,37 @@ namespace NLog.Targets
         /// <docgen category='Layout Options' order='10' />
         public bool IncludeScopeNested { get => _contextLayout.IncludeScopeNested; set => _contextLayout.IncludeScopeNested = value; }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeProperties"/> with NLog v5.
+        /// Gets or sets whether to include the contents of the <see cref="MappedDiagnosticsContext"/>-dictionary.
+        /// </summary>
         /// <docgen category='Layout Options' order='10' />
         [Obsolete("Replaced by IncludeScopeProperties. Marked obsolete on NLog 5.0")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IncludeMdc { get => _contextLayout.IncludeMdc; set => _contextLayout.IncludeMdc = value; }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeNested"/> with NLog v5.
+        /// Gets or sets whether to include the contents of the <see cref="NestedDiagnosticsContext"/>-stack.
+        /// </summary>
         /// <docgen category='Layout Options' order='10' />
         [Obsolete("Replaced by IncludeScopeNested. Marked obsolete on NLog 5.0")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IncludeNdc { get => _contextLayout.IncludeNdc; set => _contextLayout.IncludeNdc = value; }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeProperties"/> with NLog v5.
+        /// Gets or sets whether to include the contents of the <see cref="MappedDiagnosticsLogicalContext"/>-properties.
+        /// </summary>
         /// <docgen category='Layout Options' order='10' />
         [Obsolete("Replaced by IncludeScopeProperties. Marked obsolete on NLog 5.0")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IncludeMdlc { get => _contextLayout.IncludeMdlc; set => _contextLayout.IncludeMdlc = value; }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Obsolete and replaced by <see cref="IncludeScopeNested"/> with NLog v5.
+        /// Gets or sets whether to include the contents of the <see cref="NestedDiagnosticsLogicalContext"/>-stack.
+        /// </summary>
         /// <docgen category='Layout Options' order='10' />
         [Obsolete("Replaced by IncludeScopeNested. Marked obsolete on NLog 5.0")]
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -320,6 +332,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="GetScopeContextProperties"/> with NLog v5.
         /// Returns the captured snapshot of <see cref="MappedDiagnosticsContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
@@ -350,6 +363,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="GetScopeContextProperties"/> with NLog v5.
         /// Returns the captured snapshot of <see cref="MappedDiagnosticsLogicalContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
@@ -366,6 +380,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="GetScopeContextNested"/> with NLog v5.
         /// Returns the captured snapshot of <see cref="NestedDiagnosticsContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
@@ -396,6 +411,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="GetScopeContextNested"/> with NLog v5.
         /// Returns the captured snapshot of <see cref="NestedDiagnosticsLogicalContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
@@ -484,6 +500,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="CaptureScopeContextProperties"/> with NLog v5.
         /// Takes snapshot of <see cref="MappedDiagnosticsContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
@@ -511,6 +528,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="SerializeScopeContextProperty"/> with NLog v5.
         /// Take snapshot of a single object value from <see cref="MappedDiagnosticsContext"/>
         /// </summary>
         /// <param name="logEvent">Log event</param>
@@ -532,6 +550,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="CaptureScopeContextProperties"/> with NLog v5.
         /// Takes snapshot of <see cref="MappedDiagnosticsLogicalContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
@@ -580,6 +599,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="SerializeScopeContextProperty"/> with NLog v5.
         /// Take snapshot of a single object value from <see cref="MappedDiagnosticsLogicalContext"/>
         /// </summary>
         /// <param name="logEvent">Log event</param>
@@ -614,6 +634,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="CaptureScopeContextNested"/> with NLog v5.
         /// Takes snapshot of <see cref="NestedDiagnosticsContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
@@ -651,6 +672,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="SerializeScopeContextNestedState"/> with NLog v5.
         /// Take snapshot of a single object value from <see cref="NestedDiagnosticsContext"/>
         /// </summary>
         /// <param name="logEvent">Log event</param>
@@ -665,6 +687,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="CaptureScopeContextNested"/> with NLog v5.
         /// Takes snapshot of <see cref="NestedDiagnosticsLogicalContext"/> for the <see cref="LogEventInfo"/>
         /// </summary>
         /// <param name="logEvent"></param>
@@ -712,6 +735,7 @@ namespace NLog.Targets
         }
 
         /// <summary>
+        /// Obsolete and replaced by <see cref="SerializeScopeContextNestedState"/> with NLog v5.
         /// Take snapshot of a single object value from <see cref="NestedDiagnosticsLogicalContext"/>
         /// </summary>
         /// <param name="logEvent">Log event</param>


### PR DESCRIPTION
XML-docs can redirect using intellisense navigation, instead of just raw text in the obsolete-attribute.

Also SandCastle doesn't pickup the obsolete-message, but just says **Obsolete** in docs.