### PR TITLE
Marked IFactory RegisterType as obsolete, since it will disappear with NLog v6

### DIFF
--- a/src/NLog/Config/IFactory.cs
+++ b/src/NLog/Config/IFactory.cs
@@ -43,7 +43,7 @@ namespace NLog.Config
     {
         void Clear();
 
-        [Obsolete("Instead use RegisterType<T>, as dynamic Assembly loading will be moved out. Marked obsolete with NLog v5.2")]
+        [Obsolete("Instead use NLog.LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.2")]
         void ScanTypes(Type[] types, string assemblyName, string itemNamePrefix);
 
         void RegisterType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] Type type, string itemNamePrefix);
@@ -57,6 +57,7 @@ namespace NLog.Config
         /// <summary>
         /// Registers type-creation with type-alias
         /// </summary>
+        [Obsolete("Instead use NLog.LogManager.Setup().SetupExtensions(). Marked obsolete with NLog v5.5")]
         void RegisterType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] TType>(string typeAlias) where TType : TBaseType, new();
         /// <summary>
         /// Tries to create an item instance with type-alias


### PR DESCRIPTION
NLog v6 tries to support AOT-builds with trimming, where it only auto-register NLog types when loading from configuration-file. See also #5724
- [x] Wait for NLog v5.5