### PR TITLE
FileTarget - Activate legacy ArchiveFileName when ArchiveSuffixFormat contains legacy placeholder

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -296,7 +296,7 @@ namespace NLog.Targets
         /// <docgen category='Archival Options' order='50' />
         public Layout? ArchiveFileName
         {
-            get => _archiveFileName;
+            get => _archiveFileName ?? (_archiveSuffixFormat?.IndexOf("{1") >= 0 ? FileName : null);
             set
             {
                 var archiveSuffixFormat = _archiveSuffixFormat;
@@ -422,6 +422,7 @@ namespace NLog.Targets
             {
                 if (!string.IsNullOrEmpty(value) && ArchiveFileName is SimpleLayout simpleLayout)
                 {
+                    // When legacy ArchiveFileName only contains file-extension, then strip away leading underscore from suffix
                     var fileName = Path.GetFileNameWithoutExtension(simpleLayout.OriginalText);
                     if (StringHelpers.IsNullOrWhiteSpace(fileName) && value.IndexOf('_') == 0)
                     {


### PR DESCRIPTION
See also: #5920 