### PR TITLE
InternalLogger - Auto enable LogLevel.Info when activated

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -58,21 +58,25 @@ namespace NLog.Common
         public static void Reset()
         {
             ExceptionThrowWhenWriting = false;
-            LogWriter = null;
-            InternalEventOccurred = null;
-            LogLevel = LogLevel.Off;
             IncludeTimestamp = true;
+            LogWriter = null;
             LogToConsole = false;
             LogToConsoleError = false;
             LogFile = null;
+            InternalEventOccurred = null;
+            _logLevel = null;
         }
 
         /// <summary>
         /// Gets or sets the minimal internal log level.
         /// </summary>
         /// <example>If set to <see cref="NLog.LogLevel.Info"/>, then messages of the levels <see cref="NLog.LogLevel.Info"/>, <see cref="NLog.LogLevel.Error"/> and <see cref="NLog.LogLevel.Fatal"/> will be written.</example>
-        public static LogLevel LogLevel { get => _logLevel; set => _logLevel = value ?? LogLevel.Off; }
-        private static LogLevel _logLevel = LogLevel.Off;
+        public static LogLevel LogLevel
+        {
+            get => _logLevel ?? LogLevel.Off;
+            set => _logLevel = value;
+        }
+        private static LogLevel? _logLevel;
 
         /// <summary>
         /// Gets or sets a value indicating whether internal messages should be written to the console output stream.
@@ -87,7 +91,11 @@ namespace NLog.Common
                 {
                     InternalEventOccurred -= LogToConsoleSubscription;
                     if (value)
+                    {
                         InternalEventOccurred += LogToConsoleSubscription;
+                        if (_logLevel is null)
+                            _logLevel = LogLevel.Info;
+                    }
                     _logToConsole = value;
                 }
             }
@@ -107,7 +115,11 @@ namespace NLog.Common
                 {
                     InternalEventOccurred -= LogToConsoleErrorSubscription;
                     if (value)
+                    {
                         InternalEventOccurred += LogToConsoleErrorSubscription;
+                        if (_logLevel is null)
+                            _logLevel = LogLevel.Info;
+                    }
                     _logToConsoleError = value;
                 }
             }
@@ -131,7 +143,11 @@ namespace NLog.Common
                 {
                     InternalEventOccurred -= LogToFileSubscription;
                     if (!string.IsNullOrEmpty(value))
+                    {
                         InternalEventOccurred += LogToFileSubscription;
+                        if (_logLevel is null)
+                            _logLevel = LogLevel.Info;
+                    }
                     _logFile = value;
                 }
 
@@ -148,7 +164,20 @@ namespace NLog.Common
         /// <summary>
         /// Gets or sets the text writer that will receive internal logs.
         /// </summary>
-        public static TextWriter? LogWriter { get; set; }
+        public static TextWriter? LogWriter
+        {
+            get => _logWriter;
+            set
+            {
+                if (value != null)
+                {
+                    if (_logLevel is null)
+                        _logLevel = LogLevel.Info;
+                }
+                _logWriter = value;
+            }
+        }
+        private static TextWriter? _logWriter;
 
         /// <summary>
         /// Internal LogEvent written to the InternalLogger
@@ -288,14 +317,14 @@ namespace NLog.Common
                 return;
             }
 
-            if (IsSeriousException(ex))
+            if (InternalEventOccurred is null && _logWriter is null)
             {
-                //no logging!
                 return;
             }
 
-            if (InternalEventOccurred is null && LogWriter is null)
+            if (IsSeriousException(ex))
             {
+                //no logging!
                 return;
             }
 
@@ -335,12 +364,12 @@ namespace NLog.Common
 
         private static void WriteToLog(LogLevel level, Exception? ex, string fullMessage, IInternalLoggerContext? loggerContext)
         {
-            if (LogWriter != null)
+            if (_logWriter != null)
             {
                 var logLine = CreateLogLine(ex, level, fullMessage);
                 lock (LockObject)
                 {
-                    LogWriter?.WriteLine(logLine);
+                    _logWriter?.WriteLine(logLine);
                 }
             }
 
@@ -398,19 +427,7 @@ namespace NLog.Common
         /// <returns><see langword="true"/> if logging is enabled; otherwise, <see langword="false"/>.</returns>
         private static bool IsLogLevelEnabled(LogLevel logLevel)
         {
-            return !ReferenceEquals(_logLevel, LogLevel.Off) && _logLevel.CompareTo(logLevel) <= 0;
-        }
-
-        /// <summary>
-        /// Determine if logging is enabled.
-        /// </summary>
-        /// <returns><see langword="true"/> if logging is enabled; otherwise, <see langword="false"/>.</returns>
-        internal static bool HasActiveLoggers()
-        {
-            if (InternalEventOccurred is null && LogWriter is null)
-                return false;
-            else
-                return true;
+            return _logLevel is not null && logLevel is not null && _logLevel.Ordinal <= logLevel.Ordinal;
         }
 
         private static void CreateDirectoriesIfNeeded(string filename)

--- a/src/NLog/Config/ConfigSectionHandler.cs
+++ b/src/NLog/Config/ConfigSectionHandler.cs
@@ -57,7 +57,7 @@ namespace NLog.Config
         /// Gets the default <see cref="LoggingConfiguration" /> object by parsing
         /// the application configuration file (<c>app.exe.config</c>).
         /// </summary>
-        internal static LoggingConfiguration? AppConfig
+        public static LoggingConfiguration? AppConfig
         {
             get
             {

--- a/src/NLog/Config/LoggingConfigurationParser.cs
+++ b/src/NLog/Config/LoggingConfigurationParser.cs
@@ -129,7 +129,6 @@ namespace NLog.Config
 
             CultureInfo? defaultCultureInfo = DefaultCultureInfo ?? LogFactory._defaultCultureInfo;
             bool? parseMessageTemplates = LogFactory.ServiceRepository.ResolveParseMessageTemplates();
-            bool internalLoggerEnabled = false;
             bool autoLoadExtensions = false;
             foreach (var configItem in sortedList)
             {
@@ -143,7 +142,6 @@ namespace NLog.Config
                         break;
                     case "INTERNALLOGLEVEL":
                         InternalLogger.LogLevel = ParseLogLevelSafe(configItem.Key, configItem.Value ?? string.Empty, InternalLogger.LogLevel);
-                        internalLoggerEnabled = InternalLogger.LogLevel != LogLevel.Off;
                         break;
                     case "USEINVARIANTCULTURE":
                         if (ParseBooleanValue(configItem.Key, configItem.Value ?? string.Empty, false))
@@ -189,11 +187,6 @@ namespace NLog.Config
             if (defaultCultureInfo != null && !ReferenceEquals(DefaultCultureInfo, defaultCultureInfo))
             {
                 DefaultCultureInfo = defaultCultureInfo;
-            }
-
-            if (!internalLoggerEnabled && !InternalLogger.HasActiveLoggers())
-            {
-                InternalLogger.LogLevel = LogLevel.Off; // Reduce overhead of the InternalLogger when not configured
             }
 
             if (autoLoadExtensions)

--- a/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
+++ b/tests/NLog.UnitTests/Common/InternalLoggerTests.cs
@@ -61,6 +61,16 @@ namespace NLog.UnitTests.Common
             Assert.True(InternalLogger.IsErrorEnabled);
             Assert.True(InternalLogger.IsFatalEnabled);
 
+            // Switch off the internal logging.
+            InternalLogger.Reset();
+
+            Assert.False(InternalLogger.IsTraceEnabled);
+            Assert.False(InternalLogger.IsDebugEnabled);
+            Assert.False(InternalLogger.IsInfoEnabled);
+            Assert.False(InternalLogger.IsWarnEnabled);
+            Assert.False(InternalLogger.IsErrorEnabled);
+            Assert.False(InternalLogger.IsFatalEnabled);
+
             // Setup LogLevel to maximum named level.
             InternalLogger.LogLevel = LogLevel.Fatal;
 

--- a/tests/NLog.UnitTests/Config/XmlConfigTests.cs
+++ b/tests/NLog.UnitTests/Config/XmlConfigTests.cs
@@ -48,6 +48,8 @@ namespace NLog.UnitTests.Config
         {
             using (new InternalLoggerScope())
             {
+                InternalLogger.Reset();
+
                 var xml = "<nlog></nlog>";
                 var config = XmlLoggingConfiguration.CreateFromXmlString(xml);
 
@@ -57,7 +59,7 @@ namespace NLog.UnitTests.Config
                 Assert.False(InternalLogger.LogToConsoleError);
                 Assert.True(InternalLogger.IncludeTimestamp);
                 Assert.Null(InternalLogger.LogWriter);
-                Assert.Equal(LogLevel.Off, InternalLogger.LogLevel);
+                Assert.Equal(LogLevel.Off, InternalLogger.LogLevel);    // Not auto-enabled
             }
         }
 
@@ -66,6 +68,8 @@ namespace NLog.UnitTests.Config
         {
             using (new InternalLoggerScope())
             {
+                InternalLogger.Reset();
+
                 using (new NoThrowNLogExceptions())
                 {
                     var xml = "<nlog logfile='test.txt' internalLogIncludeTimestamp='false' internalLogToConsole='true' internalLogToConsoleError='true'></nlog>";
@@ -77,7 +81,7 @@ namespace NLog.UnitTests.Config
                     Assert.True(InternalLogger.LogToConsoleError);
                     Assert.False(InternalLogger.IncludeTimestamp);
                     Assert.Null(InternalLogger.LogWriter);
-                    Assert.Equal(LogLevel.Info, InternalLogger.LogLevel);
+                    Assert.Equal(LogLevel.Info, InternalLogger.LogLevel);   // Auto-enabled
                 }
             }
         }

--- a/tests/NLog.UnitTests/LayoutRenderers/MdlcLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/MdlcLayoutRendererTests.cs
@@ -34,16 +34,12 @@
 namespace NLog.UnitTests.LayoutRenderers
 {
     using System;
-    using System.Xml.Linq;
     using NLog.Config;
-    using NLog.Targets;
     using Xunit;
 
     [Obsolete("Replaced by ScopeContext.PushProperty or Logger.PushScopeProperty using ${scopeproperty}. Marked obsolete on NLog 5.0")]
     public class MdlcLayoutRendererTests : NLogTestBase
     {
-        private DebugTarget _target;
-
         public MdlcLayoutRendererTests()
         {
             const string configXml = @"
@@ -56,9 +52,6 @@ namespace NLog.UnitTests.LayoutRenderers
 
             var config = XmlLoggingConfiguration.CreateFromXmlString(configXml);
             LogManager.Configuration = config;
-
-            _target = LogManager.Configuration.FindTargetByName("debug") as DebugTarget;
-
             MappedDiagnosticsLogicalContext.Clear();
         }
 
@@ -85,7 +78,7 @@ namespace NLog.UnitTests.LayoutRenderers
         {
             const string message = "message";
             LogManager.GetLogger("A").Debug(message);
-            Assert.Equal(message, _target.LastMessage);
+            AssertDebugLastMessage("debug", message);
         }
 
         [Fact]
@@ -97,8 +90,7 @@ namespace NLog.UnitTests.LayoutRenderers
 
             MappedDiagnosticsLogicalContext.Set(key, item);
             LogManager.GetLogger("A").Debug(message);
-
-            Assert.Equal(item + message, _target.LastMessage);
+            AssertDebugLastMessage("debug", item + message);
         }
     }
 }

--- a/tests/NLog.UnitTests/Mocks/AppEnvironmentMock.cs
+++ b/tests/NLog.UnitTests/Mocks/AppEnvironmentMock.cs
@@ -34,7 +34,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Xml;
 using NLog.Internal.Fakeables;
 
 namespace NLog.UnitTests.Mocks


### PR DESCRIPTION
Partially reverts #4547 and #2935 - Auto-enable LogLevel.Info unless explicitly configured to LogLevel.Off.

Has the side-effect that explicit configuring `internalLogLevel="Off"` gives a minor performance hit.

Also has the side-effect that if having explicit configured `internalLogToConsole="true"` or `internalLogToConsoleError="true"` or `internalLogFile="..."`, then logging is now automatically activated without having assigned `internalLogLevel` (Similar behavior as NLog v4.7.15 and older)