### PR TITLE
Logger skipping parameters-array allocation when properties

### DIFF
--- a/src/NLog/ILoggerExtensions.cs
+++ b/src/NLog/ILoggerExtensions.cs
@@ -252,7 +252,7 @@ namespace NLog
         {
             if (logger.IsDebugEnabled)
             {
-                logger.Debug(message, new object[] { argument });
+                logger.Debug<object>(message, argument);
             }
         }
 
@@ -271,7 +271,7 @@ namespace NLog
         {
             if (logger.IsDebugEnabled)
             {
-                logger.Debug(message, new object[] { argument1, argument2 });
+                logger.Debug<object, object>(message, argument1, argument2);
             }
         }
 
@@ -292,7 +292,7 @@ namespace NLog
         {
             if (logger.IsDebugEnabled)
             {
-                logger.Debug(message, new object[] { argument1, argument2, argument3 });
+                logger.Debug<object, object, object>(message, argument1, argument2, argument3);
             }
         }
 
@@ -419,7 +419,7 @@ namespace NLog
         {
             if (logger.IsTraceEnabled)
             {
-                logger.Trace(message, new object[] { argument });
+                logger.Trace<object>(message, argument);
             }
         }
 
@@ -438,7 +438,7 @@ namespace NLog
         {
             if (logger.IsTraceEnabled)
             {
-                logger.Trace(message, new object[] { argument1, argument2 });
+                logger.Trace<object, object>(message, argument1, argument2);
             }
         }
 
@@ -459,7 +459,7 @@ namespace NLog
         {
             if (logger.IsTraceEnabled)
             {
-                logger.Trace(message, new object[] { argument1, argument2, argument3 });
+                logger.Trace<object, object, object>(message, argument1, argument2, argument3);
             }
         }
 

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -614,15 +614,10 @@ namespace NLog
             // we need to preformat message if it contains any parameters which could possibly
             // do logging in their ToString()
             if (parameters is null || parameters.Length == 0)
-            {
                 return false;
-            }
 
             if (parameters.Length > 5)
-            {
-                // too many parameters, too costly to check
-                return true;
-            }
+                return true;    // too many parameters, too costly to check
 
             foreach (var parameter in parameters)
             {
@@ -632,6 +627,25 @@ namespace NLog
 
             return false;
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        internal static bool NeedToPreformatMessage(in ReadOnlySpan<object> parameters)
+        {
+            if (parameters.IsEmpty)
+                return false;
+
+            if (parameters.Length > 5)
+                return true;    // too many parameters, too costly to check
+
+            foreach (var parameter in parameters)
+            {
+                if (!IsSafeToDeferFormatting(parameter))
+                    return true;
+            }
+
+            return false;
+        }
+#endif
 
         private static bool IsSafeToDeferFormatting(object value)
         {

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -69,6 +69,7 @@ namespace NLog
         internal LoggingConfiguration _config;
         internal LogMessageFormatter ActiveMessageFormatter;
         internal LogMessageFormatter SingleTargetMessageFormatter;
+        internal LogMessageTemplateFormatter AutoMessageTemplateFormatter;
         private LogLevel _globalThreshold = LogLevel.MinLevel;
         private bool _configLoaded;
         private int _supendLoggingCounter;
@@ -305,11 +306,14 @@ namespace NLog
             ActiveMessageFormatter = messageFormatter.FormatMessage;
             if (messageFormatter is LogMessageTemplateFormatter templateFormatter)
             {
-                SingleTargetMessageFormatter = new LogMessageTemplateFormatter(this, templateFormatter.EnableMessageTemplateParser == true, true).FormatMessage;
+                var logMessageTemplateFormatter = new LogMessageTemplateFormatter(this, templateFormatter.EnableMessageTemplateParser == true, true);
+                SingleTargetMessageFormatter = logMessageTemplateFormatter.FormatMessage;
+                AutoMessageTemplateFormatter = templateFormatter.EnableMessageTemplateParser == true ? null : logMessageTemplateFormatter;
             }
             else
             {
                 SingleTargetMessageFormatter = null;
+                AutoMessageTemplateFormatter = null;
             }
         }
 

--- a/src/NLog/Logger-V1Compat.cs
+++ b/src/NLog/Logger-V1Compat.cs
@@ -95,10 +95,18 @@ namespace NLog
 #endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2)
         {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+            var targetsForLevel = GetTargetsForLevelSafe(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+            }
+#else
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new[] { arg1, arg2 });
             }
+#endif
         }
 
         /// <summary>
@@ -116,10 +124,18 @@ namespace NLog
 #endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, object arg1, object arg2, object arg3)
         {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+            var targetsForLevel = GetTargetsForLevelSafe(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+            }
+#else
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new[] { arg1, arg2, arg3 });
             }
+#endif
         }
 
         /// <summary>
@@ -487,10 +503,18 @@ namespace NLog
 #endif
         public void Log(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+            var targetsForLevel = GetTargetsForLevelSafe(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, null, formatProvider, message, argument);
+            }
+#else
             if (IsEnabled(level))
             {
                 WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
+#endif
         }
 
         /// <summary>
@@ -506,10 +530,18 @@ namespace NLog
 #endif
         public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, object argument)
         {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+            var targetsForLevel = GetTargetsForLevelSafe(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, argument);
+            }
+#else
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument });
             }
+#endif
         }
 
         /// <summary>
@@ -635,7 +667,7 @@ namespace NLog
             }
         }
 
-        #endregion
+#endregion
 
         #region Trace() overloads
 
@@ -687,7 +719,11 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#else
                 WriteToTargets(LogLevel.Trace, message, new[] { arg1, arg2 });
+#endif
             }
         }
 
@@ -707,7 +743,11 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#else
                 WriteToTargets(LogLevel.Trace, message, new[] { arg1, arg2, arg3 });
+#endif
             }
         }
 
@@ -1059,7 +1099,11 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, argument);
+#else
                 WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
+#endif
             }
         }
 
@@ -1077,7 +1121,11 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, argument);
+#else
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument });
+#endif
             }
         }
 
@@ -1250,7 +1298,11 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#else
                 WriteToTargets(LogLevel.Debug, message, new[] { arg1, arg2 });
+#endif
             }
         }
 
@@ -1270,7 +1322,11 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#else
                 WriteToTargets(LogLevel.Debug, message, new[] { arg1, arg2, arg3 });
+#endif
             }
         }
 
@@ -1622,7 +1678,11 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, argument);
+#else
+                WriteToTargets(LogLevel.Debug, formatProvider, message, new[] { argument });
+#endif
             }
         }
 
@@ -1640,7 +1700,11 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-                WriteToTargets(LogLevel.Debug, message, new object[] { argument });
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, argument);
+#else
+                WriteToTargets(LogLevel.Debug, message, new[] { argument });
+#endif
             }
         }
 
@@ -1761,7 +1825,7 @@ namespace NLog
             }
         }
 
-        #endregion
+#endregion
 
         #region Info() overloads
 
@@ -1813,7 +1877,11 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#else
                 WriteToTargets(LogLevel.Info, message, new[] { arg1, arg2 });
+#endif
             }
         }
 
@@ -1833,7 +1901,11 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#else
                 WriteToTargets(LogLevel.Info, message, new[] { arg1, arg2, arg3 });
+#endif
             }
         }
 
@@ -2185,7 +2257,11 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, argument);
+#else
+                WriteToTargets(LogLevel.Info, formatProvider, message, new[] { argument });
+#endif
             }
         }
 
@@ -2203,7 +2279,11 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-                WriteToTargets(LogLevel.Info, message, new object[] { argument });
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, argument);
+#else
+                WriteToTargets(LogLevel.Info, message, new[] { argument });
+#endif
             }
         }
 
@@ -2376,7 +2456,11 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#else
                 WriteToTargets(LogLevel.Warn, message, new[] { arg1, arg2 });
+#endif
             }
         }
 
@@ -2396,7 +2480,11 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#else
                 WriteToTargets(LogLevel.Warn, message, new[] { arg1, arg2, arg3 });
+#endif
             }
         }
 
@@ -2748,7 +2836,11 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, argument);
+#else
+                WriteToTargets(LogLevel.Warn, formatProvider, message, new[] { argument });
+#endif
             }
         }
 
@@ -2766,7 +2858,11 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-                WriteToTargets(LogLevel.Warn, message, new object[] { argument });
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, argument);
+#else
+                WriteToTargets(LogLevel.Warn, message, new[] { argument });
+#endif
             }
         }
 
@@ -2939,7 +3035,11 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#else
                 WriteToTargets(LogLevel.Error, message, new[] { arg1, arg2 });
+#endif
             }
         }
 
@@ -2959,7 +3059,11 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#else
                 WriteToTargets(LogLevel.Error, message, new[] { arg1, arg2, arg3 });
+#endif
             }
         }
 
@@ -3311,7 +3415,11 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, argument);
+#else
+                WriteToTargets(LogLevel.Error, formatProvider, message, new[] { argument });
+#endif
             }
         }
 
@@ -3329,7 +3437,11 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-                WriteToTargets(LogLevel.Error, message, new object[] { argument });
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, argument);
+#else
+                WriteToTargets(LogLevel.Error, message, new[] { argument });
+#endif
             }
         }
 
@@ -3502,7 +3614,11 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#else
                 WriteToTargets(LogLevel.Fatal, message, new[] { arg1, arg2 });
+#endif
             }
         }
 
@@ -3522,7 +3638,11 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#else
                 WriteToTargets(LogLevel.Fatal, message, new[] { arg1, arg2, arg3 });
+#endif
             }
         }
 
@@ -3874,7 +3994,11 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, argument);
+#else
+                WriteToTargets(LogLevel.Fatal, formatProvider, message, new[] { argument });
+#endif
             }
         }
 
@@ -3892,7 +4016,11 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-                WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, argument);
+#else
+                WriteToTargets(LogLevel.Fatal, message, new[] { argument });
+#endif
             }
         }
 

--- a/src/NLog/Logger-generated.cs
+++ b/src/NLog/Logger-generated.cs
@@ -193,11 +193,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Trace([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.Trace);
-            if (targetsForLevel != null)
+            if (IsTraceEnabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.Trace, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, args);
             }
         }
 
@@ -210,11 +208,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Trace(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.Trace);
-            if (targetsForLevel != null)
+            if (IsTraceEnabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.Trace, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargetsWithSpan(LogLevel.Trace, exception, Factory.DefaultCultureInfo, message, args);
             }
         }
 #endif
@@ -275,7 +271,11 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, argument);
+#else
                 WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument });
+#endif
             }
         }
 
@@ -290,7 +290,11 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, argument);
+#else
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument });
+#endif
             }
         }
 
@@ -308,7 +312,11 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -325,7 +333,11 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -345,7 +357,11 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.Trace, formatProvider, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 
@@ -364,7 +380,11 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.Trace, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 
@@ -465,11 +485,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Debug([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.Debug);
-            if (targetsForLevel != null)
+            if (IsDebugEnabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.Debug, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, args);
             }
         }
 
@@ -482,11 +500,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Debug(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.Debug);
-            if (targetsForLevel != null)
+            if (IsDebugEnabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.Debug, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargetsWithSpan(LogLevel.Debug, exception, Factory.DefaultCultureInfo, message, args);
             }
         }
 #endif
@@ -547,7 +563,11 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, argument);
+#else
                 WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument });
+#endif
             }
         }
 
@@ -562,7 +582,11 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, argument);
+#else
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument });
+#endif
             }
         }
 
@@ -580,7 +604,11 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -597,7 +625,11 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -617,7 +649,11 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.Debug, formatProvider, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 
@@ -636,7 +672,11 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.Debug, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 
@@ -737,11 +777,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Info([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.Info);
-            if (targetsForLevel != null)
+            if (IsInfoEnabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.Info, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, args);
             }
         }
 
@@ -754,11 +792,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Info(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.Info);
-            if (targetsForLevel != null)
+            if (IsInfoEnabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.Info, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargetsWithSpan(LogLevel.Info, exception, Factory.DefaultCultureInfo, message, args);
             }
         }
 #endif
@@ -819,7 +855,11 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, argument);
+#else
                 WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument });
+#endif
             }
         }
 
@@ -834,7 +874,11 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, argument);
+#else
                 WriteToTargets(LogLevel.Info, message, new object[] { argument });
+#endif
             }
         }
 
@@ -852,7 +896,11 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -869,7 +917,11 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.Info, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -889,7 +941,11 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.Info, formatProvider, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 
@@ -908,7 +964,11 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.Info, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 
@@ -1009,11 +1069,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Warn([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.Warn);
-            if (targetsForLevel != null)
+            if (IsWarnEnabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.Warn, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, args);
             }
         }
 
@@ -1026,11 +1084,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Warn(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.Warn);
-            if (targetsForLevel != null)
+            if (IsWarnEnabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.Warn, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargetsWithSpan(LogLevel.Warn, exception, Factory.DefaultCultureInfo, message, args);
             }
         }
 #endif
@@ -1091,7 +1147,11 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, argument);
+#else
                 WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument });
+#endif
             }
         }
 
@@ -1106,7 +1166,11 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, argument);
+#else
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument });
+#endif
             }
         }
 
@@ -1124,7 +1188,11 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -1141,7 +1209,11 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -1161,7 +1233,11 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.Warn, formatProvider, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 
@@ -1180,7 +1256,11 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.Warn, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 
@@ -1281,11 +1361,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Error([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.Error);
-            if (targetsForLevel != null)
+            if (IsErrorEnabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.Error, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, args);
             }
         }
 
@@ -1298,11 +1376,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Error(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.Error);
-            if (targetsForLevel != null)
+            if (IsErrorEnabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.Error, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargetsWithSpan(LogLevel.Error, exception, Factory.DefaultCultureInfo, message, args);
             }
         }
 #endif
@@ -1363,7 +1439,11 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, argument);
+#else
                 WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument });
+#endif
             }
         }
 
@@ -1378,7 +1458,11 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, argument);
+#else
                 WriteToTargets(LogLevel.Error, message, new object[] { argument });
+#endif
             }
         }
 
@@ -1396,7 +1480,11 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -1413,7 +1501,11 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.Error, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -1433,7 +1525,11 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.Error, formatProvider, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 
@@ -1452,7 +1548,11 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.Error, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 
@@ -1553,11 +1653,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Fatal([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.Fatal);
-            if (targetsForLevel != null)
+            if (IsFatalEnabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.Fatal, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, args);
             }
         }
 
@@ -1570,11 +1668,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Fatal(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.Fatal);
-            if (targetsForLevel != null)
+            if (IsFatalEnabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.Fatal, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargetsWithSpan(LogLevel.Fatal, exception, Factory.DefaultCultureInfo, message, args);
             }
         }
 #endif
@@ -1635,7 +1731,11 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, argument);
+#else
                 WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument });
+#endif
             }
         }
 
@@ -1650,7 +1750,11 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, argument);
+#else
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument });
+#endif
             }
         }
 
@@ -1668,7 +1772,11 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -1685,7 +1793,11 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -1705,7 +1817,11 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.Fatal, formatProvider, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 
@@ -1724,7 +1840,11 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.Fatal, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 

--- a/src/NLog/Logger-generated.tt
+++ b/src/NLog/Logger-generated.tt
@@ -169,11 +169,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void <#=level#>([Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.<#=level#>);
-            if (targetsForLevel != null)
+            if (Is<#=level#>Enabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.<#=level#>, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargets(LogLevel.<#=level#>, null, Factory.DefaultCultureInfo, message, args);
             }
         }
 
@@ -186,11 +184,9 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void <#=level#>(Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
         {
-            var targetsForLevel = GetTargetsForLevel(LogLevel.<#=level#>);
-            if (targetsForLevel != null)
+            if (Is<#=level#>Enabled)
             {
-                var logEvent = LogEventInfo.Create(LogLevel.<#=level#>, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteToTargets(LogLevel.<#=level#>, exception, Factory.DefaultCultureInfo, message, args);
             }
         }
 #endif
@@ -251,7 +247,11 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargets(LogLevel.<#=level#>, null, formatProvider, message, argument);
+#else
                 WriteToTargets(LogLevel.<#=level#>, formatProvider, message, new object[] { argument });
+#endif
             }
         }
 
@@ -266,7 +266,11 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargets(LogLevel.<#=level#>, null, Factory.DefaultCultureInfo, message, argument);
+#else
                 WriteToTargets(LogLevel.<#=level#>, message, new object[] { argument });
+#endif
             }
         }
 
@@ -284,7 +288,11 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargets(LogLevel.<#=level#>, null, formatProvider, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.<#=level#>, formatProvider, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -301,7 +309,11 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargets(LogLevel.<#=level#>, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#else
                 WriteToTargets(LogLevel.<#=level#>, message, new object[] { argument1, argument2 });
+#endif
             }
         }
 
@@ -321,7 +333,11 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargets(LogLevel.<#=level#>, null, formatProvider, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.<#=level#>, formatProvider, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 
@@ -340,7 +356,11 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+                WriteToTargets(LogLevel.<#=level#>, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#else
                 WriteToTargets(LogLevel.<#=level#>, message, new object[] { argument1, argument2, argument3 });
+#endif
             }
         }
 

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -251,7 +251,7 @@ namespace NLog
                     logEvent.LoggerName = Name;
                 if (logEvent.FormatProvider is null)
                     logEvent.FormatProvider = Factory.DefaultCultureInfo;
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteLogEventToTargets(logEvent, targetsForLevel);
             }
         }
 
@@ -269,7 +269,7 @@ namespace NLog
                     logEvent.LoggerName = Name;
                 if (logEvent.FormatProvider is null)
                     logEvent.FormatProvider = Factory.DefaultCultureInfo;
-                WriteToTargets(wrapperType, logEvent, targetsForLevel);
+                WriteLogEventToTargets(wrapperType, logEvent, targetsForLevel);
             }
         }
 
@@ -382,44 +382,6 @@ namespace NLog
             }
         }
 
-
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-        /// <summary>
-        /// Writes the diagnostic message at the specified level using the specified parameters.
-        /// </summary>
-        /// <param name="level">The log level.</param>
-        /// <param name="message">A <see langword="string" /> containing format items.</param>
-        /// <param name="args">Arguments to format.</param>
-        [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
-        {
-            var targetsForLevel = GetTargetsForLevel(level);
-            if (targetsForLevel != null)
-            {
-                var logEvent = LogEventInfo.Create(level, Name, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
-            }
-        }
-
-        /// <summary>
-        /// Writes the diagnostic message and exception at the specified level.
-        /// </summary>
-        /// <param name="level">The log level.</param>
-        /// <param name="exception">An exception to be logged.</param>
-        /// <param name="message">A <see langword="string" /> to be written.</param>
-        /// <param name="args">Arguments to format.</param>
-        [MessageTemplateFormatMethod("message")]
-        public void Log(LogLevel level, Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
-        {
-            var targetsForLevel = GetTargetsForLevel(level);
-            if (targetsForLevel != null)
-            {
-                var logEvent = LogEventInfo.Create(level, Name, exception, Factory.DefaultCultureInfo, message, args.IsEmpty ? null : args.ToArray());
-                WriteToTargets(logEvent, targetsForLevel);
-            }
-        }
-#endif
-
         /// <summary>
         /// Writes the diagnostic message and exception at the specified level.
         /// </summary>
@@ -448,10 +410,18 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Log<TArgument>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, TArgument argument)
         {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+            var targetsForLevel = GetTargetsForLevelSafe(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, null, formatProvider, message, argument);
+            }
+#else
             if (IsEnabled(level))
             {
                 WriteToTargets(level, formatProvider, message, new object[] { argument });
             }
+#endif
         }
 
         /// <summary>
@@ -464,10 +434,18 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Log<TArgument>(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, TArgument argument)
         {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+            var targetsForLevel = GetTargetsForLevelSafe(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, argument);
+            }
+#else
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument });
             }
+#endif
         }
 
         /// <summary>
@@ -483,10 +461,18 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Log<TArgument1, TArgument2>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2)
         {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+            var targetsForLevel = GetTargetsForLevelSafe(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, null, formatProvider, message, argument1, argument2);
+            }
+#else
             if (IsEnabled(level))
             {
                 WriteToTargets(level, formatProvider, message, new object[] { argument1, argument2 });
             }
+#endif
         }
 
         /// <summary>
@@ -501,10 +487,18 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Log<TArgument1, TArgument2>(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2)
         {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+            var targetsForLevel = GetTargetsForLevelSafe(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+            }
+#else
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument1, argument2 });
             }
+#endif
         }
 
         /// <summary>
@@ -522,10 +516,18 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, IFormatProvider formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+            var targetsForLevel = GetTargetsForLevelSafe(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, null, formatProvider, message, argument1, argument2, argument3);
+            }
+#else
             if (IsEnabled(level))
             {
                 WriteToTargets(level, formatProvider, message, new object[] { argument1, argument2, argument3 });
             }
+#endif
         }
 
         /// <summary>
@@ -542,11 +544,94 @@ namespace NLog
         [MessageTemplateFormatMethod("message")]
         public void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+            var targetsForLevel = GetTargetsForLevelSafe(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+            }
+#else
             if (IsEnabled(level))
             {
                 WriteToTargets(level, message, new object[] { argument1, argument2, argument3 });
             }
+#endif
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the diagnostic message at the specified level using the specified parameters.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevelSafe(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, args);
+            }
+        }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the specified level.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="args">Arguments to format.</param>
+        [MessageTemplateFormatMethod("message")]
+        public void Log(LogLevel level, Exception exception, [Localizable(false)][StructuredMessageTemplate] string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevelSafe(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, exception, Factory.DefaultCultureInfo, message, args);
+            }
+        }
+
+        private void WriteToTargetsWithSpan(LogLevel level, Exception exception, IFormatProvider formatProvider, string message, params ReadOnlySpan<object> args)
+        {
+            var targetsForLevel = GetTargetsForLevel(level);
+            if (targetsForLevel != null)
+            {
+                WriteToTargetsWithSpan(targetsForLevel, level, exception, formatProvider, message, args);
+            }
+        }
+
+        private void WriteToTargetsWithSpan(ITargetWithFilterChain targetsForLevel, LogLevel level, Exception exception, IFormatProvider formatProvider, string message, params ReadOnlySpan<object> args)
+        {
+            if (Factory.AutoMessageTemplateFormatter is null || !LogEventInfo.NeedToPreformatMessage(args))
+            {
+                // Deferred message formatting and capturing of Properties
+                var logEvent = LogEventInfo.Create(level, Name, exception, formatProvider, message, args.IsEmpty ? null : args.ToArray());
+                WriteLogEventToTargets(logEvent, targetsForLevel);
+            }
+            else
+            {
+                // Pre-format upfront and skip parameter-object[]-array-allocation when possible
+                var templateEnumerator = new MessageTemplates.TemplateEnumerator(message);
+                if (templateEnumerator.MoveNext() && !templateEnumerator.Current.MaybePositionalTemplate)
+                {
+                    // Convert parameters into Properties and skip Parameters-array-allocation (Like with Microsoft Extension Logging)
+                    var formattedMessage = Factory.AutoMessageTemplateFormatter.Render(ref templateEnumerator, formatProvider, in args, out var messageTemplateParameters);
+                    var logEvent = new LogEventInfo(level, Name, formattedMessage, message, messageTemplateParameters);
+                    logEvent.Exception = exception;
+                    WriteLogEventToTargets(logEvent, targetsForLevel);
+                }
+                else
+                {
+                    // Pre-format using string.Format, and provide Parameters-array for Targets that fallback to Parameters-array when no Properties
+                    var logEvent = LogEventInfo.Create(level, Name, exception, formatProvider, message, args.ToArray());
+                    logEvent.MessageFormatter = LogMessageStringFormatter.Default.MessageFormatter; // Force string.Format since confirmed
+                    WriteLogEventToTargets(logEvent, targetsForLevel);
+                }
+            }
+        }
+#endif
+        #endregion
 
         private LogEventInfo PrepareLogEventInfo(LogEventInfo logEvent)
         {
@@ -562,9 +647,6 @@ namespace NLog
             }
             return logEvent;
         }
-
-        #endregion
-
 
         /// <summary>
         /// Runs the provided action. If the action throws, the exception is logged at <c>Error</c> level. The exception is not propagated outside of this method.
@@ -718,7 +800,7 @@ namespace NLog
             if (targetsForLevel != null)
             {
                 var logEvent = LogEventInfo.Create(level, Name, formatProvider, message, args);
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteLogEventToTargets(logEvent, targetsForLevel);
             }
         }
 
@@ -730,7 +812,7 @@ namespace NLog
                 // please note that this overload calls the overload of LogEventInfo.Create with object[] parameter on purpose -
                 // to avoid unnecessary string.Format (in case of calling Create(LogLevel, string, IFormatProvider, object))
                 var logEvent = LogEventInfo.Create(level, Name, Factory.DefaultCultureInfo, message, (object[])null);
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteLogEventToTargets(logEvent, targetsForLevel);
             }
         }
 
@@ -740,7 +822,7 @@ namespace NLog
             if (targetsForLevel != null)
             {
                 var logEvent = LogEventInfo.Create(level, Name, formatProvider, value);
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteLogEventToTargets(logEvent, targetsForLevel);
             }
         }
 
@@ -753,7 +835,7 @@ namespace NLog
                 var logEvent = message is null && ex != null && !(args?.Length > 0) ?
                     LogEventInfo.Create(level, Name, ExceptionMessageFormatProvider.Instance, ex) :
                     LogEventInfo.Create(level, Name, ex, Factory.DefaultCultureInfo, message, args);
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteLogEventToTargets(logEvent, targetsForLevel);
             }
         }
 
@@ -763,11 +845,11 @@ namespace NLog
             if (targetsForLevel != null)
             {
                 var logEvent = LogEventInfo.Create(level, Name, ex, formatProvider, message, args);
-                WriteToTargets(logEvent, targetsForLevel);
+                WriteLogEventToTargets(logEvent, targetsForLevel);
             }
         }
 
-        private void WriteToTargets([NotNull] LogEventInfo logEvent, [NotNull] ITargetWithFilterChain targetsForLevel)
+        private void WriteLogEventToTargets([NotNull] LogEventInfo logEvent, [NotNull] ITargetWithFilterChain targetsForLevel)
         {
             try
             {
@@ -787,7 +869,7 @@ namespace NLog
             }
         }
 
-        private void WriteToTargets(Type wrapperType, [NotNull] LogEventInfo logEvent, [NotNull] ITargetWithFilterChain targetsForLevel)
+        private void WriteLogEventToTargets(Type wrapperType, [NotNull] LogEventInfo logEvent, [NotNull] ITargetWithFilterChain targetsForLevel)
         {
             try
             {

--- a/src/NLog/MessageTemplates/LiteralHole.cs
+++ b/src/NLog/MessageTemplates/LiteralHole.cs
@@ -56,7 +56,7 @@ namespace NLog.MessageTemplates
 #endif
             Hole Hole;       // Not readonly to avoid struct-copy, and to avoid VerificationException when medium-trust AppDomain
 
-        public LiteralHole(Literal literal, Hole hole)
+        public LiteralHole(in Literal literal, in Hole hole)
         {
             Literal = literal;
             Hole = hole;

--- a/src/NLog/MessageTemplates/TemplateEnumerator.cs
+++ b/src/NLog/MessageTemplates/TemplateEnumerator.cs
@@ -54,6 +54,8 @@ namespace NLog.MessageTemplates
         private LiteralHole _current;
         private const short Zero = 0;
 
+        public string Template => _template;
+
         /// <summary>
         /// Parse a template.
         /// </summary>


### PR DESCRIPTION
Followup to #5800 to resolve #5537

When NLog needs to render message template upfront, then it will now skip Parameters-array-allocation, and instead rely on Properties-dictionary (Now matches NLog.Extensions.Logging)