### PR TITLE
FileTarget - Closing on OpenFileCacheTimeout should depend on least recently used

### DIFF
--- a/src/NLog/Targets/FileAppenders/DiscardAllFileAppender.cs
+++ b/src/NLog/Targets/FileAppenders/DiscardAllFileAppender.cs
@@ -41,6 +41,8 @@ namespace NLog.Targets.FileAppenders
 
         public DateTime OpenStreamTime { get; }
 
+        public DateTime LastWriteTime => OpenStreamTime;
+
         public DateTime FileLastModified => OpenStreamTime;
 
         public DateTime NextArchiveTime => DateTime.MaxValue;

--- a/src/NLog/Targets/FileAppenders/ExclusiveFileLockingAppender.cs
+++ b/src/NLog/Targets/FileAppenders/ExclusiveFileLockingAppender.cs
@@ -53,6 +53,8 @@ namespace NLog.Targets.FileAppenders
 
         public DateTime OpenStreamTime { get; }
 
+        public DateTime LastWriteTime => FileLastModified;
+
         public DateTime FileLastModified { get; private set; }
 
         private DateTime FileBirthTime
@@ -97,7 +99,7 @@ namespace NLog.Targets.FileAppenders
         {
             FileLastModified = NLog.Time.TimeSource.Current.Time;
 
-            if (_fileTarget.ArchiveFileName is null && _fileTarget.ArchiveEvery == FileArchivePeriod.None && _fileTarget.ArchiveAboveSize <= 0)
+            if (_fileTarget.ArchiveEvery == FileArchivePeriod.None && _fileTarget.ArchiveAboveSize <= 0 && _fileTarget.ArchiveFileName is null)
                 return 0;
 
             try

--- a/src/NLog/Targets/FileAppenders/IFileAppender.cs
+++ b/src/NLog/Targets/FileAppenders/IFileAppender.cs
@@ -44,6 +44,7 @@ namespace NLog.Targets.FileAppenders
         long FileSize { get; }
 
         DateTime OpenStreamTime { get; }
+        DateTime LastWriteTime { get; }
         DateTime FileLastModified { get; }
         DateTime NextArchiveTime { get; }
 

--- a/src/NLog/Targets/FileAppenders/MinimalFileLockingAppender.cs
+++ b/src/NLog/Targets/FileAppenders/MinimalFileLockingAppender.cs
@@ -50,6 +50,8 @@ namespace NLog.Targets.FileAppenders
 
         public DateTime OpenStreamTime { get; }
 
+        public DateTime LastWriteTime { get; private set; }
+
         public DateTime FileLastModified
         {
             get
@@ -99,7 +101,7 @@ namespace NLog.Targets.FileAppenders
             _fileTarget = fileTarget;
             _filePath = filePath;
             _initialFileOpen = true;
-            OpenStreamTime = Time.TimeSource.Current.Time;
+            OpenStreamTime = LastWriteTime = Time.TimeSource.Current.Time;
         }
 
         public void Write(byte[] buffer, int offset, int count)
@@ -122,6 +124,8 @@ namespace NLog.Targets.FileAppenders
                     }
                 }
             }
+
+            LastWriteTime = NLog.Time.TimeSource.Current.Time;
         }
 
         public void Dispose()


### PR DESCRIPTION
Revert to same behavior as NLog v5 FileTarget:
- Closing the least recently used files, because dangerous to momentarily close "active" file-handles, since other background services might take over the file-handle and block application logging.