### PR TITLE
LogMessageTemplateFormatter - Also use IValueFormatter for positional templates

### DIFF
--- a/src/NLog/Internal/LogMessageTemplateFormatter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatter.cs
@@ -169,7 +169,7 @@ namespace NLog.Internal
                     if (hole.Index != -1 && messageTemplateParameters is null)
                     {
                         holeIndex++;
-                        RenderHole(sb, hole, formatProvider, parameters[hole.Index], true);
+                        RenderHolePositional(sb, hole, formatProvider, parameters[hole.Index]);
                     }
                     else
                     {
@@ -204,22 +204,28 @@ namespace NLog.Internal
             }
         }
 
-        private void RenderHole(StringBuilder sb, Hole hole, IFormatProvider formatProvider, object value, bool legacy = false)
+        private void RenderHolePositional(StringBuilder sb, in Hole hole, IFormatProvider formatProvider, object value)
         {
-            RenderHole(sb, hole.CaptureType, hole.Format, formatProvider, value, legacy);
+            if (hole.CaptureType == CaptureType.Serialize)
+            {
+                RenderHole(sb, CaptureType.Serialize, hole.Format, formatProvider, value);
+            }
+            else
+            {
+                RenderHole(sb, CaptureType.Stringify, hole.Format ?? string.Empty, formatProvider, value);
+            }
         }
 
-        private void RenderHole(StringBuilder sb, CaptureType captureType, string holeFormat, IFormatProvider formatProvider, object value, bool legacy = false)
+        private void RenderHole(StringBuilder sb, in Hole hole, IFormatProvider formatProvider, object value)
+        {
+            RenderHole(sb, hole.CaptureType, hole.Format, formatProvider, value);
+        }
+
+        private void RenderHole(StringBuilder sb, CaptureType captureType, string holeFormat, IFormatProvider formatProvider, object value)
         {
             if (value is null)
             {
                 sb.Append("NULL");
-                return;
-            }
-
-            if (captureType == CaptureType.Normal && legacy)
-            {
-                MessageTemplates.ValueFormatter.FormatToString(value, holeFormat, formatProvider, sb);
             }
             else
             {

--- a/src/NLog/MessageTemplates/ValueFormatter.cs
+++ b/src/NLog/MessageTemplates/ValueFormatter.cs
@@ -83,9 +83,12 @@ namespace NLog.MessageTemplates
                     }
                 case CaptureType.Stringify:
                     {
-                        builder.Append('"');
-                        FormatToString(value, null, formatProvider, builder);
-                        builder.Append('"');
+                        bool includeQuotes = format is null;
+                        if (includeQuotes)
+                            builder.Append('"');
+                        FormatToString(value, format, formatProvider, builder);
+                        if (includeQuotes)
+                            builder.Append('"');
                         return true;
                     }
                 default:
@@ -131,34 +134,37 @@ namespace NLog.MessageTemplates
                 return true;
             }
 
+            // Optimize for types that are pretty much invariant in all cultures when no format-string
+            if (value is IConvertible convertible)
+            {
+                SerializeConvertibleObject(convertible, format, formatProvider, builder);
+                return true;
+            }
+
+            if (value is IFormattable formattable)
+            {
+#if !NETFRAMEWORK
+                if (string.IsNullOrEmpty(format))
+                    builder.AppendFormat(formatProvider, "{0}", formattable); // Support ISpanFormattable
+                else
+#endif
+                    builder.Append(formattable.ToString(format, formatProvider));
+                return true;
+            }
+
             if (value is null)
             {
                 builder.Append("NULL");
                 return true;
             }
 
-            // Optimize for types that are pretty much invariant in all cultures when no format-string
-            if (value is IConvertible convertibleValue)
+            if (convertToString)
             {
-                SerializeConvertibleObject(convertibleValue, format, formatProvider, builder);
+                SerializeConvertToString(value, formatProvider, builder);
                 return true;
             }
-            else
-            {
-                if (!string.IsNullOrEmpty(format) && value is IFormattable formattable)
-                {
-                    builder.Append(formattable.ToString(format, formatProvider));
-                    return true;
-                }
 
-                if (convertToString)
-                {
-                    SerializeConvertToString(value, formatProvider, builder);
-                    return true;
-                }
-
-                return false;
-            }
+            return false;
         }
 
         private void SerializeConvertibleObject(IConvertible value, string format, IFormatProvider formatProvider, StringBuilder builder)
@@ -341,8 +347,7 @@ namespace NLog.MessageTemplates
         /// <param name="builder">Append to this</param>
         public static void FormatToString(object value, string format, IFormatProvider formatProvider, StringBuilder builder)
         {
-            var stringValue = value as string;
-            if (stringValue != null)
+            if (value is string stringValue)
             {
                 builder.Append(stringValue);
             }

--- a/tests/NLog.UnitTests/MessageTemplates/RendererTests.cs
+++ b/tests/NLog.UnitTests/MessageTemplates/RendererTests.cs
@@ -35,6 +35,7 @@ namespace NLog.UnitTests.MessageTemplates
 {
     using System;
     using System.Globalization;
+    using NLog.Config;
     using Xunit;
 
     public class RendererTests
@@ -106,6 +107,23 @@ namespace NLog.UnitTests.MessageTemplates
         }
 
         [Theory]
+        [InlineData("test {0}", "1970-01-01", "test 1970-01-01 00:00:00")]
+        [InlineData("test {0:u}", "1970-01-01", "test 1970-01-01 00:00:00Z")]
+        [InlineData("test {0:MM/dd/yy}", "1970-01-01", "test 01/01/70")]
+        public void RenderDateTimeOverride(string input, string arg, string expected)
+        {
+            var culture = CultureInfo.InvariantCulture;
+
+            var logFactory = new LogFactory();
+            var orgValueFormatter = logFactory.ServiceRepository.ResolveService<IValueFormatter>();
+            var newValueFormatter = new OverrideValueFormatter(orgValueFormatter);
+            logFactory.ServiceRepository.RegisterSingleton<IValueFormatter>(newValueFormatter);
+
+            DateTime dt = DateTime.Parse(arg, culture, DateTimeStyles.AdjustToUniversal);
+            RenderAndTest(input, culture, new object[] { dt }, expected, logFactory);
+        }
+
+        [Theory]
         [InlineData("test {0:c}", "1:2:3:4.5", "test 1.02:03:04.5000000")]
         [InlineData("test {0:hh\\:mm\\:ss\\.ff}", "1:2:3:4.5", "test 02:03:04.50")]
         public void RenderTimeSpan(string input, string arg, string expected)
@@ -127,12 +145,36 @@ namespace NLog.UnitTests.MessageTemplates
             RenderAndTest(input, culture, new object[] { dto }, expected);
         }
 
-        private static void RenderAndTest(string input, CultureInfo culture, object[] args, string expected)
+        private static void RenderAndTest(string input, CultureInfo culture, object[] args, string expected, LogFactory logFactory = null)
         {
             var logEventInfoAlways = new LogEventInfo(LogLevel.Info, "Logger", culture, input, args);
-            logEventInfoAlways.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter(LogManager.LogFactory.ServiceRepository, true, false).MessageFormatter, null);
+            logEventInfoAlways.SetMessageFormatter(new NLog.Internal.LogMessageTemplateFormatter((logFactory ?? new LogFactory()).ServiceRepository, true, false).MessageFormatter, null);
             var templateAlways = logEventInfoAlways.MessageTemplateParameters;
             Assert.Equal(expected, logEventInfoAlways.FormattedMessage);
+        }
+
+        private sealed class OverrideValueFormatter : IValueFormatter
+        {
+            private readonly IValueFormatter _orgValueFormatter;
+
+            public OverrideValueFormatter(IValueFormatter orgValueFormatter)
+            {
+                _orgValueFormatter = orgValueFormatter;
+            }
+
+            public bool FormatValue(object value, string format, NLog.MessageTemplates.CaptureType captureType, IFormatProvider formatProvider, System.Text.StringBuilder builder)
+            {
+                if (string.IsNullOrEmpty(format))
+                {
+                    if (value is DateTime)
+                    {
+                        formatProvider = System.Globalization.CultureInfo.InvariantCulture;
+                        format = "yyyy-MM-dd HH:mm:ss.FFFFFFFK";
+                    }
+                }
+
+                return _orgValueFormatter.FormatValue(value, format, captureType, formatProvider, builder);
+            }
         }
     }
 }


### PR DESCRIPTION
When having forced NLog to use its own LogMessageTemplateFormatter, then it should always use the NLog IValueFormatter.