### PR TITLE
CallSiteLayoutRenderer - Obsolete CleanNamesOfAnonymousDelegates + CleanNamesOfAsyncContinuation

### DIFF
--- a/src/NLog/LayoutRenderers/CallSiteLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CallSiteLayoutRenderer.cs
@@ -33,6 +33,8 @@
 
 namespace NLog.LayoutRenderers
 {
+    using System;
+    using System.ComponentModel;
     using System.IO;
     using System.Text;
     using NLog.Config;
@@ -75,6 +77,8 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <remarks>Default: <see langword="true"/></remarks>
         /// <docgen category='Layout Options' order='10' />
+        [Obsolete("Should always be enabled. Marked obsolete with v6.1")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool CleanNamesOfAnonymousDelegates { get; set; } = true;
 
         /// <summary>
@@ -83,6 +87,8 @@ namespace NLog.LayoutRenderers
         /// </summary>
         /// <remarks>Default: <see langword="true"/></remarks>
         /// <docgen category='Layout Options' order='10' />
+        [Obsolete("Should always be enabled. Marked obsolete with v6.1")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool CleanNamesOfAsyncContinuations { get; set; } = true;
 
         /// <summary>
@@ -141,13 +147,17 @@ namespace NLog.LayoutRenderers
 
                 if (ClassName)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     var className = logEventCallSize.GetCallerClassName(method, IncludeNamespace, CleanNamesOfAsyncContinuations, CleanNamesOfAnonymousDelegates);
+#pragma warning restore CS0618 // Type or member is obsolete
                     builder.Append(string.IsNullOrEmpty(className) ? "<no type>" : className);
                 }
 
                 if (MethodName)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     var methodName = logEventCallSize.GetCallerMethodName(method, false, CleanNamesOfAsyncContinuations, CleanNamesOfAnonymousDelegates);
+#pragma warning restore CS0618 // Type or member is obsolete
                     if (ClassName)
                     {
                         builder.Append('.');
@@ -192,7 +202,9 @@ namespace NLog.LayoutRenderers
             {
                 if (ClassName)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     var className = StackTraceUsageUtils.GetStackFrameMethodClassName(targetSite, true, CleanNamesOfAsyncContinuations, CleanNamesOfAnonymousDelegates);
+#pragma warning restore CS0618 // Type or member is obsolete
                     builder.Append(className);
                 }
 
@@ -202,7 +214,9 @@ namespace NLog.LayoutRenderers
                     {
                         builder.Append('.');
                     }
+#pragma warning disable CS0618 // Type or member is obsolete
                     var methodName = StackTraceUsageUtils.GetStackFrameMethodName(targetSite, false, CleanNamesOfAsyncContinuations, CleanNamesOfAnonymousDelegates);
+#pragma warning restore CS0618 // Type or member is obsolete
                     builder.Append(methodName);
                 }
             }

--- a/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/CallSiteTests.cs
@@ -379,7 +379,7 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${callsite:ClassName=false:CleanNamesOfAnonymousDelegates=true}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${callsite:ClassName=false}' /></targets>
                     <rules>
                         <logger name='*' levels='Fatal' writeTo='debug' />
                     </rules>
@@ -408,53 +408,11 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
-        public void DontCleanMethodNamesOfAnonymousDelegatesTest()
-        {
-#if !NETFRAMEWORK
-            if (IsLinux())
-            {
-                Console.WriteLine("[SKIP] DontCleanMethodNamesOfAnonymousDelegatesTest because unstable with NET8");
-                return;
-            }
-#endif
-
-            var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
-                <nlog>
-                    <targets><target name='debug' type='Debug' layout='${callsite:ClassName=false:CleanNamesOfAnonymousDelegates=false}' /></targets>
-                    <rules>
-                        <logger name='*' levels='Fatal' writeTo='debug' />
-                    </rules>
-                </nlog>").LogFactory;
-
-            var logger = logFactory.GetLogger("A");
-
-            bool done = false;
-            ThreadPool.QueueUserWorkItem(
-                state =>
-                {
-                    logger.Fatal("message");
-                    done = true;
-                },
-                null);
-
-            while (done == false)
-            {
-                Thread.Sleep(10);
-            }
-
-            if (done == true)
-            {
-                string lastMessage = GetDebugLastMessage("debug", logFactory);
-                Assert.StartsWith("<DontCleanMethodNamesOfAnonymousDelegatesTest>", lastMessage);
-            }
-        }
-
-        [Fact]
         public void CleanClassNamesOfAnonymousDelegatesTest()
         {
             var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${callsite:ClassName=true:MethodName=false:CleanNamesOfAnonymousDelegates=true}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${callsite:ClassName=true:MethodName=false}' /></targets>
                     <rules>
                         <logger name='*' levels='Fatal' writeTo='debug' />
                     </rules>
@@ -483,52 +441,11 @@ namespace NLog.UnitTests.LayoutRenderers
         }
 
         [Fact]
-        public void DontCleanClassNamesOfAnonymousDelegatesTest()
-        {
-#if !NETFRAMEWORK
-            if (IsLinux())
-            {
-                Console.WriteLine("[SKIP] DontCleanClassNamesOfAnonymousDelegatesTest because unstable with NET8");
-                return;
-            }
-#endif
-
-            var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
-                <nlog>
-                    <targets><target name='debug' type='Debug' layout='${callsite:ClassName=true:MethodName=false:CleanNamesOfAnonymousDelegates=false}' /></targets>
-                    <rules>
-                        <logger name='*' levels='Fatal' writeTo='debug' />
-                    </rules>
-                </nlog>").LogFactory;
-
-            var logger = logFactory.GetLogger("A");
-
-            bool done = false;
-            ThreadPool.QueueUserWorkItem(
-                state =>
-                {
-                    logger.Fatal("message");
-                    done = true;
-                },
-                null);
-
-            while (done == false)
-            {
-                Thread.Sleep(10);
-            }
-
-            if (done == true)
-            {
-                logFactory.AssertDebugLastMessageContains("+<>");
-            }
-        }
-
-        [Fact]
         public void When_NotIncludeNameSpace_Then_CleanAnonymousDelegateClassNameShouldReturnParentClassName()
         {
             var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${callsite:ClassName=true:MethodName=false:IncludeNamespace=false:CleanNamesOfAnonymousDelegates=true}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${callsite:ClassName=true:MethodName=false:IncludeNamespace=false}' /></targets>
                     <rules>
                         <logger name='*' levels='Fatal' writeTo='debug' />
                     </rules>
@@ -1247,7 +1164,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${callsite:classname=false:cleannamesofasynccontinuations=true}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${callsite:classname=false}' /></targets>
                     <rules>
                         <logger name='*' levels='Debug' writeTo='debug' />
                     </rules>
@@ -1277,7 +1194,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
                 <nlog>
-                    <targets><target name='debug' type='Debug' layout='${callsite:classname=true:includenamespace=true:cleannamesofasynccontinuations=true:cleanNamesOfAnonymousDelegates=true}' /></targets>
+                    <targets><target name='debug' type='Debug' layout='${callsite:classname=true:includenamespace=true}' /></targets>
                     <rules>
                         <logger name='*' levels='Debug' writeTo='debug' />
                     </rules>
@@ -1297,42 +1214,6 @@ namespace NLog.UnitTests.LayoutRenderers
 
             new InnerClassAsyncMethod6().AsyncMethod6b(logFactory);
             logFactory.AssertDebugLastMessage($"{typeof(InnerClassAsyncMethod6).ToString()}.AsyncMethod6b");
-        }
-
-#if NET35
-        [Fact(Skip = "NET35 not supporting async callstack")]
-#elif MONO
-        [Fact(Skip = "Not working under MONO - not sure if unit test is wrong, or the code")]
-#else
-        [Fact]
-#endif
-        public void LogAfterTaskRunAwait_CleanNamesOfAsyncContinuationsIsFalse_ShouldNotCleanNames()
-        {
-#if !NETFRAMEWORK
-            if (IsLinux())
-            {
-                Console.WriteLine("[SKIP] LogAfterTaskRunAwait_CleanNamesOfAsyncContinuationsIsFalse_ShouldNotCleanNames because unstable with NET8");
-                return;
-            }
-#endif
-
-            var logFactory = new LogFactory().Setup().LoadConfigurationFromXml(@"
-                <nlog>
-                    <targets><target name='debug' type='Debug' layout='${callsite:includenamespace=true:cleannamesofasynccontinuations=false}' /></targets>
-                    <rules>
-                        <logger name='*' levels='Debug' writeTo='debug' />
-                    </rules>
-                </nlog>").LogFactory;
-
-            Task.Run(async () =>
-            {
-                await AMinimalAsyncMethod();
-                var logger = logFactory.GetCurrentClassLogger();
-                logger.Debug("dude");
-            }).Wait();
-
-            logFactory.AssertDebugLastMessageContains("NLog.UnitTests.LayoutRenderers.CallSiteTests");
-            logFactory.AssertDebugLastMessageContains("MoveNext");
         }
 
         private class InnerClassAsyncMethod6


### PR DESCRIPTION
Unit-tests on Linux frequently fails when CleanNamesOfAnonymousDelegates=false or CleanNamesOfAsyncContinuation=false when running on NET8 (instead of NET6)
- LogAfterTaskRunAwait_CleanNamesOfAsyncContinuationsIsFalse_ShouldNotCleanNames

Maybe some new optimization in the NET8 JIT-compiler (inlines so cleanup is not needed)
- [x] Wait for NLog v6.1

See also #5923