### PR TITLE
TestTrimPublish - Output process filesize

### DIFF
--- a/tests/TestTrimPublish/Program.cs
+++ b/tests/TestTrimPublish/Program.cs
@@ -39,6 +39,9 @@ var result = consoleWriter.ToString();
 
 Console.WriteLine(result);
 
+var processPath = Environment.ProcessPath ?? string.Empty;
+Console.WriteLine($"ProcessPath: '{processPath}' with FileSize: {new FileInfo(processPath).Length}");
+
 if (result == $"{Environment.CurrentManagedThreadId}|Success{System.Environment.NewLine}")
     return 0;
 else


### PR DESCRIPTION
> ProcessPath: 'C:\projects\nlog\tests\TestTrimPublish\bin\release\net8.0\win-x64\publish\TestTrimPublish.exe' with FileSize: 5414400