### PR TITLE
LayoutRenderer - Culture can now override LogEvent FormatProvider

### DIFF
--- a/src/NLog/Config/PropertyTypeConverter.cs
+++ b/src/NLog/Config/PropertyTypeConverter.cs
@@ -36,6 +36,7 @@ namespace NLog.Config
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
     using NLog.Internal;
 
     /// <summary>
@@ -56,7 +57,7 @@ namespace NLog.Config
             return new Dictionary<Type, Func<string, string, IFormatProvider, object>>()
             {
                 { typeof(System.Text.Encoding), (stringvalue, format, formatProvider) => ConvertToEncoding(stringvalue) },
-                { typeof(System.Globalization.CultureInfo), (stringvalue, format, formatProvider) => new System.Globalization.CultureInfo(stringvalue) },
+                { typeof(System.Globalization.CultureInfo), (stringvalue, format, formatProvider) => ConvertToCultureInfo(stringvalue) },
                 { typeof(Type), (stringvalue, format, formatProvider) => ConvertToType(stringvalue, true) },
                 { typeof(NLog.Targets.LineEndingMode), (stringvalue, format, formatProvider) => NLog.Targets.LineEndingMode.FromString(stringvalue) },
                 { typeof(LogLevel), (stringvalue, format, formatProvider) => LogLevel.FromString(stringvalue) },
@@ -193,6 +194,17 @@ namespace NLog.Config
 #else
             return new Guid(propertyString);
 #endif
+        }
+
+        private static object ConvertToCultureInfo(string stringValue)
+        {
+            if (StringHelpers.IsNullOrWhiteSpace(stringValue))
+                return null;
+            if (nameof(CultureInfo.InvariantCulture).Equals(stringValue, StringComparison.OrdinalIgnoreCase))
+                return CultureInfo.InvariantCulture;
+            if (nameof(CultureInfo.CurrentCulture).Equals(stringValue, StringComparison.CurrentCulture))
+                return CultureInfo.CurrentCulture;
+            return new CultureInfo(stringValue);
         }
 
         private static object ConvertToEncoding(string stringValue)

--- a/src/NLog/Internal/FormatHelper.cs
+++ b/src/NLog/Internal/FormatHelper.cs
@@ -40,44 +40,33 @@ namespace NLog.Internal
         /// <summary>
         /// Convert object to string
         /// </summary>
-        /// <param name="o">value</param>
+        /// <param name="value">value</param>
         /// <param name="formatProvider">format for conversion.</param>
         /// <returns></returns>
         /// <remarks>
-        /// If <paramref name="formatProvider"/> is <c>null</c> and <paramref name="o"/> isn't a <see cref="string"/> already, then the <see cref="LogFactory"/> will get a locked by <see cref="LogManager.Configuration"/>
+        /// If <paramref name="formatProvider"/> is <c>null</c> and <paramref name="value"/> isn't a <see cref="string"/> already, then the <see cref="LogFactory"/> will get a locked by <see cref="LogManager.Configuration"/>
         /// </remarks>
-        internal static string ConvertToString(object o, IFormatProvider formatProvider)
+        internal static string ConvertToString(object value, IFormatProvider formatProvider)
         {
+            if (value is string stringValue)
+                return stringValue;
+            if (value is null)
+                return string.Empty;
+
             // if no IFormatProvider is specified, use the Configuration.DefaultCultureInfo value.
             if (formatProvider is null)
             {
-                if (SkipFormattableToString(o))
-                    return o?.ToString() ?? string.Empty;
-
-                if (o is IFormattable)
+                if (value is IFormattable)
                 {
                     formatProvider = LogManager.LogFactory.DefaultCultureInfo;
                 }
             }
 
-            return Convert.ToString(o, formatProvider);
-        }
-
-        private static bool SkipFormattableToString(object value)
-        {
-            switch (Convert.GetTypeCode(value))
-            {
-                case TypeCode.String: return true;
-                case TypeCode.Empty: return true;
-                default: return false;
-            }
+            return Convert.ToString(value, formatProvider);
         }
 
         internal static string TryFormatToString(object value, string format, IFormatProvider formatProvider)
         {
-            if (SkipFormattableToString(value))
-                return value?.ToString() ?? string.Empty;
-
             if (value is IFormattable formattable)
             {
                 return formattable.ToString(format, formatProvider);

--- a/src/NLog/LayoutRenderers/DateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/DateLayoutRenderer.cs
@@ -62,7 +62,7 @@ namespace NLog.LayoutRenderers
         /// Gets or sets the culture used for rendering.
         /// </summary>
         /// <docgen category='Layout Options' order='100' />
-        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+        public CultureInfo Culture { get; set; }
 
         /// <summary>
         /// Gets or sets the date format. Can be any argument accepted by DateTime.ToString(format).

--- a/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
@@ -109,8 +109,7 @@ namespace NLog.LayoutRenderers
         {
             if (TryGetValue(logEvent, out var value))
             {
-                var formatProvider = GetFormatProvider(logEvent, Culture);
-                builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
+                AppendFormattedValue(builder, logEvent, value, Format, Culture);
             }
         }
 

--- a/src/NLog/LayoutRenderers/ExceptionDataLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionDataLayoutRenderer.cs
@@ -93,8 +93,7 @@ namespace NLog.LayoutRenderers
                 var value = primaryException.Data[Item];
                 if (value != null)
                 {
-                    var formatProvider = GetFormatProvider(logEvent, Culture);
-                    builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
+                    AppendFormattedValue(builder, logEvent, value, Format, Culture);
                 }
             }
         }

--- a/src/NLog/LayoutRenderers/FuncLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/FuncLayoutRenderer.cs
@@ -94,8 +94,7 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var value = RenderValue(logEvent);
-            var formatProvider = GetFormatProvider(logEvent, Culture);
-            builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
+            AppendFormattedValue(builder, logEvent, value, Format, Culture);
         }
 
         string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);

--- a/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
@@ -77,8 +77,7 @@ namespace NLog.LayoutRenderers
             object value = GetValue();
             if (value != null || !string.IsNullOrEmpty(Format))
             {
-                var formatProvider = GetFormatProvider(logEvent, Culture);
-                builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
+                AppendFormattedValue(builder, logEvent, value, Format, Culture);
             }
         }
 

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -183,6 +183,19 @@ namespace NLog.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected abstract void Append(StringBuilder builder, LogEventInfo logEvent);
 
+        internal void AppendFormattedValue(StringBuilder builder, LogEventInfo logEvent, object value, string format, CultureInfo culture)
+        {
+            if (format is null && value is string stringValue)
+            {
+                builder.Append(stringValue);
+            }
+            else
+            {
+                var formatProvider = GetFormatProvider(logEvent, culture);
+                builder.AppendFormattedValue(value, format, formatProvider, ValueFormatter);
+            }
+        }
+
         /// <summary>
         /// Initializes the layout renderer.
         /// </summary>
@@ -205,7 +218,7 @@ namespace NLog.LayoutRenderers
         /// <returns></returns>
         protected IFormatProvider GetFormatProvider(LogEventInfo logEvent, IFormatProvider layoutCulture = null)
         {
-            return logEvent.FormatProvider ?? layoutCulture ?? LoggingConfiguration?.DefaultCultureInfo;
+            return layoutCulture ?? logEvent.FormatProvider ?? LoggingConfiguration?.DefaultCultureInfo;
         }
 
         /// <summary>
@@ -219,7 +232,7 @@ namespace NLog.LayoutRenderers
         /// </remarks>
         protected CultureInfo GetCulture(LogEventInfo logEvent, CultureInfo layoutCulture = null)
         {
-            return logEvent.FormatProvider as CultureInfo ?? layoutCulture ?? LoggingConfiguration?.DefaultCultureInfo;
+            return layoutCulture ?? logEvent.FormatProvider as CultureInfo ?? LoggingConfiguration?.DefaultCultureInfo ?? CultureInfo.CurrentCulture;
         }
 
         /// <summary>

--- a/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
@@ -70,7 +70,7 @@ namespace NLog.LayoutRenderers
         /// Gets or sets the culture used for rendering.
         /// </summary>
         /// <docgen category='Layout Options' order='100' />
-        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+        public CultureInfo Culture { get; set; }
 
         /// <inheritdoc/>
         protected override void InitializeLayoutRenderer()
@@ -101,8 +101,7 @@ namespace NLog.LayoutRenderers
             var value = GetValue();
             if (value != null)
             {
-                var formatProvider = GetFormatProvider(logEvent, Culture);
-                builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
+                AppendFormattedValue(builder, logEvent, value, Format, Culture);
             }
         }
 

--- a/src/NLog/LayoutRenderers/ProcessTimeLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessTimeLayoutRenderer.cs
@@ -60,8 +60,7 @@ namespace NLog.LayoutRenderers
         /// Gets or sets the culture used for rendering.
         /// </summary>
         /// <docgen category='Layout Options' order='100' />
-        [RequiredParameter]
-        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+        public CultureInfo Culture { get; set; }
 
         /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)

--- a/src/NLog/LayoutRenderers/ScopeContextNestedStatesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ScopeContextNestedStatesLayoutRenderer.cs
@@ -91,7 +91,7 @@ namespace NLog.LayoutRenderers
                 // Allows fast rendering of topframes=1
                 var topFrame = ScopeContext.PeekNestedState();
                 if (topFrame != null)
-                    builder.AppendFormattedValue(topFrame, Format, GetFormatProvider(logEvent, Culture), ValueFormatter);
+                    AppendFormattedValue(builder, logEvent, topFrame, Format, Culture);
                 return;
             }
 
@@ -117,7 +117,6 @@ namespace NLog.LayoutRenderers
         private void AppendNestedStates(StringBuilder builder, IList<object> messages, int startPos, int endPos, LogEventInfo logEvent)
         {
             bool formatAsJson = MessageTemplates.ValueFormatter.FormatAsJson.Equals(Format, StringComparison.Ordinal);
-            var formatProvider = GetFormatProvider(logEvent, Culture);
 
             string separator = null;
             string itemSeparator = null;
@@ -136,11 +135,11 @@ namespace NLog.LayoutRenderers
                 {
                     builder.Append(currentSeparator);
                     if (formatAsJson)
-                        AppendJsonFormattedValue(messages[i], formatProvider, builder, separator, itemSeparator);
+                        AppendJsonFormattedValue(messages[i], Culture ?? CultureInfo.InvariantCulture, builder, separator, itemSeparator);
                     else if (messages[i] is IEnumerable<KeyValuePair<string, object>>)
                         builder.Append(Convert.ToString(messages[i]));   // Special support for Microsoft Extension Logging ILogger.BeginScope
                     else
-                        builder.AppendFormattedValue(messages[i], Format, formatProvider, ValueFormatter);
+                        AppendFormattedValue(builder, logEvent, messages[i], Format, Culture);
                     currentSeparator = itemSeparator ?? _separator?.Render(logEvent) ?? string.Empty;
                 }
             }

--- a/src/NLog/LayoutRenderers/ScopeContextPropertyLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ScopeContextPropertyLayoutRenderer.cs
@@ -74,8 +74,7 @@ namespace NLog.LayoutRenderers
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var value = GetValue();
-            var formatProvider = GetFormatProvider(logEvent, Culture);
-            builder.AppendFormattedValue(value, Format, formatProvider, ValueFormatter);
+            AppendFormattedValue(builder, logEvent, value, Format, Culture);
         }
 
         string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue(logEvent);

--- a/src/NLog/LayoutRenderers/ScopeContextTimingLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ScopeContextTimingLayoutRenderer.cs
@@ -80,7 +80,7 @@ namespace NLog.LayoutRenderers
         /// Gets or sets the culture used for rendering.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
-        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+        public CultureInfo Culture { get; set; }
 
         /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)

--- a/src/NLog/LayoutRenderers/TimeLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/TimeLayoutRenderer.cs
@@ -67,8 +67,7 @@ namespace NLog.LayoutRenderers
         /// Gets or sets the culture used for rendering.
         /// </summary>
         /// <docgen category='Layout Options' order='100' />
-        [RequiredParameter]
-        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+        public CultureInfo Culture { get; set; }
 
         /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)

--- a/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/LowercaseLayoutRendererWrapper.cs
@@ -72,7 +72,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// Gets or sets the culture used for rendering.
         /// </summary>
         /// <docgen category='Layout Options' order='100' />
-        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+        public CultureInfo Culture { get; set; }
 
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
@@ -80,7 +80,7 @@ namespace NLog.LayoutRenderers.Wrappers
             Inner.Render(logEvent, builder);
             if (Lowercase && builder.Length > orgLength)
             {
-                TransformToLowerCase(builder, orgLength);
+                TransformToLowerCase(builder, logEvent, orgLength);
             }
         }
 
@@ -90,9 +90,9 @@ namespace NLog.LayoutRenderers.Wrappers
             throw new NotSupportedException();
         }
 
-        private void TransformToLowerCase(StringBuilder target, int startPos)
+        private void TransformToLowerCase(StringBuilder target, LogEventInfo logEvent, int startPos)
         {
-            CultureInfo culture = Culture;
+            CultureInfo culture = GetCulture(logEvent, Culture);
             for (int i = startPos; i < target.Length; ++i)
             {
                 target[i] = char.ToLower(target[i], culture);

--- a/src/NLog/LayoutRenderers/Wrappers/ObjectPathRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ObjectPathRendererWrapper.cs
@@ -87,7 +87,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// Gets or sets the culture used for rendering.
         /// </summary>
         /// <docgen category="Layout Options" order="100"/>
-        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+        public CultureInfo Culture { get; set; }
 
         /// <inheritdoc/>
         protected override string Transform(string text)
@@ -100,8 +100,7 @@ namespace NLog.LayoutRenderers.Wrappers
         {
             if (TryGetRawPropertyValue(logEvent, out object propertyValue))
             {
-                var formatProvider = GetFormatProvider(logEvent, Culture);
-                builder.AppendFormattedValue(propertyValue, Format, formatProvider, ValueFormatter);
+                AppendFormattedValue(builder, logEvent, propertyValue, Format, Culture);
             }
         }
 

--- a/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/UppercaseLayoutRendererWrapper.cs
@@ -77,7 +77,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// Gets or sets the culture used for rendering.
         /// </summary>
         /// <docgen category='Layout Options' order='100' />
-        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+        public CultureInfo Culture { get; set; }
 
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
@@ -85,7 +85,7 @@ namespace NLog.LayoutRenderers.Wrappers
             Inner.Render(logEvent, builder);
             if (Uppercase && builder.Length > orgLength)
             {
-                TransformToUpperCase(builder, orgLength);
+                TransformToUpperCase(builder, logEvent, orgLength);
             }
         }
 
@@ -95,9 +95,9 @@ namespace NLog.LayoutRenderers.Wrappers
             throw new NotSupportedException();
         }
 
-        private void TransformToUpperCase(StringBuilder target, int startPos)
+        private void TransformToUpperCase(StringBuilder target, LogEventInfo logEvent, int startPos)
         {
-            CultureInfo culture = Culture;
+            CultureInfo culture = GetCulture(logEvent, Culture);
             for (int i = startPos; i < target.Length; ++i)
             {
                 target[i] = char.ToUpper(target[i], culture);

--- a/tests/NLog.UnitTests/Config/CultureInfoTests.cs
+++ b/tests/NLog.UnitTests/Config/CultureInfoTests.cs
@@ -116,9 +116,13 @@ namespace NLog.UnitTests.Config
 
             var renderer = new EventPropertiesLayoutRenderer();
             renderer.Item = "ADouble";
+            renderer.Culture = null;
             string output = renderer.Render(logEventInfo);
-
             Assert.Equal(expected, output);
+
+            renderer.Culture = System.Globalization.CultureInfo.InvariantCulture;   // Wins over LogEventInfo.FormatProvider
+            output = renderer.Render(logEventInfo);
+            Assert.Equal("1.23", output);
         }
 
         [Fact]
@@ -164,9 +168,13 @@ namespace NLog.UnitTests.Config
             logEventInfo.Properties["ADouble"] = 1.23;
 
             var renderer = new AllEventPropertiesLayoutRenderer();
+            renderer.Culture = null;
             string output = renderer.Render(logEventInfo);
-
             Assert.Equal(expected, output);
+
+            renderer.Culture = System.Globalization.CultureInfo.InvariantCulture;   // Wins over LogEventInfo.FormatProvider
+            output = renderer.Render(logEventInfo);
+            Assert.Equal("ADouble=1.23", output);
         }
 
         private static LogEventInfo CreateLogEventInfo(string cultureName)

--- a/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
@@ -170,13 +170,6 @@ namespace NLog.UnitTests.Config
             Assert.NotNull(otherDependency);
         }
 
-        private static void AssertCycleException<T>(LogFactory logFactory) where T : class
-        {
-            var ex = Assert.Throws<NLogDependencyResolveException>(() => logFactory.ServiceRepository.ResolveService<T>());
-            Assert.Contains("cycle", ex.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Equal(typeof(T), ex.ServiceType);
-        }
-
         private static void InitializeLogFactoryJsonConverter(LogFactory logFactory, string testValue, out Logger logger, out DebugTarget target)
         {
             logFactory.ServiceRepository.RegisterService(typeof(IJsonConverter), new MySimpleJsonConverter { Test = testValue });


### PR DESCRIPTION
Resolves #5479 - Usually the FormatProvider on the LogEvent is only for string.Format of FormattedMessage. The LayoutRenderer Culture should take precedence when specified.

Decided that LayoutRenderer related to structured-logging will enforce InvariantCulture by default. But LayoutRenderer related to time-formatting will rely on CurrentCulture unless something else has been specified. If wanting LogEvent.FormatProvider to win, then one can specify `${event-properties:Culture=}` to remove the override.

This means `${date}` and `${time}` will get a performance boost when specifying `${date:Culture=InvariantCulture}` or `${time:Culture=InvariantCulture}`