### PR TITLE
LogManager GetCurrentClassLogger fallback to assembly-name when no namespace

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 5.0.0-{build} # Only change for mayor versions (e.g. 6.0)
 image:
   - Visual Studio 2022
-  - Previous Ubuntu
+  - Ubuntu2004
 configuration: Release
 build: false
 test: false
@@ -54,7 +54,7 @@ for:
   -
     matrix:
       only:
-        - image: Previous Ubuntu
+        - image: Ubuntu2004
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       FrameworkPathOverride: /usr/lib/mono/4.6.1-api/

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSite/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSite/CallSiteTests.cs
@@ -139,7 +139,7 @@ namespace NLog.UnitTests.LayoutRenderers
             string lastMessage = GetDebugLastMessage("debug", logFactory);
             // There's a difference in handling line numbers between .NET and Mono
             // We're just interested in checking if it's above 100000
-            Assert.Contains("callsitetests.cs:" + linenumber, lastMessage); // Expected prefix of 10000
+            Assert.Contains("callsitetests.cs:" + linenumber, lastMessage.ToLowerInvariant()); // Expected prefix of 10000
 #if DEBUG
 #line default
 #endif


### PR DESCRIPTION
- [ ] Waiting for NLog v5.3 (Since breaking behavior change)

To improve this use-case with NET6/NET7/NET8 (not specifying any namespace):
```
using NLog;

var logger = LogManager.GetCurrentClassLogger();
```
Fallback to Assembly-Name when caller-method is missing namespace.