### PR TITLE
Introduced OnConfigurationAssigned to signal activation of LoggingConfiguration

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -449,9 +449,8 @@ namespace NLog.Common
         {
             try
             {
-#if !NETSTANDARD1_3 && !NETSTANDARD1_5
-                var fileVersionInfo = !string.IsNullOrEmpty(assembly.Location) ?
-                    System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location) : null;
+                var fileVersion = assembly.GetFirstCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
+                var productVersion = assembly.GetFirstCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
                 var globalAssemblyCache = false;
 #if !NETSTANDARD
                 if (assembly.GlobalAssemblyCache)
@@ -459,12 +458,9 @@ namespace NLog.Common
 #endif
                 Info("{0}. File version: {1}. Product version: {2}. GlobalAssemblyCache: {3}",
                     assembly.FullName,
-                    fileVersionInfo?.FileVersion,
-                    fileVersionInfo?.ProductVersion,
+                    fileVersion,
+                    productVersion,
                     globalAssemblyCache);
-#else
-                Info(assembly.FullName);
-#endif
             }
             catch (Exception ex)
             {

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -516,6 +516,21 @@ namespace NLog.Config
         }
 
         /// <summary>
+        /// Notify the configuration when <see cref="LogFactory.Configuration"/> has been assigned / unassigned.
+        /// </summary>
+        /// <param name="logFactory">LogFactory that configuration has been assigned to.</param>
+        protected internal virtual void OnConfigurationAssigned(LogFactory logFactory)
+        {
+            if (!ReferenceEquals(logFactory, LogFactory) && logFactory != null)
+            {
+                if (ReferenceEquals(LogFactory, LogManager.LogFactory))
+                    InternalLogger.Info("Configuration assigned to local LogFactory, but constructed using global LogFactory");
+                else
+                    InternalLogger.Info("Configuration assigned to LogFactory, but constructed using other LogFactory");
+            }
+        }
+
+        /// <summary>
         /// Removes the specified named target.
         /// </summary>
         /// <param name="name">Name of the target.</param>


### PR DESCRIPTION
Initial step for #5576

Allow NLogLoggingConfiguration to move away from using `FileNamesToWatch`-getter as signal for config being assigned. See also: https://github.com/NLog/NLog.Extensions.Logging/pull/761