### PR TITLE
Layout.FromMethod without boxing

### DIFF
--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -141,7 +141,7 @@ namespace NLog.Layouts
         /// Create a <see cref="SimpleLayout"/> from a lambda method.
         /// </summary>
         /// <param name="layoutMethod">Method that renders the layout.</param>
-        /// <param name="options">Tell if method is safe for concurrent threading.</param>
+        /// <param name="options">Whether method is ThreadAgnostic and doesn't depend on context of the logging application thread.</param>
         /// <returns>Instance of <see cref="SimpleLayout"/>.</returns>
         public static Layout FromMethod(Func<LogEventInfo, object> layoutMethod, LayoutRenderOptions options = LayoutRenderOptions.None)
         {

--- a/src/NLog/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog/SetupExtensionsBuilderExtensions.cs
@@ -300,7 +300,7 @@ namespace NLog
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="name">The layout-renderer type-alias for use in NLog configuration - without '${ }'</param>
         /// <param name="layoutMethod">Callback that returns the value for the layout renderer.</param>
-        /// <param name="options">Options of the layout renderer.</param>
+        /// <param name="options">Whether method is ThreadAgnostic and doesn't depend on context of the logging application thread.</param>
         public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder setupBuilder, string name, Func<LogEventInfo, object> layoutMethod, LayoutRenderOptions options)
         {
             return RegisterLayoutRenderer(setupBuilder, name, (info, configuration) => layoutMethod(info), options);
@@ -312,7 +312,7 @@ namespace NLog
         /// <param name="setupBuilder">Fluent interface parameter.</param>
         /// <param name="name">The layout-renderer type-alias for use in NLog configuration - without '${ }'</param>
         /// <param name="layoutMethod">Callback that returns the value for the layout renderer.</param>
-        /// <param name="options">Options of the layout renderer.</param>
+        /// <param name="options">Whether method is ThreadAgnostic and doesn't depend on context of the logging application thread.</param>
         public static ISetupExtensionsBuilder RegisterLayoutRenderer(this ISetupExtensionsBuilder setupBuilder, string name, Func<LogEventInfo, LoggingConfiguration, object> layoutMethod, LayoutRenderOptions options)
         {
             FuncLayoutRenderer layoutRenderer = Layout.CreateFuncLayoutRenderer(layoutMethod, options, name);

--- a/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
+++ b/tests/NLog.UnitTests/Layouts/LayoutTypedTests.cs
@@ -206,7 +206,7 @@ namespace NLog.UnitTests.Layouts
 
             // Assert
             Assert.Null(result);
-            Assert.Equal(5, result5);
+            Assert.Null(result5);   // Value returned from assigned method always wins
             Assert.Equal("", layout.Render(LogEventInfo.CreateNullEvent()));
             Assert.False(layout.IsFixed);
             Assert.NotEqual("null", layout.ToString());
@@ -250,6 +250,7 @@ namespace NLog.UnitTests.Layouts
 
             // Assert
             Assert.Equal(uri, result);
+            Assert.Same(uri, result);   // Direct pass-through without parsing and allocation
             Assert.Same(result, layout.RenderValue(LogEventInfo.CreateNullEvent()));
             Assert.Equal(uri.ToString(), layout.Render(LogEventInfo.CreateNullEvent()));
             Assert.NotEqual(uri, layout);

--- a/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
+++ b/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
@@ -36,6 +36,7 @@ namespace NLog.UnitTests.Targets
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using NLog.Targets;
     using NLog.Targets.Wrappers;
     using Xunit;
@@ -357,6 +358,7 @@ namespace NLog.UnitTests.Targets
                             <contextproperty name='timestamp' layout='${date}' propertyType='System.DateTime' />
                             <contextproperty name='int-non-existing' layout='${event-properties:non-existing}' propertyType='System.Int32' includeEmptyValue='true' />
                             <contextproperty name='int-non-existing-empty' layout='${event-properties:non-existing}' propertyType='System.Int32' includeEmptyValue='false' />
+                            <contextproperty name='string-non-existing' layout='${event-properties:non-existing}' propertyType='System.String' includeEmptyValue='true' />
                             <contextproperty name='object-non-existing' layout='${event-properties:non-existing}' propertyType='System.Object' includeEmptyValue='true' />
                             <contextproperty name='object-non-existing-empty' layout='${event-properties:non-existing}' propertyType='System.Object' includeEmptyValue='false' />
                        </target>
@@ -380,7 +382,8 @@ namespace NLog.UnitTests.Targets
             Assert.Contains(new KeyValuePair<string, object>("processid", CurrentProcessId), lastCombinedProperties);
             Assert.Contains(new KeyValuePair<string, object>("int-non-existing", 0), lastCombinedProperties);
             Assert.DoesNotContain("int-non-existing-empty", lastCombinedProperties.Keys);
-            Assert.Contains(new KeyValuePair<string, object>("object-non-existing", ""), lastCombinedProperties);
+            Assert.Contains(new KeyValuePair<string, object>("string-non-existing", ""), lastCombinedProperties);
+            Assert.Contains(new KeyValuePair<string, object>("object-non-existing", null), lastCombinedProperties);
             Assert.DoesNotContain("object-non-existing-empty", lastCombinedProperties.Keys);
         }
     }


### PR DESCRIPTION
Resolves #5575 and Resolves #5262

- `Layout<T>` can now be constructed to use different typed-value-engines:
  - Fixed Value where `Layout<T>` becomes its own type-value-engine (To reduce memory allocations)
  - Dynamic Layout where `Layout<T>` creates a type-value-engine that can parse value from Layout-result.
  - Dynamic Method where `Layout<T>` creates a type-value-engine that returns value directly from Func (without boxing).
- Updated `ValueTypeLayoutInfo` to not rely on creating generic `Layout<T>`. Probably need to re-visit the `ValueType`-property and `DefaultValue`-property.
  - Have tried to keep the fixed-value optimization, since no longer depending on `Layout<T>`.