### PR TITLE
AsyncTargetWrapper - LogEventDropped and EventQueueGrow events fixes

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
+++ b/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
@@ -93,8 +93,8 @@ namespace NLog.Targets.Wrappers
 
                         case AsyncTargetWrapperOverflowAction.Grow:
                             InternalLogger.Debug("AsyncQueue - Growing the size of queue, because queue is full");
-                            OnLogEventQueueGrows(currentCount + 1);
                             RequestLimit *= 2;
+                            OnLogEventQueueGrows(currentCount + 1);
                             break;
 
                         case AsyncTargetWrapperOverflowAction.Block:

--- a/src/NLog/Targets/Wrappers/AsyncRequestQueueBase.cs
+++ b/src/NLog/Targets/Wrappers/AsyncRequestQueueBase.cs
@@ -40,18 +40,12 @@ namespace NLog.Targets.Wrappers
 
     internal abstract class AsyncRequestQueueBase
     {
-        protected volatile int _requestLimit;
-
         public abstract bool IsEmpty { get; }
 
         /// <summary>
         /// Gets or sets the request limit.
         /// </summary>
-        public int RequestLimit
-        {
-            get => _requestLimit;
-            set => _requestLimit = value;
-        }
+        public int RequestLimit { get; set; }
 
         /// <summary>
         /// Gets or sets the action to be taken when there's no more room in

--- a/src/NLog/Targets/Wrappers/AsyncRequestQueueBase.cs
+++ b/src/NLog/Targets/Wrappers/AsyncRequestQueueBase.cs
@@ -40,12 +40,18 @@ namespace NLog.Targets.Wrappers
 
     internal abstract class AsyncRequestQueueBase
     {
+        protected volatile int _requestLimit;
+
         public abstract bool IsEmpty { get; }
 
         /// <summary>
         /// Gets or sets the request limit.
         /// </summary>
-        public int RequestLimit { get; set; }
+        public int RequestLimit
+        {
+            get => _requestLimit;
+            set => _requestLimit = value;
+        }
 
         /// <summary>
         /// Gets or sets the action to be taken when there's no more room in

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -158,7 +158,7 @@ namespace NLog.Targets.Wrappers
         {
             add
             {
-                if (_eventQueueGrowEvent == null && _requestQueue != null)
+                if (_logEventDroppedEvent  == null)
                 {
                     _requestQueue.LogEventDropped += OnRequestQueueDropItem;
                 }
@@ -169,7 +169,7 @@ namespace NLog.Targets.Wrappers
             {
                 _logEventDroppedEvent -= value;
 
-                if (_eventQueueGrowEvent == null && _requestQueue != null)
+                if (_logEventDroppedEvent == null)
                 {
                     _requestQueue.LogEventDropped -= OnRequestQueueDropItem;
                 }
@@ -183,7 +183,7 @@ namespace NLog.Targets.Wrappers
         {
             add
             {
-                if (_eventQueueGrowEvent == null && _requestQueue != null)
+                if (_eventQueueGrowEvent == null)
                 {
                     _requestQueue.LogEventQueueGrow += OnRequestQueueGrow;
                 }
@@ -194,7 +194,7 @@ namespace NLog.Targets.Wrappers
             {
                 _eventQueueGrowEvent -= value;
 
-                if (_eventQueueGrowEvent == null && _requestQueue != null)
+                if (_eventQueueGrowEvent == null)
                 {
                     _requestQueue.LogEventQueueGrow -= OnRequestQueueGrow;
                 }

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -158,7 +158,7 @@ namespace NLog.Targets.Wrappers
         {
             add
             {
-                if (_logEventDroppedEvent  == null)
+                if (_logEventDroppedEvent is null)
                 {
                     _requestQueue.LogEventDropped += OnRequestQueueDropItem;
                 }
@@ -169,7 +169,7 @@ namespace NLog.Targets.Wrappers
             {
                 _logEventDroppedEvent -= value;
 
-                if (_logEventDroppedEvent == null)
+                if (_logEventDroppedEvent is null)
                 {
                     _requestQueue.LogEventDropped -= OnRequestQueueDropItem;
                 }
@@ -183,7 +183,7 @@ namespace NLog.Targets.Wrappers
         {
             add
             {
-                if (_eventQueueGrowEvent == null)
+                if (_eventQueueGrowEvent is null)
                 {
                     _requestQueue.LogEventQueueGrow += OnRequestQueueGrow;
                 }
@@ -194,7 +194,7 @@ namespace NLog.Targets.Wrappers
             {
                 _eventQueueGrowEvent -= value;
 
-                if (_eventQueueGrowEvent == null)
+                if (_eventQueueGrowEvent is null)
                 {
                     _requestQueue.LogEventQueueGrow -= OnRequestQueueGrow;
                 }

--- a/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
+++ b/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
@@ -97,8 +97,8 @@ namespace NLog.Targets.Wrappers
                     case AsyncTargetWrapperOverflowAction.Grow:
                         {
                             InternalLogger.Debug("AsyncQueue - Growing the size of queue, because queue is full");
-                            OnLogEventQueueGrows(currentCount);
                             RequestLimit *= 2;
+                            OnLogEventQueueGrows(currentCount);
                         }
                         break;
                 }

--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncRequestQueueTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncRequestQueueTests.cs
@@ -210,43 +210,16 @@ namespace NLog.UnitTests.Targets.Wrappers
         [Fact]
         public void RaiseEventLogEventQueueGrow_OnLogItems()
         {
-            const int RequestsLimit = 2;
-            const int EventsCount = 5;
-            const int ExpectedCountOfGrovingTimes = 2;
-            const int ExpectedFinalSize = 8;
-            int grovingItemsCount = 0;
-
-            AsyncRequestQueue requestQueue = new AsyncRequestQueue(RequestsLimit, AsyncTargetWrapperOverflowAction.Grow);
-
-            requestQueue.LogEventQueueGrow += (o, e) => { grovingItemsCount++; };
-
-            for (int i = 0; i < EventsCount; i++)
-            {
-                requestQueue.Enqueue(new AsyncLogEventInfo());
-            }
-
-            Assert.Equal(ExpectedCountOfGrovingTimes, grovingItemsCount);
-            Assert.Equal(ExpectedFinalSize, requestQueue.RequestLimit);
+            CommonRequestQueueTests.RaiseEventLogEventQueueGrow_OnLogItems(GetAsyncRequestQueue);
         }
 
         [Fact]
         public void RaiseEventLogEventDropped_OnLogItems()
         {
-            const int RequestsLimit = 2;
-            const int EventsCount = 5;
-            int discardedItemsCount = 0;
-
-            int ExpectedDiscardedItemsCount = EventsCount - RequestsLimit;
-            AsyncRequestQueue requestQueue = new AsyncRequestQueue(RequestsLimit, AsyncTargetWrapperOverflowAction.Discard);
-
-            requestQueue.LogEventDropped += (o, e) => { discardedItemsCount++; };
-
-            for (int i = 0; i < EventsCount; i++)
-            {
-                requestQueue.Enqueue(new AsyncLogEventInfo());
-            }
-
-            Assert.Equal(ExpectedDiscardedItemsCount, discardedItemsCount);
+            CommonRequestQueueTests.RaiseEventLogEventDropped_OnLogItems(GetAsyncRequestQueue);
         }
+
+        private AsyncRequestQueueBase GetAsyncRequestQueue(int size, AsyncTargetWrapperOverflowAction action) =>
+            new AsyncRequestQueue(size, action);
     }
 }

--- a/tests/NLog.UnitTests/Targets/Wrappers/CommonRequestQueueTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/CommonRequestQueueTests.cs
@@ -1,0 +1,69 @@
+﻿namespace NLog.UnitTests.Targets.Wrappers
+{
+    using System;
+    using NLog.Common;
+    using NLog.Targets.Wrappers;
+    using Xunit;
+
+    internal static class CommonRequestQueueTests
+    {
+        internal static void RaiseEventLogEventQueueGrow_OnLogItems(Func<int, AsyncTargetWrapperOverflowAction, AsyncRequestQueueBase> getQueue)
+        {
+            const int InitialSize = 1;
+            const int ExpectedFinalSize = 8;
+
+            var requestQueue = getQueue(InitialSize, AsyncTargetWrapperOverflowAction.Grow);
+
+            int growingTimesCount = 0;
+            long reportedRequestsCount = 0;
+            long reportedNewQueueSize = 0;
+            requestQueue.LogEventQueueGrow += (_, e) =>
+            {
+                growingTimesCount++;
+                reportedRequestsCount = e.RequestsCount;
+                reportedNewQueueSize = e.NewQueueSize;
+            };
+
+            requestQueue.Enqueue(new AsyncLogEventInfo());
+            Assert.Equal(0, growingTimesCount);
+
+            requestQueue.Enqueue(new AsyncLogEventInfo());
+            Assert.Equal(1, growingTimesCount);
+            Assert.Equal(2, reportedRequestsCount);
+            Assert.Equal(2, reportedNewQueueSize);
+
+            requestQueue.Enqueue(new AsyncLogEventInfo());
+            Assert.Equal(2, growingTimesCount);
+            Assert.Equal(3, reportedRequestsCount);
+            Assert.Equal(4, reportedNewQueueSize);
+
+            requestQueue.Enqueue(new AsyncLogEventInfo());
+            Assert.Equal(2, growingTimesCount);
+
+            requestQueue.Enqueue(new AsyncLogEventInfo());
+            Assert.Equal(3, growingTimesCount);
+            Assert.Equal(5, reportedRequestsCount);
+            Assert.Equal(ExpectedFinalSize, reportedNewQueueSize);
+            Assert.Equal(ExpectedFinalSize, requestQueue.RequestLimit);
+        }
+
+        internal static void RaiseEventLogEventDropped_OnLogItems(Func<int, AsyncTargetWrapperOverflowAction, AsyncRequestQueueBase> getQueue)
+        {
+            const int RequestsLimit = 2;
+            const int EventsCount = 5;
+            const int ExpectedDiscardedItemsCount = EventsCount - RequestsLimit;
+
+            var requestQueue = getQueue(RequestsLimit, AsyncTargetWrapperOverflowAction.Discard);
+
+            int discardedItemsCount = 0;
+            requestQueue.LogEventDropped += (o, e) => { discardedItemsCount++; };
+
+            for (int i = 0; i < EventsCount; i++)
+            {
+                requestQueue.Enqueue(new AsyncLogEventInfo());
+            }
+
+            Assert.Equal(ExpectedDiscardedItemsCount, discardedItemsCount);
+        }
+    }
+}

--- a/tests/NLog.UnitTests/Targets/Wrappers/CommonRequestQueueTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/CommonRequestQueueTests.cs
@@ -1,4 +1,37 @@
-﻿namespace NLog.UnitTests.Targets.Wrappers
+﻿//
+// Copyright (c) 2004-2024 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of Jaroslaw Kowalski nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+namespace NLog.UnitTests.Targets.Wrappers
 {
     using System;
     using NLog.Common;

--- a/tests/NLog.UnitTests/Targets/Wrappers/ConcurrentRequestQueueTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/ConcurrentRequestQueueTests.cs
@@ -68,44 +68,17 @@ namespace NLog.UnitTests.Targets.Wrappers
         [Fact]
         public void RaiseEventLogEventQueueGrow_OnLogItems()
         {
-            const int RequestsLimit = 2;
-            const int EventsCount = 5;
-            const int ExpectedCountOfGrovingTimes = 2;
-            const int ExpectedFinalSize = 8;
-            int grovingItemsCount = 0;
-
-            ConcurrentRequestQueue requestQueue = new ConcurrentRequestQueue(RequestsLimit, AsyncTargetWrapperOverflowAction.Grow);
-
-            requestQueue.LogEventQueueGrow += (o, e) => { grovingItemsCount++; };
-
-            for (int i = 0; i < EventsCount; i++)
-            {
-                requestQueue.Enqueue(new AsyncLogEventInfo());
-            }
-
-            Assert.Equal(ExpectedCountOfGrovingTimes, grovingItemsCount);
-            Assert.Equal(ExpectedFinalSize, requestQueue.RequestLimit);
+            CommonRequestQueueTests.RaiseEventLogEventQueueGrow_OnLogItems(GetConcurrentReuestQueue);
         }
 
         [Fact]
         public void RaiseEventLogEventDropped_OnLogItems()
         {
-            const int RequestsLimit = 2;
-            const int EventsCount = 5;
-            int discardedItemsCount = 0;
-
-            int ExpectedDiscardedItemsCount = EventsCount - RequestsLimit;
-            ConcurrentRequestQueue requestQueue = new ConcurrentRequestQueue(RequestsLimit, AsyncTargetWrapperOverflowAction.Discard);
-
-            requestQueue.LogEventDropped += (o, e) => { discardedItemsCount++; };
-
-            for (int i = 0; i < EventsCount; i++)
-            {
-                requestQueue.Enqueue(new AsyncLogEventInfo());
-            }
-
-            Assert.Equal(ExpectedDiscardedItemsCount, discardedItemsCount);
+            CommonRequestQueueTests.RaiseEventLogEventDropped_OnLogItems(GetConcurrentReuestQueue);
         }
+
+        private AsyncRequestQueueBase GetConcurrentReuestQueue(int size, AsyncTargetWrapperOverflowAction action) =>
+            new ConcurrentRequestQueue(size, action);
     }
 }
 


### PR DESCRIPTION
Problems fixed:
- if one was already subscribed for `EventQueueGrow` event, subscribing for `LogEventDropped` had no effect (wrong field was being checked for null)
- `EventQueueGrow` reported old queue size despite parameter name `LogEventQueueGrowEventArgs.NewQueueSize`. Fixed that by doubling `RequestLimit` first, then invoking the event
- `ConcurrentRequestQueue` could erroneously multiply its `RequestLimit` more than once when hitting current limit under concurrent load because of a race condition

Improvements:
- unified `OnLogEventDropped` and `OnLogEventQueueGrows` unit-tests for `ConcurrentRequestQueue` and `AsyncRequestQueue` - they should behave the same
- added unit test to illustrate `RequestLimit` race in `ConcurrentRequestQueue`