### PR TITLE
SimpleLayout - Marked Text-setter as obsolete

### DIFF
--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -123,6 +123,7 @@ namespace NLog.Layouts
         public string Text
         {
             get => _layoutText;
+            [Obsolete("SimpleLayout will be changed to be immutable, instead use constructor. Marked obsolete with NLog v5.4")]
             set => SetLayoutText(value);
         }
 


### PR DESCRIPTION
Already now NLog v5 expects SimpleLayout to be immutable, so make the contract clear.