### PR TITLE
Add Benchmark project and fix boxing issue in ConsoleRowHighlightingRule

### DIFF
--- a/src/NLog.Benchmarks/ColoredConsoleTargetBenchmark.cs
+++ b/src/NLog.Benchmarks/ColoredConsoleTargetBenchmark.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+
+using BenchmarkDotNet.Attributes;
+
+using NLog.Config;
+using NLog.Targets;
+
+namespace NLog.Benchmarks
+{
+    public class ColoredConsoleTargetBenchmark
+    {
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+        private static readonly string message = "The cat sat at the bar.";
+        private MemoryStream memoryStream = new MemoryStream();
+        private StreamWriter streamWriter;
+        private TextWriter oldConsoleOutWriter;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var config = new LoggingConfiguration();
+            var target = new ColoredConsoleTarget("ColoredConsole")
+                { Layout = "${logger} ${message}" };
+            target.WordHighlightingRules.Add(
+                new ConsoleWordHighlightingRule
+                {
+                    ForegroundColor = ConsoleOutputColor.Red,
+                    Text = "at",
+                    IgnoreCase = true
+                });
+
+            config.AddTarget(target);
+            config.AddRule(LogLevel.Debug, LogLevel.Fatal, target);
+
+            LogManager.Configuration = config;
+
+            streamWriter = new StreamWriter(memoryStream);
+            oldConsoleOutWriter = Console.Out;
+            Console.SetOut(streamWriter);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            Console.SetOut(oldConsoleOutWriter);
+            streamWriter.Dispose();
+            memoryStream.Dispose();
+        }
+
+        [Benchmark]
+        public void WordHighlightingTextIgnoreCase()
+        {
+            memoryStream.SetLength(0); // Clear out the previous run
+            for (int i = 0; i < 1000; ++i)
+            {
+                logger.Debug(message);
+            }
+        }
+    }
+}

--- a/src/NLog.Benchmarks/NLog.Benchmarks.csproj
+++ b/src/NLog.Benchmarks/NLog.Benchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36328.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\tests\NLog.UnitTests\NLog.UnitTests.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/NLog.Benchmarks/NLog.Benchmarks.csproj
+++ b/src/NLog.Benchmarks/NLog.Benchmarks.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <OutputType>Exe</OutputType>
+    <SonarQubeTestProject>true</SonarQubeTestProject>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NLog.Benchmarks/NLog.Benchmarks.csproj
+++ b/src/NLog.Benchmarks/NLog.Benchmarks.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
-    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36328.1" />
+    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36422.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\tests\NLog.UnitTests\NLog.UnitTests.csproj" />
+    <ProjectReference Include="..\NLog\NLog.csproj" />
   </ItemGroup>
 </Project>

--- a/src/NLog.Benchmarks/NLog.Benchmarks.csproj
+++ b/src/NLog.Benchmarks/NLog.Benchmarks.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
-    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36422.2" />
+    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36421.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NLog.Benchmarks/Program.cs
+++ b/src/NLog.Benchmarks/Program.cs
@@ -1,0 +1,22 @@
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+
+namespace NLog.Benchmarks
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(System.Reflection.Assembly.GetExecutingAssembly()).Run(
+                args,
+                DefaultConfig.Instance
+                    .AddJob(BenchmarkDotNet.Jobs.Job.Default.WithIterationCount(5).WithWarmupCount(1).WithEnvironmentVariables(Microsoft.VSDiagnostics.VSDiagnosticsConfigurations.GetDotNetObjectAllocEnvironmentVariables(1)).AsMutator())
+                    .AddDiagnoser(new Microsoft.VSDiagnostics.DotNetObjectAllocDiagnoser())
+            ); return;
+#pragma warning disable CS0162 // Unreachable code detected
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig());
+#pragma warning restore CS0162 // Unreachable code detected
+        }
+    }
+}

--- a/src/NLog.Benchmarks/Program.cs
+++ b/src/NLog.Benchmarks/Program.cs
@@ -1,6 +1,4 @@
 using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Jobs;
 
 namespace NLog.Benchmarks
 {
@@ -8,15 +6,7 @@ namespace NLog.Benchmarks
     {
         static void Main(string[] args)
         {
-            BenchmarkSwitcher.FromAssembly(System.Reflection.Assembly.GetExecutingAssembly()).Run(
-                args,
-                DefaultConfig.Instance
-                    .AddJob(BenchmarkDotNet.Jobs.Job.Default.WithIterationCount(5).WithWarmupCount(1).WithEnvironmentVariables(Microsoft.VSDiagnostics.VSDiagnosticsConfigurations.GetDotNetObjectAllocEnvironmentVariables(1)).AsMutator())
-                    .AddDiagnoser(new Microsoft.VSDiagnostics.DotNetObjectAllocDiagnoser())
-            ); return;
-#pragma warning disable CS0162 // Unreachable code detected
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig());
-#pragma warning restore CS0162 // Unreachable code detected
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         }
     }
 }

--- a/src/NLog.sln
+++ b/src/NLog.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.5.33627.172
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.10913.16 main
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog", "NLog\NLog.csproj", "{A0BFF0DB-ED9A-4639-AE86-8E709A1EFC66}"
 EndProject
@@ -80,6 +80,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.Targets.GZipFile", "NLog.Targets.GZipFile\NLog.Targets.GZipFile.csproj", "{D21F3DA2-B45C-4CBC-A392-03ACA2021CC1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.Targets.GZipFile.Tests", "..\tests\NLog.Targets.GZipFile.Tests\NLog.Targets.GZipFile.Tests.csproj", "{DED8D8EC-B0E6-4F2C-9BB8-744FA34230B5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.Benchmarks", "NLog.Benchmarks\NLog.Benchmarks.csproj", "{A20861A9-411E-6150-BF5C-69E8196E5D22}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -199,6 +201,10 @@ Global
 		{DED8D8EC-B0E6-4F2C-9BB8-744FA34230B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DED8D8EC-B0E6-4F2C-9BB8-744FA34230B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DED8D8EC-B0E6-4F2C-9BB8-744FA34230B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A20861A9-411E-6150-BF5C-69E8196E5D22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A20861A9-411E-6150-BF5C-69E8196E5D22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A20861A9-411E-6150-BF5C-69E8196E5D22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A20861A9-411E-6150-BF5C-69E8196E5D22}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -230,6 +236,7 @@ Global
 		{2365D168-476A-4239-9086-71DC8F5A2B75} = {194AB4BD-C817-4C59-A86C-49D89B8C3A64}
 		{D21F3DA2-B45C-4CBC-A392-03ACA2021CC1} = {194AB4BD-C817-4C59-A86C-49D89B8C3A64}
 		{DED8D8EC-B0E6-4F2C-9BB8-744FA34230B5} = {194AB4BD-C817-4C59-A86C-49D89B8C3A64}
+		{A20861A9-411E-6150-BF5C-69E8196E5D22} = {194AB4BD-C817-4C59-A86C-49D89B8C3A64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6B4C8E9F-1E2F-4AB3-993A-8776CFA08DC0}

--- a/src/NLog/Conditions/ConditionMethodExpression.cs
+++ b/src/NLog/Conditions/ConditionMethodExpression.cs
@@ -87,6 +87,11 @@ namespace NLog.Conditions
             return new ConditionMethodExpression(conditionMethodName, ArrayHelper.Empty<ConditionExpression>(), new EvaluateMethodNoParameters(method));
         }
 
+        public static ConditionMethodExpression CreateMethodNoParameters(string conditionMethodName, Func<LogEventInfo, bool> method)
+        {
+            return CreateMethodNoParameters(conditionMethodName, (evt) => method(evt) ? BoxedTrue : BoxedFalse);
+        }
+
         public static ConditionMethodExpression CreateMethodOneParameter(string conditionMethodName, Func<LogEventInfo, object?, object?> method, IList<ConditionExpression> methodParameters)
         {
             var methodParameter = methodParameters[0];

--- a/src/NLog/Targets/ColoredConsoleSystemPrinter.cs
+++ b/src/NLog/Targets/ColoredConsoleSystemPrinter.cs
@@ -101,12 +101,12 @@ namespace NLog.Targets
 
         public IList<ConsoleRowHighlightingRule> DefaultConsoleRowHighlightingRules { get; } = new List<ConsoleRowHighlightingRule>()
         {
-            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Fatal", static (evt) => evt.Level == LogLevel.Fatal ? NLog.Conditions.ConditionExpression.BoxedTrue : NLog.Conditions.ConditionExpression.BoxedFalse), ConsoleOutputColor.Red, ConsoleOutputColor.NoChange),
-            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Error", static (evt) => evt.Level == LogLevel.Error ? NLog.Conditions.ConditionExpression.BoxedTrue : NLog.Conditions.ConditionExpression.BoxedFalse), ConsoleOutputColor.Red, ConsoleOutputColor.NoChange),
-            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Warn", static (evt) => evt.Level == LogLevel.Warn ? NLog.Conditions.ConditionExpression.BoxedTrue : NLog.Conditions.ConditionExpression.BoxedFalse), ConsoleOutputColor.Yellow, ConsoleOutputColor.NoChange),
-            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Info", static (evt) => evt.Level == LogLevel.Info ? NLog.Conditions.ConditionExpression.BoxedTrue : NLog.Conditions.ConditionExpression.BoxedFalse), ConsoleOutputColor.White, ConsoleOutputColor.NoChange),
-            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Debug", static (evt) => evt.Level == LogLevel.Debug ? NLog.Conditions.ConditionExpression.BoxedTrue : NLog.Conditions.ConditionExpression.BoxedFalse), ConsoleOutputColor.Gray, ConsoleOutputColor.NoChange),
-            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Trace", static (evt) => evt.Level == LogLevel.Trace ? NLog.Conditions.ConditionExpression.BoxedTrue : NLog.Conditions.ConditionExpression.BoxedFalse), ConsoleOutputColor.Gray, ConsoleOutputColor.NoChange),
+            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Fatal", (evt) => evt.Level == LogLevel.Fatal), ConsoleOutputColor.Red, ConsoleOutputColor.NoChange),
+            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Error", (evt) => evt.Level == LogLevel.Error), ConsoleOutputColor.Red, ConsoleOutputColor.NoChange),
+            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Warn", (evt) => evt.Level == LogLevel.Warn), ConsoleOutputColor.Yellow, ConsoleOutputColor.NoChange),
+            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Info", (evt) => evt.Level == LogLevel.Info), ConsoleOutputColor.White, ConsoleOutputColor.NoChange),
+            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Debug", (evt) => evt.Level == LogLevel.Debug), ConsoleOutputColor.Gray, ConsoleOutputColor.NoChange),
+            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Trace", (evt) => evt.Level == LogLevel.Trace), ConsoleOutputColor.Gray, ConsoleOutputColor.NoChange),
         };
     }
 }

--- a/src/NLog/Targets/ColoredConsoleSystemPrinter.cs
+++ b/src/NLog/Targets/ColoredConsoleSystemPrinter.cs
@@ -101,12 +101,12 @@ namespace NLog.Targets
 
         public IList<ConsoleRowHighlightingRule> DefaultConsoleRowHighlightingRules { get; } = new List<ConsoleRowHighlightingRule>()
         {
-            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Fatal", (evt) => evt.Level == LogLevel.Fatal), ConsoleOutputColor.Red, ConsoleOutputColor.NoChange),
-            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Error", (evt) => evt.Level == LogLevel.Error), ConsoleOutputColor.Red, ConsoleOutputColor.NoChange),
-            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Warn", (evt) => evt.Level == LogLevel.Warn), ConsoleOutputColor.Yellow, ConsoleOutputColor.NoChange),
-            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Info", (evt) => evt.Level == LogLevel.Info), ConsoleOutputColor.White, ConsoleOutputColor.NoChange),
-            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Debug", (evt) => evt.Level == LogLevel.Debug), ConsoleOutputColor.Gray, ConsoleOutputColor.NoChange),
-            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Trace", (evt) => evt.Level == LogLevel.Trace), ConsoleOutputColor.Gray, ConsoleOutputColor.NoChange),
+            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Fatal", static (evt) => evt.Level == LogLevel.Fatal ? NLog.Conditions.ConditionExpression.BoxedTrue : NLog.Conditions.ConditionExpression.BoxedFalse), ConsoleOutputColor.Red, ConsoleOutputColor.NoChange),
+            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Error", static (evt) => evt.Level == LogLevel.Error ? NLog.Conditions.ConditionExpression.BoxedTrue : NLog.Conditions.ConditionExpression.BoxedFalse), ConsoleOutputColor.Red, ConsoleOutputColor.NoChange),
+            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Warn", static (evt) => evt.Level == LogLevel.Warn ? NLog.Conditions.ConditionExpression.BoxedTrue : NLog.Conditions.ConditionExpression.BoxedFalse), ConsoleOutputColor.Yellow, ConsoleOutputColor.NoChange),
+            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Info", static (evt) => evt.Level == LogLevel.Info ? NLog.Conditions.ConditionExpression.BoxedTrue : NLog.Conditions.ConditionExpression.BoxedFalse), ConsoleOutputColor.White, ConsoleOutputColor.NoChange),
+            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Debug", static (evt) => evt.Level == LogLevel.Debug ? NLog.Conditions.ConditionExpression.BoxedTrue : NLog.Conditions.ConditionExpression.BoxedFalse), ConsoleOutputColor.Gray, ConsoleOutputColor.NoChange),
+            new ConsoleRowHighlightingRule(Conditions.ConditionMethodExpression.CreateMethodNoParameters("level == LogLevel.Trace", static (evt) => evt.Level == LogLevel.Trace ? NLog.Conditions.ConditionExpression.BoxedTrue : NLog.Conditions.ConditionExpression.BoxedFalse), ConsoleOutputColor.Gray, ConsoleOutputColor.NoChange),
         };
     }
 }


### PR DESCRIPTION
The new benchmark measures the performance of using `ColoredConsoleTarget` to log to a console. The performance fix is to remove the boxing that is occurring in the condition passed to `ConsoleRowHighlightingRule`. It now checks the condition of the expression and returns a cached boxed boolean value from `ConditionExpression`. The current benchmarks results in saving ~8% allocations (from 1.33Mb to 1.22Mb). This doesn't result in a noticable CPU performance saving but should help with GC overhead.

# Before - 1.33Mb
<img width="746" height="217" alt="Before" src="https://github.com/user-attachments/assets/526cda42-a43a-4373-8340-65ad380ffd3b" />
<img width="1231" height="219" alt="image" src="https://github.com/user-attachments/assets/8614d66a-240c-412c-93b6-7e67a9f7b9b5" />

# After - 1.22Mb
<img width="745" height="181" alt="After" src="https://github.com/user-attachments/assets/c64c074a-7e7c-4566-b4df-93b3630b6075" />
<img width="558" height="292" alt="image" src="https://github.com/user-attachments/assets/bffebf0f-60db-49a5-a870-406768d37b6b" />
