### PR TITLE
TargetWithContext - Reduce allocation for RenderLogEvent when SimpleLayout

### DIFF
--- a/src/NLog/Internal/AppendBuilderCreator.cs
+++ b/src/NLog/Internal/AppendBuilderCreator.cs
@@ -73,10 +73,8 @@ namespace NLog.Internal
         public void Dispose()
         {
             if (!ReferenceEquals(_builder.Item, _appendTarget))
-            {
                 _builder.Item.CopyTo(_appendTarget);
-                _builder.Dispose();
-            }
+            _builder.Dispose();
         }
     }
 }

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -57,7 +57,7 @@ namespace NLog.Layouts
     [Layout("SimpleLayout")]
     [ThreadAgnostic]
     [AppDomainFixedOutput]
-    public class SimpleLayout : Layout, IUsesStackTrace
+    public class SimpleLayout : Layout, IUsesStackTrace, IStringValueRenderer
     {
         private string _fixedText;
         private string _layoutText;
@@ -487,6 +487,15 @@ namespace NLog.Layouts
             }
 
             RenderAllRenderers(logEvent, target);
+        }
+
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent)
+        {
+            if (IsFixedText)
+                return FixedText;
+            if (IsSimpleStringText)
+                return Render(logEvent, false);
+            return null;
         }
     }
 }

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -573,9 +573,11 @@ namespace NLog.Layouts
 
         private string RenderStringValue(LogEventInfo logEvent, StringBuilder stringBuilder, string previousStringValue)
         {
-            if (_innerLayout is SimpleLayout simpleLayout && simpleLayout.IsSimpleStringText)
+            if (_innerLayout is IStringValueRenderer stringLayout)
             {
-                return simpleLayout.Render(logEvent, false);
+                var result = stringLayout.GetFormattedString(logEvent);
+                if (result != null)
+                    return result;
             }
 
             if (stringBuilder?.Length == 0)

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -694,9 +694,11 @@ namespace NLog.Targets
             if (layout is null || logEvent is null)
                 return null;    // Signal that input was wrong
 
-            if (layout is SimpleLayout simpleLayout && (simpleLayout.IsFixedText || simpleLayout.IsSimpleStringText))
+            if (layout is IStringValueRenderer stringLayout)
             {
-                return simpleLayout.Render(logEvent, false);
+                var result = stringLayout.GetFormattedString(logEvent);
+                if (result != null)
+                    return result;
             }
 
             if (TryGetCachedValue(layout, logEvent, out var value))

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -792,10 +792,19 @@ namespace NLog.Targets
         }
 
         [ThreadAgnostic]
-        internal sealed class TargetWithContextLayout : Layout, IIncludeContext, IUsesStackTrace
+        internal sealed class TargetWithContextLayout : Layout, IIncludeContext, IUsesStackTrace, IStringValueRenderer
         {
-            public Layout TargetLayout { get => _targetLayout; set => _targetLayout = ReferenceEquals(this, value) ? _targetLayout : value; }
+            public Layout TargetLayout
+            {
+                get => _targetLayout;
+                set
+                {
+                    _targetLayout = ReferenceEquals(this, value) ? _targetLayout : value;
+                    _targetStringLayout = _targetLayout as IStringValueRenderer;
+                }
+            }
             private Layout _targetLayout;
+            private IStringValueRenderer _targetStringLayout;
 
             /// <summary>Internal Layout that allows capture of <see cref="ScopeContext"/> properties-dictionary</summary>
             internal LayoutScopeContextProperties ScopeContextPropertiesLayout { get; }
@@ -953,6 +962,11 @@ namespace NLog.Targets
             protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
             {
                 TargetLayout?.Render(logEvent, target);
+            }
+
+            string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent)
+            {
+                return _targetStringLayout?.GetFormattedString(logEvent);
             }
 
             public class LayoutScopeContextProperties : Layout

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -199,7 +199,7 @@ namespace NLog.UnitTests
         {
             foreach (Type type in allTypes)
             {
-                if (typeof(NLog.Internal.IStringValueRenderer).IsAssignableFrom(type) && !type.IsInterface)
+                if (typeof(NLog.Internal.IStringValueRenderer).IsAssignableFrom(type) && !type.IsInterface && !typeof(NLog.Layouts.SimpleLayout).Equals(type))
                 {
                     var appDomainFixedOutputAttribute = type.GetCustomAttribute<AppDomainFixedOutputAttribute>();
                     Assert.True(appDomainFixedOutputAttribute is null, $"{type.ToString()} should not implement IStringValueRenderer");

--- a/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
+++ b/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
@@ -203,6 +203,22 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void TargetWithContextStringLayoutTest()
+        {
+            var target = new CustomTargetWithContext() { Layout = "${message}", SkipAssert = true };
+            var logFactory = new LogFactory().Setup()
+                                             .SetupExtensions(ext => ext.RegisterTarget<CustomTargetWithContext>("contexttarget"))
+                                             .LoadConfiguration(cfg => cfg.ForLogger().WriteTo(target)).LogFactory;
+
+            var logEventInfo = LogEventInfo.Create(LogLevel.Info, null, null, "Hello {World}", new[] { "Earth" });
+            var expectedMessage = logEventInfo.FormattedMessage;
+
+            logFactory.GetCurrentClassLogger().Info(logEventInfo);
+
+            Assert.Same(expectedMessage, target.LastMessage);
+        }
+
+        [Fact]
         public void TargetWithContextConfigTest()
         {
             var logFactory = new LogFactory().Setup()


### PR DESCRIPTION
Allow the internal `TargetWithContextLayout` to benefit from the same optimization as `SimpleLayout` (Skip appending to `StringBuilder` and doing `ToString()`)

- [x] Wait for NLog v5.5

See also:  #5793