### PR TITLE
Target - Reduce code complexity of WriteAsyncLogEvents

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -773,7 +773,7 @@ namespace NLog.Config
                     }
                 }
 
-                if (initialize is Target target && target.InitializeException is NLogDependencyResolveException)
+                if (initialize is Target target && target.InitializeMissingDependencyException != null)
                 {
                     _missingServiceTypes = true;
                 }
@@ -789,11 +789,12 @@ namespace NLog.Config
                 var allTargets = AllTargets;
                 foreach (var target in allTargets)
                 {
-                    if (target.InitializeException is NLogDependencyResolveException resolveException)
+                    var dependencyResolveException = target.InitializeMissingDependencyException;
+                    if (dependencyResolveException != null)
                     {
                         missingServiceTypes = true;
 
-                        if (typeof(IServiceProvider).IsAssignableFrom(serviceType) || IsMissingServiceType(resolveException, serviceType))
+                        if (typeof(IServiceProvider).IsAssignableFrom(serviceType) || IsMissingServiceType(dependencyResolveException, serviceType))
                         {
                             target.Close(); // Close Target to allow re-initialize
                         }

--- a/src/NLog/Config/MethodFactory.cs
+++ b/src/NLog/Config/MethodFactory.cs
@@ -213,10 +213,9 @@ namespace NLog.Config
             }
             catch (TargetInvocationException ex)
             {
-                if (ex.InnerException is null)
-                    throw;
-
-                throw ex.InnerException;
+                if (ex.InnerException != null)
+                    throw ex.InnerException;
+                throw;
             }
         }
 

--- a/src/NLog/Internal/ReflectionHelpers.cs
+++ b/src/NLog/Internal/ReflectionHelpers.cs
@@ -80,9 +80,11 @@ namespace NLog.Internal
                     {
                         return methodInfo.Invoke(target, args);
                     }
-                    catch (TargetInvocationException exception)
+                    catch (TargetInvocationException ex)
                     {
-                        throw exception.InnerException ?? exception;
+                        if (ex.InnerException != null)
+                            throw ex.InnerException;
+                        throw;
                     }
                 };
             }

--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -379,9 +379,10 @@ namespace NLog.Targets
         ///
         /// Enqueue logevent for later processing when target failed to initialize because of unresolved service dependency.
         /// </summary>
-        protected override void WriteFailedNotInitialized(AsyncLogEventInfo logEvent, Exception initializeException)
+        protected override void WriteFailedNotInitialized(AsyncLogEventInfo logEvent, Exception? initializeException)
         {
-            if (initializeException is Config.NLogDependencyResolveException && OverflowAction == AsyncTargetWrapperOverflowAction.Discard)
+            var dependencyResolveException = initializeException as Config.NLogDependencyResolveException ?? initializeException?.InnerException as Config.NLogDependencyResolveException;
+            if (dependencyResolveException != null && OverflowAction == AsyncTargetWrapperOverflowAction.Discard)
             {
                 _missingServiceTypes = true;
                 Write(logEvent);

--- a/src/NLog/Targets/Target.cs
+++ b/src/NLog/Targets/Target.cs
@@ -64,7 +64,7 @@ namespace NLog.Targets
         /// </summary>
         internal StackTraceUsage StackTraceUsage { get; private set; }
 
-        internal Exception? InitializeException => _initializeException;
+        internal NLogDependencyResolveException? InitializeMissingDependencyException => _initializeException as NLogDependencyResolveException ?? _initializeException?.InnerException as NLogDependencyResolveException;
 
         /// <summary>
         /// Gets or sets the name of the target.
@@ -307,26 +307,17 @@ namespace NLog.Targets
         /// <param name="logEvent">Log event to write.</param>
         public void WriteAsyncLogEvent(AsyncLogEventInfo logEvent)
         {
-            if (!IsInitialized)
+            if (!IsInitialized || _initializeException != null)
             {
                 lock (SyncRoot)
                 {
-                    logEvent.Continuation(null);
+                    WriteFailedNotInitialized(logEvent, _initializeException);
                 }
                 return;
             }
 
             var wrappedContinuation = AsyncHelpers.PreventMultipleCalls(logEvent.Continuation);
             var wrappedLogEvent = logEvent.LogEvent.WithContinuation(wrappedContinuation);
-
-            if (_initializeException != null)
-            {
-                lock (SyncRoot)
-                {
-                    WriteFailedNotInitialized(wrappedLogEvent, _initializeException);
-                }
-                return;
-            }
 
             try
             {
@@ -359,28 +350,11 @@ namespace NLog.Targets
         /// <param name="logEvents">The log events.</param>
         public void WriteAsyncLogEvents(IList<AsyncLogEventInfo> logEvents)
         {
-            if (logEvents is null || logEvents.Count == 0)
-            {
-                return;
-            }
-
-            if (!IsInitialized)
+            if (!IsInitialized || _initializeException != null || logEvents is null)
             {
                 lock (SyncRoot)
                 {
-                    for (int i = 0; i < logEvents.Count; ++i)
-                    {
-                        logEvents[i].Continuation(null);
-                    }
-                }
-                return;
-            }
-
-            if (_initializeException != null)
-            {
-                lock (SyncRoot)
-                {
-                    for (int i = 0; i < logEvents.Count; ++i)
+                    for (int i = 0; i < logEvents?.Count; ++i)
                     {
                         WriteFailedNotInitialized(logEvents[i], _initializeException);
                     }
@@ -413,19 +387,19 @@ namespace NLog.Targets
         /// <summary>
         /// LogEvent is written to target, but target failed to successfully initialize
         /// </summary>
-        protected virtual void WriteFailedNotInitialized(AsyncLogEventInfo logEvent, Exception initializeException)
+        protected virtual void WriteFailedNotInitialized(AsyncLogEventInfo logEvent, Exception? initializeException)
         {
+            var innerException = initializeException?.InnerException ?? initializeException;
             if (!_scannedForLayouts)
             {
                 _scannedForLayouts = true;
-                InternalLogger.Error(_initializeException, "{0}: No output because target failed initialize.", this);
+                InternalLogger.Error(innerException, "{0}: No output because target failed initialize.", this);
             }
             else
             {
-                InternalLogger.Debug("{0}: No output because target failed initialize. {1} {2}", this, _initializeException?.GetType(), _initializeException?.Message);
+                InternalLogger.Debug("{0}: No output because target failed initialize. {1} {2}", this, innerException?.GetType(), innerException?.Message);
             }
-            var initializeFailedException = new NLogRuntimeException($"Target {this} failed to initialize.", initializeException);
-            logEvent.Continuation(initializeFailedException);
+            logEvent.Continuation(initializeException);
         }
 
         /// <summary>
@@ -456,7 +430,7 @@ namespace NLog.Targets
                     catch (NLogDependencyResolveException exception)
                     {
                         // Target is now in disabled state, and cannot be used for writing LogEvents
-                        _initializeException = exception;
+                        _initializeException = new NLogRuntimeException($"Target {this} failed to initialize.", exception);
                         _scannedForLayouts = false;
                         if (ExceptionMustBeRethrown(exception))
                             throw;
@@ -464,7 +438,7 @@ namespace NLog.Targets
                     catch (Exception exception)
                     {
                         // Target is now in disabled state, and cannot be used for writing LogEvents
-                        _initializeException = exception;
+                        _initializeException = new NLogRuntimeException($"Target {this} failed to initialize.", exception);
                         _scannedForLayouts = false;
                         if (ExceptionMustBeRethrown(exception))
                             throw;

--- a/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/AsyncTargetWrapper.cs
@@ -284,7 +284,7 @@ namespace NLog.Targets.Wrappers
 
             _layoutWithLock = _layoutWithLock ?? WrappedTarget?._layoutWithLock;
 
-            if (WrappedTarget != null && WrappedTarget.InitializeException is Config.NLogDependencyResolveException && OverflowAction == AsyncTargetWrapperOverflowAction.Discard)
+            if (WrappedTarget != null && OverflowAction == AsyncTargetWrapperOverflowAction.Discard && WrappedTarget.InitializeMissingDependencyException != null)
             {
                 _missingServiceTypes = true;
                 InternalLogger.Debug("{0} WrappedTarget has unresolved missing dependencies.", this);
@@ -566,7 +566,7 @@ namespace NLog.Targets.Wrappers
 
             if (_missingServiceTypes)
             {
-                if (WrappedTarget.InitializeException is Config.NLogDependencyResolveException)
+                if (WrappedTarget.InitializeMissingDependencyException != null)
                 {
                     return 0;
                 }

--- a/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
+++ b/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
@@ -83,7 +83,9 @@ namespace NLog.UnitTests.Targets
                     }
                     catch (System.Reflection.TargetInvocationException ex)
                     {
-                        throw ex.InnerException;
+                        if (ex.InnerException != null)
+                            throw ex.InnerException;
+                        throw;
                     }
                 }
             }

--- a/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/AsyncTargetWrapperTests.cs
@@ -993,7 +993,9 @@ namespace NLog.UnitTests.Targets.Wrappers
                     }
                     catch (System.Reflection.TargetInvocationException ex)
                     {
-                        throw ex.InnerException;
+                        if (ex.InnerException != null)
+                            throw ex.InnerException;
+                        throw;
                     }
                 }
             }


### PR DESCRIPTION
Failing to initialize NLog targets is an exotic situation, so changing behavior to simplify logic should be acceptable.

- [x] Wait for NLog v6.2