### PR TITLE
Reduce usage of MakeGenericType for Dictionary enumeration

### DIFF
--- a/src/NLog/SetupInternalLoggerBuilderExtensions.cs
+++ b/src/NLog/SetupInternalLoggerBuilderExtensions.cs
@@ -143,7 +143,7 @@ namespace NLog
         }
 
         /// <summary>
-        /// Resets the InternalLogger configuration without resolving default values from Environment-varialbes or App.config
+        /// Resets the InternalLogger configuration without resolving default values from Environment-variables or App.config
         /// </summary>
         public static ISetupInternalLoggerBuilder ResetConfig(this ISetupInternalLoggerBuilder setupBuilder)
         {

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -218,7 +218,7 @@ namespace NLog.Targets
                 }
             }
 
-            if (value is IEnumerable enumerable)
+            if (value is IEnumerable collection)
             {
                 if (_objectReflectionCache.TryLookupExpandoObject(value, out var objectPropertyList))
                 {
@@ -228,7 +228,7 @@ namespace NLog.Targets
                 {
                     using (StartCollectionScope(ref objectsInPath, value))
                     {
-                        SerializeCollectionObject(enumerable, destination, options, objectsInPath, depth);
+                        SerializeCollectionObject(collection, destination, options, objectsInPath, depth);
                         return true;
                     }
                 }

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -52,7 +52,9 @@ namespace NLog.UnitTests.Config
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
 
                 Assert.False(config.AutoReload);
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.True(config.InitializeSucceeded);
+#pragma warning restore CS0618 // Type or member is obsolete
                 Assert.Equal("", InternalLogger.LogFile);
                 Assert.False(InternalLogger.LogToConsole);
                 Assert.False(InternalLogger.LogToConsoleError);
@@ -73,7 +75,9 @@ namespace NLog.UnitTests.Config
                     var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
 
                     Assert.False(config.AutoReload);
+#pragma warning disable CS0618 // Type or member is obsolete
                     Assert.True(config.InitializeSucceeded);
+#pragma warning restore CS0618 // Type or member is obsolete
                     Assert.Equal("", InternalLogger.LogFile);
                     Assert.True(InternalLogger.LogToConsole);
                     Assert.True(InternalLogger.LogToConsoleError);

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteFileNameLayoutTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteFileNameLayoutTests.cs
@@ -105,7 +105,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             // Act
             var logEvent = new LogEventInfo(LogLevel.Info, null, "msg");
-            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true), 0);
+            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true));
             logFactory.GetLogger("A").Log(logEvent);
 
             // Assert

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteLineNumberTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteLineNumberTests.cs
@@ -128,7 +128,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             // Act
             var logEvent = new LogEventInfo(LogLevel.Info, null, "msg");
-            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true), 0);
+            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true));
             logFactory.GetLogger("A").Log(logEvent);
 
             // Assert

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -253,7 +253,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             // Act
             var logEvent = new LogEventInfo(LogLevel.Info, null, "msg");
-            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true), 0);
+            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true));
             logFactory.GetLogger("A").Log(logEvent);
 
             // Assert

--- a/tests/NLog.UnitTests/LayoutRenderers/StackTraceRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/StackTraceRendererTests.cs
@@ -111,7 +111,7 @@ namespace NLog.UnitTests.LayoutRenderers
             </nlog>").LogFactory;
 
             var logEvent = new LogEventInfo(LogLevel.Info, null, "I am:");
-            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true), 0);
+            logEvent.SetStackTrace(new System.Diagnostics.StackTrace(true));
             logFactory.GetCurrentClassLogger().Log(logEvent);
             logFactory.AssertDebugLastMessageContains($" => {nameof(StackTraceRendererTests)}.{nameof(RenderStackTraceNoCaptureStackTraceWithStackTrace)}");
         }

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -762,7 +762,6 @@ namespace NLog.UnitTests.Targets
             }
         }
 
-
         [Fact]
         public void TypedLayoutTargetTest()
         {
@@ -789,6 +788,9 @@ namespace NLog.UnitTests.Targets
                         typeProperty='System.Int32'
                         uriProperty='https://nlog-project.org'
                         lineEndingModeProperty='default'
+                        shortSetProperty='1,2,3'
+                        shortListProperty='1,2,3'
+                        longListProperty='1,2,3'
                         />
                 </targets>
             </nlog>");
@@ -811,6 +813,18 @@ namespace NLog.UnitTests.Targets
             Assert.Equal(typeof(int), myTarget.TypeProperty.FixedValue);
             Assert.Equal(new Uri("https://nlog-project.org"), myTarget.UriProperty.FixedValue);
             Assert.Equal(LineEndingMode.Default, myTarget.LineEndingModeProperty.FixedValue);
+            Assert.Equal(3, myTarget.ShortSetProperty.Count);
+            Assert.Contains((short)1, myTarget.ShortSetProperty);
+            Assert.Contains((short)2, myTarget.ShortSetProperty);
+            Assert.Contains((short)3, myTarget.ShortSetProperty);
+            Assert.Equal(3, myTarget.ShortListProperty.Count);
+            Assert.Contains((short)1, myTarget.ShortListProperty);
+            Assert.Contains((short)2, myTarget.ShortListProperty);
+            Assert.Contains((short)3, myTarget.ShortListProperty);
+            Assert.Equal(3, myTarget.LongListProperty.Count);
+            Assert.Contains(1L, myTarget.LongListProperty);
+            Assert.Contains(2L, myTarget.LongListProperty);
+            Assert.Contains(3L, myTarget.LongListProperty);
         }
 
         [Fact]
@@ -1021,6 +1035,15 @@ namespace NLog.UnitTests.Targets
             public Layout<Uri> UriProperty { get; set; }
 
             public Layout<LineEndingMode> LineEndingModeProperty { get; set; }
+
+#if NET35
+            public HashSet<short> ShortSetProperty { get; set; }
+#else
+            public IList<short> ShortSetProperty { get; set; }
+#endif
+
+            public IList<short> ShortListProperty { get; set; }
+            public IList<long> LongListProperty { get; set; } = new List<long>();
 
             protected override void Write(LogEventInfo logEvent)
             {


### PR DESCRIPTION
Increase the chance of AOT working for NLog v5. Seems people are using AOT and ignoring build-warnings, maybe because so many from different dependencies.