### PR TITLE
 Marked JsonLayout EscapeForwardSlash as obsolete

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
@@ -34,6 +34,7 @@
 namespace NLog.LayoutRenderers.Wrappers
 {
     using System;
+    using System.ComponentModel;
     using System.Text;
     using NLog.Config;
 
@@ -69,6 +70,8 @@ namespace NLog.LayoutRenderers.Wrappers
         /// If not set explicitly then the value of the parent will be used as default.
         /// </remarks>
         /// <docgen category="Layout Options" order="10"/>
+        [Obsolete("Marked obsolete with NLog 5.5. Should never escape forward slash")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool EscapeForwardSlash { get; set; }
 
         /// <inheritdoc/>
@@ -77,7 +80,10 @@ namespace NLog.LayoutRenderers.Wrappers
             Inner.Render(logEvent, builder);
             if (JsonEncode && builder.Length > orgLength)
             {
-                Targets.DefaultJsonSerializer.PerformJsonEscapeWhenNeeded(builder, orgLength, EscapeUnicode, EscapeForwardSlash);
+#pragma warning disable CS0618 // Type or member is obsolete
+                bool escapeForwardSlash = EscapeForwardSlash;
+#pragma warning restore CS0618 // Type or member is obsolete
+                Targets.DefaultJsonSerializer.PerformJsonEscapeWhenNeeded(builder, orgLength, EscapeUnicode, escapeForwardSlash);
             }
         }
 

--- a/src/NLog/Layouts/JSON/JsonLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonLayout.cs
@@ -56,7 +56,10 @@ namespace NLog.Layouts
 
         private LimitRecursionJsonConvert JsonConverter
         {
-            get => _jsonConverter ?? (_jsonConverter = new LimitRecursionJsonConvert(MaxRecursionLimit, EscapeForwardSlash, ResolveService<IJsonConverter>()));
+            get => _jsonConverter ??
+#pragma warning disable CS0618 // Type or member is obsolete
+                (_jsonConverter = new LimitRecursionJsonConvert(MaxRecursionLimit, EscapeForwardSlash, ResolveService<IJsonConverter>()));
+#pragma warning restore CS0618 // Type or member is obsolete
             set => _jsonConverter = value;
         }
         private LimitRecursionJsonConvert _jsonConverter;
@@ -77,7 +80,13 @@ namespace NLog.Layouts
             {
                 _converter = converter;
                 _serializer = converter as Targets.DefaultJsonSerializer;
-                _serializerOptions = new Targets.JsonSerializeOptions() { MaxRecursionLimit = Math.Max(0, maxRecursionLimit), EscapeForwardSlash = escapeForwardSlash };
+                _serializerOptions = new Targets.JsonSerializeOptions()
+                {
+                    MaxRecursionLimit = Math.Max(0, maxRecursionLimit),
+#pragma warning disable CS0618 // Type or member is obsolete
+                    EscapeForwardSlash = escapeForwardSlash
+#pragma warning restore CS0618 // Type or member is obsolete
+                };
             }
 
             public bool SerializeObject(object value, StringBuilder builder)
@@ -232,6 +241,8 @@ namespace NLog.Layouts
         /// If not set explicitly then the value of the parent will be used as default.
         /// </remarks>
         /// <docgen category='Layout Options' order='100' />
+        [Obsolete("Marked obsolete with NLog 5.5. Should never escape forward slash")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool EscapeForwardSlash
         {
             get => _escapeForwardSlashInternal ?? false;
@@ -466,7 +477,10 @@ namespace NLog.Layouts
                 // Overrides MaxRecursionLimit as message-template tells us it is unsafe
                 int originalStart = sb.Length;
                 ValueFormatter.FormatValue(propertyValue, format, captureType, formatProvider, sb);
-                PerformJsonEscapeIfNeeded(sb, originalStart, EscapeForwardSlash);
+#pragma warning disable CS0618 // Type or member is obsolete
+                bool escapeForwardSlash = EscapeForwardSlash;
+#pragma warning restore CS0618 // Type or member is obsolete
+                PerformJsonEscapeIfNeeded(sb, originalStart, escapeForwardSlash);
             }
             else
             {

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -95,9 +95,13 @@ namespace NLog.Targets
             }
             else if (value is string str)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
+                bool escapeForwardSlash = options.EscapeForwardSlash;
+#pragma warning restore CS0618 // Type or member is obsolete
+                bool escapeUnicode = options.EscapeUnicode;
                 foreach (var chr in str)
                 {
-                    if (RequiresJsonEscape(chr, options.EscapeUnicode, options.EscapeForwardSlash))
+                    if (RequiresJsonEscape(chr, escapeUnicode, escapeForwardSlash))
                     {
                         StringBuilder sb = new StringBuilder(str.Length + 4);
                         sb.Append('"');
@@ -266,7 +270,10 @@ namespace NLog.Targets
 #else
                 int startPos = destination.Length;
                 destination.AppendFormat(CultureInfo.InvariantCulture, "{0}", formattable); // Support ISpanFormattable
-                PerformJsonEscapeWhenNeeded(destination, startPos, options.EscapeUnicode, options.EscapeForwardSlash);
+#pragma warning disable CS0618 // Type or member is obsolete
+                var escapeForwardSlash = options.EscapeForwardSlash;
+#pragma warning restore CS0618 // Type or member is obsolete
+                PerformJsonEscapeWhenNeeded(destination, startPos, options.EscapeUnicode, escapeForwardSlash);
 #endif
                 destination.Append('"');
                 return true;
@@ -575,7 +582,10 @@ namespace NLog.Targets
         /// <returns>JSON escaped string</returns>
         private static void AppendStringEscape(StringBuilder destination, string text, JsonSerializeOptions options)
         {
-            AppendStringEscape(destination, text, options.EscapeUnicode, options.EscapeForwardSlash);
+#pragma warning disable CS0618 // Type or member is obsolete
+            var escapeForwardSlash = options.EscapeForwardSlash;
+#pragma warning restore CS0618 // Type or member is obsolete
+            AppendStringEscape(destination, text, options.EscapeUnicode, escapeForwardSlash);
         }
 
         /// <summary>

--- a/src/NLog/Targets/JsonSerializeOptions.cs
+++ b/src/NLog/Targets/JsonSerializeOptions.cs
@@ -70,6 +70,8 @@ namespace NLog.Targets
         /// <summary>
         /// Should forward slashes be escaped? If true, / will be converted to \/
         /// </summary>
+        [Obsolete("Marked obsolete with NLog 5.5. Should never escape forward slash")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool EscapeForwardSlash { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Resolves #5764 and followup to #5695

- [x] Wait for NLog v5.5