### PR TITLE
Restored SetupFromEnvironmentVariables

### DIFF
--- a/src/NLog/SetupInternalLoggerBuilderExtensions.cs
+++ b/src/NLog/SetupInternalLoggerBuilderExtensions.cs
@@ -173,8 +173,6 @@ namespace NLog
         /// - nlog.internalLogToTrace
         /// - nlog.internalLogIncludeTimestamp
         /// </remarks>
-        [Obsolete("Replaced by ResetConfig to reset configurtion. Marked obsolete with NLog v5.4")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static ISetupInternalLoggerBuilder SetupFromEnvironmentVariables(this ISetupInternalLoggerBuilder setupBuilder)
         {
             InternalLogger.Reset();

--- a/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
+++ b/tests/NLog.UnitTests/Config/LogFactorySetupTests.cs
@@ -587,7 +587,6 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
-        [Obsolete("Replaced by ResetLogOutput to reset configurtion. Marked obsolete with NLog v5.4")]
         public void SetupInternalLoggerSetupFromEnvironmentVariablesTest()
         {
             try


### PR DESCRIPTION
NLog v6 removed the setting-lookup logic from InternalLogger-class, but #5709 restores the ability using extension-method.

Guess I was a little too eager to cleanup.