### PR TITLE
LogFactory - Refactor BuildLoggerConfiguration to return ITargetWithFilterChain

### DIFF
--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -127,9 +127,11 @@ namespace NLog.Config
         /// </summary>
         [Obsolete("Very exotic feature without any unit-tests, not sure if it works. Marked obsolete with NLog v5.3")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public IList<LoggingRule> ChildRules { get; } = new List<LoggingRule>();
+        public IList<LoggingRule> ChildRules => _childRules;
         [Obsolete("Very exotic feature without any unit-tests, not sure if it works. Marked obsolete with NLog v5.3")]
-        internal List<LoggingRule> GetChildRulesThreadSafe() { lock (ChildRules) return ChildRules.ToList(); }
+        private readonly List<LoggingRule> _childRules = new List<LoggingRule>();
+        [Obsolete("Very exotic feature without any unit-tests, not sure if it works. Marked obsolete with NLog v5.3")]
+        internal LoggingRule[] GetChildRulesThreadSafe() { lock (_childRules) return _childRules.ToArray(); }
         internal Target[] GetTargetsThreadSafe() { lock (_targets) return _targets.Count == 0 ? NLog.Internal.ArrayHelper.Empty<Target>() : _targets.ToArray(); }
         internal bool RemoveTargetThreadSafe(Target target) { lock (_targets) return _targets.Remove(target); }
 

--- a/src/NLog/Internal/TargetWithFilterChain.cs
+++ b/src/NLog/Internal/TargetWithFilterChain.cs
@@ -117,11 +117,8 @@ namespace NLog.Internal
             return stackTraceUsage;
         }
 
-        static internal TargetWithFilterChain[] BuildLoggerConfiguration(string loggerName, List<LoggingRule> loggingRules, LogLevel globalLogLevel)
+        static internal TargetWithFilterChain[] BuildLoggerConfiguration(string loggerName, LoggingRule[] loggingRules, LogLevel globalLogLevel)
         {
-            if (loggingRules is null || loggingRules.Count == 0 || LogLevel.Off.Equals(globalLogLevel))
-                return TargetWithFilterChain.NoTargetsByLevel;
-
             TargetWithFilterChain[] targetsByLevel = TargetWithFilterChain.CreateLoggerConfiguration();
             TargetWithFilterChain[] lastTargetsByLevel = TargetWithFilterChain.CreateLoggerConfiguration();
             bool[] suppressedLevels = new bool[LogLevel.MaxLevel.Ordinal + 1];
@@ -130,7 +127,7 @@ namespace NLog.Internal
             return targetsFound ? targetsByLevel : TargetWithFilterChain.NoTargetsByLevel;
         }
 
-        static private bool GetTargetsByLevelForLogger(string name, List<LoggingRule> loggingRules, LogLevel globalLogLevel, TargetWithFilterChain[] targetsByLevel, TargetWithFilterChain[] lastTargetsByLevel, bool[] suppressedLevels)
+        static private bool GetTargetsByLevelForLogger(string name, LoggingRule[] loggingRules, LogLevel globalLogLevel, TargetWithFilterChain[] targetsByLevel, TargetWithFilterChain[] lastTargetsByLevel, bool[] suppressedLevels)
         {
             IList<KeyValuePair<FilterResult?, IList<Filter>>> finalMinLevelWithFilters = null;
             bool targetsFound = false;

--- a/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
+++ b/tests/NLog.UnitTests/Config/RuleConfigurationTests.cs
@@ -544,8 +544,8 @@ namespace NLog.UnitTests.Config
                 </rules>
             </nlog>").LogFactory;
 
-            var loggerConfig = logFactory.BuildLoggerConfiguration("AAA", logFactory.Configuration?.GetLoggingRulesThreadSafe());
-            var targets = loggerConfig[LogLevel.Warn.Ordinal];
+            var loggerConfig = logFactory.BuildLoggerConfiguration("AAA");
+            var targets = loggerConfig[LogLevel.Warn.Ordinal] as TargetWithFilterChain;
             Assert.Equal("d1", targets.Target.Name);
             Assert.Equal("d2", targets.NextInChain.Target.Name);
             Assert.Equal("d3", targets.NextInChain.NextInChain.Target.Name);


### PR DESCRIPTION
Resolves #5486, but reverts #5351

The goal should be that LogFactory only knows about creating Loggers. Everything about targets / layouts / logging-rules should be handled by `LoggingConfiguration`