### PR TITLE
ValueFormatter - Skip quotes for CaptureType.Stringify unless legacy mode

### DIFF
--- a/src/NLog/Internal/LogMessageTemplateFormatter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatter.cs
@@ -279,13 +279,13 @@ namespace NLog.Internal
 
         private void RenderHolePositional(StringBuilder sb, in Hole hole, IFormatProvider? formatProvider, object? value)
         {
-            if (hole.CaptureType == CaptureType.Serialize)
+            if (hole.CaptureType == CaptureType.Serialize || (value is null && hole.CaptureType != CaptureType.Stringify))
             {
-                RenderHole(sb, CaptureType.Serialize, hole.Format, formatProvider, value);
+                RenderHole(sb, hole.CaptureType, hole.Format, formatProvider, value);
             }
             else
             {
-                RenderHole(sb, CaptureType.Stringify, hole.Format ?? string.Empty, formatProvider, value);
+                ValueFormatter.FormatValue(value, hole.Format, CaptureType.Stringify, formatProvider, sb);
             }
         }
 
@@ -296,7 +296,13 @@ namespace NLog.Internal
 
         private void RenderHole(StringBuilder sb, CaptureType captureType, string? holeFormat, IFormatProvider? formatProvider, object? value)
         {
-            if (value is null)
+            if (captureType == CaptureType.Stringify)
+            {
+                sb.Append('"');
+                ValueFormatter.FormatValue(value, holeFormat, captureType, formatProvider, sb);
+                sb.Append('"');
+            }
+            else if (value is null)
             {
                 sb.Append("NULL");
             }

--- a/src/NLog/Layouts/JSON/JsonLayout.cs
+++ b/src/NLog/Layouts/JSON/JsonLayout.cs
@@ -453,9 +453,10 @@ namespace NLog.Layouts
 
                 BeginJsonProperty(sb, propName, beginJsonMessage, true);
 
-                // Overrides MaxRecursionLimit as message-template tells us it is unsafe
                 int originalStart = sb.Length;
+                sb.Append('"');
                 ValueFormatter.FormatValue(propertyValue, format, captureType, formatProvider, sb);
+                sb.Append('"');
                 PerformJsonEscapeIfNeeded(sb, originalStart);
             }
             else

--- a/src/NLog/MessageTemplates/ValueFormatter.cs
+++ b/src/NLog/MessageTemplates/ValueFormatter.cs
@@ -118,7 +118,7 @@ namespace NLog.MessageTemplates
                     }
                 case CaptureType.Stringify:
                     {
-                        bool includeQuotes = format is null || _legacyStringQuotes;
+                        bool includeQuotes = _legacyStringQuotes && (builder.Length == 0 || builder[builder.Length - 1] != '"');
                         if (includeQuotes)
                             builder.Append('"');
                         FormatToString(value, format, formatProvider, builder);

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -578,6 +578,27 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(@"{""Message"":{""data"":{}}}", jsonLayout.Render(logEventInfo));
         }
 
+        [Theory]
+        [InlineData("Hello World", @"{""stringifyMe"":""Hello World""}")]
+        [InlineData("Hello\nWorld", @"{""stringifyMe"":""Hello\nWorld""}")]
+        [InlineData(default(string), @"{""stringifyMe"":""""}")]
+        [InlineData(1234, @"{""stringifyMe"":""1234""}")]
+        [InlineData(false, @"{""stringifyMe"":""False""}")]
+        [InlineData(true, @"{""stringifyMe"":""True""}")]
+        [InlineData(1.1, @"{""stringifyMe"":""1.1""}")]
+        public void JsonEncodeStringifyValues(IConvertible propertyValue, string expectedOutput)
+        {
+            var jsonLayout = new JsonLayout()
+            {
+                IncludeEventProperties = true,
+                MaxRecursionLimit = 1,
+            };
+
+            var logEventInfo = LogEventInfo.Create(LogLevel.Info, string.Empty, System.Globalization.CultureInfo.InvariantCulture, "{$stringifyMe}", new object[] { propertyValue });
+
+            Assert.Equal(expectedOutput, jsonLayout.Render(logEventInfo));
+        }
+
         [Fact]
         [Obsolete("Replaced by ScopeContext.PushProperty or Logger.PushScopeProperty using ${scopeproperty}. Marked obsolete on NLog 5.0")]
         public void IncludeMdcJsonProperties()

--- a/tests/NLog.UnitTests/MessageTemplates/RendererTests.cs
+++ b/tests/NLog.UnitTests/MessageTemplates/RendererTests.cs
@@ -77,6 +77,9 @@ namespace NLog.UnitTests.MessageTemplates
         [InlineData("Always use the correct {enum:D}", new object[] { NLog.Config.ExceptionRenderingFormat.Method }, "Always use the correct 4")]
         [InlineData("hello {0,-10}", new object[] { null }, "hello NULL      ")]
         [InlineData("hello {0,10}", new object[] { null }, "hello       NULL")]
+        [InlineData("hello {$world}", new object[] { null }, @"hello """"")]    // stringify always adds quotes
+        [InlineData("hello {$world}", new object[] { 123 }, @"hello ""123""")]  // stringify always adds quotes
+        [InlineData("hello {$world}", new object[] { "World" }, @"hello ""World""")]  // stringify always adds quotes
         [InlineData("Status [0x{status:X8}]", new object[] { 16 }, "Status [0x00000010]")]
         public void RenderTest(string input, object[] args, string expected)
         {

--- a/tests/NLog.UnitTests/MessageTemplates/ValueFormatterTest.cs
+++ b/tests/NLog.UnitTests/MessageTemplates/ValueFormatterTest.cs
@@ -85,7 +85,7 @@ namespace NLog.UnitTests.MessageTemplates
             StringBuilder builder = new StringBuilder();
             var result = CreateValueFormatter().FormatValue(@class, null, CaptureType.Stringify, new CultureInfo("fr-FR"), builder);
             Assert.True(result);
-            Assert.Equal("\"str\"", builder.ToString());
+            Assert.Equal("str", builder.ToString());
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace NLog.UnitTests.MessageTemplates
             StringBuilder builder = new StringBuilder();
             var result = CreateValueFormatter().FormatValue(@class, null, CaptureType.Stringify, new CultureInfo("fr-FR"), builder);
             Assert.True(result);
-            Assert.Equal("\"Test\"", builder.ToString());
+            Assert.Equal("Test", builder.ToString());
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace NLog.UnitTests.MessageTemplates
             StringBuilder builder = new StringBuilder();
             var result = CreateValueFormatter().FormatValue(@class, null, CaptureType.Stringify, new CultureInfo("fr-FR"), builder);
             Assert.True(result);
-            var expectedValue = $"\"{typeof(Test1).FullName}\"";
+            var expectedValue = $"{typeof(Test1).FullName}";
             Assert.Equal(expectedValue, builder.ToString());
         }
 
@@ -152,7 +152,7 @@ namespace NLog.UnitTests.MessageTemplates
         [Theory]
         [InlineData(CaptureType.Normal, "NULL")]
         [InlineData(CaptureType.Serialize, "null")]
-        [InlineData(CaptureType.Stringify, "\"\"")]
+        [InlineData(CaptureType.Stringify, "")]
         public void TestSerializationWillBeSuccessfulForNull(CaptureType captureType, string expected)
         {
             StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
Followup to #5955 (Instead of magic-value logic around Format-parameter, then change the official contract)

`CaptureType.Stringify` is kind of exotic, so not expecting much friction from the change (and legacy mode is available).