### PR TITLE
NetworkTarget - Added SendTimeoutSeconds to assign TCP Socket SendTimeout

### DIFF
--- a/src/NLog/Internal/NetworkSenders/HttpNetworkSender.cs
+++ b/src/NLog/Internal/NetworkSenders/HttpNetworkSender.cs
@@ -44,6 +44,8 @@ namespace NLog.Internal.NetworkSenders
 
         internal IWebRequestFactory HttpRequestFactory { get; set; } = WebRequestFactory.Instance;
 
+        internal TimeSpan SendTimeout { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpNetworkSender"/> class.
         /// </summary>
@@ -63,7 +65,12 @@ namespace NLog.Internal.NetworkSenders
 
             var webRequest = HttpRequestFactory.CreateWebRequest(_addressUri);
             webRequest.Method = "POST";
-
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            if (SendTimeout > TimeSpan.Zero)
+            {
+                webRequest.Timeout = (int)SendTimeout.TotalMilliseconds;
+            }
+#endif
             AsyncCallback onResponse =
                 r =>
                 {

--- a/src/NLog/Internal/NetworkSenders/INetworkSenderFactory.cs
+++ b/src/NLog/Internal/NetworkSenders/INetworkSenderFactory.cs
@@ -50,9 +50,10 @@ namespace NLog.Internal.NetworkSenders
         /// <param name="maxMessageSize">The maximum message size.</param>
         /// <param name="sslProtocols">SSL protocols for TCP</param>
         /// <param name="keepAliveTime">KeepAliveTime for TCP</param>
+        /// <param name="sendTimeout">SendTimeout for TCP</param>
         /// <returns>
         /// A newly created network sender.
         /// </returns>
-        QueuedNetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime);
+        QueuedNetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime, TimeSpan sendTimeout);
     }
 }

--- a/src/NLog/Internal/NetworkSenders/NetworkSenderFactory.cs
+++ b/src/NLog/Internal/NetworkSenders/NetworkSenderFactory.cs
@@ -45,7 +45,7 @@ namespace NLog.Internal.NetworkSenders
         public static readonly INetworkSenderFactory Default = new NetworkSenderFactory();
 
         /// <inheritdoc/>
-        public QueuedNetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime)
+        public QueuedNetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime, TimeSpan sendTimeout)
         {
             if (url.StartsWith("tcp://", StringComparison.OrdinalIgnoreCase))
             {
@@ -55,6 +55,7 @@ namespace NLog.Internal.NetworkSenders
                     OnQueueOverflow = onQueueOverflow,
                     SslProtocols = sslProtocols,
                     KeepAliveTime = keepAliveTime,
+                    SendTimeout = sendTimeout,
                 };
             }
 
@@ -66,6 +67,7 @@ namespace NLog.Internal.NetworkSenders
                     OnQueueOverflow = onQueueOverflow,
                     SslProtocols = sslProtocols,
                     KeepAliveTime = keepAliveTime,
+                    SendTimeout = sendTimeout,
                 };
             }
 
@@ -77,6 +79,7 @@ namespace NLog.Internal.NetworkSenders
                     OnQueueOverflow = onQueueOverflow,
                     SslProtocols = sslProtocols,
                     KeepAliveTime = keepAliveTime,
+                    SendTimeout = sendTimeout,
                 };
             }
 
@@ -116,6 +119,7 @@ namespace NLog.Internal.NetworkSenders
                 {
                     MaxQueueSize = maxQueueSize,
                     OnQueueOverflow = onQueueOverflow,
+                    SendTimeout = sendTimeout,
                 };
             }
 
@@ -125,6 +129,7 @@ namespace NLog.Internal.NetworkSenders
                 {
                     MaxQueueSize = maxQueueSize,
                     OnQueueOverflow = onQueueOverflow,
+                    SendTimeout = sendTimeout,
                 };
             }
 

--- a/src/NLog/Targets/NetworkTarget.cs
+++ b/src/NLog/Targets/NetworkTarget.cs
@@ -235,6 +235,12 @@ namespace NLog.Targets
         public int KeepAliveTimeSeconds { get; set; }
 
         /// <summary>
+        /// The number of seconds a TCP socket send-operation will block before timeout error. Default wait forever when network cable unplugged and tcp-buffer becomes full.
+        /// </summary>
+        /// <docgen category='Connection Options' order='10' />
+        public int SendTimeoutSeconds { get; set; }
+
+        /// <summary>
         /// Type of compression for protocol payload. Useful for UDP where datagram max-size is 8192 bytes.
         /// </summary>
         public NetworkTargetCompressionType Compress { get; set; }
@@ -610,7 +616,7 @@ namespace NLog.Targets
 
         private NetworkSender CreateNetworkSender(string address)
         {
-            var sender = SenderFactory.Create(address, MaxQueueSize, OnQueueOverflow, MaxMessageSize, SslProtocols, TimeSpan.FromSeconds(KeepAliveTimeSeconds));
+            var sender = SenderFactory.Create(address, MaxQueueSize, OnQueueOverflow, MaxMessageSize, SslProtocols, TimeSpan.FromSeconds(KeepAliveTimeSeconds), TimeSpan.FromSeconds(SendTimeoutSeconds));
             sender.Initialize();
             if (KeepConnection || LogEventDropped != null)
             {

--- a/tests/NLog.UnitTests/Internal/NetworkSenders/HttpNetworkSenderTests.cs
+++ b/tests/NLog.UnitTests/Internal/NetworkSenders/HttpNetworkSenderTests.cs
@@ -85,7 +85,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             Assert.Equal("HttpHappyPathTestLogger|test message1|", requestedString);
             Assert.Equal("POST", mock.Method);
 
-            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 1234, NetworkTargetQueueOverflowAction.Block, 0, SslProtocols.None, new TimeSpan());
+            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 1234, NetworkTargetQueueOverflowAction.Block, 0, SslProtocols.None, TimeSpan.Zero, TimeSpan.Zero);
 
             // Cleanup
             mock.Dispose();
@@ -131,7 +131,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
             Assert.Equal("HttpHappyPathTestLogger|test message2|", requestedString);
             Assert.Equal("POST", mock.Method);
 
-            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 1234, NetworkTargetQueueOverflowAction.Block, 0, SslProtocols.None, new TimeSpan()); // Only created one HttpNetworkSender
+            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 1234, NetworkTargetQueueOverflowAction.Block, 0, SslProtocols.None, TimeSpan.Zero, TimeSpan.Zero); // Only created one HttpNetworkSender
 
             // Cleanup
             mock.Dispose();
@@ -142,7 +142,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
         {
             var networkSenderFactoryMock = Substitute.For<INetworkSenderFactory>();
 
-            networkSenderFactoryMock.Create(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<NetworkTargetQueueOverflowAction>(), Arg.Any<int>(), Arg.Any<SslProtocols>(), Arg.Any<TimeSpan>())
+            networkSenderFactoryMock.Create(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<NetworkTargetQueueOverflowAction>(), Arg.Any<int>(), Arg.Any<SslProtocols>(), Arg.Any<TimeSpan>(), Arg.Any<TimeSpan>())
                 .Returns(url => new HttpNetworkSender(url.Arg<string>())
                 {
                     HttpRequestFactory = new WebRequestFactoryMock(webRequestMock)

--- a/tests/NLog.UnitTests/Internal/NetworkSenders/TcpNetworkSenderTests.cs
+++ b/tests/NLog.UnitTests/Internal/NetworkSenders/TcpNetworkSenderTests.cs
@@ -137,7 +137,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
         public void TcpProxyTest()
         {
             var sender = new TcpNetworkSender("tcp://foo:1234", AddressFamily.Unspecified);
-            var socket = sender.CreateSocket("foo", AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var socket = sender.CreateSocket("foo", AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp, TimeSpan.Zero);
             Assert.IsType<SocketProxy>(socket);
         }
 
@@ -265,7 +265,7 @@ namespace NLog.UnitTests.Internal.NetworkSenders
                 Log = new StringWriter();
             }
 
-            protected internal override ISocket CreateSocket(string host, AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
+            protected internal override ISocket CreateSocket(string host, AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, TimeSpan sendTimeout)
             {
                 return new MockSocket(addressFamily, socketType, protocolType, this);
             }


### PR DESCRIPTION
TCP Socket will automatically block when send-buffer becomes full, to throttle when receiver cannot keep up.

By default the TCP Socket SendTimeout is zero, which means block forever, which can happen when network-cable is unplugged and send-buffer gets full.

The new setting `SendTimeoutSeconds` will enable timer, when send-buffer becomes full. Consider using a timeout-value of `100` seconds.