### PR TITLE
FileTarget - Improve archive cleanup when using ArchiveSuffixFormat with datetime

### DIFF
--- a/src/NLog/Targets/FileArchiveHandlers/LegacyArchiveFileNameHandler.cs
+++ b/src/NLog/Targets/FileArchiveHandlers/LegacyArchiveFileNameHandler.cs
@@ -172,7 +172,7 @@ namespace NLog.Targets.FileArchiveHandlers
             if (!File.Exists(archiveFullPath))
             {
                 // Move active file to archive
-                InternalLogger.Info("{0}: Move file from '{1}' to '{2}'", _fileTarget, newFileInfo.FullName, archiveFullPath);
+                InternalLogger.Info("{0}: Archive moving file from '{1}' to '{2}'", _fileTarget, newFileInfo.FullName, archiveFullPath);
                 File.Move(newFileInfo.FullName, archiveFullPath);
                 return true;
             }
@@ -201,7 +201,7 @@ namespace NLog.Targets.FileArchiveHandlers
         private void ArchiveFileAppendExisting(string newFilePath, string archiveFilePath)
         {
             // TODO Handle double footer
-            InternalLogger.Info("{0}: Already exists, append to {1}", _fileTarget, archiveFilePath);
+            InternalLogger.Info("{0}: Archive appending to already existing file: {1}", _fileTarget, archiveFilePath);
 
             var fileShare = FileShare.Read | FileShare.Delete;
             using (FileStream newFileStream = File.Open(newFilePath, FileMode.Open, FileAccess.ReadWrite, fileShare))

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -820,7 +820,7 @@ namespace NLog.Targets
             if (currentFileSize == 0 || currentFileSize + 1 < ArchiveAboveSize)
                 return false;
 
-            InternalLogger.Debug("{0}: Archive because of filesize={1} of file: {2}", this, currentFileSize, fileAppender.FilePath);
+            InternalLogger.Debug("{0}: Archive because of rolling filesize={1} for file: {2}", this, currentFileSize, fileAppender.FilePath);
             return true;
         }
 
@@ -830,7 +830,7 @@ namespace NLog.Targets
             if (nextArchiveTime >= firstLogEvent.TimeStamp)
                 return false;
 
-            InternalLogger.Debug("{0}: Archive because of filetime of file: {1}", this, fileAppender.FilePath);
+            InternalLogger.Debug("{0}: Archive because of rolling filetime={1} for file: {2}", this, nextArchiveTime, fileAppender.FilePath);
             return true;
         }
 


### PR DESCRIPTION
The archive-cleanup-logic was very strict about excluding old files matching wildcard when suffix part contained letters, now only extra strict when using `archiveSuffixFormat="_{0}"`.

Adding support for:
```xml
    <target xsi:type="File" name="fileTarget" fileName="app.log"
            archiveEvery="Day"
            archiveSuffixFormat="_{1:ddd}"
            maxArchiveDays="7" />
```