### PR TITLE
XmlLoggingConfiguration - Reduce output for InternalLogger Info-Level

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -258,7 +258,7 @@ namespace NLog.Config
                 {
                     if (fileWatcher != null && !fileWatcher.IsDisposed)
                     {
-                        InternalLogger.Info("AutoReload Config File Monitor stopping, since no active configuration");
+                        InternalLogger.Debug("AutoReload Config File Monitor stopping, since no active configuration");
                         fileWatcher.Dispose();
                     }
                 }
@@ -267,7 +267,7 @@ namespace NLog.Config
                     InternalLogger.Debug("AutoReload Config File Monitor refreshing after configuration changed");
                     if (fileWatcher is null || fileWatcher.IsDisposed)
                     {
-                        InternalLogger.Info("AutoReload Config File Monitor starting");
+                        InternalLogger.Debug("AutoReload Config File Monitor starting");
                         fileWatcher = new AutoReloadConfigFileWatcher(configFactory);
                         lock (_watchers)
                         {
@@ -600,7 +600,10 @@ namespace NLog.Config
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{base.ToString()}, FilePath={_originalFileName}";
+            if (AutoReload)
+                return $"{base.ToString()}, AutoReload=true, FilePath={_originalFileName}";
+            else
+                return $"{base.ToString()}, FilePath={_originalFileName}";
         }
 
         private sealed class AutoReloadConfigFileWatcher : IDisposable

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -282,7 +282,7 @@ namespace NLog
             _config.OnConfigurationAssigned(this);
             _config.Dump();
             ReconfigExistingLoggers();
-            InternalLogger.Info("Configuration initialized.");
+            InternalLogger.Info("Configuration initialized: {0}", config);
         }
 
         private void ServiceRepository_TypeRegistered(object sender, ServiceRepositoryUpdateEventArgs e)


### PR DESCRIPTION
NLog v6 have become more noisy, lets improve:
```
2025-09-30 12:02:06.8120 Info Registered target NLog.Targets.FileTarget(Name=logfile)
2025-09-30 12:02:06.8292 Info NLog, Version=6.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c. File version: 6.0.4.4534. Product version: 6.0.4+0f63723442db07c29eb838b0bce8b5633031a04e. GlobalAssemblyCache: False
2025-09-30 12:02:06.8292 Info AutoReload Config File Monitor starting
2025-09-30 12:02:06.8551 Info Configuration initialized.
2025-09-30 12:06:14.3522 Info AppDomain Shutting down. LogFactory closing...
2025-09-30 12:06:14.3522 Info AutoReload Config File Monitor stopping, since no active configuration
2025-09-30 12:06:14.3635 Info LogFactory has been disposed.
```