### PR TITLE
DumpApiXml - Scan multiple assemblies

### DIFF
--- a/src/NLog.proj
+++ b/src/NLog.proj
@@ -103,6 +103,7 @@
   </Target>
 
   <Target Name="BuildApiDumpTool">
+    <MSBuild Projects="..\tools\DumpApiXml\DumpApiXml.csproj" Targets="Restore" Properties="IsRestoring=true" />
     <MSBuild Projects="..\tools\DumpApiXml\DumpApiXml.csproj" />
   </Target>
 
@@ -117,7 +118,7 @@
     Inputs="@(TargetFramework -> '$(BaseOutputDirectory)\bin\$(Configuration)\%(Identity)\NLog.dll');$(DumpApiXml);$(MergeApiXml)"
     Outputs="$(BaseOutputDirectory)\bin\$(Configuration)\NLogMerged.api.xml"
     >
-    <Exec Command='"$(DumpApiXml)" -assembly NLog.dll -assembly $(MSBuildProjectDirectory)\NLog.Database\Bin\$(Configuration)\%(TargetFramework.Identity)\NLog.Database.dll -output API\NLog.api'
+    <Exec Command='"$(DumpApiXml)" -assembly NLog.dll -output API\NLog.api'
           WorkingDirectory="$(BaseOutputDirectory)\bin\$(Configuration)\%(TargetFramework.Identity)"
           ContinueOnError="$(BuildAllFrameworks)" />
     <Exec Command='"$(MergeApiXml)" "$(BaseOutputDirectory)\bin\$(Configuration)"' />

--- a/tools/DumpApiXml/DumpApiXml.csproj
+++ b/tools/DumpApiXml/DumpApiXml.csproj
@@ -1,56 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{773C477E-2626-432D-B959-325B3B146744}</ProjectGuid>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>DumpApiXml</RootNamespace>
-    <AssemblyName>DumpApiXml</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     <OutputPath>..\..\build\bin\Tools\</OutputPath>
-    <IntermediateOutputPath>..\..\build\obj\Tools\</IntermediateOutputPath>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Xml" />
+    <ProjectReference Include="..\NLogNugetPackages\NLogNugetPackages.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="DocFileBuilder.cs" />
-    <Compile Include="Program.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
+  <Target Name="_ResolveCopyLocalNuGetPackageXmls" AfterTargets="ResolveReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).xml')" Condition="Exists('%(RootDir)%(Directory)%(Filename).xml')" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/tools/DumpApiXml/DumpApiXml.sln
+++ b/tools/DumpApiXml/DumpApiXml.sln
@@ -1,7 +1,11 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35931.197 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DumpApiXml", "DumpApiXml.csproj", "{773C477E-2626-432D-B959-325B3B146744}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLogNugetPackages", "..\NLogNugetPackages\NLogNugetPackages.csproj", "{6C7CF943-03E5-FBA1-7103-FAFF78DEAE0F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,8 +17,15 @@ Global
 		{773C477E-2626-432D-B959-325B3B146744}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{773C477E-2626-432D-B959-325B3B146744}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{773C477E-2626-432D-B959-325B3B146744}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C7CF943-03E5-FBA1-7103-FAFF78DEAE0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C7CF943-03E5-FBA1-7103-FAFF78DEAE0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C7CF943-03E5-FBA1-7103-FAFF78DEAE0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C7CF943-03E5-FBA1-7103-FAFF78DEAE0F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {003EDB45-0CA0-43AD-95CA-7C0389D2E186}
 	EndGlobalSection
 EndGlobal

--- a/tools/DumpApiXml/Program.cs
+++ b/tools/DumpApiXml/Program.cs
@@ -63,6 +63,38 @@ namespace DumpApiXml
                     return 1;
                 }
 
+                var outputDir = Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName);
+                if (!string.IsNullOrEmpty(outputDir))
+                {
+                    var assemblyFiles = Directory.GetFiles(outputDir, "NLog*.dll");
+                    Console.WriteLine("Detected {0} assemblies in folder: {1}", assemblyFiles.Length, outputDir);
+
+                    foreach (var assembly in assemblyFiles)
+                    {
+                        if (assembly.EndsWith("NLog.dll", StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        try
+                        {
+                            builder.LoadAssembly(assembly);
+                            string docpath = Path.ChangeExtension(assembly, ".xml");
+                            if (File.Exists(docpath))
+                            {
+                                builder.LoadComments(docpath);
+                                Console.WriteLine("Loaded assembly with XML-docs: {0}", Path.GetFileName(assembly));
+                            }
+                            else
+                            {
+                                Console.WriteLine("Loaded assembly without XML-docs: {0}", Path.GetFileName(assembly));
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine("Failed loading assembly {0} - {1}", Path.GetFullPath(assembly), ex);
+                        }
+                    }
+                }
+
                 outputFile = Path.GetFullPath(outputFile);
                 Console.WriteLine("Generating '{0}'...", outputFile);
                 Directory.CreateDirectory(Path.GetDirectoryName(outputFile));

--- a/tools/NLogNugetPackages/NLogNugetPackages.csproj
+++ b/tools/NLogNugetPackages/NLogNugetPackages.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb;.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Include the packages needed for the API docs -->
+    <PackageReference Include="NLog.Database" Version="6.0.0-preview1" />
+    <PackageReference Include="NLog.DiagnosticSource" version="5.*" />
+    <PackageReference Include="NLog.Extensions.Hosting" Version="5.*" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.*" />
+    <PackageReference Include="NLog.MailKit" version="5.*" />
+    <PackageReference Include="NLog.MSMQ" Version="5.*" />
+    <PackageReference Include="NLog.OutputDebugString" Version="6.0.0-preview1" />
+    <PackageReference Include="NLog.Owin.Logging" version="4.*" />
+    <PackageReference Include="NLog.PerformanceCounter" Version="5.*" />
+    <PackageReference Include="NLog.RegEx" Version="6.0.0-preview1" />
+    <PackageReference Include="NLog.Targets.AtomicFile" Version="6.0.0-preview1" />
+    <PackageReference Include="NLog.Targets.GZipFile" Version="6.0.0-preview1" />
+    <PackageReference Include="NLog.Targets.Mail" Version="6.0.0-preview1" />
+    <PackageReference Include="NLog.Targets.Network" Version="6.0.0-preview1" />
+    <PackageReference Include="NLog.Targets.Trace" Version="6.0.0-preview1" />
+    <PackageReference Include="NLog.Targets.WebService" Version="6.0.0-preview1" />
+    <PackageReference Include="NLog.Wcf" Version="5.*" />
+    <PackageReference Include="NLog.Web" Version="5.*" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="5.*" />
+    <PackageReference Include="NLog.WindowsIdentity" Version="5.*" />
+    <PackageReference Include="NLog.WindowsRegistry" Version="6.0.0-preview1" />
+  </ItemGroup>
+
+</Project>

--- a/tools/SandcastleDocs/dll_to_doc/dll_to_doc.csproj
+++ b/tools/SandcastleDocs/dll_to_doc/dll_to_doc.csproj
@@ -3,76 +3,24 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net472</TargetFramework>
-		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<!-- Include the packages needed for the API docs -->
-		<PackageReference Include="NLog" Version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog)\lib\net46\NLog.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.Database" Version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_Database)\lib\net46\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.DiagnosticSource" version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_DiagnosticSource)\lib\net45\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.Extensions.Hosting" Version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_Extensions_Hosting)\lib\netstandard2.0\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.Extensions.Logging" Version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_Extensions_Logging)\lib\netstandard2.0\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.MailKit" version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_MailKit)\lib\netstandard2.0\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.MSMQ" Version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_MSMQ)\lib\net46\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.OutputDebugString" Version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_OutputDebugString)\lib\net46\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.Owin.Logging" version="4.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_Owin_Logging)\lib\net45\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.PerformanceCounter" Version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_PerformanceCounter)\lib\net46\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.Wcf" Version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_Wcf)\lib\net46\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.Web" Version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_Web)\lib\net46\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.Web.AspNetCore" Version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_Web_AspNetCore)\lib\net461\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.Windows.Forms" version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_Windows_Forms)\lib\net35\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.WindowsIdentity" Version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_WindowsIdentity)\lib\net46\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<PackageReference Include="NLog.WindowsRegistry" Version="5.*" GeneratePathProperty="true" />
-		<None Include="$(PkgNLog_WindowsRegistry)\lib\net46\NLog.*.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
+		<PackageReference Include="NLog" Version="6.0.0-preview1" />
+    <PackageReference Include="NLog.Windows.Forms" version="5.*" />
 	</ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\NLogNugetPackages\NLogNugetPackages.csproj">
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
+	</ItemGroup>
+
+  <Target Name="_ResolveCopyLocalNuGetPackageXmls" AfterTargets="ResolveReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).xml')" Condition="Exists('%(RootDir)%(Directory)%(Filename).xml')" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/tools/SandcastleDocs/dll_to_doc/dll_to_doc.sln
+++ b/tools/SandcastleDocs/dll_to_doc/dll_to_doc.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.2.32516.85
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dll_to_doc", "dll_to_doc.csproj", "{AA900992-9A6B-44F4-B891-193531554B55}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLogNugetPackages", "..\..\NLogNugetPackages\NLogNugetPackages.csproj", "{97E582D4-2DC1-0776-FDE6-BBD03EFD8375}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{AA900992-9A6B-44F4-B891-193531554B55}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AA900992-9A6B-44F4-B891-193531554B55}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AA900992-9A6B-44F4-B891-193531554B55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97E582D4-2DC1-0776-FDE6-BBD03EFD8375}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97E582D4-2DC1-0776-FDE6-BBD03EFD8375}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97E582D4-2DC1-0776-FDE6-BBD03EFD8375}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97E582D4-2DC1-0776-FDE6-BBD03EFD8375}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
With NLog v6 then it becomes more relevant to merge XML-docs from multiple NLog-extension-assemblies.

Resolves #1168