### PR TITLE
ReplaceNewLinesLayoutRendererWrapper - Replace all line ending characters

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -84,29 +84,41 @@ namespace NLog.LayoutRenderers.Wrappers
                     orgLength = lineEndIndex > orgLength ? lineEndIndex - 1 : orgLength;
                     string str = builder.ToString(orgLength, builder.Length - orgLength);
                     builder.Length = orgLength;
-                    int current = 0;
-                    int index = IndexOfLineEndCharacters(str, 0);
-                    while (index > -1)
+
+                    bool ignoreNewLine = false;
+                    foreach (var chr in str)
                     {
-                        builder.Append(str.Substring(current, index - current));
-                        builder.Append(Replacement);
-                        if (index < str.Length - 1 && str[index] == '\r' && str[index + 1] == '\n')
+                        if (IsLineEndCharacter(chr))  // switches on chr, and allow method-reuse
                         {
-                            index += 2;
+                            if (!ignoreNewLine || chr != '\n')
+                            {
+                                builder.Append(Replacement);
+                            }
+                            ignoreNewLine = chr == '\r';
                         }
                         else
                         {
-                            index++;
+                            builder.Append(chr);
+                            ignoreNewLine = false;
                         }
-                        current = index;
-                        index = IndexOfLineEndCharacters(str, index);
-                    }
-                    if (current < str.Length - 1)
-                    {
-                        builder.Append(str.Substring(current));
                     }
                 }
             }
+        }
+
+        private static bool IsLineEndCharacter(char ch)
+        {
+            switch (ch)
+            {
+                case '\r':
+                case '\n':
+                case '\u0085':
+                case '\u2028':
+                case '\u000C':
+                case '\u2029':
+                    return true;
+            }
+            return false;
         }
 
         private static int IndexOfLineEndCharacters(string builder, int startPosition)

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -102,10 +102,10 @@ namespace NLog.LayoutRenderers.Wrappers
             {
                 case '\r':
                 case '\n':
-                case '\u0085':
-                case '\u2028':
-                case '\u000C':
-                case '\u2029':
+                case '\u000C':  // FORM FEED (FF)
+                case '\u0085':  // NEXT LINE (NEL)
+                case '\u2028':  // LINE SEPARATOR
+                case '\u2029': // PARAGRAPH SEPARATOR
                     return true;
             }
             return false;

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -100,12 +100,12 @@ namespace NLog.LayoutRenderers.Wrappers
         {
             switch (ch)
             {
-                case '\r':
-                case '\n':
-                case '\u000C':  // FORM FEED (FF)
+                case '\r':      // CARRIAGE RETURN
+                case '\n':      // LINE FEED
+                case '\f':      // FORM FEED (FF)
                 case '\u0085':  // NEXT LINE (NEL)
                 case '\u2028':  // LINE SEPARATOR
-                case '\u2029': // PARAGRAPH SEPARATOR
+                case '\u2029':  // PARAGRAPH SEPARATOR
                     return true;
             }
             return false;

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -78,12 +78,14 @@ namespace NLog.LayoutRenderers.Wrappers
             Inner?.Render(logEvent, builder);
             if (builder.Length > orgLength)
             {
-                if (ContainsLineEndCharacters(builder, orgLength))
+                int lineEndIndex = IndexOfLineEndCharacters(builder, orgLength);
+                if (lineEndIndex > -1)
                 {
+                    orgLength = lineEndIndex > orgLength ? lineEndIndex - 1 : orgLength;
                     string str = builder.ToString(orgLength, builder.Length - orgLength);
                     builder.Length = orgLength;
                     int current = 0;
-                    int index = IndexOfLineEndChar(str, 0);
+                    int index = IndexOfLineEndCharacters(str, 0);
                     while (index > -1)
                     {
                         builder.Append(str.Substring(current, index - current));
@@ -97,7 +99,7 @@ namespace NLog.LayoutRenderers.Wrappers
                             index++;
                         }
                         current = index;
-                        index = IndexOfLineEndChar(str, index);
+                        index = IndexOfLineEndCharacters(str, index);
                     }
                     if (current < str.Length - 1)
                     {
@@ -107,7 +109,7 @@ namespace NLog.LayoutRenderers.Wrappers
             }
         }
 
-        private static int IndexOfLineEndChar(string builder, int startPosition)
+        private static int IndexOfLineEndCharacters(string builder, int startPosition)
         {
             for (int i = startPosition; i < builder.Length; i++)
             {
@@ -125,7 +127,7 @@ namespace NLog.LayoutRenderers.Wrappers
             return -1;
         }
 
-        private static bool ContainsLineEndCharacters(StringBuilder builder, int startPosition)
+        private static int IndexOfLineEndCharacters(StringBuilder builder, int startPosition)
         {
             for (int i = startPosition; i < builder.Length; i++)
             {
@@ -137,10 +139,10 @@ namespace NLog.LayoutRenderers.Wrappers
                     case '\u2028':
                     case '\u000C':
                     case '\u2029':
-                        return true;
+                        return i;
                 }
             }
-            return false;
+            return -1;
         }
 
 

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -34,10 +34,8 @@
 namespace NLog.LayoutRenderers.Wrappers
 {
     using System;
-    using System.Linq;
     using System.Text;
     using NLog.Config;
-    using NLog.Internal;
 
     /// <summary>
     /// Replaces newline characters from the result of another layout renderer with spaces.
@@ -121,37 +119,13 @@ namespace NLog.LayoutRenderers.Wrappers
             return false;
         }
 
-        private static int IndexOfLineEndCharacters(string builder, int startPosition)
-        {
-            for (int i = startPosition; i < builder.Length; i++)
-            {
-                switch (builder[i])
-                {
-                    case '\r':
-                    case '\n':
-                    case '\u0085':
-                    case '\u2028':
-                    case '\u000C':
-                    case '\u2029':
-                        return i;
-                }
-            }
-            return -1;
-        }
-
         private static int IndexOfLineEndCharacters(StringBuilder builder, int startPosition)
         {
             for (int i = startPosition; i < builder.Length; i++)
             {
-                switch (builder[i])
+                if (IsLineEndCharacter(builder[i]))
                 {
-                    case '\r':
-                    case '\n':
-                    case '\u0085':
-                    case '\u2028':
-                    case '\u000C':
-                    case '\u2029':
-                        return i;
+                    return i;
                 }
             }
             return -1;

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -72,15 +72,13 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <docgen category='Layout Options' order='50' />
         public string ReplaceNewLines { get => Replacement; set => Replacement = value; }
 
-        private static readonly char[] LineEndCharacters = new char[] { '\u000D', '\u000A', '\u0085', '\u2028', '\u000C', '\u2029' };
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
             Inner?.Render(logEvent, builder);
             if (builder.Length > orgLength)
             {
-                var containsNewLines = builder.IndexOfAny(LineEndCharacters, orgLength) >= 0;
-                if (containsNewLines)
+                if (ContainsLineEndCharacters(builder, orgLength))
                 {
                     string str = builder.ToString(orgLength, builder.Length - orgLength);
                     builder.Length = orgLength;
@@ -125,6 +123,24 @@ namespace NLog.LayoutRenderers.Wrappers
                 }
             }
             return -1;
+        }
+
+        private static bool ContainsLineEndCharacters(StringBuilder builder, int startPosition)
+        {
+            for (int i = startPosition; i < builder.Length; i++)
+            {
+                switch (builder[i])
+                {
+                    case '\r':
+                    case '\n':
+                    case '\u0085':
+                    case '\u2028':
+                    case '\u000C':
+                    case '\u2029':
+                        return true;
+                }
+            }
+            return false;
         }
 
 

--- a/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/ReplaceNewLinesLayoutRendererWrapper.cs
@@ -54,15 +54,7 @@ namespace NLog.LayoutRenderers.Wrappers
         /// Gets or sets a value indicating the string that should be used to replace newlines.
         /// </summary>
         /// <docgen category='Layout Options' order='10' />
-        public string Replacement
-        {
-            get => _replacement;
-            set
-            {
-                _replacement = value;
-            }
-        }
-        private string _replacement = " ";
+        public string Replacement { get; set; } = " ";
 
         /// <summary>
         /// Gets or sets a value indicating the string that should be used to replace newlines.

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -485,7 +485,6 @@ namespace NLog.UnitTests
                 "NLog.LayoutRenderers.CounterLayoutRenderer",
                 "NLog.LayoutRenderers.ExceptionLayoutRenderer",
                 "NLog.LayoutRenderers.LevelLayoutRenderer",
-                "NLog.LayoutRenderers.Wrappers.ReplaceNewLinesLayoutRendererWrapper",
                 "NLog.Internal.AppendBuilderCreator",
                 "NLog.Internal.CallSiteInformation",
                 "NLog.Internal.DictionaryEntryEnumerable+EmptyDictionaryEnumerator",

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -485,6 +485,7 @@ namespace NLog.UnitTests
                 "NLog.LayoutRenderers.CounterLayoutRenderer",
                 "NLog.LayoutRenderers.ExceptionLayoutRenderer",
                 "NLog.LayoutRenderers.LevelLayoutRenderer",
+                "NLog.LayoutRenderers.Wrappers.ReplaceNewLinesLayoutRendererWrapper",
                 "NLog.Internal.AppendBuilderCreator",
                 "NLog.Internal.CallSiteInformation",
                 "NLog.Internal.DictionaryEntryEnumerable+EmptyDictionaryEnumerator",

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ReplaceNewLinesTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ReplaceNewLinesTests.cs
@@ -207,5 +207,17 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
             // Assert
             Assert.Equal("line1 line2 line3 line4 line5 line6 line7 line8", result);
         }
+
+        [Fact]
+        public void ReplaceSingleLineEndingWithDefault()
+        {
+            // Arrange
+            var foo = "\n";
+            SimpleLayout l = "${replace-newlines:${event-properties:foo}}";
+            // Act
+            var result = l.Render(LogEventInfo.Create(LogLevel.Info, null, null, "{foo}", new[] { foo }));
+            // Assert
+            Assert.Equal(" ", result);
+        }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ReplaceNewLinesTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ReplaceNewLinesTests.cs
@@ -173,6 +173,18 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
         }
 
         [Fact]
+        public void ReplaceUnicodeConsecutiveLineEndingsWithSpecifiedMulticharacterSeparationStringTest()
+        {
+            // Arrange
+            var foo = "line1\r\r\n\nline2";
+            SimpleLayout l = "${replace-newlines:replacement=||:${event-properties:foo}}";
+            // Act
+            var result = l.Render(LogEventInfo.Create(LogLevel.Info, null, null, "{foo}", new[] { foo }));
+            // Assert
+            Assert.Equal("line1||||||line2", result);
+        }
+
+        [Fact]
         public void ReplaceWindowsLineEndingsEndOfTextWithSpecifiedSeparationStringTest()
         {
             // Arrange

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ReplaceNewLinesTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ReplaceNewLinesTests.cs
@@ -161,6 +161,30 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
         }
 
         [Fact]
+        public void ReplaceUnicodeLineEndingsWithSpecifiedMulticharacterSeparationStringTest()
+        {
+            // Arrange
+            var foo = "line1\nline2\r\nline3\rline4\u0085line5\u2028line6\u000Cline7\u2029line8\r\n";
+            SimpleLayout l = "${replace-newlines:replacement=||||:${event-properties:foo}}";
+            // Act
+            var result = l.Render(LogEventInfo.Create(LogLevel.Info, null, null, "{foo}", new[] { foo }));
+            // Assert
+            Assert.Equal("line1||||line2||||line3||||line4||||line5||||line6||||line7||||line8||||", result);
+        }
+
+        [Fact]
+        public void ReplaceWindowsLineEndingsEndOfTextWithSpecifiedSeparationStringTest()
+        {
+            // Arrange
+            var foo = "line1\r\n";
+            SimpleLayout l = "${replace-newlines:replacement=|:${event-properties:foo}}";
+            // Act
+            var result = l.Render(LogEventInfo.Create(LogLevel.Info, null, null, "{foo}", new[] { foo }));
+            // Assert
+            Assert.Equal("line1|", result);
+        }
+
+        [Fact]
         public void ReplaceUnicodeLineEndingsWithDefault()
         {
             // Arrange

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ReplaceNewLinesTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/ReplaceNewLinesTests.cs
@@ -135,5 +135,41 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
             // Assert
             Assert.Equal("bar\r\n123\r\n", result);
         }
+
+        [Fact]
+        public void ReplaceCarriageReturnWithSpecifiedSeparationStringTest()
+        {
+            // Arrange
+            var foo = "bar\r123";
+            SimpleLayout l = "${replace-newlines:replacement=|:${event-properties:foo}}";
+            // Act
+            var result = l.Render(LogEventInfo.Create(LogLevel.Info, null, null, "{foo}", new[] { foo }));
+            // Assert
+            Assert.Equal("bar|123", result);
+        }
+
+        [Fact]
+        public void ReplaceUnicodeLineEndingsWithSpecifiedSeparationStringTest()
+        {
+            // Arrange
+            var foo = "line1\nline2\r\nline3\rline4\u0085line5\u2028line6\u000Cline7\u2029line8";
+            SimpleLayout l = "${replace-newlines:replacement=|:${event-properties:foo}}";
+            // Act
+            var result = l.Render(LogEventInfo.Create(LogLevel.Info, null, null, "{foo}", new[] { foo }));
+            // Assert
+            Assert.Equal("line1|line2|line3|line4|line5|line6|line7|line8", result);
+        }
+
+        [Fact]
+        public void ReplaceUnicodeLineEndingsWithDefault()
+        {
+            // Arrange
+            var foo = "line1\nline2\r\nline3\rline4\u0085line5\u2028line6\u000Cline7\u2029line8";
+            SimpleLayout l = "${replace-newlines:${event-properties:foo}}";
+            // Act
+            var result = l.Render(LogEventInfo.Create(LogLevel.Info, null, null, "{foo}", new[] { foo }));
+            // Assert
+            Assert.Equal("line1 line2 line3 line4 line5 line6 line7 line8", result);
+        }
     }
 }


### PR DESCRIPTION
Windows uses \r\n, Linux and new Macs use \n. Older Macs use \r. Unicode adds more line endings. Old implementation didn't even replace single \r characters. Text editors like notepad++ treat single \r as new line character and log files aren't formatted as expected when using newline replacements.

Line ending characters replaced are those defined in unicode 16.0.0 specification section 5.8 Newline guidelines in table 5-1.