### PR TITLE
LogAssemblyVersion should check InternalLogger IsInfoEnabled

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -449,6 +449,9 @@ namespace NLog.Common
         {
             try
             {
+                if (!IsInfoEnabled)
+                    return;
+
                 var fileVersion = assembly.GetFirstCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
                 var productVersion = assembly.GetFirstCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
                 var globalAssemblyCache = false;

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -407,9 +407,6 @@ namespace NLog
         [Obsolete("LogFactory should be minimal. Marked obsolete with NLog v5.3")]
         internal static void LogNLogAssemblyVersion()
         {
-            if (!InternalLogger.IsInfoEnabled)
-                return;
-
             try
             {
                 InternalLogger.LogAssemblyVersion(typeof(LogFactory).GetAssembly());

--- a/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
+++ b/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
@@ -141,7 +141,7 @@ namespace NLog.UnitTests.Internal
 
             // NOTE Using BufferingWrapper to validate that DomainUnload remembers to perform flush
             var configXml = $@"
-            <nlog throwExceptions='false' autoShutdown='{autoShutdown}'>
+            <nlog throwExceptions='false' autoShutdown='{autoShutdown}' internalLogLevel='Info'>
                 <targets async='true'>
                     <target name='file' type='BufferingWrapper' bufferSize='10000'>
                         <target name='filewrapped' type='file' layout='${{message}} ${{threadid}}' filename='{filePath}' LineEnding='lf' concurrentWrites='true' />


### PR DESCRIPTION
Skip scanning for Assembly version-attributes when logging output is disabled. Resolves #5629