### PR TITLE
FileTarget - Fix archive cleanup when only single old file and using MaxArchiveDays

### DIFF
--- a/src/NLog/Targets/FileArchiveHandlers/RollingArchiveFileHandler.cs
+++ b/src/NLog/Targets/FileArchiveHandlers/RollingArchiveFileHandler.cs
@@ -57,6 +57,7 @@ namespace NLog.Targets.FileArchiveHandlers
             {
                 var newFilePath = FileTarget.CleanFullFilePath(newFileName);
                 var parseArchiveSequenceNo = !Path.GetFileNameWithoutExtension(newFilePath).Any(c => char.IsDigit(c));
+                bool initialFileExists = initialFileOpen && File.Exists(newFilePath);
                 bool deletedOldFiles = DeleteOldFilesBeforeArchive(newFilePath, initialFileOpen, parseArchiveSequenceNo);
 
                 if (_fileTarget.MaxArchiveFiles == 0 || _fileTarget.MaxArchiveFiles == 1 || (initialFileOpen && _fileTarget.DeleteOldFileOnStartup))
@@ -66,6 +67,11 @@ namespace NLog.Targets.FileArchiveHandlers
                         FixWindowsFileSystemTunneling(newFilePath);
                     }
                     return 0;
+                }
+
+                if (initialFileExists && deletedOldFiles)
+                {
+                    FixWindowsFileSystemTunneling(newFilePath);
                 }
             }
 


### PR DESCRIPTION
Fixed bug in archive-cleanup where it skipped cleanup when wildcard only finds single file. Fixed resetting of Windows Tunneling File-Timestamp when recycling old FileName.

Adding support for:
```xml
    <target xsi:type="File" name="fileTarget" fileName="app_${date:format=ddd}.log" maxArchiveDays="6" />
```