### PR TITLE
FileTarget - Fix Windows FileSystem Tunneling when KeepFileOpen=false

### DIFF
--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -1751,14 +1751,20 @@ namespace NLog.UnitTests.Targets
                 LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
                 logger.Debug("123456789");
-                LogManager.Flush();
+                LogManager.Configuration = null;
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
 
+                timeSource.AddToLocalTime(TimeSpan.FromDays(1));
+                if (!dateInLogFilePath)
+                    File.SetCreationTimeUtc(logFile, timeSource.Time.ToUniversalTime());
                 timeSource.AddToLocalTime(TimeSpan.FromDays(1));
 
                 // This should archive the log before logging.
                 logger.Debug("123456789");
 
-                timeSource.AddToSystemTime(TimeSpan.FromDays(1));   // Archive only once
+                LogManager.Configuration = null;
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(fileTarget));
+                timeSource.AddToSystemTime(TimeSpan.FromDays(2));   // Archive only once
 
                 // This must not archive.
                 logger.Debug("123456789");


### PR DESCRIPTION
Resolving #5426

Bug introduced with #5381 + #5382 + #5384

NLog v5.2.6 tried to make FileTarget more stable by not momentarily releasing-file-handle when starting new log-file. By updating file-timestamp on the newly opened file. But when using FileTarget KeepFileOpen=false, then file-handle is opened with exclusive write-access, and caused `File.SetCreationTimeUtc` to fail and not set correct file-creation-timestamp.