### PR TITLE
FileTarget - Replace Environment.TickCount with LogEventInfo.TimeStamp

### DIFF
--- a/src/NLog/Targets/FileAppenders/DiscardAllFileAppender.cs
+++ b/src/NLog/Targets/FileAppenders/DiscardAllFileAppender.cs
@@ -55,7 +55,7 @@ namespace NLog.Targets.FileAppenders
             OpenStreamTime = Time.TimeSource.Current.Time;
         }
 
-        public void Write(byte[] buffer, int offset, int count)
+        public void Write(DateTime timestamp, byte[] buffer, int offset, int count)
         {
             // SONAR: Nothing to write
         }

--- a/src/NLog/Targets/FileAppenders/ExclusiveFileLockingAppender.cs
+++ b/src/NLog/Targets/FileAppenders/ExclusiveFileLockingAppender.cs
@@ -46,7 +46,7 @@ namespace NLog.Targets.FileAppenders
         private readonly FileTarget _fileTarget;
         private readonly string _filePath;
         private Stream _fileStream;
-        private int _lastFileDeletedCheck;
+        private DateTime _lastFileDeletedCheck;
         private long? _countedFileSize;
 
         public string FilePath => _filePath;
@@ -87,7 +87,7 @@ namespace NLog.Targets.FileAppenders
             _fileTarget = fileTarget;
             _filePath = filePath;
             OpenStreamTime = Time.TimeSource.Current.Time;
-            _lastFileDeletedCheck = Environment.TickCount;
+            _lastFileDeletedCheck = OpenStreamTime;
 
             var fileInfoSize = RefreshFileBirthTimeUtc(true);
 
@@ -125,19 +125,31 @@ namespace NLog.Targets.FileAppenders
             }
         }
 
-        public void Write(byte[] buffer, int offset, int count)
+        public void Write(DateTime timestamp, byte[] buffer, int offset, int count)
         {
-            var lastFileSizeCheck = Environment.TickCount - _lastFileDeletedCheck;
-            if (lastFileSizeCheck > 1000 || lastFileSizeCheck < -1000)
-            {
+            if (HasFileBeenDeletedTime(timestamp))
                 MonitorFileHasBeenDeleted();
-                _lastFileDeletedCheck = Environment.TickCount;
-                FileLastModified = NLog.Time.TimeSource.Current.Time;
-            }
 
             _fileStream.Write(buffer, offset, count);
             if (_countedFileSize.HasValue)
                 _countedFileSize += count;
+        }
+
+        private bool HasFileBeenDeletedTime(DateTime timestamp)
+        {
+            var lastFileSizeCheck = timestamp.Ticks - _lastFileDeletedCheck.Ticks;
+            if (lastFileSizeCheck > TimeSpan.TicksPerSecond || lastFileSizeCheck < -TimeSpan.TicksPerSecond)
+            {
+                var currentFileDeletedCheck = NLog.Time.TimeSource.Current.Time;
+                FileLastModified = currentFileDeletedCheck;
+                var currentFileSizeCheck = currentFileDeletedCheck.Ticks - _lastFileDeletedCheck.Ticks;
+                if (currentFileSizeCheck > TimeSpan.TicksPerSecond || currentFileSizeCheck < -TimeSpan.TicksPerSecond)
+                {
+                    _lastFileDeletedCheck = currentFileDeletedCheck;
+                    return true;
+                }
+            }
+            return false;
         }
 
         public void Flush()

--- a/src/NLog/Targets/FileAppenders/IFileAppender.cs
+++ b/src/NLog/Targets/FileAppenders/IFileAppender.cs
@@ -51,10 +51,11 @@ namespace NLog.Targets.FileAppenders
         /// <summary>
         /// Writes the specified bytes to a file.
         /// </summary>
+        /// <param name="timestamp">LogEvent Timestamp.</param>
         /// <param name="buffer">The bytes array.</param>
         /// <param name="offset">The bytes array offset.</param>
         /// <param name="count">The number of bytes.</param>
-        void Write(byte[] buffer, int offset, int count);
+        void Write(DateTime timestamp, byte[] buffer, int offset, int count);
 
         void Flush();
 

--- a/src/NLog/Targets/FileAppenders/MinimalFileLockingAppender.cs
+++ b/src/NLog/Targets/FileAppenders/MinimalFileLockingAppender.cs
@@ -126,7 +126,7 @@ namespace NLog.Targets.FileAppenders
             OpenStreamTime = LastWriteTime = Time.TimeSource.Current.Time;
         }
 
-        public void Write(byte[] buffer, int offset, int count)
+        public void Write(DateTime timestamp, byte[] buffer, int offset, int count)
         {
             int overrideBufferSize = Math.Min((count / 4096 + 1) * 4096, _fileTarget.BufferSize);
 

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -760,7 +760,7 @@ namespace NLog.Targets
                     openFile = RollArchiveFile(filename, openFile, firstLogEvent, hasWritten);
                 }
 
-                openFile.FileAppender.Write(ms.GetBuffer(), 0, (int)ms.Length);
+                openFile.FileAppender.Write(firstLogEvent.TimeStamp, ms.GetBuffer(), 0, (int)ms.Length);
 
                 if (AutoFlush)
                 {
@@ -1001,7 +1001,7 @@ namespace NLog.Targets
                     var footerBytes = GetFooterLayoutBytes();
                     if (footerBytes?.Length > 0)
                     {
-                        openFile.FileAppender.Write(footerBytes, 0, footerBytes.Length);
+                        openFile.FileAppender.Write(openFile.FileAppender.FileLastModified, footerBytes, 0, footerBytes.Length);
                     }
                 }
             }


### PR DESCRIPTION
Skip operating system call for coarse timestamp, when already have LogEventInfo.TimeStamp (NET11 will make Environment.TickCount slower on Windows in exchange for higher time-precision)