### PR TITLE
PropertiesDictionary - Simplify enumerator when mixing property types

### DIFF
--- a/src/NLog/Internal/PropertiesDictionary.cs
+++ b/src/NLog/Internal/PropertiesDictionary.cs
@@ -446,29 +446,28 @@ namespace NLog.Internal
         {
             private readonly PropertiesDictionary _dictionary;
             private Dictionary<object, PropertyValue>.Enumerator _eventEnumerator;
-            private int? _messagePropertiesIndex;
+            private int _messagePropertiesIndex;
 
             public PropertyDictionaryEnumerator(PropertiesDictionary dictionary)
             {
                 _dictionary = dictionary;
+                _messagePropertiesIndex = (dictionary._messageProperties?.Count > 0 && dictionary._eventProperties is null) ? -1 : int.MinValue;
                 _eventEnumerator = dictionary._eventProperties?.GetEnumerator() ?? default(Dictionary<object, PropertyValue>.Enumerator);
-                _messagePropertiesIndex = dictionary._messageProperties?.Count > 0 ? -1 : default(int?);
             }
 
             public KeyValuePair<object, object?> Current
             {
                 get
                 {
-                    if (_messagePropertiesIndex.HasValue)
+                    if (_messagePropertiesIndex >= 0)
                     {
-                        var property = _dictionary.MessageProperties[_messagePropertiesIndex.Value];
+                        var property = _dictionary.MessageProperties[_messagePropertiesIndex];
                         return new KeyValuePair<object, object?>(property.Name, property.Value);
                     }
-                    if (_dictionary._eventProperties != null)
+                    else
                     {
                         return new KeyValuePair<object, object?>(_eventEnumerator.Current.Key, _eventEnumerator.Current.Value.Value);
                     }
-                    throw new InvalidOperationException();
                 }
             }
 
@@ -476,16 +475,15 @@ namespace NLog.Internal
             {
                 get
                 {
-                    if (_messagePropertiesIndex.HasValue)
+                    if (_messagePropertiesIndex >= 0)
                     {
-                        return _dictionary.MessageProperties[_messagePropertiesIndex.Value];
+                        return _dictionary.MessageProperties[_messagePropertiesIndex];
                     }
-                    if (_dictionary._eventProperties != null)
+                    else
                     {
                         string parameterName = XmlHelper.XmlConvertToString(_eventEnumerator.Current.Key ?? string.Empty) ?? string.Empty;
                         return new MessageTemplateParameter(parameterName, _eventEnumerator.Current.Value.Value, null, CaptureType.Unknown);
                     }
-                    throw new InvalidOperationException();
                 }
             }
 
@@ -493,17 +491,16 @@ namespace NLog.Internal
             {
                 get
                 {
-                    if (_messagePropertiesIndex.HasValue)
+                    if (_messagePropertiesIndex >= 0)
                     {
-                        var property = _dictionary.MessageProperties[_messagePropertiesIndex.Value];
+                        var property = _dictionary.MessageProperties[_messagePropertiesIndex];
                         return new KeyValuePair<string, object?>(property.Name, property.Value);
                     }
-                    if (_dictionary._eventProperties != null)
+                    else
                     {
                         string propertyName = XmlHelper.XmlConvertToString(_eventEnumerator.Current.Key ?? string.Empty) ?? string.Empty;
                         return new KeyValuePair<string, object?>(propertyName, _eventEnumerator.Current.Value.Value);
                     }
-                    throw new InvalidOperationException();
                 }
             }
 
@@ -511,53 +508,23 @@ namespace NLog.Internal
 
             public bool MoveNext()
             {
-                if (_messagePropertiesIndex.HasValue && MoveNextValidMessageParameter())
+                if (_messagePropertiesIndex >= -1)
                 {
-                    return true;
-                }
-
-                if (_dictionary._eventProperties != null)
-                {
-                    return MoveNextValidEventProperty();
-                }
-
-                return false;
-            }
-
-            private bool MoveNextValidEventProperty()
-            {
-                while (_eventEnumerator.MoveNext())
-                {
-                    if (!_eventEnumerator.Current.Value.IsMessageProperty)
-                        return true;
-                }
-                return false;
-            }
-
-            private bool MoveNextValidMessageParameter()
-            {
-                var messageProperties = _dictionary.MessageProperties;
-                if (_messagePropertiesIndex.HasValue && messageProperties != null && _messagePropertiesIndex.Value + 1 < messageProperties.Count)
-                {
-                    var eventProperties = _dictionary._eventProperties;
-                    if (eventProperties is null)
+                    if (_messagePropertiesIndex + 1 < _dictionary._messageProperties?.Count)
                     {
-                        _messagePropertiesIndex = _messagePropertiesIndex.Value + 1;
+                        _messagePropertiesIndex += 1;
                         return true;
                     }
-
-                    for (int i = _messagePropertiesIndex.Value + 1; i < messageProperties.Count; ++i)
-                    {
-                        if (eventProperties.TryGetValue(messageProperties[i].Name, out var valueItem) && valueItem.IsMessageProperty)
-                        {
-                            _messagePropertiesIndex = i;
-                            return true;
-                        }
-                    }
+                    return false;
                 }
-
-                _messagePropertiesIndex = null;
-                return false;
+                else if (_dictionary._eventProperties is null)
+                {
+                    return false;
+                }
+                else
+                {
+                    return _eventEnumerator.MoveNext();
+                }
             }
 
             public void Dispose()
@@ -567,8 +534,8 @@ namespace NLog.Internal
 
             public void Reset()
             {
-                _messagePropertiesIndex = _dictionary._messageProperties?.Count > 0 ? -1 : default(int?);
-                _eventEnumerator = default(Dictionary<object, PropertyValue>.Enumerator);
+                _messagePropertiesIndex = (_dictionary._messageProperties?.Count > 0 && _dictionary._eventProperties is null ) ? -1 : int.MinValue;
+                _eventEnumerator = _dictionary._eventProperties?.GetEnumerator() ?? default(Dictionary<object, PropertyValue>.Enumerator);
             }
         }
 

--- a/tests/NLog.UnitTests/Internal/PropertiesDictionaryTests.cs
+++ b/tests/NLog.UnitTests/Internal/PropertiesDictionaryTests.cs
@@ -369,67 +369,62 @@ namespace NLog.UnitTests.Internal
             Assert.True(dictionary.Values.Contains(666));
             Assert.False(dictionary.Values.Contains(42));
 
-            int i = 0;
+            HashSet<string> keys = new HashSet<string>();
             foreach (var item in dictionary)
             {
-                switch (i++)
+                if (item.Key.Equals("Hello World"))
                 {
-                    case 1:
-                        Assert.Equal("Hello World", item.Key);
-                        Assert.Equal(999, item.Value);
-                        break;
-                    case 0:
-                        Assert.Equal("Goodbye World", item.Key);
-                        Assert.Equal(666, item.Value);
-                        break;
+                    Assert.Equal(999, item.Value);
+                    Assert.True(keys.Add((string)item.Key));
+                }
+                else if (item.Key.Equals("Goodbye World"))
+                {
+                    Assert.Equal(666, item.Value);
+                    Assert.True(keys.Add((string)item.Key));
+                }
+                else
+                {
+                    Assert.Null(item.Key);
                 }
             }
-            Assert.Equal(2, i);
+            Assert.Equal(2, keys.Count);
 
-            i = 0;
+            keys.Clear();
             foreach (var item in dictionary.Keys)
             {
-                switch (i++)
-                {
-                    case 1:
-                        Assert.Equal("Hello World", item);
-                        break;
-                    case 0:
-                        Assert.Equal("Goodbye World", item);
-                        break;
-                }
+                if (item.Equals("Hello World"))
+                    Assert.True(keys.Add((string)item));
+                else if (item.Equals("Goodbye World"))
+                    Assert.True(keys.Add((string)item));
+                else
+                    Assert.Null(item);
             }
-            Assert.Equal(2, i);
+            Assert.Equal(2, keys.Count);
 
-            i = 0;
+            keys.Clear();
             foreach (var item in dictionary.Values)
             {
-                switch (i++)
-                {
-                    case 1:
-                        Assert.Equal(999, item);
-                        break;
-                    case 0:
-                        Assert.Equal(666, item);
-                        break;
-                }
+                if (item.Equals(999))
+                    Assert.True(keys.Add(item.ToString()));
+                else if (item.Equals(666))
+                    Assert.True(keys.Add(item.ToString()));
+                else
+                    Assert.Null(item);
             }
+            Assert.Equal(2, keys.Count);
 
+            keys.Clear();
             dictionary["Goodbye World"] = 42;
-            i = 0;
             foreach (var item in dictionary.Keys)
             {
-                switch (i++)
-                {
-                    case 0:
-                        Assert.Equal("Hello World", item);
-                        break;
-                    case 1:
-                        Assert.Equal("Goodbye World", item);
-                        break;
-                }
+                if (item.Equals("Hello World"))
+                    Assert.True(keys.Add(item.ToString()));
+                else if (item.Equals("Goodbye World"))
+                    Assert.True(keys.Add(item.ToString()));
+                else
+                    Assert.Null(item);
             }
-            Assert.Equal(2, i);
+            Assert.Equal(2, keys.Count);
 
             dictionary.Remove("Hello World");
             Assert.Single(dictionary);


### PR DESCRIPTION
No longer attempt to guarantee property ordering, when overriding message-template-properties with additional properties.

By default the underlying Dictionary will try to keep the insert ordering to some point.