### PR TITLE
Logger with support for params ReadOnlySpan

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,7 @@ for:
         - image: Ubuntu2204
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      MSBUILDTERMINALLOGGER: off
       FrameworkPathOverride: /usr/lib/mono/4.6.1-api/
     build_script:
     - ps: dotnet --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 6.0.0-{build} # Only change for mayor versions (e.g. 7.0)
 image:
   - Visual Studio 2022
-  - Ubuntu2004
+  - Ubuntu2204
 configuration: Release
 build: false
 test: false
@@ -54,7 +54,7 @@ for:
   -
     matrix:
       only:
-        - image: Ubuntu2004
+        - image: Ubuntu2204
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       FrameworkPathOverride: /usr/lib/mono/4.6.1-api/

--- a/src/NLog/Common/InternalLogger-generated.cs
+++ b/src/NLog/Common/InternalLogger-generated.cs
@@ -70,6 +70,33 @@ namespace NLog.Common
         public static bool IsFatalEnabled => IsLogLevelEnabled(LogLevel.Fatal);
 
 
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Logs the specified message without an <see cref="Exception"/> at the Trace level.
+        /// </summary>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Trace([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsTraceEnabled)
+                Write(null, LogLevel.Trace, message, args.IsEmpty ? null : args.ToArray());
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Trace level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Trace(Exception ex, [Localizable(false)] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsTraceEnabled)
+                Write(ex, LogLevel.Trace, message, args.IsEmpty ? null : args.ToArray());
+        }
+#endif
+
         /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Trace level.
         /// </summary>
@@ -183,6 +210,33 @@ namespace NLog.Common
             if (IsTraceEnabled)
                 Write(ex, LogLevel.Trace, messageFunc(), null);
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Logs the specified message without an <see cref="Exception"/> at the Debug level.
+        /// </summary>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Debug([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsDebugEnabled)
+                Write(null, LogLevel.Debug, message, args.IsEmpty ? null : args.ToArray());
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Debug level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Debug(Exception ex, [Localizable(false)] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsDebugEnabled)
+                Write(ex, LogLevel.Debug, message, args.IsEmpty ? null : args.ToArray());
+        }
+#endif
 
         /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Debug level.
@@ -298,6 +352,33 @@ namespace NLog.Common
                 Write(ex, LogLevel.Debug, messageFunc(), null);
         }
 
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Logs the specified message without an <see cref="Exception"/> at the Info level.
+        /// </summary>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Info([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsInfoEnabled)
+                Write(null, LogLevel.Info, message, args.IsEmpty ? null : args.ToArray());
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Info level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Info(Exception ex, [Localizable(false)] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsInfoEnabled)
+                Write(ex, LogLevel.Info, message, args.IsEmpty ? null : args.ToArray());
+        }
+#endif
+
         /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Info level.
         /// </summary>
@@ -411,6 +492,33 @@ namespace NLog.Common
             if (IsInfoEnabled)
                 Write(ex, LogLevel.Info, messageFunc(), null);
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Logs the specified message without an <see cref="Exception"/> at the Warn level.
+        /// </summary>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Warn([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsWarnEnabled)
+                Write(null, LogLevel.Warn, message, args.IsEmpty ? null : args.ToArray());
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Warn level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Warn(Exception ex, [Localizable(false)] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsWarnEnabled)
+                Write(ex, LogLevel.Warn, message, args.IsEmpty ? null : args.ToArray());
+        }
+#endif
 
         /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Warn level.
@@ -526,6 +634,33 @@ namespace NLog.Common
                 Write(ex, LogLevel.Warn, messageFunc(), null);
         }
 
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Logs the specified message without an <see cref="Exception"/> at the Error level.
+        /// </summary>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Error([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsErrorEnabled)
+                Write(null, LogLevel.Error, message, args.IsEmpty ? null : args.ToArray());
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Error level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Error(Exception ex, [Localizable(false)] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsErrorEnabled)
+                Write(ex, LogLevel.Error, message, args.IsEmpty ? null : args.ToArray());
+        }
+#endif
+
         /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Error level.
         /// </summary>
@@ -640,6 +775,33 @@ namespace NLog.Common
                 Write(ex, LogLevel.Error, messageFunc(), null);
         }
 
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Logs the specified message without an <see cref="Exception"/> at the Fatal level.
+        /// </summary>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Fatal([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsFatalEnabled)
+                Write(null, LogLevel.Fatal, message, args.IsEmpty ? null : args.ToArray());
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the Fatal level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Fatal(Exception ex, [Localizable(false)] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsFatalEnabled)
+                Write(ex, LogLevel.Fatal, message, args.IsEmpty ? null : args.ToArray());
+        }
+#endif
+
         /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the Fatal level.
         /// </summary>
@@ -753,6 +915,5 @@ namespace NLog.Common
             if (IsFatalEnabled)
                 Write(ex, LogLevel.Fatal, messageFunc(), null);
         }
-
     }
 }

--- a/src/NLog/Common/InternalLogger-generated.tt
+++ b/src/NLog/Common/InternalLogger-generated.tt
@@ -33,9 +33,9 @@
 
 namespace NLog.Common
 {
-    using JetBrains.Annotations;
     using System;
     using System.ComponentModel;
+    using JetBrains.Annotations;
 
     public static partial class InternalLogger
     {
@@ -55,6 +55,33 @@ namespace NLog.Common
     foreach(var level in levels)
     {
 #>
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Logs the specified message without an <see cref="Exception"/> at the <#=level#> level.
+        /// </summary>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void <#=level#>([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            if (Is<#=level#>Enabled)
+                Write(null, LogLevel.<#=level#>, message, args.IsEmpty ? null : args.ToArray());
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the <#=level#> level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void <#=level#>(Exception ex, [Localizable(false)] string message, params ReadOnlySpan<object> args)
+        {
+            if (Is<#=level#>Enabled)
+                Write(ex, LogLevel.<#=level#>, message, args.IsEmpty ? null : args.ToArray());
+        }
+#endif
 
         /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the <#=level#> level.

--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -181,6 +181,35 @@ namespace NLog.Common
             Write(null, level, message, args);
         }
 
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Logs the specified message without an <see cref="Exception"/> at the specified level.
+        /// </summary>
+        /// <param name="level">Log level.</param>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Log(LogLevel level, [Localizable(false)] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsLogLevelEnabled(level))
+                Write(null, level, message, args.IsEmpty ? null : args.ToArray());
+        }
+
+        /// <summary>
+        /// Logs the specified message with an <see cref="Exception"/> at the specified level.
+        /// </summary>
+        /// <param name="ex">Exception to be logged.</param>
+        /// <param name="level">Log level.</param>
+        /// <param name="message">Message which may include positional parameters.</param>
+        /// <param name="args">Arguments to the message.</param>
+        [StringFormatMethod("message")]
+        public static void Log(Exception ex, LogLevel level, [Localizable(false)] string message, params ReadOnlySpan<object> args)
+        {
+            if (IsLogLevelEnabled(level))
+                Write(ex, level, message, args.IsEmpty ? null : args.ToArray());
+        }
+#endif
+
         /// <summary>
         /// Logs the specified message without an <see cref="Exception"/> at the specified level.
         /// </summary>

--- a/src/NLog/ILogger-V1.cs
+++ b/src/NLog/ILogger-V1.cs
@@ -35,6 +35,7 @@ namespace NLog
 {
     using System;
     using System.ComponentModel;
+    using System.Runtime.CompilerServices;
     using JetBrains.Annotations;
 
     /// <content>
@@ -50,6 +51,9 @@ namespace NLog
         /// </summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(object value);
 
         /// <summary>
@@ -58,6 +62,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, object value);
 
         /// <summary>
@@ -68,6 +75,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2);
 
         /// <summary>
@@ -79,6 +89,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3);
 
         /// <summary>
@@ -89,6 +102,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -98,6 +114,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -108,6 +127,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -117,6 +139,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -127,6 +152,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -136,6 +164,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -146,6 +177,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -155,6 +189,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -165,6 +202,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -174,6 +214,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -184,6 +227,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -193,6 +239,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -203,6 +252,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -212,6 +264,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -222,6 +277,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -231,6 +289,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -241,6 +302,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -250,6 +314,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -260,6 +327,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -269,6 +339,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -279,6 +352,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>s
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -288,6 +364,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -298,6 +377,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -307,6 +389,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -317,6 +402,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         /// <summary>
@@ -326,6 +414,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Trace([Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         #endregion
@@ -337,6 +428,9 @@ namespace NLog
         /// </summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(object value);
 
         /// <summary>
@@ -345,6 +439,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, object value);
 
         /// <summary>
@@ -355,6 +452,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2);
 
         /// <summary>
@@ -366,6 +466,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3);
 
         /// <summary>
@@ -376,6 +479,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -385,6 +491,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -395,6 +504,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -404,6 +516,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -414,6 +529,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -423,6 +541,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -433,6 +554,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -442,6 +566,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -452,6 +579,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -461,6 +591,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -471,6 +604,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -480,6 +616,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -490,6 +629,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -499,6 +641,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -509,6 +654,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -518,6 +666,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -528,6 +679,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -537,6 +691,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -547,6 +704,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -556,6 +716,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -566,6 +729,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -575,6 +741,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -585,6 +754,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -594,6 +766,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -604,6 +779,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         /// <summary>
@@ -613,6 +791,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Debug([Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         #endregion
@@ -624,6 +805,9 @@ namespace NLog
         /// </summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(object value);
 
         /// <summary>
@@ -632,6 +816,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, object value);
 
         /// <summary>
@@ -642,6 +829,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2);
 
         /// <summary>
@@ -653,6 +843,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3);
 
         /// <summary>
@@ -663,6 +856,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -672,6 +868,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -682,6 +881,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -691,6 +893,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -701,6 +906,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -710,6 +918,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -720,6 +931,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -729,6 +943,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -739,6 +956,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -748,6 +968,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -758,6 +981,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -767,6 +993,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -777,6 +1006,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -786,6 +1018,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -796,6 +1031,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -805,6 +1043,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -815,6 +1056,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -824,6 +1068,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -834,6 +1081,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -843,6 +1093,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -853,6 +1106,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -862,6 +1118,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -872,6 +1131,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -881,6 +1143,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -891,6 +1156,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         /// <summary>
@@ -900,6 +1168,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Info([Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         #endregion
@@ -911,6 +1182,9 @@ namespace NLog
         /// </summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(object value);
 
         /// <summary>
@@ -919,6 +1193,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, object value);
 
         /// <summary>
@@ -929,6 +1206,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2);
 
         /// <summary>
@@ -940,6 +1220,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3);
 
         /// <summary>
@@ -950,6 +1233,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -959,6 +1245,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -969,6 +1258,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -978,6 +1270,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -988,6 +1283,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -997,6 +1295,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -1007,6 +1308,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -1016,6 +1320,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -1026,6 +1333,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -1035,6 +1345,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -1045,6 +1358,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -1054,6 +1370,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -1064,6 +1383,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -1073,6 +1395,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -1083,6 +1408,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -1092,6 +1420,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -1102,6 +1433,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -1111,6 +1445,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -1121,6 +1458,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -1130,6 +1470,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -1140,6 +1483,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -1149,6 +1495,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -1159,6 +1508,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -1168,6 +1520,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -1178,6 +1533,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         /// <summary>
@@ -1187,6 +1545,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Warn([Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         #endregion
@@ -1198,6 +1559,9 @@ namespace NLog
         /// </summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(object value);
 
         /// <summary>
@@ -1206,6 +1570,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, object value);
 
         /// <summary>
@@ -1216,6 +1583,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2);
 
         /// <summary>
@@ -1227,6 +1597,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3);
 
         /// <summary>
@@ -1237,6 +1610,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -1245,6 +1621,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -1255,6 +1634,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -1264,6 +1646,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -1274,6 +1659,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -1282,6 +1670,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -1292,6 +1683,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -1301,6 +1695,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -1311,6 +1708,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -1320,6 +1720,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -1330,6 +1733,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -1339,6 +1745,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -1349,6 +1758,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -1357,6 +1769,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -1367,6 +1782,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -1376,6 +1794,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -1386,6 +1807,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -1395,6 +1819,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -1405,6 +1832,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -1414,6 +1844,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -1424,6 +1857,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -1433,6 +1869,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -1443,6 +1882,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -1452,6 +1894,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -1462,6 +1907,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         /// <summary>
@@ -1471,6 +1919,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Error([Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         #endregion
@@ -1482,6 +1933,9 @@ namespace NLog
         /// </summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(object value);
 
         /// <summary>
@@ -1490,6 +1944,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, object value);
 
         /// <summary>
@@ -1500,6 +1957,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2);
 
         /// <summary>
@@ -1511,6 +1971,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3);
 
         /// <summary>
@@ -1521,6 +1984,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -1530,6 +1996,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -1540,6 +2009,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -1549,6 +2021,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -1559,6 +2034,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -1568,6 +2046,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -1578,6 +2059,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -1587,6 +2071,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -1597,6 +2084,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -1606,6 +2096,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -1616,6 +2109,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -1625,6 +2121,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -1635,6 +2134,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -1644,6 +2146,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -1654,6 +2159,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -1663,6 +2171,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -1673,6 +2184,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -1681,6 +2195,9 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -1691,6 +2208,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -1700,6 +2220,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -1710,6 +2233,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -1719,6 +2245,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -1729,6 +2258,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -1738,6 +2270,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -1748,6 +2283,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         /// <summary>
@@ -1757,6 +2295,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Fatal([Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         #endregion

--- a/src/NLog/ILoggerBase-V1.cs
+++ b/src/NLog/ILoggerBase-V1.cs
@@ -35,6 +35,7 @@ namespace NLog
 {
     using System;
     using System.ComponentModel;
+    using System.Runtime.CompilerServices;
     using JetBrains.Annotations;
 
     /// <content>
@@ -51,6 +52,9 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, object value);
 
         /// <summary>
@@ -60,6 +64,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, object value);
 
         /// <summary>
@@ -71,6 +78,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2);
 
         /// <summary>
@@ -83,6 +93,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3);
 
         /// <summary>
@@ -94,6 +107,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -104,6 +120,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, bool argument);
 
         /// <summary>
@@ -115,6 +134,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -125,6 +147,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, char argument);
 
         /// <summary>
@@ -136,6 +161,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -146,6 +174,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, byte argument);
 
         /// <summary>
@@ -157,6 +188,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -167,6 +201,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, string argument);
 
         /// <summary>
@@ -178,6 +215,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -188,6 +228,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, int argument);
 
         /// <summary>
@@ -199,6 +242,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -209,6 +255,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, long argument);
 
         /// <summary>
@@ -220,6 +269,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -230,6 +282,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, float argument);
 
         /// <summary>
@@ -241,6 +296,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -251,6 +309,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, double argument);
 
         /// <summary>
@@ -262,6 +323,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -272,6 +336,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument);
 
         /// <summary>
@@ -283,6 +350,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -293,6 +363,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, object argument);
 
         /// <summary>
@@ -304,6 +377,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -314,6 +390,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument);
 
         /// <summary>
@@ -325,6 +404,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -336,6 +418,9 @@ namespace NLog
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, uint argument);
 
         /// <summary>
@@ -348,6 +433,9 @@ namespace NLog
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         /// <summary>
@@ -359,6 +447,9 @@ namespace NLog
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument);
 
         #endregion

--- a/src/NLog/Internal/OverloadResolutionPriorityAttribute.cs
+++ b/src/NLog/Internal/OverloadResolutionPriorityAttribute.cs
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2004-2024 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of Jaroslaw Kowalski nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#if NETSTANDARD2_1_OR_GREATER && !NET9_0_OR_GREATER
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Specifies the priority of a member in overload resolution. When unspecified, the default priority is 0.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    internal sealed class OverloadResolutionPriorityAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OverloadResolutionPriorityAttribute"/> class.
+        /// </summary>
+        /// <param name="priority">The priority of the attributed member. Higher numbers are prioritized, lower numbers are deprioritized. 0 is the default if no attribute is present.</param>
+        public OverloadResolutionPriorityAttribute(int priority)
+        {
+            Priority = priority;
+        }
+
+        /// <summary>
+        /// The priority of the member.
+        /// </summary>
+        public int Priority { get; }
+    }
+}
+
+#endif

--- a/src/NLog/Logger-Conditional.cs
+++ b/src/NLog/Logger-Conditional.cs
@@ -36,6 +36,7 @@ namespace NLog
     using System;
     using System.ComponentModel;
     using System.Diagnostics;
+    using System.Runtime.CompilerServices;
     using JetBrains.Annotations;
 
     /// <content>
@@ -102,6 +103,21 @@ namespace NLog
             Debug(exception, message, args);
         }
 
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// Only executed when the DEBUG conditional compilation symbol is set.</summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        [Conditional("DEBUG")]
+        [MessageTemplateFormatMethod("message")]
+        public void ConditionalDebug(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            Debug(exception, message, args);
+        }
+#endif
+
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Debug</c> level.
         /// Only executed when the DEBUG conditional compilation symbol is set.</summary>
@@ -151,6 +167,19 @@ namespace NLog
             Debug(message, args);
         }
 
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level using the specified parameters.
+        /// Only executed when the DEBUG conditional compilation symbol is set.</summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+        [Conditional("DEBUG")]
+        [MessageTemplateFormatMethod("message")]
+        public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            Debug(message, args);
+        }
+#endif
 
         /// <summary>
         /// Writes the diagnostic message at the <c>Debug</c> level using the specified parameter and formatting it with the supplied format provider.
@@ -250,9 +279,13 @@ namespace NLog
         /// Only executed when the DEBUG conditional compilation symbol is set.</summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug(object value)
         {
-            Debug(value);
+            Debug<object>(value);
         }
 
         /// <summary>
@@ -261,9 +294,13 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug(IFormatProvider formatProvider, object value)
         {
-            Debug(formatProvider, value);
+            Debug<object>(formatProvider, value);
         }
 
         /// <summary>
@@ -273,10 +310,14 @@ namespace NLog
         /// <param name="arg1">First argument to format.</param>
         /// <param name="arg2">Second argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
-            Debug(message, arg1, arg2);
+            Debug<object, object>(message, arg1, arg2);
         }
 
         /// <summary>
@@ -287,10 +328,14 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         /// <param name="arg3">Third argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
-            Debug(message, arg1, arg2, arg3);
+            Debug<object, object, object>(message, arg1, arg2, arg3);
         }
 
         /// <summary>
@@ -300,10 +345,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
-            Debug(formatProvider, message, argument);
+            Debug<bool>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -312,10 +361,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
-            Debug(message, argument);
+            Debug<bool>(message, argument);
         }
 
         /// <summary>
@@ -325,10 +378,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
-            Debug(formatProvider, message, argument);
+            Debug<char>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -337,10 +394,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
-            Debug(message, argument);
+            Debug<char>(message, argument);
         }
 
         /// <summary>
@@ -350,10 +411,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
-            Debug(formatProvider, message, argument);
+            Debug<byte>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -362,10 +427,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
-            Debug(message, argument);
+            Debug<byte>(message, argument);
         }
 
         /// <summary>
@@ -375,10 +444,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
-            Debug(formatProvider, message, argument);
+            Debug<string>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -387,10 +460,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
-            Debug(message, argument);
+            Debug<string>(message, argument);
         }
 
         /// <summary>
@@ -400,10 +477,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
-            Debug(formatProvider, message, argument);
+            Debug<int>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -412,10 +493,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
-            Debug(message, argument);
+            Debug<int>(message, argument);
         }
 
         /// <summary>
@@ -425,10 +510,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
-            Debug(formatProvider, message, argument);
+            Debug<long>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -437,10 +526,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
-            Debug(message, argument);
+            Debug<long>(message, argument);
         }
 
         /// <summary>
@@ -450,10 +543,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
-            Debug(formatProvider, message, argument);
+            Debug<float>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -462,10 +559,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
-            Debug(message, argument);
+            Debug<float>(message, argument);
         }
 
         /// <summary>
@@ -475,10 +576,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
-            Debug(formatProvider, message, argument);
+            Debug<double>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -487,10 +592,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
-            Debug(message, argument);
+            Debug<double>(message, argument);
         }
 
         /// <summary>
@@ -500,10 +609,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
-            Debug(formatProvider, message, argument);
+            Debug<decimal>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -512,10 +625,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
-            Debug(message, argument);
+            Debug<decimal>(message, argument);
         }
 
         /// <summary>
@@ -525,10 +642,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
-            Debug(formatProvider, message, argument);
+            Debug<object>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -537,10 +658,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalDebug([Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
-            Debug(message, argument);
+            Debug<object>(message, argument);
         }
 
         #endregion
@@ -596,6 +721,21 @@ namespace NLog
             Trace(exception, message, args);
         }
 
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// Only executed when the DEBUG conditional compilation symbol is set.</summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        [Conditional("DEBUG")]
+        [MessageTemplateFormatMethod("message")]
+        public void ConditionalTrace(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            Trace(exception, message, args);
+        }
+#endif
+
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Trace</c> level.
         /// Only executed when the DEBUG conditional compilation symbol is set.</summary>
@@ -645,6 +785,20 @@ namespace NLog
         {
             Trace(message, args);
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified parameters.
+        /// Only executed when the DEBUG conditional compilation symbol is set.</summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+        [Conditional("DEBUG")]
+        [MessageTemplateFormatMethod("message")]
+        public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            Trace(message, args);
+        }
+#endif
 
         /// <summary>
         /// Writes the diagnostic message at the <c>Trace</c> level using the specified parameter and formatting it with the supplied format provider.
@@ -744,9 +898,13 @@ namespace NLog
         /// Only executed when the DEBUG conditional compilation symbol is set.</summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace(object value)
         {
-            Trace(value);
+            Trace<object>(value);
         }
 
         /// <summary>
@@ -755,9 +913,13 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace(IFormatProvider formatProvider, object value)
         {
-            Trace(formatProvider, value);
+            Trace<object>(formatProvider, value);
         }
 
         /// <summary>
@@ -767,10 +929,14 @@ namespace NLog
         /// <param name="arg1">First argument to format.</param>
         /// <param name="arg2">Second argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
-            Trace(message, arg1, arg2);
+            Trace<object, object>(message, arg1, arg2);
         }
 
         /// <summary>
@@ -781,10 +947,14 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         /// <param name="arg3">Third argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
-            Trace(message, arg1, arg2, arg3);
+            Trace<object, object, object>(message, arg1, arg2, arg3);
         }
 
         /// <summary>
@@ -794,10 +964,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
-            Trace(formatProvider, message, argument);
+            Trace<bool>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -806,10 +980,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
-            Trace(message, argument);
+            Trace<bool>(message, argument);
         }
 
         /// <summary>
@@ -819,10 +997,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
-            Trace(formatProvider, message, argument);
+            Trace<char>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -831,10 +1013,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
-            Trace(message, argument);
+            Trace<char>(message, argument);
         }
 
         /// <summary>
@@ -844,10 +1030,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
-            Trace(formatProvider, message, argument);
+            Trace<byte>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -856,10 +1046,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
-            Trace(message, argument);
+            Trace<byte>(message, argument);
         }
 
         /// <summary>
@@ -869,10 +1063,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
-            Trace(formatProvider, message, argument);
+            Trace<string>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -881,10 +1079,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
-            Trace(message, argument);
+            Trace<string>(message, argument);
         }
 
         /// <summary>
@@ -894,10 +1096,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
-            Trace(formatProvider, message, argument);
+            Trace<int>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -906,10 +1112,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
-            Trace(message, argument);
+            Trace<int>(message, argument);
         }
 
         /// <summary>
@@ -919,10 +1129,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
-            Trace(formatProvider, message, argument);
+            Trace<long>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -931,10 +1145,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
-            Trace(message, argument);
+            Trace<long>(message, argument);
         }
 
         /// <summary>
@@ -944,10 +1162,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
-            Trace(formatProvider, message, argument);
+            Trace<float>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -956,10 +1178,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
-            Trace(message, argument);
+            Trace<float>(message, argument);
         }
 
         /// <summary>
@@ -969,10 +1195,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
-            Trace(formatProvider, message, argument);
+            Trace<double>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -981,10 +1211,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
-            Trace(message, argument);
+            Trace<double>(message, argument);
         }
 
         /// <summary>
@@ -994,10 +1228,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
-            Trace(formatProvider, message, argument);
+            Trace<decimal>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -1006,10 +1244,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
-            Trace(message, argument);
+            Trace<decimal>(message, argument);
         }
 
         /// <summary>
@@ -1019,10 +1261,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
-            Trace(formatProvider, message, argument);
+            Trace<object>(formatProvider, message, argument);
         }
 
         /// <summary>
@@ -1031,10 +1277,14 @@ namespace NLog
         /// <param name="message">A <see langword="string" /> containing one format item.</param>
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void ConditionalTrace([Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
-            Trace(message, argument);
+            Trace<object>(message, argument);
         }
 
 

--- a/src/NLog/Logger-V1Compat.cs
+++ b/src/NLog/Logger-V1Compat.cs
@@ -35,6 +35,7 @@ namespace NLog
 {
     using System;
     using System.ComponentModel;
+    using System.Runtime.CompilerServices;
     using JetBrains.Annotations;
 
     /// <content>
@@ -51,6 +52,9 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, object value)
         {
             if (IsEnabled(level))
@@ -66,6 +70,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, object value)
         {
             if (IsEnabled(level))
@@ -83,6 +90,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsEnabled(level))
@@ -101,6 +111,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsEnabled(level))
@@ -118,6 +131,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsEnabled(level))
@@ -134,6 +150,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsEnabled(level))
@@ -151,6 +170,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsEnabled(level))
@@ -167,6 +189,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsEnabled(level))
@@ -184,6 +209,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsEnabled(level))
@@ -200,6 +228,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsEnabled(level))
@@ -217,6 +248,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsEnabled(level))
@@ -233,6 +267,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsEnabled(level))
@@ -250,6 +287,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, int argument)
         {
             if (IsEnabled(level))
@@ -266,6 +306,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsEnabled(level))
@@ -283,6 +326,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsEnabled(level))
@@ -299,6 +345,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsEnabled(level))
@@ -316,6 +365,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsEnabled(level))
@@ -332,6 +384,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsEnabled(level))
@@ -349,6 +404,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsEnabled(level))
@@ -365,6 +423,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsEnabled(level))
@@ -382,6 +443,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsEnabled(level))
@@ -398,6 +462,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsEnabled(level))
@@ -415,6 +482,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsEnabled(level))
@@ -431,6 +501,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsEnabled(level))
@@ -449,6 +522,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsEnabled(level))
@@ -466,6 +542,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsEnabled(level))
@@ -484,6 +563,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsEnabled(level))
@@ -501,6 +583,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsEnabled(level))
@@ -519,6 +604,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsEnabled(level))
@@ -536,6 +624,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsEnabled(level))
@@ -553,6 +644,9 @@ namespace NLog
         /// </summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(object value)
         {
             if (IsTraceEnabled)
@@ -567,6 +661,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, object value)
         {
             if (IsTraceEnabled)
@@ -583,6 +680,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsTraceEnabled)
@@ -600,6 +700,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsTraceEnabled)
@@ -616,6 +719,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsTraceEnabled)
@@ -631,6 +737,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsTraceEnabled)
@@ -647,6 +756,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsTraceEnabled)
@@ -662,6 +774,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsTraceEnabled)
@@ -678,6 +793,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsTraceEnabled)
@@ -693,6 +811,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsTraceEnabled)
@@ -709,6 +830,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsTraceEnabled)
@@ -724,6 +848,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsTraceEnabled)
@@ -740,6 +867,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, string message, int argument)
         {
             if (IsTraceEnabled)
@@ -755,6 +885,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsTraceEnabled)
@@ -771,6 +904,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsTraceEnabled)
@@ -786,6 +922,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsTraceEnabled)
@@ -802,6 +941,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsTraceEnabled)
@@ -817,6 +959,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsTraceEnabled)
@@ -833,6 +978,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsTraceEnabled)
@@ -848,6 +996,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsTraceEnabled)
@@ -864,6 +1015,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsTraceEnabled)
@@ -879,6 +1033,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsTraceEnabled)
@@ -895,6 +1052,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsTraceEnabled)
@@ -910,6 +1070,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsTraceEnabled)
@@ -927,6 +1090,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsTraceEnabled)
@@ -943,6 +1109,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsTraceEnabled)
@@ -960,6 +1129,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsTraceEnabled)
@@ -976,6 +1148,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsTraceEnabled)
@@ -993,6 +1168,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsTraceEnabled)
@@ -1009,6 +1187,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsTraceEnabled)
@@ -1026,6 +1207,9 @@ namespace NLog
         /// </summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(object value)
         {
             if (IsDebugEnabled)
@@ -1040,6 +1224,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, object value)
         {
             if (IsDebugEnabled)
@@ -1056,6 +1243,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsDebugEnabled)
@@ -1073,6 +1263,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsDebugEnabled)
@@ -1089,6 +1282,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsDebugEnabled)
@@ -1104,6 +1300,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsDebugEnabled)
@@ -1120,6 +1319,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsDebugEnabled)
@@ -1135,6 +1337,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsDebugEnabled)
@@ -1151,6 +1356,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsDebugEnabled)
@@ -1166,6 +1374,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsDebugEnabled)
@@ -1182,6 +1393,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsDebugEnabled)
@@ -1197,6 +1411,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsDebugEnabled)
@@ -1213,6 +1430,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsDebugEnabled)
@@ -1228,6 +1448,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsDebugEnabled)
@@ -1244,6 +1467,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsDebugEnabled)
@@ -1259,6 +1485,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsDebugEnabled)
@@ -1275,6 +1504,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsDebugEnabled)
@@ -1290,6 +1522,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsDebugEnabled)
@@ -1306,6 +1541,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsDebugEnabled)
@@ -1321,6 +1559,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsDebugEnabled)
@@ -1337,6 +1578,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsDebugEnabled)
@@ -1352,6 +1596,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsDebugEnabled)
@@ -1368,6 +1615,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsDebugEnabled)
@@ -1383,6 +1633,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsDebugEnabled)
@@ -1400,6 +1653,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsDebugEnabled)
@@ -1416,6 +1672,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsDebugEnabled)
@@ -1433,6 +1692,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsDebugEnabled)
@@ -1449,6 +1711,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsDebugEnabled)
@@ -1466,6 +1731,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsDebugEnabled)
@@ -1482,6 +1750,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsDebugEnabled)
@@ -1499,6 +1770,9 @@ namespace NLog
         /// </summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(object value)
         {
             if (IsInfoEnabled)
@@ -1513,6 +1787,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, object value)
         {
             if (IsInfoEnabled)
@@ -1529,6 +1806,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsInfoEnabled)
@@ -1546,6 +1826,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsInfoEnabled)
@@ -1562,6 +1845,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsInfoEnabled)
@@ -1577,6 +1863,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsInfoEnabled)
@@ -1593,6 +1882,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsInfoEnabled)
@@ -1608,6 +1900,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsInfoEnabled)
@@ -1624,6 +1919,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsInfoEnabled)
@@ -1639,6 +1937,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsInfoEnabled)
@@ -1655,6 +1956,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsInfoEnabled)
@@ -1670,6 +1974,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsInfoEnabled)
@@ -1686,6 +1993,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsInfoEnabled)
@@ -1701,6 +2011,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsInfoEnabled)
@@ -1717,6 +2030,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsInfoEnabled)
@@ -1732,6 +2048,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsInfoEnabled)
@@ -1748,6 +2067,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsInfoEnabled)
@@ -1763,6 +2085,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsInfoEnabled)
@@ -1779,6 +2104,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsInfoEnabled)
@@ -1794,6 +2122,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsInfoEnabled)
@@ -1810,6 +2141,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsInfoEnabled)
@@ -1825,6 +2159,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsInfoEnabled)
@@ -1841,6 +2178,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsInfoEnabled)
@@ -1856,6 +2196,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsInfoEnabled)
@@ -1873,6 +2216,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsInfoEnabled)
@@ -1889,6 +2235,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsInfoEnabled)
@@ -1906,6 +2255,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsInfoEnabled)
@@ -1922,6 +2274,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsInfoEnabled)
@@ -1939,6 +2294,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsInfoEnabled)
@@ -1955,6 +2313,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsInfoEnabled)
@@ -1972,6 +2333,9 @@ namespace NLog
         /// </summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(object value)
         {
             if (IsWarnEnabled)
@@ -1986,6 +2350,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, object value)
         {
             if (IsWarnEnabled)
@@ -2002,6 +2369,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsWarnEnabled)
@@ -2019,6 +2389,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsWarnEnabled)
@@ -2035,6 +2408,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsWarnEnabled)
@@ -2050,6 +2426,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsWarnEnabled)
@@ -2066,6 +2445,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsWarnEnabled)
@@ -2081,6 +2463,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsWarnEnabled)
@@ -2097,6 +2482,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsWarnEnabled)
@@ -2112,6 +2500,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsWarnEnabled)
@@ -2128,6 +2519,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsWarnEnabled)
@@ -2143,6 +2537,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsWarnEnabled)
@@ -2159,6 +2556,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsWarnEnabled)
@@ -2174,6 +2574,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsWarnEnabled)
@@ -2190,6 +2593,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsWarnEnabled)
@@ -2205,6 +2611,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsWarnEnabled)
@@ -2221,6 +2630,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsWarnEnabled)
@@ -2236,6 +2648,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsWarnEnabled)
@@ -2252,6 +2667,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsWarnEnabled)
@@ -2267,6 +2685,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsWarnEnabled)
@@ -2283,6 +2704,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsWarnEnabled)
@@ -2298,6 +2722,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsWarnEnabled)
@@ -2314,6 +2741,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsWarnEnabled)
@@ -2329,6 +2759,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsWarnEnabled)
@@ -2346,6 +2779,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsWarnEnabled)
@@ -2362,6 +2798,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsWarnEnabled)
@@ -2379,6 +2818,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsWarnEnabled)
@@ -2395,6 +2837,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsWarnEnabled)
@@ -2412,6 +2857,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsWarnEnabled)
@@ -2428,6 +2876,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsWarnEnabled)
@@ -2445,6 +2896,9 @@ namespace NLog
         /// </summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(object value)
         {
             if (IsErrorEnabled)
@@ -2459,6 +2913,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, object value)
         {
             if (IsErrorEnabled)
@@ -2475,6 +2932,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsErrorEnabled)
@@ -2492,6 +2952,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsErrorEnabled)
@@ -2508,6 +2971,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsErrorEnabled)
@@ -2523,6 +2989,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsErrorEnabled)
@@ -2539,6 +3008,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsErrorEnabled)
@@ -2554,6 +3026,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsErrorEnabled)
@@ -2570,6 +3045,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsErrorEnabled)
@@ -2585,6 +3063,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsErrorEnabled)
@@ -2601,6 +3082,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsErrorEnabled)
@@ -2616,6 +3100,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsErrorEnabled)
@@ -2632,6 +3119,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsErrorEnabled)
@@ -2647,6 +3137,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsErrorEnabled)
@@ -2663,6 +3156,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsErrorEnabled)
@@ -2678,6 +3174,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsErrorEnabled)
@@ -2694,6 +3193,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsErrorEnabled)
@@ -2709,6 +3211,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsErrorEnabled)
@@ -2725,6 +3230,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsErrorEnabled)
@@ -2740,6 +3248,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsErrorEnabled)
@@ -2756,6 +3267,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsErrorEnabled)
@@ -2771,6 +3285,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsErrorEnabled)
@@ -2787,6 +3304,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsErrorEnabled)
@@ -2802,6 +3322,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsErrorEnabled)
@@ -2819,6 +3342,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsErrorEnabled)
@@ -2835,6 +3361,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsErrorEnabled)
@@ -2852,6 +3381,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsErrorEnabled)
@@ -2868,6 +3400,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsErrorEnabled)
@@ -2885,6 +3420,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsErrorEnabled)
@@ -2901,6 +3439,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsErrorEnabled)
@@ -2918,6 +3459,9 @@ namespace NLog
         /// </summary>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(object value)
         {
             if (IsFatalEnabled)
@@ -2932,6 +3476,9 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, object value)
         {
             if (IsFatalEnabled)
@@ -2948,6 +3495,9 @@ namespace NLog
         /// <param name="arg2">Second argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
             if (IsFatalEnabled)
@@ -2965,6 +3515,9 @@ namespace NLog
         /// <param name="arg3">Third argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
             if (IsFatalEnabled)
@@ -2981,6 +3534,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsFatalEnabled)
@@ -2996,6 +3552,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, bool argument)
         {
             if (IsFatalEnabled)
@@ -3012,6 +3571,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsFatalEnabled)
@@ -3027,6 +3589,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, char argument)
         {
             if (IsFatalEnabled)
@@ -3043,6 +3608,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsFatalEnabled)
@@ -3058,6 +3626,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, byte argument)
         {
             if (IsFatalEnabled)
@@ -3074,6 +3645,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsFatalEnabled)
@@ -3089,6 +3663,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, string argument)
         {
             if (IsFatalEnabled)
@@ -3105,6 +3682,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsFatalEnabled)
@@ -3120,6 +3700,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, int argument)
         {
             if (IsFatalEnabled)
@@ -3136,6 +3719,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsFatalEnabled)
@@ -3151,6 +3737,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, long argument)
         {
             if (IsFatalEnabled)
@@ -3167,6 +3756,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsFatalEnabled)
@@ -3182,6 +3774,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, float argument)
         {
             if (IsFatalEnabled)
@@ -3198,6 +3793,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsFatalEnabled)
@@ -3213,6 +3811,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, double argument)
         {
             if (IsFatalEnabled)
@@ -3229,6 +3830,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsFatalEnabled)
@@ -3244,6 +3848,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, decimal argument)
         {
             if (IsFatalEnabled)
@@ -3260,6 +3867,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsFatalEnabled)
@@ -3275,6 +3885,9 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
             if (IsFatalEnabled)
@@ -3292,6 +3905,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsFatalEnabled)
@@ -3308,6 +3924,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, sbyte argument)
         {
             if (IsFatalEnabled)
@@ -3325,6 +3944,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsFatalEnabled)
@@ -3341,6 +3963,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, uint argument)
         {
             if (IsFatalEnabled)
@@ -3358,6 +3983,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsFatalEnabled)
@@ -3374,6 +4002,9 @@ namespace NLog
         [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, ulong argument)
         {
             if (IsFatalEnabled)

--- a/src/NLog/Logger-generated.cs
+++ b/src/NLog/Logger-generated.cs
@@ -139,7 +139,6 @@ namespace NLog
             if (IsTraceEnabled)
             {
                 Guard.ThrowIfNull(messageFunc);
-
                 WriteToTargets(LogLevel.Trace, messageFunc());
             }
         }
@@ -184,6 +183,41 @@ namespace NLog
                 WriteToTargets(LogLevel.Trace, message, args);
             }
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.Trace);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Trace, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Trace(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.Trace);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Trace, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+#endif
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Trace</c> level.
@@ -377,7 +411,6 @@ namespace NLog
             if (IsDebugEnabled)
             {
                 Guard.ThrowIfNull(messageFunc);
-
                 WriteToTargets(LogLevel.Debug, messageFunc());
             }
         }
@@ -422,6 +455,41 @@ namespace NLog
                 WriteToTargets(LogLevel.Debug, message, args);
             }
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.Debug);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Debug, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Debug(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.Debug);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Debug, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+#endif
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Debug</c> level.
@@ -615,7 +683,6 @@ namespace NLog
             if (IsInfoEnabled)
             {
                 Guard.ThrowIfNull(messageFunc);
-
                 WriteToTargets(LogLevel.Info, messageFunc());
             }
         }
@@ -660,6 +727,41 @@ namespace NLog
                 WriteToTargets(LogLevel.Info, message, args);
             }
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.Info);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Info, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Info(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.Info);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Info, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+#endif
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Info</c> level.
@@ -853,7 +955,6 @@ namespace NLog
             if (IsWarnEnabled)
             {
                 Guard.ThrowIfNull(messageFunc);
-
                 WriteToTargets(LogLevel.Warn, messageFunc());
             }
         }
@@ -898,6 +999,41 @@ namespace NLog
                 WriteToTargets(LogLevel.Warn, message, args);
             }
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.Warn);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Warn, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Warn(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.Warn);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Warn, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+#endif
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Warn</c> level.
@@ -1091,7 +1227,6 @@ namespace NLog
             if (IsErrorEnabled)
             {
                 Guard.ThrowIfNull(messageFunc);
-
                 WriteToTargets(LogLevel.Error, messageFunc());
             }
         }
@@ -1136,6 +1271,41 @@ namespace NLog
                 WriteToTargets(LogLevel.Error, message, args);
             }
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.Error);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Error, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Error(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.Error);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Error, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+#endif
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Error</c> level.
@@ -1329,7 +1499,6 @@ namespace NLog
             if (IsFatalEnabled)
             {
                 Guard.ThrowIfNull(messageFunc);
-
                 WriteToTargets(LogLevel.Fatal, messageFunc());
             }
         }
@@ -1374,6 +1543,41 @@ namespace NLog
                 WriteToTargets(LogLevel.Fatal, message, args);
             }
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.Fatal);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Fatal, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Fatal(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.Fatal);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.Fatal, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+#endif
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c>Fatal</c> level.

--- a/src/NLog/Logger-generated.tt
+++ b/src/NLog/Logger-generated.tt
@@ -45,6 +45,7 @@ namespace NLog
     using System;
     using System.ComponentModel;
     using JetBrains.Annotations;
+    using NLog.Internal;
 
     /// <summary>
     /// Provides logging interface and utility functions.
@@ -113,11 +114,7 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-                if (messageFunc is null)
-                {
-                    throw new ArgumentNullException(nameof(messageFunc));
-                }
-
+                Guard.ThrowIfNull(messageFunc);
                 WriteToTargets(LogLevel.<#=level#>, messageFunc());
             }
         }
@@ -162,6 +159,41 @@ namespace NLog
                 WriteToTargets(LogLevel.<#=level#>, message, args);
             }
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message at the <c><#=level#></c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#>([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.<#=level#>);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.<#=level#>, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c><#=level#></c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void <#=level#>(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(LogLevel.<#=level#>);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(LogLevel.<#=level#>, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+#endif
 
         /// <summary>
         /// Writes the diagnostic message and exception at the <c><#=level#></c> level.

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -382,6 +382,44 @@ namespace NLog
             }
         }
 
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message at the specified level using the specified parameters.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(level);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(level, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the specified level.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(level);
+            if (targetsForLevel != null)
+            {
+                var logEvent = LogEventInfo.Create(level, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
+                WriteToTargets(logEvent, targetsForLevel);
+            }
+        }
+#endif
+
         /// <summary>
         /// Writes the diagnostic message and exception at the specified level.
         /// </summary>

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -11,8 +11,7 @@ NLog supports traditional logging, structured logging and the combination of bot
 Supported platforms:
 
 - .NET 5, 6, 7, 8 and 9
-- .NET Core 1, 2 and 3
-- .NET Standard 1.3+ and 2.0+
+- .NET Standard 2.0 and 2.1
 - .NET Framework 3.5 - 4.8
 - Xamarin Android + iOS (.NET Standard)
 - Mono 4
@@ -65,6 +64,7 @@ For all config options and platform support, check https://nlog-project.org/conf
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableTrimAnalyzer Condition=" '$(TargetFramework)' == 'netstandard2.1' ">true</EnableTrimAnalyzer>
     <IsTrimmable Condition=" '$(TargetFramework)' == 'netstandard2.1' ">true</IsTrimmable>
+    <LangVersion Condition=" '$(TargetFramework)' == 'netstandard2.1' ">13</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">17.0</VisualStudioVersion>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' AND '$(VisualStudioVersion)' &lt; '17.0' ">net35;net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net35;net46;netstandard2.0;netstandard2.1</TargetFrameworks>
 
     <Title>NLog for .NET Framework and .NET Standard</Title>

--- a/tests/NLog.UnitTests/Fluent/LogEventBuilderTests.cs
+++ b/tests/NLog.UnitTests/Fluent/LogEventBuilderTests.cs
@@ -311,7 +311,7 @@ namespace NLog.UnitTests.Fluent
             Assert.Throws<ArgumentNullException>(() => new LogEventBuilder(logger, null));
 
             var logBuilder = new LogEventBuilder(logger);
-            Assert.Throws<ArgumentNullException>(() => logBuilder.Properties(null));
+            Assert.Throws<ArgumentNullException>(() => logBuilder.Properties((KeyValuePair<string, object>[])null));
             Assert.Throws<ArgumentNullException>(() => logBuilder.Property(null, "b"));
         }
 


### PR DESCRIPTION
Skip params `object[]`-allocation when LogLevel is not enabled.

First step for resolving #5537 (Still missing the logic to skip `object[]`-allocation when message-template with properties like with Microsoft Extension Logging)

Changed NETSTANDARD2.1 to use LangVersion=13 to support `params ReadOnlySpan` and `OverloadResolutionPriority`:

- https://devblogs.microsoft.com/dotnet/csharp13-calling-methods-is-easier-and-faster/
- https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-13.0/overload-resolution-priority

Maybe the `[OverloadResolutionPriority(-1)]` can be a long-game approach for cleaning up the V1 Logger-API with less users affected by the breaking changes (Can cleanup when NET8 has reached end-of-support, some time in 2027)