### PR TITLE
JsonLayout - Faster Json encoding with INoAllocationStringValueRenderer

### DIFF
--- a/src/NLog/Internal/INoAllocationStringValueRenderer.cs
+++ b/src/NLog/Internal/INoAllocationStringValueRenderer.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2004-2024 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
 //
 // All rights reserved.
@@ -31,59 +31,21 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-namespace NLog.LayoutRenderers
+namespace NLog.Internal
 {
-    using System.Text;
-    using NLog.Config;
-    using NLog.Internal;
-
     /// <summary>
-    /// A string literal.
+    /// Supports rendering as string value with no allocations
     /// </summary>
     /// <remarks>
-    /// This is used to escape '${' sequence
-    /// as ;${literal:text=${}'
-    ///
-    /// <a href="https://github.com/NLog/NLog/wiki/Literal-Layout-Renderer">See NLog Wiki</a>
+    /// Implementors should not have the [AppDomainFixedOutput] attribute
     /// </remarks>
-    /// <seealso href="https://github.com/NLog/NLog/wiki/Literal-Layout-Renderer">Documentation on NLog Wiki</seealso>
-    [LayoutRenderer("literal")]
-    [ThreadAgnostic]
-    [AppDomainFixedOutput]
-    public class LiteralLayoutRenderer : LayoutRenderer, INoAllocationStringValueRenderer
+    internal interface INoAllocationStringValueRenderer : IStringValueRenderer
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="LiteralLayoutRenderer" /> class.
+        /// Renders the value of layout renderer in the context of the specified log event
         /// </summary>
-        public LiteralLayoutRenderer()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LiteralLayoutRenderer" /> class.
-        /// </summary>
-        /// <param name="text">The literal text value.</param>
-        /// <remarks>This is used by the layout compiler.</remarks>
-        public LiteralLayoutRenderer(string text)
-        {
-            Text = text;
-        }
-
-        /// <summary>
-        /// Gets or sets the literal text.
-        /// </summary>
-        /// <docgen category='Layout Options' order='10' />
-        [DefaultParameter]
-        public string Text { get; set; } = string.Empty;
-
-        /// <inheritdoc/>
-        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
-        {
-            builder.Append(Text);
-        }
-
-        string? IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => Text;
-
-        string? INoAllocationStringValueRenderer.GetFormattedStringNoAllocation(LogEventInfo logEvent) => Text;
+        /// <param name="logEvent"></param>
+        /// <returns>null if not possible or unknown</returns>
+        string? GetFormattedStringNoAllocation(LogEventInfo logEvent);
     }
 }

--- a/src/NLog/Internal/IStringValueRenderer.cs
+++ b/src/NLog/Internal/IStringValueRenderer.cs
@@ -37,9 +37,9 @@ namespace NLog.Internal
     /// Supports rendering as string value with limited or no allocations (preferred)
     /// </summary>
     /// <remarks>
-    /// Implementors must not have the [AppDomainFixedOutput] attribute
+    /// Implementors should not have the [AppDomainFixedOutput] attribute
     /// </remarks>
-    interface IStringValueRenderer
+    internal interface IStringValueRenderer
     {
         /// <summary>
         /// Renders the value of layout renderer in the context of the specified log event

--- a/src/NLog/LayoutRenderers/AppSettingLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/AppSettingLayoutRenderer.cs
@@ -107,7 +107,7 @@ namespace NLog.LayoutRenderers
         private string GetStringValue()
         {
             if (string.IsNullOrEmpty(Item))
-                return Default;
+                return Default ?? string.Empty;
 
             var value = _connectionStringName is null ?
                 ConfigurationManager.AppSettings[Item] :

--- a/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/EventPropertiesLayoutRenderer.cs
@@ -50,7 +50,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("event-context")]
     [ThreadAgnostic]
     [ThreadAgnosticImmutable]
-    public class EventPropertiesLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
+    public class EventPropertiesLayoutRenderer : LayoutRenderer, IRawValue, INoAllocationStringValueRenderer
     {
         private ObjectReflectionCache ObjectReflectionCache => _objectReflectionCache ?? (_objectReflectionCache = new ObjectReflectionCache(LoggingConfiguration.GetServiceProvider()));
         private ObjectReflectionCache? _objectReflectionCache;
@@ -145,6 +145,14 @@ namespace NLog.LayoutRenderers
                 return string.Empty;
             }
             return null;
+        }
+
+        string? INoAllocationStringValueRenderer.GetFormattedStringNoAllocation(LogEventInfo logEvent)
+        {
+            if (Format is null)
+                return (!TryGetValue(logEvent, out var value) || value is null) ? string.Empty : value as string;
+            else
+                return null;
         }
 
         private bool TryGetValue(LogEventInfo logEvent, out object? value)

--- a/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/GdcLayoutRenderer.cs
@@ -47,7 +47,7 @@ namespace NLog.LayoutRenderers
     /// <seealso href="https://github.com/NLog/NLog/wiki/Gdc-Layout-Renderer">Documentation on NLog Wiki</seealso>
     [LayoutRenderer("gdc")]
     [ThreadAgnostic]
-    public class GdcLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
+    public class GdcLayoutRenderer : LayoutRenderer, IRawValue, INoAllocationStringValueRenderer
     {
         private CachedLookup _cachedLookup = new CachedLookup(string.Empty, null);
 
@@ -107,6 +107,11 @@ namespace NLog.LayoutRenderers
                 return stringValue;
             }
             return null;
+        }
+
+        string? INoAllocationStringValueRenderer.GetFormattedStringNoAllocation(LogEventInfo logEvent)
+        {
+            return Format is null ? GetValue() as string : null;
         }
 
         private object? GetValue()

--- a/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LevelLayoutRenderer.cs
@@ -33,7 +33,6 @@
 
 namespace NLog.LayoutRenderers
 {
-    using System;
     using System.Text;
     using NLog.Config;
     using NLog.Internal;
@@ -48,89 +47,121 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("level")]
     [LayoutRenderer("loglevel")]
     [ThreadAgnostic]
-    public class LevelLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
+    public class LevelLayoutRenderer : LayoutRenderer, IRawValue, INoAllocationStringValueRenderer
     {
-        private static readonly string[] _upperCaseMapper = new string[]
-        {
-            LogLevel.Trace.ToString().ToUpperInvariant(),
-            LogLevel.Debug.ToString().ToUpperInvariant(),
-            LogLevel.Info.ToString().ToUpperInvariant(),
-            LogLevel.Warn.ToString().ToUpperInvariant(),
-            LogLevel.Error.ToString().ToUpperInvariant(),
-            LogLevel.Fatal.ToString().ToUpperInvariant(),
-            LogLevel.Off.ToString().ToUpperInvariant(),
-        };
+        private readonly static string[] _defaultNames = GenerateLevelNames(LevelFormat.Name, false);
+        private readonly static string[] _defaultUppercaseNames = GenerateLevelNames(LevelFormat.Name, true);
+        private string[] _levelNames = _defaultNames;
 
         /// <summary>
         /// Gets or sets a value indicating the output format of the level.
         /// </summary>
         /// <remarks>Default: <see cref="LevelFormat.Name"/></remarks>
         /// <docgen category='Layout Options' order='10' />
-        public LevelFormat Format { get; set; } = LevelFormat.Name;
+        public LevelFormat Format
+        {
+            get => _format;
+            set
+            {
+                if (_format != value)
+                {
+                    _format = value;
+                    _levelNames = GenerateLevelNames(_format, _uppercase);
+                }
+            }
+        }
+        private LevelFormat _format = LevelFormat.Name;
 
         /// <summary>
         /// Gets or sets a value indicating whether upper case conversion should be applied.
         /// </summary>
         /// <remarks>Default: <see langword="false"/></remarks>
         /// <docgen category='Layout Options' order='10' />
-        public bool Uppercase { get; set; }
+        public bool Uppercase
+        {
+            get => _uppercase;
+            set
+            {
+                if (_uppercase != value)
+                {
+                    _uppercase = value;
+                    if (_format == LevelFormat.Name)
+                        _levelNames = _uppercase ? _defaultUppercaseNames : _defaultNames;
+                    else
+                        _levelNames = GenerateLevelNames(_format, _uppercase);
+                }
+            }
+        }
+        private bool _uppercase;
 
         /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            LogLevel level = GetValue(logEvent);
-            switch (Format)
+            builder.Append(GetLogLevelStringValue(logEvent));
+        }
+
+        private string GetLogLevelStringValue(LogEventInfo logEvent)
+        {
+            var logLevel = GetValue(logEvent) ?? LogLevel.Trace;
+            var ordinal = logLevel.Ordinal;
+            return (ordinal >= 0 && ordinal < _levelNames.Length) ? _levelNames[ordinal] : GetFormattedLevelName(logLevel, _format, _uppercase);
+        }
+
+        private static string[] GenerateLevelNames(LevelFormat format, bool upperCase)
+        {
+            string[] newLevelNames = new string[LogLevel.MaxLevel.Ordinal + 2];
+            newLevelNames[LogLevel.Trace.Ordinal] = GetFormattedLevelName(LogLevel.Trace, format, upperCase);
+            newLevelNames[LogLevel.Debug.Ordinal] = GetFormattedLevelName(LogLevel.Debug, format, upperCase);
+            newLevelNames[LogLevel.Info.Ordinal] = GetFormattedLevelName(LogLevel.Info, format, upperCase);
+            newLevelNames[LogLevel.Warn.Ordinal] = GetFormattedLevelName(LogLevel.Warn, format, upperCase);
+            newLevelNames[LogLevel.Error.Ordinal] = GetFormattedLevelName(LogLevel.Error, format, upperCase);
+            newLevelNames[LogLevel.Fatal.Ordinal] = GetFormattedLevelName(LogLevel.Fatal, format, upperCase);
+            newLevelNames[LogLevel.Off.Ordinal] = GetFormattedLevelName(LogLevel.Off, format, upperCase);
+            return newLevelNames;
+        }
+
+        private static string GetFormattedLevelName(LogLevel logLevel, LevelFormat format, bool upperCase)
+        {
+            switch (format)
             {
-                case LevelFormat.Name:
-                    builder.Append(Uppercase ? GetUpperCaseString(level) : level.ToString());
-                    break;
                 case LevelFormat.FirstCharacter:
-                    builder.Append(level.ToString()[0]);
-                    break;
+                    return logLevel.ToString()[0].ToString();
                 case LevelFormat.Ordinal:
-                    builder.AppendInvariant(level.Ordinal);
-                    break;
+                    return logLevel.Ordinal.ToString();
                 case LevelFormat.FullName:
-                    builder.Append(GetFullNameString(level));
-                    break;
+                    return upperCase ? GetFullNameString(logLevel).ToUpperInvariant() : GetFullNameString(logLevel);
                 case LevelFormat.TriLetter:
-                    builder.Append(GetTriLetterString(level));
-                    break;
+                    return upperCase ? GetTriLetterString(logLevel).ToUpperInvariant() : GetTriLetterString(logLevel);
+                default:
+                    return upperCase ? logLevel.ToString().ToUpperInvariant() : logLevel.ToString();
             }
         }
 
-        private static string GetUpperCaseString(LogLevel level)
+        private static string GetFullNameString(LogLevel logLevel)
         {
-            var ordinal = level.Ordinal;
-            if (ordinal < 0 || ordinal >= _upperCaseMapper.Length)
-                return level.ToString().ToUpperInvariant();
+            if (logLevel == LogLevel.Info)
+                return "Information";
+            else if (logLevel == LogLevel.Warn)
+                return "Warning";
             else
-                return _upperCaseMapper[ordinal];
+                return logLevel.ToString();
         }
 
-        private string GetFullNameString(LogLevel level)
+        private static string GetTriLetterString(LogLevel level)
         {
-            if (level == LogLevel.Info)
-                return Uppercase ? "INFORMATION" : "Information";
-            if (level == LogLevel.Warn)
-                return Uppercase ? "WARNING" : "Warning";
-
-            return Uppercase ? GetUpperCaseString(level) : level.ToString();
-        }
-
-        private string GetTriLetterString(LogLevel level)
-        {
+            if (level == LogLevel.Trace)
+                return "Trc";
             if (level == LogLevel.Debug)
-                return Uppercase ? "DBG" : "Dbg";
+                return "Dbg";
             if (level == LogLevel.Info)
-                return Uppercase ? "INF" : "Inf";
+                return "Inf";
             if (level == LogLevel.Warn)
-                return Uppercase ? "WRN" : "Wrn";
+                return "Wrn";
             if (level == LogLevel.Error)
-                return Uppercase ? "ERR" : "Err";
+                return "Err";
             if (level == LogLevel.Fatal)
-                return Uppercase ? "FTL" : "Ftl";
-            return Uppercase ? "TRC" : "Trc";
+                return "Ftl";
+            return level.ToString();
         }
 
         bool IRawValue.TryGetRawValue(LogEventInfo logEvent, out object value)
@@ -139,15 +170,9 @@ namespace NLog.LayoutRenderers
             return true;
         }
 
-        string? IStringValueRenderer.GetFormattedString(LogEventInfo logEvent)
-        {
-            if (Format == LevelFormat.Name)
-            {
-                var level = GetValue(logEvent);
-                return Uppercase ? GetUpperCaseString(level) : level.ToString();
-            }
-            return null;
-        }
+        string? IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) => GetLogLevelStringValue(logEvent);
+
+        string? INoAllocationStringValueRenderer.GetFormattedStringNoAllocation(LogEventInfo logEvent) => GetLogLevelStringValue(logEvent);
 
         private static LogLevel GetValue(LogEventInfo logEvent)
         {

--- a/src/NLog/LayoutRenderers/LoggerNameLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/LoggerNameLayoutRenderer.cs
@@ -47,7 +47,7 @@ namespace NLog.LayoutRenderers
     [LayoutRenderer("loggername")]
     [LayoutRenderer("logger")]
     [ThreadAgnostic]
-    public class LoggerNameLayoutRenderer : LayoutRenderer, IStringValueRenderer
+    public class LoggerNameLayoutRenderer : LayoutRenderer, INoAllocationStringValueRenderer
     {
         /// <summary>
         /// Gets or sets a value indicating whether to render short logger name (the part after the trailing dot character).
@@ -113,6 +113,11 @@ namespace NLog.LayoutRenderers
         private static int TryGetLastDotForShortName(string loggerName)
         {
             return loggerName?.LastIndexOf('.') ?? -1;
+        }
+
+        string? INoAllocationStringValueRenderer.GetFormattedStringNoAllocation(LogEventInfo logEvent)
+        {
+            return (!ShortName && !PrefixName) ? (logEvent.LoggerName ?? string.Empty) : null;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/MessageLayoutRenderer.cs
@@ -48,7 +48,7 @@ namespace NLog.LayoutRenderers
     /// <seealso href="https://github.com/NLog/NLog/wiki/Message-Layout-Renderer">Documentation on NLog Wiki</seealso>
     [LayoutRenderer("message")]
     [ThreadAgnostic]
-    public class MessageLayoutRenderer : LayoutRenderer, IStringValueRenderer
+    public class MessageLayoutRenderer : LayoutRenderer, INoAllocationStringValueRenderer
     {
         /// <summary>
         /// Gets or sets a value indicating whether to log exception along with message.
@@ -155,6 +155,14 @@ namespace NLog.LayoutRenderers
                 return null;
             else
                 return (Raw ? logEvent.Message : logEvent.FormattedMessage) ?? string.Empty;
+        }
+
+        string? INoAllocationStringValueRenderer.GetFormattedStringNoAllocation(LogEventInfo logEvent)
+        {
+            if (Raw)
+                return WithException ? null : (logEvent.Message ?? string.Empty);
+            else
+                return (WithException || logEvent.Parameters?.Length > 0) ? null : (logEvent.FormattedMessage ?? logEvent.Message ?? string.Empty);
         }
     }
 }

--- a/src/NLog/Layouts/JSON/JsonAttribute.cs
+++ b/src/NLog/Layouts/JSON/JsonAttribute.cs
@@ -171,7 +171,7 @@ namespace NLog.Layouts
             var simpleStringValue = _layoutInfo.SimpleStringValue;
             if (simpleStringValue != null)
             {
-                var stringValue = simpleStringValue.Invoke(logEvent);
+                var stringValue = simpleStringValue.GetFormattedStringNoAllocation(logEvent);
                 if (stringValue != null)
                 {
                     // Optimize for simple LogEvents that contains basic string-value, for faster Json-encoding

--- a/src/NLog/Layouts/JSON/JsonAttribute.cs
+++ b/src/NLog/Layouts/JSON/JsonAttribute.cs
@@ -168,6 +168,17 @@ namespace NLog.Layouts
                 return RenderAppendJsonValue(logEvent, builder, valueStart);
             }
 
+            var simpleStringValue = _layoutInfo.SimpleStringValue;
+            if (simpleStringValue != null)
+            {
+                var stringValue = simpleStringValue.Invoke(logEvent);
+                if (stringValue != null)
+                {
+                    // Optimize for simple LogEvents that contains basic string-value, for faster Json-encoding
+                    return RenderAppendJsonStringValue(builder, stringValue);
+                }
+            }
+
             if (ValueType is null)
             {
                 builder.Append('"');
@@ -187,6 +198,17 @@ namespace NLog.Layouts
 
                 jsonConverter.SerializeObject(objectValue, builder);
             }
+            return true;
+        }
+
+        private bool RenderAppendJsonStringValue(StringBuilder builder, string stringValue)
+        {
+            if (!IncludeEmptyValue && string.IsNullOrEmpty(stringValue))
+                return false;
+
+            builder.Append('"');
+            Targets.DefaultJsonSerializer.AppendStringEscape(builder, stringValue, EscapeUnicode);
+            builder.Append('"');
             return true;
         }
 

--- a/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
+++ b/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
@@ -39,8 +39,6 @@ namespace NLog.Layouts
     using System.Text;
     using NLog.Config;
     using NLog.Internal;
-    using NLog.LayoutRenderers;
-    using NLog.LayoutRenderers.Wrappers;
 
     /// <summary>
     /// Typed Value that is easily configured from NLog.config file
@@ -77,30 +75,17 @@ namespace NLog.Layouts
         }
         private Layout _layout = Layout.Empty;
 
-        internal Func<LogEventInfo, string?>? SimpleStringValue { get; private set; }
+        internal INoAllocationStringValueRenderer? SimpleStringValue { get; private set; }
 
-        private static Func<LogEventInfo, string?>? ResolveStringValueMethod(Layout layout)
+        private static INoAllocationStringValueRenderer? ResolveStringValueMethod(Layout layout)
         {
-            var stringValueRenderer = (layout is SimpleLayout simpleLayout && simpleLayout.LayoutRenderers.Count() == 1) ? simpleLayout.LayoutRenderers.First() as IStringValueRenderer : null;
-            if (stringValueRenderer is null)
-                return null;
-
-            if (stringValueRenderer is MessageLayoutRenderer messageLayoutRenderer && !messageLayoutRenderer.WithException)
+            var stringValueRenderer = (layout is SimpleLayout simpleLayout && simpleLayout.LayoutRenderers.Count() == 1) ? simpleLayout.LayoutRenderers.First() as INoAllocationStringValueRenderer : null;
+            if (stringValueRenderer != null)
             {
-                return messageLayoutRenderer.Raw ?
-                    (logEvent => stringValueRenderer.GetFormattedString(logEvent)) :
-                    (logEvent => (logEvent.Parameters is null || logEvent.Parameters.Length == 0) ? stringValueRenderer.GetFormattedString(logEvent) : null);
+                var stringValue = stringValueRenderer.GetFormattedStringNoAllocation(LogEventInfo.CreateNullEvent());
+                return stringValue is null ? null : stringValueRenderer;
             }
-            if (stringValueRenderer is LiteralLayoutRenderer || stringValueRenderer is LevelLayoutRenderer || stringValueRenderer is CachedLayoutRendererWrapper)
-            {
-                return logEvent => stringValueRenderer.GetFormattedString(logEvent);
-            }
-            if (stringValueRenderer is LoggerNameLayoutRenderer loggerNameLayoutRenderer && !loggerNameLayoutRenderer.ShortName && !loggerNameLayoutRenderer.PrefixName)
-            {
-                return logEvent => stringValueRenderer.GetFormattedString(logEvent);
-            }
-
-            return null;
+            return stringValueRenderer;
         }
 
         /// <summary>
@@ -114,7 +99,7 @@ namespace NLog.Layouts
             set
             {
                 _valueType = value;
-                SimpleStringValue = null;
+                SimpleStringValue = (_valueType is null || typeof(string).Equals(_valueType)) ? ResolveStringValueMethod(_layout) : null;
                 if (value?.IsValueType == true)
                     _createDefaultValue = () => Activator.CreateInstance(value);
                 else

--- a/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
+++ b/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
@@ -35,9 +35,12 @@ namespace NLog.Layouts
 {
     using System;
     using System.Globalization;
+    using System.Linq;
     using System.Text;
     using NLog.Config;
     using NLog.Internal;
+    using NLog.LayoutRenderers;
+    using NLog.LayoutRenderers.Wrappers;
 
     /// <summary>
     /// Typed Value that is easily configured from NLog.config file
@@ -68,10 +71,37 @@ namespace NLog.Layouts
                 {
                     ValueType = layoutTyped.InnerType;
                 }
+                SimpleStringValue = ValueType is null ? ResolveStringValueMethod(_layout) : null;
                 _layoutValue = null;
             }
         }
         private Layout _layout = Layout.Empty;
+
+        internal Func<LogEventInfo, string?>? SimpleStringValue { get; private set; }
+
+        private static Func<LogEventInfo, string?>? ResolveStringValueMethod(Layout layout)
+        {
+            var stringValueRenderer = (layout is SimpleLayout simpleLayout && simpleLayout.LayoutRenderers.Count() == 1) ? simpleLayout.LayoutRenderers.First() as IStringValueRenderer : null;
+            if (stringValueRenderer is null)
+                return null;
+
+            if (stringValueRenderer is MessageLayoutRenderer messageLayoutRenderer && !messageLayoutRenderer.WithException)
+            {
+                return messageLayoutRenderer.Raw ?
+                    (logEvent => stringValueRenderer.GetFormattedString(logEvent)) :
+                    (logEvent => (logEvent.Parameters is null || logEvent.Parameters.Length == 0) ? stringValueRenderer.GetFormattedString(logEvent) : null);
+            }
+            if (stringValueRenderer is LiteralLayoutRenderer || stringValueRenderer is LevelLayoutRenderer || stringValueRenderer is CachedLayoutRendererWrapper)
+            {
+                return logEvent => stringValueRenderer.GetFormattedString(logEvent);
+            }
+            if (stringValueRenderer is LoggerNameLayoutRenderer loggerNameLayoutRenderer && !loggerNameLayoutRenderer.ShortName && !loggerNameLayoutRenderer.PrefixName)
+            {
+                return logEvent => stringValueRenderer.GetFormattedString(logEvent);
+            }
+
+            return null;
+        }
 
         /// <summary>
         /// Gets or sets the result value type, for conversion of layout rendering output
@@ -84,6 +114,7 @@ namespace NLog.Layouts
             set
             {
                 _valueType = value;
+                SimpleStringValue = null;
                 if (value?.IsValueType == true)
                     _createDefaultValue = () => Activator.CreateInstance(value);
                 else

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -263,7 +263,7 @@ namespace NLog.Targets
 
                 destination.Append('"');
 #if NETFRAMEWORK
-                var str = formattable.ToString(null, CultureInfo.InvariantCulture);
+                var str = formattable.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty;
                 AppendStringEscape(destination, str, options);
 #else
                 int startPos = destination.Length;
@@ -595,9 +595,6 @@ namespace NLog.Targets
         /// <returns>JSON escaped string</returns>
         internal static void AppendStringEscape(StringBuilder destination, string text, bool escapeUnicode)
         {
-            if (string.IsNullOrEmpty(text))
-                return;
-
             int i = 0;
             foreach (var chr in text)
             {

--- a/tests/NLog.UnitTests/ApiTests.cs
+++ b/tests/NLog.UnitTests/ApiTests.cs
@@ -40,6 +40,7 @@ namespace NLog.UnitTests
     using System.Runtime.CompilerServices;
     using System.Text;
     using NLog.Config;
+    using NLog.LayoutRenderers;
     using Xunit;
 
     /// <summary>
@@ -190,7 +191,7 @@ namespace NLog.UnitTests
         {
             foreach (Type type in allTypes)
             {
-                if (typeof(NLog.Internal.IStringValueRenderer).IsAssignableFrom(type) && !type.IsInterface && !typeof(NLog.Layouts.SimpleLayout).Equals(type) && !typeof(NLog.LayoutRenderers.Wrappers.WrapperLayoutRendererBase).IsAssignableFrom(type))
+                if (typeof(NLog.Internal.IStringValueRenderer).IsAssignableFrom(type) && !type.IsInterface && !typeof(NLog.Layouts.SimpleLayout).Equals(type) && !typeof(NLog.LayoutRenderers.Wrappers.WrapperLayoutRendererBase).IsAssignableFrom(type) && !typeof(NLog.LayoutRenderers.LiteralLayoutRenderer).IsAssignableFrom(type))
                 {
                     var appDomainFixedOutputAttribute = type.GetCustomAttribute<AppDomainFixedOutputAttribute>();
                     Assert.True(appDomainFixedOutputAttribute is null, $"{type.ToString()} should not implement IStringValueRenderer");


### PR DESCRIPTION
It is much faster to enumerate a string to check if Json-encoding needed, than appending string to StringBuilder and enumerate the StringBuilder to check if Json-encoding needed.

When NLog is used as Microsoft Logging Provider, then it will by default generate simple LogEvents (message formatting done upfront).

My own use-case is using NLog for writing string-blobs into a json-file, and want to reduce the overhead (writing 10000 blobs/sec)

| Method       | Mean     | Error   | StdDev  | Gen0    | Allocated |
|------------- |---------:|--------:|--------:|--------:|----------:|
| Before-PR | 344.5 us | 1.34 us | 1.25 us | 21.9727 | 203.13 KB |
| After-PR | 248.1 us | 0.78 us | 0.69 us | 21.9727 | 203.13 KB |

With the following `JsonLayout`, and the log-message `"The cat sat at the bar."`.
```csharp
            var jsonLayout = new NLog.Layouts.JsonLayout
            {
                Attributes =
                {
                    new NLog.Layouts.JsonAttribute("time", "${date:format=o}"),
                    new NLog.Layouts.JsonAttribute("level", "${level:upperCase=true}"),
                    new NLog.Layouts.JsonAttribute("message", "${message}"),
                    new NLog.Layouts.JsonAttribute("logger", "${logger}"),
                }
            };
```
Even for a very small payloads, then there is a 50pct speed-improvement. And when increasing log-message to 500 characters, then 250pct speed-improvement:

| Method       | Mean     | Error     | StdDev    | Gen0    | Allocated |
|------------- |---------:|----------:|----------:|--------:|----------:|
| Before-PR | 1.404 ms | 0.0055 ms | 0.0051 ms | 21.4844 | 203.13 KB |
| After-PR | 570.0 us | 3.08 us | 2.73 us | 21.4844 | 203.13 KB |