### PR TITLE
Removed obsolete method LogAssemblyVersion from InternalLogger

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -37,7 +37,6 @@ namespace NLog.Common
     using System.ComponentModel;
     using System.Globalization;
     using System.IO;
-    using System.Reflection;
     using JetBrains.Annotations;
     using NLog.Internal;
     using NLog.Time;
@@ -385,33 +384,6 @@ namespace NLog.Common
                 return true;
         }
 
-        /// <summary>
-        /// Logs the assembly version and file version of the given Assembly.
-        /// </summary>
-        /// <param name="assembly">The assembly to log.</param>
-        [Obsolete("InternalLogger should be minimal. Marked obsolete with NLog v5.3")]
-        public static void LogAssemblyVersion(Assembly assembly)
-        {
-            try
-            {
-                var fileVersion = assembly.GetFirstCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
-                var productVersion = assembly.GetFirstCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-                var globalAssemblyCache = false;
-#if NETFRAMEWORK
-                if (assembly.GlobalAssemblyCache)
-                    globalAssemblyCache = true;
-#endif
-                Info("{0}. File version: {1}. Product version: {2}. GlobalAssemblyCache: {3}",
-                    assembly.FullName,
-                    fileVersion,
-                    productVersion,
-                    globalAssemblyCache);
-            }
-            catch (Exception ex)
-            {
-                Error(ex, "Error logging version of assembly {0}.", assembly?.FullName);
-            }
-        }
         private static void CreateDirectoriesIfNeeded(string filename)
         {
             try

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -345,15 +345,11 @@ namespace NLog
         }
         internal CultureInfo _defaultCultureInfo;
 
-        [Obsolete("LogFactory should be minimal. Marked obsolete with NLog v5.3")]
         internal static void LogNLogAssemblyVersion()
         {
-            if (!InternalLogger.IsInfoEnabled)
-                return;
-
             try
             {
-                InternalLogger.LogAssemblyVersion(typeof(LogFactory).Assembly);
+                AssemblyHelpers.LogAssemblyVersion(typeof(LogFactory).Assembly);
             }
             catch (Exception ex)
             {

--- a/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
+++ b/tests/NLog.UnitTests/Internal/AppDomainPartialTrustTests.cs
@@ -141,7 +141,7 @@ namespace NLog.UnitTests.Internal
 
             // NOTE Using BufferingWrapper to validate that DomainUnload remembers to perform flush
             var configXml = $@"
-            <nlog throwExceptions='false' autoShutdown='{autoShutdown}'>
+            <nlog throwExceptions='false' autoShutdown='{autoShutdown}' internalLogLevel='Info'>
                 <targets async='true'>
                     <target name='file' type='BufferingWrapper' bufferSize='10000'>
                         <target name='filewrapped' type='file' layout='${{message}} ${{threadid}}' filename='{filePath}' LineEnding='lf' concurrentWrites='true' />
@@ -157,10 +157,8 @@ namespace NLog.UnitTests.Internal
             {
                 LogManager.Configuration = XmlLoggingConfiguration.CreateFromXmlString(configXml);
 
-#pragma warning disable CS0618 // Type or member is obsolete
                 //this method gave issues
                 LogFactory.LogNLogAssemblyVersion();
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 var logger = LogManager.GetLogger("NLog.UnitTests.Targets.FileTargetTests");
 


### PR DESCRIPTION
Keep `InternalLogger` simple without knowledge about Assembly-attributes.