### PR TITLE
AsyncTargetWrapper - Updated FullBatchSizeWriteLimit default value from 5 to 10

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -232,7 +232,7 @@ namespace NLog.Targets.Wrappers
         /// Performance is better when writing many small batches, than writing a single large batch
         /// </remarks>
         /// <docgen category='Buffering Options' order='100' />
-        public int FullBatchSizeWriteLimit { get; set; } = 5;
+        public int FullBatchSizeWriteLimit { get; set; } = 10;
 
         /// <summary>
         /// Gets or sets whether to use the locking queue, instead of a lock-free concurrent queue


### PR DESCRIPTION
Scheduling a new Timer-event has an overhead, so performing more work within the Timer-event will be faster.

Instead of limited to 5 * 200 every 1ms (1.000.000 logevents/sec) then it will be 10 * 200 every 1ms (2.000.000 logevents/sec)

Reducing the chance of dropping logevents with default overflowAction = discard. And better benchmark scores.