### PR TITLE
Marked ILoggerBase and ISuppress as obsolete and instead use ILogger

### DIFF
--- a/src/NLog/Abstractions/ILogger.cs
+++ b/src/NLog/Abstractions/ILogger.cs
@@ -40,7 +40,11 @@ namespace NLog
     /// <summary>
     /// Provides logging interface and utility functions.
     /// </summary>
-    public partial interface ILogger : ILoggerBase, ISuppress
+    public partial interface ILogger
+#pragma warning disable CS0618 // Type or member is obsolete
+        : ISuppress
+        , ILoggerBase
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         /// <summary>
         /// Gets a value indicating whether logging is enabled for the <c>Trace</c> level.
@@ -289,16 +293,6 @@ namespace NLog
         void Debug(LogMessageGenerator messageFunc);
 
         /// <summary>
-        /// Obsolete and replaced by <see cref="Debug(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Debug</c> level.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use Debug(Exception exception, string message) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        void DebugException([Localizable(false)] string message, Exception exception);
-
-        /// <summary>
         /// Writes the diagnostic message and exception at the <c>Debug</c> level.
         /// </summary>
         /// <param name="message">A <see langword="string" /> to be written.</param>
@@ -346,16 +340,6 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [MessageTemplateFormatMethod("message")]
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
-
-        /// <summary>
-        /// Obsolete and replaced by <see cref="Debug(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Debug</c> level.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use Debug(Exception exception, string message) method instead. Marked obsolete with v4.3.11")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        void Debug([Localizable(false)] string message, Exception exception);
 
         /// <summary>
         /// Writes the diagnostic message at the <c>Debug</c> level using the specified parameter and formatting it with the supplied format provider.
@@ -426,6 +410,26 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         void Debug<TArgument1, TArgument2, TArgument3>([Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
+        /// <summary>
+        /// Obsolete and replaced by <see cref="Debug(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Debug(Exception exception, string message) method instead. Marked obsolete with v4.3.11")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void Debug([Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Obsolete and replaced by <see cref="Debug(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Debug(Exception exception, string message) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void DebugException([Localizable(false)] string message, Exception exception);
+
         #endregion
 
         #region Info() overloads 
@@ -453,16 +457,6 @@ namespace NLog
         /// </summary>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
         void Info(LogMessageGenerator messageFunc);
-
-        /// <summary>
-        /// Obsolete and replaced by <see cref="Info(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Info</c> level.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use Info(Exception exception, string message) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        void InfoException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Info</c> level.
@@ -512,16 +506,6 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [MessageTemplateFormatMethod("message")]
         void Info([Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
-
-        /// <summary>
-        /// Obsolete and replaced by <see cref="Info(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Info</c> level.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use Info(Exception exception, string message) method instead. Marked obsolete with v4.3.11")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        void Info([Localizable(false)] string message, Exception exception);
 
         /// <summary>
         /// Writes the diagnostic message at the <c>Info</c> level using the specified parameter and formatting it with the supplied format provider.
@@ -592,6 +576,26 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         void Info<TArgument1, TArgument2, TArgument3>([Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
+        /// <summary>
+        /// Obsolete and replaced by <see cref="Info(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Info(Exception exception, string message) method instead. Marked obsolete with v4.3.11")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void Info([Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Obsolete and replaced by <see cref="Info(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Info(Exception exception, string message) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void InfoException([Localizable(false)] string message, Exception exception);
+
         #endregion
 
         #region Warn() overloads 
@@ -619,16 +623,6 @@ namespace NLog
         /// </summary>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
         void Warn(LogMessageGenerator messageFunc);
-
-        /// <summary>
-        /// Obsolete and replaced by <see cref="Warn(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Warn</c> level.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use Warn(Exception exception, string message) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        void WarnException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Warn</c> level.
@@ -678,16 +672,6 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [MessageTemplateFormatMethod("message")]
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
-
-        /// <summary>
-        /// Obsolete and replaced by <see cref="Warn(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Warn</c> level.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use Warn(Exception exception, string message) method instead. Marked obsolete with v4.3.11")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        void Warn([Localizable(false)] string message, Exception exception);
 
         /// <summary>
         /// Writes the diagnostic message at the <c>Warn</c> level using the specified parameter and formatting it with the supplied format provider.
@@ -758,6 +742,26 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         void Warn<TArgument1, TArgument2, TArgument3>([Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
+        /// <summary>
+        /// Obsolete and replaced by <see cref="Warn(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Warn(Exception exception, string message) method instead. Marked obsolete with v4.3.11")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void Warn([Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Obsolete and replaced by <see cref="Warn(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Warn(Exception exception, string message) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void WarnException([Localizable(false)] string message, Exception exception);
+
         #endregion
 
         #region Error() overloads 
@@ -785,16 +789,6 @@ namespace NLog
         /// </summary>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
         void Error(LogMessageGenerator messageFunc);
-
-        /// <summary>
-        /// Obsolete and replaced by <see cref="Error(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Error</c> level.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use Error(Exception exception, string message) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        void ErrorException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Error</c> level.
@@ -845,16 +839,6 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [MessageTemplateFormatMethod("message")]
         void Error([Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
-
-        /// <summary>
-        /// Obsolete and replaced by <see cref="Error(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Error</c> level.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use Error(Exception exception, string message) method instead. Marked obsolete with v4.3.11")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        void Error([Localizable(false)] string message, Exception exception);
 
         /// <summary>
         /// Writes the diagnostic message at the <c>Error</c> level using the specified parameter and formatting it with the supplied format provider.
@@ -925,6 +909,26 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         void Error<TArgument1, TArgument2, TArgument3>([Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
+        /// <summary>
+        /// Obsolete and replaced by <see cref="Error(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Error(Exception exception, string message) method instead. Marked obsolete with v4.3.11")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void Error([Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Obsolete and replaced by <see cref="Error(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Error(Exception exception, string message) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void ErrorException([Localizable(false)] string message, Exception exception);
+
         #endregion
 
         #region Fatal() overloads 
@@ -952,16 +956,6 @@ namespace NLog
         /// </summary>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
         void Fatal(LogMessageGenerator messageFunc);
-
-        /// <summary>
-        /// Obsolete and replaced by <see cref="Fatal(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Fatal</c> level.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use Fatal(Exception exception, string message) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        void FatalException([Localizable(false)] string message, Exception exception);
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
@@ -1011,16 +1005,6 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [MessageTemplateFormatMethod("message")]
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
-
-        /// <summary>
-        /// Obsolete and replaced by <see cref="Fatal(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Fatal</c> level.
-        /// </summary>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use Fatal(Exception exception, string message) method instead. Marked obsolete with v4.3.11")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        void Fatal([Localizable(false)] string message, Exception exception);
 
         /// <summary>
         /// Writes the diagnostic message at the <c>Fatal</c> level using the specified parameter and formatting it with the supplied format provider.
@@ -1090,6 +1074,26 @@ namespace NLog
         /// <param name="argument3">The third argument to format.</param>
         [MessageTemplateFormatMethod("message")]
         void Fatal<TArgument1, TArgument2, TArgument3>([Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+
+        /// <summary>
+        /// Obsolete and replaced by <see cref="Fatal(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Fatal(Exception exception, string message) method instead. Marked obsolete with v4.3.11")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void Fatal([Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Obsolete and replaced by <see cref="Fatal(Exception, string)"/> - Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Fatal(Exception exception, string message) method instead. Marked obsolete with v4.3.11 (Only here because of LibLog)")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void FatalException([Localizable(false)] string message, Exception exception);
 
         #endregion
 

--- a/src/NLog/Abstractions/ILoggerBase.cs
+++ b/src/NLog/Abstractions/ILoggerBase.cs
@@ -40,11 +40,15 @@ namespace NLog
     /// <summary>
     /// Logger with only generic methods (passing 'LogLevel' to methods) and core properties.
     /// </summary>
+    [Obsolete("ILoggerBase should be replaced with ILogger. Marked obsolete with NLog v5.3")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public partial interface ILoggerBase
     {
         /// <summary>
         /// Occurs when logger configuration changes.
         /// </summary>
+        [Obsolete("LoggerReconfigured-EventHandler is very exotic for ILogger-interface. Instead use Logger.LoggerReconfigured. Marked obsolete with NLog v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         event EventHandler<EventArgs> LoggerReconfigured;
 
         /// <summary>
@@ -58,6 +62,8 @@ namespace NLog
         /// <summary>
         /// Gets the factory that created this logger.
         /// </summary>
+        [Obsolete("Factory-property is hard to mock for ILogger-interface. Instead use Logger.Factory. Marked obsolete with NLog v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         LogFactory Factory
         {
             get;
@@ -113,17 +119,6 @@ namespace NLog
         void Log(LogLevel level, LogMessageGenerator messageFunc);
 
         /// <summary>
-        /// Obsolete and replaced by <see cref="Log(LogLevel, Exception, string, object[])"/> - Writes the diagnostic message and exception at the specified level.
-        /// </summary>
-        /// <param name="level">The log level.</param>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args) instead. Marked obsolete with v4.3.11")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        void LogException(LogLevel level, [Localizable(false)] string message, Exception exception);
-
-        /// <summary>
         /// Writes the diagnostic message and exception at the specified level.
         /// </summary>
         /// <param name="level">The log level.</param>
@@ -169,17 +164,6 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [MessageTemplateFormatMethod("message")]
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, params object[] args);
-
-        /// <summary>
-        /// Obsolete and replaced by <see cref="Log(LogLevel, Exception, string, object[])"/> - Writes the diagnostic message and exception at the specified level.
-        /// </summary>
-        /// <param name="level">The log level.</param>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
-        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args) instead. Marked obsolete with v4.3.11")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        void Log(LogLevel level, [Localizable(false)] string message, Exception exception);
 
         /// <summary>
         /// Writes the diagnostic message at the specified level using the specified parameter and formatting it with the supplied format provider.
@@ -256,6 +240,27 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
+        /// <summary>
+        /// Obsolete and replaced by <see cref="Log(LogLevel, Exception, string, object[])"/> - Writes the diagnostic message and exception at the specified level.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args) instead. Marked obsolete with v4.3.11")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void Log(LogLevel level, [Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Obsolete and replaced by <see cref="Log(LogLevel, Exception, string, object[])"/> - Writes the diagnostic message and exception at the specified level.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Log(LogLevel level, Exception exception, [Localizable(false)] string message, params object[] args) instead. Marked obsolete with v4.3.11")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void LogException(LogLevel level, [Localizable(false)] string message, Exception exception);
         #endregion
     }
 }

--- a/src/NLog/Abstractions/ISuppress.cs
+++ b/src/NLog/Abstractions/ISuppress.cs
@@ -34,6 +34,7 @@
 namespace NLog
 {
     using System;
+    using System.ComponentModel;
 #if !NET35 && !NET40
     using System.Threading.Tasks;
 #endif
@@ -41,6 +42,8 @@ namespace NLog
     /// <summary>
     /// Provides an interface to execute System.Actions without surfacing any exceptions raised for that action.
     /// </summary>
+    [Obsolete("ISuppress should be replaced with ILogger. Marked obsolete with NLog v5.3")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public interface ISuppress
     {
         /// <summary>


### PR DESCRIPTION
- [x] Waiting for NLog v5.3

Also marked these two members as obsolete on the ILogger-interface. Instead use the Logger-class:
- `event EventHandler<EventArgs> LoggerReconfigured`
- `LogFactory Factory`

Both are very exotic, and `Factory`-property is hard to mock correctly, since not interface-type.