### PR TITLE
Fix nullable warnings from NET10 annotations

### DIFF
--- a/src/NLog/Common/AsyncLogEventInfo.cs
+++ b/src/NLog/Common/AsyncLogEventInfo.cs
@@ -89,7 +89,7 @@ namespace NLog.Common
         public bool Equals(AsyncLogEventInfo other) => ReferenceEquals(Continuation, other.Continuation) && ReferenceEquals(LogEvent, other.LogEvent);
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is AsyncLogEventInfo other && Equals(other);
+        public override bool Equals(object? obj) => obj is AsyncLogEventInfo other && Equals(other);
 
         /// <inheritdoc/>
         public override int GetHashCode()

--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -422,7 +422,7 @@ namespace NLog.Common
                     return;
                 }
 
-                string parentDirectory = Path.GetDirectoryName(filename);
+                var parentDirectory = Path.GetDirectoryName(filename);
                 if (!string.IsNullOrEmpty(parentDirectory))
                 {
                     Directory.CreateDirectory(parentDirectory);

--- a/src/NLog/Conditions/ConditionExpression.cs
+++ b/src/NLog/Conditions/ConditionExpression.cs
@@ -53,7 +53,7 @@ namespace NLog.Conditions
         /// </summary>
         /// <param name="conditionExpressionText">Condition text to be converted.</param>
         /// <returns>Condition expression tree.</returns>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(conditionExpressionText))]
 #endif
         public static implicit operator ConditionExpression?(string? conditionExpressionText)

--- a/src/NLog/Conditions/ConditionLiteralExpression.cs
+++ b/src/NLog/Conditions/ConditionLiteralExpression.cs
@@ -78,7 +78,7 @@ namespace NLog.Conditions
                 return $"'{charValue}'";
             }
 
-            return Convert.ToString(LiteralValue, CultureInfo.InvariantCulture);
+            return Convert.ToString(LiteralValue, CultureInfo.InvariantCulture) ?? string.Empty;
         }
 
         /// <summary>

--- a/src/NLog/Conditions/ConditionMethods.cs
+++ b/src/NLog/Conditions/ConditionMethods.cs
@@ -78,7 +78,10 @@ namespace NLog.Conditions
         [ConditionMethod("contains")]
         public static bool Contains(string? haystack, string? needle, [Optional, DefaultParameterValue(true)] bool ignoreCase)
         {
-            return haystack?.IndexOf(needle, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) >= 0;
+            if (haystack is null || needle is null)
+                return false;
+
+            return haystack.IndexOf(needle, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) >= 0;
         }
 
         /// <summary>
@@ -91,7 +94,10 @@ namespace NLog.Conditions
         [ConditionMethod("starts-with")]
         public static bool StartsWith(string? haystack, string? needle, [Optional, DefaultParameterValue(true)] bool ignoreCase)
         {
-            return haystack?.StartsWith(needle, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) == true;
+            if (haystack is null || needle is null)
+                return false;
+
+            return haystack.StartsWith(needle, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -104,7 +110,10 @@ namespace NLog.Conditions
         [ConditionMethod("ends-with")]
         public static bool EndsWith(string? haystack, string? needle, [Optional, DefaultParameterValue(true)] bool ignoreCase)
         {
-            return haystack?.EndsWith(needle, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) == true;
+            if (haystack is null || needle is null)
+                return false;
+
+            return haystack.EndsWith(needle, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/src/NLog/Conditions/ConditionRelationalExpression.cs
+++ b/src/NLog/Conditions/ConditionRelationalExpression.cs
@@ -216,14 +216,14 @@ namespace NLog.Conditions
 
                 if (type1 == typeof(LogLevel))
                 {
-                    string strval = Convert.ToString(val, CultureInfo.InvariantCulture);
+                    string strval = Convert.ToString(val, CultureInfo.InvariantCulture) ?? string.Empty;
                     val = LogLevel.FromString(strval);
                     return true;
                 }
 
                 if (type1 == typeof(string))
                 {
-                    val = Convert.ToString(val, CultureInfo.InvariantCulture);
+                    val = Convert.ToString(val, CultureInfo.InvariantCulture) ?? string.Empty;
                     return true;
                 }
             }

--- a/src/NLog/Config/AssemblyExtensionLoader.cs
+++ b/src/NLog/Config/AssemblyExtensionLoader.cs
@@ -314,7 +314,7 @@ namespace NLog.Config
         {
             HashSet<string> alreadyRegistered = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                 {
-                    nlogAssembly.FullName
+                    nlogAssembly.FullName ?? string.Empty
                 };
 
             foreach (var extensionDll in extensionDlls)
@@ -325,7 +325,7 @@ namespace NLog.Config
                     if (extensionAssembly != null)
                     {
                         LoadAssembly(factory, extensionAssembly, string.Empty);
-                        alreadyRegistered.Add(extensionAssembly.FullName);
+                        alreadyRegistered.Add(extensionAssembly.FullName ?? string.Empty);
                     }
                 }
                 catch (Exception ex)
@@ -349,7 +349,7 @@ namespace NLog.Config
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Assembly.GetTypes() Incompatible with trimming.")]
         private void RegisterAppDomainAssemblies(ConfigurationItemFactory factory, Assembly nlogAssembly, HashSet<string> alreadyRegistered)
         {
-            alreadyRegistered.Add(nlogAssembly.FullName);
+            alreadyRegistered.Add(nlogAssembly.FullName ?? string.Empty);
 
             var allAssemblies = LogFactory.DefaultAppEnvironment.GetAppDomainRuntimeAssemblies();
             foreach (var assembly in allAssemblies)
@@ -395,7 +395,7 @@ namespace NLog.Config
         internal static IEnumerable<KeyValuePair<string, string>> GetAutoLoadingFileLocations()
         {
             var nlogAssemblyLocation = AssemblyHelpers.GetAssemblyFileLocation(typeof(LogFactory).Assembly);
-            var nlogAssemblyDirectory = string.IsNullOrEmpty(nlogAssemblyLocation) ? nlogAssemblyLocation : PathHelpers.TrimDirectorySeparators(System.IO.Path.GetDirectoryName(nlogAssemblyLocation));
+            var nlogAssemblyDirectory = string.IsNullOrEmpty(nlogAssemblyLocation) ? nlogAssemblyLocation : PathHelpers.TrimDirectorySeparators(System.IO.Path.GetDirectoryName(nlogAssemblyLocation) ?? string.Empty);
             InternalLogger.Debug("Auto loading based on NLog-Assembly found location: {0}", nlogAssemblyDirectory);
             if (!string.IsNullOrEmpty(nlogAssemblyDirectory))
                 yield return new KeyValuePair<string, string>(nlogAssemblyDirectory, nameof(nlogAssemblyLocation));

--- a/src/NLog/Config/LoggerNameMatcher.cs
+++ b/src/NLog/Config/LoggerNameMatcher.cs
@@ -170,7 +170,8 @@ namespace NLog.Config
                 : base(pattern, pattern) { }
             public override bool NameMatches(string loggerName)
             {
-                if (loggerName is null) return _matchingArgument is null;
+                if (loggerName is null || _matchingArgument is null)
+                    return _matchingArgument is null;
                 return loggerName.Equals(_matchingArgument, StringComparison.Ordinal);
             }
         }
@@ -186,7 +187,8 @@ namespace NLog.Config
                 : base(pattern, pattern.Substring(0, pattern.Length - 1)) { }
             public override bool NameMatches(string loggerName)
             {
-                if (loggerName is null) return _matchingArgument is null;
+                if (loggerName is null || _matchingArgument is null)
+                    return _matchingArgument is null;
                 return loggerName.StartsWith(_matchingArgument, StringComparison.Ordinal);
             }
         }
@@ -202,7 +204,8 @@ namespace NLog.Config
                 : base(pattern, pattern.Substring(1)) { }
             public override bool NameMatches(string loggerName)
             {
-                if (loggerName is null) return _matchingArgument is null;
+                if (loggerName is null || _matchingArgument is null)
+                    return _matchingArgument is null;
                 return loggerName.EndsWith(_matchingArgument, StringComparison.Ordinal);
             }
         }
@@ -218,7 +221,8 @@ namespace NLog.Config
                 : base(pattern, pattern.Substring(1, pattern.Length - 2)) { }
             public override bool NameMatches(string loggerName)
             {
-                if (loggerName is null) return _matchingArgument is null;
+                if (loggerName is null || _matchingArgument is null)
+                    return _matchingArgument is null;
                 return loggerName.IndexOf(_matchingArgument, StringComparison.Ordinal) >= 0;
             }
         }

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -115,7 +115,7 @@ namespace NLog.Config
         internal LoggingRule[] GetLoggingRulesThreadSafe() { lock (_loggingRules) return _loggingRules.ToArray(); }
         private void AddLoggingRulesThreadSafe(LoggingRule rule) { lock (_loggingRules) _loggingRules.Add(rule); }
 
-        private bool TryGetTargetThreadSafe(string name, out Target target) { lock (_targets) return _targets.TryGetValue(name, out target); }
+        private bool TryGetTargetThreadSafe(string name, out Target? target) { lock (_targets) return _targets.TryGetValue(name, out target); }
         private List<Target> GetAllTargetsThreadSafe() { lock (_targets) return _targets.Values.ToList(); }
 
         private Target? RemoveTargetThreadSafe(string name)

--- a/src/NLog/Config/MethodFactory.cs
+++ b/src/NLog/Config/MethodFactory.cs
@@ -170,7 +170,7 @@ namespace NLog.Config
 
         internal void RegisterDefinition(string methodName, MethodInfo methodInfo)
         {
-            object[] defaultMethodParameters = ResolveDefaultMethodParameters(methodInfo, out var manyParameterMinCount, out var manyParameterMaxCount, out var includeLogEvent);
+            var defaultMethodParameters = ResolveDefaultMethodParameters(methodInfo, out var manyParameterMinCount, out var manyParameterMaxCount, out var includeLogEvent);
 
             if (manyParameterMaxCount > 0)
                 RegisterManyParameters(methodName, (inputArgs) => InvokeMethodInfo(methodInfo, ResolveMethodParameters(defaultMethodParameters, inputArgs)), manyParameterMinCount, manyParameterMaxCount, includeLogEvent, methodInfo);
@@ -205,7 +205,7 @@ namespace NLog.Config
             }
         }
 
-        private static object InvokeMethodInfo(MethodInfo methodInfo, object?[] methodArgs)
+        private static object? InvokeMethodInfo(MethodInfo methodInfo, object?[] methodArgs)
         {
             try
             {
@@ -220,13 +220,13 @@ namespace NLog.Config
             }
         }
 
-        private static object[] ResolveDefaultMethodParameters(MethodInfo methodInfo, out int manyParameterMinCount, out int manyParameterMaxCount, out bool includeLogEvent)
+        private static object?[] ResolveDefaultMethodParameters(MethodInfo methodInfo, out int manyParameterMinCount, out int manyParameterMaxCount, out bool includeLogEvent)
         {
             var methodParameters = methodInfo.GetParameters();
 
             manyParameterMinCount = 0;
             manyParameterMaxCount = methodParameters.Length;
-            var defaultMethodParameters = new object[methodParameters.Length];
+            var defaultMethodParameters = new object?[methodParameters.Length];
             for (int i = 0; i < defaultMethodParameters.Length; ++i)
             {
                 if (methodParameters[i].IsOptional)

--- a/src/NLog/Config/PropertyTypeConverter.cs
+++ b/src/NLog/Config/PropertyTypeConverter.cs
@@ -198,7 +198,7 @@ namespace NLog.Config
 
         internal static CultureInfo? ConvertToCultureInfo(string? stringValue)
         {
-            if (StringHelpers.IsNullOrWhiteSpace(stringValue))
+            if (stringValue is null || StringHelpers.IsNullOrWhiteSpace(stringValue))
                 return null;
             if (nameof(CultureInfo.InvariantCulture).Equals(stringValue, StringComparison.OrdinalIgnoreCase))
                 return CultureInfo.InvariantCulture;

--- a/src/NLog/Filters/WhenRepeatedFilter.cs
+++ b/src/NLog/Filters/WhenRepeatedFilter.cs
@@ -148,8 +148,7 @@ namespace NLog.Filters
 
                     FilterInfoKey filterInfoKey = RenderFilterInfoKey(logEvent, targetBuilder.Result);
 
-                    FilterInfo filterInfo;
-                    if (!_repeatFilter.TryGetValue(filterInfoKey, out filterInfo))
+                    if (!_repeatFilter.TryGetValue(filterInfoKey, out var filterInfo))
                     {
                         filterInfo = CreateFilterInfo(logEvent);
                         if (filterInfo.StringBuffer != null)
@@ -379,7 +378,7 @@ namespace NLog.Filters
                 }
                 else
                 {
-                    StringHashCode = StringComparer.Ordinal.GetHashCode(StringValue);
+                    StringHashCode = stringValue is null ? 0 : StringComparer.Ordinal.GetHashCode(stringValue);
                 }
             }
 
@@ -406,7 +405,7 @@ namespace NLog.Filters
                 return ReferenceEquals(_stringBuffer, other._stringBuffer) && ReferenceEquals(StringValue, other.StringValue);
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return obj is FilterInfoKey key && Equals(key);
             }

--- a/src/NLog/Internal/AppEnvironmentWrapper.cs
+++ b/src/NLog/Internal/AppEnvironmentWrapper.cs
@@ -248,7 +248,7 @@ namespace NLog.Internal.Fakeables
             var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
             var entryLocation = AssemblyHelpers.GetAssemblyFileLocation(entryAssembly);
             if (!string.IsNullOrEmpty(entryLocation))
-                return Path.GetDirectoryName(entryLocation);
+                return Path.GetDirectoryName(entryLocation) ?? string.Empty;
             else
                 return string.Empty;
         }

--- a/src/NLog/Internal/AssemblyHelpers.cs
+++ b/src/NLog/Internal/AssemblyHelpers.cs
@@ -43,7 +43,7 @@ namespace NLog.Internal
     internal static class AssemblyHelpers
     {
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Returns empty string for assemblies embedded in a single-file app", "IL3000")]
-        public static string GetAssemblyFileLocation(Assembly assembly)
+        public static string GetAssemblyFileLocation(Assembly? assembly)
         {
 #if !NETFRAMEWORK
             // Notice assembly can be loaded from nuget-cache using NTFS-hard-link, and return unexpected file-location.

--- a/src/NLog/Internal/CallSiteInformation.cs
+++ b/src/NLog/Internal/CallSiteInformation.cs
@@ -307,13 +307,18 @@ namespace NLog.Internal
         /// </summary>
         private static bool SkipStackFrameWhenHidden(MethodBase? stackMethod)
         {
+            if (stackMethod is null)
+                return true;
+
             var assembly = StackTraceUsageUtils.LookupAssemblyFromMethod(stackMethod);
             if (assembly is null || IsHiddenAssembly(assembly))
-            {
                 return true;
-            }
 
-            return stackMethod is null || IsHiddenClassType(stackMethod.DeclaringType);
+            var declaringType = stackMethod.DeclaringType;
+            if (declaringType != null && IsHiddenClassType(declaringType))
+                return true;
+
+            return false;
         }
 
         /// <summary>
@@ -321,7 +326,7 @@ namespace NLog.Internal
         /// </summary>
         private static bool SkipStackFrameWhenLoggerType(MethodBase? stackMethod, Type loggerType)
         {
-            Type? declaringType = stackMethod?.DeclaringType;
+            var declaringType = stackMethod?.DeclaringType;
             var isLoggerType = declaringType != null && (loggerType == declaringType || declaringType.IsSubclassOf(loggerType) || loggerType.IsAssignableFrom(declaringType));
             return isLoggerType;
         }

--- a/src/NLog/Internal/DictionaryEntryEnumerable.cs
+++ b/src/NLog/Internal/DictionaryEntryEnumerable.cs
@@ -106,7 +106,7 @@ namespace NLog.Internal
         {
             public static readonly IDictionaryEnumerator Default = new EmptyDictionaryEnumerator();
             public DictionaryEntry Entry => default;
-            public object? Key => default;
+            public object Key => string.Empty;
             public object? Value => default;
             object? IEnumerator.Current => Entry;
             public bool MoveNext() => false;

--- a/src/NLog/Internal/ExceptionMessageFormatProvider.cs
+++ b/src/NLog/Internal/ExceptionMessageFormatProvider.cs
@@ -42,7 +42,7 @@ namespace NLog.Internal
     {
         internal static readonly ExceptionMessageFormatProvider Instance = new ExceptionMessageFormatProvider();
 
-        string ICustomFormatter.Format(string format, object arg, IFormatProvider formatProvider)
+        string ICustomFormatter.Format(string? format, object? arg, IFormatProvider? formatProvider)
         {
             if (arg is Exception exception)
             {
@@ -77,7 +77,7 @@ namespace NLog.Internal
             return exception;
         }
 
-        object? IFormatProvider.GetFormat(Type formatType)
+        object? IFormatProvider.GetFormat(Type? formatType)
         {
             return (formatType == typeof(ICustomFormatter)) ? this : null;
         }

--- a/src/NLog/Internal/FormatHelper.cs
+++ b/src/NLog/Internal/FormatHelper.cs
@@ -62,7 +62,7 @@ namespace NLog.Internal
                 }
             }
 
-            return Convert.ToString(value, formatProvider);
+            return Convert.ToString(value, formatProvider) ?? string.Empty;
         }
 
         internal static string? TryFormatToString(object? value, string? format, IFormatProvider? formatProvider)

--- a/src/NLog/Internal/LogMessageTemplateFormatter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatter.cs
@@ -199,7 +199,7 @@ namespace NLog.Internal
             messageTemplateParameters = VerifyMessageTemplateParameters(messageTemplateParameters, holeIndex);
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         internal string Render(ref TemplateEnumerator templateEnumerator, IFormatProvider? formatProvider, in ReadOnlySpan<object?> parameters, out IList<MessageTemplateParameter>? messageTemplateParameters)
         {
             // Handle message-template-format or string-format or mixed-format

--- a/src/NLog/Internal/MultiFileWatcher.cs
+++ b/src/NLog/Internal/MultiFileWatcher.cs
@@ -110,7 +110,7 @@ namespace NLog.Internal
         {
             try
             {
-                var directory = Path.GetDirectoryName(fileName);
+                var directory = Path.GetDirectoryName(fileName) ?? string.Empty;
                 var fileFilter = Path.GetFileName(fileName);
                 directory = Path.GetFullPath(directory);
                 if (!Directory.Exists(directory))

--- a/src/NLog/Internal/ObjectGraphScanner.cs
+++ b/src/NLog/Internal/ObjectGraphScanner.cs
@@ -198,7 +198,9 @@ namespace NLog.Internal
                     {
                         for (int i = 0; i < list.Count; i++)
                         {
-                            elements.Add(list[i]);
+                            var item = list[i];
+                            if (item != null)
+                                elements.Add(item);
                         }
                     }
                     return elements;
@@ -209,7 +211,7 @@ namespace NLog.Internal
 
             //new list to prevent: Collection was modified after the enumerator was instantiated.
             //note .Cast is tread-unsafe! But at least it isn't a ICollection / IList
-            return enumerable.Cast<object>().ToList();
+            return enumerable.Cast<object>().Where(o => o != null).ToList();
         }
     }
 }

--- a/src/NLog/Internal/ObjectReflectionCache.cs
+++ b/src/NLog/Internal/ObjectReflectionCache.cs
@@ -260,10 +260,18 @@ namespace NLog.Internal
             foreach (var prop in properties)
             {
                 var getterMethod = prop.GetGetMethod();
-                Type propertyType = getterMethod.ReturnType;
-                ReflectionHelpers.LateBoundMethod valueLookup = ReflectionHelpers.CreateLateBoundMethod(getterMethod);
-                TypeCode typeCode = Type.GetTypeCode(propertyType); // Skip cyclic-reference checks when not TypeCode.Object
-                fastLookup[fastAccessIndex++] = new FastPropertyLookup(prop.Name, typeCode, valueLookup);
+                var propertyType = getterMethod?.ReturnType;
+                if (getterMethod is null || propertyType is null)
+                {
+                    // Should never happen due to IsValidPublicProperty check
+                    fastLookup[fastAccessIndex++] = new FastPropertyLookup(prop.Name, TypeCode.String, (o, p) => null);
+                }
+                else
+                {
+                    ReflectionHelpers.LateBoundMethod valueLookup = ReflectionHelpers.CreateLateBoundMethod(getterMethod);
+                    TypeCode typeCode = Type.GetTypeCode(propertyType); // Skip cyclic-reference checks when not TypeCode.Object
+                    fastLookup[fastAccessIndex++] = new FastPropertyLookup(prop.Name, typeCode, valueLookup);
+                }
             }
             return fastLookup;
         }

--- a/src/NLog/Internal/PropertiesDictionary.cs
+++ b/src/NLog/Internal/PropertiesDictionary.cs
@@ -747,7 +747,7 @@ namespace NLog.Internal
 
             public bool Equals(string propertyName) => Equals(_propertyName, propertyName);
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 if (obj is string stringObj)
                     return Equals(_propertyName, stringObj);

--- a/src/NLog/Internal/PropertyHelper.cs
+++ b/src/NLog/Internal/PropertyHelper.cs
@@ -172,15 +172,15 @@ namespace NLog.Internal
         {
             InternalLogger.Debug("Object reflection needed to configure instance of type: {0} (Lookup property={1})", obj.GetType(), propertyName);
 
-            PropertyInfo propInfo = obj.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
-            if (propInfo != null)
+            var propInfo = obj.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
+            if (propInfo is null)
             {
-                result = propInfo;
-                return true;
+                result = null;
+                return false;
             }
 
-            result = null;
-            return false;
+            result = propInfo;
+            return true;
         }
 
         internal static Type? GetArrayItemType(PropertyInfo propInfo)
@@ -259,7 +259,7 @@ namespace NLog.Internal
                     return false;
                 }
 
-                MethodInfo operatorImplicitMethod = resultType.GetMethod("op_Implicit", BindingFlags.Public | BindingFlags.Static, null, new Type[] { value.GetType() }, null);
+                var operatorImplicitMethod = resultType.GetMethod("op_Implicit", BindingFlags.Public | BindingFlags.Static, null, new Type[] { value.GetType() }, null);
                 if (operatorImplicitMethod is null || !resultType.IsAssignableFrom(operatorImplicitMethod.ReturnType))
                 {
                     result = null;
@@ -436,7 +436,7 @@ namespace NLog.Internal
                     object? hashSetComparer = null;
                     var existingType = existingValue.GetType();
                     var comparerPropInfo = existingType.GetProperty("Comparer", BindingFlags.Public | BindingFlags.Instance);
-                    if (comparerPropInfo.IsValidPublicProperty())
+                    if (comparerPropInfo != null && comparerPropInfo.IsValidPublicProperty())
                     {
                         hashSetComparer = comparerPropInfo.GetPropertyValue(existingValue);
                     }

--- a/src/NLog/Internal/ReflectionHelpers.cs
+++ b/src/NLog/Internal/ReflectionHelpers.cs
@@ -71,7 +71,7 @@ namespace NLog.Internal
         /// <returns>Optimized delegate for invoking the MethodInfo</returns>
         public static LateBoundMethod CreateLateBoundMethod(MethodInfo methodInfo)
         {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
             if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
             {
                 return (target, args) =>
@@ -180,12 +180,12 @@ namespace NLog.Internal
             return (TAttr[])type.GetCustomAttributes(typeof(TAttr), inherit);
         }
 
-        public static bool IsValidPublicProperty(this PropertyInfo p)
+        public static bool IsValidPublicProperty(this PropertyInfo? p)
         {
             return p != null && p.CanRead && p.GetIndexParameters().Length == 0 && p.GetGetMethod() != null;
         }
 
-        public static object GetPropertyValue(this PropertyInfo p, object instance)
+        public static object? GetPropertyValue(this PropertyInfo p, object instance)
         {
 #if !NET35 && !NET40
             return p.GetValue(instance);

--- a/src/NLog/Internal/ScopeContextAsyncState.cs
+++ b/src/NLog/Internal/ScopeContextAsyncState.cs
@@ -588,7 +588,7 @@ namespace NLog.Internal
             if (NestedContext?.Length > 0)
                 return NestedContext[NestedContext.Length - 1]?.ToString() ?? "null";
             else
-                return base.ToString();
+                return base.ToString() ?? GetType().ToString();
         }
     }
 }

--- a/src/NLog/Internal/SingleItemOptimizedHashSet.cs
+++ b/src/NLog/Internal/SingleItemOptimizedHashSet.cs
@@ -239,7 +239,7 @@ namespace NLog.Internal
         {
             public static readonly ReferenceEqualityComparer Default = new ReferenceEqualityComparer();
 
-            bool IEqualityComparer<T>.Equals(T x, T y)
+            bool IEqualityComparer<T>.Equals(T? x, T? y)
             {
                 return ReferenceEquals(x, y);
             }

--- a/src/NLog/Internal/StackTraceUsageUtils.cs
+++ b/src/NLog/Internal/StackTraceUsageUtils.cs
@@ -104,7 +104,7 @@ namespace NLog.Internal
 
             if (includeMethodInfo && methodName == method.Name)
             {
-                methodName = method.ToString();
+                methodName = method.ToString() ?? methodName;
             }
 
             return methodName;
@@ -216,9 +216,9 @@ namespace NLog.Internal
         /// Returns the assembly from the provided StackFrame (If not internal assembly)
         /// </summary>
         /// <returns>Valid assembly, or null if assembly was internal</returns>
-        public static Assembly? LookupAssemblyFromMethod(MethodBase? method)
+        public static Assembly? LookupAssemblyFromMethod(MethodBase method)
         {
-            var assembly = method?.DeclaringType?.Assembly ?? method?.Module?.Assembly;
+            var assembly = method.DeclaringType?.Assembly ?? method.Module?.Assembly;
 
             // skip stack frame if the method declaring type assembly is from hidden assemblies list
             if (assembly == nlogAssembly)

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -421,7 +421,7 @@ namespace NLog.Internal
             }
             else
 #endif
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
             {
                 builder.Append([
                     (char)(((number / 1000) % 10) + '0'),

--- a/src/NLog/Internal/TargetWithFilterChain.cs
+++ b/src/NLog/Internal/TargetWithFilterChain.cs
@@ -373,7 +373,7 @@ namespace NLog.Internal
                 return MethodName.GetHashCode() ^ FileSourceName.GetHashCode() ^ FileSourceLineNumber;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return obj is CallSiteKey key && Equals(key);
             }

--- a/src/NLog/Internal/TimeoutContinuation.cs
+++ b/src/NLog/Internal/TimeoutContinuation.cs
@@ -93,7 +93,7 @@ namespace NLog.Internal
             currentTimer?.WaitForDispose(TimeSpan.Zero);
         }
 
-        private void TimerElapsed(object state)
+        private void TimerElapsed(object? state)
         {
             Function(new TimeoutException("Timeout."));
         }

--- a/src/NLog/Internal/XmlHelper.cs
+++ b/src/NLog/Internal/XmlHelper.cs
@@ -357,7 +357,9 @@ namespace NLog.Internal
         {
             try
             {
-                string valueString = Convert.ToString(value, CultureInfo.InvariantCulture);
+                var valueString = Convert.ToString(value, CultureInfo.InvariantCulture);
+                if (valueString is null)
+                    return string.Empty;
                 return safeConversion ? RemoveInvalidXmlChars(valueString) : valueString;
             }
             catch

--- a/src/NLog/LayoutRenderers/AssemblyVersionLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AssemblyVersionLayoutRenderer.cs
@@ -175,7 +175,7 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Gets the assembly specified by <see cref="Name"/>, or entry assembly otherwise
         /// </summary>
-        protected virtual System.Reflection.Assembly GetAssembly()
+        protected virtual System.Reflection.Assembly? GetAssembly()
         {
             if (string.IsNullOrEmpty(Name))
             {

--- a/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/BaseDirLayoutRenderer.cs
@@ -154,7 +154,7 @@ namespace NLog.LayoutRenderers
 
         private string GetProcessDir()
         {
-            return Path.GetDirectoryName(_appEnvironment.CurrentProcessFilePath);
+            return Path.GetDirectoryName(_appEnvironment.CurrentProcessFilePath) ?? string.Empty;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/NLogDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/NLogDirLayoutRenderer.cs
@@ -90,7 +90,7 @@ namespace NLog.LayoutRenderers
             var nlogLocation = AssemblyHelpers.GetAssemblyFileLocation(nlogAssembly);
             if (!string.IsNullOrEmpty(nlogLocation))
             {
-                return Path.GetDirectoryName(nlogLocation);
+                return Path.GetDirectoryName(nlogLocation) ?? string.Empty;
             }
             else
             {

--- a/src/NLog/LayoutRenderers/ProcessDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessDirLayoutRenderer.cs
@@ -83,7 +83,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         internal ProcessDirLayoutRenderer(IAppEnvironment appEnvironment)
         {
-            _processDir = Path.GetDirectoryName(appEnvironment.CurrentProcessFilePath);
+            _processDir = Path.GetDirectoryName(appEnvironment.CurrentProcessFilePath) ?? string.Empty;
         }
 
         /// <inheritdoc/>

--- a/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
@@ -86,7 +86,13 @@ namespace NLog.LayoutRenderers
                 throw new ArgumentException($"Property '{Property}' not found in System.Diagnostics.Process");
             }
 
-            _lateBoundPropertyGet = ReflectionHelpers.CreateLateBoundMethod(propertyInfo.GetGetMethod());
+            var getGetMethodInfo = propertyInfo.GetGetMethod();
+            if (getGetMethodInfo is null)
+            {
+                throw new ArgumentException($"Property '{Property}' not found in System.Diagnostics.Process with valid getter-method");
+            }
+
+            _lateBoundPropertyGet = ReflectionHelpers.CreateLateBoundMethod(getGetMethodInfo);
 
             _process = Process.GetCurrentProcess();
         }

--- a/src/NLog/LayoutRenderers/StackTraceLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/StackTraceLayoutRenderer.cs
@@ -170,7 +170,7 @@ namespace NLog.LayoutRenderers
 
             public int Count => _startingFrame - _endingFrame;
 
-            public StackFrame this[int index]
+            public StackFrame? this[int index]
             {
                 get
                 {
@@ -193,64 +193,48 @@ namespace NLog.LayoutRenderers
             string? separator = null;
             for (int i = 0; i < stackFrameList.Count; ++i)
             {
+                var f = stackFrameList[i]?.ToString();
+                if (string.IsNullOrEmpty(f))
+                    continue;   // Net Native can have StackFrames without managed methods
+
                 builder.Append(separator);
-                StackFrame f = stackFrameList[i];
-                builder.Append(f.ToString());
+                builder.Append(f);
                 separator = separator ?? _separator ?? string.Empty;
             }
         }
 
         private void AppendFlat(StringBuilder builder, StackFrameList stackFrameList)
         {
-            bool first = true;
+            string? separator = null;
             for (int i = 0; i < stackFrameList.Count; ++i)
             {
                 var method = StackTraceUsageUtils.GetStackMethod(stackFrameList[i]);
                 if (method is null)
-                {
                     continue;   // Net Native can have StackFrames without managed methods
-                }
 
-                if (!first)
-                {
-                    builder.Append(_separator);
-                }
-
+                builder.Append(separator);
                 var type = method.DeclaringType;
-                if (type is null)
-                {
-                    builder.Append("<no type>");
-                }
-                else
-                {
-                    builder.Append(type.Name);
-                }
-
+                builder.Append(type?.Name ?? "<no type>");
                 builder.Append('.');
                 builder.Append(method.Name);
-                first = false;
+                separator = separator ?? _separator ?? string.Empty;
             }
         }
 
         private void AppendDetailedFlat(StringBuilder builder, StackFrameList stackFrameList)
         {
-            bool first = true;
+            string? separator = null;
             for (int i = 0; i < stackFrameList.Count; ++i)
             {
                 var method = StackTraceUsageUtils.GetStackMethod(stackFrameList[i]);
                 if (method is null)
-                {
                     continue;   // Net Native can have StackFrames without managed methods
-                }
 
-                if (!first)
-                {
-                    builder.Append(_separator);
-                }
+                builder.Append(separator);
                 builder.Append('[');
                 builder.Append(method);
                 builder.Append(']');
-                first = false;
+                separator = separator ?? _separator ?? string.Empty;
             }
         }
     }

--- a/src/NLog/LayoutRenderers/ThreadNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ThreadNameLayoutRenderer.cs
@@ -52,11 +52,11 @@ namespace NLog.LayoutRenderers
             builder.Append(GetStringValue());
         }
 
-        private static string GetStringValue()
+        private static string? GetStringValue()
         {
             return System.Threading.Thread.CurrentThread.Name;
         }
 
-        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue();
+        string? IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetStringValue();
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/WrapLineLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/WrapLineLayoutRendererWrapper.cs
@@ -77,7 +77,7 @@ namespace NLog.LayoutRenderers.Wrappers
                     chunkLength = text.Length - pos;
                 }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
                 result.Append(text.AsSpan(pos, chunkLength));
 #else
                 result.Append(text.Substring(pos, chunkLength));

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -188,7 +188,7 @@ namespace NLog.Layouts
         /// </summary>
         /// <param name="text">Text to be converted.</param>
         /// <returns>A <see cref="SimpleLayout"/> object.</returns>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(text))]
 #endif
         public static implicit operator SimpleLayout?([Localizable(false)] string text)

--- a/src/NLog/Layouts/Typed/Layout.cs
+++ b/src/NLog/Layouts/Typed/Layout.cs
@@ -361,7 +361,7 @@ namespace NLog.Layouts
 
             public override string ToString()
             {
-                return _layoutMethod.ToString();
+                return _layoutMethod.ToString() ?? GetType().ToString();
             }
         }
 
@@ -377,7 +377,7 @@ namespace NLog.Layouts
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (IsFixed)
             {
@@ -398,7 +398,7 @@ namespace NLog.Layouts
         /// <summary>
         /// Implements Equals using <see cref="FixedValue"/>
         /// </summary>
-        public bool Equals(T other)
+        public bool Equals(T? other)
         {
             // Support property-compare
             return IsFixed && object.Equals(FixedObjectValue, other);
@@ -623,7 +623,7 @@ namespace NLog.Layouts
 
         public override string ToString()
         {
-            return _innerLayout.ToString();
+            return _innerLayout.ToString() ?? GetType().ToString();
         }
 
         object? IPropertyTypeConverter.Convert(object? propertyValue, Type propertyType, string? format, IFormatProvider? formatProvider)

--- a/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
+++ b/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
@@ -271,7 +271,7 @@ namespace NLog.Layouts
 
             public override string ToString()
             {
-                return _innerLayout.ToString();
+                return _innerLayout.ToString() ?? GetType().ToString();
             }
         }
     }

--- a/src/NLog/LogEventBuilder.cs
+++ b/src/NLog/LogEventBuilder.cs
@@ -120,7 +120,7 @@ namespace NLog
             return this;
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         /// <summary>
         /// Sets multiple per-event context properties on the logging event.
         /// </summary>

--- a/src/NLog/LogEventInfo.cs
+++ b/src/NLog/LogEventInfo.cs
@@ -133,7 +133,7 @@ namespace NLog
             _messageFormatter = (l) => l._formattedMessage ?? l.Message ?? string.Empty;
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         /// <summary>
         /// Initializes a new instance of the <see cref="LogEventInfo" /> class.
         /// </summary>
@@ -158,7 +158,7 @@ namespace NLog
         }
 #endif
 
-#if !NET35
+#if !NET35 && !NET40
         /// <summary>
         /// Initializes a new instance of the <see cref="LogEventInfo" /> class.
         /// </summary>
@@ -672,7 +672,7 @@ namespace NLog
             return false;
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         internal static bool NeedToPreformatMessage(in ReadOnlySpan<object?> parameters)
         {
             if (parameters.IsEmpty)

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -51,7 +51,7 @@ namespace NLog
     /// Creates and manages instances of <see cref="NLog.Logger" /> objects.
     /// </summary>
     public class LogFactory : IDisposable
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
 , IAsyncDisposable
 #endif
     {
@@ -285,7 +285,7 @@ namespace NLog
             InternalLogger.Info("Configuration initialized: {0}", config);
         }
 
-        private void ServiceRepository_TypeRegistered(object sender, ServiceRepositoryUpdateEventArgs e)
+        private void ServiceRepository_TypeRegistered(object? sender, ServiceRepositoryUpdateEventArgs e)
         {
             _config?.CheckForMissingServiceTypes(e.ServiceType);
 
@@ -373,7 +373,7 @@ namespace NLog
             GC.SuppressFinalize(this);
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         /// <summary>
         /// Flush any pending log messages, and shutdown logging
         /// </summary>
@@ -652,7 +652,7 @@ namespace NLog
                     return true;
                 }
 
-                asyncContinuation = asyncContinuation is null ? null : AsyncHelpers.PreventMultipleCalls(asyncContinuation);
+                asyncContinuation = asyncContinuation is null ? null : NLog.Common.AsyncHelpers.PreventMultipleCalls(asyncContinuation);
 
                 using (var waitForFlush = new ManualResetEvent(false))
                 {
@@ -1110,7 +1110,7 @@ namespace NLog
                 return ConcreteType.GetHashCode() ^ Name.GetHashCode();
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return obj is LoggerCacheKey key && Equals(key);
             }
@@ -1224,7 +1224,7 @@ namespace NLog
             }
         }
 
-        private static void OnLoggerShutdown(object sender, EventArgs args)
+        private static void OnLoggerShutdown(object? sender, EventArgs args)
         {
             try
             {
@@ -1246,7 +1246,7 @@ namespace NLog
             }
         }
 
-        private void OnStopLogging(object sender, EventArgs args)
+        private void OnStopLogging(object? sender, EventArgs args)
         {
             try
             {

--- a/src/NLog/LogLevelTypeConverter.cs
+++ b/src/NLog/LogLevelTypeConverter.cs
@@ -43,13 +43,13 @@ namespace NLog.Attributes
     public class LogLevelTypeConverter : TypeConverter
     {
         /// <inheritdoc/>
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             return sourceType == typeof(string) || IsNumericType(sourceType) || base.CanConvertFrom(context, sourceType);
         }
 
         /// <inheritdoc/>
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object? ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
             var valueType = value?.GetType();
             if (typeof(string).Equals(valueType))
@@ -61,13 +61,13 @@ namespace NLog.Attributes
         }
 
         /// <inheritdoc/>
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
         {
             return destinationType == typeof(string) || IsNumericType(destinationType) || base.CanConvertTo(context, destinationType);
         }
 
         /// <inheritdoc/>
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object? ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
             if (value is LogLevel logLevel)
             {

--- a/src/NLog/Logger-V1Compat.cs
+++ b/src/NLog/Logger-V1Compat.cs
@@ -71,7 +71,7 @@ namespace NLog
         /// <param name="value">A <see langword="object" /> to be written.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-       [OverloadResolutionPriority(-1)]
+        [OverloadResolutionPriority(-1)]
 #endif
         public void Log(LogLevel level, IFormatProvider? formatProvider, object? value)
         {
@@ -98,8 +98,8 @@ namespace NLog
             var targetsForLevel = GetTargetsForLevelSafe(level);
             if (targetsForLevel != null)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, [arg1, arg2]);
 #else
                 WriteToTargets(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2 });
 #endif
@@ -124,8 +124,8 @@ namespace NLog
             var targetsForLevel = GetTargetsForLevelSafe(level);
             if (targetsForLevel != null)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, [arg1, arg2, arg3]);
 #else
                 WriteToTargets(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2, arg3 });
 #endif
@@ -265,7 +265,11 @@ namespace NLog
         {
             if (IsEnabled(level))
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(level, null, formatProvider, message, [argument]);
+#else
                 WriteToTargets(level, formatProvider, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -284,7 +288,11 @@ namespace NLog
         {
             if (IsEnabled(level))
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(level, null, Factory.DefaultCultureInfo,  message, [argument]);
+#else
                 WriteToTargets(level, Factory.DefaultCultureInfo, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -500,8 +508,8 @@ namespace NLog
             var targetsForLevel = GetTargetsForLevelSafe(level);
             if (targetsForLevel != null)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(targetsForLevel, level, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(targetsForLevel, level, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(targetsForLevel, level, null, formatProvider, message, new object?[] { argument });
 #endif
@@ -524,8 +532,8 @@ namespace NLog
             var targetsForLevel = GetTargetsForLevelSafe(level);
             if (targetsForLevel != null)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -707,8 +715,8 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, [arg1, arg2]);
 #else
                 WriteToTargets(LogLevel.Trace, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2 });
 #endif
@@ -731,8 +739,8 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, [arg1, arg2, arg3]);
 #else
                 WriteToTargets(LogLevel.Trace, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2, arg3 });
 #endif
@@ -865,7 +873,11 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, [argument]);
+#else
                 WriteToTargets(LogLevel.Trace, formatProvider, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -883,7 +895,11 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, [argument]);
+#else
                 WriteToTargets(LogLevel.Trace, Factory.DefaultCultureInfo, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -1087,8 +1103,8 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Trace, formatProvider, message, new object?[] { argument });
 #endif
@@ -1109,8 +1125,8 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Trace, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -1234,7 +1250,7 @@ namespace NLog
             }
         }
 
-        #endregion
+#endregion
 
         #region Debug() overloads
 
@@ -1286,8 +1302,8 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, [arg1, arg2]);
 #else
                 WriteToTargets(LogLevel.Debug, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2 });
 #endif
@@ -1310,8 +1326,8 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, [arg1, arg2, arg3]);
 #else
                 WriteToTargets(LogLevel.Debug, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2, arg3 });
 #endif
@@ -1444,7 +1460,11 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, [argument]);
+#else
                 WriteToTargets(LogLevel.Debug, formatProvider, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -1462,7 +1482,11 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, [argument]);
+#else
                 WriteToTargets(LogLevel.Debug, Factory.DefaultCultureInfo, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -1666,8 +1690,8 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Debug, formatProvider, message, new object?[] { argument });
 #endif
@@ -1688,8 +1712,8 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Debug, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -1865,8 +1889,8 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, [arg1, arg2]);
 #else
                 WriteToTargets(LogLevel.Info, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2 });
 #endif
@@ -1889,8 +1913,8 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, [arg1, arg2, arg3]);
 #else
                 WriteToTargets(LogLevel.Info, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2, arg3 });
 #endif
@@ -2016,14 +2040,18 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NETNET9_0_OR_GREATER
         [OverloadResolutionPriority(-1)]
 #endif
         public void Info(IFormatProvider? formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, string? argument)
         {
             if (IsInfoEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, [argument]);
+#else
                 WriteToTargets(LogLevel.Info, formatProvider, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -2041,7 +2069,11 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, [argument]);
+#else
                 WriteToTargets(LogLevel.Info, Factory.DefaultCultureInfo, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -2245,8 +2277,8 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Info, formatProvider, message, new object?[] { argument });
 #endif
@@ -2267,8 +2299,8 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Info, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -2392,7 +2424,7 @@ namespace NLog
             }
         }
 
-        #endregion
+#endregion
 
         #region Warn() overloads
 
@@ -2444,8 +2476,8 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, [arg1, arg2]);
 #else
                 WriteToTargets(LogLevel.Warn, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2 });
 #endif
@@ -2468,8 +2500,8 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, [arg1, arg2, arg3]);
 #else
                 WriteToTargets(LogLevel.Warn, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2, arg3 });
 #endif
@@ -2602,7 +2634,11 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, [argument]);
+#else
                 WriteToTargets(LogLevel.Warn, formatProvider, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -2620,7 +2656,11 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, [argument]);
+#else
                 WriteToTargets(LogLevel.Warn, Factory.DefaultCultureInfo, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -2706,7 +2746,7 @@ namespace NLog
         /// <param name="argument">The argument to format.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MessageTemplateFormatMethod("message")]
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         [OverloadResolutionPriority(-1)]
 #endif
         public void Warn(IFormatProvider? formatProvider, [Localizable(false)][StructuredMessageTemplate] string message, float argument)
@@ -2824,8 +2864,8 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Warn, formatProvider, message, new object?[] { argument });
 #endif
@@ -2846,8 +2886,8 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Warn, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -2971,7 +3011,7 @@ namespace NLog
             }
         }
 
-        #endregion
+#endregion
 
         #region Error() overloads
 
@@ -3023,8 +3063,8 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, [arg1, arg2]);
 #else
                 WriteToTargets(LogLevel.Error, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2 });
 #endif
@@ -3047,8 +3087,8 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, [arg1, arg2, arg3]);
 #else
                 WriteToTargets(LogLevel.Error, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2, arg3 });
 #endif
@@ -3181,7 +3221,11 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, [argument]);
+#else
                 WriteToTargets(LogLevel.Error, formatProvider, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -3199,7 +3243,11 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, [argument]);
+#else
                 WriteToTargets(LogLevel.Error, Factory.DefaultCultureInfo, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -3403,8 +3451,8 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Error, formatProvider, message, new object?[] { argument });
 #endif
@@ -3425,8 +3473,8 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Error, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -3550,7 +3598,7 @@ namespace NLog
             }
         }
 
-        #endregion
+#endregion
 
         #region Fatal() overloads
 
@@ -3602,8 +3650,8 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, arg1, arg2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, [arg1, arg2]);
 #else
                 WriteToTargets(LogLevel.Fatal, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2 });
 #endif
@@ -3626,8 +3674,8 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, arg1, arg2, arg3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, [arg1, arg2, arg3]);
 #else
                 WriteToTargets(LogLevel.Fatal, Factory.DefaultCultureInfo, message, new object?[] { arg1, arg2, arg3 });
 #endif
@@ -3760,7 +3808,11 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, [argument]);
+#else
                 WriteToTargets(LogLevel.Fatal, formatProvider, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -3778,7 +3830,11 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, [argument]);
+#else
                 WriteToTargets(LogLevel.Fatal, Factory.DefaultCultureInfo, message, new object?[] { argument });
+#endif
             }
         }
 
@@ -3982,8 +4038,8 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Fatal, formatProvider, message, new object?[] { argument });
 #endif
@@ -4004,8 +4060,8 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Fatal, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -4129,7 +4185,7 @@ namespace NLog
             }
         }
 
-        #endregion
+#endregion
 
         // end of generated code
 

--- a/src/NLog/Logger-generated.cs
+++ b/src/NLog/Logger-generated.cs
@@ -271,8 +271,8 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Trace, formatProvider, message, new object?[] { argument });
 #endif
@@ -290,8 +290,8 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Trace, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -312,8 +312,8 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.Trace, formatProvider, message, new object?[] { argument1, argument2 });
 #endif
@@ -333,8 +333,8 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.Trace, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2 });
 #endif
@@ -357,8 +357,8 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Trace, null, formatProvider, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.Trace, formatProvider, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -380,8 +380,8 @@ namespace NLog
         {
             if (IsTraceEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Trace, null, Factory.DefaultCultureInfo, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.Trace, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -563,8 +563,8 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Debug, formatProvider, message, new object?[] { argument });
 #endif
@@ -582,8 +582,8 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Debug, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -604,8 +604,8 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.Debug, formatProvider, message, new object?[] { argument1, argument2 });
 #endif
@@ -625,8 +625,8 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.Debug, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2 });
 #endif
@@ -649,8 +649,8 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Debug, null, formatProvider, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.Debug, formatProvider, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -672,8 +672,8 @@ namespace NLog
         {
             if (IsDebugEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Debug, null, Factory.DefaultCultureInfo, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.Debug, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -855,8 +855,8 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Info, formatProvider, message, new object?[] { argument });
 #endif
@@ -874,8 +874,8 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Info, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -896,8 +896,8 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.Info, formatProvider, message, new object?[] { argument1, argument2 });
 #endif
@@ -917,8 +917,8 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.Info, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2 });
 #endif
@@ -941,8 +941,8 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Info, null, formatProvider, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.Info, formatProvider, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -964,8 +964,8 @@ namespace NLog
         {
             if (IsInfoEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Info, null, Factory.DefaultCultureInfo, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.Info, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -1147,8 +1147,8 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Warn, formatProvider, message, new object?[] { argument });
 #endif
@@ -1166,8 +1166,8 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Warn, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -1188,8 +1188,8 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.Warn, formatProvider, message, new object?[] { argument1, argument2 });
 #endif
@@ -1209,8 +1209,8 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.Warn, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2 });
 #endif
@@ -1233,8 +1233,8 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Warn, null, formatProvider, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.Warn, formatProvider, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -1256,8 +1256,8 @@ namespace NLog
         {
             if (IsWarnEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Warn, null, Factory.DefaultCultureInfo, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.Warn, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -1439,8 +1439,8 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Error, formatProvider, message, new object?[] { argument });
 #endif
@@ -1458,8 +1458,8 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Error, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -1480,8 +1480,8 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.Error, formatProvider, message, new object?[] { argument1, argument2 });
 #endif
@@ -1501,8 +1501,8 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.Error, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2 });
 #endif
@@ -1525,8 +1525,8 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Error, null, formatProvider, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.Error, formatProvider, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -1548,8 +1548,8 @@ namespace NLog
         {
             if (IsErrorEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Error, null, Factory.DefaultCultureInfo, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.Error, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -1731,8 +1731,8 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Fatal, formatProvider, message, new object?[] { argument });
 #endif
@@ -1750,8 +1750,8 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.Fatal, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -1772,8 +1772,8 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.Fatal, formatProvider, message, new object?[] { argument1, argument2 });
 #endif
@@ -1793,8 +1793,8 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.Fatal, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2 });
 #endif
@@ -1817,8 +1817,8 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, formatProvider, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.Fatal, formatProvider, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -1840,8 +1840,8 @@ namespace NLog
         {
             if (IsFatalEnabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.Fatal, null, Factory.DefaultCultureInfo, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.Fatal, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2, argument3 });
 #endif

--- a/src/NLog/Logger-generated.tt
+++ b/src/NLog/Logger-generated.tt
@@ -247,8 +247,8 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.<#=level#>, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.<#=level#>, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(LogLevel.<#=level#>, formatProvider, message, new object?[] { argument });
 #endif
@@ -266,8 +266,8 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.<#=level#>, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.<#=level#>, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(LogLevel.<#=level#>, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -288,8 +288,8 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.<#=level#>, null, formatProvider, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.<#=level#>, null, formatProvider, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.<#=level#>, formatProvider, message, new object?[] { argument1, argument2 });
 #endif
@@ -309,8 +309,8 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.<#=level#>, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.<#=level#>, null, Factory.DefaultCultureInfo, message, [argument1, argument2]);
 #else
                 WriteToTargets(LogLevel.<#=level#>, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2 });
 #endif
@@ -333,8 +333,8 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.<#=level#>, null, formatProvider, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.<#=level#>, null, formatProvider, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.<#=level#>, formatProvider, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -356,8 +356,8 @@ namespace NLog
         {
             if (Is<#=level#>Enabled)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(LogLevel.<#=level#>, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(LogLevel.<#=level#>, null, Factory.DefaultCultureInfo, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(LogLevel.<#=level#>, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2, argument3 });
 #endif

--- a/src/NLog/Logger.cs
+++ b/src/NLog/Logger.cs
@@ -441,8 +441,8 @@ namespace NLog
             var targetsForLevel = GetTargetsForLevelSafe(level);
             if (targetsForLevel != null)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(targetsForLevel, level, null, formatProvider, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(targetsForLevel, level, null, formatProvider, message, [argument]);
 #else
                 WriteToTargets(targetsForLevel, level, null, formatProvider, message, new object?[] { argument });
 #endif         
@@ -462,8 +462,8 @@ namespace NLog
             var targetsForLevel = GetTargetsForLevelSafe(level);
             if (targetsForLevel != null)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, argument);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, [argument]);
 #else
                 WriteToTargets(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, new object?[] { argument });
 #endif
@@ -486,8 +486,8 @@ namespace NLog
             var targetsForLevel = GetTargetsForLevelSafe(level);
             if (targetsForLevel != null)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(targetsForLevel, level, null, formatProvider, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(targetsForLevel, level, null, formatProvider, message, [argument1, argument2]);
 #else
                 WriteToTargets(targetsForLevel, level, null, formatProvider, message, new object?[] { argument1, argument2 });
 #endif
@@ -509,8 +509,8 @@ namespace NLog
             var targetsForLevel = GetTargetsForLevelSafe(level);
             if (targetsForLevel != null)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, argument1, argument2);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, [argument1, argument2]);
 #else
                 WriteToTargets(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2 });
 #endif
@@ -535,8 +535,8 @@ namespace NLog
             var targetsForLevel = GetTargetsForLevelSafe(level);
             if (targetsForLevel != null)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(targetsForLevel, level, null, formatProvider, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(targetsForLevel, level, null, formatProvider, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(targetsForLevel, level, null, formatProvider, message, new object?[] { argument1, argument2, argument3 });
 #endif
@@ -560,15 +560,15 @@ namespace NLog
             var targetsForLevel = GetTargetsForLevelSafe(level);
             if (targetsForLevel != null)
             {
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
-                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, argument1, argument2, argument3);
+#if NETSTANDARD2_1_OR_GREATER || NET
+                WriteToTargetsWithSpan(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, [argument1, argument2, argument3]);
 #else
                 WriteToTargets(targetsForLevel, level, null, Factory.DefaultCultureInfo, message, new object?[] { argument1, argument2, argument3 });
 #endif
             }
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NET9_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         /// <summary>
         /// Writes the diagnostic message at the specified level using the specified parameters.
         /// </summary>
@@ -601,8 +601,10 @@ namespace NLog
                 WriteToTargetsWithSpan(targetsForLevel, level, exception, Factory.DefaultCultureInfo, message, args);
             }
         }
+#endif
 
-        private void WriteToTargetsWithSpan(LogLevel level, Exception? exception, IFormatProvider? formatProvider, string message, params ReadOnlySpan<object?> args)
+#if NETSTANDARD2_1_OR_GREATER || NET
+        private void WriteToTargetsWithSpan(LogLevel level, Exception? exception, IFormatProvider? formatProvider, string message, in ReadOnlySpan<object?> args)
         {
             var targetsForLevel = GetTargetsForLevel(level);
             if (targetsForLevel != null)
@@ -611,7 +613,7 @@ namespace NLog
             }
         }
 
-        private void WriteToTargetsWithSpan(ITargetWithFilterChain targetsForLevel, LogLevel level, Exception? exception, IFormatProvider? formatProvider, string message, params ReadOnlySpan<object?> args)
+        private void WriteToTargetsWithSpan(ITargetWithFilterChain targetsForLevel, LogLevel level, Exception? exception, IFormatProvider? formatProvider, string message, in ReadOnlySpan<object?> args)
         {
             if (Factory.AutoMessageTemplateFormatter is null || !LogEventInfo.NeedToPreformatMessage(args))
             {

--- a/src/NLog/MessageTemplates/ValueFormatter.cs
+++ b/src/NLog/MessageTemplates/ValueFormatter.cs
@@ -263,7 +263,7 @@ namespace NLog.MessageTemplates
                 builder.Append(Convert.ToString(value, formatProvider));
         }
 
-        private void SerializeStringObject(string stringValue, string? format, StringBuilder builder)
+        private void SerializeStringObject(string? stringValue, string? format, StringBuilder builder)
         {
             bool includeQuotes = _legacyStringQuotes && format != LiteralFormatSymbol;
             if (includeQuotes) builder.Append('"');
@@ -352,7 +352,7 @@ namespace NLog.MessageTemplates
             return true;
         }
 
-        private void SerializeCollectionItem(object item, string? format, IFormatProvider? formatProvider, StringBuilder builder, ref SingleItemOptimizedHashSet<object> objectsInPath, int depth)
+        private void SerializeCollectionItem(object? item, string? format, IFormatProvider? formatProvider, StringBuilder builder, ref SingleItemOptimizedHashSet<object> objectsInPath, int depth)
         {
             if (item is IConvertible convertible)
                 SerializeConvertibleObject(convertible, format, formatProvider, builder);

--- a/src/NLog/ScopeContext.cs
+++ b/src/NLog/ScopeContext.cs
@@ -524,7 +524,7 @@ namespace NLog
 
             public override string ToString()
             {
-                return _collapsed.ToString();
+                return _collapsed.ToString() ?? GetType().ToString();
             }
         }
 

--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -80,7 +80,7 @@ namespace NLog.Targets
         private CancellationTokenSource _cancelTokenSource;
         AsyncRequestQueueBase _requestQueue;
         private readonly Action _taskCancelledTokenReInit;
-        private readonly Action<Task, object> _taskCompletion;
+        private readonly Action<Task, object?> _taskCompletion;
         private Task? _previousTask;
         private readonly Timer _lazyWriterTimer;
         private readonly LogEventInfo _flushEvent = LogEventInfo.Create(LogLevel.Off, null, "NLog Async Task Flush Event");
@@ -704,7 +704,7 @@ namespace NLog.Targets
         /// </summary>
         /// <param name="completedTask">Task just completed</param>
         /// <param name="continuation">AsyncContinuation to notify of success or failure</param>
-        private void TaskCompletion(Task completedTask, object continuation)
+        private void TaskCompletion(Task completedTask, object? continuation)
         {
             bool success = true;
             bool fullBatchCompleted = true;
@@ -783,7 +783,7 @@ namespace NLog.Targets
         /// Timer method, that is fired when pending task fails to complete within timeout
         /// </summary>
         /// <param name="state"></param>
-        private void TaskTimeout(object state)
+        private void TaskTimeout(object? state)
         {
             try
             {

--- a/src/NLog/Targets/ColoredConsoleAnsiPrinter.cs
+++ b/src/NLog/Targets/ColoredConsoleAnsiPrinter.cs
@@ -85,7 +85,7 @@ namespace NLog.Targets
 
         public void WriteSubString(TextWriter consoleWriter, string text, int index, int endIndex)
         {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
             consoleWriter.Write(text.AsSpan(index, endIndex - index));
 #else
             // No need to allocate SubString, because we are already writing in-memory

--- a/src/NLog/Targets/ColoredConsoleSystemPrinter.cs
+++ b/src/NLog/Targets/ColoredConsoleSystemPrinter.cs
@@ -86,7 +86,7 @@ namespace NLog.Targets
 
         public void WriteSubString(TextWriter consoleWriter, string text, int index, int endIndex)
         {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
             consoleWriter.Write(text.AsSpan(index, endIndex - index));
 #else
             consoleWriter.Write(text.Substring(index, endIndex - index));

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -441,7 +441,7 @@ namespace NLog.Targets
             else if (objTypeCode == TypeCode.String || objTypeCode == TypeCode.Char)
             {
                 destination.Append('"');
-                AppendStringEscape(destination, value.ToString(), options);
+                AppendStringEscape(destination, value.ToString() ?? string.Empty, options);
                 destination.Append('"');
             }
             else
@@ -512,7 +512,7 @@ namespace NLog.Targets
         {
             if (!_enumCache.TryGetValue(value, out var textValue))
             {
-                textValue = Convert.ToString(value, CultureInfo.InvariantCulture);
+                textValue = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
                 _enumCache.TryAddValue(value, textValue);
             }
             return textValue ?? string.Empty;
@@ -747,7 +747,7 @@ namespace NLog.Targets
                     return true;
                 }
 
-                var str = Convert.ToString(value, CultureInfo.InvariantCulture);
+                var str = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
                 destination.Append('"');
                 AppendStringEscape(destination, str, options);
                 destination.Append('"');

--- a/src/NLog/Targets/FileArchiveHandlers/BaseFileArchiveHandler.cs
+++ b/src/NLog/Targets/FileArchiveHandlers/BaseFileArchiveHandler.cs
@@ -53,7 +53,7 @@ namespace NLog.Targets.FileArchiveHandlers
         {
             // Get all files matching the filename, order by timestamp, and when same timestamp then order by filename
             //  - First start with removing the oldest files
-            string fileDirectory = Path.GetDirectoryName(filePath);
+            string fileDirectory = Path.GetDirectoryName(filePath) ?? string.Empty;
             // Replace all non-letter with '*' replace all '**' with single '*'
             string fileWildcard = GetDeleteOldFileNameWildcard(filePath);
             return DeleteOldFilesBeforeArchive(fileDirectory, fileWildcard, initialFileOpen, parseArchiveSequenceNo, excludeFileName);

--- a/src/NLog/Targets/FileArchiveHandlers/LegacyArchiveFileNameHandler.cs
+++ b/src/NLog/Targets/FileArchiveHandlers/LegacyArchiveFileNameHandler.cs
@@ -86,7 +86,7 @@ namespace NLog.Targets.FileArchiveHandlers
                 {
                     string archiveFilePath = BuildArchiveFilePath(archiveFileName, int.MaxValue, DateTime.MinValue);
                     string archiveFileWildcard = archiveFilePath.Replace(int.MaxValue.ToString(), "*");
-                    string archiveDirectory = Path.GetDirectoryName(archiveFilePath);
+                    string archiveDirectory = Path.GetDirectoryName(archiveFilePath) ?? string.Empty;
                     oldFilesDeleted = DeleteOldFilesBeforeArchive(archiveDirectory, Path.GetFileName(archiveFileWildcard), initialFileOpen, parseArchiveSequenceNo: true, excludeFileName: excludeFileName);
                 }
                 else

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -1015,7 +1015,7 @@ namespace NLog.Targets
             }
         }
 
-        private void OpenFileMonitorTimer(object state)
+        private void OpenFileMonitorTimer(object? state)
         {
             bool startTimer = !(_openFileMonitorTimer is null);
 
@@ -1245,7 +1245,7 @@ namespace NLog.Targets
 
                 InternalLogger.Debug("{0}: DirectoryNotFoundException - Attempting to create directory for file: {1}", this, filePath);
 
-                var directoryName = Path.GetDirectoryName(filePath);
+                var directoryName = Path.GetDirectoryName(filePath) ?? string.Empty;
 
                 try
                 {

--- a/src/NLog/Targets/LineEndingMode.cs
+++ b/src/NLog/Targets/LineEndingMode.cs
@@ -185,7 +185,7 @@ namespace NLog.Targets
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is LineEndingMode mode && Equals(mode);
         }
@@ -193,7 +193,7 @@ namespace NLog.Targets
         /// <summary>Indicates whether the current object is equal to another object of the same type.</summary>
         /// <returns><see langword="true"/> if the current object is equal to the <paramref name="other" /> parameter; otherwise, <see langword="false"/>.</returns>
         /// <param name="other">An object to compare with this object.</param>
-        public bool Equals(LineEndingMode other)
+        public bool Equals(LineEndingMode? other)
         {
             return ReferenceEquals(this, other) || string.Equals(_newLineCharacters, other?._newLineCharacters, StringComparison.Ordinal);
         }
@@ -210,7 +210,7 @@ namespace NLog.Targets
             }
 
             /// <inheritdoc/>
-            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            public override object? ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
             {
                 var name = value as string;
                 return name != null ? FromString(name) : base.ConvertFrom(context, culture, value);

--- a/src/NLog/Targets/MethodCallTarget.cs
+++ b/src/NLog/Targets/MethodCallTarget.cs
@@ -267,7 +267,9 @@ namespace NLog.Targets
                 catch (TargetInvocationException ex)
                 {
                     InternalLogger.Warn("{0}: Failed to invoke method - {1}", this, ex.Message);
-                    throw ex.InnerException;
+                    if (ex.InnerException != null)
+                        throw ex.InnerException;
+                    throw;
                 }
             }
         }

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -726,7 +726,7 @@ namespace NLog.Targets
 
             public override string ToString()
             {
-                return TargetLayout?.ToString() ?? base.ToString();
+                return TargetLayout?.ToString() ?? base.ToString() ?? GetType().ToString();
             }
 
             public override void Precalculate(LogEventInfo logEvent)

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -466,7 +466,7 @@ namespace NLog.Targets.Wrappers
             }
         }
 
-        private void ProcessPendingEvents(object state)
+        private void ProcessPendingEvents(object? state)
         {
             if (_lazyWriterTimer is null)
                 return;
@@ -520,7 +520,7 @@ namespace NLog.Targets.Wrappers
             }
         }
 
-        private void FlushEventsInQueue(object state)
+        private void FlushEventsInQueue(object? state)
         {
             var asyncContinuation = state as AsyncContinuation;
             if (Monitor.TryEnter(_writeLockObject, 1500))
@@ -614,12 +614,12 @@ namespace NLog.Targets.Wrappers
             return batchSize;
         }
 
-        private void OnRequestQueueDropItem(object sender, LogEventDroppedEventArgs logEventDroppedEventArgs)
+        private void OnRequestQueueDropItem(object? sender, LogEventDroppedEventArgs logEventDroppedEventArgs)
         {
             _logEventDroppedEvent?.Invoke(this, logEventDroppedEventArgs);
         }
 
-        private void OnRequestQueueGrow(object sender, LogEventQueueGrowEventArgs logEventQueueGrowEventArgs)
+        private void OnRequestQueueGrow(object? sender, LogEventQueueGrowEventArgs logEventQueueGrowEventArgs)
         {
             _eventQueueGrowEvent?.Invoke(this, logEventQueueGrowEventArgs);
         }

--- a/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/BufferingTargetWrapper.cs
@@ -271,7 +271,7 @@ namespace NLog.Targets.Wrappers
             }
         }
 
-        private void FlushCallback(object state)
+        private void FlushCallback(object? state)
         {
             bool lockTaken = false;
 

--- a/tests/NLog.RegEx.Tests/ColoredConsoleTargetTests.cs
+++ b/tests/NLog.RegEx.Tests/ColoredConsoleTargetTests.cs
@@ -164,7 +164,7 @@ namespace NLog.RegEx.Tests
                 Values.Add(value);
             }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
             public override void Write(ReadOnlySpan<char> buffer)
             {
                 Values.Add(buffer.ToString());

--- a/tests/NLog.UnitTests/LogMessageFormatterTests.cs
+++ b/tests/NLog.UnitTests/LogMessageFormatterTests.cs
@@ -100,7 +100,7 @@ namespace NLog.UnitTests
                 new MessageTemplateParameter("Application", new StringBuilder("BestApplicationEver", 32), null, CaptureType.Normal)
             });
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
             LogEventInfo logEventInfo3 = new LogEventInfo(LogLevel.Info, "MyLogger", "Login request from John for BestApplicationEver", "Login request from {Username} for {Application}", new Span<MessageTemplateParameter>(new[]
             {
                 new MessageTemplateParameter("Username", "John", null, CaptureType.Normal),
@@ -132,7 +132,7 @@ namespace NLog.UnitTests
             var result2 = debugTarget.Layout.Render(logEventInfo2);
             Assert.Same(result2, debugTarget.LastMessage);
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
             logger.Log(logEventInfo3);
             logFactory.Flush();
             var result3 = debugTarget.Layout.Render(logEventInfo3);

--- a/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/ColoredConsoleTargetTests.cs
@@ -386,7 +386,7 @@ namespace NLog.UnitTests.Targets
                 Values.Add(value);
             }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
             public override void Write(ReadOnlySpan<char> buffer)
             {
                 Values.Add(buffer.ToString());


### PR DESCRIPTION
NET10 have added more nullable annotations for the .NET API. Trying to fix most warnings, but not all. Since being multi-target complicates things.