### PR TITLE
CachedLayoutRendererWrapper - Allow literal optimization when caching not needed

### DIFF
--- a/src/NLog/LayoutRenderers/Wrappers/CachedLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/CachedLayoutRendererWrapper.cs
@@ -51,6 +51,7 @@ namespace NLog.LayoutRenderers.Wrappers
     [AmbientProperty(nameof(Cached))]
     [AmbientProperty(nameof(ClearCache))]
     [AmbientProperty(nameof(CachedSeconds))]
+    [AppDomainFixedOutput]
     [ThreadAgnostic]
     public sealed class CachedLayoutRendererWrapper : WrapperLayoutRendererBase, IStringValueRenderer
     {


### PR DESCRIPTION
Avoid overhead if by accident having assigned `cached=true` to something that is completely static.