### PR TITLE
RegEx IsMatch is faster with RegexOptions.ExplicitCapture to skip capture

### DIFF
--- a/src/NLog/Conditions/ConditionMethods.cs
+++ b/src/NLog/Conditions/ConditionMethods.cs
@@ -129,7 +129,7 @@ namespace NLog.Conditions
         [ConditionMethod("regex-matches")]
         public static bool RegexMatches(string input, string pattern, [Optional, DefaultParameterValue("")] string options)
         {
-            RegexOptions regexOpts = ParseRegexOptions(options);
+            RegexOptions regexOpts = ParseRegexOptions(options) | RegexOptions.ExplicitCapture;
             return Regex.IsMatch(input, pattern, regexOpts);
         }
 

--- a/src/NLog/Config/LoggerNameMatcher.cs
+++ b/src/NLog/Config/LoggerNameMatcher.cs
@@ -246,7 +246,7 @@ namespace NLog.Config
             public MultiplePatternLoggerNameMatcher(string pattern) 
                 : base(pattern, ConvertToRegex(pattern))
             {
-                _regex = new Regex(_matchingArgument, RegexOptions.CultureInvariant);
+                _regex = new Regex(_matchingArgument, RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture);
             }
             public override bool NameMatches(string loggerName)
             {


### PR DESCRIPTION
Capturing groups that are not subsequently used can be expensive, because the regular expression engine must populate both the [GroupCollection](https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.groupcollection) and [CaptureCollection](https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.capturecollection) collection objects. As an alternative, you can use either the [RegexOptions.ExplicitCapture](https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regexoptions#system-text-regularexpressions-regexoptions-explicitcapture) option or the n inline option to specify that the only valid captures are explicitly named or numbered groups that are designated by the (?<name> subexpression) construct.

See also: https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options#explicit-captures-only