### PR TITLE
BufferingTargetWrapper - Improve InternalLogger output when WrappedTarget is NULL

### DIFF
--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -560,7 +560,7 @@ namespace NLog.Targets.Wrappers
         {
             if (WrappedTarget is null)
             {
-                InternalLogger.Error("{0}: WrappedTarget is NULL", this);
+                InternalLogger.Debug("{0}: No output because WrappedTarget is NULL", this);
                 return 0;
             }
 

--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -316,7 +316,7 @@ namespace NLog.Targets.Wrappers
         {
             if (WrappedTarget is null)
             {
-                InternalLogger.Error("{0}: WrappedTarget is NULL", this);
+                InternalLogger.Debug("{0}: No output because WrappedTarget is NULL", this);
                 return;
             }
 


### PR DESCRIPTION
NLog already alerts when initialization fails, no need to repeat the same error over and over.