### PR TITLE
EventProperties - Format Dictionary Properties correctly

### DIFF
--- a/src/NLog/Internal/FormatHelper.cs
+++ b/src/NLog/Internal/FormatHelper.cs
@@ -65,7 +65,7 @@ namespace NLog.Internal
             return Convert.ToString(value, formatProvider);
         }
 
-        internal static string TryFormatToString(object? value, string? format, IFormatProvider? formatProvider)
+        internal static string? TryFormatToString(object? value, string? format, IFormatProvider? formatProvider)
         {
             if (value is IFormattable formattable)
             {
@@ -75,13 +75,13 @@ namespace NLog.Internal
             {
                 return convertible.ToString(formatProvider);
             }
-            else if (value is System.Collections.IEnumerable)
+            else if (value is null)
             {
                 return string.Empty;
             }
             else
             {
-                return value?.ToString() ?? string.Empty;
+                return null;    // Complex formatting requires IValueFormatter
             }
         }
     }

--- a/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
@@ -139,7 +139,7 @@ namespace NLog.LayoutRenderers
             {
                 if (TryGetValue(logEvent, out var value))
                 {
-                    string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, Culture));
+                    var stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, Culture));
                     return stringValue;
                 }
                 return string.Empty;

--- a/src/NLog/LayoutRenderers/FuncLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/FuncLayoutRenderer.cs
@@ -106,7 +106,7 @@ namespace NLog.LayoutRenderers
             if (!MessageTemplates.ValueFormatter.FormatAsJson.Equals(Format))
             {
                 var value = RenderValue(logEvent);
-                string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, Culture));
+                var stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, Culture));
                 return stringValue;
             }
             return null;

--- a/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
@@ -103,7 +103,7 @@ namespace NLog.LayoutRenderers
             if (!MessageTemplates.ValueFormatter.FormatAsJson.Equals(Format))
             {
                 var value = GetValue();
-                string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, Culture));
+                var stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, Culture));
                 return stringValue;
             }
             return null;

--- a/src/NLog/LayoutRenderers/ScopeContextPropertyLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ScopeContextPropertyLayoutRenderer.cs
@@ -93,7 +93,7 @@ namespace NLog.LayoutRenderers
             if (!MessageTemplates.ValueFormatter.FormatAsJson.Equals(Format))
             {
                 var value = GetValue();
-                string stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, Culture));
+                var stringValue = FormatHelper.TryFormatToString(value, Format, GetFormatProvider(logEvent, Culture));
                 return stringValue;
             }
             return null;

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -190,7 +190,7 @@ namespace NLog.Layouts
         protected override string GetFormattedMessage(LogEventInfo logEvent)
         {
             var objectValue = IsFixed ? FixedObjectValue : RenderObjectValue(logEvent, null);
-            return FormatHelper.TryFormatToString(objectValue, null, CultureInfo.InvariantCulture);
+            return FormatHelper.TryFormatToString(objectValue, null, CultureInfo.InvariantCulture) ?? objectValue?.ToString() ?? string.Empty;
         }
 
         /// <inheritdoc/>

--- a/tests/NLog.UnitTests/LayoutRenderers/EventPropertiesTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/EventPropertiesTests.cs
@@ -34,6 +34,7 @@
 namespace NLog.UnitTests.LayoutRenderers
 {
     using System;
+    using System.Collections.Generic;
     using NLog.Layouts;
     using Xunit;
 
@@ -80,6 +81,20 @@ namespace NLog.UnitTests.LayoutRenderers
 
             // empty
             Assert.Equal("", layout.Render(logEvent));
+        }
+
+        [Fact]
+        public void TestDictionaryProperty()
+        {
+            Layout layout = "${event-properties:prop1}";
+            LogEventInfo logEvent = LogEventInfo.Create(LogLevel.Info, "logger1", "message1");
+            logEvent.Properties["prop1"] = new Dictionary<string, string>()
+            {
+                { "key1", "value1" }
+            };
+
+            // Dictionary should render as key-value pairs
+            Assert.Equal("key1=value1", layout.Render(logEvent));
         }
 
         [Fact]


### PR DESCRIPTION
Fix bug introduced with the change to nullable API. See also: #5809