### PR TITLE
DatabaseTarget - Constructor with dbConnectionFactory-delegate set empty ConnectionString

### DIFF
--- a/src/NLog.Database/DatabaseTarget.cs
+++ b/src/NLog.Database/DatabaseTarget.cs
@@ -343,7 +343,8 @@ namespace NLog.Targets
                 throw new NLogRuntimeException("Creation of DbConnection failed");
             }
 
-            if (!string.IsNullOrEmpty(connectionString))
+            // do not overwrite the connection string if it is already set
+            if (string.IsNullOrEmpty(dbConnection.ConnectionString))
             {
                 dbConnection.ConnectionString = connectionString;
             }

--- a/src/NLog.Database/DatabaseTarget.cs
+++ b/src/NLog.Database/DatabaseTarget.cs
@@ -79,7 +79,6 @@ namespace NLog.Targets
     [Target("Database")]
     public class DatabaseTarget : Target, IInstallable
     {
-        private readonly bool _dbConnectionFactoryProvided;
         private readonly Func<IDbConnection> _dbConnectionFactory;
         private readonly Func<Type?>? _resolveConnectionType;
         private IDbConnection? _activeConnection;
@@ -121,9 +120,9 @@ namespace NLog.Targets
         /// </param>
         public DatabaseTarget(Func<IDbConnection> dbConnectionFactory)
         {
-            CommandType = CommandType.Text;
             _dbConnectionFactory = dbConnectionFactory ?? throw new ArgumentNullException(nameof(dbConnectionFactory));
-            _dbConnectionFactoryProvided = true;
+            CommandType = CommandType.Text;
+            ConnectionString = new SimpleLayout("");
         }
 
         /// <summary>
@@ -165,8 +164,8 @@ namespace NLog.Targets
 #endif
 
         /// <summary>
-        /// Gets or sets the connection string. Only used when dbConnectionFactory is not provided.
-        /// When provided, it overrides the values specified in DBHost, DBUserName, DBPassword, DBDatabase.
+        /// Gets or sets the connection string. When provided, it overrides the values
+        /// specified in DBHost, DBUserName, DBPassword, DBDatabase.
         /// </summary>
         /// <docgen category='Connection Options' order='10' />
         public Layout ConnectionString { get; set; } = Layout.Empty;
@@ -199,7 +198,7 @@ namespace NLog.Targets
         public bool KeepConnection { get; set; }
 
         /// <summary>
-        /// Gets or sets the database host name. If the dbConnectionFactory and ConnectionString are not provided
+        /// Gets or sets the database host name. If the ConnectionString is not provided
         /// this value will be used to construct the "Server=" part of the
         /// connection string.
         /// </summary>
@@ -207,7 +206,7 @@ namespace NLog.Targets
         public Layout DBHost { get; set; } = ".";
 
         /// <summary>
-        /// Gets or sets the database user name. If the dbConnectionFactory and ConnectionString are not provided
+        /// Gets or sets the database user name. If the ConnectionString is not provided
         /// this value will be used to construct the "User ID=" part of the
         /// connection string.
         /// </summary>
@@ -215,7 +214,7 @@ namespace NLog.Targets
         public Layout? DBUserName { get; set; }
 
         /// <summary>
-        /// Gets or sets the database password. If the dbConnectionFactory and ConnectionString are not provided
+        /// Gets or sets the database password. If the ConnectionString is not provided
         /// this value will be used to construct the "Password=" part of the
         /// connection string.
         /// </summary>
@@ -236,7 +235,7 @@ namespace NLog.Targets
         private string? _dbPasswordFixed;
 
         /// <summary>
-        /// Gets or sets the database name. If the dbConnectionFactory and ConnectionString are not provided
+        /// Gets or sets the database name. If the ConnectionString is not provided
         /// this value will be used to construct the "Database=" part of the
         /// connection string.
         /// </summary>
@@ -914,12 +913,6 @@ namespace NLog.Targets
         /// <returns></returns>
         protected string BuildConnectionString(LogEventInfo logEvent)
         {
-            // ConnectionString is already set by the factory, so no need to build it again.
-            if (_dbConnectionFactoryProvided)
-            {
-                return string.Empty; 
-            }
-            
             if (ConnectionString != null && !ReferenceEquals(ConnectionString, Layout.Empty))
             {
                 return RenderLogEvent(ConnectionString, logEvent);

--- a/src/NLog.Database/DatabaseTarget.cs
+++ b/src/NLog.Database/DatabaseTarget.cs
@@ -345,7 +345,6 @@ namespace NLog.Targets
                 throw new NLogRuntimeException("Creation of DbConnection failed");
             }
 
-            // do not overwrite the connection string if it is already set
             if (!string.IsNullOrEmpty(connectionString))
             {
                 dbConnection.ConnectionString = connectionString;

--- a/tests/NLog.Database.Tests/DatabaseTargetTests.cs
+++ b/tests/NLog.Database.Tests/DatabaseTargetTests.cs
@@ -2082,13 +2082,14 @@ INSERT INTO NLogSqlLiteTestAppNames(Id, Name) VALUES (1, @appName);"">
         }
 
         [Theory]
-        [InlineData("A", "", "A")]
+        [InlineData("A", "", "Server=.;Trusted_Connection=SSPI;")]
+        [InlineData(null, "", "Server=.;Trusted_Connection=SSPI;")]
+        [InlineData("", "", "Server=.;Trusted_Connection=SSPI;")]
         [InlineData("A", null, "A")]
-        [InlineData("A", "B", "A")]
-        [InlineData("", "B", "")]
         [InlineData("", null, "")]
-        [InlineData(null, "B", null)]
-        [InlineData(null, "", null)]
+        [InlineData("A", "B", "B")]
+        [InlineData("", "B", "B")]
+        [InlineData(null, "B", "B")]
         public void DbFactoryConnectionStringTest2(string csInConn, string csInDbTarget, string csExpected)
         {
             // Arrange

--- a/tests/NLog.Database.Tests/DatabaseTargetTests.cs
+++ b/tests/NLog.Database.Tests/DatabaseTargetTests.cs
@@ -2073,8 +2073,8 @@ INSERT INTO NLogSqlLiteTestAppNames(Id, Name) VALUES (1, @appName);"">
 
         [Theory]
         [InlineData("A", "A")]
-        [InlineData("", "Server=.;Trusted_Connection=SSPI;")]
-        [InlineData(null, "Server=.;Trusted_Connection=SSPI;")]
+        [InlineData("", "")]
+        [InlineData(null, null)]
         public void DbFactoryConnectionStringTest1(string csInConn, string csExpected)
         {
             // Arrange
@@ -2089,8 +2089,8 @@ INSERT INTO NLogSqlLiteTestAppNames(Id, Name) VALUES (1, @appName);"">
         [InlineData("A", "", "A")]
         [InlineData("A", null, "A")]
         [InlineData("A", "B", "A")]
-        [InlineData("", "B", "B")]
-        [InlineData(null, "B", "B")]
+        [InlineData("", "B", "")]
+        [InlineData(null, "B", null)]
         public void DbFactoryConnectionStringTest2(string csInConn, string csInDbTarget, string csExpected)
         {
             // Arrange

--- a/tests/NLog.Database.Tests/DatabaseTargetTests.cs
+++ b/tests/NLog.Database.Tests/DatabaseTargetTests.cs
@@ -2071,11 +2071,13 @@ INSERT INTO NLogSqlLiteTestAppNames(Id, Name) VALUES (1, @appName);"">
         [InlineData(null, "B", "B")]
         public void DbFactoryConnectionStringTest(string csInConn, string csInDbTarget, string csExpected)
         {
-            // Arrange
+            // Create a DatabaseTarget with a mock connection
             var dt = new DatabaseTarget(() => new MockDbConnection(csInConn))
             {
                 ConnectionString = csInDbTarget
             };
+
+            // Get the connection string without setting the DBProvider
             var cs = GetConnectionString(dt, false);
 
             // Assert

--- a/tests/NLog.Database.Tests/DatabaseTargetTests.cs
+++ b/tests/NLog.Database.Tests/DatabaseTargetTests.cs
@@ -2077,7 +2077,7 @@ INSERT INTO NLogSqlLiteTestAppNames(Id, Name) VALUES (1, @appName);"">
                 ConnectionString = csInDbTarget
             };
             var cs = GetConnectionString(dt, false);
-            
+
             // Assert
             Assert.Equal(csExpected, cs);
         }

--- a/tests/NLog.Database.Tests/DatabaseTargetTests.cs
+++ b/tests/NLog.Database.Tests/DatabaseTargetTests.cs
@@ -951,8 +951,8 @@ Dispose()
             dt.DBUserName = "user1";
             dt.DBPassword = "password1";
             Assert.Equal("customConnectionString42", GetConnectionString(dt));
-            return;
             
+            // local function to create a target with the provider set
             DatabaseTarget CreateTargetWithProvider() => new DatabaseTarget { DBProvider = dbProvider };
         }
 
@@ -2111,7 +2111,6 @@ INSERT INTO NLogSqlLiteTestAppNames(Id, Name) VALUES (1, @appName);"">
         private static string GetConnectionString(DatabaseTarget dt)
         {
             MockDbConnection.ClearLog();
-            MockDbConnection.ClearLastConnectionString();
 
             dt.CommandText = "NotImportant";
             var logFactory = new LogFactory().Setup().LoadConfiguration(cfg => cfg.Configuration.AddRuleForAllLevels(dt)).LogFactory;
@@ -2191,10 +2190,6 @@ INSERT INTO NLogSqlLiteTestAppNames(Id, Name) VALUES (1, @appName);"">
             public static void ClearLog()
             {
                 Log = string.Empty;
-            }
-
-            public static void ClearLastConnectionString()
-            {
                 LastConnectionString = null;
             }
 


### PR DESCRIPTION
My wish; I want to go from this (this is working correctly with version `6.0.0-rc4`):

```c#
new DatabaseTarget(() => new NpgsqlConnection())
{
    ConnectionString = connectionString,
    CommandText = INSERT_QUERY,
    Parameters = ...
}
```

To this:

```c#
new DatabaseTarget(() => new NpgsqlConnection(connectionString))
{
    CommandText = INSERT_QUERY,
    Parameters = ...
}
```

So not specifying `ConnectionString` at all when creating the `DatabaseTarget`.

