### PR TITLE
TargetWithContext - Reduce allocation for RenderLogEvent when SimpleLayout

### DIFF
--- a/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
@@ -131,7 +131,7 @@ namespace NLog.LayoutRenderers
 
         string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent)
         {
-            if (WithException)
+            if (WithException && logEvent.Exception != null)
                 return null;
             else
                 return (Raw ? logEvent.Message : logEvent.FormattedMessage) ?? string.Empty;

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -57,7 +57,7 @@ namespace NLog.Layouts
     [Layout("SimpleLayout")]
     [ThreadAgnostic]
     [AppDomainFixedOutput]
-    public class SimpleLayout : Layout, IUsesStackTrace
+    public class SimpleLayout : Layout, IUsesStackTrace, IStringValueRenderer
     {
         private readonly IRawValue _rawValueRenderer;
         private IStringValueRenderer _stringValueRenderer;
@@ -493,6 +493,15 @@ namespace NLog.Layouts
             {
                 target.Append(FixedText);
             }
+        }
+
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent)
+        {
+            if (IsFixedText)
+                return FixedText;
+            if (IsSimpleStringText)
+                return Render(logEvent, false);
+            return null;
         }
     }
 }

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -572,9 +572,11 @@ namespace NLog.Layouts
 
         private string RenderStringValue(LogEventInfo logEvent, StringBuilder stringBuilder, string previousStringValue)
         {
-            if (_innerLayout is SimpleLayout simpleLayout && simpleLayout.IsSimpleStringText)
+            if (_innerLayout is IStringValueRenderer stringLayout)
             {
-                return simpleLayout.Render(logEvent, false);
+                var result = stringLayout.GetFormattedString(logEvent);
+                if (result != null)
+                    return result;
             }
 
             if (stringBuilder?.Length == 0)

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -705,9 +705,11 @@ namespace NLog.Targets
             if (layout is null || logEvent is null)
                 return null;    // Signal that input was wrong
 
-            if (layout is SimpleLayout simpleLayout && (simpleLayout.IsFixedText || simpleLayout.IsSimpleStringText))
+            if (layout is IStringValueRenderer stringLayout)
             {
-                return simpleLayout.Render(logEvent, false);
+                var result = stringLayout.GetFormattedString(logEvent);
+                if (result != null)
+                    return result;
             }
 
             if (TryGetCachedValue(layout, logEvent, out var value))

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -563,10 +563,19 @@ namespace NLog.Targets
         }
 
         [ThreadAgnostic]
-        internal sealed class TargetWithContextLayout : Layout, IIncludeContext, IUsesStackTrace
+        internal sealed class TargetWithContextLayout : Layout, IIncludeContext, IUsesStackTrace, IStringValueRenderer
         {
-            public Layout TargetLayout { get => _targetLayout; set => _targetLayout = ReferenceEquals(this, value) ? _targetLayout : value; }
+            public Layout TargetLayout
+            {
+                get => _targetLayout;
+                set
+                {
+                    _targetLayout = ReferenceEquals(this, value) ? _targetLayout : value;
+                    _targetStringLayout = _targetLayout as IStringValueRenderer;
+                }
+            }
             private Layout _targetLayout;
+            private IStringValueRenderer _targetStringLayout;
 
             /// <summary>Internal Layout that allows capture of <see cref="ScopeContext"/> properties-dictionary</summary>
             internal LayoutScopeContextProperties ScopeContextPropertiesLayout { get; }
@@ -724,6 +733,11 @@ namespace NLog.Targets
             protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
             {
                 TargetLayout?.Render(logEvent, target);
+            }
+
+            string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent)
+            {
+                return _targetStringLayout?.GetFormattedString(logEvent);
             }
 
             public class LayoutScopeContextProperties : Layout

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -189,7 +189,7 @@ namespace NLog.UnitTests
         {
             foreach (Type type in allTypes)
             {
-                if (typeof(NLog.Internal.IStringValueRenderer).IsAssignableFrom(type) && !type.IsInterface)
+                if (typeof(NLog.Internal.IStringValueRenderer).IsAssignableFrom(type) && !type.IsInterface && !typeof(NLog.Layouts.SimpleLayout).Equals(type))
                 {
                     var appDomainFixedOutputAttribute = type.GetCustomAttribute<AppDomainFixedOutputAttribute>();
                     Assert.True(appDomainFixedOutputAttribute is null, $"{type.ToString()} should not implement IStringValueRenderer");

--- a/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
+++ b/tests/NLog.UnitTests/Targets/TargetWithContextTest.cs
@@ -202,6 +202,22 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
+        public void TargetWithContextStringLayoutTest()
+        {
+            var target = new CustomTargetWithContext() { Layout = "${message}", SkipAssert = true };
+            var logFactory = new LogFactory().Setup()
+                                             .SetupExtensions(ext => ext.RegisterTarget<CustomTargetWithContext>("contexttarget"))
+                                             .LoadConfiguration(cfg => cfg.ForLogger().WriteTo(target)).LogFactory;
+
+            var logEventInfo = LogEventInfo.Create(LogLevel.Info, null, null, "Hello {World}", new[] { "Earth" });
+            var expectedMessage = logEventInfo.FormattedMessage;
+
+            logFactory.GetCurrentClassLogger().Info(logEventInfo);
+
+            Assert.Same(expectedMessage, target.LastMessage);
+        }
+
+        [Fact]
         public void TargetWithContextConfigTest()
         {
             var logFactory = new LogFactory().Setup()


### PR DESCRIPTION
Allow the internal `TargetWithContextLayout` to benefit from the same optimization as `SimpleLayout` (Skip appending to `StringBuilder` and doing `ToString()`-allocation)

See also: #5792
