### PR TITLE
NetworkTarget - Added support for loading SSL certificate from file

### DIFF
--- a/src/NLog.Targets.Network/Internal/PlatformDetector.cs
+++ b/src/NLog.Targets.Network/Internal/PlatformDetector.cs
@@ -62,6 +62,8 @@ namespace NLog.Targets.Internal
                 return PlatformOS.MacOSX;
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
                 return PlatformOS.Windows;
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Create("ANDROID")))
+                return PlatformOS.Linux;
 #endif
             return PlatformOS.Unknown;
         }

--- a/src/NLog.Targets.Network/NetworkSenders/INetworkSenderFactory.cs
+++ b/src/NLog.Targets.Network/NetworkSenders/INetworkSenderFactory.cs
@@ -34,6 +34,7 @@
 namespace NLog.Internal.NetworkSenders
 {
     using System;
+    using System.Security.Cryptography.X509Certificates;
     using NLog.Targets;
 
     /// <summary>
@@ -49,11 +50,12 @@ namespace NLog.Internal.NetworkSenders
         /// <param name="onQueueOverflow">The overflow action when reaching maximum queue size.</param>
         /// <param name="maxMessageSize">The maximum message size.</param>
         /// <param name="sslProtocols">SSL protocols for TCP</param>
+        /// <param name="sslCertificateOverride">SSL Certificate override</param>
         /// <param name="keepAliveTime">KeepAliveTime for TCP</param>
         /// <param name="sendTimeout">SendTimeout for TCP</param>
         /// <returns>
         /// A newly created network sender.
         /// </returns>
-        QueuedNetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime, TimeSpan sendTimeout);
+        QueuedNetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, X509Certificate2Collection sslCertificateOverride, TimeSpan keepAliveTime, TimeSpan sendTimeout);
     }
 }

--- a/src/NLog.Targets.Network/NetworkSenders/NetworkSenderFactory.cs
+++ b/src/NLog.Targets.Network/NetworkSenders/NetworkSenderFactory.cs
@@ -35,6 +35,7 @@ namespace NLog.Internal.NetworkSenders
 {
     using System;
     using System.Net.Sockets;
+    using System.Security.Cryptography.X509Certificates;
     using NLog.Targets;
 
     /// <summary>
@@ -45,7 +46,7 @@ namespace NLog.Internal.NetworkSenders
         public static readonly INetworkSenderFactory Default = new NetworkSenderFactory();
 
         /// <inheritdoc/>
-        public QueuedNetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, TimeSpan keepAliveTime, TimeSpan sendTimeout)
+        public QueuedNetworkSender Create(string url, int maxQueueSize, NetworkTargetQueueOverflowAction onQueueOverflow, int maxMessageSize, System.Security.Authentication.SslProtocols sslProtocols, X509Certificate2Collection sslCertificateOverride, TimeSpan keepAliveTime, TimeSpan sendTimeout)
         {
             if (url.StartsWith("tcp://", StringComparison.OrdinalIgnoreCase))
             {
@@ -56,6 +57,7 @@ namespace NLog.Internal.NetworkSenders
                     SslProtocols = sslProtocols,
                     KeepAliveTime = keepAliveTime,
                     SendTimeout = sendTimeout,
+                    SslCertificateOverride = sslCertificateOverride,
                 };
             }
 
@@ -68,6 +70,7 @@ namespace NLog.Internal.NetworkSenders
                     SslProtocols = sslProtocols,
                     KeepAliveTime = keepAliveTime,
                     SendTimeout = sendTimeout,
+                    SslCertificateOverride = sslCertificateOverride,
                 };
             }
 
@@ -80,6 +83,7 @@ namespace NLog.Internal.NetworkSenders
                     SslProtocols = sslProtocols,
                     KeepAliveTime = keepAliveTime,
                     SendTimeout = sendTimeout,
+                    SslCertificateOverride = sslCertificateOverride,
                 };
             }
 
@@ -120,6 +124,7 @@ namespace NLog.Internal.NetworkSenders
                     MaxQueueSize = maxQueueSize,
                     OnQueueOverflow = onQueueOverflow,
                     SendTimeout = sendTimeout,
+                    SslCertificateOverride = sslCertificateOverride,
                 };
             }
 
@@ -130,6 +135,7 @@ namespace NLog.Internal.NetworkSenders
                     MaxQueueSize = maxQueueSize,
                     OnQueueOverflow = onQueueOverflow,
                     SendTimeout = sendTimeout,
+                    SslCertificateOverride = sslCertificateOverride,
                 };
             }
 

--- a/src/NLog.Targets.Network/NetworkSenders/TcpNetworkSender.cs
+++ b/src/NLog.Targets.Network/NetworkSenders/TcpNetworkSender.cs
@@ -36,6 +36,7 @@ namespace NLog.Internal.NetworkSenders
     using System;
     using System.IO;
     using System.Net.Sockets;
+    using System.Security.Cryptography.X509Certificates;
     using NLog.Common;
     using NLog.Targets.Internal;
 
@@ -64,6 +65,8 @@ namespace NLog.Internal.NetworkSenders
         internal AddressFamily AddressFamily { get; set; }
 
         internal System.Security.Authentication.SslProtocols SslProtocols { get; set; }
+
+        internal X509Certificate2Collection SslCertificateOverride { get; set; }
 
         internal TimeSpan KeepAliveTime { get; set; }
 
@@ -94,7 +97,7 @@ namespace NLog.Internal.NetworkSenders
 
             if (SslProtocols != System.Security.Authentication.SslProtocols.None)
             {
-                return new SslSocketProxy(host, SslProtocols, socketProxy);
+                return new SslSocketProxy(host, SslProtocols, socketProxy, SslCertificateOverride);
             }
 
             return socketProxy;

--- a/tests/NLog.Targets.Network.Tests/NetworkSenders/HttpNetworkSenderTests.cs
+++ b/tests/NLog.Targets.Network.Tests/NetworkSenders/HttpNetworkSenderTests.cs
@@ -35,6 +35,7 @@ namespace NLog.Targets.Network
 {
     using System;
     using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
     using NLog.Config;
     using NLog.Internal.NetworkSenders;
     using NSubstitute;
@@ -88,7 +89,7 @@ namespace NLog.Targets.Network
             Assert.Equal("HttpHappyPathTestLogger|test message1|", requestedString);
             Assert.Equal("POST", mock.Method);
 
-            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 1234, NetworkTargetQueueOverflowAction.Block, 0, SslProtocols.None, TimeSpan.Zero, TimeSpan.Zero);
+            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 1234, NetworkTargetQueueOverflowAction.Block, 0, SslProtocols.None, null, TimeSpan.Zero, TimeSpan.Zero);
 
             // Cleanup
             mock.Dispose();
@@ -134,7 +135,7 @@ namespace NLog.Targets.Network
             Assert.Equal("HttpHappyPathTestLogger|test message2|", requestedString);
             Assert.Equal("POST", mock.Method);
 
-            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 1234, NetworkTargetQueueOverflowAction.Block, 0, SslProtocols.None, TimeSpan.Zero, TimeSpan.Zero); // Only created one HttpNetworkSender
+            networkSenderFactoryMock.Received(1).Create("http://test.with.mock", 1234, NetworkTargetQueueOverflowAction.Block, 0, SslProtocols.None, null, TimeSpan.Zero, TimeSpan.Zero); // Only created one HttpNetworkSender
 
             // Cleanup
             mock.Dispose();
@@ -145,7 +146,7 @@ namespace NLog.Targets.Network
         {
             var networkSenderFactoryMock = Substitute.For<INetworkSenderFactory>();
 
-            networkSenderFactoryMock.Create(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<NetworkTargetQueueOverflowAction>(), Arg.Any<int>(), Arg.Any<SslProtocols>(), Arg.Any<TimeSpan>(), Arg.Any<TimeSpan>())
+            networkSenderFactoryMock.Create(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<NetworkTargetQueueOverflowAction>(), Arg.Any<int>(), Arg.Any<SslProtocols>(), Arg.Any<X509Certificate2Collection>(), Arg.Any<TimeSpan>(), Arg.Any<TimeSpan>())
                 .Returns(url => new HttpNetworkSender(url.Arg<string>())
                 {
                     HttpRequestFactory = new WebRequestFactoryMock(webRequestMock)


### PR DESCRIPTION
Resolves #3033 by introducing 2 new options for NetworkTarget:
- public Layout SslCertificateFile { get; set; }
- public Layout SslCertificatePassword { get; set; }
