### PR TITLE
LogEventInfo SequenceID marked obsolete, instead use CounterLayoutRenderer

### DIFF
--- a/src/NLog/Config/AssemblyExtensionTypes.cs
+++ b/src/NLog/Config/AssemblyExtensionTypes.cs
@@ -38,6 +38,7 @@ namespace NLog.Config
     /// </summary>
     internal static class AssemblyExtensionTypes
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         public static void RegisterTargetTypes(ConfigurationItemFactory factory, bool skipCheckExists)
         {
             factory.RegisterTypeProperties<NLog.Targets.TargetWithContext.TargetWithContextLayout>(() => null);
@@ -398,5 +399,6 @@ namespace NLog.Config
                 factory.GetConditionMethodFactory().RegisterThreeParameters("ends-with", (logEvent, arg1, arg2, arg3) => NLog.Conditions.ConditionMethods.EndsWith(arg1?.ToString(), arg2?.ToString(), arg3 is bool ignoreCase ? ignoreCase : true));
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/NLog/Config/AssemblyExtensionTypes.tt
+++ b/src/NLog/Config/AssemblyExtensionTypes.tt
@@ -48,6 +48,7 @@ namespace NLog.Config
     /// </summary>
     internal static class AssemblyExtensionTypes
     {
+#pragma warning disable CS0618 // Type or member is obsolete
 <#
     string[] NetFrameworkOnly = new [] {
         "NLog.LayoutRenderers.AppSettingLayoutRenderer",
@@ -259,5 +260,6 @@ namespace NLog.Config
                 factory.GetConditionMethodFactory().RegisterThreeParameters("ends-with", (logEvent, arg1, arg2, arg3) => NLog.Conditions.ConditionMethods.EndsWith(arg1?.ToString(), arg2?.ToString(), arg3 is bool ignoreCase ? ignoreCase : true));
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -417,9 +417,11 @@ namespace NLog.Internal
                 case TypeCode.Int64:
                     {
                         long int64 = value.ToInt64(CultureInfo.InvariantCulture);
+#if NETFRAMEWORK
                         if (int64 < int.MaxValue && int64 > int.MinValue)
                             sb.AppendInvariant((int)int64);
                         else
+#endif
                             sb.Append(int64);
                     }
                     break;
@@ -428,9 +430,11 @@ namespace NLog.Internal
                 case TypeCode.UInt64:
                     {
                         ulong uint64 = value.ToUInt64(CultureInfo.InvariantCulture);
+#if NETFRAMEWORK
                         if (uint64 < uint.MaxValue)
                             sb.AppendInvariant((uint)uint64);
                         else
+#endif
                             sb.Append(uint64);
                     }
                     break;

--- a/src/NLog/LayoutRenderers/GuidLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GuidLayoutRenderer.cs
@@ -97,7 +97,9 @@ namespace NLog.LayoutRenderers
                 byte i = (byte)((zeroDateTicks >> 16) & 0xFF);
                 byte j = (byte)((zeroDateTicks >> 8) & 0xFF);
                 byte k = (byte)(zeroDateTicks & 0XFF);
+#pragma warning disable CS0618 // Type or member is obsolete
                 guid = new Guid(logEvent.SequenceID, b, c, d, e, f, g, h, i, j, k);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             else
             {

--- a/src/NLog/LayoutRenderers/SequenceIdLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/SequenceIdLayoutRenderer.cs
@@ -33,12 +33,16 @@
 
 namespace NLog.LayoutRenderers
 {
+    using System;
+    using System.ComponentModel;
     using System.Text;
     using NLog.Config;
     using NLog.Internal;
 
     /// <summary>
     /// The sequence ID
+    ///
+    /// Marked obsolete with NLog 6.0, instead use ${counter}
     /// </summary>
     /// <remarks>
     /// <a href="https://github.com/NLog/NLog/wiki/SequenceId-layout-renderer">See NLog Wiki</a>
@@ -46,6 +50,8 @@ namespace NLog.LayoutRenderers
     /// <seealso href="https://github.com/NLog/NLog/wiki/SequenceId-layout-renderer">Documentation on NLog Wiki</seealso>
     [LayoutRenderer("sequenceid")]
     [ThreadAgnostic]
+    [Obsolete("Use ${counter:sequence=global} instead of ${sequenceid}. Marked obsolete with NLog 6.0")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class SequenceIdLayoutRenderer : LayoutRenderer, IRawValue
     {
         /// <inheritdoc/>

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -185,10 +185,13 @@ namespace NLog
         }
 
         /// <summary>
-        /// Gets the unique identifier of log event which is automatically generated
-        /// and monotonously increasing.
+        /// Gets the sequence number for this LogEvent, which monotonously increasing for each LogEvent until int-overflow
+        ///
+        /// Marked obsolete with NLog 6.0, instead use ${counter:sequence=global} or ${guid:GeneratedFromLogEvent=true}
         /// </summary>
         // ReSharper disable once InconsistentNaming
+        [Obsolete("Use ${counter:sequence=global} instead of ${sequenceid}. Marked obsolete with NLog 6.0")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public int SequenceID
         {
             get

--- a/tests/NLog.UnitTests/LayoutRenderers/CounterTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CounterTests.cs
@@ -100,13 +100,13 @@ namespace NLog.UnitTests.LayoutRenderers
             var logger = LogManager.GetLogger("A");
             logger.Debug("a");
             logger.Info("a");
-            AssertDebugLastMessage("debug", "a 1 1");
+            AssertDebugLastMessage("debug", "a 4 1");
             logger.Warn("a");
-            AssertDebugLastMessage("debug", "a 4 2");
+            AssertDebugLastMessage("debug", "a 7 2");
             logger.Error("a");
-            AssertDebugLastMessage("debug", "a 7 3");
+            AssertDebugLastMessage("debug", "a 10 3");
             logger.Fatal("a");
-            AssertDebugLastMessage("debug", "a 10 4");
+            AssertDebugLastMessage("debug", "a 13 4");
         }
 
         [Fact]

--- a/tests/NLog.UnitTests/LayoutRenderers/SequenceIdLayoutRendererTest.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/SequenceIdLayoutRendererTest.cs
@@ -33,12 +33,13 @@
 
 namespace NLog.UnitTests.LayoutRenderers
 {
+    using System;
     using System.Globalization;
     using Xunit;
 
+    [Obsolete("Use ${counter:sequence=global} instead of ${sequenceid}. Marked obsolete with NLog 6.0")]
     public class SequenceIdLayoutRendererTest : NLogTestBase
     {
-
         [Fact]
         public void RenderSequenceIdLayoutRenderer()
         {

--- a/tests/NLog.UnitTests/Targets/TargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/TargetTests.cs
@@ -873,7 +873,9 @@ namespace NLog.UnitTests.Targets
             Assert.Equal((byte)42, logEvent.Properties["ByteProperty"]);
             Assert.Equal((short)43, logEvent.Properties["Int16Property"]);
             Assert.Equal(CurrentManagedThreadId, logEvent.Properties["Int32Property"]);
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Equal((long)logEvent.SequenceID, logEvent.Properties["Int64Property"]);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Equal(AppDomain.CurrentDomain.FriendlyName, logEvent.Properties["StringProperty"]);
             Assert.Equal(true, logEvent.Properties["BoolProperty"]);
             Assert.Equal(3.14159, logEvent.Properties["DoubleProperty"]);

--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
@@ -121,7 +121,9 @@ namespace NLog.UnitTests.Targets.Wrappers
                 for (int i = 0; i < itemPrepareList.Capacity; ++i)
                 {
                     var logEvent = new LogEventInfo();
+#pragma warning disable CS0618 // Type or member is obsolete
                     int sequenceID = logEvent.SequenceID;
+#pragma warning restore CS0618 // Type or member is obsolete
                     bool blockConsumer = (itemPrepareList.Capacity / 2) == i;  // Force producers to get into blocking-mode
                     itemPrepareList.Add(logEvent.WithContinuation((ex) => { if (blockConsumer) Thread.Sleep(125); itemWrittenList.Add(sequenceID); }));
                 }


### PR DESCRIPTION
Another step towards resolving #4159, where `${sequenceid}` can be replaced by `${counter:sequence=global}`

And added a little sugar by optimizing `${counter}` to use Interlocked and ConcurrentDictionary