### PR TITLE
ConditionExpression - Implicit string conversion operator with nullable

### DIFF
--- a/src/NLog/Conditions/ConditionExpression.cs
+++ b/src/NLog/Conditions/ConditionExpression.cs
@@ -49,17 +49,13 @@ namespace NLog.Conditions
         internal static readonly object BoxedFalse = false;
 
         /// <summary>
-        /// Default Condition-value that evalutes to string.Empty
-        /// </summary>
-        public static ConditionExpression Empty { get; } = new ConditionLiteralExpression(string.Empty);
-
-        /// <summary>
         /// Converts condition text to a condition expression tree.
         /// </summary>
         /// <param name="conditionExpressionText">Condition text to be converted.</param>
         /// <returns>Condition expression tree.</returns>
-        public static implicit operator ConditionExpression(string conditionExpressionText)
+        public static implicit operator ConditionExpression?(string? conditionExpressionText)
         {
+            if (conditionExpressionText is null) return null;
             return ConditionParser.ParseExpression(conditionExpressionText);
         }
 

--- a/src/NLog/Conditions/ConditionParser.cs
+++ b/src/NLog/Conditions/ConditionParser.cs
@@ -214,7 +214,7 @@ namespace NLog.Conditions
                 var simpleLayout = string.IsNullOrEmpty(stringTokenValue) ? SimpleLayout.Default : new SimpleLayout(stringTokenValue, _configurationItemFactory);
                 _tokenizer.GetNextToken();
                 if (simpleLayout.IsFixedText)
-                    return string.IsNullOrEmpty(simpleLayout.FixedText) ? ConditionLiteralExpression.Empty : new ConditionLiteralExpression(simpleLayout.FixedText);
+                    return new ConditionLiteralExpression(simpleLayout.FixedText);
                 else
                     return new ConditionLayoutExpression(simpleLayout);
             }

--- a/src/NLog/Filters/ConditionBasedFilter.cs
+++ b/src/NLog/Filters/ConditionBasedFilter.cs
@@ -51,14 +51,14 @@ namespace NLog.Filters
         /// Gets or sets the condition expression.
         /// </summary>
         /// <docgen category='Filtering Options' order='10' />
-        public ConditionExpression Condition { get; set; } = ConditionExpression.Empty;
+        public ConditionExpression? Condition { get; set; }
 
         internal FilterResult FilterDefaultAction { get; set; } = FilterResult.Neutral;
 
         /// <inheritdoc/>
         protected override FilterResult Check(LogEventInfo logEvent)
         {
-            var val = Condition.Evaluate(logEvent);
+            var val = Condition?.Evaluate(logEvent);
             return ConditionExpression.BoxedTrue.Equals(val) ? Action : FilterDefaultAction;
         }
     }

--- a/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WhenLayoutRendererWrapper.cs
@@ -56,7 +56,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// Gets or sets the condition that must be met for the <see cref="WrapperLayoutRendererBase.Inner"/> layout to be printed.
         /// </summary>
         /// <docgen category="Condition Options" order="10"/>
-        public ConditionExpression When { get; set; } = ConditionExpression.Empty;
+        public ConditionExpression? When { get; set; }
 
         /// <summary>
         /// If <see cref="When"/> is not met, print this layout.
@@ -67,7 +67,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <inheritdoc/>
         protected override void InitializeLayoutRenderer()
         {
-            if (When is null || ReferenceEquals(When, ConditionExpression.Empty))
+            if (When is null)
                 throw new NLogConfigurationException("When-LayoutRenderer When-property must be assigned.");
 
             base.InitializeLayoutRenderer();
@@ -103,7 +103,7 @@ namespace NLog.LayoutRenderers.Wrappers
 
         private bool ShouldRenderInner(LogEventInfo logEvent)
         {
-            return When is null || ReferenceEquals(When, ConditionExpression.Empty) || true.Equals(When.Evaluate(logEvent));
+            return When is null || true.Equals(When.Evaluate(logEvent));
         }
 
         bool IRawValue.TryGetRawValue(LogEventInfo logEvent, out object? value)

--- a/src/NLog/Targets/ConsoleRowHighlightingRule.cs
+++ b/src/NLog/Targets/ConsoleRowHighlightingRule.cs
@@ -55,7 +55,7 @@ namespace NLog.Targets
         /// <param name="condition">The condition.</param>
         /// <param name="foregroundColor">Color of the foreground.</param>
         /// <param name="backgroundColor">Color of the background.</param>
-        public ConsoleRowHighlightingRule(ConditionExpression condition, ConsoleOutputColor foregroundColor, ConsoleOutputColor backgroundColor)
+        public ConsoleRowHighlightingRule(ConditionExpression? condition, ConsoleOutputColor foregroundColor, ConsoleOutputColor backgroundColor)
         {
             Condition = condition;
             ForegroundColor = foregroundColor;
@@ -65,13 +65,13 @@ namespace NLog.Targets
         /// <summary>
         /// Gets the default highlighting rule. Doesn't change the color.
         /// </summary>
-        public static ConsoleRowHighlightingRule Default { get; } = new ConsoleRowHighlightingRule(ConditionExpression.Empty, ConsoleOutputColor.NoChange, ConsoleOutputColor.NoChange);
+        public static ConsoleRowHighlightingRule Default { get; } = new ConsoleRowHighlightingRule(null, ConsoleOutputColor.NoChange, ConsoleOutputColor.NoChange);
 
         /// <summary>
         /// Gets or sets the condition that must be met in order to set the specified foreground and background color.
         /// </summary>
         /// <docgen category='Highlighting Rules' order='10' />
-        public ConditionExpression Condition { get; set; } = ConditionExpression.Empty;
+        public ConditionExpression? Condition { get; set; }
 
         /// <summary>
         /// Gets or sets the foreground color.
@@ -90,7 +90,7 @@ namespace NLog.Targets
         /// </summary>
         public bool CheckCondition(LogEventInfo logEvent)
         {
-            return Condition is null || ReferenceEquals(Condition, ConditionExpression.Empty) || true.Equals(Condition.Evaluate(logEvent));
+            return Condition is null || true.Equals(Condition.Evaluate(logEvent));
         }
     }
 }

--- a/src/NLog/Targets/ConsoleWordHighlightingRule.cs
+++ b/src/NLog/Targets/ConsoleWordHighlightingRule.cs
@@ -68,7 +68,7 @@ namespace NLog.Targets
         /// Gets or sets the condition that must be met before scanning the row for highlight of words
         /// </summary>
         /// <docgen category='Highlighting Rules' order='10' />
-        public ConditionExpression Condition { get; set; } = ConditionExpression.Empty;
+        public ConditionExpression? Condition { get; set; }
 
         /// <summary>
         /// Gets or sets the text to be matched. You must specify either <c>text</c> or <c>regex</c>.
@@ -155,7 +155,7 @@ namespace NLog.Targets
         /// </summary>
         internal bool CheckCondition(LogEventInfo logEvent)
         {
-            return Condition is null || ReferenceEquals(Condition, ConditionExpression.Empty) || true.Equals(Condition.Evaluate(logEvent));
+            return Condition is null || true.Equals(Condition.Evaluate(logEvent));
         }
     }
 }

--- a/src/NLog/Targets/Wrappers/AutoFlushTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AutoFlushTargetWrapper.cs
@@ -64,7 +64,7 @@ namespace NLog.Targets.Wrappers
         /// a flush on the wrapped target.
         /// </summary>
         /// <docgen category='General Options' order='10' />
-        public ConditionExpression Condition { get; set; } = ConditionExpression.Empty;
+        public ConditionExpression? Condition { get; set; }
 
         /// <summary>
         /// Delay the flush until the LogEvent has been confirmed as written
@@ -149,7 +149,7 @@ namespace NLog.Targets.Wrappers
         /// <param name="logEvent">Logging event to be written out.</param>
         protected override void Write(AsyncLogEventInfo logEvent)
         {
-            if (Condition is null || ReferenceEquals(Condition, ConditionExpression.Empty) ||  ConditionExpression.BoxedTrue.Equals(Condition.Evaluate(logEvent.LogEvent)))
+            if (Condition is null || ConditionExpression.BoxedTrue.Equals(Condition.Evaluate(logEvent.LogEvent)))
             {
                 if (AsyncFlush)
                 {

--- a/src/NLog/Targets/Wrappers/FilteringRule.cs
+++ b/src/NLog/Targets/Wrappers/FilteringRule.cs
@@ -46,7 +46,6 @@ namespace NLog.Targets.Wrappers
         /// Initializes a new instance of the FilteringRule class.
         /// </summary>
         public FilteringRule()
-            : this(ConditionExpression.Empty, ConditionExpression.Empty)
         {
         }
 
@@ -65,12 +64,12 @@ namespace NLog.Targets.Wrappers
         /// Gets or sets the condition to be tested.
         /// </summary>
         /// <docgen category='Filtering Options' order='10' />
-        public ConditionExpression Exists { get; set; }
+        public ConditionExpression? Exists { get; set; }
 
         /// <summary>
         /// Gets or sets the resulting filter to be applied when the condition matches.
         /// </summary>
         /// <docgen category='Filtering Options' order='10' />
-        public ConditionExpression Filter { get; set; }
+        public ConditionExpression? Filter { get; set; }
     }
 }

--- a/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/FilteringTargetWrapper.cs
@@ -98,7 +98,7 @@ namespace NLog.Targets.Wrappers
         /// to the wrapped target.
         /// </summary>
         /// <docgen category='Filtering Options' order='10' />
-        public ConditionExpression? Condition { get => (Filter as ConditionBasedFilter)?.Condition; set => Filter = CreateFilter(value ?? ConditionExpression.Empty); }
+        public ConditionExpression? Condition { get => (Filter as ConditionBasedFilter)?.Condition; set => Filter = CreateFilter(value); }
 
         /// <summary>
         /// Gets or sets the filter. Log events who evaluates to <see cref="FilterResult.Ignore"/> will be discarded
@@ -109,7 +109,7 @@ namespace NLog.Targets.Wrappers
         /// <inheritdoc/>
         protected override void InitializeTarget()
         {
-            if (Filter is null || ReferenceEquals(Condition, ConditionExpression.Empty))
+            if (Filter is null || ReferenceEquals(Filter, ConditionBasedFilter.Empty))
                 throw new NLogConfigurationException($"FilteringTargetWrapper Filter-property must be assigned. Filter LogEvents using blank Filter not supported.");
 
             base.InitializeTarget();
@@ -153,9 +153,9 @@ namespace NLog.Targets.Wrappers
             }
         }
 
-        private static ConditionBasedFilter CreateFilter(ConditionExpression value)
+        private static ConditionBasedFilter CreateFilter(ConditionExpression? value)
         {
-            if (value is null || ReferenceEquals(value, ConditionExpression.Empty))
+            if (value is null)
                 return ConditionBasedFilter.Empty;
 
             return new ConditionBasedFilter { Condition = value, FilterDefaultAction = FilterResult.Ignore };

--- a/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/PostFilteringTargetWrapper.cs
@@ -95,7 +95,7 @@ namespace NLog.Targets.Wrappers
         /// Gets or sets the default filter to be applied when no specific rule matches.
         /// </summary>
         /// <docgen category='Filtering Options' order='10' />
-        public ConditionExpression DefaultFilter { get; set; } = ConditionExpression.Empty;
+        public ConditionExpression? DefaultFilter { get; set; }
 
         /// <summary>
         /// Gets the collection of filtering rules. The rules are processed top-down
@@ -113,10 +113,10 @@ namespace NLog.Targets.Wrappers
 
             foreach (var rule in Rules)
             {
-                if (rule.Exists is null || ReferenceEquals(rule.Exists, ConditionExpression.Empty))
+                if (rule.Exists is null)
                     throw new NLogConfigurationException("PostFilteringTargetWrapper When-Rules with unassigned Exists-property.");
 
-                if (rule.Filter is null || ReferenceEquals(rule.Filter, ConditionExpression.Empty))
+                if (rule.Filter is null)
                     throw new NLogConfigurationException("PostFilteringTargetWrapper When-Rules with unassigned Filter-property.");
             }
         }
@@ -139,7 +139,7 @@ namespace NLog.Targets.Wrappers
             InternalLogger.Trace("{0}: Running on {1} events", this, logEvents.Count);
 
             var resultFilter = EvaluateAllRules(logEvents);
-            if (resultFilter is null || ReferenceEquals(resultFilter, ConditionExpression.Empty))
+            if (resultFilter is null)
             {
                 WrappedTarget?.WriteAsyncLogEvents(logEvents);
             }
@@ -175,7 +175,7 @@ namespace NLog.Targets.Wrappers
         /// </summary>
         /// <param name="logEvents"></param>
         /// <returns></returns>
-        private ConditionExpression EvaluateAllRules(IList<AsyncLogEventInfo> logEvents)
+        private ConditionExpression? EvaluateAllRules(IList<AsyncLogEventInfo> logEvents)
         {
             if (Rules.Count == 0)
                 return DefaultFilter;
@@ -185,7 +185,7 @@ namespace NLog.Targets.Wrappers
                 for (int j = 0; j < Rules.Count; ++j)
                 {
                     var rule = Rules[j];
-                    var v = rule.Exists.Evaluate(logEvents[i].LogEvent);
+                    var v = rule.Exists?.Evaluate(logEvents[i].LogEvent);
                     if (ConditionExpression.BoxedTrue.Equals(v))
                     {
                         InternalLogger.Trace("{0}: Rule matched: {1}", this, rule.Exists);


### PR DESCRIPTION
Resolves #5897

It was a mistake to introduce `ConditionExpression.Empty` to simulate `Layout.Empty`. Because Condition = null has the meaning that filtering is not active, which is often needed and `ConditionExpression.Empty` doesn't provide that capability.