### PR TITLE
LoggingConfigurationParser - Prioritize LoggingRules from current config

### DIFF
--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -89,12 +89,19 @@ namespace NLog.Config
             }
 
             var rulesList = new List<ValidatedConfigurationElement>();
+            var rulesInsertPosition = LoggingRules.Count;
 
             //parse all other direct elements
             foreach (var child in validatedConfig.ValidChildren)
             {
                 if (child.MatchesName("rules"))
                 {
+                    if (rulesList.Count == 0)
+                    {
+                        // Give higher priority to LoggingRules from current config-element
+                        // But until having read first LoggingRule, then allow new LoggingRules from include-files 
+                        rulesInsertPosition = LoggingRules.Count;
+                    }
                     //postpone parsing <rules> to the end
                     rulesList.Add(child);
                 }
@@ -112,7 +119,7 @@ namespace NLog.Config
 
             foreach (var ruleChild in rulesList)
             {
-                ParseRulesElement(ruleChild, LoggingRules);
+                ParseRulesElement(ruleChild, LoggingRules, rulesInsertPosition);
             }
         }
 
@@ -523,12 +530,15 @@ namespace NLog.Config
         /// <summary>
         /// Parse {Rules} xml element
         /// </summary>
-        /// <param name="rulesElement"></param>
-        /// <param name="rulesCollection">Rules are added to this parameter.</param>
-        private void ParseRulesElement(ValidatedConfigurationElement rulesElement, IList<LoggingRule> rulesCollection)
+        private void ParseRulesElement(ValidatedConfigurationElement rulesElement, IList<LoggingRule> rulesCollection, int rulesInsertPosition)
         {
             InternalLogger.Trace("ParseRulesElement");
             rulesElement.AssertName("rules");
+
+            if (rulesInsertPosition > rulesCollection.Count)
+            {
+                rulesInsertPosition = rulesCollection.Count;
+            }
 
             foreach (var childItem in rulesElement.ValidChildren)
             {
@@ -537,7 +547,7 @@ namespace NLog.Config
                 {
                     lock (rulesCollection)
                     {
-                        rulesCollection.Add(loggingRule);
+                        rulesCollection.Insert(rulesInsertPosition++, loggingRule);
                     }
                 }
             }

--- a/tests/NLog.UnitTests/Config/IncludeTests.cs
+++ b/tests/NLog.UnitTests/Config/IncludeTests.cs
@@ -69,6 +69,7 @@ namespace NLog.UnitTests.Config
             Directory.CreateDirectory(tempDir);
 
             CreateConfigFile(tempDir, "included.nlog", @"<nlog xmlns='http://www.nlog-project.org/schemas/NLog.xsd'>
+                    <rules><logger name='*' maxLevel='Debug' writeTo='' final='true' /></rules>
                     <targets><target name='debug' type='Debug' layout='${message}' /></targets>
             </nlog>");
 
@@ -86,6 +87,8 @@ namespace NLog.UnitTests.Config
                 LogManager.Configuration = new XmlLoggingConfiguration(fileToLoad);
 
                 LogManager.GetLogger("A").Debug("aaa");
+                AssertDebugLastMessage("debug", "");
+                LogManager.GetLogger("A").Info("aaa");
                 AssertDebugLastMessage("debug", "aaa");
             }
             finally


### PR DESCRIPTION
Trying to resolve #5816, by extending the reorder-logic introduced with #2113

Instead of always adding logging-rules to the end of the list, then it will prioritize using the active insert position. Supporting include-files that insert logging-rules before and after the logging-rules-section of the current-file.

- [x] Wait for NLog v5.5 (Because changes handling of `NLog.config` include-files)