### PR TITLE
LiteralWithRawValueLayoutRenderer - Only support RawValue when possible (Fix bug)

### DIFF
--- a/src/NLog/Layouts/LayoutParser.cs
+++ b/src/NLog/Layouts/LayoutParser.cs
@@ -697,7 +697,7 @@ namespace NLog.Layouts
                     // Combined literals don't support rawValue
                     if (lr1 is LiteralWithRawValueLayoutRenderer)
                     {
-                        list[i - 1] = new LiteralLayoutRenderer(lr1.Text);
+                        list[i - 1] = lr1 = new LiteralLayoutRenderer(lr1.Text);
                     }
                     lr1.Text += lr2.Text;
                     list.RemoveAt(i);


### PR DESCRIPTION
Followup to #6087