### PR TITLE
InternalLogger - Obsoleted API to reduce dependencies

### DIFF
--- a/src/NLog/Common/InternalEventOccurredHandler.cs
+++ b/src/NLog/Common/InternalEventOccurredHandler.cs
@@ -33,54 +33,11 @@
 
 namespace NLog.Common
 {
-    using System;
-    using System.ComponentModel;
-    using JetBrains.Annotations;
-
     /// <summary>
-    /// A message has been written to the internal logger
+    /// Handle Internal LogEvent written to the InternalLogger
     /// </summary>
-    [Obsolete("Instead use InternalEventOccurred and InternalLogEventArgs. Marked obsolete with NLog v5.3")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public sealed class InternalLoggerMessageEventArgs : EventArgs
-    {
-        /// <summary>
-        /// The rendered message
-        /// </summary>
-        public string Message { get; }
-
-        /// <summary>
-        /// The log level
-        /// </summary>
-        public LogLevel Level { get; }
-
-        /// <summary>
-        /// The exception. Could be null.
-        /// </summary>
-        [CanBeNull]
-        public Exception Exception { get; }
-
-        /// <summary>
-        /// The type that triggered this internal log event, for example the FileTarget. 
-        /// This property is not always populated. 
-        /// </summary>
-        [CanBeNull]
-        public Type SenderType { get; }
-
-        /// <summary>
-        /// The context name that triggered this internal log event, for example the name of the Target. 
-        /// This property is not always populated. 
-        /// </summary>
-        [CanBeNull]
-        public string SenderName { get; }
-
-        internal InternalLoggerMessageEventArgs(string message, LogLevel level, [CanBeNull] Exception exception, [CanBeNull] Type senderType, [CanBeNull] string senderName)
-        {
-            Message = message;
-            Level = level;
-            Exception = exception;
-            SenderType = senderType;
-            SenderName = senderName;
-        }
-    }
+    /// <remarks>
+    /// Never use/call NLog Logger-objects when handling these internal events, as it will lead to deadlock / stackoverflow.
+    /// </remarks>
+    public delegate void InternalEventOccurredHandler(object sender, InternalLogEventArgs e);
 }

--- a/src/NLog/Common/InternalLogEventArgs.cs
+++ b/src/NLog/Common/InternalLogEventArgs.cs
@@ -34,15 +34,12 @@
 namespace NLog.Common
 {
     using System;
-    using System.ComponentModel;
     using JetBrains.Annotations;
 
     /// <summary>
-    /// A message has been written to the internal logger
+    /// Internal LogEvent details from <see cref="InternalLogger"/> 
     /// </summary>
-    [Obsolete("Instead use InternalEventOccurred and InternalLogEventArgs. Marked obsolete with NLog v5.3")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public sealed class InternalLoggerMessageEventArgs : EventArgs
+    public readonly struct InternalLogEventArgs
     {
         /// <summary>
         /// The rendered message
@@ -74,7 +71,7 @@ namespace NLog.Common
         [CanBeNull]
         public string SenderName { get; }
 
-        internal InternalLoggerMessageEventArgs(string message, LogLevel level, [CanBeNull] Exception exception, [CanBeNull] Type senderType, [CanBeNull] string senderName)
+        internal InternalLogEventArgs(string message, LogLevel level, [CanBeNull] Exception exception, [CanBeNull] Type senderType, [CanBeNull] string senderName)
         {
             Message = message;
             Level = level;

--- a/src/NLog/Common/InternalLogger-generated.cs
+++ b/src/NLog/Common/InternalLogger-generated.cs
@@ -95,7 +95,9 @@ namespace NLog.Common
         /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Trace.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Trace([Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Trace(Func<string> messageFunc)
         {
             if (IsTraceEnabled)
                 Write(null, LogLevel.Trace, messageFunc(), null);
@@ -174,7 +176,9 @@ namespace NLog.Common
         /// </summary>
         /// <param name="ex">Exception to be logged.</param>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Trace(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Trace(Exception ex, Func<string> messageFunc)
         {
             if (IsTraceEnabled)
                 Write(ex, LogLevel.Trace, messageFunc(), null);
@@ -205,7 +209,9 @@ namespace NLog.Common
         /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Debug.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Debug([Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Debug(Func<string> messageFunc)
         {
             if (IsDebugEnabled)
                 Write(null, LogLevel.Debug, messageFunc(), null);
@@ -284,7 +290,9 @@ namespace NLog.Common
         /// </summary>
         /// <param name="ex">Exception to be logged.</param>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Debug(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Debug(Exception ex, Func<string> messageFunc)
         {
             if (IsDebugEnabled)
                 Write(ex, LogLevel.Debug, messageFunc(), null);
@@ -315,7 +323,9 @@ namespace NLog.Common
         /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Info.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Info([Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Info(Func<string> messageFunc)
         {
             if (IsInfoEnabled)
                 Write(null, LogLevel.Info, messageFunc(), null);
@@ -394,7 +404,9 @@ namespace NLog.Common
         /// </summary>
         /// <param name="ex">Exception to be logged.</param>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Info(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Info(Exception ex, Func<string> messageFunc)
         {
             if (IsInfoEnabled)
                 Write(ex, LogLevel.Info, messageFunc(), null);
@@ -425,7 +437,9 @@ namespace NLog.Common
         /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Warn.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Warn([Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Warn(Func<string> messageFunc)
         {
             if (IsWarnEnabled)
                 Write(null, LogLevel.Warn, messageFunc(), null);
@@ -504,7 +518,9 @@ namespace NLog.Common
         /// </summary>
         /// <param name="ex">Exception to be logged.</param>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Warn(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Warn(Exception ex, Func<string> messageFunc)
         {
             if (IsWarnEnabled)
                 Write(ex, LogLevel.Warn, messageFunc(), null);
@@ -535,7 +551,9 @@ namespace NLog.Common
         /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Error.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Error([Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Error(Func<string> messageFunc)
         {
             if (IsErrorEnabled)
                 Write(null, LogLevel.Error, messageFunc(), null);
@@ -614,7 +632,9 @@ namespace NLog.Common
         /// </summary>
         /// <param name="ex">Exception to be logged.</param>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Error(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Error(Exception ex, Func<string> messageFunc)
         {
             if (IsErrorEnabled)
                 Write(ex, LogLevel.Error, messageFunc(), null);
@@ -645,7 +665,9 @@ namespace NLog.Common
         /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  Fatal.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Fatal([Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Fatal(Func<string> messageFunc)
         {
             if (IsFatalEnabled)
                 Write(null, LogLevel.Fatal, messageFunc(), null);
@@ -724,7 +746,9 @@ namespace NLog.Common
         /// </summary>
         /// <param name="ex">Exception to be logged.</param>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void Fatal(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Fatal(Exception ex, Func<string> messageFunc)
         {
             if (IsFatalEnabled)
                 Write(ex, LogLevel.Fatal, messageFunc(), null);

--- a/src/NLog/Common/InternalLogger-generated.tt
+++ b/src/NLog/Common/InternalLogger-generated.tt
@@ -81,7 +81,9 @@ namespace NLog.Common
         /// <paramref name="messageFunc"/> will be only called when logging is enabled for level  <#=level#>.
         /// </summary>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void <#=level#>([Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void <#=level#>(Func<string> messageFunc)
         {
             if (Is<#=level#>Enabled)
                 Write(null, LogLevel.<#=level#>, messageFunc(), null);
@@ -160,7 +162,9 @@ namespace NLog.Common
         /// </summary>
         /// <param name="ex">Exception to be logged.</param>
         /// <param name="messageFunc">Function that returns the log message.</param>
-        public static void <#=level#>(Exception ex, [Localizable(false)] Func<string> messageFunc)
+        [Obsolete("Avoid delegate capture allocations. Marked obsolete with v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void <#=level#>(Exception ex, Func<string> messageFunc)
         {
             if (Is<#=level#>Enabled)
                 Write(ex, LogLevel.<#=level#>, messageFunc(), null);

--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -86,7 +86,6 @@ namespace NLog.Common
         /// Gets or sets a value indicating whether internal messages should be written to the console output stream.
         /// </summary>
         /// <remarks>Your application must be a console application.</remarks>
-        [Obsolete("Instead use InternalLogger.LogWriter = System.Console.Out. Marked obsolete with NLog v5.3")]
         public static bool LogToConsole
         {
             get => _logToConsole;
@@ -107,7 +106,6 @@ namespace NLog.Common
         /// Gets or sets a value indicating whether internal messages should be written to the console error stream.
         /// </summary>
         /// <remarks>Your application must be a console application.</remarks>
-        [Obsolete("Instead use InternalLogger.LogWriter = System.Console.Error. Marked obsolete with NLog v5.3")]
         public static bool LogToConsoleError
         {
             get => _logToConsoleError;
@@ -148,7 +146,6 @@ namespace NLog.Common
         /// Gets or sets the file path of the internal log file.
         /// </summary>
         /// <remarks>A value of <see langword="null" /> value disables internal logging to a file.</remarks>
-        [Obsolete("Instead use InternalLogger.LogWriter = new System.IO.StreamWriter(logFilePath, true). Marked obsolete with NLog v5.3")]
         public static string LogFile
         {
             get
@@ -574,7 +571,6 @@ namespace NLog.Common
             }
         }
 
-        [Obsolete("InternalLogger should be minimal. Marked obsolete with NLog v5.3")]
         private static void CreateDirectoriesIfNeeded(string filename)
         {
             try
@@ -601,7 +597,6 @@ namespace NLog.Common
             }
         }
 
-        [Obsolete("InternalLogger should be minimal. Marked obsolete with NLog v5.3")]
         private static string ExpandFilePathVariables(string internalLogFile)
         {
             try
@@ -634,7 +629,6 @@ namespace NLog.Common
             }
         }
 
-        [Obsolete("InternalLogger should be minimal. Marked obsolete with NLog v5.3")]
         private static bool ContainsSubStringIgnoreCase(string haystack, string needle, out string result)
         {
             int needlePos = haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase);
@@ -642,7 +636,6 @@ namespace NLog.Common
             return result != null;
         }
 
-        [Obsolete("Instead use InternalLogger.LogWriter = System.Console.Out. Marked obsolete with NLog v5.3")]
         private static void LogToConsoleSubscription(object sender, InternalLogEventArgs eventArgs)
         {
 #if !NETSTANDARD1_3
@@ -651,7 +644,6 @@ namespace NLog.Common
 #endif
         }
 
-        [Obsolete("Instead use InternalLogger.LogWriter = System.Console.Error. Marked obsolete with NLog v5.3")]
         private static void LogToConsoleErrorSubscription(object sender, InternalLogEventArgs eventArgs)
         {
 #if !NETSTANDARD1_3
@@ -669,7 +661,6 @@ namespace NLog.Common
 #endif
         }
 
-        [Obsolete("Instead use InternalLogger.LogWriter = new System.IO.StreamWriter(logFilePath, true). Marked obsolete with NLog v5.3")]
         private static void LogToFileSubscription(object sender, InternalLogEventArgs eventArgs)
         {
             var logLine = CreateLogLine(eventArgs.Exception, eventArgs.Level, eventArgs.Message);

--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -53,26 +53,26 @@ namespace NLog.Common
     public static partial class InternalLogger
     {
         private static readonly object LockObject = new object();
-        private static string _logFile;
 
        /// <summary>
         /// Set the config of the InternalLogger with defaults and config.
         /// </summary>
         public static void Reset()
         {
-            // TODO: Extract class - InternalLoggerConfigurationReader
-
-            LogToConsole = GetSetting("nlog.internalLogToConsole", "NLOG_INTERNAL_LOG_TO_CONSOLE", false);
-            LogToConsoleError = GetSetting("nlog.internalLogToConsoleError", "NLOG_INTERNAL_LOG_TO_CONSOLE_ERROR", false);
-            LogLevel = GetSetting("nlog.internalLogLevel", "NLOG_INTERNAL_LOG_LEVEL", LogLevel.Off);
-            LogFile = GetSetting("nlog.internalLogFile", "NLOG_INTERNAL_LOG_FILE", string.Empty);
-            LogToTrace = GetSetting("nlog.internalLogToTrace", "NLOG_INTERNAL_LOG_TO_TRACE", false);
-            IncludeTimestamp = GetSetting("nlog.internalLogIncludeTimestamp", "NLOG_INTERNAL_INCLUDE_TIMESTAMP", true);
-            Info("NLog internal logger initialized.");
-     
             ExceptionThrowWhenWriting = false;
             LogWriter = null;
-            LogMessageReceived = null;
+            InternalEventOccurred = null;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            _logMessageReceived = null;
+            LogLevel = GetSetting("nlog.internalLogLevel", "NLOG_INTERNAL_LOG_LEVEL", LogLevel.Off);
+            IncludeTimestamp = GetSetting("nlog.internalLogIncludeTimestamp", "NLOG_INTERNAL_INCLUDE_TIMESTAMP", true);
+            LogToConsole = GetSetting("nlog.internalLogToConsole", "NLOG_INTERNAL_LOG_TO_CONSOLE", false);
+            LogToConsoleError = GetSetting("nlog.internalLogToConsoleError", "NLOG_INTERNAL_LOG_TO_CONSOLE_ERROR", false);
+            LogFile = GetSetting("nlog.internalLogFile", "NLOG_INTERNAL_LOG_FILE", string.Empty);
+            LogToTrace = GetSetting("nlog.internalLogToTrace", "NLOG_INTERNAL_LOG_TO_TRACE", false);
+#pragma warning restore CS0618 // Type or member is obsolete
+            Info("NLog internal logger initialized.");
         }
 
         /// <summary>
@@ -86,23 +86,69 @@ namespace NLog.Common
         /// Gets or sets a value indicating whether internal messages should be written to the console output stream.
         /// </summary>
         /// <remarks>Your application must be a console application.</remarks>
-        public static bool LogToConsole { get; set; }
+        [Obsolete("Instead use InternalLogger.LogWriter = System.Console.Out. Marked obsolete with NLog v5.3")]
+        public static bool LogToConsole
+        {
+            get => _logToConsole;
+            set
+            {
+                if (_logToConsole != value)
+                {
+                    InternalEventOccurred -= LogToConsoleSubscription;
+                    if (value)
+                        InternalEventOccurred += LogToConsoleSubscription;
+                    _logToConsole = value;
+                }
+            }
+        }
+        private static bool _logToConsole;
 
         /// <summary>
         /// Gets or sets a value indicating whether internal messages should be written to the console error stream.
         /// </summary>
         /// <remarks>Your application must be a console application.</remarks>
-        public static bool LogToConsoleError { get; set; }
+        [Obsolete("Instead use InternalLogger.LogWriter = System.Console.Error. Marked obsolete with NLog v5.3")]
+        public static bool LogToConsoleError
+        {
+            get => _logToConsoleError;
+            set
+            {
+                if (_logToConsoleError != value)
+                {
+                    InternalEventOccurred -= LogToConsoleErrorSubscription;
+                    if (value)
+                        InternalEventOccurred += LogToConsoleErrorSubscription;
+                    _logToConsoleError = value;
+                }
+            }
+        }
+        private static bool _logToConsoleError;
 
         /// <summary>
         /// Gets or sets a value indicating whether internal messages should be written to the <see cref="System.Diagnostics"/>.Trace
         /// </summary>
-        public static bool LogToTrace { get; set; }
+        [Obsolete("Instead use InternalLogger.LogWriter. Marked obsolete with NLog v5.3")]
+        public static bool LogToTrace
+        {
+            get => _logToTrace;
+            set
+            {
+                if (_logToTrace != value)
+                {
+                    InternalEventOccurred -= LogToTraceSubscription;
+                    if (value)
+                        InternalEventOccurred += LogToTraceSubscription;
+                    _logToTrace = value;
+                }
+            }
+        }
+        private static bool _logToTrace;
 
         /// <summary>
         /// Gets or sets the file path of the internal log file.
         /// </summary>
         /// <remarks>A value of <see langword="null" /> value disables internal logging to a file.</remarks>
+        [Obsolete("Instead use InternalLogger.LogWriter = new System.IO.StreamWriter(logFilePath, true). Marked obsolete with NLog v5.3")]
         public static string LogFile
         {
             get
@@ -112,7 +158,14 @@ namespace NLog.Common
 
             set
             {
-                _logFile = value;
+                if (!string.Equals(_logFile, value))
+                {
+                    InternalEventOccurred -= LogToFileSubscription;
+                    if (!string.IsNullOrEmpty(value))
+                        InternalEventOccurred += LogToFileSubscription;
+                    _logFile = value;
+                }
+
                 if (!string.IsNullOrEmpty(value))
                 {
                     _logFile = ExpandFilePathVariables(value);
@@ -120,6 +173,7 @@ namespace NLog.Common
                 }
             }
         }
+        private static string _logFile;
 
         /// <summary>
         /// Gets or sets the text writer that will receive internal logs.
@@ -134,7 +188,34 @@ namespace NLog.Common
         /// 
         /// Avoid using/calling NLog Logger-objects when handling these internal events, as it will lead to deadlock / stackoverflow.
         /// </remarks>
-        public static event EventHandler<InternalLoggerMessageEventArgs> LogMessageReceived;
+        [Obsolete("Instead use InternalEventOccurred. Marked obsolete with NLog v5.3")]
+        public static event EventHandler<InternalLoggerMessageEventArgs> LogMessageReceived
+        {
+            add
+            {
+                if (_logMessageReceived == null)
+                    InternalEventOccurred += LogToMessageReceived;
+                _logMessageReceived += value;
+            }
+            remove
+            {
+                _logMessageReceived -= value;
+                if (_logMessageReceived == null)
+                    InternalEventOccurred -= LogToMessageReceived;
+            }
+        }
+        [Obsolete("Instead use InternalEventOccurred. Marked obsolete with NLog v5.3")]
+        private static event EventHandler<InternalLoggerMessageEventArgs> _logMessageReceived;
+
+        /// <summary>
+        /// Internal LogEvent written to the InternalLogger
+        /// </summary>
+        /// <remarks>
+        /// EventHandler will only be triggered for events, where severity matches the configured <see cref="LogLevel"/>.
+        /// 
+        /// Never use/call NLog Logger-objects when handling these internal events, as it will lead to deadlock / stackoverflow.
+        /// </remarks>
+        public static event InternalEventOccurredHandler InternalEventOccurred;
 
         /// <summary>
         /// Gets or sets a value indicating whether timestamp should be included in internal log output.
@@ -241,9 +322,7 @@ namespace NLog.Common
                 return;
             }
 
-            var hasActiveLoggersWithLine = HasActiveLoggersWithLine();
-            var hasEventListeners = HasEventListeners();
-            if (!hasActiveLoggersWithLine && !hasEventListeners)
+            if (InternalEventOccurred is null && LogWriter is null)
             {
                 return;
             }
@@ -252,7 +331,7 @@ namespace NLog.Common
 
             try
             {
-                fullMessage = CreateFullMessage(message, args);
+                fullMessage = args?.Length > 0 ? string.Format(CultureInfo.InvariantCulture, message, args) : message;
             }
             catch (Exception exception)
             {
@@ -264,19 +343,10 @@ namespace NLog.Common
 
             try
             {
-                if (hasActiveLoggersWithLine)
-                {
-                    WriteLogLine(ex, level, fullMessage);
-                }
+                var loggerContext = args?.Length > 0 ? args[0] as IInternalLoggerContext : null;
+                WriteToLog(level, ex, fullMessage, loggerContext);
 
-                if (hasEventListeners)
-                {
-                    var loggerContext = args?.Length > 0 ? args[0] as IInternalLoggerContext : null;
-                    var loggerContextName = string.IsNullOrEmpty(loggerContext?.Name) ? loggerContext?.ToString() : loggerContext.Name;
-                    LogMessageReceived?.Invoke(null, new InternalLoggerMessageEventArgs(fullMessage, level, ex, loggerContext?.GetType(), loggerContextName));
-
-                    ex?.MarkAsLoggedToInternalLogger();
-                }
+                ex?.MarkAsLoggedToInternalLogger();
             }
             catch (Exception exception)
             {
@@ -291,33 +361,21 @@ namespace NLog.Common
             }
         }
 
-        private static void WriteLogLine(Exception ex, LogLevel level, string message)
+        private static void WriteToLog(LogLevel level, Exception ex, string fullMessage, IInternalLoggerContext loggerContext)
         {
-            try
+            if (LogWriter != null)
             {
-                string line = CreateLogLine(ex, level, message);
-
-                WriteToLogFile(line);
-                WriteToTextWriter(line);
-
-#if !NETSTANDARD1_3
-                WriteToConsole(line);
-                WriteToErrorConsole(line);
-                WriteToTrace(line);
-#endif
-
-                ex?.MarkAsLoggedToInternalLogger();
-            }
-            catch (Exception exception)
-            {
-                ExceptionThrowWhenWriting = true;
-
-                // no log looping.
-                // we have no place to log the message to so we ignore it
-                if (exception.MustBeRethrownImmediately())
+                var logLine = CreateLogLine(ex, level, fullMessage);
+                lock (LockObject)
                 {
-                    throw;
+                    LogWriter?.WriteLine(logLine);
                 }
+            }
+
+            if (InternalEventOccurred != null)
+            {
+                var loggerContextName = string.IsNullOrEmpty(loggerContext?.Name) ? loggerContext?.ToString() : loggerContext.Name;
+                InternalEventOccurred?.Invoke(null, new InternalLogEventArgs(fullMessage, level, ex, loggerContext?.GetType(), loggerContextName));
             }
         }
 
@@ -351,13 +409,6 @@ namespace NLog.Common
             }
         }
 
-        private static string CreateFullMessage(string message, object[] args)
-        {
-            var formattedMessage =
-                (args is null) ? message : string.Format(CultureInfo.InvariantCulture, message, args);
-            return formattedMessage;
-        }
-
         /// <summary>
         /// Determine if logging should be avoided because of exception type. 
         /// </summary>
@@ -384,134 +435,17 @@ namespace NLog.Common
         /// <returns><c>true</c> if logging is enabled; otherwise, <c>false</c>.</returns>
         internal static bool HasActiveLoggers()
         {
-            return HasActiveLoggersWithLine() || HasEventListeners();
+            if (InternalEventOccurred is null && LogWriter is null)
+                return false;
+            else
+                return true;
         }
-
-        private static bool HasEventListeners()
-        {
-            return LogMessageReceived != null;
-        }
-
-        internal static bool HasActiveLoggersWithLine()
-        {
-            return !string.IsNullOrEmpty(LogFile) ||
-                   LogToConsole ||
-                   LogToConsoleError ||
-                   LogToTrace ||
-                   LogWriter != null;
-        }
-
-        /// <summary>
-        /// Write internal messages to the log file defined in <see cref="LogFile"/>.
-        /// </summary>
-        /// <param name="message">Message to write.</param>
-        /// <remarks>
-        /// Message will be logged only when the property <see cref="LogFile"/> is not <c>null</c>, otherwise the
-        /// method has no effect.
-        /// </remarks>
-        private static void WriteToLogFile(string message)
-        {
-            var logFile = LogFile;
-            if (string.IsNullOrEmpty(logFile))
-            {
-                return;
-            }
-
-            lock (LockObject)
-            {
-                using (var textWriter = File.AppendText(logFile))
-                {
-                    textWriter.WriteLine(message);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Write internal messages to the <see cref="System.IO.TextWriter"/> defined in <see cref="LogWriter"/>.
-        /// </summary>
-        /// <param name="message">Message to write.</param>
-        /// <remarks>
-        /// Message will be logged only when the property <see cref="LogWriter"/> is not <c>null</c>, otherwise the
-        /// method has no effect.
-        /// </remarks>
-        private static void WriteToTextWriter(string message)
-        {
-            var writer = LogWriter;
-            if (writer is null)
-            {
-                return;
-            }
-
-            lock (LockObject)
-            {
-                writer.WriteLine(message);
-            }
-        }
-
-#if !NETSTANDARD1_3
-        /// <summary>
-        /// Write internal messages to the <see cref="System.Console"/>.
-        /// </summary>
-        /// <param name="message">Message to write.</param>
-        /// <remarks>
-        /// Message will be logged only when the property <see cref="LogToConsole"/> is <c>true</c>, otherwise the 
-        /// method has no effect.
-        /// </remarks>
-        private static void WriteToConsole(string message)
-        {
-            if (!LogToConsole)
-            {
-                return;
-            }
-
-            NLog.Targets.ConsoleTargetHelper.WriteLineThreadSafe(Console.Out, message);
-        }
-#endif
-
-#if !NETSTANDARD1_3
-        /// <summary>
-        /// Write internal messages to the <see cref="System.Console.Error"/>.
-        /// </summary>
-        /// <param name="message">Message to write.</param>
-        /// <remarks>
-        /// Message will be logged when the property <see cref="LogToConsoleError"/> is <c>true</c>, otherwise the 
-        /// method has no effect.
-        /// </remarks>
-        private static void WriteToErrorConsole(string message)
-        {
-            if (!LogToConsoleError)
-            {
-                return;
-            }
-
-            NLog.Targets.ConsoleTargetHelper.WriteLineThreadSafe(Console.Error, message);
-        }
-
-        /// <summary>
-        /// Write internal messages to the <see cref="System.Diagnostics.Trace"/>.
-        /// </summary>
-        /// <param name="message">A message to write.</param>
-        /// <remarks>
-        /// Works when property <see cref="LogToTrace"/> set to true.
-        /// The <see cref="System.Diagnostics.Trace"/> is used in Debug and Release configuration. 
-        /// The <see cref="System.Diagnostics.Debug"/> works only in Debug configuration and this is reason why is replaced by <see cref="System.Diagnostics.Trace"/>.
-        /// in DEBUG 
-        /// </remarks>
-        private static void WriteToTrace(string message)
-        {
-            if (!LogToTrace)
-            {
-                return;
-            }
-
-            System.Diagnostics.Trace.WriteLine(message, "NLog");
-        }
-#endif
 
         /// <summary>
         /// Logs the assembly version and file version of the given Assembly.
         /// </summary>
         /// <param name="assembly">The assembly to log.</param>
+        [Obsolete("InternalLogger should be minimal. Marked obsolete with NLog v5.3")]
         public static void LogAssemblyVersion(Assembly assembly)
         {
             try
@@ -539,6 +473,7 @@ namespace NLog.Common
             }
         }
 
+        [Obsolete("InternalLogger should be minimal. Marked obsolete with NLog v5.3")]
         private static string GetAppSettings(string configName)
         {
 #if !NETSTANDARD
@@ -557,6 +492,7 @@ namespace NLog.Common
             return null;
         }
 
+        [Obsolete("InternalLogger should be minimal. Marked obsolete with NLog v5.3")]
         private static string GetSettingString(string configName, string envName)
         {
             try
@@ -590,6 +526,7 @@ namespace NLog.Common
             return null;
         }
 
+        [Obsolete("InternalLogger should be minimal. Marked obsolete with NLog v5.3")]
         private static LogLevel GetSetting(string configName, string envName, LogLevel defaultValue)
         {
             string value = GetSettingString(configName, envName);
@@ -613,6 +550,7 @@ namespace NLog.Common
             }
         }
 
+        [Obsolete("InternalLogger should be minimal. Marked obsolete with NLog v5.3")]
         private static T GetSetting<T>(string configName, string envName, T defaultValue)
         {
             string value = GetSettingString(configName, envName);
@@ -636,6 +574,7 @@ namespace NLog.Common
             }
         }
 
+        [Obsolete("InternalLogger should be minimal. Marked obsolete with NLog v5.3")]
         private static void CreateDirectoriesIfNeeded(string filename)
         {
             try
@@ -662,6 +601,7 @@ namespace NLog.Common
             }
         }
 
+        [Obsolete("InternalLogger should be minimal. Marked obsolete with NLog v5.3")]
         private static string ExpandFilePathVariables(string internalLogFile)
         {
             try
@@ -694,11 +634,65 @@ namespace NLog.Common
             }
         }
 
+        [Obsolete("InternalLogger should be minimal. Marked obsolete with NLog v5.3")]
         private static bool ContainsSubStringIgnoreCase(string haystack, string needle, out string result)
         {
             int needlePos = haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase);
             result = needlePos >= 0 ? haystack.Substring(needlePos, needle.Length) : null;
             return result != null;
+        }
+
+        [Obsolete("Instead use InternalLogger.LogWriter = System.Console.Out. Marked obsolete with NLog v5.3")]
+        private static void LogToConsoleSubscription(object sender, InternalLogEventArgs eventArgs)
+        {
+#if !NETSTANDARD1_3
+            var logLine = CreateLogLine(eventArgs.Exception, eventArgs.Level, eventArgs.Message);
+            NLog.Targets.ConsoleTargetHelper.WriteLineThreadSafe(Console.Out, logLine);
+#endif
+        }
+
+        [Obsolete("Instead use InternalLogger.LogWriter = System.Console.Error. Marked obsolete with NLog v5.3")]
+        private static void LogToConsoleErrorSubscription(object sender, InternalLogEventArgs eventArgs)
+        {
+#if !NETSTANDARD1_3
+            var logLine = CreateLogLine(eventArgs.Exception, eventArgs.Level, eventArgs.Message);
+            NLog.Targets.ConsoleTargetHelper.WriteLineThreadSafe(Console.Error, logLine);
+#endif
+        }
+
+        [Obsolete("Instead use InternalLogger.LogWriter. Marked obsolete with NLog v5.3")]
+        private static void LogToTraceSubscription(object sender, InternalLogEventArgs eventArgs)
+        {
+#if !NETSTANDARD1_3
+            var logLine = CreateLogLine(eventArgs.Exception, eventArgs.Level, eventArgs.Message);
+            System.Diagnostics.Trace.WriteLine(logLine, "NLog");
+#endif
+        }
+
+        [Obsolete("Instead use InternalLogger.LogWriter = new System.IO.StreamWriter(logFilePath, true). Marked obsolete with NLog v5.3")]
+        private static void LogToFileSubscription(object sender, InternalLogEventArgs eventArgs)
+        {
+            var logLine = CreateLogLine(eventArgs.Exception, eventArgs.Level, eventArgs.Message);
+            lock (LockObject)
+            {
+                try
+                {
+                    using (var textWriter = File.AppendText(_logFile))
+                    {
+                        textWriter.WriteLine(logLine);
+                    }
+                }
+                catch (System.IO.IOException)
+                {
+                    // No where to report
+                }
+            }
+        }
+
+        [Obsolete("Instead use InternalEventOccurred and InternalLogEventArgs. Marked obsolete with NLog v5.3")]
+        private static void LogToMessageReceived(object sender, InternalLogEventArgs eventArgs)
+        {
+            _logMessageReceived?.Invoke(null, new InternalLoggerMessageEventArgs(eventArgs.Message, eventArgs.Level, eventArgs.Exception, eventArgs.SenderType, eventArgs.SenderName));
         }
     }
 }

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -146,16 +146,24 @@ namespace NLog.Config
                         LogFactory.KeepVariablesOnReload = ParseBooleanValue(configItem.Key, configItem.Value, LogFactory.KeepVariablesOnReload);
                         break;
                     case "INTERNALLOGTOCONSOLE":
+#pragma warning disable CS0618 // Type or member is obsolete
                         InternalLogger.LogToConsole = ParseBooleanValue(configItem.Key, configItem.Value, InternalLogger.LogToConsole);
+#pragma warning restore CS0618 // Type or member is obsolete
                         break;
                     case "INTERNALLOGTOCONSOLEERROR":
+#pragma warning disable CS0618 // Type or member is obsolete
                         InternalLogger.LogToConsoleError = ParseBooleanValue(configItem.Key, configItem.Value, InternalLogger.LogToConsoleError);
+#pragma warning restore CS0618 // Type or member is obsolete
                         break;
                     case "INTERNALLOGFILE":
+#pragma warning disable CS0618 // Type or member is obsolete
                         InternalLogger.LogFile = configItem.Value?.Trim();
+#pragma warning restore CS0618 // Type or member is obsolete
                         break;
                     case "INTERNALLOGTOTRACE":
+#pragma warning disable CS0618 // Type or member is obsolete
                         InternalLogger.LogToTrace = ParseBooleanValue(configItem.Key, configItem.Value, InternalLogger.LogToTrace);
+#pragma warning restore CS0618 // Type or member is obsolete
                         break;
                     case "INTERNALLOGINCLUDETIMESTAMP":
                         InternalLogger.IncludeTimestamp = ParseBooleanValue(configItem.Key, configItem.Value, InternalLogger.IncludeTimestamp);

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -146,19 +146,13 @@ namespace NLog.Config
                         LogFactory.KeepVariablesOnReload = ParseBooleanValue(configItem.Key, configItem.Value, LogFactory.KeepVariablesOnReload);
                         break;
                     case "INTERNALLOGTOCONSOLE":
-#pragma warning disable CS0618 // Type or member is obsolete
                         InternalLogger.LogToConsole = ParseBooleanValue(configItem.Key, configItem.Value, InternalLogger.LogToConsole);
-#pragma warning restore CS0618 // Type or member is obsolete
                         break;
                     case "INTERNALLOGTOCONSOLEERROR":
-#pragma warning disable CS0618 // Type or member is obsolete
                         InternalLogger.LogToConsoleError = ParseBooleanValue(configItem.Key, configItem.Value, InternalLogger.LogToConsoleError);
-#pragma warning restore CS0618 // Type or member is obsolete
                         break;
                     case "INTERNALLOGFILE":
-#pragma warning disable CS0618 // Type or member is obsolete
                         InternalLogger.LogFile = configItem.Value?.Trim();
-#pragma warning restore CS0618 // Type or member is obsolete
                         break;
                     case "INTERNALLOGTOTRACE":
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -272,7 +272,9 @@ namespace NLog
                     {
                         try
                         {
+#pragma warning disable CS0618 // Type or member is obsolete
                             LogNLogAssemblyVersion();
+#pragma warning restore CS0618 // Type or member is obsolete
                             _config = config;
                             _configLoader.Activated(this, _config);
                             _config.Dump();
@@ -312,8 +314,10 @@ namespace NLog
                     {
                         try
                         {
+#pragma warning disable CS0618 // Type or member is obsolete
                             if (oldConfig is null)
                                 LogNLogAssemblyVersion();
+#pragma warning restore CS0618 // Type or member is obsolete
                             _configLoader.Activated(this, _config);
                             _config.Dump();
                             ReconfigExistingLoggers();
@@ -409,6 +413,7 @@ namespace NLog
         }
         internal CultureInfo _defaultCultureInfo;
 
+        [Obsolete("LogFactory should be minimal. Marked obsolete with NLog v5.3")]
         internal static void LogNLogAssemblyVersion()
         {
             if (!InternalLogger.IsInfoEnabled)

--- a/src/NLog/SetupInternalLoggerBuilderExtensions.cs
+++ b/src/NLog/SetupInternalLoggerBuilderExtensions.cs
@@ -33,6 +33,8 @@
 
 namespace NLog
 {
+    using System;
+    using System.ComponentModel;
     using System.IO;
     using NLog.Common;
     using NLog.Config;
@@ -51,11 +53,13 @@ namespace NLog
             InternalLogger.LogLevel = logLevel;
             if (InternalLogger.LogLevel != LogLevel.Off && orgValue == LogLevel.Off)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 var orgLogFile = InternalLogger.LogFile;
                 if (!string.IsNullOrEmpty(orgLogFile))
                 {
                     InternalLogger.LogFile = orgLogFile;    // InternalLogger.LogFile property-setter skips directory creation when LogLevel.Off
                 }
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             return setupBuilder;
         }
@@ -65,7 +69,9 @@ namespace NLog
         /// </summary>
         public static ISetupInternalLoggerBuilder LogToFile(this ISetupInternalLoggerBuilder setupBuilder, string fileName)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             InternalLogger.LogFile = fileName;
+#pragma warning restore CS0618 // Type or member is obsolete
             return setupBuilder;
         }
 
@@ -74,7 +80,9 @@ namespace NLog
         /// </summary>
         public static ISetupInternalLoggerBuilder LogToConsole(this ISetupInternalLoggerBuilder setupBuilder, bool enabled)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             InternalLogger.LogToConsole = enabled;
+#pragma warning restore CS0618 // Type or member is obsolete
             return setupBuilder;
         }
 
@@ -84,7 +92,9 @@ namespace NLog
         /// </summary>
         public static ISetupInternalLoggerBuilder LogToTrace(this ISetupInternalLoggerBuilder setupBuilder, bool enabled)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             InternalLogger.LogToTrace = enabled;
+#pragma warning restore CS0618 // Type or member is obsolete
             return setupBuilder;
         }
 #endif
@@ -101,7 +111,9 @@ namespace NLog
         /// <summary>
         /// Configures <see cref="InternalLogger.LogMessageReceived"/>
         /// </summary>
-        public static ISetupInternalLoggerBuilder AddLogSubscription(this ISetupInternalLoggerBuilder setupBuilder, System.EventHandler<InternalLoggerMessageEventArgs> eventSubscriber)
+        [Obsolete("Instead use AddEventSubscription. Marked obsolete with NLog v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ISetupInternalLoggerBuilder AddLogSubscription(this ISetupInternalLoggerBuilder setupBuilder, EventHandler<InternalLoggerMessageEventArgs> eventSubscriber)
         {
             InternalLogger.LogMessageReceived += eventSubscriber;
             return setupBuilder;
@@ -110,9 +122,29 @@ namespace NLog
         /// <summary>
         /// Configures <see cref="InternalLogger.LogMessageReceived"/>
         /// </summary>
-        public static ISetupInternalLoggerBuilder RemoveLogSubscription(this ISetupInternalLoggerBuilder setupBuilder, System.EventHandler<InternalLoggerMessageEventArgs> eventSubscriber)
+        [Obsolete("Instead use RemoveEventSubscription. Marked obsolete with NLog v5.3")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ISetupInternalLoggerBuilder RemoveLogSubscription(this ISetupInternalLoggerBuilder setupBuilder, EventHandler<InternalLoggerMessageEventArgs> eventSubscriber)
         {
             InternalLogger.LogMessageReceived -= eventSubscriber;
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Configures <see cref="InternalLogger.InternalEventOccurred"/>
+        /// </summary>
+        public static ISetupInternalLoggerBuilder AddEventSubscription(this ISetupInternalLoggerBuilder setupBuilder, InternalEventOccurredHandler eventSubscriber)
+        {
+            InternalLogger.InternalEventOccurred += eventSubscriber;
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Configures <see cref="InternalLogger.InternalEventOccurred"/>
+        /// </summary>
+        public static ISetupInternalLoggerBuilder RemoveEventSubscription(this ISetupInternalLoggerBuilder setupBuilder, InternalEventOccurredHandler eventSubscriber)
+        {
+            InternalLogger.InternalEventOccurred -= eventSubscriber;
             return setupBuilder;
         }
 

--- a/src/NLog/SetupInternalLoggerBuilderExtensions.cs
+++ b/src/NLog/SetupInternalLoggerBuilderExtensions.cs
@@ -53,13 +53,11 @@ namespace NLog
             InternalLogger.LogLevel = logLevel;
             if (InternalLogger.LogLevel != LogLevel.Off && orgValue == LogLevel.Off)
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 var orgLogFile = InternalLogger.LogFile;
                 if (!string.IsNullOrEmpty(orgLogFile))
                 {
                     InternalLogger.LogFile = orgLogFile;    // InternalLogger.LogFile property-setter skips directory creation when LogLevel.Off
                 }
-#pragma warning restore CS0618 // Type or member is obsolete
             }
             return setupBuilder;
         }
@@ -69,9 +67,7 @@ namespace NLog
         /// </summary>
         public static ISetupInternalLoggerBuilder LogToFile(this ISetupInternalLoggerBuilder setupBuilder, string fileName)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             InternalLogger.LogFile = fileName;
-#pragma warning restore CS0618 // Type or member is obsolete
             return setupBuilder;
         }
 
@@ -80,9 +76,7 @@ namespace NLog
         /// </summary>
         public static ISetupInternalLoggerBuilder LogToConsole(this ISetupInternalLoggerBuilder setupBuilder, bool enabled)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             InternalLogger.LogToConsole = enabled;
-#pragma warning restore CS0618 // Type or member is obsolete
             return setupBuilder;
         }
 

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -233,9 +233,7 @@ namespace NLog.UnitTests.Common
             {
                 InternalLogger.LogLevel = LogLevel.Trace;
                 InternalLogger.IncludeTimestamp = false;
-#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogToConsole = true;
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 {
                     // Named (based on LogLevel) public methods.
@@ -297,9 +295,7 @@ namespace NLog.UnitTests.Common
 
                 InternalLogger.LogLevel = LogLevel.Trace;
                 InternalLogger.IncludeTimestamp = false;
-#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogToConsoleError = true;
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 {
                     // Named (based on LogLevel) public methods.
@@ -367,9 +363,7 @@ namespace NLog.UnitTests.Common
             {
                 InternalLogger.LogLevel = LogLevel.Trace;
                 InternalLogger.IncludeTimestamp = false;
-#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogFile = tempFile;
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 // Invoke Log(LogLevel, string) for every log level.
                 InternalLogger.Log(LogLevel.Warn, "WWW");
@@ -727,9 +721,7 @@ namespace NLog.UnitTests.Common
                 Assert.False(Directory.Exists(randomSubDirectory));
 
                 // Set the log file, which will only create the needed directories
-#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogFile = tempFile;
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 Assert.Equal(Directory.Exists(randomSubDirectory), shouldCreateDirectory);
 
@@ -767,9 +759,7 @@ namespace NLog.UnitTests.Common
                     "Info III" + Environment.NewLine;
 
             // Store off the previous log file
-#pragma warning disable CS0618 // Type or member is obsolete
             string previousLogFile = InternalLogger.LogFile;
-#pragma warning restore CS0618 // Type or member is obsolete
 
             var tempFileName = Path.GetRandomFileName();
 
@@ -781,9 +771,7 @@ namespace NLog.UnitTests.Common
                 Assert.False(File.Exists(tempFileName));
 
                 // Set the log file, which only has a filename
-#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogFile = tempFileName;
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 Assert.False(File.Exists(tempFileName));
 

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -233,7 +233,9 @@ namespace NLog.UnitTests.Common
             {
                 InternalLogger.LogLevel = LogLevel.Trace;
                 InternalLogger.IncludeTimestamp = false;
+#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogToConsole = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 {
                     // Named (based on LogLevel) public methods.
@@ -271,12 +273,14 @@ namespace NLog.UnitTests.Common
                     loggerScope.ConsoleOutputWriter.Flush();
                     loggerScope.ConsoleOutputWriter.GetStringBuilder().Length = 0;
 
+#pragma warning disable CS0618 // Type or member is obsolete
                     InternalLogger.Warn(() => "WWW");
                     InternalLogger.Error(() => "EEE");
                     InternalLogger.Fatal(() => "FFF");
                     InternalLogger.Trace(() => "TTT");
                     InternalLogger.Debug(() => "DDD");
                     InternalLogger.Info(() => "III");
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     TestWriter(expected, loggerScope.ConsoleOutputWriter);
                 }
@@ -293,7 +297,9 @@ namespace NLog.UnitTests.Common
 
                 InternalLogger.LogLevel = LogLevel.Trace;
                 InternalLogger.IncludeTimestamp = false;
+#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogToConsoleError = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 {
                     // Named (based on LogLevel) public methods.
@@ -330,12 +336,14 @@ namespace NLog.UnitTests.Common
                     loggerScope.ConsoleErrorWriter.Flush();
                     loggerScope.ConsoleErrorWriter.GetStringBuilder().Length = 0;
 
+#pragma warning disable CS0618 // Type or member is obsolete
                     InternalLogger.Warn(() => "WWW");
                     InternalLogger.Error(() => "EEE");
                     InternalLogger.Fatal(() => "FFF");
                     InternalLogger.Trace(() => "TTT");
                     InternalLogger.Debug(() => "DDD");
                     InternalLogger.Info(() => "III");
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     TestWriter(expected, loggerScope.ConsoleErrorWriter);
                 }
@@ -359,7 +367,9 @@ namespace NLog.UnitTests.Common
             {
                 InternalLogger.LogLevel = LogLevel.Trace;
                 InternalLogger.IncludeTimestamp = false;
+#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogFile = tempFile;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 // Invoke Log(LogLevel, string) for every log level.
                 InternalLogger.Log(LogLevel.Warn, "WWW");
@@ -508,12 +518,14 @@ namespace NLog.UnitTests.Common
 
                     // Named (based on LogLevel) public methods.
 
+#pragma warning disable CS0618 // Type or member is obsolete
                     InternalLogger.Warn(ex1, () => "WWW2");
                     InternalLogger.Error(ex2, () => "EEE2");
                     InternalLogger.Fatal(ex3, () => "FFF2");
                     InternalLogger.Trace(ex4, () => "TTT2");
                     InternalLogger.Debug(ex5, () => "DDD2");
                     InternalLogger.Info(ex6, () => "III2");
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     consoleOutWriter.Flush();
                     var strings = consoleOutWriter.ToString();
@@ -569,12 +581,14 @@ namespace NLog.UnitTests.Common
 
                     // Named (based on LogLevel) public methods.
 
+#pragma warning disable CS0618 // Type or member is obsolete
                     InternalLogger.Log(ex1, LogLevel.Warn, () => "WWW4");
                     InternalLogger.Log(ex2, LogLevel.Error, () => "EEE4");
                     InternalLogger.Log(ex3, LogLevel.Fatal, () => "FFF4");
                     InternalLogger.Log(ex4, LogLevel.Trace, () => "TTT4");
                     InternalLogger.Log(ex5, LogLevel.Debug, () => "DDD4");
                     InternalLogger.Log(ex6, LogLevel.Info, () => "III4");
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     var strings = consoleOutWriter.ToString();
                     Assert.Equal(expected, strings);
@@ -640,12 +654,14 @@ namespace NLog.UnitTests.Common
         {
             Action log = () =>
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.Fatal(() => "L1");
                 InternalLogger.Error(() => "L2");
                 InternalLogger.Warn(() => "L3");
                 InternalLogger.Info(() => "L4");
                 InternalLogger.Debug(() => "L5");
                 InternalLogger.Trace(() => "L6");
+#pragma warning restore CS0618 // Type or member is obsolete
             };
 
             TestMinLevelSwitch_inner(rawLogLevel, count, log);
@@ -711,7 +727,9 @@ namespace NLog.UnitTests.Common
                 Assert.False(Directory.Exists(randomSubDirectory));
 
                 // Set the log file, which will only create the needed directories
+#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogFile = tempFile;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 Assert.Equal(Directory.Exists(randomSubDirectory), shouldCreateDirectory);
 
@@ -749,7 +767,9 @@ namespace NLog.UnitTests.Common
                     "Info III" + Environment.NewLine;
 
             // Store off the previous log file
+#pragma warning disable CS0618 // Type or member is obsolete
             string previousLogFile = InternalLogger.LogFile;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var tempFileName = Path.GetRandomFileName();
 
@@ -761,7 +781,9 @@ namespace NLog.UnitTests.Common
                 Assert.False(File.Exists(tempFileName));
 
                 // Set the log file, which only has a filename
+#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogFile = tempFileName;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 Assert.False(File.Exists(tempFileName));
 
@@ -787,6 +809,7 @@ namespace NLog.UnitTests.Common
         }
 
         [Fact]
+        [Obsolete("Instead use InternalEventOccurred. Marked obsolete with NLog v5.3")]
         public void TestReceivedLogEventTest()
         {
             using (var loggerScope = new InternalLoggerScope())
@@ -816,6 +839,7 @@ namespace NLog.UnitTests.Common
         }
 
         [Fact]
+        [Obsolete("Instead use InternalEventOccurred. Marked obsolete with NLog v5.3")]
         public void TestReceivedLogEventThrowingTest()
         {
             using (var loggerScope = new InternalLoggerScope())
@@ -842,6 +866,7 @@ namespace NLog.UnitTests.Common
         }
 
         [Fact]
+        [Obsolete("Instead use InternalEventOccurred. Marked obsolete with NLog v5.3")]
         public void TestReceivedLogEventContextTest()
         {
             using (var loggerScope = new InternalLoggerScope())

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests_Trace.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests_Trace.cs
@@ -268,7 +268,9 @@ namespace NLog.UnitTests.Common
 
             if (logToTrace.HasValue)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogToTrace = logToTrace.Value;
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             T traceListener;

--- a/tests/NLog.UnitTests/Config/InternalLoggingTests.cs
+++ b/tests/NLog.UnitTests/Config/InternalLoggingTests.cs
@@ -66,26 +66,30 @@ namespace NLog.UnitTests.Config
             using (new InternalLoggerScope(true))
             {
                 InternalLogger.LogLevel = LogLevel.Error;
+#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogToConsole = true;
                 InternalLogger.LogToConsoleError = true;
+                InternalLogger.LogToTrace = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                 LogManager.GlobalThreshold = LogLevel.Fatal;
                 LogManager.ThrowExceptions = true;
                 LogManager.ThrowConfigExceptions = null;
                 LogManager.AutoShutdown = true;
-                InternalLogger.LogToTrace = true;
 
                 XmlLoggingConfiguration.CreateFromXmlString(@"
 <nlog>
 </nlog>");
 
                 Assert.Same(LogLevel.Error, InternalLogger.LogLevel);
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.True(InternalLogger.LogToConsole);
                 Assert.True(InternalLogger.LogToConsoleError);
+                Assert.True(InternalLogger.LogToTrace);
+#pragma warning restore CS0618 // Type or member is obsolete
                 Assert.Same(LogLevel.Fatal, LogManager.GlobalThreshold);
                 Assert.True(LogManager.ThrowExceptions);
                 Assert.Null(LogManager.ThrowConfigExceptions);
                 Assert.True(LogManager.AutoShutdown);
-                Assert.True(InternalLogger.LogToTrace);
             }
         }
 
@@ -161,19 +165,18 @@ namespace NLog.UnitTests.Config
 
                 Assert.Same(logLevel, InternalLogger.LogLevel);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Equal(file, InternalLogger.LogFile);
-
                 Assert.Equal(logToConsole, InternalLogger.LogToConsole);
-
                 Assert.Equal(logToConsoleError, InternalLogger.LogToConsoleError);
+                Assert.Equal(logToTrace, InternalLogger.LogToTrace);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 Assert.Same(globalThreshold, LogManager.GlobalThreshold);
 
                 Assert.Equal(throwExceptions, LogManager.ThrowExceptions);
 
                 Assert.Equal(throwConfigExceptions, LogManager.ThrowConfigExceptions);
-
-                Assert.Equal(logToTrace, InternalLogger.LogToTrace);
 
                 Assert.Equal(autoShutdown, LogManager.AutoShutdown);
             }

--- a/tests/NLog.UnitTests/Config/InternalLoggingTests.cs
+++ b/tests/NLog.UnitTests/Config/InternalLoggingTests.cs
@@ -66,9 +66,9 @@ namespace NLog.UnitTests.Config
             using (new InternalLoggerScope(true))
             {
                 InternalLogger.LogLevel = LogLevel.Error;
-#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogToConsole = true;
                 InternalLogger.LogToConsoleError = true;
+#pragma warning disable CS0618 // Type or member is obsolete
                 InternalLogger.LogToTrace = true;
 #pragma warning restore CS0618 // Type or member is obsolete
                 LogManager.GlobalThreshold = LogLevel.Fatal;
@@ -81,9 +81,9 @@ namespace NLog.UnitTests.Config
 </nlog>");
 
                 Assert.Same(LogLevel.Error, InternalLogger.LogLevel);
-#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.True(InternalLogger.LogToConsole);
                 Assert.True(InternalLogger.LogToConsoleError);
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.True(InternalLogger.LogToTrace);
 #pragma warning restore CS0618 // Type or member is obsolete
                 Assert.Same(LogLevel.Fatal, LogManager.GlobalThreshold);
@@ -165,10 +165,10 @@ namespace NLog.UnitTests.Config
 
                 Assert.Same(logLevel, InternalLogger.LogLevel);
 
-#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Equal(file, InternalLogger.LogFile);
                 Assert.Equal(logToConsole, InternalLogger.LogToConsole);
                 Assert.Equal(logToConsoleError, InternalLogger.LogToConsoleError);
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Equal(logToTrace, InternalLogger.LogToTrace);
 #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
+++ b/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
@@ -514,9 +514,7 @@ namespace NLog.UnitTests.Config
                 logFactory.Setup().SetupInternalLogger(b => b.LogToFile(logFile).SetMinimumLogLevel(LogLevel.Fatal));
 
                 // Assert
-#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Equal(logFile, InternalLogger.LogFile);
-#pragma warning restore CS0618 // Type or member is obsolete
             }
             finally
             {
@@ -537,9 +535,7 @@ namespace NLog.UnitTests.Config
                 logFactory.Setup().SetupInternalLogger(b => b.SetMinimumLogLevel(LogLevel.Fatal).LogToConsole(true));
 
                 // Assert
-#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.True(InternalLogger.LogToConsole);
-#pragma warning restore CS0618 // Type or member is obsolete
             }
             finally
             {

--- a/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
+++ b/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
@@ -514,7 +514,9 @@ namespace NLog.UnitTests.Config
                 logFactory.Setup().SetupInternalLogger(b => b.LogToFile(logFile).SetMinimumLogLevel(LogLevel.Fatal));
 
                 // Assert
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Equal(logFile, InternalLogger.LogFile);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             finally
             {
@@ -535,7 +537,9 @@ namespace NLog.UnitTests.Config
                 logFactory.Setup().SetupInternalLogger(b => b.SetMinimumLogLevel(LogLevel.Fatal).LogToConsole(true));
 
                 // Assert
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.True(InternalLogger.LogToConsole);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             finally
             {
@@ -556,7 +560,9 @@ namespace NLog.UnitTests.Config
                 logFactory.Setup().SetupInternalLogger(b => b.SetMinimumLogLevel(LogLevel.Fatal).LogToTrace(true));
 
                 // Assert
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.True(InternalLogger.LogToTrace);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             finally
             {
@@ -593,13 +599,13 @@ namespace NLog.UnitTests.Config
                 // Arrange
                 InternalLogger.Reset();
                 var logFactory = new LogFactory();
-                InternalLogger.LogToConsole = true;
+                InternalLogger.IncludeTimestamp = false;
 
                 // Act
                 logFactory.Setup().SetupInternalLogger(b => b.SetupFromEnvironmentVariables().SetMinimumLogLevel(LogLevel.Fatal));
 
                 // Assert
-                Assert.False(InternalLogger.LogToConsole);
+                Assert.True(InternalLogger.IncludeTimestamp);
                 Assert.Equal(LogLevel.Fatal, InternalLogger.LogLevel);
             }
             finally

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -53,11 +53,9 @@ namespace NLog.UnitTests.Config
 
                 Assert.False(config.AutoReload);
                 Assert.True(config.InitializeSucceeded);
-#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Equal("", InternalLogger.LogFile);
                 Assert.False(InternalLogger.LogToConsole);
                 Assert.False(InternalLogger.LogToConsoleError);
-#pragma warning restore CS0618 // Type or member is obsolete
                 Assert.True(InternalLogger.IncludeTimestamp);
                 Assert.Null(InternalLogger.LogWriter);
                 Assert.Equal(LogLevel.Off, InternalLogger.LogLevel);
@@ -76,11 +74,9 @@ namespace NLog.UnitTests.Config
 
                     Assert.False(config.AutoReload);
                     Assert.True(config.InitializeSucceeded);
-#pragma warning disable CS0618 // Type or member is obsolete
                     Assert.Equal("", InternalLogger.LogFile);
                     Assert.True(InternalLogger.LogToConsole);
                     Assert.True(InternalLogger.LogToConsoleError);
-#pragma warning restore CS0618 // Type or member is obsolete
                     Assert.False(InternalLogger.IncludeTimestamp);
                     Assert.Null(InternalLogger.LogWriter);
                     Assert.Equal(LogLevel.Info, InternalLogger.LogLevel);
@@ -95,27 +91,21 @@ namespace NLog.UnitTests.Config
             {
                 var xml = "<nlog internalLogFile='${CurrentDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
-#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(System.IO.Directory.GetCurrentDirectory(), InternalLogger.LogFile);
-#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             using (new InternalLoggerScope())
             {
                 var xml = "<nlog internalLogFile='${BaseDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
-#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(AppDomain.CurrentDomain.BaseDirectory, InternalLogger.LogFile);
-#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             using (new InternalLoggerScope())
             {
                 var xml = "<nlog internalLogFile='${TempDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
-#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(System.IO.Path.GetTempPath(), InternalLogger.LogFile);
-#pragma warning restore CS0618 // Type or member is obsolete
             }
 
 #if !NETSTANDARD1_3
@@ -123,9 +113,7 @@ namespace NLog.UnitTests.Config
             {
                 var xml = "<nlog internalLogFile='${ProcessDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
-#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(Path.GetDirectoryName(CurrentProcessPath), InternalLogger.LogFile);
-#pragma warning restore CS0618 // Type or member is obsolete
             }
 #endif
 
@@ -134,27 +122,21 @@ namespace NLog.UnitTests.Config
             {
                 var xml = "<nlog internalLogFile='${CommonApplicationDataDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
-#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), InternalLogger.LogFile);
-#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             using (new InternalLoggerScope())
             {
                 var xml = "<nlog internalLogFile='${UserApplicationDataDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
-#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), InternalLogger.LogFile);
-#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             using (new InternalLoggerScope())
             {
                 var xml = "<nlog internalLogFile='${UserLocalApplicationDataDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
-#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), InternalLogger.LogFile);
-#pragma warning restore CS0618 // Type or member is obsolete
             }
 #endif
 
@@ -164,9 +146,7 @@ namespace NLog.UnitTests.Config
                 var xml = "<nlog internalLogFile='%USERNAME%_test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
                 if (!string.IsNullOrEmpty(userName))
-#pragma warning disable CS0618 // Type or member is obsolete
                     Assert.Contains(userName, InternalLogger.LogFile);
-#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -53,10 +53,12 @@ namespace NLog.UnitTests.Config
 
                 Assert.False(config.AutoReload);
                 Assert.True(config.InitializeSucceeded);
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Equal("", InternalLogger.LogFile);
-                Assert.True(InternalLogger.IncludeTimestamp);
                 Assert.False(InternalLogger.LogToConsole);
                 Assert.False(InternalLogger.LogToConsoleError);
+#pragma warning restore CS0618 // Type or member is obsolete
+                Assert.True(InternalLogger.IncludeTimestamp);
                 Assert.Null(InternalLogger.LogWriter);
                 Assert.Equal(LogLevel.Off, InternalLogger.LogLevel);
             }
@@ -74,10 +76,12 @@ namespace NLog.UnitTests.Config
 
                     Assert.False(config.AutoReload);
                     Assert.True(config.InitializeSucceeded);
+#pragma warning disable CS0618 // Type or member is obsolete
                     Assert.Equal("", InternalLogger.LogFile);
-                    Assert.False(InternalLogger.IncludeTimestamp);
                     Assert.True(InternalLogger.LogToConsole);
                     Assert.True(InternalLogger.LogToConsoleError);
+#pragma warning restore CS0618 // Type or member is obsolete
+                    Assert.False(InternalLogger.IncludeTimestamp);
                     Assert.Null(InternalLogger.LogWriter);
                     Assert.Equal(LogLevel.Info, InternalLogger.LogLevel);
                 }
@@ -91,21 +95,27 @@ namespace NLog.UnitTests.Config
             {
                 var xml = "<nlog internalLogFile='${CurrentDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(System.IO.Directory.GetCurrentDirectory(), InternalLogger.LogFile);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             using (new InternalLoggerScope())
             {
                 var xml = "<nlog internalLogFile='${BaseDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(AppDomain.CurrentDomain.BaseDirectory, InternalLogger.LogFile);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             using (new InternalLoggerScope())
             {
                 var xml = "<nlog internalLogFile='${TempDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(System.IO.Path.GetTempPath(), InternalLogger.LogFile);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
 #if !NETSTANDARD1_3
@@ -113,7 +123,9 @@ namespace NLog.UnitTests.Config
             {
                 var xml = "<nlog internalLogFile='${ProcessDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(Path.GetDirectoryName(CurrentProcessPath), InternalLogger.LogFile);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 #endif
 
@@ -122,21 +134,27 @@ namespace NLog.UnitTests.Config
             {
                 var xml = "<nlog internalLogFile='${CommonApplicationDataDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), InternalLogger.LogFile);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             using (new InternalLoggerScope())
             {
                 var xml = "<nlog internalLogFile='${UserApplicationDataDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), InternalLogger.LogFile);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             using (new InternalLoggerScope())
             {
                 var xml = "<nlog internalLogFile='${UserLocalApplicationDataDir}test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Contains(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), InternalLogger.LogFile);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 #endif
 
@@ -146,7 +164,9 @@ namespace NLog.UnitTests.Config
                 var xml = "<nlog internalLogFile='%USERNAME%_test.txt'></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
                 if (!string.IsNullOrEmpty(userName))
+#pragma warning disable CS0618 // Type or member is obsolete
                     Assert.Contains(userName, InternalLogger.LogFile);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 

--- a/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
+++ b/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
@@ -159,8 +159,10 @@ namespace NLog.UnitTests.Internal
             {
                 LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(configXml);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 //this method gave issues
                 LogFactory.LogNLogAssemblyVersion();
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 var logger = LogManager.GetLogger("NLog.UnitTests.Targets.FileTargetTests");
 

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -553,7 +553,9 @@ namespace NLog.UnitTests
 
             public void Dispose()
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 var logFile = InternalLogger.LogFile;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 InternalLogger.Reset();
                 LogManager.GlobalThreshold = globalThreshold;
@@ -565,13 +567,7 @@ namespace NLog.UnitTests
                 if (ConsoleErrorWriter != null)
                     Console.SetError(oldConsoleErrorWriter);
 
-                if (!string.IsNullOrEmpty(InternalLogger.LogFile))
-                {
-                    if (File.Exists(InternalLogger.LogFile))
-                        File.Delete(InternalLogger.LogFile);
-                }
-
-                if (!string.IsNullOrEmpty(logFile) && logFile != InternalLogger.LogFile)
+                if (!string.IsNullOrEmpty(logFile))
                 {
                     if (File.Exists(logFile))
                         File.Delete(logFile);

--- a/tests/NLog.UnitTests/NLogTestBase.cs
+++ b/tests/NLog.UnitTests/NLogTestBase.cs
@@ -553,9 +553,7 @@ namespace NLog.UnitTests
 
             public void Dispose()
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 var logFile = InternalLogger.LogFile;
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 InternalLogger.Reset();
                 LogManager.GlobalThreshold = globalThreshold;


### PR DESCRIPTION
- [x] Waiting for NLog v5.3

Just like LogFactory should be platform-independent (Not require console or filesystem), then the same goes for InternalLogger.

Seems it is enough to just disconnect InternalLogger from the actual console- and file-writing (changed to subscription-logic). So now it is only when directly using `LogToConsole`- or `LogFile`-property, that the penalty comes.