### PR TITLE
Marked JsonLayout EscapeForwardSlash as obsolete and without any effect

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/JsonEncodeLayoutRendererWrapper.cs
@@ -34,6 +34,7 @@
 namespace NLog.LayoutRenderers.Wrappers
 {
     using System;
+    using System.ComponentModel;
     using System.Text;
     using NLog.Config;
 
@@ -70,6 +71,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// </remarks>
         /// <docgen category="Layout Options" order="10"/>
         [Obsolete("Marked obsolete with NLog 5.5. Should never escape forward slash")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool EscapeForwardSlash { get; set; }
 
         /// <inheritdoc/>

--- a/src/NLog/Layouts/JSON/JsonAttribute.cs
+++ b/src/NLog/Layouts/JSON/JsonAttribute.cs
@@ -34,6 +34,7 @@
 namespace NLog.Layouts
 {
     using System;
+    using System.ComponentModel;
     using System.Text;
     using NLog.Config;
 
@@ -133,7 +134,8 @@ namespace NLog.Layouts
         /// If not set explicitly then the value of the parent will be used as default.
         /// </remarks>
         /// <docgen category='Layout Options' order='100' />
-        [Obsolete("Marked obsolete with NLog 5.5. Should never escape forward slash")]
+        [Obsolete("Marked obsolete since forward slash are valid JSON. Marked obsolete with NLog v5.4")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool EscapeForwardSlash { get; set; }
 
         /// <summary>

--- a/src/NLog/Layouts/JSON/JsonLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonLayout.cs
@@ -234,6 +234,7 @@ namespace NLog.Layouts
         /// </remarks>
         /// <docgen category='Layout Options' order='100' />
         [Obsolete("Marked obsolete with NLog 5.5. Should never escape forward slash")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool EscapeForwardSlash { get; set; }
 
         /// <inheritdoc/>

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -95,9 +95,10 @@ namespace NLog.Targets
             }
             else if (value is string str)
             {
+                var escapeUnicode = options.EscapeUnicode;
                 foreach (var chr in str)
                 {
-                    if (RequiresJsonEscape(chr, options.EscapeUnicode))
+                    if (RequiresJsonEscape(chr, escapeUnicode))
                     {
                         StringBuilder sb = new StringBuilder(str.Length + 4);
                         sb.Append('"');

--- a/src/NLog/Targets/JsonSerializeOptions.cs
+++ b/src/NLog/Targets/JsonSerializeOptions.cs
@@ -71,6 +71,7 @@ namespace NLog.Targets
         /// Should forward slashes be escaped? If true, / will be converted to \/
         /// </summary>
         [Obsolete("Marked obsolete with NLog 5.5. Should never escape forward slash")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool EscapeForwardSlash { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Followup to #5695 for NLog v6, where EscapeForwardSlash no longer has any effect.