### PR TITLE
LogFactory - FlushAsync + IAsyncDisposable DisposeAsync

### DIFF
--- a/src/NLog/Common/AsyncHelpers.cs
+++ b/src/NLog/Common/AsyncHelpers.cs
@@ -165,6 +165,8 @@ namespace NLog.Common
         /// <param name="asyncContinuation">The asynchronous continuation.</param>
         /// <param name="timeout">The timeout.</param>
         /// <returns>Wrapped continuation.</returns>
+        [Obsolete("Marked obsolete on NLog 6.0")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static AsyncContinuation WithTimeout(AsyncContinuation asyncContinuation, TimeSpan timeout)
         {
             return new TimeoutContinuation(asyncContinuation, timeout).Function;

--- a/src/NLog/Internal/TimeoutContinuation.cs
+++ b/src/NLog/Internal/TimeoutContinuation.cs
@@ -34,12 +34,14 @@
 namespace NLog.Internal
 {
     using System;
+    using System.ComponentModel;
     using System.Threading;
     using NLog.Common;
 
     /// <summary>
     /// Wraps <see cref="AsyncContinuation"/> with a timeout.
     /// </summary>
+    [Obsolete("Marked obsolete on NLog 6.0")]
     internal sealed class TimeoutContinuation : IDisposable
     {
         private AsyncContinuation _asyncContinuation;

--- a/tests/NLog.UnitTests/AsyncHelperTests.cs
+++ b/tests/NLog.UnitTests/AsyncHelperTests.cs
@@ -133,6 +133,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Marked obsolete on NLog 6.0")]
         public void ContinuationTimeoutTest()
         {
             RetryingIntegrationTest(3, () =>
@@ -165,6 +166,7 @@ namespace NLog.UnitTests
         }
 
         [Fact]
+        [Obsolete("Marked obsolete on NLog 6.0")]
         public void ContinuationTimeoutNotHitTest()
         {
             var exceptions = new List<Exception>();
@@ -192,8 +194,8 @@ namespace NLog.UnitTests
             Assert.Null(exceptions[0]);
         }
 
-
         [Fact]
+        [Obsolete("Marked obsolete on NLog 6.0")]
         public void ContinuationErrorTimeoutNotHitTest()
         {
             var exceptions = new List<Exception>();


### PR DESCRIPTION
Resolves #5453 by changing LogFactory.Dispose to skip flush, and perform synchronous close / dispose (not starting new threads).

Trying to resolve #3958 by not blocking forever during Target-Flush (releasing threads), but bad targets can still block everything on Target-Close. LogFactory DisposeAsync will not get stuck forever, but will have timeout for Target-Close.

Instead introduced FlushAsync / DisposeAsync so one can easily Flush / Dispose at scope-exit.

Refactored LoggingConfiguration.FlushAllTargets so it can be used together with `TaskCompletionSource` and `CancellationToken`.