### PR TITLE
PropertiesDictionary - Initial 3 properties without dictionary

### DIFF
--- a/src/NLog/Internal/LogMessageTemplateFormatter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatter.cs
@@ -135,7 +135,7 @@ namespace NLog.Internal
         /// <param name="parameters">Parameters for the holes.</param>
         /// <param name="sb">The String Builder destination.</param>
         /// <param name="messageTemplateParameters">Parameters for the holes.</param>
-        private void Render(string template, IFormatProvider? formatProvider, object?[] parameters, StringBuilder sb, out IList<MessageTemplateParameter>? messageTemplateParameters)
+        private void Render(string template, IFormatProvider? formatProvider, object?[] parameters, StringBuilder sb, out MessageTemplateParameter[]? messageTemplateParameters)
         {
             messageTemplateParameters = null;
 
@@ -200,7 +200,7 @@ namespace NLog.Internal
         }
 
 #if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-        internal string Render(ref TemplateEnumerator templateEnumerator, IFormatProvider? formatProvider, in ReadOnlySpan<object?> parameters, out IList<MessageTemplateParameter>? messageTemplateParameters)
+        internal string Render(ref TemplateEnumerator templateEnumerator, IFormatProvider? formatProvider, in ReadOnlySpan<object?> parameters, out MessageTemplateParameter[]? messageTemplateParameters)
         {
             // Handle message-template-format or string-format or mixed-format
             messageTemplateParameters = null;
@@ -264,9 +264,9 @@ namespace NLog.Internal
         }
 #endif
 
-        private static IList<MessageTemplateParameter>? VerifyMessageTemplateParameters(IList<MessageTemplateParameter>? messageTemplateParameters, int holeIndex)
+        private static MessageTemplateParameter[]? VerifyMessageTemplateParameters(MessageTemplateParameter[]? messageTemplateParameters, int holeIndex)
         {
-            if (messageTemplateParameters != null && holeIndex != messageTemplateParameters.Count)
+            if (messageTemplateParameters != null && holeIndex != messageTemplateParameters.Length)
             {
                 var truncateParameters = new MessageTemplateParameter[holeIndex];
                 for (int i = 0; i < truncateParameters.Length; ++i)

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -465,9 +465,10 @@ namespace NLog
         {
             get
             {
-                if (_properties?.MessageProperties.Count > 0)
+                var messageProperties = _properties?.MessageProperties;
+                if (messageProperties?.Length > 0)
                 {
-                    return new MessageTemplateParameters(_properties.MessageProperties);
+                    return new MessageTemplateParameters(messageProperties);
                 }
                 else if (_parameters?.Length > 0)
                 {
@@ -711,7 +712,7 @@ namespace NLog
             if (properties.Count > 5)
                 return false; // too many properties, too costly to check
 
-            if (properties.Count == _parameters?.Length && properties.Count == properties.MessageProperties.Count)
+            if (properties.Count == _parameters?.Length && properties.Count == properties.MessageProperties.Length)
                 return true; // Already checked formatted message, no need to do it twice
 
             return HasImmutableProperties(properties);
@@ -720,12 +721,11 @@ namespace NLog
         private static bool HasImmutableProperties(PropertiesDictionary properties)
         {
             var messageProperties = properties.MessageProperties;
-            if (properties.Count == messageProperties.Count)
+            if (properties.Count == messageProperties.Length)
             {
                 // Skip enumerator allocation when all properties comes from the message-template
-                for (int i = 0; i < messageProperties.Count; ++i)
+                foreach (var property in messageProperties)
                 {
-                    var property = messageProperties[i];
                     if (!IsSafeToDeferFormatting(property.Value))
                         return false;
                 }
@@ -841,7 +841,7 @@ namespace NLog
             }
 
             // If message-template-properties have not been provided as contructor-input, then allow parsing of message-template.
-            return _properties.MessageProperties.Count == 0 || _properties.MessageProperties[0].CaptureType == CaptureType.Unknown;
+            return _properties.MessageProperties.Length == 0;
         }
     }
 }

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -411,24 +411,24 @@ namespace NLog
         /// Gets the dictionary of per-event context properties.
         /// </summary>
         /// <param name="templateParameters">Provided when having parsed the message template and capture template parameters (else null)</param>
-        internal PropertiesDictionary? TryCreatePropertiesInternal(IList<MessageTemplateParameter>? templateParameters = null)
+        internal PropertiesDictionary? TryCreatePropertiesInternal(MessageTemplateParameter[]? templateParameters = null)
         {
             var properties = _properties;
             if (properties is null)
             {
-                if (templateParameters?.Count > 0 || (templateParameters is null && HasMessageTemplateParameters))
+                if (templateParameters?.Length > 0 || (templateParameters is null && HasMessageTemplateParameters))
                 {
                     return CreatePropertiesInternal(templateParameters);
                 }
             }
             else if (templateParameters != null)
             {
-                properties.ResetMessageProperties(templateParameters);
+                properties.ResetMessageProperties(templateParameters, templateParameters.Length);
             }
             return properties;
         }
 
-        internal PropertiesDictionary CreatePropertiesInternal(IList<MessageTemplateParameter>? templateParameters = null, int initialCapacity = 0)
+        internal PropertiesDictionary CreatePropertiesInternal(MessageTemplateParameter[]? templateParameters = null, int initialCapacity = 0)
         {
             if (_properties is null)
             {
@@ -841,7 +841,7 @@ namespace NLog
             }
 
             // If message-template-properties have not been provided as contructor-input, then allow parsing of message-template.
-            return _properties.MessageProperties.Count == 0;
+            return _properties.MessageProperties.Count == 0 || _properties.MessageProperties[0].CaptureType == CaptureType.Unknown;
         }
     }
 }

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -642,7 +642,7 @@ namespace NLog
         private LogEventInfo RenderPreformattedLogEvent(LogMessageTemplateFormatter messageTemplateFormatter, LogLevel level, Exception? exception, IFormatProvider? formatProvider, string messageTemplate, in ReadOnlySpan<object?> args, ref MessageTemplates.TemplateEnumerator templateEnumerator)
         {
             string formattedMessage = messageTemplate;
-            IList<MessageTemplates.MessageTemplateParameter>? messageTemplateParameters = null;
+            MessageTemplates.MessageTemplateParameter[]? messageTemplateParameters = null;
 
             try
             {

--- a/tests/NLog.Benchmarks/Internal/PropertiesDictionaryBenchmark.cs
+++ b/tests/NLog.Benchmarks/Internal/PropertiesDictionaryBenchmark.cs
@@ -1,0 +1,346 @@
+//
+// Copyright (c) 2004-2024 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of Jaroslaw Kowalski nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+namespace NLog.Benchmarks
+{
+    using BenchmarkDotNet.Attributes;
+    using NLog.Internal;
+
+    public class PropertiesDictionaryBenchmark
+    {
+        [Benchmark]
+        public void CreateOneProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello"] = "World";
+        }
+
+        [Benchmark]
+        public void CreateTwoProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+        }
+
+        [Benchmark]
+        public void CreateThreeProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            properties["Hello3"] = "World3";
+        }
+
+        [Benchmark]
+        public void CreateFourProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            properties["Hello3"] = "World3";
+            properties["Hello4"] = "World4";
+        }
+
+        [Benchmark]
+        public void CreateFiveProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            properties["Hello3"] = "World3";
+            properties["Hello4"] = "World4";
+            properties["Hello5"] = "World5";
+        }
+
+        [Benchmark]
+        public void LookupOneProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello"] = "World";
+            for (int i = 0; i < 1000; i++)
+            {
+                if (!properties.TryGetValue("Hello", out var _))
+                    break;
+            }
+        }
+
+        [Benchmark]
+        public void LookupTwoProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            for (int i = 0; i < 1000; i++)
+            {
+                if (!properties.TryGetValue("Hello1", out var _))
+                    break;
+                if (!properties.TryGetValue("Hello2", out var _))
+                    break;
+            }
+        }
+
+        [Benchmark]
+        public void LookupThreeProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            properties["Hello3"] = "World3";
+            for (int i = 0; i < 1000; i++)
+            {
+                if (!properties.TryGetValue("Hello1", out var _))
+                    break;
+                if (!properties.TryGetValue("Hello2", out var _))
+                    break;
+                if (!properties.TryGetValue("Hello3", out var _))
+                    break;
+            }
+        }
+
+        [Benchmark]
+        public void LookupFourProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            properties["Hello3"] = "World3";
+            properties["Hello4"] = "World4";
+            for (int i = 0; i < 1000; i++)
+            {
+                if (!properties.TryGetValue("Hello1", out var _))
+                    break;
+                if (!properties.TryGetValue("Hello2", out var _))
+                    break;
+                if (!properties.TryGetValue("Hello3", out var _))
+                    break;
+                if (!properties.TryGetValue("Hello4", out var _))
+                    break;
+            }
+        }
+
+        [Benchmark]
+        public void LookupFiveProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            properties["Hello3"] = "World3";
+            properties["Hello4"] = "World4";
+            properties["Hello5"] = "World5";
+            for (int i = 0; i < 1000; i++)
+            {
+                if (!properties.TryGetValue("Hello1", out var _))
+                    break;
+                if (!properties.TryGetValue("Hello2", out var _))
+                    break;
+                if (!properties.TryGetValue("Hello3", out var _))
+                    break;
+                if (!properties.TryGetValue("Hello4", out var _))
+                    break;
+                if (!properties.TryGetValue("Hello5", out var _))
+                    break;
+            }
+        }
+
+        [Benchmark]
+        public void NotFoundLookupOneProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello"] = "World";
+            for (int i = 0; i < 1000; i++)
+            {
+                if (properties.TryGetValue("Hello6", out var _))
+                    break;
+            }
+        }
+
+        [Benchmark]
+        public void NotFoundLookupTwoProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            for (int i = 0; i < 1000; i++)
+            {
+                if (properties.TryGetValue("Hello6", out var _))
+                    break;
+            }
+        }
+
+        [Benchmark]
+        public void NotFoundLookupThreeProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            properties["Hello3"] = "World3";
+            for (int i = 0; i < 1000; i++)
+            {
+                if (properties.TryGetValue("Hello6", out var _))
+                    break;
+            }
+        }
+
+        [Benchmark]
+        public void NotFoundLookupFourProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            properties["Hello3"] = "World3";
+            properties["Hello4"] = "World4";
+            for (int i = 0; i < 1000; i++)
+            {
+                if (properties.TryGetValue("Hello6", out var _))
+                    break;
+            }
+        }
+
+        [Benchmark]
+        public void NotFoundLookupFiveProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            properties["Hello3"] = "World3";
+            properties["Hello4"] = "World4";
+            properties["Hello5"] = "World5";
+            for (int i = 0; i < 1000; i++)
+            {
+                if (properties.TryGetValue("Hello6", out var _))
+                    break;
+            }
+        }
+
+        [Benchmark]
+        public void EnumerateOneProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello"] = "World";
+            for (int i = 0; i < 1000; i++)
+            {
+                using (var propertyEnumerator = properties.GetPropertyEnumerator())
+                {
+                    while (propertyEnumerator.MoveNext())
+                    {
+                        if (propertyEnumerator.Current.Key is null)
+                            return;
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void EnumerateTwoProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            for (int i = 0; i < 1000; i++)
+            {
+                using (var propertyEnumerator = properties.GetPropertyEnumerator())
+                {
+                    while (propertyEnumerator.MoveNext())
+                    {
+                        if (propertyEnumerator.Current.Key is null)
+                            return;
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void EnumerateThreeProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            properties["Hello3"] = "World3";
+            for (int i = 0; i < 1000; i++)
+            {
+                using (var propertyEnumerator = properties.GetPropertyEnumerator())
+                {
+                    while (propertyEnumerator.MoveNext())
+                    {
+                        if (propertyEnumerator.Current.Key is null)
+                            return;
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void EnumerateFourProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            properties["Hello3"] = "World3";
+            properties["Hello4"] = "World4";
+            for (int i = 0; i < 1000; i++)
+            {
+                using (var propertyEnumerator = properties.GetPropertyEnumerator())
+                {
+                    while (propertyEnumerator.MoveNext())
+                    {
+                        if (propertyEnumerator.Current.Key is null)
+                            return;
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void EnumerateFiveProperty()
+        {
+            var properties = new PropertiesDictionary();
+            properties["Hello1"] = "World1";
+            properties["Hello2"] = "World2";
+            properties["Hello3"] = "World3";
+            properties["Hello4"] = "World4";
+            properties["Hello5"] = "World5";
+            for (int i = 0; i < 1000; i++)
+            {
+                using (var propertyEnumerator = properties.GetPropertyEnumerator())
+                {
+                    while (propertyEnumerator.MoveNext())
+                    {
+                        if (propertyEnumerator.Current.Key is null)
+                            return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/NLog.UnitTests/LogMessageFormatterTests.cs
+++ b/tests/NLog.UnitTests/LogMessageFormatterTests.cs
@@ -224,5 +224,25 @@ namespace NLog.UnitTests
             Assert.Contains(new MessageTemplateParameter("Username", "John", null, CaptureType.Serialize), logEventInfo.MessageTemplateParameters);
             Assert.Contains(new MessageTemplateParameter("Application", "BestApplicationEver", "l", CaptureType.Normal), logEventInfo.MessageTemplateParameters);
         }
+
+        [Fact]
+        public void MessageTemplatePositional()
+        {
+            var logEventInfo = new LogEventInfo(LogLevel.Info, "MyLogger", null, "{0} {1} {2}", new object[] { "Foo", 123, Guid.NewGuid() });
+            logEventInfo.Properties["0"] = "HelloWorld1";
+            logEventInfo.Properties["1"] = "HelloWorld2";
+            logEventInfo.Properties["2"] = "HelloWorld3";
+            var messageTemplateParameters = logEventInfo.MessageTemplateParameters;
+            Assert.True(messageTemplateParameters.IsValidTemplate);
+            Assert.True(messageTemplateParameters.IsPositional);
+            Assert.Equal(3, messageTemplateParameters.Count);
+            Assert.Contains(new MessageTemplateParameter("0", logEventInfo.Parameters[0], null, CaptureType.Normal), messageTemplateParameters);
+            Assert.Contains(new MessageTemplateParameter("1", logEventInfo.Parameters[1], null, CaptureType.Normal), messageTemplateParameters);
+            Assert.Contains(new MessageTemplateParameter("2", logEventInfo.Parameters[2], null, CaptureType.Normal), messageTemplateParameters);
+            Assert.Equal(3, logEventInfo.Properties.Count);
+            Assert.Equal("HelloWorld1", logEventInfo.Properties["0"]);
+            Assert.Equal("HelloWorld2", logEventInfo.Properties["1"]);
+            Assert.Equal("HelloWorld3", logEventInfo.Properties["2"]);
+        }
     }
 }


### PR DESCRIPTION
Not sure I like the increased complexity to reduce memory-allocation for LogEvents with 3 properties or less.

But still curious of the performance gain, by not doing dictionary allocation for LogEvents with just EventId / EventName (When not coming from NLog.Extensions.Logging that already performs this optimization).