### PR TITLE
Added IncludeSourceRevisionInInformationalVersion to fix InformationalVersion 

### DIFF
--- a/tests/NLogAutoLoadExtension/NLogAutoLoadExtension.csproj
+++ b/tests/NLogAutoLoadExtension/NLogAutoLoadExtension.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
 
     <InformationalVersion>2.0.0.2</InformationalVersion>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>


### PR DESCRIPTION
Avoid git-commit-hash as InformationalVersion suffix for test-library-project.