### PR TITLE
Improve nullability ergonomics for `ConditionExpression` cast

### DIFF
--- a/src/NLog/Conditions/ConditionExpression.cs
+++ b/src/NLog/Conditions/ConditionExpression.cs
@@ -53,6 +53,9 @@ namespace NLog.Conditions
         /// </summary>
         /// <param name="conditionExpressionText">Condition text to be converted.</param>
         /// <returns>Condition expression tree.</returns>
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(conditionExpressionText))]
+#endif
         public static implicit operator ConditionExpression?(string? conditionExpressionText)
         {
             if (conditionExpressionText is null) return null;


### PR DESCRIPTION
This currently produces a "_Possible null reference assignment. [CS8601](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8601))_" warning:
```csharp
var filter = new ConditionBasedFilter {
    Condition = "1 == 1",
    Action = FilterResult.IgnoreFinal
};
```

This is because the `ConditionExpression` implicit cast from `string?` returns a `ConditionExpression?` (i.e. it may be null), but the `ConditionBasedFilter.Condition` property does not allow nulls.

In this case though, the warning is a false positive, because the cast only actually returns null when the original string is null - and we (and the compiler) can clearly see that the string is not null. Fortunately, we can easily resolve this using the [`[NotNullIfNotNull]` attribute](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/nullable-analysis#conditional-post-conditions-notnullwhen-maybenullwhen-and-notnullifnotnull) (available in .NET Core 3+ and .NET Standard 2.1).