### PR TITLE
docs(readme): update Visual Studio version requirement to 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ See [LICENSE.txt](LICENSE.txt) for details.
 
 How to build
 ---
-Use Visual Studio 2019 and open the solution 'NLog.sln'.
+Use Visual Studio 2022 (or later) to open the solution 'NLog.sln'.
 
 For building in the cloud we use:
 - AppVeyor for Windows- and Linux-builds


### PR DESCRIPTION
Replaced outdated instruction to use Visual Studio 2019
Clarified that VS 2022 (or later) is required to open the solution
Prevents confusion and failed builds for new contributors