### PR TITLE
ReplaceLayoutRendererWrapper - SearchFor and ReplaceWith with basic Layout support

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -417,7 +417,7 @@ namespace NLog.Config
             try
             {
                 newFileName = ExpandSimpleVariables(newFileName);
-                newFileName = SimpleLayout.Evaluate(newFileName);
+                newFileName = SimpleLayout.Evaluate(newFileName, this);
                 var fullNewFileName = newFileName;
                 if (baseDirectory != null)
                 {

--- a/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ExceptionLayoutRenderer.cs
@@ -138,7 +138,6 @@ namespace NLog.LayoutRenderers
         public string InnerFormat
         {
             get => _innerFormat;
-
             set
             {
                 _innerFormat = value;
@@ -150,15 +149,33 @@ namespace NLog.LayoutRenderers
         /// Gets or sets the separator used to concatenate parts specified in the Format.
         /// </summary>
         /// <docgen category='Layout Options' order='50' />
-        public string Separator { get => _seperator; set => _seperator = new NLog.Layouts.SimpleLayout(value).Render(LogEventInfo.CreateNullEvent()); }
-        private string _seperator = " ";
+        public string Separator
+        {
+            get => _separatorOriginal ?? _separator;
+            set
+            {
+                _separatorOriginal = value;
+                _separator = Layouts.SimpleLayout.Evaluate(value, LoggingConfiguration, throwConfigExceptions: false);
+            }
+        }
+        private string _separator = " ";
+        private string _separatorOriginal;
 
         /// <summary>
         /// Gets or sets the separator used to concatenate exception data specified in the Format.
         /// </summary>
         /// <docgen category='Layout Options' order='50' />
-        public string ExceptionDataSeparator { get => _exceptionDataSeparator; set => _exceptionDataSeparator = new NLog.Layouts.SimpleLayout(value).Render(LogEventInfo.CreateNullEvent()); }
+        public string ExceptionDataSeparator
+        {
+            get => _exceptionDataSeparatorOriginal ?? _exceptionDataSeparator;
+            set
+            {
+                _exceptionDataSeparatorOriginal = value;
+                _exceptionDataSeparator = Layouts.SimpleLayout.Evaluate(value, LoggingConfiguration, throwConfigExceptions: false);
+            }
+        }
         private string _exceptionDataSeparator = ";";
+        private string _exceptionDataSeparatorOriginal;
 
         /// <summary>
         /// Gets or sets the maximum number of inner exceptions to include in the output.
@@ -221,6 +238,16 @@ namespace NLog.LayoutRenderers
         private Exception GetTopException(LogEventInfo logEvent)
         {
             return BaseException ? logEvent.Exception?.GetBaseException() : logEvent.Exception;
+        }
+
+        /// <inheritdoc/>
+        protected override void InitializeLayoutRenderer()
+        {
+            base.InitializeLayoutRenderer();
+            if (_separatorOriginal != null)
+                _separator = Layouts.SimpleLayout.Evaluate(_separatorOriginal, LoggingConfiguration);
+            if (_exceptionDataSeparatorOriginal != null)
+                _exceptionDataSeparator = Layouts.SimpleLayout.Evaluate(_exceptionDataSeparatorOriginal, LoggingConfiguration);
         }
 
         /// <inheritdoc/>
@@ -335,7 +362,7 @@ namespace NLog.LayoutRenderers
                 if (builder.Length != beforeRenderLength)
                 {
                     currentLength = builder.Length;
-                    builder.Append(Separator);
+                    builder.Append(_separator);
                 }
             }
 
@@ -493,7 +520,7 @@ namespace NLog.LayoutRenderers
             if (aggregateException?.Data?.Count > 0 && !ReferenceEquals(ex, aggregateException))
             {
                 AppendData(builder, aggregateException);
-                builder.Append(Separator);
+                builder.Append(_separator);
             }
             AppendData(builder, ex);
         }
@@ -514,13 +541,13 @@ namespace NLog.LayoutRenderers
                     try
                     {
                         sb.AppendFormat("{0}: ", key);
+                        separator = _exceptionDataSeparator;
                         sb.AppendFormat("{0}", ex.Data[key]);
                     }
                     catch (Exception exception)
                     {
                         InternalLogger.Warn(exception, "Exception-LayoutRenderer Could not output Data-collection for Exception: {0}", ex.GetType());
                     }
-                    separator = ExceptionDataSeparator;
                 }
             }
         }
@@ -549,13 +576,22 @@ namespace NLog.LayoutRenderers
                 if (ExcludeDefaultProperties.Contains(property.Name))
                     continue;
 
-                var propertyValue = property.Value?.ToString();
-                if (string.IsNullOrEmpty(propertyValue))
-                    continue;
+                try
+                {
+                    var propertyValue = property.Value?.ToString();
+                    if (string.IsNullOrEmpty(propertyValue))
+                        continue;
 
-                sb.Append(separator);
-                sb.AppendFormat("{0}: {1}", property.Name, propertyValue);
-                separator = ExceptionDataSeparator;
+                    sb.Append(separator);
+                    sb.Append(property.Name);
+                    separator = _exceptionDataSeparator;
+                    sb.Append(": ");
+                    sb.AppendFormat("{0}", propertyValue);
+                }
+                catch (Exception exception)
+                {
+                    InternalLogger.Warn(exception, "Exception-LayoutRenderer Could not output Property-collection for Exception: {0}", ex.GetType());
+                }
             }
         }
 

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceLayoutRendererWrapper.cs
@@ -58,14 +58,34 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <value>The text search for.</value>
         /// <docgen category='Layout Options' order='10' />
         [RequiredParameter]
-        public string SearchFor { get; set; }
+        public string SearchFor
+        {
+            get => _searchForOriginal ?? _searchFor;
+            set
+            {
+                _searchForOriginal = value;
+                _searchFor = Layouts.SimpleLayout.Evaluate(value, LoggingConfiguration, throwConfigExceptions: false);
+            }
+        }
+        private string _searchFor;
+        private string _searchForOriginal;
 
         /// <summary>
         /// Gets or sets the replacement string.
         /// </summary>
         /// <value>The replacement string.</value>
         /// <docgen category='Layout Options' order='10' />
-        public string ReplaceWith { get; set; } = string.Empty;
+        public string ReplaceWith
+        {
+            get => _replaceWithOriginal ?? _replaceWith;
+            set
+            {
+                _replaceWithOriginal = value;
+                _replaceWith = Layouts.SimpleLayout.Evaluate(value, LoggingConfiguration, throwConfigExceptions: false);
+            }
+        }
+        private string _replaceWith = string.Empty;
+        private string _replaceWithOriginal;
 
         /// <summary>
         /// Gets or sets a value indicating whether to ignore case.
@@ -82,16 +102,26 @@ namespace NLog.LayoutRenderers.Wrappers
         public bool WholeWords { get; set; }
 
         /// <inheritdoc/>
+        protected override void InitializeLayoutRenderer()
+        {
+            base.InitializeLayoutRenderer();
+            if (_searchForOriginal != null)
+                _searchFor = Layouts.SimpleLayout.Evaluate(_searchForOriginal, LoggingConfiguration);
+            if (_replaceWithOriginal != null)
+                _replaceWith = Layouts.SimpleLayout.Evaluate(_replaceWithOriginal, LoggingConfiguration);
+        }
+
+        /// <inheritdoc/>
         protected override string Transform(string text)
         {
             if (IgnoreCase || WholeWords)
             {
                 var stringComparer = IgnoreCase ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
-                return StringHelpers.Replace(text, SearchFor, ReplaceWith, stringComparer, WholeWords);
+                return StringHelpers.Replace(text, _searchFor, _replaceWith, stringComparer, WholeWords);
             }
             else
             {
-                return text.Replace(SearchFor, ReplaceWith);
+                return text.Replace(_searchFor, _replaceWith);
             }
         }
     }

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ReplaceTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ReplaceTests.cs
@@ -77,5 +77,17 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
             // Assert
             Assert.Equal("BAR bar bar foobar barfoo bar BAR", result);
         }
+
+        [Fact]
+        public void ReplaceTestWithSecretVariable()
+        {
+            var memoryTarget = new NLog.Targets.MemoryTarget() { Layout = "${replace:inner=${message}:searchFor=${var:secret}:replaceWith=******" };
+            var logFactory = new LogFactory().Setup().LoadConfigurationFromXml("<nlog><variable name='secret' value='secret' /></nlog>").
+                LoadConfiguration(cfg => cfg.ForLogger().WriteTo(memoryTarget)).LogFactory;
+
+            logFactory.GetLogger(nameof(ReplaceTestWithSecretVariable)).Info("My name is secret");
+            Assert.Single(memoryTarget.Logs);
+            Assert.Equal("My name is ******", memoryTarget.Logs[0]);
+        }
     }
 }


### PR DESCRIPTION
Resolves #4042 for NLog v6

Also applies the same technique for these:
- AllEventPropertiesLayoutRenderer - Separator
- ExceptionLayoutRenderer - Separator + ExceptionDataSeparator
- ScopeContextNestedStatesLayoutRenderer - Separator
- StackTraceLayoutRenderer  - Separator