### PR TITLE
Layout Render without caching, as handled by Precalculate

### DIFF
--- a/src/NLog/Filters/WhenContainsFilter.cs
+++ b/src/NLog/Filters/WhenContainsFilter.cs
@@ -62,7 +62,7 @@ namespace NLog.Filters
             StringComparison comparisonType = IgnoreCase
                                               ? StringComparison.OrdinalIgnoreCase
                                               : StringComparison.Ordinal;
-            string result = Layout.Render(logEvent, cacheLayoutResult: false);
+            string result = Layout.Render(logEvent);
             if (result.IndexOf(Substring, comparisonType) >= 0)
             {
                 return Action;

--- a/src/NLog/Filters/WhenEqualFilter.cs
+++ b/src/NLog/Filters/WhenEqualFilter.cs
@@ -62,7 +62,7 @@ namespace NLog.Filters
             StringComparison comparisonType = IgnoreCase
                                                   ? StringComparison.OrdinalIgnoreCase
                                                   : StringComparison.Ordinal;
-            string result = Layout.Render(logEvent, cacheLayoutResult: false);
+            string result = Layout.Render(logEvent);
             if (result.Equals(CompareTo, comparisonType))
             {
                 return Action;

--- a/src/NLog/Filters/WhenNotContainsFilter.cs
+++ b/src/NLog/Filters/WhenNotContainsFilter.cs
@@ -62,7 +62,7 @@ namespace NLog.Filters
             StringComparison comparison = IgnoreCase
                                               ? StringComparison.OrdinalIgnoreCase
                                               : StringComparison.Ordinal;
-            string result = Layout.Render(logEvent, cacheLayoutResult: false);
+            string result = Layout.Render(logEvent);
             if (result.IndexOf(Substring, comparison) < 0)
             {
                 return Action;

--- a/src/NLog/Filters/WhenNotEqualFilter.cs
+++ b/src/NLog/Filters/WhenNotEqualFilter.cs
@@ -69,7 +69,7 @@ namespace NLog.Filters
             StringComparison comparisonType = IgnoreCase
                                                   ? StringComparison.OrdinalIgnoreCase
                                                   : StringComparison.Ordinal;
-            string result = Layout.Render(logEvent, cacheLayoutResult: false);
+            string result = Layout.Render(logEvent);
             if (!result.Equals(CompareTo, comparisonType))
             {
                 return Action;

--- a/src/NLog/Filters/WhenRepeatedFilter.cs
+++ b/src/NLog/Filters/WhenRepeatedFilter.cs
@@ -255,7 +255,7 @@ namespace NLog.Filters
                     targetBuilder.Length = MaxLength;
                 return new FilterInfoKey(targetBuilder, null);
             }
-            string value = Layout.Render(logEvent, cacheLayoutResult: false);
+            string value = Layout.Render(logEvent);
             if (value.Length > MaxLength)
                 value = value.Substring(0, MaxLength);
             return new FilterInfoKey(null, value);

--- a/src/NLog/Internal/AppendBuilderCreator.cs
+++ b/src/NLog/Internal/AppendBuilderCreator.cs
@@ -73,10 +73,8 @@ namespace NLog.Internal
         public void Dispose()
         {
             if (!ReferenceEquals(_builder.Item, _appendTarget))
-            {
                 _builder.Item.CopyTo(_appendTarget);
-                _builder.Dispose();
-            }
+            _builder.Dispose();
         }
     }
 }

--- a/src/NLog/LayoutRenderers/CounterLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CounterLayoutRenderer.cs
@@ -90,7 +90,7 @@ namespace NLog.LayoutRenderers
                 return currentValue;
             }
 
-            var sequenceName = Sequence.Render(logEvent, cacheLayoutResult: false);
+            var sequenceName = Sequence.Render(logEvent);
             lock (Sequences)
             {
                 if (!Sequences.TryGetValue(sequenceName, out var nextValue))

--- a/src/NLog/LayoutRenderers/EnvironmentLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EnvironmentLayoutRenderer.cs
@@ -77,7 +77,7 @@ namespace NLog.LayoutRenderers
             if (simpleLayout is null)
                 return string.Empty;
             if (simpleLayout.IsFixedText || simpleLayout.IsSimpleStringText)
-                return simpleLayout.Render(logEvent, cacheLayoutResult: false);
+                return simpleLayout.Render(logEvent);
             return null;
         }
 

--- a/src/NLog/LayoutRenderers/LayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LayoutRenderer.cs
@@ -156,18 +156,18 @@ namespace NLog.LayoutRenderers
         /// <param name="builder">The layout render output is appended to builder</param>
         internal void RenderAppendBuilder(LogEventInfo logEvent, StringBuilder builder)
         {
-            if (!_isInitialized)
-            {
-                Initialize();
-            }
-
             try
             {
+                if (!_isInitialized)
+                {
+                    Initialize();
+                }
+
                 Append(builder, logEvent);
             }
             catch (Exception exception)
             {
-                InternalLogger.Warn(exception, "Exception in layout renderer.");
+                InternalLogger.Warn(exception, "Exception in '{0}.Append()'", GetType());
 
                 if (exception.MustBeRethrown())
                 {

--- a/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
@@ -131,7 +131,7 @@ namespace NLog.LayoutRenderers
 
         string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent)
         {
-            if (WithException && logEvent.Exception != null)
+            if (WithException)
                 return null;
             else
                 return (Raw ? logEvent.Message : logEvent.FormattedMessage) ?? string.Empty;

--- a/src/NLog/LayoutRenderers/ScopeContextIndentLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ScopeContextIndentLayoutRenderer.cs
@@ -62,7 +62,7 @@ namespace NLog.LayoutRenderers
             var messages = ScopeContext.GetAllNestedStateList();
             for (int i = 0; i < messages.Count; ++i)
             {
-                indent = indent ?? Indent?.Render(logEvent, cacheLayoutResult: false) ?? string.Empty;
+                indent = indent ?? Indent?.Render(logEvent) ?? string.Empty;
                 builder.Append(indent);
             }
         }

--- a/src/NLog/LayoutRenderers/Wrappers/CachedLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/CachedLayoutRendererWrapper.cs
@@ -134,7 +134,7 @@ namespace NLog.LayoutRenderers.Wrappers
         {
             if (Cached)
             {
-                var newCacheKey = CacheKey?.Render(logEvent, cacheLayoutResult: false) ?? string.Empty;
+                var newCacheKey = CacheKey?.Render(logEvent) ?? string.Empty;
                 var cachedValue = LookupValidCachedValue(logEvent, newCacheKey);
 
                 if (cachedValue is null)

--- a/src/NLog/LayoutRenderers/Wrappers/ObjectPathRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ObjectPathRendererWrapper.cs
@@ -106,12 +106,8 @@ namespace NLog.LayoutRenderers.Wrappers
 
         private bool TryGetRawPropertyValue(LogEventInfo logEvent, out object propertyValue)
         {
-            if (Inner != null &&
-                Inner.TryGetRawValue(logEvent, out var rawValue) &&
-                TryGetPropertyValue(rawValue, out propertyValue))
-            {
+            if (Inner?.TryGetRawValue(logEvent, out var rawValue) == true && TryGetPropertyValue(rawValue, out propertyValue))
                 return true;
-            }
 
             propertyValue = null;
             return false;

--- a/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenEmptyLayoutRendererWrapper.cs
@@ -90,14 +90,14 @@ namespace NLog.LayoutRenderers.Wrappers
 
             if (TryGetStringValue(out var innerLayout, out var whenEmptyLayout))
             {
-                var innerValue = innerLayout.Render(logEvent, cacheLayoutResult: false);
+                var innerValue = innerLayout.Render(logEvent);
                 if (!string.IsNullOrEmpty(innerValue))
                 {
                     return innerValue;
                 }
 
                 // render WhenEmpty when the inner layout was empty
-                return whenEmptyLayout.Render(logEvent, cacheLayoutResult: false);
+                return whenEmptyLayout.Render(logEvent);
             }
 
             _skipStringValueRenderer = true;
@@ -129,7 +129,7 @@ namespace NLog.LayoutRenderers.Wrappers
             }
             else
             {
-                var innerResult = Inner?.Render(logEvent, cacheLayoutResult: false); // Beware this can be very expensive call
+                var innerResult = Inner?.Render(logEvent); // Beware this can be very expensive call
                 if (!string.IsNullOrEmpty(innerResult))
                 {
                     value = null;

--- a/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBase.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapperLayoutRendererBase.cs
@@ -123,7 +123,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <returns>Contents of inner layout.</returns>
         protected virtual string RenderInner(LogEventInfo logEvent)
         {
-            return Inner?.Render(logEvent, cacheLayoutResult: false) ?? string.Empty;
+            return Inner?.Render(logEvent) ?? string.Empty;
         }
     }
 }

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -238,7 +238,7 @@ namespace NLog.Layouts
             return new Layout<T>(layoutMethod, options);
         }
 
-        private void PrecalculateInnerLayout(LogEventInfo logEvent, StringBuilder target)
+        private void PrecalculateInnerLayout(LogEventInfo logEvent, [CanBeNull] StringBuilder target)
         {
             if (IsFixed || (_layoutValue.ThreadAgnostic && !_layoutValue.ThreadAgnosticImmutable))
                 return;

--- a/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
+++ b/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
@@ -267,7 +267,7 @@ namespace NLog.Layouts
 
             public object RenderObjectValue(LogEventInfo logEvent, StringBuilder stringBuilder)
             {
-                return _innerLayout.Render(logEvent, false);
+                return _innerLayout.Render(logEvent);
             }
 
             public override string ToString()

--- a/tests/NLog.UnitTests/Layouts/CsvLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/CsvLayoutTests.cs
@@ -319,6 +319,9 @@ namespace NLog.UnitTests.Layouts
                 Message = "hello, world"
             };
 
+            csvLayout.Precalculate(e1);
+            csvLayout.Precalculate(e2);
+
             var r11 = csvLayout.Render(e1);
             var r12 = csvLayout.Render(e1);
             var r21 = csvLayout.Render(e2);

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
@@ -75,6 +75,7 @@ namespace NLog.UnitTests.Layouts
         {
             var l = new SimpleLayout("xx${threadid}yy");
             var ev = LogEventInfo.CreateNullEvent();
+            l.Precalculate(ev);
             string output1 = l.Render(ev);
             string output2 = l.Render(ev);
             Assert.Same(output1, output2);
@@ -182,8 +183,9 @@ namespace NLog.UnitTests.Layouts
         public void TryGetRawValue_MultipleLayoutRender_ShouldGiveNullRawValue()
         {
             // Arrange
-            SimpleLayout l = "${sequenceid} ";
+            SimpleLayout l = "${sequenceid}${threadid}";
             var logEventInfo = LogEventInfo.CreateNullEvent();
+            l.Precalculate(logEventInfo);
 
             // Act
             var success = l.TryGetRawValue(logEventInfo, out var value);


### PR DESCRIPTION
Avoid the pitfall of constantly having to avoid cache-capture with with NLog v6, since it is only the NLog Precalculation-Logic that should perform capture, and everywhere else capture should be avoided. If there are situations where caching in `Render` was needed to make async Layout-Precalculate work, then it should be fixed by improving the Layout-Precalculate-implementation.

Follow up to #5758

Custom Layout-classes that override `Precalculate`-method to perform conditional-capture, must now call `base.Precalculate()` to perform layout-value-capture, and not depend on `Render()`.