### PR TITLE
Target reports when disabled because failed to initialize

### DIFF
--- a/tests/NLog.UnitTests/LayoutRenderers/ScopeNestedTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ScopeNestedTests.cs
@@ -395,7 +395,7 @@ namespace NLog.UnitTests.LayoutRenderers
             measurements = messageFirstScopeSleep.Split(new[] { '|' }, System.StringSplitOptions.RemoveEmptyEntries);
             Assert.Equal(7, measurements.Length);
             Assert.Equal("ala", measurements[0]);
-            Assert.InRange(double.Parse(measurements[1], System.Globalization.CultureInfo.InvariantCulture), 10, 999);
+            Assert.InRange(double.Parse(measurements[1], System.Globalization.CultureInfo.InvariantCulture), 9, 999);
             Assert.InRange(int.Parse(measurements[3]), 10, 999);
             Assert.InRange(int.Parse(measurements[5]), 100000, 9999999);
             Assert.Equal("b", measurements[measurements.Length - 1]);
@@ -403,7 +403,7 @@ namespace NLog.UnitTests.LayoutRenderers
             measurements = messageSecondScope.Split(new[] { '|' }, System.StringSplitOptions.RemoveEmptyEntries);
             Assert.Equal(7, measurements.Length);
             Assert.Equal("ala ma", measurements[0]);
-            Assert.InRange(double.Parse(measurements[1], System.Globalization.CultureInfo.InvariantCulture), 10, 999);
+            Assert.InRange(double.Parse(measurements[1], System.Globalization.CultureInfo.InvariantCulture), 9, 999);
             Assert.InRange(int.Parse(measurements[3]), 10, 999);
             Assert.InRange(int.Parse(measurements[5]), 0, 9999999);
             Assert.Equal("a", measurements[measurements.Length - 1]);
@@ -411,7 +411,7 @@ namespace NLog.UnitTests.LayoutRenderers
             measurements = messageSecondScopeSleep.Split(new[] { '|' }, System.StringSplitOptions.RemoveEmptyEntries);
             Assert.Equal(7, measurements.Length);
             Assert.Equal("ala ma", measurements[0]);
-            Assert.InRange(double.Parse(measurements[1], System.Globalization.CultureInfo.InvariantCulture), 20, 999);
+            Assert.InRange(double.Parse(measurements[1], System.Globalization.CultureInfo.InvariantCulture), 19, 999);
             Assert.InRange(int.Parse(measurements[3]), 20, 999);
             Assert.InRange(int.Parse(measurements[5]), 100000, 9999999);
             Assert.Equal("b", measurements[measurements.Length - 1]);
@@ -419,7 +419,7 @@ namespace NLog.UnitTests.LayoutRenderers
             measurements = messageFirstScopeExit.Split(new[] { '|' }, System.StringSplitOptions.RemoveEmptyEntries);
             Assert.Equal(7, measurements.Length);
             Assert.Equal("ala", measurements[0]);
-            Assert.InRange(double.Parse(measurements[1], System.Globalization.CultureInfo.InvariantCulture), 20, 999);
+            Assert.InRange(double.Parse(measurements[1], System.Globalization.CultureInfo.InvariantCulture), 19, 999);
             Assert.InRange(int.Parse(measurements[3]), 20, 999);
             Assert.InRange(int.Parse(measurements[5]), 200000, 9999999);
             Assert.Equal("c", measurements[measurements.Length - 1]);

--- a/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
+++ b/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
@@ -127,7 +127,7 @@ namespace NLog.UnitTests.Targets
         private static bool WaitForLastMessage(CustomTargetWithContext target)
         {
             System.Threading.Thread.Sleep(1);
-            for (int i = 0; i < 1000; ++i)
+            for (int i = 0; i < 5000; ++i)
             {
                 if (target.LastMessage != null)
                     return true;
@@ -328,7 +328,7 @@ namespace NLog.UnitTests.Targets
             logger.Error("log message");
             var target = logFactory.Configuration.AllTargets.OfType<CustomTargetWithContext>().FirstOrDefault();
             System.Threading.Thread.Sleep(1);
-            for (int i = 0; i < 1000; ++i)
+            for (int i = 0; i < 5000; ++i)
             {
                 if (target.LastMessage != null)
                     break;


### PR DESCRIPTION
Improve NLog InternalLogger output, when late in the game. See also: #5674