### PR TITLE
Version 6.0 RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Date format: (year/month/day)
 
 ## Change Log
 
+### Version 6.0 RC1 (2025/04/25)
+
+**Major changes**
+- Updated NLog API with `<Nullable>enable</Nullable>` and introduced `Layout.Empty`
+- Marked `[RequiredParameter]` as obsolete, and replaced with explicit option validation during initialization.
+- Marked `LogEventInfo.SequenceID` and `${sequenceid}` as obsolete, and instead use `${counter:sequence=global}`.
+- Added support for params ReadOnlySpan when using C# 13
+- Prioritize generic Logger-methods by marking legacy methods with `[OverloadResolutionPriority(-1)]` when using C# 13
+- Skip LogEventInfo.Parameters-array-allocation when unable to defer message-template formatting.
+- Renamed ChainsawTarget to Log4JXmlTarget to match Log4JXmlEventLayout
+- Updated NLog.Schema to include intellisense for multiple NLog-assemblies.
+
 ### Version 6.0 Preview 1 (2025/04/27)
 
 **Major Changes**

--- a/build.ps1
+++ b/build.ps1
@@ -3,7 +3,7 @@
 dotnet --version
 
 $versionPrefix = "6.0.0"
-$versionSuffix = "preview1"
+$versionSuffix = "rc1"
 $versionFile = $versionPrefix + "." + ${env:APPVEYOR_BUILD_NUMBER}
 $versionProduct = $versionPrefix;
 if (-Not $versionSuffix.Equals(""))

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -28,7 +28,7 @@ For ASP.NET Core, check: https://www.nuget.org/packages/NLog.Web.AspNetCore
     <Copyright>Copyright (c) 2004-$(CurrentYear) NLog Project - https://nlog-project.org/ </Copyright>
 
     <PackageReleaseNotes>
-NLog v6.0 Preview1 with the following major changes:
+NLog v6.0 RC1 with the following major changes:
 
 - Support AOT builds without build warnings.
 - New FileTarget without ConcurrentWrites support, but still support KeepFileOpen true / false.
@@ -43,6 +43,14 @@ NLog v6.0 Preview1 with the following major changes:
 - Moved WebServiceTarget into the new nuget-package NLog.Targets.WebService
 - Removed dependency on System.Text.RegularExpressions and introduced new nuget-package NLog.RegEx.
 - Removed dependency on System.Xml.XmlReader by implementing own internal basic XML-Parser.
+- Updated NLog API with Nullable-support and introduced Layout.Empty
+- Marked [RequiredParameter] as obsolete, and replaced with explicit option validation during initialization.
+- Marked LogEventInfo.SequenceID and ${sequenceid} as obsolete, and instead use ${counter:sequence=global}.
+- Added support for params ReadOnlySpan when using C# 13
+- Prioritize generic Logger-methods by marking legacy methods with [OverloadResolutionPriority(-1)] when using C# 13
+- Skip LogEventInfo.Parameters-array-allocation when unable to defer message-template formatting.
+- Renamed ChainsawTarget to Log4JXmlTarget to match Log4JXmlEventLayout
+- Updated NLog.Schema to include intellisense for multiple NLog-assemblies.
 
 NLog v6.0 release notes: https://nlog-project.org/2025/04/29/nlog-6-0-major-changes.html
 


### PR DESCRIPTION
Not planning to bring more breaking changes into the NLog v6 milestone.

Unless something bad is discovered, then this will be the last preview-release, before the official release.