### PR TITLE
ConsoleWordHighlightingRule - Support List of Words for simpler configuration

### DIFF
--- a/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
@@ -235,7 +235,7 @@ namespace NLog.UnitTests.Targets
             target.UseDefaultRowHighlightingRules = false;
             target.WordHighlightingRules.Add(new ConsoleWordHighlightingRule
             {
-                Words = new List<string>(new string[] { "big", "bigger", "big big bigger" }),
+                Words = new List<string>(new string[] { "big", "bigger", "big big bigger", "b" }),
                 ForegroundColor = ConsoleOutputColor.DarkRed,
                 BackgroundColor = ConsoleOutputColor.NoChange
             });


### PR DESCRIPTION
With RegEx one could do the following:
```
regex="abc|def|ghi"
```
Now one can do this (Remember to remove any leading/trailing white-spaces):
```
words="abc,def,ghi"
```