### PR TITLE
ILoggingConfigurationElement - Values with nullable reference

### DIFF
--- a/src/NLog/Config/ILoggingConfigurationElement.cs
+++ b/src/NLog/Config/ILoggingConfigurationElement.cs
@@ -47,7 +47,7 @@ namespace NLog.Config
         /// <summary>
         /// Configuration Key/Value Pairs
         /// </summary>
-        IEnumerable<KeyValuePair<string, string>> Values { get; }
+        IEnumerable<KeyValuePair<string, string?>> Values { get; }
         /// <summary>
         /// Child configuration elements
         /// </summary>

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -209,14 +209,14 @@ namespace NLog.Config
         /// </summary>
         /// <param name="nlogConfig"></param>
         /// <returns></returns>
-        private ICollection<KeyValuePair<string, string>> CreateUniqueSortedListFromConfig(ILoggingConfigurationElement nlogConfig)
+        private ICollection<KeyValuePair<string, string?>> CreateUniqueSortedListFromConfig(ILoggingConfigurationElement nlogConfig)
         {
             var configurationElement = ValidatedConfigurationElement.Create(nlogConfig, LogFactory);
             var dict = configurationElement.Values;
             if (dict.Count <= 1)
                 return dict;
 
-            var sortedList = new List<KeyValuePair<string, string>>(dict.Count);
+            var sortedList = new List<KeyValuePair<string, string?>>(dict.Count);
             var highPriorityList = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "ThrowExceptions",
@@ -230,7 +230,7 @@ namespace NLog.Config
                 var settingValue = configurationElement.GetOptionalValue(highPrioritySetting, null);
                 if (settingValue != null)
                 {
-                    sortedList.Add(new KeyValuePair<string, string>(highPrioritySetting, settingValue));
+                    sortedList.Add(new KeyValuePair<string, string?>(highPrioritySetting, settingValue));
                 }
             }
             foreach (var configItem in configurationElement.Values)
@@ -582,7 +582,7 @@ namespace NLog.Config
                         namePattern = childProperty.Value;
                         break;
                     case "ENABLED":
-                        enabled = ParseBooleanValue(childProperty.Key, childProperty.Value, true);
+                        enabled = ParseBooleanValue(childProperty.Key, childProperty.Value ?? string.Empty, true);
                         break;
                     case "APPENDTO":
                         writeTargets = childProperty.Value;
@@ -591,7 +591,7 @@ namespace NLog.Config
                         writeTargets = childProperty.Value;
                         break;
                     case "FINAL":
-                        final = ParseBooleanValue(childProperty.Key, childProperty.Value, false);
+                        final = ParseBooleanValue(childProperty.Key, childProperty.Value ?? string.Empty, false);
                         break;
                     case "LEVEL":
                     case "LEVELS":
@@ -1078,8 +1078,8 @@ namespace NLog.Config
         {
             foreach (var kvp in element.Values)
             {
-                string childName = kvp.Key;
-                string childValue = kvp.Value;
+                var childName = kvp.Key;
+                var childValue = kvp.Value;
 
                 if (ignoreType && MatchesName(childName, "type"))
                 {
@@ -1090,7 +1090,7 @@ namespace NLog.Config
             }
         }
 
-        private void SetPropertyValueFromString<T>(T targetObject, string propertyName, string propertyValue, ValidatedConfigurationElement element) where T : class
+        private void SetPropertyValueFromString<T>(T targetObject, string propertyName, string? propertyValue, ValidatedConfigurationElement element) where T : class
         {
             try
             {
@@ -1568,8 +1568,8 @@ namespace NLog.Config
 
             public string Name { get; }
 
-            public ICollection<KeyValuePair<string, string>> Values => _valueLookup ?? (ICollection<KeyValuePair<string, string>>)ArrayHelper.Empty<KeyValuePair<string, string>>();
-            private readonly IDictionary<string, string>? _valueLookup;
+            public ICollection<KeyValuePair<string, string?>> Values => _valueLookup ?? (ICollection<KeyValuePair<string, string?>>)ArrayHelper.Empty<KeyValuePair<string, string?>>();
+            private readonly IDictionary<string, string?>? _valueLookup;
 
             public IEnumerable<ValidatedConfigurationElement> ValidChildren
             {
@@ -1600,7 +1600,7 @@ namespace NLog.Config
             /// </remarks>
             IEnumerable<ILoggingConfigurationElement> ILoggingConfigurationElement.Children => ValidChildren.Cast<ILoggingConfigurationElement>();
 
-            IEnumerable<KeyValuePair<string, string>> ILoggingConfigurationElement.Values => Values;
+            IEnumerable<KeyValuePair<string, string?>> ILoggingConfigurationElement.Values => Values;
 
             public string GetRequiredValue(string attributeName, string section)
             {
@@ -1624,18 +1624,18 @@ namespace NLog.Config
                 if (_valueLookup is null)
                     return defaultValue;
 
-                _valueLookup.TryGetValue(attributeName, out string value);
+                _valueLookup.TryGetValue(attributeName, out var value);
                 return value ?? defaultValue;
             }
 
-            private static IDictionary<string, string>? CreateValueLookup(ILoggingConfigurationElement element, bool throwConfigExceptions)
+            private static IDictionary<string, string?>? CreateValueLookup(ILoggingConfigurationElement element, bool throwConfigExceptions)
             {
-                IDictionary<string, string>? valueLookup = null;
+                IDictionary<string, string?>? valueLookup = null;
                 List<string>? warnings = null;
                 foreach (var attribute in element.Values)
                 {
                     var attributeKey = attribute.Key?.Trim() ?? string.Empty;
-                    valueLookup = valueLookup ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    valueLookup = valueLookup ?? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
                     if (!string.IsNullOrEmpty(attributeKey) && !valueLookup.ContainsKey(attributeKey))
                     {
                         valueLookup[attributeKey] = attribute.Value;

--- a/src/NLog/Config/XmlLoggingConfigurationElement.cs
+++ b/src/NLog/Config/XmlLoggingConfigurationElement.cs
@@ -72,7 +72,7 @@ namespace NLog.Config
         /// <summary>
         /// Gets the dictionary of attribute values.
         /// </summary>
-        public IList<KeyValuePair<string, string>> AttributeValues { get; }
+        public IList<KeyValuePair<string, string?>> AttributeValues { get; }
 
         /// <summary>
         /// Gets the collection of child elements.
@@ -86,7 +86,7 @@ namespace NLog.Config
 
         public string Name => LocalName;
 
-        public IEnumerable<KeyValuePair<string, string>> Values
+        public IEnumerable<KeyValuePair<string, string?>> Values
         {
             get
             {
@@ -96,7 +96,7 @@ namespace NLog.Config
                     if (SingleValueElement(child))
                     {
                         // Values assigned using nested node-elements. Maybe in combination with attributes
-                        return AttributeValues.Concat(Children.Where(item => SingleValueElement(item)).Select(item => new KeyValuePair<string, string>(item.Name, item.Value ?? string.Empty)));
+                        return AttributeValues.Concat(Children.Where(item => SingleValueElement(item)).Select(item => new KeyValuePair<string, string?>(item.Name, item.Value ?? string.Empty)));
                     }
                 }
                 return AttributeValues;
@@ -174,9 +174,9 @@ namespace NLog.Config
             return children ?? ArrayHelper.Empty<XmlLoggingConfigurationElement>();
         }
 
-        private static IList<KeyValuePair<string, string>> ParseAttributes(XmlReader reader, bool nestedElement)
+        private static IList<KeyValuePair<string, string?>> ParseAttributes(XmlReader reader, bool nestedElement)
         {
-            IList<KeyValuePair<string, string>>? attributes = null;
+            IList<KeyValuePair<string, string?>>? attributes = null;
             if (reader.MoveToFirstAttribute())
             {
                 do
@@ -186,14 +186,14 @@ namespace NLog.Config
                         continue;
                     }
 
-                    attributes = attributes ?? new List<KeyValuePair<string, string>>();
-                    attributes.Add(new KeyValuePair<string, string>(reader.LocalName, reader.Value));
+                    attributes = attributes ?? new List<KeyValuePair<string, string?>>();
+                    attributes.Add(new KeyValuePair<string, string?>(reader.LocalName, reader.Value));
                 }
                 while (reader.MoveToNextAttribute());
                 reader.MoveToElement();
             }
 
-            return attributes ?? ArrayHelper.Empty<KeyValuePair<string, string>>();
+            return attributes ?? ArrayHelper.Empty<KeyValuePair<string, string?>>();
         }
 
         /// <summary>

--- a/src/NLog/Config/XmlParserConfigurationElement.cs
+++ b/src/NLog/Config/XmlParserConfigurationElement.cs
@@ -53,14 +53,14 @@ namespace NLog.Config
         /// <summary>
         /// Gets the dictionary of attribute values.
         /// </summary>
-        public IList<KeyValuePair<string, string>> AttributeValues { get; }
+        public IList<KeyValuePair<string, string?>> AttributeValues { get; }
 
         /// <summary>
         /// Gets the collection of child elements.
         /// </summary>
         public IList<XmlParserConfigurationElement> Children { get; }
 
-        public IEnumerable<KeyValuePair<string, string>> Values
+        public IEnumerable<KeyValuePair<string, string?>> Values
         {
             get
             {
@@ -70,7 +70,7 @@ namespace NLog.Config
                     if (SingleValueElement(child))
                     {
                         // Values assigned using nested node-elements. Maybe in combination with attributes
-                        return AttributeValues.Concat(Children.Where(item => SingleValueElement(item)).Select(item => new KeyValuePair<string, string>(item.Name, item.Value ?? string.Empty)));
+                        return AttributeValues.Concat(Children.Where(item => SingleValueElement(item)).Select(item => new KeyValuePair<string, string?>(item.Name, item.Value ?? string.Empty)));
                     }
                 }
                 return AttributeValues;
@@ -102,7 +102,9 @@ namespace NLog.Config
             var namePrefixIndex = xmlElement.Name.IndexOf(':');
             Name = namePrefixIndex >= 0 ? xmlElement.Name.Substring(namePrefixIndex + 1) : xmlElement.Name;
             Value = xmlElement.InnerText;
+#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
             AttributeValues = ParseAttributes(xmlElement, nestedElement);
+#pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
             Children = ParseChildren(xmlElement, nestedElement);
         }
 


### PR DESCRIPTION
Discovered NLog.Extensions.Logging has the ability to assign null-value when loading from JSON-config-file.