### PR TITLE
Fix AOT warnings by not using MakeGenericType

### DIFF
--- a/src/NLog/Config/AssemblyExtensionLoader.cs
+++ b/src/NLog/Config/AssemblyExtensionLoader.cs
@@ -402,7 +402,7 @@ namespace NLog.Config
         internal static IEnumerable<KeyValuePair<string, string>> GetAutoLoadingFileLocations()
         {
             var nlogAssembly = typeof(LogFactory).Assembly;
-            var nlogAssemblyLocation = PathHelpers.TrimDirectorySeparators(AssemblyHelpers.GetAssemblyFileLocation(nlogAssembly));
+            var nlogAssemblyLocation = PathHelpers.TrimDirectorySeparators(System.IO.Path.GetDirectoryName(AssemblyHelpers.GetAssemblyFileLocation(nlogAssembly)));
             InternalLogger.Debug("Auto loading based on NLog-Assembly found location: {0}", nlogAssemblyLocation);
             if (!string.IsNullOrEmpty(nlogAssemblyLocation))
                 yield return new KeyValuePair<string, string>(nlogAssemblyLocation, nameof(nlogAssemblyLocation));

--- a/src/NLog/Config/LoggingConfigurationFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationFileLoader.cs
@@ -259,7 +259,8 @@ namespace NLog.Config
         {
             var nlogAssembly = typeof(LogFactory).Assembly;
             // Get path to NLog.dll.nlog only if the assembly is not in the GAC
-            var nlogAssemblyLocation = nlogAssembly.Location;
+            // Notice NLog.dll can be loaded from nuget-cache using NTFS-hard-link, and return unexpected file-location.
+            var nlogAssemblyLocation = AssemblyHelpers.GetAssemblyFileLocation(nlogAssembly);
             if (!string.IsNullOrEmpty(nlogAssemblyLocation))
             {
 #if NETFRAMEWORK

--- a/src/NLog/Internal/AppEnvironmentWrapper.cs
+++ b/src/NLog/Internal/AppEnvironmentWrapper.cs
@@ -249,15 +249,11 @@ namespace NLog.Internal.Fakeables
         private static string LookupEntryAssemblyLocation()
         {
             var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
-            var entryLocation = entryAssembly?.Location;
+            var entryLocation = AssemblyHelpers.GetAssemblyFileLocation(entryAssembly);
             if (!string.IsNullOrEmpty(entryLocation))
-            {
                 return Path.GetDirectoryName(entryLocation);
-            }
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            return AssemblyHelpers.GetAssemblyFileLocation(entryAssembly);
-#pragma warning restore CS0618 // Type or member is obsolete
+            else
+                return string.Empty;
         }
 
         private static string LookupEntryAssemblyFileName()
@@ -265,11 +261,9 @@ namespace NLog.Internal.Fakeables
             try
             {
                 var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
-                var entryLocation = entryAssembly?.Location;
+                var entryLocation = AssemblyHelpers.GetAssemblyFileLocation(entryAssembly);
                 if (!string.IsNullOrEmpty(entryLocation))
-                {
                     return Path.GetFileName(entryLocation);
-                }
 
                 // Fallback to the Assembly-Name when unable to extract FileName from Location
                 var assemblyName = entryAssembly?.GetName()?.Name;

--- a/src/NLog/Internal/AssemblyHelpers.cs
+++ b/src/NLog/Internal/AssemblyHelpers.cs
@@ -33,7 +33,6 @@
 namespace NLog.Internal
 {
     using System;
-    using System.IO;
     using System.Reflection;
     using NLog.Common;
 
@@ -42,28 +41,20 @@ namespace NLog.Internal
     /// </summary>
     internal static class AssemblyHelpers
     {
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Returns empty string for assemblies embedded in a single-file app", "IL3000")]
         public static string GetAssemblyFileLocation(Assembly assembly)
         {
-            string assemblyFullName = string.Empty;
+#if !NETFRAMEWORK
+            // Notice assembly can be loaded from nuget-cache using NTFS-hard-link, and return unexpected file-location.
+            return assembly?.Location ?? string.Empty;
+#else
+            if (assembly is null)
+                return string.Empty;
+
+            var assemblyFullName = assembly.FullName;
 
             try
             {
-                if (assembly is null)
-                {
-                    return string.Empty;
-                }
-
-                assemblyFullName = assembly.FullName;
-
-#if NETSTANDARD
-                if (string.IsNullOrEmpty(assembly.Location))
-                {
-                    // Assembly with no actual location should be skipped (Avoid PlatformNotSupportedException)
-                    InternalLogger.Debug("Ignoring assembly location because location is empty: {0}", assemblyFullName);
-                    return string.Empty;
-                }
-#endif
-
                 Uri assemblyCodeBase;
                 if (!Uri.TryCreate(assembly.CodeBase, UriKind.RelativeOrAbsolute, out assemblyCodeBase))
                 {
@@ -71,14 +62,14 @@ namespace NLog.Internal
                     return string.Empty;
                 }
 
-                var assemblyLocation = Path.GetDirectoryName(assemblyCodeBase.LocalPath);
+                var assemblyLocation = System.IO.Path.GetDirectoryName(assemblyCodeBase.LocalPath);
                 if (string.IsNullOrEmpty(assemblyLocation))
                 {
                     InternalLogger.Debug("Ignoring assembly location because it is not a valid directory: '{0}' ({1})", assemblyCodeBase.LocalPath, assemblyFullName);
                     return string.Empty;
                 }
 
-                DirectoryInfo directoryInfo = new DirectoryInfo(assemblyLocation);
+                var directoryInfo = new System.IO.DirectoryInfo(assemblyLocation);
                 if (!directoryInfo.Exists)
                 {
                     InternalLogger.Debug("Ignoring assembly location because directory doesn't exists: '{0}' ({1})", assemblyLocation, assemblyFullName);
@@ -86,7 +77,8 @@ namespace NLog.Internal
                 }
 
                 InternalLogger.Debug("Found assembly location directory: '{0}' ({1})", directoryInfo.FullName, assemblyFullName);
-                return directoryInfo.FullName;
+                var assemblyFileName = string.IsNullOrEmpty(assembly.Location) ? System.IO.Path.GetFileName(assemblyCodeBase.LocalPath) : System.IO.Path.GetFileName(assembly.Location);
+                return System.IO.Path.Combine(directoryInfo.FullName, assemblyFileName);
             }
             catch (System.PlatformNotSupportedException ex)
             {
@@ -115,6 +107,7 @@ namespace NLog.Internal
                 }
                 return string.Empty;
             }
+#endif
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/NLogDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/NLogDirLayoutRenderer.cs
@@ -91,15 +91,14 @@ namespace NLog.LayoutRenderers
         private static string ResolveNLogDir()
         {
             var nlogAssembly = typeof(LogFactory).Assembly;
-            if (!string.IsNullOrEmpty(nlogAssembly.Location))
+            var nlogLocation = AssemblyHelpers.GetAssemblyFileLocation(nlogAssembly);
+            if (!string.IsNullOrEmpty(nlogLocation))
             {
-                return Path.GetDirectoryName(nlogAssembly.Location);
+                return Path.GetDirectoryName(nlogLocation);
             }
             else
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                return AssemblyHelpers.GetAssemblyFileLocation(nlogAssembly) ?? string.Empty;
-#pragma warning restore CS0618 // Type or member is obsolete
+                return string.Empty;
             }
         }
     }

--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -503,6 +503,8 @@ namespace NLog.Layouts
             return layoutRenderer;
         }
 
+
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming - Allow converting option-values from config", "IL2072")]
         private static object ParseLayoutRendererPropertyValue(ConfigurationItemFactory configurationItemFactory, SimpleStringReader stringReader, bool? throwConfigExceptions, string targetTypeName, PropertyInfo propertyInfo)
         {
             if (typeof(Layout).IsAssignableFrom(propertyInfo.PropertyType))
@@ -512,8 +514,7 @@ namespace NLog.Layouts
 
                 if (propertyInfo.PropertyType.IsGenericType && propertyInfo.PropertyType.GetGenericTypeDefinition() == typeof(Layout<>))
                 {
-                    var concreteType = typeof(Layout<>).MakeGenericType(propertyInfo.PropertyType.GetGenericArguments());
-                    nestedLayout = (Layout)Activator.CreateInstance(concreteType, BindingFlags.Instance | BindingFlags.Public, null, new object[] { nestedLayout }, null);
+                    nestedLayout = (Layout)Activator.CreateInstance(propertyInfo.PropertyType, BindingFlags.Instance | BindingFlags.Public, null, new object[] { nestedLayout }, null);
                 }
 
                 return nestedLayout;

--- a/src/NLog/SetupInternalLoggerBuilderExtensions.cs
+++ b/src/NLog/SetupInternalLoggerBuilderExtensions.cs
@@ -109,7 +109,7 @@ namespace NLog
         }
 
         /// <summary>
-        /// Resets the InternalLogger configuration without resolving default values from Environment-varialbes or App.config
+        /// Resets the InternalLogger configuration without resolving default values from Environment-variables or App.config
         /// </summary>
         public static ISetupInternalLoggerBuilder ResetConfig(this ISetupInternalLoggerBuilder setupBuilder)
         {

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -218,7 +218,7 @@ namespace NLog.Targets
                 }
             }
 
-            if (value is IEnumerable enumerable)
+            if (value is IEnumerable collection)
             {
                 if (_objectReflectionCache.TryLookupExpandoObject(value, out var objectPropertyList))
                 {
@@ -228,7 +228,7 @@ namespace NLog.Targets
                 {
                     using (StartCollectionScope(ref objectsInPath, value))
                     {
-                        SerializeCollectionObject(enumerable, destination, options, objectsInPath, depth);
+                        SerializeCollectionObject(collection, destination, options, objectsInPath, depth);
                         return true;
                     }
                 }

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteFileNameLayoutTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteFileNameLayoutTests.cs
@@ -105,7 +105,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             // Act
             var logEvent = new LogEventInfo(LogLevel.Info, null, "msg");
-            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true), 0);
+            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true));
             logFactory.GetLogger("A").Log(logEvent);
 
             // Assert

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteLineNumberTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteLineNumberTests.cs
@@ -127,7 +127,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             // Act
             var logEvent = new LogEventInfo(LogLevel.Info, null, "msg");
-            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true), 0);
+            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true));
             logFactory.GetLogger("A").Log(logEvent);
 
             // Assert

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -253,7 +253,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             // Act
             var logEvent = new LogEventInfo(LogLevel.Info, null, "msg");
-            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true), 0);
+            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true));
             logFactory.GetLogger("A").Log(logEvent);
 
             // Assert

--- a/tests/NLog.UnitTests/LayoutRenderers/StackTraceRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/StackTraceRendererTests.cs
@@ -111,7 +111,7 @@ namespace NLog.UnitTests.LayoutRenderers
             </nlog>").LogFactory;
 
             var logEvent = new LogEventInfo(LogLevel.Info, null, "I am:");
-            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true), 0);
+            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true));
             logFactory.GetCurrentClassLogger().Log(logEvent);
             logFactory.AssertDebugLastMessageContains($" => {nameof(StackTraceRendererTests)}.{nameof(RenderStackTraceNoCaptureStackTraceWithStackTrace)}");
         }

--- a/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
+++ b/tests/NLog.UnitTests/Targets/DefaultJsonSerializerTestsBase.cs
@@ -563,7 +563,7 @@ namespace NLog.UnitTests.Targets
             public override string ToString() => "nullValue";
         }
 
-#if !NET35 && !NET40
+#if !NET35 && !NET40 && NETFRAMEWORK
 
         [Fact]
         public void SerializeExpandoObject_Test()

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -762,7 +762,6 @@ namespace NLog.UnitTests.Targets
             }
         }
 
-
         [Fact]
         public void TypedLayoutTargetTest()
         {
@@ -789,6 +788,9 @@ namespace NLog.UnitTests.Targets
                         typeProperty='System.Int32'
                         uriProperty='https://nlog-project.org'
                         lineEndingModeProperty='default'
+                        shortSetProperty='1,2,3'
+                        shortListProperty='1,2,3'
+                        longListProperty='1,2,3'
                         />
                 </targets>
             </nlog>");
@@ -811,6 +813,18 @@ namespace NLog.UnitTests.Targets
             Assert.Equal(typeof(int), myTarget.TypeProperty.FixedValue);
             Assert.Equal(new Uri("https://nlog-project.org"), myTarget.UriProperty.FixedValue);
             Assert.Equal(LineEndingMode.Default, myTarget.LineEndingModeProperty.FixedValue);
+            Assert.Equal(3, myTarget.ShortSetProperty.Count);
+            Assert.Contains((short)1, myTarget.ShortSetProperty);
+            Assert.Contains((short)2, myTarget.ShortSetProperty);
+            Assert.Contains((short)3, myTarget.ShortSetProperty);
+            Assert.Equal(3, myTarget.ShortListProperty.Count);
+            Assert.Contains((short)1, myTarget.ShortListProperty);
+            Assert.Contains((short)2, myTarget.ShortListProperty);
+            Assert.Contains((short)3, myTarget.ShortListProperty);
+            Assert.Equal(3, myTarget.LongListProperty.Count);
+            Assert.Contains(1L, myTarget.LongListProperty);
+            Assert.Contains(2L, myTarget.LongListProperty);
+            Assert.Contains(3L, myTarget.LongListProperty);
         }
 
         [Fact]
@@ -1021,6 +1035,15 @@ namespace NLog.UnitTests.Targets
             public Layout<Uri> UriProperty { get; set; }
 
             public Layout<LineEndingMode> LineEndingModeProperty { get; set; }
+
+#if NET35
+            public HashSet<short> ShortSetProperty { get; set; }
+#else
+            public IList<short> ShortSetProperty { get; set; }
+#endif
+
+            public IList<short> ShortListProperty { get; set; }
+            public IList<long> LongListProperty { get; set; } = new List<long>();
 
             protected override void Write(LogEventInfo logEvent)
             {

--- a/tests/TestTrimPublish/TestTrimPublish.csproj
+++ b/tests/TestTrimPublish/TestTrimPublish.csproj
@@ -10,12 +10,16 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishTrimmed>true</PublishTrimmed>
+    <!--
     <PublishSingleFile>true</PublishSingleFile>
+    -->
     <PublishReadyToRun>true</PublishReadyToRun>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <PublishAot>true</PublishAot>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Stop using obsolete Assembly-CodeBase (original source-location), but instead always using Assembly-Location (can be nuget-cache-folder, because of NTFS-links)