### PR TITLE
AsyncTargetWrapper - LogEventDropped and EventQueueGrow events fixes

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
+++ b/src/NLog/Targets/Wrappers/AsyncRequestQueue-T.cs
@@ -93,8 +93,8 @@ namespace NLog.Targets.Wrappers
 
                         case AsyncTargetWrapperOverflowAction.Grow:
                             InternalLogger.Debug("AsyncQueue - Growing the size of queue, because queue is full");
-                            OnLogEventQueueGrows(currentCount + 1);
                             QueueLimit *= 2;
+                            OnLogEventQueueGrows(currentCount + 1);
                             break;
 
                         case AsyncTargetWrapperOverflowAction.Block:

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -161,7 +161,7 @@ namespace NLog.Targets.Wrappers
         {
             add
             {
-                if (_eventQueueGrowEvent == null && _requestQueue != null)
+                if (_logEventDroppedEvent is null)
                 {
                     _requestQueue.LogEventDropped += OnRequestQueueDropItem;
                 }
@@ -172,7 +172,7 @@ namespace NLog.Targets.Wrappers
             {
                 _logEventDroppedEvent -= value;
 
-                if (_eventQueueGrowEvent == null && _requestQueue != null)
+                if (_logEventDroppedEvent is null)
                 {
                     _requestQueue.LogEventDropped -= OnRequestQueueDropItem;
                 }
@@ -186,7 +186,7 @@ namespace NLog.Targets.Wrappers
         {
             add
             {
-                if (_eventQueueGrowEvent == null && _requestQueue != null)
+                if (_eventQueueGrowEvent is null)
                 {
                     _requestQueue.LogEventQueueGrow += OnRequestQueueGrow;
                 }
@@ -197,7 +197,7 @@ namespace NLog.Targets.Wrappers
             {
                 _eventQueueGrowEvent -= value;
 
-                if (_eventQueueGrowEvent == null && _requestQueue != null)
+                if (_eventQueueGrowEvent is null)
                 {
                     _requestQueue.LogEventQueueGrow -= OnRequestQueueGrow;
                 }

--- a/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
+++ b/src/NLog/Targets/Wrappers/ConcurrentRequestQueue.cs
@@ -97,8 +97,12 @@ namespace NLog.Targets.Wrappers
                     case AsyncTargetWrapperOverflowAction.Grow:
                         {
                             InternalLogger.Debug("AsyncQueue - Growing the size of queue, because queue is full");
+                            var currentQueueLimit = QueueLimit;
+                            if (currentCount > currentQueueLimit)
+                            {
+                                QueueLimit = currentQueueLimit * 2;
+                            }
                             OnLogEventQueueGrows(currentCount);
-                            QueueLimit *= 2;
                         }
                         break;
                 }

--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncRequestQueueTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncRequestQueueTests.cs
@@ -210,43 +210,16 @@ namespace NLog.UnitTests.Targets.Wrappers
         [Fact]
         public void RaiseEventLogEventQueueGrow_OnLogItems()
         {
-            const int RequestsLimit = 2;
-            const int EventsCount = 5;
-            const int ExpectedCountOfGrovingTimes = 2;
-            const int ExpectedFinalSize = 8;
-            int grovingItemsCount = 0;
-
-            AsyncRequestQueue requestQueue = new AsyncRequestQueue(RequestsLimit, AsyncTargetWrapperOverflowAction.Grow);
-
-            requestQueue.LogEventQueueGrow += (o, e) => { grovingItemsCount++; };
-
-            for (int i = 0; i < EventsCount; i++)
-            {
-                requestQueue.Enqueue(new AsyncLogEventInfo());
-            }
-
-            Assert.Equal(ExpectedCountOfGrovingTimes, grovingItemsCount);
-            Assert.Equal(ExpectedFinalSize, requestQueue.QueueLimit);
+            CommonRequestQueueTests.RaiseEventLogEventQueueGrow_OnLogItems(GetAsyncRequestQueue);
         }
 
         [Fact]
         public void RaiseEventLogEventDropped_OnLogItems()
         {
-            const int RequestsLimit = 2;
-            const int EventsCount = 5;
-            int discardedItemsCount = 0;
-
-            int ExpectedDiscardedItemsCount = EventsCount - RequestsLimit;
-            AsyncRequestQueue requestQueue = new AsyncRequestQueue(RequestsLimit, AsyncTargetWrapperOverflowAction.Discard);
-
-            requestQueue.LogEventDropped += (o, e) => { discardedItemsCount++; };
-
-            for (int i = 0; i < EventsCount; i++)
-            {
-                requestQueue.Enqueue(new AsyncLogEventInfo());
-            }
-
-            Assert.Equal(ExpectedDiscardedItemsCount, discardedItemsCount);
+            CommonRequestQueueTests.RaiseEventLogEventDropped_OnLogItems(GetAsyncRequestQueue);
         }
+
+        private static AsyncRequestQueueBase GetAsyncRequestQueue(int size, AsyncTargetWrapperOverflowAction action) =>
+            new AsyncRequestQueue(size, action);
     }
 }

--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
@@ -84,7 +84,7 @@ namespace NLog.UnitTests.Targets.Wrappers
         {
             RetryingIntegrationTest(3, () =>
             {
-                AsyncTargetWrapperSyncTest_WhenTimeToSleepBetweenBatchesIsEqualToZero(false);                
+                AsyncTargetWrapperSyncTest_WhenTimeToSleepBetweenBatchesIsEqualToZero(false);
             });
         }
 
@@ -516,11 +516,12 @@ namespace NLog.UnitTests.Targets.Wrappers
         }
 
         [Fact]
-        public void LogEventDropped_OnRequestqueueOverflow()
+        public void LogEventDropped_OnRequestQueueOverflow()
         {
-            int queueLimit = 2;
-            int loggedEventCount = 5;
-            int eventsCounter = 0;
+            const int queueLimit = 2;
+            const int loggedEventCount = 5;
+            const int expectedEventsDropped = loggedEventCount - queueLimit;
+            int eventsDroppedCounter = 0;
             var myTarget = new MyTarget();
 
             var targetWrapper = new AsyncTargetWrapper()
@@ -539,18 +540,38 @@ namespace NLog.UnitTests.Targets.Wrappers
 
             try
             {
-                targetWrapper.LogEventDropped += (o, e) => { eventsCounter++; };
+                // subscribe, log, assert values were reported
+                targetWrapper.LogEventDropped += OnLogEventDropped;
 
-                for (int i = 0; i < loggedEventCount; i++)
-                {
-                    logger.Info("Hello");
-                }
+                LogEvents();
 
-                Assert.Equal(loggedEventCount - queueLimit, eventsCounter);
+                Assert.Equal(expectedEventsDropped, eventsDroppedCounter);
+
+                // unsubscribe, log, assert values were not reported
+                targetWrapper.LogEventDropped -= OnLogEventDropped;
+
+                LogEvents();
+
+                Assert.Equal(expectedEventsDropped, eventsDroppedCounter);
             }
             finally
             {
                 logFactory.Configuration = null;
+            }
+
+            return;
+
+            void LogEvents()
+            {
+                for (int i = 0; i < loggedEventCount; i++)
+                {
+                    logger.Info("Hello");
+                }
+            }
+
+            void OnLogEventDropped(object _, LogEventDroppedEventArgs logEventDroppedEventArgs)
+            {
+                eventsDroppedCounter++;
             }
         }
 
@@ -633,12 +654,15 @@ namespace NLog.UnitTests.Targets.Wrappers
         [Fact]
         public void EventQueueGrow_OnQueueGrow()
         {
-            int queueLimit = 2;
-            int loggedEventCount = 10;
+            const int queueLimit = 2;
+            const int loggedEventCount = 10;
+            const int expectedGrowingNumber = 3;
+            const int expectedNewQueueSize = 16;
+            const int expectedRequestsCount = expectedNewQueueSize / 2 + 1;
 
-            int expectedGrowingNumber = 3;
-
-            int eventsCounter = 0;
+            int growEventsCounter = 0;
+            long reportedRequestsCount = 0;
+            long reportedNewQueueSize = 0;
             var myTarget = new MyTarget();
 
             var targetWrapper = new AsyncTargetWrapper()
@@ -657,18 +681,145 @@ namespace NLog.UnitTests.Targets.Wrappers
 
             try
             {
-                targetWrapper.EventQueueGrow += (o, e) => { eventsCounter++; };
+                // subscribe, log, assert values were reported
+                targetWrapper.EventQueueGrow += OnEventQueueGrow;
 
-                for (int i = 0; i < loggedEventCount; i++)
-                {
-                    logger.Info("Hello");
-                }
+                LogEvents();
 
-                Assert.Equal(expectedGrowingNumber, eventsCounter);
+                Assert.Equal(expectedGrowingNumber, growEventsCounter);
+                Assert.Equal(expectedRequestsCount, reportedRequestsCount);
+                Assert.Equal(expectedNewQueueSize, reportedNewQueueSize);
+
+                // unsubscribe, log, assert values were not reported
+                targetWrapper.EventQueueGrow -= OnEventQueueGrow;
+
+                LogEvents();
+
+                Assert.Equal(expectedGrowingNumber, growEventsCounter);
+                Assert.Equal(expectedRequestsCount, reportedRequestsCount);
+                Assert.Equal(expectedNewQueueSize, reportedNewQueueSize);
             }
             finally
             {
                 logFactory.Configuration = null;
+            }
+
+            return;
+
+            void LogEvents()
+            {
+                for (int i = 0; i < loggedEventCount; i++)
+                {
+                    logger.Info("Hello");
+                }
+            }
+
+            void OnEventQueueGrow(object _, LogEventQueueGrowEventArgs e)
+            {
+                growEventsCounter++;
+                reportedRequestsCount = e.RequestsCount;
+                reportedNewQueueSize = e.NewQueueSize;
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void EnqueueLimitReached_EventsAreCalled_SubscriptionOrderDoesntMatter(bool reverseSubscribeOrder)
+        {
+            const int queueLimit = 2;
+            const int loggedEventCount = 5;
+            const int expectedEventsDropped = loggedEventCount - queueLimit;
+            const int expectedGrowingNumber = 2;
+            const int expectedNewQueueSize = 8;
+
+            int eventsDroppedCounter = 0;
+            int growEventsCounter = 0;
+            long reportedRequestsCount = 0;
+            long reportedNewQueueSize = 0;
+            var myTarget = new MyTarget();
+
+            var targetWrapper = new AsyncTargetWrapper()
+            {
+                WrappedTarget = myTarget,
+                QueueLimit = queueLimit,
+                TimeToSleepBetweenBatches = 500,    // Make it slow
+                OverflowAction = AsyncTargetWrapperOverflowAction.Discard,
+            };
+
+            var logFactory = new LogFactory();
+            var loggingConfig = new NLog.Config.LoggingConfiguration(logFactory);
+            loggingConfig.AddRuleForAllLevels(targetWrapper);
+            logFactory.Configuration = loggingConfig;
+            var logger = logFactory.GetLogger("Test");
+
+            try
+            {
+                // subscribe, log, assert values were reported - discards at first, then grows
+                if (reverseSubscribeOrder)
+                {
+                    targetWrapper.LogEventDropped += OnLogEventDropped;
+                    targetWrapper.EventQueueGrow += OnEventQueueGrow;
+                }
+                else
+                {
+                    targetWrapper.EventQueueGrow += OnEventQueueGrow;
+                    targetWrapper.LogEventDropped += OnLogEventDropped;
+                }
+
+                LogEvents();
+
+                Assert.Equal(expectedEventsDropped, eventsDroppedCounter);
+                Assert.Equal(0, growEventsCounter);
+
+                // and now grow
+                targetWrapper.OverflowAction = AsyncTargetWrapperOverflowAction.Grow;
+
+                LogEvents();
+
+                Assert.Equal(expectedGrowingNumber, growEventsCounter);
+                Assert.Equal(loggedEventCount, reportedRequestsCount);
+                Assert.Equal(expectedNewQueueSize, reportedNewQueueSize);
+                Assert.Equal(expectedEventsDropped, eventsDroppedCounter);
+
+                // unsubscribe, log, assert values were not reported
+                targetWrapper.LogEventDropped -= OnLogEventDropped;
+                targetWrapper.EventQueueGrow -= OnEventQueueGrow;
+
+                targetWrapper.OverflowAction = AsyncTargetWrapperOverflowAction.Discard;
+                LogEvents();
+
+                targetWrapper.OverflowAction = AsyncTargetWrapperOverflowAction.Grow;
+                LogEvents();
+
+                Assert.Equal(expectedGrowingNumber, growEventsCounter);
+                Assert.Equal(expectedEventsDropped, eventsDroppedCounter);
+            }
+            finally
+            {
+                logFactory.Configuration = null;
+            }
+
+            return;
+
+            void LogEvents()
+            {
+                for (int i = 0; i < loggedEventCount; i++)
+                {
+                    logger.Info("Hello");
+                }
+            }
+
+            void OnLogEventDropped(object _, LogEventDroppedEventArgs logEventDroppedEventArgs)
+            {
+                eventsDroppedCounter++;
+            }
+
+            void OnEventQueueGrow(object _, LogEventQueueGrowEventArgs e)
+            {
+                growEventsCounter++;
+                reportedRequestsCount = e.RequestsCount;
+                reportedNewQueueSize = e.NewQueueSize;
             }
         }
 

--- a/tests/NLog.UnitTests/Targets/Wrappers/CommonRequestQueueTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/CommonRequestQueueTests.cs
@@ -1,0 +1,128 @@
+﻿//
+// Copyright (c) 2004-2024 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of Jaroslaw Kowalski nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+namespace NLog.UnitTests.Targets.Wrappers
+{
+    using System;
+    using NLog.Common;
+    using NLog.Targets.Wrappers;
+    using Xunit;
+
+    internal static class CommonRequestQueueTests
+    {
+        internal static void RaiseEventLogEventQueueGrow_OnLogItems(Func<int, AsyncTargetWrapperOverflowAction, AsyncRequestQueueBase> getQueue)
+        {
+            const int InitialSize = 1;
+            const int ExpectedFinalGrowingTimes = 3;
+            const int ExpectedFinalSize = 8;
+
+            var requestQueue = getQueue(InitialSize, AsyncTargetWrapperOverflowAction.Grow);
+
+            int growingTimesCount = 0;
+            long reportedRequestsCount = 0;
+            long reportedNewQueueSize = 0;
+
+            requestQueue.LogEventQueueGrow += OnLogEventQueueGrow;
+
+            requestQueue.Enqueue(new AsyncLogEventInfo());
+            Assert.Equal(0, growingTimesCount);
+
+            requestQueue.Enqueue(new AsyncLogEventInfo());
+            Assert.Equal(1, growingTimesCount);
+            Assert.Equal(2, reportedRequestsCount);
+            Assert.Equal(2, reportedNewQueueSize);
+
+            requestQueue.Enqueue(new AsyncLogEventInfo());
+            Assert.Equal(2, growingTimesCount);
+            Assert.Equal(3, reportedRequestsCount);
+            Assert.Equal(4, reportedNewQueueSize);
+
+            requestQueue.Enqueue(new AsyncLogEventInfo());
+            Assert.Equal(2, growingTimesCount);
+
+            requestQueue.Enqueue(new AsyncLogEventInfo());
+            Assert.Equal(ExpectedFinalGrowingTimes, growingTimesCount);
+            Assert.Equal(5, reportedRequestsCount);
+            Assert.Equal(ExpectedFinalSize, reportedNewQueueSize);
+            Assert.Equal(ExpectedFinalSize, requestQueue.QueueLimit);
+
+            requestQueue.LogEventQueueGrow -= OnLogEventQueueGrow;
+
+            for (var i = reportedRequestsCount; i < ExpectedFinalSize + 1; i++)
+            {
+                requestQueue.Enqueue(new AsyncLogEventInfo());
+            }
+
+            Assert.Equal(ExpectedFinalGrowingTimes, growingTimesCount);
+            Assert.Equal(ExpectedFinalSize * 2, requestQueue.QueueLimit);
+
+            return;
+
+            void OnLogEventQueueGrow(object _, LogEventQueueGrowEventArgs e)
+            {
+                growingTimesCount++;
+                reportedRequestsCount = e.RequestsCount;
+                reportedNewQueueSize = e.NewQueueSize;
+            }
+        }
+
+        internal static void RaiseEventLogEventDropped_OnLogItems(Func<int, AsyncTargetWrapperOverflowAction, AsyncRequestQueueBase> getQueue)
+        {
+            const int RequestsLimit = 2;
+            const int EventsCount = 5;
+            const int ExpectedDiscardedItemsCount = EventsCount - RequestsLimit;
+            int discardedItemsCount = 0;
+
+            var requestQueue = getQueue(RequestsLimit, AsyncTargetWrapperOverflowAction.Discard);
+            requestQueue.LogEventDropped += OnLogEventDropped;
+
+            for (int i = 0; i < EventsCount; i++)
+            {
+                requestQueue.Enqueue(new AsyncLogEventInfo());
+            }
+
+            Assert.Equal(ExpectedDiscardedItemsCount, discardedItemsCount);
+
+            requestQueue.LogEventDropped -= OnLogEventDropped;
+            requestQueue.Enqueue(new AsyncLogEventInfo());
+            Assert.Equal(ExpectedDiscardedItemsCount, discardedItemsCount);
+
+            return;
+
+            void OnLogEventDropped(object o, LogEventDroppedEventArgs e)
+            {
+                discardedItemsCount++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
#5883 for NLog v6