### PR TITLE
Target reports when disabled because failed to initialize

### DIFF
--- a/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
+++ b/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
@@ -128,7 +128,7 @@ namespace NLog.UnitTests.Targets
         private static bool WaitForLastMessage(CustomTargetWithContext target)
         {
             System.Threading.Thread.Sleep(1);
-            for (int i = 0; i < 1000; ++i)
+            for (int i = 0; i < 5000; ++i)
             {
                 if (target.LastMessage != null)
                     return true;
@@ -329,7 +329,7 @@ namespace NLog.UnitTests.Targets
             logger.Error("log message");
             var target = logFactory.Configuration.AllTargets.OfType<CustomTargetWithContext>().FirstOrDefault();
             System.Threading.Thread.Sleep(1);
-            for (int i = 0; i < 1000; ++i)
+            for (int i = 0; i < 5000; ++i)
             {
                 if (target.LastMessage != null)
                     break;


### PR DESCRIPTION
Improve NLog InternalLogger output, when late in the game. See also: #5674