### PR TITLE
TargetWithContext - Skip caching when render value for ContextProperties

### DIFF
--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -195,12 +195,18 @@ namespace NLog.Layouts
         /// <returns>The formatted output as string.</returns>
         public string Render(LogEventInfo logEvent)
         {
+            return Render(logEvent, true);
+        }
+
+        internal string Render(LogEventInfo logEvent, bool cacheLayoutResult)
+        {
             if (!IsInitialized)
             {
                 Initialize(LoggingConfiguration);
             }
 
-            if (!ThreadAgnostic || ThreadAgnosticImmutable)
+            bool lookupCacheLayout = !ThreadAgnostic || ThreadAgnosticImmutable;
+            if (lookupCacheLayout)
             {
                 object cachedValue;
                 if (logEvent.TryGetCachedLayoutValue(this, out cachedValue))
@@ -210,7 +216,7 @@ namespace NLog.Layouts
             }
 
             string layoutValue = GetFormattedMessage(logEvent) ?? string.Empty;
-            if (!ThreadAgnostic || ThreadAgnosticImmutable)
+            if (lookupCacheLayout && cacheLayoutResult)
             {
                 // Would be nice to only do this in Precalculate(), but we need to ensure internal cache
                 // is updated for custom Layouts that overrides Precalculate (without calling base.Precalculate)

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -284,7 +284,7 @@ namespace NLog.Layouts
         {
             if (_innerLayout is SimpleLayout simpleLayout && simpleLayout.IsSimpleStringText)
             {
-                return simpleLayout.Render(logEvent);
+                return simpleLayout.Render(logEvent, false);
             }
 
             if (stringBuilder?.Length == 0)

--- a/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
+++ b/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
@@ -184,15 +184,15 @@ namespace NLog.Layouts
                 var defaultValue = GetTypedDefaultValue();
                 return _typedLayout.RenderValue(logEvent, defaultValue);
             }
-            else if (layout != null)
+
+            if (layout != null)
             {
-                var valueType = _valueType ?? (_valueType = ValueType ?? typeof(string));
-                if (valueType == typeof(object) && layout.TryGetRawValue(logEvent, out var rawValue))
+                if (typeof(object).Equals(ValueType) && layout.TryGetRawValue(logEvent, out var rawValue))
                 {
                     return rawValue;
                 }
 
-                var stringValue = layout.Render(logEvent);
+                string stringValue = layout.Render(logEvent, false);
                 if (string.IsNullOrEmpty(stringValue))
                 {
                     return GetTypedDefaultValue();
@@ -200,10 +200,8 @@ namespace NLog.Layouts
 
                 return stringValue;
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
 
         private object GetTypedDefaultValue()

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -681,20 +681,14 @@ namespace NLog.Targets
             if (layout is null || logEvent is null)
                 return null;    // Signal that input was wrong
 
-            SimpleLayout simpleLayout = layout as SimpleLayout;
-            if (simpleLayout != null && simpleLayout.IsFixedText)
+            if (layout is SimpleLayout simpleLayout && (simpleLayout.IsFixedText || simpleLayout.IsSimpleStringText))
             {
-                return simpleLayout.Render(logEvent);
+                return simpleLayout.Render(logEvent, false);
             }
 
             if (TryGetCachedValue(layout, logEvent, out var value))
             {
                 return value?.ToString() ?? string.Empty;
-            }
-
-            if (simpleLayout != null && simpleLayout.IsSimpleStringText)
-            {
-                return simpleLayout.Render(logEvent);
             }
 
             using (var localTarget = ReusableLayoutBuilder.Allocate())
@@ -724,10 +718,7 @@ namespace NLog.Targets
 
             if (TryGetCachedValue(layout, logEvent, out var value))
             {
-                if (value is null)
-                    return defaultValue;
-                else
-                    return (T)value;
+                return value is null ? defaultValue : (T)value;
             }
 
             using (var localTarget = ReusableLayoutBuilder.Allocate())


### PR DESCRIPTION
Caching of Layout-result happens automatically with async-processing