### PR TITLE
NLog.Targets.AtomicFile.Tests - Changed to dynamic sequence archive

### DIFF
--- a/src/NLog/Targets/FileArchiveHandlers/BaseFileArchiveHandler.cs
+++ b/src/NLog/Targets/FileArchiveHandlers/BaseFileArchiveHandler.cs
@@ -307,12 +307,12 @@ namespace NLog.Targets.FileArchiveHandlers
 
             if (lastLength > 0)
             {
-                return filename.Substring(0, lastStart) + "*" + filename.Substring(lastStart + lastLength, filename.Length - lastStart - lastLength) + fileext;
+                var prefix = filename.Substring(0, lastStart);
+                var suffix = filename.Substring(lastStart + lastLength, filename.Length - lastStart - lastLength);
+                return string.IsNullOrEmpty(suffix) ? string.Concat(prefix, "*", fileext) : string.Concat(prefix, "*", suffix, "*", fileext);
             }
-            else
-            {
-                return filename + "*" + fileext;
-            }
+
+            return string.Concat(filename, "*", fileext);
         }
 
         protected bool DeleteOldArchiveFile(string filepath)

--- a/tests/NLog.Targets.AtomicFile.Tests/ConcurrentWritesMultiProcessTests.cs
+++ b/tests/NLog.Targets.AtomicFile.Tests/ConcurrentWritesMultiProcessTests.cs
@@ -73,8 +73,6 @@ namespace NLog.Targets.AtomicFile.Tests
             ft.ArchiveAboveSize = Array.IndexOf(modes, "archive") >= 0 ? 50 : -1;
             if (ft.ArchiveAboveSize > 0)
             {
-                string archivePath = Path.Combine(Path.GetDirectoryName(fileName), "Archive");
-                ft.ArchiveFileName = Path.Combine(archivePath, Path.GetFileName(fileName));
                 ft.ArchiveSuffixFormat = "_{0:0000}";
                 ft.MaxArchiveFiles = 10000;
             }
@@ -124,7 +122,7 @@ namespace NLog.Targets.AtomicFile.Tests
 
 #if !DISABLE_FILE_INTERNAL_LOGGING
             var logWriter = new StringWriter { NewLine = Environment.NewLine };
-            NLog.Common.InternalLogger.LogLevel = LogLevel.Warn;
+            NLog.Common.InternalLogger.LogLevel = LogLevel.Debug;
             NLog.Common.InternalLogger.LogFile = Path.Combine(Path.GetDirectoryName(fileName), string.Format("Internal_{0}.txt", processIndex));
             NLog.Common.InternalLogger.LogWriter = logWriter;
             NLog.Common.InternalLogger.LogToConsole = true;
@@ -211,8 +209,9 @@ namespace NLog.Targets.AtomicFile.Tests
                     processes[i] = null;
                 }
 
-                var files = new System.Collections.Generic.List<string>(Directory.GetFiles(archivePath));
-                files.Add(logFile);
+                var files = new System.Collections.Generic.List<string>(new DirectoryInfo(tempPath).GetFiles("test_*.txt").Select(f => f.FullName));
+                if (files.Count == 0)
+                    files.Add(logFile);
 
                 bool verifyFileSize = files.Count > 1;
 
@@ -243,7 +242,7 @@ namespace NLog.Targets.AtomicFile.Tests
 
                         if (verifyFileSize)
                         {
-                            if (sr.BaseStream.Length > 150)
+                            if (sr.BaseStream.Length > 120)
                                 throw new InvalidOperationException(
                                     $"Error when reading file {file}, size {sr.BaseStream.Length} is too large");
                             else if (sr.BaseStream.Length < 35 && files[files.Count - 1] != file)


### PR DESCRIPTION
Followup to #5770 - AtomFileTarget has no mutex-protection, so change to new archive mode without file-move, which should make the unit-test more stable (also on Linux)