### PR TITLE
ColoredConsoleTarget - Recognize NO_COLOR environment variable

### DIFF
--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -169,7 +169,7 @@ namespace NLog.Targets
                 _pauseLogging = !ConsoleTargetHelper.IsConsoleAvailable(out reason);
                 if (_pauseLogging)
                 {
-                    InternalLogger.Info("{0}: Console has been detected as turned off. Disable DetectConsoleAvailable to skip detection. Reason: {1}", this, reason);
+                    InternalLogger.Info("{0}: Console detected as turned off. Set DetectConsoleAvailable=false to skip detection. Reason: {1}", this, reason);
                 }
             }
 

--- a/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
@@ -297,6 +297,14 @@ namespace NLog.UnitTests.Targets
         }
 #endif
 
+        [Fact]
+        public void ColoredConsoleNoColor()
+        {
+            var target = new ColoredConsoleTarget { Layout = "${logger} ${message}", NoColor = true };
+            AssertOutput(target, "The Cat Sat At The Bar.",
+                new string[] { "The Cat Sat At The Bar." });
+        }
+
         private static void AssertOutput(Target target, string message, string[] expectedParts, string loggerName = "Logger ")
         {
             var consoleOutWriter = new PartsWriter();


### PR DESCRIPTION
The NO_COLOR=1 environment variable has emerged as a de-facto standard for this, and is supported by a wide range of software. More information at https://no-color.org/

Resolves #5631