### PR TITLE
ColoredConsoleTarget - Recognize NO_COLOR environment variable

### DIFF
--- a/src/NLog/Targets/ColoredConsoleTarget.cs
+++ b/src/NLog/Targets/ColoredConsoleTarget.cs
@@ -39,9 +39,11 @@ namespace NLog.Targets
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.IO;
+    using System.Linq;
     using System.Text;
     using NLog.Common;
     using NLog.Config;
+    using NLog.Layouts;
 
     /// <summary>
     /// Writes log messages to the console with customizable coloring.
@@ -216,6 +218,11 @@ namespace NLog.Targets
         public bool EnableAnsiOutput { get; set; }
 
         /// <summary>
+        /// Support NO_COLOR=1 environment variable. See also <see href="https://no-color.org/" />
+        /// </summary>
+        public Layout<bool> NoColor { get; set; } = Layout<bool>.FromMethod((evt) => new string[] { "1", "TRUE" }.Contains(NLog.Internal.EnvironmentHelper.GetSafeEnvironmentVariable("NO_COLOR")?.Trim().ToUpper()));
+
+        /// <summary>
         /// Gets the row highlighting rules.
         /// </summary>
         /// <docgen category='Highlighting Rules' order='10' />
@@ -241,7 +248,7 @@ namespace NLog.Targets
                 _pauseLogging = !ConsoleTargetHelper.IsConsoleAvailable(out reason);
                 if (_pauseLogging)
                 {
-                    InternalLogger.Info("{0}: Console detected as turned off. Disable DetectConsoleAvailable to skip detection. Reason: {1}", this, reason);
+                    InternalLogger.Info("{0}: Console detected as turned off. Set DetectConsoleAvailable=false to skip detection. Reason: {1}", this, reason);
                 }
             }
 
@@ -256,7 +263,7 @@ namespace NLog.Targets
                     _disableColors = StdErr ? Console.IsErrorRedirected : Console.IsOutputRedirected;
                     if (_disableColors)
                     {
-                        InternalLogger.Info("{0}: Console output is redirected so no colors. Disable DetectOutputRedirected to skip detection.", this);
+                        InternalLogger.Info("{0}: Console output is redirected so no colors. Set DetectOutputRedirected=false to skip detection.", this);
                         if (!AutoFlush && GetOutput() is StreamWriter streamWriter && !streamWriter.AutoFlush)
                         {
                             AutoFlush = true;
@@ -269,6 +276,12 @@ namespace NLog.Targets
                 }
             }
 #endif
+
+            if (!_disableColors && NoColor?.RenderValue(LogEventInfo.CreateNullEvent()) == true)
+            {
+                _disableColors = true;
+                InternalLogger.Info("{0}: Environment with NO_COLOR, so colors are disabled. Set NoColor=false to skip detection.", this);
+            }
 
             base.InitializeTarget();
 

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -171,7 +171,7 @@ namespace NLog.Targets
                 _pauseLogging = !ConsoleTargetHelper.IsConsoleAvailable(out reason);
                 if (_pauseLogging)
                 {
-                    InternalLogger.Info("{0}: Console has been detected as turned off. Disable DetectConsoleAvailable to skip detection. Reason: {1}", this, reason);
+                    InternalLogger.Info("{0}: Console detected as turned off. Set DetectConsoleAvailable=false to skip detection. Reason: {1}", this, reason);
                 }
             }
 

--- a/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
@@ -348,6 +348,14 @@ namespace NLog.UnitTests.Targets
         }
 #endif
 
+        [Fact]
+        public void ColoredConsoleNoColor()
+        {
+            var target = new ColoredConsoleTarget { Layout = "${logger} ${message}", NoColor = true };
+            AssertOutput(target, "The Cat Sat At The Bar.",
+                new string[] { "The Cat Sat At The Bar." });
+        }
+
         private static void AssertOutput(Target target, string message, string[] expectedParts, string loggerName = "Logger ")
         {
             var consoleOutWriter = new PartsWriter();


### PR DESCRIPTION
The NO_COLOR=1 environment variable has emerged as a de-facto standard for this, and is supported by a wide range of software. More information at https://no-color.org/

Resolves #5631