### PR TITLE
Removed NotNull + CanBeNull since now using nullable annotations

### DIFF
--- a/src/NLog.Targets.ConcurrentFile/FileAppenders/BaseMutexFileAppender.cs
+++ b/src/NLog.Targets.ConcurrentFile/FileAppenders/BaseMutexFileAppender.cs
@@ -38,7 +38,6 @@ namespace NLog.Internal.FileAppenders
     using System.Security;
     using System.Threading;
     using System.Text;
-    using JetBrains.Annotations;
 
 #if NETFRAMEWORK
     using System.Security.AccessControl;

--- a/src/NLog/Common/IInternalLoggerContext.cs
+++ b/src/NLog/Common/IInternalLoggerContext.cs
@@ -33,8 +33,6 @@
 
 namespace NLog.Common
 {
-    using JetBrains.Annotations;
-
     /// <summary>
     /// Enables <see cref="InternalLogger"/> to extract extra context details for <see cref="InternalLogger.InternalEventOccurred"/>
     /// </summary>
@@ -48,7 +46,6 @@ namespace NLog.Common
         /// <summary>
         /// The current LogFactory next to LogManager
         /// </summary>
-        [CanBeNull]
         LogFactory? LogFactory { get; }
     }
 }

--- a/src/NLog/Common/InternalLogEventArgs.cs
+++ b/src/NLog/Common/InternalLogEventArgs.cs
@@ -34,7 +34,6 @@
 namespace NLog.Common
 {
     using System;
-    using JetBrains.Annotations;
 
     /// <summary>
     /// Internal LogEvent details from <see cref="InternalLogger"/>
@@ -54,24 +53,21 @@ namespace NLog.Common
         /// <summary>
         /// The exception. Could be null.
         /// </summary>
-        [CanBeNull]
         public Exception? Exception { get; }
 
         /// <summary>
         /// The type that triggered this internal log event, for example the FileTarget.
         /// This property is not always populated.
         /// </summary>
-        [CanBeNull]
         public Type? SenderType { get; }
 
         /// <summary>
         /// The context name that triggered this internal log event, for example the name of the Target.
         /// This property is not always populated.
         /// </summary>
-        [CanBeNull]
         public string? SenderName { get; }
 
-        internal InternalLogEventArgs(string message, LogLevel level, [CanBeNull] Exception? exception, [CanBeNull] Type? senderType, [CanBeNull] string? senderName)
+        internal InternalLogEventArgs(string message, LogLevel level, Exception? exception, Type? senderType, string? senderName)
         {
             Message = message;
             Level = level;

--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -281,7 +281,7 @@ namespace NLog.Common
         /// <param name="level">level</param>
         /// <param name="message">message</param>
         /// <param name="args">optional args for <paramref name="message"/></param>
-        private static void Write([CanBeNull] Exception? ex, LogLevel level, string message, [CanBeNull] object?[]? args)
+        private static void Write(Exception? ex, LogLevel level, string message, object?[]? args)
         {
             if (!IsLogLevelEnabled(level))
             {
@@ -354,7 +354,7 @@ namespace NLog.Common
         /// <summary>
         /// Create log line with timestamp, exception message etc (if configured)
         /// </summary>
-        private static string CreateLogLine([CanBeNull] Exception? ex, LogLevel level, string fullMessage)
+        private static string CreateLogLine(Exception? ex, LogLevel level, string fullMessage)
         {
             const string timeStampFormat = "yyyy-MM-dd HH:mm:ss.ffff";
             const string fieldSeparator = " ";

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -40,8 +40,6 @@ namespace NLog.Config
     using System.Globalization;
     using System.Linq;
     using System.Threading;
-    using JetBrains.Annotations;
-
     using NLog.Common;
     using NLog.Internal;
     using NLog.Layouts;
@@ -172,7 +170,6 @@ namespace NLog.Config
         /// <value>
         /// Specific culture info or null to use <see cref="CultureInfo.CurrentCulture"/>
         /// </value>
-        [CanBeNull]
         public CultureInfo? DefaultCultureInfo { get; set; }
 
         /// <summary>
@@ -210,7 +207,7 @@ namespace NLog.Config
         /// The target object with a non <see langword="null"/> <see cref="Target.Name"/>
         /// </param>
         /// <exception cref="ArgumentNullException">when <paramref name="target"/> is <see langword="null"/></exception>
-        public void AddTarget([NotNull] Target target)
+        public void AddTarget(Target target)
         {
             Guard.ThrowIfNull(target);
 
@@ -228,7 +225,7 @@ namespace NLog.Config
         /// <param name="target">The target object.</param>
         /// <exception cref="ArgumentException">when <paramref name="name"/> is <see langword="null"/></exception>
         /// <exception cref="ArgumentNullException">when <paramref name="target"/> is <see langword="null"/></exception>
-        public void AddTarget(string name, [NotNull] Target target)
+        public void AddTarget(string name, Target target)
         {
             Guard.ThrowIfNull(name);
             Guard.ThrowIfNull(target);
@@ -866,13 +863,11 @@ namespace NLog.Config
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>
-        [NotNull]
         internal string ExpandSimpleVariables(string? input)
         {
             return ExpandSimpleVariables(input, out var _);
         }
 
-        [NotNull]
         internal string ExpandSimpleVariables(string? input, out string? matchingVariableName)
         {
             var output = input;

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -56,8 +56,6 @@ namespace NLog.Config
     /// </remarks>
     public abstract class LoggingConfigurationParser : LoggingConfiguration
     {
-        private readonly ServiceRepository _serviceRepository;
-
         /// <summary>
         /// Constructor
         /// </summary>
@@ -65,7 +63,6 @@ namespace NLog.Config
         protected LoggingConfigurationParser(LogFactory logFactory)
             : base(logFactory)
         {
-            _serviceRepository = logFactory.ServiceRepository;
         }
 
         /// <summary>
@@ -204,7 +201,7 @@ namespace NLog.Config
                 ConfigurationItemFactory.Default.AssemblyLoader.ScanForAutoLoadExtensions(ConfigurationItemFactory.Default);
             }
 
-            _serviceRepository.ParseMessageTemplates(LogFactory, parseMessageTemplates);
+            LogFactory.ServiceRepository.ParseMessageTemplates(LogFactory, parseMessageTemplates);
         }
 
         /// <summary>

--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -38,9 +38,9 @@ namespace NLog.Config
     using System.Collections.ObjectModel;
     using System.ComponentModel;
     using System.Globalization;
-    using System.Linq;
     using System.Text;
     using NLog.Filters;
+    using NLog.Internal;
     using NLog.Targets;
 
     /// <summary>
@@ -57,7 +57,6 @@ namespace NLog.Config
         /// Create an empty <see cref="LoggingRule" />.
         /// </summary>
         public LoggingRule()
-            : this(null)
         {
         }
 
@@ -77,8 +76,8 @@ namespace NLog.Config
         /// <param name="maxLevel">Maximum log level needed to trigger this rule.</param>
         /// <param name="target">Target to be written to when the rule matches.</param>
         public LoggingRule(string loggerNamePattern, LogLevel minLevel, LogLevel maxLevel, Target target)
-            : this()
         {
+            Guard.ThrowIfNull(target);
             LoggerNamePattern = loggerNamePattern;
             _targets.Add(target);
             EnableLoggingForLevels(minLevel, maxLevel);
@@ -91,8 +90,8 @@ namespace NLog.Config
         /// <param name="minLevel">Minimum log level needed to trigger this rule.</param>
         /// <param name="target">Target to be written to when the rule matches.</param>
         public LoggingRule(string loggerNamePattern, LogLevel minLevel, Target target)
-            : this()
         {
+            Guard.ThrowIfNull(target);
             LoggerNamePattern = loggerNamePattern;
             _targets.Add(target);
             EnableLoggingForLevels(minLevel, LogLevel.MaxLevel);
@@ -104,8 +103,8 @@ namespace NLog.Config
         /// <param name="loggerNamePattern">Logger name pattern used for <see cref="LoggerNamePattern"/>. It may include one or more '*' or '?' wildcards at any position.</param>
         /// <param name="target">Target to be written to when the rule matches.</param>
         public LoggingRule(string loggerNamePattern, Target target)
-            : this()
         {
+            Guard.ThrowIfNull(target);
             LoggerNamePattern = loggerNamePattern;
             _targets.Add(target);
         }
@@ -132,7 +131,7 @@ namespace NLog.Config
         private readonly List<LoggingRule> _childRules = new List<LoggingRule>();
         [Obsolete("Very exotic feature without any unit-tests, not sure if it works. Marked obsolete with NLog v5.3")]
         internal LoggingRule[] GetChildRulesThreadSafe() { lock (_childRules) return _childRules.ToArray(); }
-        internal Target[] GetTargetsThreadSafe() { lock (_targets) return _targets.Count == 0 ? NLog.Internal.ArrayHelper.Empty<Target>() : _targets.ToArray(); }
+        internal Target[] GetTargetsThreadSafe() { lock (_targets) return _targets.Count == 0 ? ArrayHelper.Empty<Target>() : _targets.ToArray(); }
         internal bool RemoveTargetThreadSafe(Target target) { lock (_targets) return _targets.Remove(target); }
 
         /// <summary>
@@ -274,6 +273,8 @@ namespace NLog.Config
         /// <param name="maxLevel">Maximum log level to be disabled.</param>
         public void DisableLoggingForLevels(LogLevel minLevel, LogLevel maxLevel)
         {
+            Guard.ThrowIfNull(minLevel);
+            Guard.ThrowIfNull(maxLevel);
             _logLevelFilter = _logLevelFilter.GetSimpleFilterForUpdate().SetLoggingLevels(minLevel, maxLevel, false);
         }
 
@@ -284,6 +285,8 @@ namespace NLog.Config
         /// <param name="maxLevel">Maximum log level needed to trigger this rule.</param>
         public void SetLoggingLevels(LogLevel minLevel, LogLevel maxLevel)
         {
+            Guard.ThrowIfNull(minLevel);
+            Guard.ThrowIfNull(maxLevel);
             _logLevelFilter = _logLevelFilter.GetSimpleFilterForUpdate().SetLoggingLevels(LogLevel.MinLevel, LogLevel.MaxLevel, false).SetLoggingLevels(minLevel, maxLevel, true);
         }
 

--- a/src/NLog/Config/NLogDependencyResolveException.cs
+++ b/src/NLog/Config/NLogDependencyResolveException.cs
@@ -34,7 +34,6 @@
 namespace NLog.Config
 {
     using System;
-    using JetBrains.Annotations;
     using NLog.Internal;
 
     /// <summary>
@@ -45,12 +44,12 @@ namespace NLog.Config
         /// <summary>
         /// Typed we tried to resolve
         /// </summary>
-        [NotNull] public Type ServiceType { get; }
+        public Type ServiceType { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NLogDependencyResolveException" /> class.
         /// </summary>
-        public NLogDependencyResolveException(string message, [NotNull] Type serviceType) : base(CreateFullMessage(serviceType, message))
+        public NLogDependencyResolveException(string message, Type serviceType) : base(CreateFullMessage(serviceType, message))
         {
             ServiceType = Guard.ThrowIfNull(serviceType);
         }
@@ -58,7 +57,7 @@ namespace NLog.Config
         /// <summary>
         /// Initializes a new instance of the <see cref="NLogDependencyResolveException" /> class.
         /// </summary>
-        public NLogDependencyResolveException(string message, Exception innerException, [NotNull] Type serviceType) : base(CreateFullMessage(serviceType, message), innerException)
+        public NLogDependencyResolveException(string message, Exception innerException, Type serviceType) : base(CreateFullMessage(serviceType, message), innerException)
         {
             ServiceType = Guard.ThrowIfNull(serviceType);
         }

--- a/src/NLog/Config/ServiceRepositoryExtensions.cs
+++ b/src/NLog/Config/ServiceRepositoryExtensions.cs
@@ -34,13 +34,12 @@
 namespace NLog.Config
 {
     using System;
-    using JetBrains.Annotations;
     using NLog.Internal;
     using NLog.Targets;
 
     internal static class ServiceRepositoryExtensions
     {
-        internal static ServiceRepository GetServiceProvider([CanBeNull] this LoggingConfiguration? loggingConfiguration)
+        internal static ServiceRepository GetServiceProvider(this LoggingConfiguration? loggingConfiguration)
         {
             return loggingConfiguration?.LogFactory?.ServiceRepository ?? LogManager.LogFactory.ServiceRepository;
         }
@@ -138,7 +137,7 @@ namespace NLog.Config
         /// <summary>
         /// Registers the string serializer to use with <see cref="LogEventInfo.MessageTemplateParameters"/>
         /// </summary>
-        internal static ServiceRepository RegisterValueFormatter(this ServiceRepository serviceRepository, [NotNull] IValueFormatter valueFormatter)
+        internal static ServiceRepository RegisterValueFormatter(this ServiceRepository serviceRepository, IValueFormatter valueFormatter)
         {
             Guard.ThrowIfNull(valueFormatter);
 
@@ -146,7 +145,7 @@ namespace NLog.Config
             return serviceRepository;
         }
 
-        internal static ServiceRepository RegisterJsonConverter(this ServiceRepository serviceRepository, [NotNull] IJsonConverter jsonConverter)
+        internal static ServiceRepository RegisterJsonConverter(this ServiceRepository serviceRepository, IJsonConverter jsonConverter)
         {
             Guard.ThrowIfNull(jsonConverter);
 
@@ -154,7 +153,7 @@ namespace NLog.Config
             return serviceRepository;
         }
 
-        internal static ServiceRepository RegisterPropertyTypeConverter(this ServiceRepository serviceRepository, [NotNull] IPropertyTypeConverter converter)
+        internal static ServiceRepository RegisterPropertyTypeConverter(this ServiceRepository serviceRepository, IPropertyTypeConverter converter)
         {
             Guard.ThrowIfNull(converter);
 
@@ -162,7 +161,7 @@ namespace NLog.Config
             return serviceRepository;
         }
 
-        internal static ServiceRepository RegisterObjectTypeTransformer(this ServiceRepository serviceRepository, [NotNull] IObjectTypeTransformer transformer)
+        internal static ServiceRepository RegisterObjectTypeTransformer(this ServiceRepository serviceRepository, IObjectTypeTransformer transformer)
         {
             Guard.ThrowIfNull(transformer);
 

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -39,7 +39,6 @@ namespace NLog.Config
     using System.IO;
     using System.Linq;
     using System.Threading;
-    using JetBrains.Annotations;
     using NLog.Common;
     using NLog.Internal;
     using NLog.Layouts;
@@ -68,7 +67,7 @@ namespace NLog.Config
         /// Initializes a new instance of the <see cref="XmlLoggingConfiguration" /> class.
         /// </summary>
         /// <param name="fileName">Path to the config-file to read.</param>
-        public XmlLoggingConfiguration([NotNull] string fileName)
+        public XmlLoggingConfiguration(string fileName)
             : this(fileName, LogManager.LogFactory)
         { }
 
@@ -77,7 +76,7 @@ namespace NLog.Config
         /// </summary>
         /// <param name="fileName">Path to the config-file to read.</param>
         /// <param name="logFactory">The <see cref="LogFactory" /> to which to apply any applicable configuration values.</param>
-        public XmlLoggingConfiguration([NotNull] string fileName, LogFactory logFactory)
+        public XmlLoggingConfiguration(string fileName, LogFactory logFactory)
             : base(logFactory)
         {
             Guard.ThrowIfNullOrEmpty(fileName);
@@ -88,7 +87,7 @@ namespace NLog.Config
         /// Initializes a new instance of the <see cref="XmlLoggingConfiguration" /> class.
         /// </summary>
         /// <param name="xmlSource">Configuration file to be read.</param>
-        public XmlLoggingConfiguration([NotNull] TextReader xmlSource)
+        public XmlLoggingConfiguration(TextReader xmlSource)
             : this(xmlSource, null)
         {
         }
@@ -98,7 +97,7 @@ namespace NLog.Config
         /// </summary>
         /// <param name="xmlSource">Configuration file to be read.</param>
         /// <param name="filePath">Path to the config-file that contains the element (to be used as a base for including other files). <c>null</c> is allowed.</param>
-        public XmlLoggingConfiguration([NotNull] TextReader xmlSource, string? filePath)
+        public XmlLoggingConfiguration(TextReader xmlSource, string? filePath)
             : this(xmlSource, filePath, LogManager.LogFactory)
         {
         }
@@ -109,7 +108,7 @@ namespace NLog.Config
         /// <param name="xmlSource">Configuration file to be read.</param>
         /// <param name="filePath">Path to the config-file that contains the element (to be used as a base for including other files). <c>null</c> is allowed.</param>
         /// <param name="logFactory">The <see cref="LogFactory" /> to which to apply any applicable configuration values.</param>
-        public XmlLoggingConfiguration([NotNull] TextReader xmlSource, string? filePath, LogFactory logFactory)
+        public XmlLoggingConfiguration(TextReader xmlSource, string? filePath, LogFactory logFactory)
             : base(logFactory)
         {
             Guard.ThrowIfNull(xmlSource);
@@ -122,7 +121,7 @@ namespace NLog.Config
         /// </summary>
         /// <param name="reader">XML reader to read from.</param>
         [Obsolete("Instead use TextReader as input. Marked obsolete with NLog 6.0")]
-        public XmlLoggingConfiguration([NotNull] System.Xml.XmlReader reader)
+        public XmlLoggingConfiguration(System.Xml.XmlReader reader)
             : this(reader, null) { }
 
         /// <summary>
@@ -131,7 +130,7 @@ namespace NLog.Config
         /// <param name="reader">XmlReader containing the configuration section.</param>
         /// <param name="fileName">Path to the config-file that contains the element (to be used as a base for including other files). <c>null</c> is allowed.</param>
         [Obsolete("Instead use TextReader as input. Marked obsolete with NLog 6.0")]
-        public XmlLoggingConfiguration([NotNull] System.Xml.XmlReader reader, [CanBeNull] string? fileName)
+        public XmlLoggingConfiguration(System.Xml.XmlReader reader, string? fileName)
             : this(reader, fileName, LogManager.LogFactory)
         { }
 
@@ -142,7 +141,7 @@ namespace NLog.Config
         /// <param name="fileName">Path to the config-file that contains the element (to be used as a base for including other files). <c>null</c> is allowed.</param>
         /// <param name="logFactory">The <see cref="LogFactory" /> to which to apply any applicable configuration values.</param>
         [Obsolete("Instead use TextReader as input. Marked obsolete with NLog 6.0")]
-        public XmlLoggingConfiguration([NotNull] System.Xml.XmlReader reader, [CanBeNull] string? fileName, LogFactory logFactory)
+        public XmlLoggingConfiguration(System.Xml.XmlReader reader, string? fileName, LogFactory logFactory)
             : base(logFactory)
         {
             Guard.ThrowIfNull(reader);
@@ -156,7 +155,7 @@ namespace NLog.Config
         /// <param name="xmlContents">NLog configuration as XML string.</param>
         /// <param name="filePath">Path to the config-file that contains the element (to be used as a base for including other files). <c>null</c> is allowed.</param>
         /// <param name="logFactory">The <see cref="LogFactory" /> to which to apply any applicable configuration values.</param>
-        internal XmlLoggingConfiguration([NotNull] string xmlContents, [CanBeNull] string filePath, LogFactory logFactory)
+        internal XmlLoggingConfiguration(string xmlContents, string filePath, LogFactory logFactory)
             : base(logFactory)
         {
             Guard.ThrowIfNullOrEmpty(xmlContents);
@@ -338,7 +337,7 @@ namespace NLog.Config
 
 #if NETFRAMEWORK
         [Obsolete("Instead use TextReader as input. Marked obsolete with NLog 6.0")]
-        private void ParseFromXmlReader([NotNull] System.Xml.XmlReader reader, [CanBeNull] string? filePath)
+        private void ParseFromXmlReader(System.Xml.XmlReader reader, string? filePath)
         {
             try
             {
@@ -391,7 +390,7 @@ namespace NLog.Config
         /// <summary>
         /// Include new file into the configuration. Check if not already included.
         /// </summary>
-        private void IncludeNewConfigFile([NotNull] string filePath, bool autoReloadDefault)
+        private void IncludeNewConfigFile(string filePath, bool autoReloadDefault)
         {
             if (!_fileMustAutoReloadLookup.ContainsKey(GetFileLookupKey(filePath)))
             {
@@ -409,7 +408,7 @@ namespace NLog.Config
         /// <param name="content"></param>
         /// <param name="filePath">Path to the config-file that contains the element (to be used as a base for including other files). <c>null</c> is allowed.</param>
         /// <param name="autoReloadDefault">The default value for the autoReload option.</param>
-        private void ParseTopLevel(ILoggingConfigurationElement content, [CanBeNull] string? filePath, bool autoReloadDefault)
+        private void ParseTopLevel(ILoggingConfigurationElement content, string? filePath, bool autoReloadDefault)
         {
             content.AssertName("nlog", "configuration");
 
@@ -431,7 +430,7 @@ namespace NLog.Config
         /// <param name="configurationElement"></param>
         /// <param name="filePath">Path to the config-file that contains the element (to be used as a base for including other files). <c>null</c> is allowed.</param>
         /// <param name="autoReloadDefault">The default value for the autoReload option.</param>
-        private void ParseConfigurationElement(ILoggingConfigurationElement configurationElement, [CanBeNull] string? filePath, bool autoReloadDefault)
+        private void ParseConfigurationElement(ILoggingConfigurationElement configurationElement, string? filePath, bool autoReloadDefault)
         {
             InternalLogger.Trace("ParseConfigurationElement");
             configurationElement.AssertName("configuration");
@@ -449,7 +448,7 @@ namespace NLog.Config
         /// <param name="nlogElement"></param>
         /// <param name="filePath">Path to the config-file that contains the element (to be used as a base for including other files). <c>null</c> is allowed.</param>
         /// <param name="autoReloadDefault">The default value for the autoReload option.</param>
-        private void ParseNLogElement(ILoggingConfigurationElement nlogElement, [CanBeNull] string? filePath, bool autoReloadDefault)
+        private void ParseNLogElement(ILoggingConfigurationElement nlogElement, string? filePath, bool autoReloadDefault)
         {
             InternalLogger.Trace("ParseNLogElement");
             nlogElement.AssertName("nlog");

--- a/src/NLog/ILoggerExtensions.cs
+++ b/src/NLog/ILoggerExtensions.cs
@@ -54,7 +54,7 @@ namespace NLog
         /// <param name="logger">The logger to write the log event to.</param>
         /// <param name="logLevel">The log level. When not</param>
         /// <returns><see cref="LogEventBuilder"/> for chaining calls.</returns>
-        public static LogEventBuilder ForLogEvent([NotNull] this ILogger logger, LogLevel? logLevel = null)
+        public static LogEventBuilder ForLogEvent(this ILogger logger, LogLevel? logLevel = null)
         {
             return logLevel is null ? new LogEventBuilder(logger) : new LogEventBuilder(logger, logLevel);
         }
@@ -64,7 +64,7 @@ namespace NLog
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
         /// <returns><see cref="LogEventBuilder"/> for chaining calls.</returns>
-        public static LogEventBuilder ForTraceEvent([NotNull] this ILogger logger)
+        public static LogEventBuilder ForTraceEvent(this ILogger logger)
         {
             return new LogEventBuilder(logger, LogLevel.Trace);
         }
@@ -74,7 +74,7 @@ namespace NLog
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
         /// <returns><see cref="LogEventBuilder"/> for chaining calls.</returns>
-        public static LogEventBuilder ForDebugEvent([NotNull] this ILogger logger)
+        public static LogEventBuilder ForDebugEvent(this ILogger logger)
         {
             return new LogEventBuilder(logger, LogLevel.Debug);
         }
@@ -84,7 +84,7 @@ namespace NLog
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
         /// <returns><see cref="LogEventBuilder"/> for chaining calls.</returns>
-        public static LogEventBuilder ForInfoEvent([NotNull] this ILogger logger)
+        public static LogEventBuilder ForInfoEvent(this ILogger logger)
         {
             return new LogEventBuilder(logger, LogLevel.Info);
         }
@@ -94,7 +94,7 @@ namespace NLog
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
         /// <returns><see cref="LogEventBuilder"/> for chaining calls.</returns>
-        public static LogEventBuilder ForWarnEvent([NotNull] this ILogger logger)
+        public static LogEventBuilder ForWarnEvent(this ILogger logger)
         {
             return new LogEventBuilder(logger, LogLevel.Warn);
         }
@@ -104,7 +104,7 @@ namespace NLog
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
         /// <returns><see cref="LogEventBuilder"/> for chaining calls.</returns>
-        public static LogEventBuilder ForErrorEvent([NotNull] this ILogger logger)
+        public static LogEventBuilder ForErrorEvent(this ILogger logger)
         {
             return new LogEventBuilder(logger, LogLevel.Error);
         }
@@ -114,7 +114,7 @@ namespace NLog
         /// </summary>
         /// <param name="logger">The logger to write the log event to.</param>
         /// <returns><see cref="LogEventBuilder"/> for chaining calls.</returns>
-        public static LogEventBuilder ForFatalEvent([NotNull] this ILogger logger)
+        public static LogEventBuilder ForFatalEvent(this ILogger logger)
         {
             return new LogEventBuilder(logger, LogLevel.Fatal);
         }
@@ -126,7 +126,7 @@ namespace NLog
         /// <param name="exception">The exception information of the logging event.</param>
         /// <param name="logLevel">The <see cref="LogLevel"/> for the log event. Defaults to <see cref="LogLevel.Error"/> when not specified.</param>
         /// <returns><see cref="LogEventBuilder"/> for chaining calls.</returns>
-        public static LogEventBuilder ForExceptionEvent([NotNull] this ILogger logger, Exception? exception, LogLevel? logLevel = null)
+        public static LogEventBuilder ForExceptionEvent(this ILogger logger, Exception? exception, LogLevel? logLevel = null)
         {
             return ForLogEvent(logger, logLevel ?? LogLevel.Error).Exception(exception);
         }
@@ -143,7 +143,7 @@ namespace NLog
         /// <param name="logger">A logger implementation that will handle the message.</param>
         /// <param name="value">The value to be written.</param>
         [Conditional("DEBUG")]
-        public static void ConditionalDebug<T>([NotNull] this ILogger logger, T? value)
+        public static void ConditionalDebug<T>(this ILogger logger, T? value)
         {
             logger.Debug(value);
         }
@@ -156,7 +156,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">The value to be written.</param>
         [Conditional("DEBUG")]
-        public static void ConditionalDebug<T>([NotNull] this ILogger logger, IFormatProvider? formatProvider, T? value)
+        public static void ConditionalDebug<T>(this ILogger logger, IFormatProvider? formatProvider, T? value)
         {
             logger.Debug(formatProvider, value);
         }
@@ -167,7 +167,7 @@ namespace NLog
         /// <param name="logger">A logger implementation that will handle the message.</param>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
         [Conditional("DEBUG")]
-        public static void ConditionalDebug([NotNull] this ILogger logger, LogMessageGenerator messageFunc)
+        public static void ConditionalDebug(this ILogger logger, LogMessageGenerator messageFunc)
         {
             logger.Debug(messageFunc);
         }
@@ -181,7 +181,7 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalDebug([NotNull] this ILogger logger, Exception? exception, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
+        public static void ConditionalDebug(this ILogger logger, Exception? exception, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
         {
             logger.Debug(exception, message, args);
         }
@@ -196,7 +196,7 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalDebug([NotNull] this ILogger logger, Exception? exception, IFormatProvider? formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
+        public static void ConditionalDebug(this ILogger logger, Exception? exception, IFormatProvider? formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
         {
             logger.Debug(exception, formatProvider, message, args);
         }
@@ -207,7 +207,7 @@ namespace NLog
         /// <param name="logger">A logger implementation that will handle the message.</param>
         /// <param name="message">Log message.</param>
         [Conditional("DEBUG")]
-        public static void ConditionalDebug([NotNull] this ILogger logger, [Localizable(false)] string message)
+        public static void ConditionalDebug(this ILogger logger, [Localizable(false)] string message)
         {
             logger.Debug(message);
         }
@@ -220,7 +220,7 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalDebug([NotNull] this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
+        public static void ConditionalDebug(this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
         {
             logger.Debug(message, args);
         }
@@ -234,7 +234,7 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalDebug([NotNull] this ILogger logger, IFormatProvider? formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
+        public static void ConditionalDebug(this ILogger logger, IFormatProvider? formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
         {
             logger.Debug(formatProvider, message, args);
         }
@@ -248,7 +248,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalDebug<TArgument>([NotNull] this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, TArgument? argument)
+        public static void ConditionalDebug<TArgument>(this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, TArgument? argument)
         {
             if (logger.IsDebugEnabled)
             {
@@ -267,7 +267,7 @@ namespace NLog
         /// <param name="argument2">The second argument to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalDebug<TArgument1, TArgument2>([NotNull] this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1? argument1, TArgument2? argument2)
+        public static void ConditionalDebug<TArgument1, TArgument2>(this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1? argument1, TArgument2? argument2)
         {
             if (logger.IsDebugEnabled)
             {
@@ -288,7 +288,7 @@ namespace NLog
         /// <param name="argument3">The third argument to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalDebug<TArgument1, TArgument2, TArgument3>([NotNull] this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1? argument1, TArgument2? argument2, TArgument3? argument3)
+        public static void ConditionalDebug<TArgument1, TArgument2, TArgument3>(this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1? argument1, TArgument2? argument2, TArgument3? argument3)
         {
             if (logger.IsDebugEnabled)
             {
@@ -310,7 +310,7 @@ namespace NLog
         /// <param name="logger">A logger implementation that will handle the message.</param>
         /// <param name="value">The value to be written.</param>
         [Conditional("DEBUG")]
-        public static void ConditionalTrace<T>([NotNull] this ILogger logger, T? value)
+        public static void ConditionalTrace<T>(this ILogger logger, T? value)
         {
             logger.Trace(value);
         }
@@ -323,7 +323,7 @@ namespace NLog
         /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
         /// <param name="value">The value to be written.</param>
         [Conditional("DEBUG")]
-        public static void ConditionalTrace<T>([NotNull] this ILogger logger, IFormatProvider? formatProvider, T? value)
+        public static void ConditionalTrace<T>(this ILogger logger, IFormatProvider? formatProvider, T? value)
         {
             logger.Trace(formatProvider, value);
         }
@@ -334,7 +334,7 @@ namespace NLog
         /// <param name="logger">A logger implementation that will handle the message.</param>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
         [Conditional("DEBUG")]
-        public static void ConditionalTrace([NotNull] this ILogger logger, LogMessageGenerator messageFunc)
+        public static void ConditionalTrace(this ILogger logger, LogMessageGenerator messageFunc)
         {
             logger.Trace(messageFunc);
         }
@@ -348,7 +348,7 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalTrace([NotNull] this ILogger logger, Exception? exception, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
+        public static void ConditionalTrace(this ILogger logger, Exception? exception, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
         {
             logger.Trace(exception, message, args);
         }
@@ -363,7 +363,7 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalTrace([NotNull] this ILogger logger, Exception? exception, IFormatProvider? formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
+        public static void ConditionalTrace(this ILogger logger, Exception? exception, IFormatProvider? formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
         {
             logger.Trace(exception, formatProvider, message, args);
         }
@@ -374,7 +374,7 @@ namespace NLog
         /// <param name="logger">A logger implementation that will handle the message.</param>
         /// <param name="message">Log message.</param>
         [Conditional("DEBUG")]
-        public static void ConditionalTrace([NotNull] this ILogger logger, [Localizable(false)] string message)
+        public static void ConditionalTrace(this ILogger logger, [Localizable(false)] string message)
         {
             logger.Trace(message);
         }
@@ -387,7 +387,7 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalTrace([NotNull] this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
+        public static void ConditionalTrace(this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
         {
             logger.Trace(message, args);
         }
@@ -401,7 +401,7 @@ namespace NLog
         /// <param name="args">Arguments to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalTrace([NotNull] this ILogger logger, IFormatProvider? formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
+        public static void ConditionalTrace(this ILogger logger, IFormatProvider? formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, params object?[] args)
         {
             logger.Trace(formatProvider, message, args);
         }
@@ -415,7 +415,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalTrace<TArgument>([NotNull] this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, TArgument? argument)
+        public static void ConditionalTrace<TArgument>(this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, TArgument? argument)
         {
             if (logger.IsTraceEnabled)
             {
@@ -434,7 +434,7 @@ namespace NLog
         /// <param name="argument2">The second argument to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalTrace<TArgument1, TArgument2>([NotNull] this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1? argument1, TArgument2? argument2)
+        public static void ConditionalTrace<TArgument1, TArgument2>(this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1? argument1, TArgument2? argument2)
         {
             if (logger.IsTraceEnabled)
             {
@@ -455,7 +455,7 @@ namespace NLog
         /// <param name="argument3">The third argument to format.</param>
         [Conditional("DEBUG")]
         [MessageTemplateFormatMethod("message")]
-        public static void ConditionalTrace<TArgument1, TArgument2, TArgument3>([NotNull] this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1? argument1, TArgument2? argument2, TArgument3? argument3)
+        public static void ConditionalTrace<TArgument1, TArgument2, TArgument3>(this ILogger logger, [Localizable(false)][StructuredMessageTemplate] string message, TArgument1? argument1, TArgument2? argument2, TArgument3? argument3)
         {
             if (logger.IsTraceEnabled)
             {
@@ -472,7 +472,7 @@ namespace NLog
         /// <param name="level">The log level.</param>
         /// <param name="exception">An exception to be logged.</param>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
-        public static void Log([NotNull] this ILogger logger, LogLevel level, Exception? exception, LogMessageGenerator messageFunc)
+        public static void Log(this ILogger logger, LogLevel level, Exception? exception, LogMessageGenerator messageFunc)
         {
             if (logger.IsEnabled(level))
             {
@@ -486,7 +486,7 @@ namespace NLog
         /// <param name="logger">A logger implementation that will handle the message.</param>
         /// <param name="exception">An exception to be logged.</param>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
-        public static void Trace([NotNull] this ILogger logger, Exception? exception, LogMessageGenerator messageFunc)
+        public static void Trace(this ILogger logger, Exception? exception, LogMessageGenerator messageFunc)
         {
             if (logger.IsTraceEnabled)
             {
@@ -502,7 +502,7 @@ namespace NLog
         /// <param name="logger">A logger implementation that will handle the message.</param>
         /// <param name="exception">An exception to be logged.</param>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
-        public static void Debug([NotNull] this ILogger logger, Exception? exception, LogMessageGenerator messageFunc)
+        public static void Debug(this ILogger logger, Exception? exception, LogMessageGenerator messageFunc)
         {
             if (logger.IsDebugEnabled)
             {
@@ -518,7 +518,7 @@ namespace NLog
         /// <param name="logger">A logger implementation that will handle the message.</param>
         /// <param name="exception">An exception to be logged.</param>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
-        public static void Info([NotNull] this ILogger logger, Exception? exception, LogMessageGenerator messageFunc)
+        public static void Info(this ILogger logger, Exception? exception, LogMessageGenerator messageFunc)
         {
             if (logger.IsInfoEnabled)
             {
@@ -534,7 +534,7 @@ namespace NLog
         /// <param name="logger">A logger implementation that will handle the message.</param>
         /// <param name="exception">An exception to be logged.</param>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
-        public static void Warn([NotNull] this ILogger logger, Exception? exception, LogMessageGenerator messageFunc)
+        public static void Warn(this ILogger logger, Exception? exception, LogMessageGenerator messageFunc)
         {
             if (logger.IsWarnEnabled)
             {
@@ -550,7 +550,7 @@ namespace NLog
         /// <param name="logger">A logger implementation that will handle the message.</param>
         /// <param name="exception">An exception to be logged.</param>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
-        public static void Error([NotNull] this ILogger logger, Exception? exception, LogMessageGenerator messageFunc)
+        public static void Error(this ILogger logger, Exception? exception, LogMessageGenerator messageFunc)
         {
             if (logger.IsErrorEnabled)
             {
@@ -566,7 +566,7 @@ namespace NLog
         /// <param name="logger">A logger implementation that will handle the message.</param>
         /// <param name="exception">An exception to be logged.</param>
         /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
-        public static void Fatal([NotNull] this ILogger logger, Exception? exception, LogMessageGenerator messageFunc)
+        public static void Fatal(this ILogger logger, Exception? exception, LogMessageGenerator messageFunc)
         {
             if (logger.IsFatalEnabled)
             {

--- a/src/NLog/Internal/CollectionExtensions.cs
+++ b/src/NLog/Internal/CollectionExtensions.cs
@@ -35,7 +35,6 @@ namespace NLog.Internal
 {
     using System;
     using System.Collections.Generic;
-    using JetBrains.Annotations;
 
     internal static class CollectionExtensions
     {
@@ -43,8 +42,7 @@ namespace NLog.Internal
         /// Memory optimized filtering
         /// </summary>
         /// <remarks>Passing state too avoid delegate capture and memory-allocations.</remarks>
-        [NotNull]
-        public static IList<TItem> Filter<TItem, TState>([NotNull] this IList<TItem> items, TState state, Func<TItem, TState, bool> filter)
+        public static IList<TItem> Filter<TItem, TState>(this IList<TItem> items, TState state, Func<TItem, TState, bool> filter)
         {
             var hasIgnoredLogEvents = false;
             IList<TItem>? filterLogEvents = null;

--- a/src/NLog/Internal/LogMessageTemplateFormatter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatter.cs
@@ -37,7 +37,6 @@ namespace NLog.Internal
     using System.Collections.Generic;
     using System.Globalization;
     using System.Text;
-    using JetBrains.Annotations;
     using MessageTemplates;
     using NLog.Config;
 
@@ -62,7 +61,7 @@ namespace NLog.Internal
         /// <param name="forceMessageTemplateRenderer">When true: Do not fallback to StringBuilder.Format for positional templates</param>
         /// <param name="singleTargetOnly"></param>
         /// 
-        public LogMessageTemplateFormatter([NotNull] LogFactory logFactory, bool forceMessageTemplateRenderer, bool singleTargetOnly)
+        public LogMessageTemplateFormatter(LogFactory logFactory, bool forceMessageTemplateRenderer, bool singleTargetOnly)
         {
             _logFactory = logFactory;
             _forceMessageTemplateRenderer = forceMessageTemplateRenderer;

--- a/src/NLog/Internal/ReflectionHelpers.cs
+++ b/src/NLog/Internal/ReflectionHelpers.cs
@@ -38,7 +38,6 @@ namespace NLog.Internal
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
-    using JetBrains.Annotations;
 
     /// <summary>
     /// Reflection helpers.
@@ -159,20 +158,17 @@ namespace NLog.Internal
             return valueCast;
         }
 
-        [CanBeNull]
         public static TAttr? GetFirstCustomAttribute<TAttr>(this Type type) where TAttr : Attribute
         {
             return Attribute.GetCustomAttributes(type, typeof(TAttr)).FirstOrDefault() as TAttr;
         }
 
-        [CanBeNull]
         public static TAttr? GetFirstCustomAttribute<TAttr>(this PropertyInfo info)
              where TAttr : Attribute
         {
             return Attribute.GetCustomAttributes(info, typeof(TAttr)).FirstOrDefault() as TAttr;
         }
 
-        [CanBeNull]
         public static TAttr? GetFirstCustomAttribute<TAttr>(this Assembly assembly)
             where TAttr : Attribute
         {

--- a/src/NLog/Internal/StringHelpers.cs
+++ b/src/NLog/Internal/StringHelpers.cs
@@ -85,7 +85,7 @@ namespace NLog.Internal
         /// Replace string with <paramref name="comparison"/>
         /// </summary>
         /// <returns>The same reference of nothing has been replaced.</returns>
-        public static string Replace([NotNull] string str, [NotNull] string oldValue, string newValue, StringComparison comparison, bool wholeWords = false)
+        public static string Replace(string str, string oldValue, string newValue, StringComparison comparison, bool wholeWords = false)
         {
             Guard.ThrowIfNull(str);
 

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -39,7 +39,6 @@ namespace NLog.Layouts
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Text;
-    using JetBrains.Annotations;
     using NLog.Common;
     using NLog.Config;
     using NLog.Internal;
@@ -83,7 +82,6 @@ namespace NLog.Layouts
         /// <summary>
         /// Gets the logging configuration this target is part of.
         /// </summary>
-        [CanBeNull]
         protected internal LoggingConfiguration? LoggingConfiguration { get; private set; }
 
         /// <summary>

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -37,7 +37,6 @@ namespace NLog.Layouts
     using System.ComponentModel;
     using System.Globalization;
     using System.Text;
-    using JetBrains.Annotations;
     using NLog.Common;
     using NLog.Config;
     using NLog.Internal;
@@ -149,7 +148,7 @@ namespace NLog.Layouts
             return RenderTypedValue(logEvent, null, defaultValue);
         }
 
-        internal T? RenderTypedValue(LogEventInfo logEvent, [CanBeNull] StringBuilder? stringBuilder, T? defaultValue)
+        internal T? RenderTypedValue(LogEventInfo logEvent, StringBuilder? stringBuilder, T? defaultValue)
         {
             if (IsFixed)
                 return _fixedValue;
@@ -173,7 +172,7 @@ namespace NLog.Layouts
             return defaultValue;
         }
 
-        private object? RenderObjectValue(LogEventInfo logEvent, [CanBeNull] StringBuilder? stringBuilder)
+        private object? RenderObjectValue(LogEventInfo logEvent, StringBuilder? stringBuilder)
         {
             if (logEvent is null)
                 return null;
@@ -238,7 +237,7 @@ namespace NLog.Layouts
             return new Layout<T>(layoutMethod, options);
         }
 
-        private void PrecalculateInnerLayout(LogEventInfo logEvent, [CanBeNull] StringBuilder? target)
+        private void PrecalculateInnerLayout(LogEventInfo logEvent, StringBuilder? target)
         {
             if (IsFixed || (_layoutValue.ThreadAgnostic && !_layoutValue.ThreadAgnosticImmutable))
                 return;

--- a/src/NLog/Layouts/Typed/LayoutTypedExtensions.cs
+++ b/src/NLog/Layouts/Typed/LayoutTypedExtensions.cs
@@ -33,7 +33,6 @@
 
 namespace NLog
 {
-    using JetBrains.Annotations;
     using NLog.Layouts;
     using NLog.Targets;
 
@@ -51,7 +50,7 @@ namespace NLog
         /// <param name="logEvent">The logevent info.</param>
         /// <param name="defaultValue">Fallback value when no value available</param>
         /// <returns>Result value when available, else fallback to defaultValue</returns>
-        public static T? RenderValue<T>([CanBeNull] this Layout<T>? layout, LogEventInfo logEvent, T? defaultValue = default(T))
+        public static T? RenderValue<T>(this Layout<T>? layout, LogEventInfo logEvent, T? defaultValue = default(T))
         {
             return layout is null ? defaultValue : layout.RenderTypedValue(logEvent, defaultValue);
         }

--- a/src/NLog/LogEventBuilder.cs
+++ b/src/NLog/LogEventBuilder.cs
@@ -53,7 +53,7 @@ namespace NLog
         /// Initializes a new instance of the <see cref="LogEventBuilder"/> class.
         /// </summary>
         /// <param name="logger">The <see cref="NLog.Logger"/> to send the log event.</param>
-        public LogEventBuilder([NotNull] ILogger logger)
+        public LogEventBuilder(ILogger logger)
         {
             _logger = Guard.ThrowIfNull(logger);
             _logEvent = new LogEventInfo() { LoggerName = _logger.Name };
@@ -64,7 +64,7 @@ namespace NLog
         /// </summary>
         /// <param name="logger">The <see cref="NLog.Logger"/> to send the log event.</param>
         /// <param name="logLevel">The log level. LogEvent is only created when <see cref="LogLevel"/> is enabled for <paramref name="logger"/></param>
-        public LogEventBuilder([NotNull] ILogger logger, [NotNull] LogLevel logLevel)
+        public LogEventBuilder(ILogger logger, LogLevel logLevel)
         {
             _logger = Guard.ThrowIfNull(logger);
 
@@ -83,13 +83,11 @@ namespace NLog
         /// <summary>
         /// The logger to write the log event to
         /// </summary>
-        [NotNull]
         public ILogger Logger => _logger;
 
         /// <summary>
         /// Logging event that will be written
         /// </summary>
-        [CanBeNull]
         public LogEventInfo? LogEvent => _logEvent is null ? null : ResolveLogEvent(_logEvent);
 
         /// <summary>
@@ -97,7 +95,7 @@ namespace NLog
         /// </summary>
         /// <param name="propertyName">The name of the context property.</param>
         /// <param name="propertyValue">The value of the context property.</param>
-        public LogEventBuilder Property<T>([NotNull] string propertyName, T? propertyValue)
+        public LogEventBuilder Property<T>(string propertyName, T? propertyValue)
         {
             Guard.ThrowIfNull(propertyName);
 
@@ -112,7 +110,7 @@ namespace NLog
         /// Sets multiple per-event context properties on the logging event.
         /// </summary>
         /// <param name="properties">The properties to set.</param>
-        public LogEventBuilder Properties([NotNull] IEnumerable<KeyValuePair<string, object?>> properties)
+        public LogEventBuilder Properties(IEnumerable<KeyValuePair<string, object?>> properties)
         {
             Guard.ThrowIfNull(properties);
 

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -212,9 +212,8 @@ namespace NLog
         /// </summary>
         public LogLevel Level { get; set; }
 
-        [CanBeNull] internal CallSiteInformation? CallSiteInformation { get; private set; }
+        internal CallSiteInformation? CallSiteInformation { get; private set; }
 
-        [NotNull]
         internal CallSiteInformation GetCallSiteInformationInternal() { return CallSiteInformation ?? (CallSiteInformation = new CallSiteInformation()); }
 
         /// <summary>
@@ -709,7 +708,7 @@ namespace NLog
             return true;
         }
 
-        internal void SetMessageFormatter([NotNull] LogMessageFormatter messageFormatter, [CanBeNull] LogMessageFormatter? singleTargetMessageFormatter)
+        internal void SetMessageFormatter(LogMessageFormatter messageFormatter, LogMessageFormatter? singleTargetMessageFormatter)
         {
             bool hasCustomMessageFormatter = _messageFormatter != null;
             if (!hasCustomMessageFormatter)

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -219,6 +219,7 @@ namespace NLog
         /// <remarks>
         /// Setter will re-configure all <see cref="Logger"/>-objects, so no need to also call <see cref="ReconfigExistingLoggers()" />
         /// </remarks>
+        [CanBeNull]
         public LoggingConfiguration? Configuration
         {
             get
@@ -339,7 +340,6 @@ namespace NLog
         /// <value>
         /// Specific culture info or null to use <see cref="CultureInfo.CurrentCulture"/>
         /// </value>
-        [CanBeNull]
         public CultureInfo? DefaultCultureInfo
         {
             get => _config is null ? _defaultCultureInfo : _config.DefaultCultureInfo;

--- a/src/NLog/LogManager.cs
+++ b/src/NLog/LogManager.cs
@@ -38,6 +38,7 @@ namespace NLog
     using System.Diagnostics.CodeAnalysis;
     using System.Reflection;
     using System.Runtime.CompilerServices;
+    using JetBrains.Annotations;
     using NLog.Common;
     using NLog.Config;
     using NLog.Internal;
@@ -126,6 +127,7 @@ namespace NLog
         /// <remarks>
         /// Setter will re-configure all <see cref="Logger"/>-objects, so no need to also call <see cref="ReconfigExistingLoggers()" />
         /// </remarks>
+        [CanBeNull]
         public static LoggingConfiguration? Configuration
         {
             get => LogFactory.Configuration;

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -852,7 +852,7 @@ namespace NLog
             }
         }
 
-        private void WriteLogEventToTargets([NotNull] LogEventInfo logEvent, [NotNull] ITargetWithFilterChain targetsForLevel)
+        private void WriteLogEventToTargets(LogEventInfo logEvent, ITargetWithFilterChain targetsForLevel)
         {
             try
             {
@@ -872,7 +872,7 @@ namespace NLog
             }
         }
 
-        private void WriteLogEventToTargets(Type wrapperType, [NotNull] LogEventInfo logEvent, [NotNull] ITargetWithFilterChain targetsForLevel)
+        private void WriteLogEventToTargets(Type wrapperType, LogEventInfo logEvent, ITargetWithFilterChain targetsForLevel)
         {
             try
             {

--- a/src/NLog/LoggerImpl.cs
+++ b/src/NLog/LoggerImpl.cs
@@ -36,7 +36,6 @@ namespace NLog
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using JetBrains.Annotations;
     using NLog.Common;
     using NLog.Config;
     using NLog.Filters;
@@ -49,7 +48,7 @@ namespace NLog
     {
         private const int StackTraceSkipMethods = 0;
 
-        internal static void Write([NotNull] Type loggerType, [NotNull] TargetWithFilterChain targetsForLevel, LogEventInfo logEvent, LogFactory logFactory)
+        internal static void Write(Type loggerType, TargetWithFilterChain targetsForLevel, LogEventInfo logEvent, LogFactory logFactory)
         {
             logEvent.SetMessageFormatter(logFactory.ActiveMessageFormatter, targetsForLevel.NextInChain is null ? logFactory.SingleTargetMessageFormatter : null);
 

--- a/src/NLog/MessageTemplates/MessageTemplateParameter.cs
+++ b/src/NLog/MessageTemplates/MessageTemplateParameter.cs
@@ -33,7 +33,6 @@
 
 namespace NLog.MessageTemplates
 {
-    using JetBrains.Annotations;
     using NLog.Internal;
 
     /// <summary>
@@ -45,20 +44,17 @@ namespace NLog.MessageTemplates
         /// Parameter Name extracted from <see cref="LogEventInfo.Message"/>
         /// This is everything between "{" and the first of ",:}".
         /// </summary>
-        [NotNull]
         public string Name { get; }
 
         /// <summary>
         /// Parameter Value extracted from the <see cref="LogEventInfo.Parameters"/>-array
         /// </summary>
-        [CanBeNull]
         public object? Value { get; }
 
         /// <summary>
         /// Format to render the parameter.
         /// This is everything between ":" and the first unescaped "}"
         /// </summary>
-        [CanBeNull]
         public string? Format { get; }
 
         /// <summary>
@@ -102,7 +98,7 @@ namespace NLog.MessageTemplates
         /// <param name="name">Parameter Name</param>
         /// <param name="value">Parameter Value</param>
         /// <param name="format">Parameter Format</param>
-        internal MessageTemplateParameter([NotNull] string name, object? value, string? format)
+        internal MessageTemplateParameter(string name, object? value, string? format)
         {
             Name = Guard.ThrowIfNull(name);
             Value = value;
@@ -117,7 +113,7 @@ namespace NLog.MessageTemplates
         /// <param name="value">Parameter Value</param>
         /// <param name="format">Parameter Format</param>
         /// <param name="captureType">Parameter CaptureType</param>
-        public MessageTemplateParameter([NotNull] string name, object? value, string? format, CaptureType captureType)
+        public MessageTemplateParameter(string name, object? value, string? format, CaptureType captureType)
         {
             Name = Guard.ThrowIfNull(name);
             Value = value;

--- a/src/NLog/MessageTemplates/ValueFormatter.cs
+++ b/src/NLog/MessageTemplates/ValueFormatter.cs
@@ -38,7 +38,6 @@ namespace NLog.MessageTemplates
     using System.Collections.Generic;
     using System.Globalization;
     using System.Text;
-    using JetBrains.Annotations;
     using NLog.Config;
     using NLog.Internal;
 
@@ -88,7 +87,7 @@ namespace NLog.MessageTemplates
             }
         }
 
-        public ValueFormatter([NotNull] IServiceProvider serviceProvider, bool legacyStringQuotes)
+        public ValueFormatter(IServiceProvider serviceProvider, bool legacyStringQuotes)
         {
             _serviceProvider = serviceProvider;
             _legacyStringQuotes = legacyStringQuotes;

--- a/src/NLog/Targets/LineEndingMode.cs
+++ b/src/NLog/Targets/LineEndingMode.cs
@@ -34,7 +34,6 @@
 using System;
 using System.ComponentModel;
 using System.Globalization;
-using JetBrains.Annotations;
 using NLog.Internal;
 
 namespace NLog.Targets
@@ -115,7 +114,7 @@ namespace NLog.Targets
         /// </param>
         /// <returns>The <see cref="LineEndingMode"/> value, that corresponds to the <paramref name="name"/>.</returns>
         /// <exception cref="ArgumentOutOfRangeException">There is no line ending mode with the specified name.</exception>
-        public static LineEndingMode FromString([NotNull] string name)
+        public static LineEndingMode FromString(string name)
         {
             Guard.ThrowIfNull(name);
 

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -38,7 +38,6 @@ namespace NLog.Targets
     using System.ComponentModel;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
-    using JetBrains.Annotations;
     using NLog.Common;
     using NLog.Config;
     using NLog.Internal;
@@ -698,7 +697,7 @@ namespace NLog.Targets
         /// <param name="layout">The layout.</param>
         /// <param name="logEvent">The logevent info.</param>
         /// <returns>String representing log event.</returns>
-        protected string RenderLogEvent([CanBeNull] Layout? layout, LogEventInfo logEvent)
+        protected string RenderLogEvent(Layout? layout, LogEventInfo logEvent)
         {
             if (layout is null || logEvent is null)
                 return string.Empty;    // Signal that input was wrong
@@ -729,7 +728,7 @@ namespace NLog.Targets
         /// <param name="logEvent">The logevent info.</param>
         /// <param name="defaultValue">Fallback value when no value available</param>
         /// <returns>Result value when available, else fallback to defaultValue</returns>
-        protected T? RenderLogEvent<T>([CanBeNull] Layout<T>? layout, LogEventInfo logEvent, T? defaultValue = default(T))
+        protected T? RenderLogEvent<T>(Layout<T>? layout, LogEventInfo logEvent, T? defaultValue = default(T))
         {
             if (layout is null)
                 return defaultValue;

--- a/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
+++ b/tests/NLog.UnitTests/Config/ServiceRepositoryTests.cs
@@ -36,9 +36,7 @@ namespace NLog.UnitTests.Config
 {
     using System;
     using System.Text;
-    using JetBrains.Annotations;
     using NLog.Config;
-    using NLog.Internal;
     using NLog.Targets;
     using Xunit;
 

--- a/tests/NLog.UnitTests/LogManagerTests.cs
+++ b/tests/NLog.UnitTests/LogManagerTests.cs
@@ -31,15 +31,11 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-using JetBrains.Annotations;
-
 namespace NLog.UnitTests
 {
     using System;
-    using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
-    using NLog.Common;
     using NLog.Config;
     using NLog.Targets;
     using Xunit;
@@ -242,13 +238,11 @@ namespace NLog.UnitTests
 
         private static class ImAStaticClass
         {
-            [UsedImplicitly]
             public static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
             static ImAStaticClass() { }
 
             public static void DummyToInvokeInitializers() { }
-
         }
 
         [Fact]


### PR DESCRIPTION
But introduced `[CanBeNull]` for `LogManager.Configuration` to help people on NET Framework that uses JetBrains Resharper.