### PR TITLE
Improve OpenConnection when `dbConnectionFactory` is given

### DIFF
--- a/src/NLog.Database/DatabaseTarget.cs
+++ b/src/NLog.Database/DatabaseTarget.cs
@@ -343,7 +343,11 @@ namespace NLog.Targets
                 throw new NLogRuntimeException("Creation of DbConnection failed");
             }
 
-            dbConnection.ConnectionString = connectionString;
+            if (!string.IsNullOrEmpty(connectionString))
+            {
+                dbConnection.ConnectionString = connectionString;
+            }
+
             if (ConnectionProperties?.Count > 0)
             {
                 ApplyDatabaseObjectProperties(dbConnection, ConnectionProperties, logEventInfo ?? LogEventInfo.CreateNullEvent());

--- a/tests/NLog.Database.Tests/DatabaseTargetTests.cs
+++ b/tests/NLog.Database.Tests/DatabaseTargetTests.cs
@@ -2063,6 +2063,25 @@ INSERT INTO NLogSqlLiteTestAppNames(Id, Name) VALUES (1, @appName);"">
             Assert.Throws<ArgumentNullException>(() => new DatabaseParameterInfo("Test", "AOT", null));
         }
 
+        [Fact]
+        public void DbFactoryConnectionStringTest()
+        {
+            // Data
+            const string connectionString = "MyConnectionString;User Id=myUser;Password=myPassword;";
+            
+            // Clear log
+            MockDbConnection.ClearLog();
+
+            // Arrange
+            var con = new MockDbConnection(connectionString);
+            var dt = new DatabaseTarget(() => con);
+            dt.OpenConnection(string.Empty, new LogEventInfo());
+
+            // Assert
+            var log = MockDbConnection.Log;
+            Assert.Contains($"Open('{connectionString}')", log);
+        }
+
         private static void AssertLog(string expectedLog)
         {
             Assert.Equal(expectedLog.Replace("\r", ""), MockDbConnection.Log.Replace("\r", ""));


### PR DESCRIPTION
When a `dbConnectionFactory` it could be the case that this factory already contains all information to about the connection. However `DatabaseTarget` always overwrites the `ConnectionString`. In this pull request this issue is solved