### PR TITLE
LoggingConfigurationParser - Prioritize LoggingRules from current config

### DIFF
--- a/tests/NLog.UnitTests/Config/IncludeTests.cs
+++ b/tests/NLog.UnitTests/Config/IncludeTests.cs
@@ -69,6 +69,7 @@ namespace NLog.UnitTests.Config
             Directory.CreateDirectory(tempDir);
 
             CreateConfigFile(tempDir, "included.nlog", @"<nlog xmlns='http://www.nlog-project.org/schemas/NLog.xsd'>
+                    <rules><logger name='*' maxLevel='Debug' writeTo='' final='true' /></rules>
                     <targets><target name='debug' type='Debug' layout='${message}' /></targets>
             </nlog>");
 
@@ -86,6 +87,8 @@ namespace NLog.UnitTests.Config
                 LogManager.Configuration = new XmlLoggingConfiguration(fileToLoad);
 
                 LogManager.GetLogger("A").Debug("aaa");
+                AssertDebugLastMessage("debug", "");
+                LogManager.GetLogger("A").Info("aaa");
                 AssertDebugLastMessage("debug", "aaa");
             }
             finally


### PR DESCRIPTION
Trying to resolve #5816, by extending the reorder-logic introduced with #2113

Instead of always adding logging-rules to the end of the list, then it will prioritize using the active insert position. Supporting include-files that insert logging-rules before and after the logging-rules-section of the current-file.