### PR TITLE
Removed static constructor from LogFactory

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -1245,7 +1245,7 @@ namespace NLog
         {
             try
             {
-                _loggerShutdown?.Invoke(sender, args);
+                _loggerShutdown?.Invoke(null, args);
             }
             catch (Exception ex)
             {

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -95,46 +95,24 @@ namespace NLog
         /// <summary>
         /// Event that is raised when the logging system is shutting down.
         /// </summary>
-        internal static event EventHandler<EventArgs> LoggerShutdown
+        private static event EventHandler<EventArgs> LoggerShutdown
         {
             add
             {
-                if (_loggerShutdown == null && DefaultAppEnvironment != null)
+                if (_loggerShutdown is null && DefaultAppEnvironment != null)
                 {
-                    try
-                    {
-                        InternalLogger.Debug("Registered shutdown event handler for ProcessExit.");
-                        DefaultAppEnvironment.ProcessExit += OnLoggerShutdown;
-                    }
-                    catch (Exception exception)
-                    {
-                        InternalLogger.Warn(exception, "Error registering ProcessExit event handler.");
-                        if (exception.MustBeRethrown())
-                        {
-                            throw;
-                        }
-                    }
+                    InternalLogger.Debug("Registered shutdown event handler for ProcessExit.");
+                    DefaultAppEnvironment.ProcessExit += OnLoggerShutdown;
                 }
                 _loggerShutdown += value;
             }
             remove
             {
                 _loggerShutdown -= value;
-                if (_loggerShutdown == null && DefaultAppEnvironment != null)
+                if (_loggerShutdown is null && DefaultAppEnvironment != null)
                 {
-                    try
-                    {
-                        InternalLogger.Debug("Unregistered shutdown event handler for ProcessExit.");
-                        DefaultAppEnvironment.ProcessExit -= OnLoggerShutdown;
-                    }
-                    catch (Exception exception)
-                    {
-                        InternalLogger.Warn(exception, "Error unregistering ProcessExit event handler.");
-                        if (exception.MustBeRethrown())
-                        {
-                            throw;
-                        }
-                    }
+                    InternalLogger.Debug("Unregistered shutdown event handler for ProcessExit.");
+                    DefaultAppEnvironment.ProcessExit -= OnLoggerShutdown;
                 }
             }
         }

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -1254,6 +1254,14 @@ namespace NLog
                     throw;
                 InternalLogger.Error(ex, "LogFactory failed to shutdown properly.");
             }
+            finally
+            {
+                _loggerShutdown = null;
+                if (DefaultAppEnvironment != null)
+                {
+                    DefaultAppEnvironment.ProcessExit -= OnLoggerShutdown;
+                }
+            }
         }
 
         private void OnStopLogging(object sender, EventArgs args)

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -95,7 +95,7 @@ namespace NLog
         /// <summary>
         /// Event that is raised when the logging system is shutting down.
         /// </summary>
-        public static event EventHandler<EventArgs> LoggerShutdown
+        internal static event EventHandler<EventArgs> LoggerShutdown
         {
             add
             {
@@ -103,8 +103,8 @@ namespace NLog
                 {
                     try
                     {
-                        DefaultAppEnvironment.ProcessExit += OnLoggerShutdown;
                         InternalLogger.Debug("Registered shutdown event handler for ProcessExit.");
+                        DefaultAppEnvironment.ProcessExit += OnLoggerShutdown;
                     }
                     catch (Exception exception)
                     {
@@ -124,8 +124,8 @@ namespace NLog
                 {
                     try
                     {
-                        DefaultAppEnvironment.ProcessExit -= OnLoggerShutdown;
                         InternalLogger.Debug("Unregistered shutdown event handler for ProcessExit.");
+                        DefaultAppEnvironment.ProcessExit -= OnLoggerShutdown;
                     }
                     catch (Exception exception)
                     {

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -91,7 +91,7 @@ namespace NLog
         public event EventHandler<LoggingConfigurationChangedEventArgs> ConfigurationChanged;
 
         /// <summary>
-        /// Event that is raised when the current Process / AppDomain is shutting down.
+        /// Event that is raised when the current Process / AppDomain terminates.
         /// </summary>
         private static event EventHandler<EventArgs> LoggerShutdown
         {

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -97,7 +97,7 @@ namespace NLog
         {
             add
             {
-                if (_loggerShutdown is null && DefaultAppEnvironment != null)
+                if (_loggerShutdown is null)
                 {
                     InternalLogger.Debug("Registered shutdown event handler for ProcessExit.");
                     DefaultAppEnvironment.ProcessExit += OnLoggerShutdown;
@@ -107,10 +107,10 @@ namespace NLog
             remove
             {
                 _loggerShutdown -= value;
-                if (_loggerShutdown is null && DefaultAppEnvironment != null)
+                if (_loggerShutdown is null && defaultAppEnvironment != null)
                 {
                     InternalLogger.Debug("Unregistered shutdown event handler for ProcessExit.");
-                    DefaultAppEnvironment.ProcessExit -= OnLoggerShutdown;
+                    defaultAppEnvironment.ProcessExit -= OnLoggerShutdown;
                 }
             }
         }

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -1259,7 +1259,7 @@ namespace NLog
                 _loggerShutdown = null;
                 if (defaultAppEnvironment != null)
                 {
-                    defaultAppEnvironment.ProcessExit -= OnLoggerShutdown; // Unregister from AppDomain
+                    defaultAppEnvironment.ProcessExit -= OnLoggerShutdown;  // Unregister from AppDomain
                 }
             }
         }

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -90,10 +90,8 @@ namespace NLog
         /// </remarks>
         public event EventHandler<LoggingConfigurationChangedEventArgs> ConfigurationChanged;
 
-        private static event EventHandler<EventArgs> _loggerShutdown;
-
         /// <summary>
-        /// Event that is raised when the logging system is shutting down.
+        /// Event that is raised when the current Process / AppDomain is shutting down.
         /// </summary>
         private static event EventHandler<EventArgs> LoggerShutdown
         {
@@ -116,6 +114,7 @@ namespace NLog
                 }
             }
         }
+        private static event EventHandler<EventArgs> _loggerShutdown;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LogFactory" /> class.

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -1257,9 +1257,9 @@ namespace NLog
             finally
             {
                 _loggerShutdown = null;
-                if (DefaultAppEnvironment != null)
+                if (defaultAppEnvironment != null)
                 {
-                    DefaultAppEnvironment.ProcessExit -= OnLoggerShutdown;
+                    defaultAppEnvironment.ProcessExit -= OnLoggerShutdown; // Unregister from AppDomain
                 }
             }
         }

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -474,11 +474,8 @@ namespace NLog.UnitTests
             // Known allowed explicit static constructors (full type names)
             var knownStaticConstructors = new HashSet<string>
             {
+                // Explicit static constructors
                 "NLog.LogFactory",
-                "NLog.Targets.ConcurrentFileTarget",
-                "NLog.UnitTests.DatabaseTargetTests",
-                "NLog.Targets.ConcurrentFile.Tests.ProcessRunner",
-                "NLog.UnitTests.LogManagerTests",
 
                 // Likely compiler generated or false-positives.
                 "NLog.GlobalDiagnosticsContext",

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -530,6 +530,7 @@ namespace NLog.UnitTests
                 "NLog.Internal.ObjectReflectionCache+EmptyDictionaryEnumerator",
                 "NLog.Internal.PropertiesDictionary+PropertyKeyComparer",
                 "NLog.Internal.SingleItemOptimizedHashSet`1+ReferenceEqualityComparer",
+                "NLog.Internal.ArrayHelper+EmptyArray`1",
                 "NLog.Config.LoggerNameMatcher+NoneLoggerNameMatcher",
                 "NLog.Config.LoggerNameMatcher+AllLoggerNameMatcher",
                 "NLog.Config.LoggingConfigurationParser+ValidatedConfigurationElement"

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -520,6 +520,7 @@ namespace NLog.UnitTests
                 "NLog.Config.InstallationContext",
                 "NLog.Config.LoggingRuleLevelFilter",
                 "NLog.Config.PropertyTypeConverter",
+                "NLog.Config.XmlLoggingConfiguration",
                 "NLog.Conditions.ConditionExpression",
                 "NLog.Conditions.ConditionRelationalExpression",
                 "NLog.Conditions.ConditionTokenizer",
@@ -532,9 +533,9 @@ namespace NLog.UnitTests
                 "NLog.Config.LoggerNameMatcher+NoneLoggerNameMatcher",
                 "NLog.Config.LoggerNameMatcher+AllLoggerNameMatcher",
                 "NLog.Config.LoggingConfigurationParser+ValidatedConfigurationElement"
-            };     
-            var assembly = typeof(NLog.LogFactory).Assembly;
-            var typesWithStaticConstructors = assembly.GetTypes()
+            };
+
+            var typesWithStaticConstructors = allTypes
                 // Exclude compiler-generated types (e.g., lambdas, nested <>c classes)
                 .Where(type => !type.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false))
                 .Select(type => new

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -50,7 +50,7 @@ namespace NLog.UnitTests
         private readonly Type[] allTypes;
         private readonly Assembly nlogAssembly = typeof(LogManager).Assembly;
         private readonly Dictionary<Type, int> typeUsageCount = new Dictionary<Type, int>();
-        
+
         public ApiTests()
         {
             allTypes = typeof(LogManager).Assembly.GetTypes();


### PR DESCRIPTION
This PR introduces a test to ensure that no new explicit static constructors are introduced into the codebase while allowing the existing ones.

Changes Introduced:

- Implemented a unit test that scans all .cs files in the solution for explicit static constructors.
- Allowed existing static constructors using a whitelist of class names to avoid breaking changes.
- The test will fail only if a new static constructor is added.

Why This is Needed:

- Prevents unnecessary static initialization, improving performance and maintainability.
- Avoids accidental introduction of new static constructors.
- Reduces long-term maintenance effort by tracking only class names, not specific lines.