### PR TITLE
ConsoleTarget - EnableBatchWrite = true by default

### DIFF
--- a/src/NLog/SetupLoadConfigurationExtensions.cs
+++ b/src/NLog/SetupLoadConfigurationExtensions.cs
@@ -446,17 +446,18 @@ namespace NLog
         /// <param name="encoding">Override the default Encoding for output (Ex. UTF8)</param>
         /// <param name="stderr">Write to stderr instead of standard output (stdout)</param>
         /// <param name="detectConsoleAvailable">Skip overhead from writing to console, when not available (Ex. running as Windows Service)</param>
-        /// <param name="writeBuffered">Enable batch writing of logevents, instead of Console.WriteLine for each logevent (Requires <see cref="WithAsync"/>)</param>
-        public static ISetupConfigurationTargetBuilder WriteToConsole(this ISetupConfigurationTargetBuilder configBuilder, Layout? layout = null, System.Text.Encoding? encoding = null, bool stderr = false, bool detectConsoleAvailable = false, bool writeBuffered = false)
+        /// <param name="enableBatchWrite">Enable batch writing of logevents, instead of Console.WriteLine for each logevent (For optimal performance use <see cref="WithAsync"/>)</param>
+        public static ISetupConfigurationTargetBuilder WriteToConsole(this ISetupConfigurationTargetBuilder configBuilder, Layout? layout = null, System.Text.Encoding? encoding = null, bool stderr = false, bool detectConsoleAvailable = false, bool enableBatchWrite = true)
         {
             var consoleTarget = new ConsoleTarget();
             if (layout != null)
                 consoleTarget.Layout = layout;
             if (encoding != null)
                 consoleTarget.Encoding = encoding;
-            consoleTarget.StdErr = stderr;
+            if (stderr)
+                consoleTarget.StdErr = stderr;
             consoleTarget.DetectConsoleAvailable = detectConsoleAvailable;
-            consoleTarget.WriteBuffer = writeBuffered;
+            consoleTarget.EnableBatchWrite = enableBatchWrite;
             return configBuilder.WriteTo(consoleTarget);
         }
 

--- a/src/NLog/Targets/ConsoleTarget.cs
+++ b/src/NLog/Targets/ConsoleTarget.cs
@@ -131,10 +131,17 @@ namespace NLog.Targets
         public bool AutoFlush { get; set; }
 
         /// <summary>
-        /// Gets or sets whether to activate internal buffering to allow batch writing, instead of using <see cref="Console.WriteLine()"/>
+        /// Gets or sets whether to activate internal buffering to support batch writing, instead of using <see cref="Console.WriteLine()"/>
         /// </summary>
         /// <docgen category='Console Options' order='10' />
-        public bool WriteBuffer { get; set; }
+        public bool EnableBatchWrite { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether to activate internal buffering to allow batch writing, instead of using <see cref="Console.WriteLine()"/>
+        /// </summary>
+        /// <docgen category='Console Options' order='50' />
+        [Obsolete("Replaced by EnableBatchWrite. Marked obsolete with NLog v6.0")]
+        public bool WriteBuffer { get => EnableBatchWrite; set => EnableBatchWrite = value; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConsoleTarget" /> class.
@@ -248,7 +255,7 @@ namespace NLog.Targets
                 return;
             }
 
-            if (WriteBuffer)
+            if (EnableBatchWrite)
             {
                 WriteBufferToOutput(logEvents);
             }
@@ -267,7 +274,7 @@ namespace NLog.Targets
 
             var stdErr = RenderLogEvent(StdErr, logEvent);
             var output = GetOutput(stdErr);
-            if (WriteBuffer)
+            if (EnableBatchWrite)
             {
                 WriteBufferToOutput(output, layout, logEvent);
             }


### PR DESCRIPTION
Mark `WriteBuffer` as obsolete, and replaced by `EnableBatchWrite` which is enabled by default for optimal performance.