### PR TITLE
StringBuilderPool - Reduce MaxCapacity to avoid Large Object Heap

### DIFF
--- a/src/NLog/Internal/ObjectPools/ReusableAsyncLogEventList.cs
+++ b/src/NLog/Internal/ObjectPools/ReusableAsyncLogEventList.cs
@@ -42,8 +42,8 @@ namespace NLog.Internal
     /// </summary>
     internal sealed class ReusableAsyncLogEventList : ReusableObjectCreator<IList<AsyncLogEventInfo>>
     {
-        public ReusableAsyncLogEventList(int capacity)
-            :base(capacity, (cap) => new List<AsyncLogEventInfo>(cap), (l) => l.Clear())
+        public ReusableAsyncLogEventList(int intialCapacity)
+            : base(() => new List<AsyncLogEventInfo>(intialCapacity), (l) => l.Clear())
         {
         }
     }

--- a/src/NLog/Internal/ObjectPools/ReusableBufferCreator.cs
+++ b/src/NLog/Internal/ObjectPools/ReusableBufferCreator.cs
@@ -38,8 +38,8 @@ namespace NLog.Internal
     /// </summary>
     internal sealed class ReusableBufferCreator : ReusableObjectCreator<char[]>
     {
-        public ReusableBufferCreator(int capacity)
-            :base(capacity, cap => new char[cap], (b) => { })
+        public ReusableBufferCreator(int intialCapacity)
+            : base(() => new char[intialCapacity], (b) => { })
         {
         }
     }

--- a/src/NLog/Internal/ObjectPools/ReusableBuilderCreator.cs
+++ b/src/NLog/Internal/ObjectPools/ReusableBuilderCreator.cs
@@ -40,9 +40,22 @@ namespace NLog.Internal
     /// </summary>
     internal sealed class ReusableBuilderCreator : ReusableObjectCreator<StringBuilder>
     {
+        const int MaxBuilderCapacity = 40960;   // Avoid Large-Object-Heap (LOH)
+
         public ReusableBuilderCreator()
-            : base(128, (cap) => new StringBuilder(cap), (sb) => { sb.ClearBuilder(); })
+            : base(() => new StringBuilder(128), (sb) => ResetCapacity(sb))
         {
+        }
+
+        private static void ResetCapacity(StringBuilder stringBuilder)
+        {
+            if (stringBuilder.Length > MaxBuilderCapacity && stringBuilder.Capacity > MaxBuilderCapacity * 10)
+            {
+                stringBuilder.Remove(0, stringBuilder.Length - 1);  // Attempt soft clear that skips re-allocation
+                stringBuilder.Capacity = MaxBuilderCapacity;
+            }
+
+            stringBuilder.ClearBuilder();
         }
     }
 }

--- a/src/NLog/Internal/ObjectPools/ReusableObjectCreator.cs
+++ b/src/NLog/Internal/ObjectPools/ReusableObjectCreator.cs
@@ -42,15 +42,13 @@ namespace NLog.Internal
     {
         protected T _reusableObject;
         private readonly Action<T> _clearObject;
-        private readonly Func<int, T> _createObject;
-        private readonly int _initialCapacity;
+        private readonly Func<T> _createObject;
 
-        protected ReusableObjectCreator(int initialCapacity, Func<int, T> createObject, Action<T> clearObject)
+        protected ReusableObjectCreator(Func<T> createObject, Action<T> clearObject)
         {
-            _reusableObject = createObject(initialCapacity);
+            _reusableObject = createObject();
             _clearObject = clearObject;
             _createObject = createObject;
-            _initialCapacity = initialCapacity;
         }
 
         /// <summary>
@@ -59,7 +57,7 @@ namespace NLog.Internal
         /// <returns>Handle to the reusable item, that can release it again</returns>
         public LockOject Allocate()
         {
-            var reusableObject = _reusableObject ?? _createObject(_initialCapacity);
+            var reusableObject = _reusableObject ?? _createObject();
             System.Diagnostics.Debug.Assert(_reusableObject != null);
             _reusableObject = null;
             return new LockOject(this, reusableObject);

--- a/src/NLog/Internal/ObjectPools/ReusableStreamCreator.cs
+++ b/src/NLog/Internal/ObjectPools/ReusableStreamCreator.cs
@@ -32,17 +32,43 @@
 // 
 
 using System;
+using System.IO;
 
 namespace NLog.Internal
 {
     /// <summary>
     /// Controls a single allocated MemoryStream for reuse (only one active user)
     /// </summary>
-    internal sealed class ReusableStreamCreator : ReusableObjectCreator<System.IO.MemoryStream>, IDisposable
+    internal sealed class ReusableStreamCreator : ReusableObjectCreator<MemoryStream>, IDisposable
     {
-        public ReusableStreamCreator(int capacity)
-            :base(capacity, (cap) => new System.IO.MemoryStream(cap), (m) => { m.Position = 0; m.SetLength(0); })
+        public ReusableStreamCreator()
+            : base(() => new MemoryStream(4096), (ms) => ResetCapacity(ms))
         {
+        }
+
+        public ReusableStreamCreator(bool batchStream)
+            : base(() => new MemoryStream(4096), (ms) => ResetBatchCapacity(ms))
+        {
+        }
+
+        static void ResetCapacity(MemoryStream memoryStream)
+        {
+            memoryStream.Position = 0;
+            memoryStream.SetLength(0);
+            if (memoryStream.Capacity > 1000000)
+            {
+                memoryStream.Capacity = 81920;  // Avoid Large-Object-Heap (LOH)
+            }
+        }
+
+        static void ResetBatchCapacity(MemoryStream memoryStream)
+        {
+            memoryStream.Position = 0;
+            memoryStream.SetLength(0);
+            if (memoryStream.Capacity > 10000000)
+            {
+                memoryStream.Capacity = 81920;  // Avoid Large-Object-Heap (LOH)
+            }
         }
 
         void IDisposable.Dispose()

--- a/src/NLog/Internal/ObjectPools/StringBuilderPool.cs
+++ b/src/NLog/Internal/ObjectPools/StringBuilderPool.cs
@@ -49,7 +49,7 @@ namespace NLog.Internal
         /// <param name="poolCapacity">Max number of items</param>
         /// <param name="initialBuilderCapacity">Initial StringBuilder Size</param>
         /// <param name="maxBuilderCapacity">Max StringBuilder Size</param>
-        public StringBuilderPool(int poolCapacity, int initialBuilderCapacity = 1024, int maxBuilderCapacity = 512 * 1024)
+        public StringBuilderPool(int poolCapacity, int initialBuilderCapacity = 1024, int maxBuilderCapacity = 40 * 1024)
         {
             _fastPool = new StringBuilder(10 * initialBuilderCapacity);
             _slowPool = new StringBuilder[poolCapacity];
@@ -100,7 +100,7 @@ namespace NLog.Internal
                     stringBuilder.Remove(0, stringBuilder.Length - 1);  // Attempt soft clear that skips re-allocation
                     if (stringBuilder.Capacity > maxBuilderCapacity)
                     {
-                        stringBuilder = new StringBuilder(maxBuilderCapacity / 2);
+                        stringBuilder.Capacity = _maxBuilderCapacity;
                     }
                 }
             }

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -971,8 +971,8 @@ namespace NLog.Targets
             }
         }
 
-        private readonly ReusableStreamCreator _reusableFileWriteStream = new ReusableStreamCreator(4096);
-        private readonly ReusableStreamCreator _reusableAsyncFileWriteStream = new ReusableStreamCreator(4096);
+        private readonly ReusableStreamCreator _reusableFileWriteStream = new ReusableStreamCreator();
+        private readonly ReusableStreamCreator _reusableBatchFileWriteStream = new ReusableStreamCreator(true);
         private readonly ReusableBufferCreator _reusableEncodingBuffer = new ReusableBufferCreator(1024);
 
         /// <summary>
@@ -988,7 +988,7 @@ namespace NLog.Targets
                 throw new ArgumentException("The path is not of a legal form.");
             }
 
-            using (var targetStream = _reusableFileWriteStream.Allocate())
+            using (var targetStream = _reusableBatchFileWriteStream.Allocate())
             {
                 using (var targetBuilder = ReusableLayoutBuilder.Allocate())
                 using (var targetBuffer = _reusableEncodingBuffer.Allocate())
@@ -1038,7 +1038,7 @@ namespace NLog.Targets
 
             var buckets = logEvents.BucketSort(_getFullFileNameDelegate);
 
-            using (var reusableStream = _reusableAsyncFileWriteStream.Allocate())
+            using (var reusableStream = _reusableBatchFileWriteStream.Allocate())
             {
                 var ms = reusableStream.Result ?? new MemoryStream();
 

--- a/tests/NLog.UnitTests/Internal/StringBuilderPoolTests.cs
+++ b/tests/NLog.UnitTests/Internal/StringBuilderPoolTests.cs
@@ -43,17 +43,17 @@ namespace NLog.UnitTests.Internal
         {
             int poolItemCount = 10;
             NLog.Internal.StringBuilderPool pool = new NLog.Internal.StringBuilderPool(poolItemCount);
-            string mediumPayload = new string('A', 300000);
+            string mediumPayload = new string('A', 40 * 1024);
             RecursiveAcquirePoolItems(poolItemCount, pool, mediumPayload, true);        // Verify fast-pool + slow-pool must grow
             RecursiveAcquirePoolItems(poolItemCount, pool, mediumPayload, false);       // Verify fast-pool + slow-pool has kept their capacity
 
-            string largePayload = new string('A', 1000000);
+            string largePayload = new string('A', 400000);
             RecursiveAcquirePoolItems(poolItemCount, pool, largePayload, true);
             using (var itemHolder = pool.Acquire())
             {
                 Assert.Equal(0, itemHolder.Item.Length);
-                Assert.True(largePayload.Length <= itemHolder.Item.Capacity);           // Verify fast-pool has kept its capacity
-                RecursiveAcquirePoolItems(poolItemCount, pool, mediumPayload, true);    // Verify slow-pool must grow
+                Assert.True(largePayload.Length <= itemHolder.Item.Capacity);               // Verify fast-pool has kept its capacity
+                RecursiveAcquirePoolItems(poolItemCount, pool, mediumPayload + "A", true);  // Verify slow-pool has reset its capacity
             }
         }
 


### PR DESCRIPTION
Still allow "primary" StringBuilder to be a little larger.

Also adjusted `ReusableStreamCreator` to discard/release large `MemoryStream`-objects, after having handled single huge LogEvent.

Also adjusted `ReusableBuilderCreator` to discard/release large `StringBuilder`-objects, after having handled single huge LogEvent.

My suggestion for #5548 where single FileTarget will max hold a single MemoryStream of 10 MByte