### PR TITLE
LogFactory - Disconnect from Target write and Target flush

### DIFF
--- a/src/NLog/Internal/ITargetWithFilterChain.cs
+++ b/src/NLog/Internal/ITargetWithFilterChain.cs
@@ -1,0 +1,42 @@
+﻿// 
+// Copyright (c) 2004-2021 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the following disclaimer. 
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution. 
+// 
+// * Neither the name of Jaroslaw Kowalski nor the names of its 
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+// THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+namespace NLog.Internal
+{
+    using System;
+
+    internal interface ITargetWithFilterChain
+    {
+        void WriteToLoggerTargets(Type loggerType, LogEventInfo logEvent, LogFactory logFactory);
+    }
+}

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -50,7 +50,6 @@ namespace NLog
     using NLog.Config;
     using NLog.Internal;
     using NLog.Internal.Fakeables;
-    using NLog.Targets;
 
     /// <summary>
     /// Creates and manages instances of <see cref="NLog.Logger" /> objects.
@@ -668,142 +667,33 @@ namespace NLog
             FlushInternal(timeout, asyncContinuation ?? (ex => { }));
         }
 
-        private void FlushInternal(TimeSpan timeout, AsyncContinuation asyncContinuation)
+        private void FlushInternal(TimeSpan flushTimeout, AsyncContinuation asyncContinuation)
         {
+            InternalLogger.Debug("LogFactory Flush with timeout={0} secs", flushTimeout.TotalSeconds);
+
             try
             {
-                InternalLogger.Debug("LogFactory Flush with timeout={0} secs", timeout.TotalSeconds);
                 LoggingConfiguration config;
                 lock (_syncRoot)
                 {
                     config = _config; // Flush should not attempt to auto-load Configuration
                 }
-
-                if (config != null)
-                {
-                    if (asyncContinuation != null)
-                    {
-                        FlushAllTargetsAsync(config, asyncContinuation, timeout);
-                    }
-                    else
-                    {
-                        if (FlushAllTargetsSync(config, timeout, ThrowExceptions))
-                            return;
-                    }
-                }
-                else
+                if (config is null)
                 {
                     asyncContinuation?.Invoke(null);
                 }
+                else
+                {
+                    config.FlushAllTargets(flushTimeout, asyncContinuation, ThrowExceptions);
+                }
             }
             catch (Exception ex)
             {
-                if (ThrowExceptions)
-                {
-                    throw;
-                }
 
                 InternalLogger.Error(ex, "LogFactory failed to flush targets.");
                 asyncContinuation?.Invoke(ex);
+
             }
-        }
-
-        /// <summary>
-        /// Flushes any pending log messages on all appenders.
-        /// </summary>
-        /// <param name="loggingConfiguration">Config containing Targets to Flush</param>
-        /// <param name="asyncContinuation">Flush completed notification (success / timeout)</param>
-        /// <param name="asyncTimeout">Optional timeout that guarantees that completed notification is called.</param>
-        /// <returns></returns>
-        private static AsyncContinuation FlushAllTargetsAsync(LoggingConfiguration loggingConfiguration, AsyncContinuation asyncContinuation, TimeSpan? asyncTimeout)
-        {
-            var pendingTargets = loggingConfiguration.GetAllTargetsToFlush();
-
-            AsynchronousAction<Target> flushAction = (target, cont) =>
-            {
-                target.Flush(ex =>
-                {
-                    if (ex != null)
-                        InternalLogger.Warn(ex, "Flush failed for target {0}(Name={1})", target.GetType(), target.Name);
-                    lock (pendingTargets)
-                    {
-                        pendingTargets.Remove(target);
-                    }
-                    cont(ex);
-                });
-            };
-            AsyncContinuation flushContinuation = (ex) =>
-            {
-                lock (pendingTargets)
-                {
-                    foreach (var pendingTarget in pendingTargets)
-                        InternalLogger.Debug("Flush timeout for target {0}(Name={1})", pendingTarget.GetType(), pendingTarget.Name);
-                    pendingTargets.Clear();
-                }
-                if (ex != null)
-                    InternalLogger.Warn(ex, "Flush completed with errors");
-                else
-                    InternalLogger.Debug("Flush completed");
-                asyncContinuation(ex);
-            };
-
-            if (asyncTimeout.HasValue)
-            {
-                flushContinuation = AsyncHelpers.WithTimeout(flushContinuation, asyncTimeout.Value);
-            }
-            else
-            {
-                flushContinuation = AsyncHelpers.PreventMultipleCalls(flushContinuation);
-            }
-
-            InternalLogger.Trace("Flushing all {0} targets...", pendingTargets.Count);
-            AsyncHelpers.ForEachItemInParallel(pendingTargets, flushContinuation, flushAction);
-            return flushContinuation;
-        }
-
-        private static bool FlushAllTargetsSync(LoggingConfiguration oldConfig, TimeSpan timeout, bool throwExceptions)
-        {
-            Exception lastException = null;
-
-            try
-            {
-                ManualResetEvent flushCompletedEvent = new ManualResetEvent(false);
-
-                var flushContinuation = FlushAllTargetsAsync(oldConfig, (ex) =>
-                {
-                    if (ex != null)
-                        lastException = ex;
-                    flushCompletedEvent.Set();
-                }, null);
-
-                bool flushCompleted = flushCompletedEvent.WaitOne(timeout);
-                if (!flushCompleted)
-                    flushContinuation(new TimeoutException($"Timeout when flushing all targets, after waiting {timeout.TotalSeconds} seconds."));
-            }
-            catch (Exception ex)
-            {
-#if DEBUG
-                if (ex.MustBeRethrownImmediately())
-                    throw;  // Throwing exceptions here might crash the entire application (.NET 2.0 behavior)
-#endif
-
-                InternalLogger.Error(ex, "LogFactory failed to flush targets.");
-
-                if (throwExceptions)
-                    throw new NLogRuntimeException("Asynchronous exception has occurred.", ex);
-
-                return false;
-            }
-
-            if (lastException != null)
-            {
-                if (throwExceptions)
-                    throw new NLogRuntimeException("Asynchronous exception has occurred.", lastException);
-                else
-                    return false;
-            }
-
-            return true;
         }
 
         /// <summary>
@@ -889,54 +779,18 @@ namespace NLog
         }
 #endif
 
+        /// <summary>
+        /// Change this method with NLog v6 to completely disconnect LogFactory from Targets/Layouts
+        /// - Remove LoggingRule-List-parameter
+        /// - Return ITargetWithFilterChain[]
+        /// </summary>
         internal TargetWithFilterChain[] BuildLoggerConfiguration(string loggerName, List<LoggingRule> loggingRules)
         {
-            var targetsByLevel = TargetWithFilterChain.BuildLoggerConfiguration(loggerName, loggingRules, IsLoggingEnabled() ? GlobalThreshold : LogLevel.Off);
-            if (InternalLogger.IsDebugEnabled && !DumpTargetConfigurationForLogger(loggerName, targetsByLevel))
-            {
-                InternalLogger.Debug("Targets not configured for Logger: {0}", loggerName);
-            }
-            return targetsByLevel;
+            var globalThreshold = IsLoggingEnabled() ? GlobalThreshold : LogLevel.Off;
+            return _config?.BuildLoggerConfiguration(loggerName, globalThreshold, loggingRules) ?? TargetWithFilterChain.NoTargetsByLevel;
         }
 
-        private static bool DumpTargetConfigurationForLogger(string loggerName, TargetWithFilterChain[] targetsByLevel)
-        {
-            if (ReferenceEquals(targetsByLevel, TargetWithFilterChain.NoTargetsByLevel))
-                return false;
-
-            StringBuilder sb = null;
-            for (int i = 0; i <= LogLevel.MaxLevel.Ordinal; ++i)
-            {
-                if (sb != null)
-                {
-                    sb.Length = 0;
-                    sb.AppendFormat(CultureInfo.InvariantCulture, "Logger {0} [{1}] =>", loggerName, LogLevel.FromOrdinal(i));
-                }
-
-                for (TargetWithFilterChain afc = targetsByLevel[i]; afc != null; afc = afc.NextInChain)
-                {
-                    if (sb is null)
-                    {
-                        InternalLogger.Debug("Targets configured when LogLevel >= {0} for Logger: {1}", LogLevel.FromOrdinal(i), loggerName);
-                        sb = new StringBuilder();
-                        sb.AppendFormat(CultureInfo.InvariantCulture, "Logger {0} [{1}] =>", loggerName, LogLevel.FromOrdinal(i));
-                    }
-
-                    sb.AppendFormat(CultureInfo.InvariantCulture, " {0}", afc.Target.Name);
-                    if (afc.FilterChain.Count > 0)
-                    {
-                        sb.AppendFormat(CultureInfo.InvariantCulture, " ({0} filters)", afc.FilterChain.Count);
-                    }
-                }
-
-                if (sb != null)
-                    InternalLogger.Debug(sb.ToString());
-            }
-
-            return sb != null;
-        }
-
-        /// <summary>
+         /// <summary>
         /// Currently this <see cref="LogFactory"/> is disposing?
         /// </summary>
         private bool _isDisposing;
@@ -986,7 +840,7 @@ namespace NLog
 
                 if (flushTimeout > TimeSpan.Zero)
                 {
-                    attemptClose = FlushAllTargetsSync(oldConfig, flushTimeout, false);
+                    attemptClose = oldConfig.FlushAllTargets(flushTimeout, null, false);
                 }
 
                 // Disable all loggers, so things become quiet
@@ -1001,8 +855,9 @@ namespace NLog
                 {
                     // Flush completed within timeout, lets try and close down
                     oldConfig.Close();
-                    OnConfigurationChanged(new LoggingConfigurationChangedEventArgs(null, oldConfig));
                 }
+
+                OnConfigurationChanged(new LoggingConfigurationChangedEventArgs(null, oldConfig));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Allow AOT tree-shake when just using `LogManager.GetCurrentClassLogger().Info("Hello")`

Using NLog Logger in library-project should not invite NLog Target- and NLog Layout-dependency-tree.

This is just an incremental step toward the goal. The final step will be with NLog v6.