### PR TITLE
Removed obsolete NET Framework 4.5

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -23,7 +23,7 @@ if (-Not (test-path $targetNugetExe))
 	Invoke-WebRequest $sourceNugetExe -OutFile $targetNugetExe
 }
 
-msbuild /t:Restore,Pack ./src/NLog/ /p:targetFrameworks='"net46;net45;net35;netstandard2.0;netstandard2.1"' /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:ContinuousIntegrationBuild=true  /p:EmbedUntrackedSources=true /p:PackageOutputPath=..\..\artifacts /verbosity:minimal /maxcpucount
+msbuild /t:Restore,Pack ./src/NLog/ /p:targetFrameworks='"net46;net35;netstandard2.0;netstandard2.1"' /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:ContinuousIntegrationBuild=true  /p:EmbedUntrackedSources=true /p:PackageOutputPath=..\..\artifacts /verbosity:minimal /maxcpucount
 if (-Not $LastExitCode -eq 0)
 	{ exit $LastExitCode }
 
@@ -35,9 +35,9 @@ function create-package($packageName, $targetFrameworks)
 		{ exit $LastExitCode }
 }
 
-create-package 'NLog.Targets.GZipFile' '"net45;net46;netstandard2.0;netstandard2.1"'
-create-package 'NLog.OutputDebugString' '"net35;net45;net46;netstandard2.0;netstandard2.1"'
-create-package 'NLog.RegEx' '"net35;net45;net46;netstandard2.0;netstandard2.1"'
+create-package 'NLog.Targets.GZipFile' '"net46;netstandard2.0;netstandard2.1"'
+create-package 'NLog.OutputDebugString' '"net35;net46;netstandard2.0;netstandard2.1"'
+create-package 'NLog.RegEx' '"net35;net46;netstandard2.0;netstandard2.1"'
 msbuild /t:Restore,Pack ./src/NLog.Targets.AtomicFile/ /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:ContinuousIntegrationBuild=true /p:EmbedUntrackedSources=true /p:PackageOutputPath=..\..\artifacts /verbosity:minimal  /maxcpucount
 create-package 'NLog.WindowsEventLog' '"netstandard2.0;netstandard2.1"'
 

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -39,13 +39,6 @@ if ($isWindows -or $Env:WinDir)
 	if (-Not $LastExitCode -eq 0)
 		{ exit $LastExitCode }
 
-	dotnet msbuild /t:Build /p:targetFramework=net462 /p:Configuration=Release /p:DebugType=Full /p:TestTargetFramework=net45 ./tests/NLog.UnitTests/
-	if (-Not $LastExitCode -eq 0)
-		{ exit $LastExitCode }
-	dotnet vstest ./tests/NLog.UnitTests/bin/release/net45/NLog.UnitTests.dll
-	if (-Not $LastExitCode -eq 0)
-		{ exit $LastExitCode }
-
 	dotnet list ./src package --vulnerable --include-transitive | findstr /S /c:"has the following vulnerable packages"
 	if (-Not $LastExitCode -eq 1)
 	{

--- a/src/NLog.OutputDebugString/NLog.OutputDebugString.csproj
+++ b/src/NLog.OutputDebugString/NLog.OutputDebugString.csproj
@@ -54,11 +54,6 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Title>NLog.OutputDebugString for .NET Framework 4.5</Title>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <Title>NLog.OutputDebugString for .NET Framework 3.5</Title>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>

--- a/src/NLog.RegEx/NLog.RegEx.csproj
+++ b/src/NLog.RegEx/NLog.RegEx.csproj
@@ -46,11 +46,6 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Title>NLog.RegEx for .NET Framework 4.5</Title>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <Title>NLog.RegEx for .NET Framework 3.5</Title>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>

--- a/src/NLog.Targets.AtomicFile/NLog.Targets.AtomicFile.csproj
+++ b/src/NLog.Targets.AtomicFile/NLog.Targets.AtomicFile.csproj
@@ -45,11 +45,6 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Title>NLog.Targets.AtomicFile for .NET Framework 4.5</Title>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <Title>NLog.Targets.AtomicFile for .NET Framework 3.5</Title>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
@@ -64,11 +59,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/src/NLog.Targets.GZipFile/NLog.Targets.GZipFile.csproj
+++ b/src/NLog.Targets.GZipFile/NLog.Targets.GZipFile.csproj
@@ -47,11 +47,6 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Title>NLog.Targets.GZipFile for .NET Framework 4.5</Title>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <Title>NLog.Targets.GZipFile for NetStandard 2.0</Title>
   </PropertyGroup>

--- a/src/NLog.proj
+++ b/src/NLog.proj
@@ -44,10 +44,10 @@
 
   <ItemGroup>
     <!--The info for the nuspec-->
-    <TargetFramework Include="net45" Condition="'$(BuildNetFX45)'=='true'">
-      <ProjectFileSuffix>.netfx45</ProjectFileSuffix>
+    <TargetFramework Include="net46" Condition="'$(BuildNetFX45)'=='true'">
+      <ProjectFileSuffix>.netfx46</ProjectFileSuffix>
       <ToolsVersion>15.0</ToolsVersion>
-      <NuGetDir>net45</NuGetDir>
+      <NuGetDir>net46</NuGetDir>
     </TargetFramework>
   </ItemGroup>
 

--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -74,12 +74,6 @@ For all config options and platform support, check https://nlog-project.org/conf
     <DebugType Condition=" '$(Configuration)' == 'Debug' ">Full</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Title>NLog for .NET Framework 4.5</Title>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <DebugType Condition=" '$(Configuration)' == 'Debug' ">Full</DebugType>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <Title>NLog for .NET Framework 3.5</Title>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>

--- a/tests/NLog.UnitTests/NLog.UnitTests.csproj
+++ b/tests/NLog.UnitTests/NLog.UnitTests.csproj
@@ -24,10 +24,6 @@
     <DefineConstants>$(DefineConstants);NET35</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'net8.0' AND '$(TestTargetFramework)' == 'net45' ">
-    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(monobuild)' != '' ">
     <DefineConstants>$(DefineConstants);MONO</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
- [ ] Wait for NLog v6.x ?

> C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(1259,5): error MSB3644: The reference assemblies for .NETFramework,Version=v4.5 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [C:\projects\nlog\src\NLog\NLog.csproj::TargetFramework=net45]

When NET45 is disappears from AppVeyor-build-agents, then it will become difficult to support.