### PR TITLE
MessageTemplate structs marked as readonly when not NetFramework

### DIFF
--- a/src/NLog.Targets.ConcurrentFile/Internal/SortHelpers.cs
+++ b/src/NLog.Targets.ConcurrentFile/Internal/SortHelpers.cs
@@ -136,11 +136,19 @@ namespace NLog.Internal
         /// </summary>
         /// <typeparam name="TKey">The type of the key.</typeparam>
         /// <typeparam name="TValue">The type of the value.</typeparam>
-        public struct ReadOnlySingleBucketDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+        public
+#if !NETFRAMEWORK
+            readonly
+#endif
+            struct ReadOnlySingleBucketDictionary<TKey, TValue> : IDictionary<TKey, TValue>
         {
-            KeyValuePair<TKey, TValue>? _singleBucket;  // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
-            readonly Dictionary<TKey, TValue> _multiBucket;
-            readonly IEqualityComparer<TKey> _comparer;
+            private
+#if !NETFRAMEWORK
+                readonly
+#endif
+                KeyValuePair<TKey, TValue>? _singleBucket;  // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
+            private readonly Dictionary<TKey, TValue> _multiBucket;
+            private readonly IEqualityComparer<TKey> _comparer;
             public IEqualityComparer<TKey> Comparer => _comparer;
 
             public ReadOnlySingleBucketDictionary(KeyValuePair<TKey, TValue> singleBucket)

--- a/src/NLog.Targets.Network/NetworkSenders/HttpNetworkSender.cs
+++ b/src/NLog.Targets.Network/NetworkSenders/HttpNetworkSender.cs
@@ -81,7 +81,7 @@ namespace NLog.Internal.NetworkSenders
                 {
                     if (SslCertificateOverride.Count > 0)
                         httpWebRequest.ClientCertificates = SslCertificateOverride;
-#if NET45_OR_GREATER || NETSTANDARD
+#if NET45_OR_GREATER || !NETFRAMEWORK
                     httpWebRequest.ServerCertificateValidationCallback = UserCertificateValidationCallback;
 #endif
                 }

--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -287,7 +287,7 @@ namespace NLog.Config
         public bool? ParseMessageTemplates
         {
             get => _serviceRepository.ResolveParseMessageTemplates();
-            set => _serviceRepository.ParseMessageTemplates(value);
+            set => _serviceRepository.ParseMessageTemplates(LogManager.LogFactory, value);
         }
 
         /// <summary>
@@ -484,7 +484,7 @@ namespace NLog.Config
             SafeRegisterNamedType(_targets, "database", "NLog.Targets.DatabaseTarget, NLog.Database", skipCheckExists);
             SafeRegisterNamedType(_targets, "atomfile", "NLog.Targets.AtomicFileTarget, NLog.Targets.AtomicFile", skipCheckExists);
             SafeRegisterNamedType(_targets, "atomicfile", "NLog.Targets.AtomicFileTarget, NLog.Targets.AtomicFile", skipCheckExists);
-#if NETSTANDARD
+#if !NETFRAMEWORK
             SafeRegisterNamedType(_targets, "eventlog", "NLog.Targets.EventLogTarget, NLog.WindowsEventLog", skipCheckExists);
 #endif
             SafeRegisterNamedType(_targets, "impersonatingwrapper", "NLog.Targets.Wrappers.ImpersonatingTargetWrapper, NLog.WindowsIdentity", skipCheckExists);

--- a/src/NLog/Config/LoggingConfigurationFileLoader.cs
+++ b/src/NLog/Config/LoggingConfigurationFileLoader.cs
@@ -287,7 +287,7 @@ namespace NLog.Config
                     yield return Path.ChangeExtension(configurationFile.Replace(vshostSubStr, "."), ".nlog");
                 }
             }
-#if NETSTANDARD
+#if !NETFRAMEWORK
             else
             {
                 if (string.IsNullOrEmpty(entryAssemblyLocation))

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -197,7 +197,7 @@ namespace NLog.Config
                 ConfigurationItemFactory.Default.AssemblyLoader.ScanForAutoLoadExtensions(ConfigurationItemFactory.Default);
             }
 
-            _serviceRepository.ParseMessageTemplates(parseMessageTemplates);
+            _serviceRepository.ParseMessageTemplates(LogFactory, parseMessageTemplates);
         }
 
         /// <summary>

--- a/src/NLog/Config/ServiceRepositoryExtensions.cs
+++ b/src/NLog/Config/ServiceRepositoryExtensions.cs
@@ -170,12 +170,12 @@ namespace NLog.Config
             return serviceRepository;
         }
 
-        internal static ServiceRepository ParseMessageTemplates(this ServiceRepository serviceRepository, bool? enable)
+        internal static ServiceRepository ParseMessageTemplates(this ServiceRepository serviceRepository, LogFactory logFactory, bool? enable)
         {
             if (enable == true)
             {
                 NLog.Common.InternalLogger.Debug("Message Template Format always enabled");
-                serviceRepository.RegisterSingleton<ILogMessageFormatter>(new LogMessageTemplateFormatter(serviceRepository, true, false));
+                serviceRepository.RegisterSingleton<ILogMessageFormatter>(new LogMessageTemplateFormatter(logFactory, true, false));
             }
             else if (enable == false)
             {
@@ -186,7 +186,7 @@ namespace NLog.Config
             {
                 //null = auto
                 NLog.Common.InternalLogger.Debug("Message Template Auto Format enabled");
-                serviceRepository.RegisterSingleton<ILogMessageFormatter>(new LogMessageTemplateFormatter(serviceRepository, false, false));
+                serviceRepository.RegisterSingleton<ILogMessageFormatter>(new LogMessageTemplateFormatter(logFactory, false, false));
             }
             return serviceRepository;
         }
@@ -197,10 +197,11 @@ namespace NLog.Config
             return messageFormatter?.EnableMessageTemplateParser;
         }
 
-        internal static ServiceRepository RegisterDefaults(this ServiceRepository serviceRepository)
+        internal static ServiceRepository RegisterDefaults(this ServiceRepository serviceRepository, LogFactory logFactory)
         {
+            // Maybe also include active TimeSource ? Could also be done with LogFactory extension-methods
             serviceRepository.RegisterSingleton<IServiceProvider>(serviceRepository);
-            serviceRepository.RegisterSingleton<ILogMessageFormatter>(new LogMessageTemplateFormatter(serviceRepository, false, false));
+            serviceRepository.RegisterSingleton<ILogMessageFormatter>(new LogMessageTemplateFormatter(logFactory, false, false));
             serviceRepository.RegisterJsonConverter(new DefaultJsonSerializer(serviceRepository));
             serviceRepository.RegisterValueFormatter(new MessageTemplates.ValueFormatter(serviceRepository, legacyStringQuotes: false));
             serviceRepository.RegisterPropertyTypeConverter(PropertyTypeConverter.Instance);

--- a/src/NLog/Config/ServiceRepositoryInternal.cs
+++ b/src/NLog/Config/ServiceRepositoryInternal.cs
@@ -49,13 +49,9 @@ namespace NLog.Config
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceRepositoryInternal"/> class.
         /// </summary>
-        internal ServiceRepositoryInternal(bool resetGlobalCache = false)
+        internal ServiceRepositoryInternal(LogFactory logFactory)
         {
-            if (resetGlobalCache)
-                ConfigurationItemFactory.Default = null;    //build new global factory
-
-            this.RegisterDefaults();
-            // Maybe also include active TimeSource ? Could also be done with LogFactory extension-methods
+            this.RegisterDefaults(logFactory);
         }
 
         public override void RegisterService(Type type, object instance)

--- a/src/NLog/Internal/DictionaryEntryEnumerable.cs
+++ b/src/NLog/Internal/DictionaryEntryEnumerable.cs
@@ -40,7 +40,11 @@ namespace NLog.Internal
     /// <summary>
     /// Ensures that IDictionary.GetEnumerator returns DictionaryEntry values
     /// </summary>
-    internal struct DictionaryEntryEnumerable : IEnumerable<DictionaryEntry>
+    internal
+#if !NETFRAMEWORK
+        readonly
+#endif
+        struct DictionaryEntryEnumerable : IEnumerable<DictionaryEntry>
     {
         private readonly IDictionary _dictionary;
 
@@ -64,7 +68,11 @@ namespace NLog.Internal
             return GetEnumerator();
         }
 
-        internal struct DictionaryEntryEnumerator : IEnumerator<DictionaryEntry>
+        internal
+#if !NETFRAMEWORK
+            readonly
+#endif
+            struct DictionaryEntryEnumerator : IEnumerator<DictionaryEntry>
         {
             private readonly IDictionaryEnumerator _entryEnumerator;
 

--- a/src/NLog/Internal/ObjectReflectionCache.cs
+++ b/src/NLog/Internal/ObjectReflectionCache.cs
@@ -271,7 +271,11 @@ namespace NLog.Internal
             return fastLookup;
         }
 
-        internal struct ObjectPropertyList : IEnumerable<ObjectPropertyList.PropertyValue>
+        internal
+#if !NETFRAMEWORK
+            readonly
+#endif
+            struct ObjectPropertyList : IEnumerable<ObjectPropertyList.PropertyValue>
         {
             internal static readonly StringComparer NameComparer = StringComparer.Ordinal;
             private static readonly FastPropertyLookup[] CreateIDictionaryEnumerator = new[] { new FastPropertyLookup(string.Empty, TypeCode.Object, (o, p) => ((IDictionary<string, object>)o).GetEnumerator()) };
@@ -279,7 +283,11 @@ namespace NLog.Internal
             private readonly PropertyInfo[] _properties;
             private readonly FastPropertyLookup[] _fastLookup;
 
-            public struct PropertyValue
+            public
+#if !NETFRAMEWORK
+            readonly
+#endif
+                struct PropertyValue
             {
                 public readonly string Name;
                 public readonly object Value;
@@ -509,7 +517,11 @@ namespace NLog.Internal
             }
         }
 
-        internal struct FastPropertyLookup
+        internal
+#if !NETFRAMEWORK
+            readonly
+#endif
+            struct FastPropertyLookup
         {
             public readonly string Name;
             public readonly ReflectionHelpers.LateBoundMethod ValueLookup;

--- a/src/NLog/Internal/SortHelpers.cs
+++ b/src/NLog/Internal/SortHelpers.cs
@@ -165,11 +165,19 @@ namespace NLog.Internal
         /// </summary>
         /// <typeparam name="TKey">The type of the key.</typeparam>
         /// <typeparam name="TValue">The type of the value.</typeparam>
-        public struct ReadOnlySingleBucketDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+        public
+#if !NETFRAMEWORK
+            readonly
+#endif
+            struct ReadOnlySingleBucketDictionary<TKey, TValue> : IDictionary<TKey, TValue>
         {
-            KeyValuePair<TKey, TValue>? _singleBucket;  // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
-            readonly Dictionary<TKey, TValue> _multiBucket;
-            readonly IEqualityComparer<TKey> _comparer;
+            private
+#if !NETFRAMEWORK
+                readonly
+#endif
+                KeyValuePair<TKey, TValue>? _singleBucket;  // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
+            private readonly Dictionary<TKey, TValue> _multiBucket;
+            private readonly IEqualityComparer<TKey> _comparer;
             public IEqualityComparer<TKey> Comparer => _comparer;
 
             public ReadOnlySingleBucketDictionary(KeyValuePair<TKey, TValue> singleBucket)

--- a/src/NLog/MessageTemplates/Hole.cs
+++ b/src/NLog/MessageTemplates/Hole.cs
@@ -36,7 +36,11 @@ namespace NLog.MessageTemplates
     /// <summary>
     /// A hole that will be replaced with a value
     /// </summary>
-    internal struct Hole
+    internal
+#if !NETFRAMEWORK
+        readonly
+#endif
+        struct Hole
     {
         /// <summary>
         /// Constructor

--- a/src/NLog/MessageTemplates/Literal.cs
+++ b/src/NLog/MessageTemplates/Literal.cs
@@ -36,7 +36,11 @@ namespace NLog.MessageTemplates
     /// <summary>
     /// A fixed value
     /// </summary>
-    internal struct Literal
+    internal
+#if !NETFRAMEWORK
+        readonly
+#endif
+        struct Literal
     {
         /// <summary>Number of characters from the original template to copy at the current position.</summary>
         /// <remarks>This can be 0 when the template starts with a hole or when there are multiple consecutive holes.</remarks>

--- a/src/NLog/MessageTemplates/LiteralHole.cs
+++ b/src/NLog/MessageTemplates/LiteralHole.cs
@@ -36,13 +36,25 @@ namespace NLog.MessageTemplates
     /// <summary>
     /// Combines Literal and Hole
     /// </summary>
-    internal struct LiteralHole
+    internal
+#if !NETFRAMEWORK
+        readonly
+#endif
+        struct LiteralHole
     {
         /// <summary>Literal</summary>
-        public Literal Literal; // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
+        public
+#if !NETFRAMEWORK
+            readonly
+#endif
+            Literal Literal; // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
         /// <summary>Hole</summary>
         /// <remarks>Uninitialized when <see cref="MessageTemplates.Literal.Skip"/> = 0.</remarks>
-        public Hole Hole;       // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
+        public
+#if !NETFRAMEWORK
+            readonly
+#endif
+            Hole Hole;       // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
 
         public LiteralHole(Literal literal, Hole hole)
         {

--- a/src/NLog/SetupSerializationBuilderExtensions.cs
+++ b/src/NLog/SetupSerializationBuilderExtensions.cs
@@ -50,7 +50,7 @@ namespace NLog
         /// </summary>
         public static ISetupSerializationBuilder ParseMessageTemplates(this ISetupSerializationBuilder setupBuilder, bool? enable)
         {
-            setupBuilder.LogFactory.ServiceRepository.ParseMessageTemplates(enable);
+            setupBuilder.LogFactory.ServiceRepository.ParseMessageTemplates(setupBuilder.LogFactory, enable);
             return setupBuilder;
         }
 

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -125,15 +125,17 @@ namespace NLog.Targets.Wrappers
         {
             Name = string.IsNullOrEmpty(wrappedTarget?.Name) ? Name : (wrappedTarget.Name + "_wrapper");
             WrappedTarget = wrappedTarget;
-#if NETSTANDARD2_0
+
+#if NETFRAMEWORK
+            _requestQueue = new AsyncRequestQueue(10000, AsyncTargetWrapperOverflowAction.Discard);
+#else
             // NetStandard20 includes many optimizations for ConcurrentQueue:
             //  - See: https://blogs.msdn.microsoft.com/dotnet/2017/06/07/performance-improvements-in-net-core/
             // Net40 ConcurrencyQueue can seem to leak, because it doesn't clear properly on dequeue
             //  - See: https://blogs.msdn.microsoft.com/pfxteam/2012/05/08/concurrentqueuet-holding-on-to-a-few-dequeued-elements/
             _requestQueue = new ConcurrentRequestQueue(10000, AsyncTargetWrapperOverflowAction.Discard);
-#else
-            _requestQueue = new AsyncRequestQueue(10000, AsyncTargetWrapperOverflowAction.Discard);
 #endif
+
             QueueLimit = queueLimit;
             OverflowAction = overflowAction;
         }

--- a/tests/NLog.UnitTests/MessageTemplates/ParserTests.cs
+++ b/tests/NLog.UnitTests/MessageTemplates/ParserTests.cs
@@ -80,7 +80,7 @@ namespace NLog.UnitTests.MessageTemplates
         public void ParseAndPrint(string input, int parameterCount)
         {
             var logEventInfo = new LogEventInfo(LogLevel.Info, "Logger", null, input, ManyParameters);
-            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory.ServiceRepository, true, false).MessageFormatter, null);
+            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory, true, false).MessageFormatter, null);
             var templateAuto = logEventInfo.MessageTemplateParameters;
             Assert.Equal(parameterCount, templateAuto.Count);
         }
@@ -98,7 +98,7 @@ namespace NLog.UnitTests.MessageTemplates
         public void ParsePositional(string input, int index, string format)
         {
             var logEventInfo = new LogEventInfo(LogLevel.Info, "Logger", null, input, ManyParameters);
-            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory.ServiceRepository, true, false).MessageFormatter, null);
+            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory, true, false).MessageFormatter, null);
             var template = logEventInfo.MessageTemplateParameters;
 
             Assert.True(template.IsPositional);
@@ -117,7 +117,7 @@ namespace NLog.UnitTests.MessageTemplates
         public void ParseNominal(string input)
         {
             var logEventInfo = new LogEventInfo(LogLevel.Info, "Logger", null, input, ManyParameters);
-            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory.ServiceRepository, true, false).MessageFormatter, null);
+            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory, true, false).MessageFormatter, null);
             var template = logEventInfo.MessageTemplateParameters;
 
             Assert.False(template.IsPositional);
@@ -137,7 +137,7 @@ namespace NLog.UnitTests.MessageTemplates
         public void ParseName(string input, string name)
         {
             var logEventInfo = new LogEventInfo(LogLevel.Info, "Logger", null, input, ManyParameters);
-            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory.ServiceRepository, true, false).MessageFormatter, null);
+            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory, true, false).MessageFormatter, null);
             var template = logEventInfo.MessageTemplateParameters;
 
             Assert.Equal(1, template.Count);
@@ -157,7 +157,7 @@ namespace NLog.UnitTests.MessageTemplates
         public void ParseHoleType(string input, string holeType)
         {
             var logEventInfo = new LogEventInfo(LogLevel.Info, "Logger", null, input, ManyParameters);
-            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory.ServiceRepository, true, false).MessageFormatter, null);
+            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory, true, false).MessageFormatter, null);
             var template = logEventInfo.MessageTemplateParameters;
 
             Assert.Equal(1, template.Count);
@@ -179,7 +179,7 @@ namespace NLog.UnitTests.MessageTemplates
         public void ParseFormatAndAlignment_numeric(string input, int? alignment, string format)
         {
             var logEventInfo = new LogEventInfo(LogLevel.Info, "Logger", null, input, ManyParameters);
-            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory.ServiceRepository, true, false).MessageFormatter, null);
+            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory, true, false).MessageFormatter, null);
             var template = logEventInfo.MessageTemplateParameters;
 
             Assert.Equal(1, template.Count);
@@ -198,7 +198,7 @@ namespace NLog.UnitTests.MessageTemplates
         public void ParseFormatAndAlignment_text(string input, int? alignment, string format)
         {
             var logEventInfo = new LogEventInfo(LogLevel.Info, "Logger", null, input, ManyParameters);
-            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory.ServiceRepository, true, false).MessageFormatter, null);
+            logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory, true, false).MessageFormatter, null);
             var template = logEventInfo.MessageTemplateParameters;
 
             Assert.Equal(1, template.Count);
@@ -238,7 +238,7 @@ namespace NLog.UnitTests.MessageTemplates
             Assert.Throws<TemplateParserException>(() =>
             {
                 var logEventInfo = new LogEventInfo(LogLevel.Info, "Logger", null, input, ManyParameters);
-                logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory.ServiceRepository, true, false).MessageFormatter, null);
+                logEventInfo.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory, true, false).MessageFormatter, null);
                 var template = logEventInfo.MessageTemplateParameters;
             });
         }

--- a/tests/NLog.UnitTests/MessageTemplates/RendererTests.cs
+++ b/tests/NLog.UnitTests/MessageTemplates/RendererTests.cs
@@ -130,7 +130,7 @@ namespace NLog.UnitTests.MessageTemplates
         private static void RenderAndTest(string input, CultureInfo culture, object[] args, string expected)
         {
             var logEventInfoAlways = new LogEventInfo(LogLevel.Info, "Logger", culture, input, args);
-            logEventInfoAlways.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory.ServiceRepository, true, false).MessageFormatter, null);
+            logEventInfoAlways.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory, true, false).MessageFormatter, null);
             var templateAlways = logEventInfoAlways.MessageTemplateParameters;
             Assert.Equal(expected, logEventInfoAlways.FormattedMessage);
         }


### PR DESCRIPTION
Only NET Framework has issues with readonly structs. See also  #4114