### PR TITLE
XmlLayout - Faster XML encoding with INoAllocationStringValueRenderer

### DIFF
--- a/src/NLog/Internal/XmlHelper.cs
+++ b/src/NLog/Internal/XmlHelper.cs
@@ -85,7 +85,7 @@ namespace NLog.Internal
         /// <summary>
         /// removes any unusual unicode characters that can't be encoded into XML
         /// </summary>
-        private static string RemoveInvalidXmlChars(string text)
+        private static string RemoveInvalidXmlChars(string text, StringBuilder? builder = null)
         {
             if (string.IsNullOrEmpty(text))
                 return string.Empty;
@@ -102,132 +102,141 @@ namespace NLog.Internal
                     }
                     else
                     {
-                        return CreateValidXmlString(text);   // rare expensive case
+                        return CreateValidXmlString(text, i, builder);   // rare expensive case
                     }
                 }
             }
 
+            builder?.Append(text);
             return text;
         }
 
         /// <summary>
         /// Cleans string of any invalid XML chars found
         /// </summary>
-        /// <param name="text">unclean string</param>
         /// <returns>string with only valid XML chars</returns>
-        private static string CreateValidXmlString(string text)
+        private static string CreateValidXmlString(string text, int startIndex = 0, StringBuilder? builder = null)
         {
-            var sb = new StringBuilder(text.Length);
-            for (int i = 0; i < text.Length; ++i)
+            var sb = builder ?? new StringBuilder(text.Length);
+            sb.Append(text, 0, startIndex);
+            for (int i = startIndex; i < text.Length; ++i)
             {
                 char ch = text[i];
                 if (XmlConvertIsXmlChar(ch))
                 {
                     sb.Append(ch);
                 }
-            }
-            return sb.ToString();
-        }
-
-        internal static void PerformXmlEscapeWhenNeeded(StringBuilder builder, int startPos, bool xmlEncodeNewlines)
-        {
-            if (RequiresXmlEscape(builder, startPos, xmlEncodeNewlines))
-            {
-                var str = builder.ToString(startPos, builder.Length - startPos);
-                builder.Length = startPos;
-                EscapeXmlString(str, xmlEncodeNewlines, builder);
-            }
-        }
-
-        private static bool RequiresXmlEscape(StringBuilder target, int startPos, bool xmlEncodeNewlines)
-        {
-            for (int i = startPos; i < target.Length; ++i)
-            {
-                switch (target[i])
+                else if (i + 1 < text.Length && XmlConvertIsXmlSurrogatePair(text[i + 1], ch))
                 {
-                    case '<':
-                    case '>':
-                    case '&':
-                    case '\'':
-                    case '"':
-                        return true;
-                    case '\r':
-                    case '\n':
-                        if (xmlEncodeNewlines)
-                            return true;
-                        break;
+                    sb.Append(ch);
+                    sb.Append(text[++i]);
                 }
             }
+            return builder is null ? sb.ToString() : string.Empty;
+        }
+
+        internal static void EscapeXmlWhenNeeded(StringBuilder builder, int startPos, bool xmlEncodeNewlines)
+        {
+            var builderLength = builder.Length;
+            for (int i = startPos; i < builderLength; ++i)
+            {
+                var chr = builder[i];
+                if (!XmlConvertIsXmlChar(chr) || RequiresXmlEscape(chr, xmlEncodeNewlines))
+                {
+                    var text = builder.ToString(i, builderLength - i);
+                    text = RemoveInvalidXmlChars(text);
+                    builder.Length = i;
+                    EscapeXmlString(text, xmlEncodeNewlines, 0, builder);
+                    break;
+                }
+            }
+        }
+
+        internal static string EscapeXmlWhenNeeded(string text, bool xmlEncodeNewlines, StringBuilder? builder = null)
+        {
+            var startIndex = text.IndexOfAny(xmlEncodeNewlines ? XmlEscapeNewlineChars : XmlEscapeChars);
+            if (startIndex >= 0)
+            {
+                var sb = builder ?? new StringBuilder(text.Length + 16);
+                var validText = RemoveInvalidXmlChars(text);
+                EscapeXmlString(validText, xmlEncodeNewlines, startIndex, sb);
+                return builder is null ? sb.ToString() : string.Empty;
+            }
+            else
+            {
+                return RemoveInvalidXmlChars(text, builder);
+            }
+        }
+
+        private static bool RequiresXmlEscape(char chr, bool xmlEncodeNewlines)
+        {
+            switch (chr)
+            {
+                case '<':
+                case '>':
+                case '&':
+                case '\'':
+                case '"':
+                    return true;
+                case '\r':
+                case '\n':
+                    return xmlEncodeNewlines;
+            }
+
             return false;
         }
 
         private static readonly char[] XmlEscapeChars = new char[] { '<', '>', '&', '\'', '"' };
         private static readonly char[] XmlEscapeNewlineChars = new char[] { '<', '>', '&', '\'', '"', '\r', '\n' };
 
-        internal static string EscapeXmlString(string text, bool xmlEncodeNewlines, StringBuilder? result = null)
+        private static void EscapeXmlString(string text, bool xmlEncodeNewlines, int startIndex, StringBuilder destination)
         {
-            if (result is null && SmallAndNoEscapeNeeded(text, xmlEncodeNewlines))
+            destination.Append(text, 0, startIndex);
+            for (int i = startIndex; i < text.Length; ++i)
             {
-                return text;
-            }
-
-            var sb = result ?? new StringBuilder(text.Length);
-            for (int i = 0; i < text.Length; ++i)
-            {
-                switch (text[i])
+                char chr = text[i];
+                switch (chr)
                 {
                     case '<':
-                        sb.Append("&lt;");
+                        destination.Append("&lt;");
                         break;
 
                     case '>':
-                        sb.Append("&gt;");
+                        destination.Append("&gt;");
                         break;
 
                     case '&':
-                        sb.Append("&amp;");
+                        destination.Append("&amp;");
                         break;
 
                     case '\'':
-                        sb.Append("&apos;");
+                        destination.Append("&apos;");
                         break;
 
                     case '"':
-                        sb.Append("&quot;");
+                        destination.Append("&quot;");
                         break;
 
                     case '\r':
                         if (xmlEncodeNewlines)
-                            sb.Append("&#13;");
+                            destination.Append("&#13;");
                         else
-                            sb.Append(text[i]);
+                            destination.Append(chr);
                         break;
 
                     case '\n':
                         if (xmlEncodeNewlines)
-                            sb.Append("&#10;");
+                            destination.Append("&#10;");
                         else
-                            sb.Append(text[i]);
+                            destination.Append(chr);
                         break;
 
                     default:
-                        sb.Append(text[i]);
+                        destination.Append(chr);
                         break;
                 }
+
             }
-
-            return result is null ? sb.ToString() : string.Empty;
-        }
-
-        /// <summary>
-        /// Pretest, small text and not escape needed
-        /// </summary>
-        /// <param name="text"></param>
-        /// <param name="xmlEncodeNewlines"></param>
-        /// <returns></returns>
-        private static bool SmallAndNoEscapeNeeded(string text, bool xmlEncodeNewlines)
-        {
-            return text.Length < 4096 && text.IndexOfAny(xmlEncodeNewlines ? XmlEscapeNewlineChars : XmlEscapeChars) < 0;
         }
 
         /// <summary>
@@ -480,29 +489,25 @@ namespace NLog.Internal
 
         private static readonly char[] DecimalScientificExponent = new[] { 'e', 'E' };
 
-        public static void RemoveInvalidXmlIfNeeded(StringBuilder builder, int orgLength)
-        {
-            for (int i = orgLength; i < builder.Length; ++i)
-            {
-                if (!XmlConvertIsXmlChar(builder[i]))
-                {
-                    var text = builder.ToString(i, builder.Length - i);
-                    builder.Length = i;
-                    text = RemoveInvalidXmlChars(text);
-                    builder.Append(text);
-                    break;
-                }
-            }
-        }
 
-        public static void EscapeCDataIfNeeded(StringBuilder builder, int orgLength)
+        public static void EscapeCDataWhenNeeded(StringBuilder builder, int orgLength)
         {
-            for (int i = orgLength; i < builder.Length; ++i)
+            var builderLength = builder.Length;
+            char chr0 = '\0';
+            char chr1 = chr0;
+            char chr2 = chr0;
+
+            for (int i = orgLength; i < builderLength; ++i)
             {
-                if (builder[i] == ']' && i + 2 < builder.Length && builder[i + 1] == ']' && builder[i + 2] == '>')
+                chr0 = chr1;
+                chr1 = chr2;
+                chr2 = builder[i];
+
+                if (!XmlConvertIsXmlChar(chr2) || (chr0 == ']' && chr1 == ']' && chr2 == '>'))
                 {
-                    var text = builder.ToString(i, builder.Length - i);
-                    builder.Length = i;
+                    var text = builder.ToString(i - 2, builderLength - i + 2);
+                    builder.Length = i - 2;
+                    text = RemoveInvalidXmlChars(text);
                     text = text.Replace("]]>", "]]]]><![CDATA[>");
                     builder.Append(text);
                     break;
@@ -510,15 +515,37 @@ namespace NLog.Internal
             }
         }
 
-        public static string EscapeCData(string text)
+        public static string EscapeCData(string text, StringBuilder? builder = null)
         {
             if (string.IsNullOrEmpty(text))
-                return "<![CDATA[]]>";
+            {
+                var emptyCData = "<![CDATA[]]>";
+                builder?.Append(emptyCData);
+                return emptyCData;
+            }
 
-            if (text.Contains("]]>"))
-                text = text.Replace("]]>", "]]]]><![CDATA[>");
+            builder?.Append("<![CDATA[");
+            int orgLength = builder?.Length ?? 0;
+            var validText = RemoveInvalidXmlChars(text, builder);
+            if (ReferenceEquals(validText, text) || builder is null)
+            {
+                if (validText.IndexOf("]]>", StringComparison.Ordinal) >= 0)
+                {
+                    validText = validText.Replace("]]>", "]]]]><![CDATA[>");
+                    if (builder != null)
+                    {
+                        builder.Length = orgLength;
+                        builder.Append(validText);
+                    }
+                }
+            }
+            else
+            {
+                EscapeCDataWhenNeeded(builder, orgLength);
+            }
+            builder?.Append("]]>");
 
-            return $"<![CDATA[{text}]]>";
+            return builder is null ? $"<![CDATA[{validText}]]>" : string.Empty;
         }
     }
 }

--- a/src/NLog/LayoutRenderers/Wrappers/XmlEncodeLayoutRendererWrapper.cs
+++ b/src/NLog/LayoutRenderers/Wrappers/XmlEncodeLayoutRendererWrapper.cs
@@ -36,6 +36,7 @@ namespace NLog.LayoutRenderers.Wrappers
     using System.Text;
     using NLog.Config;
     using NLog.Internal;
+    using NLog.Layouts;
 
     /// <summary>
     /// Converts the result of another layout output to be XML-compliant.
@@ -70,9 +71,39 @@ namespace NLog.LayoutRenderers.Wrappers
         /// <docgen category="Layout Options" order="10"/>
         public bool XmlEncodeNewlines { get; set; }
 
+        private INoAllocationStringValueRenderer? _stringValueRenderer;
+
+        /// <inheritdoc/>
+        protected override void InitializeLayoutRenderer()
+        {
+            base.InitializeLayoutRenderer();
+            _stringValueRenderer = ValueTypeLayoutInfo.ResolveStringValueMethod(Inner);
+        }
+
         /// <inheritdoc/>
         protected override void RenderInnerAndTransform(LogEventInfo logEvent, StringBuilder builder, int orgLength)
         {
+            if (_stringValueRenderer != null)
+            {
+                var stringValue = _stringValueRenderer.GetFormattedStringNoAllocation(logEvent);
+                if (stringValue != null)
+                {
+                    if (CDataEncode)
+                    {
+                        XmlHelper.EscapeCData(stringValue, builder);
+                    }
+                    else if (XmlEncode)
+                    {
+                        XmlHelper.EscapeXmlWhenNeeded(stringValue, XmlEncodeNewlines, builder);
+                    }
+                    else
+                    {
+                        builder.Append(stringValue);
+                    }
+                    return;
+                }
+            }
+
             if (CDataEncode)
             {
                 builder.Append("<![CDATA[");
@@ -81,16 +112,14 @@ namespace NLog.LayoutRenderers.Wrappers
 
             Inner?.Render(logEvent, builder);
 
-            XmlHelper.RemoveInvalidXmlIfNeeded(builder, orgLength);
-
             if (CDataEncode)
             {
-                XmlHelper.EscapeCDataIfNeeded(builder, orgLength);
+                XmlHelper.EscapeCDataWhenNeeded(builder, orgLength);
                 builder.Append("]]>");
             }
             else if (XmlEncode)
             {
-                XmlHelper.PerformXmlEscapeWhenNeeded(builder, orgLength, XmlEncodeNewlines);
+                XmlHelper.EscapeXmlWhenNeeded(builder, orgLength, XmlEncodeNewlines);
             }
         }
 
@@ -104,8 +133,9 @@ namespace NLog.LayoutRenderers.Wrappers
 
             if (XmlEncode)
             {
-                return XmlHelper.EscapeXmlString(text, XmlEncodeNewlines);
+                return XmlHelper.EscapeXmlWhenNeeded(text, XmlEncodeNewlines);
             }
+
             return text;
         }
     }

--- a/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
+++ b/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
@@ -77,7 +77,7 @@ namespace NLog.Layouts
 
         internal INoAllocationStringValueRenderer? SimpleStringValue { get; private set; }
 
-        private static INoAllocationStringValueRenderer? ResolveStringValueMethod(Layout layout)
+        internal static INoAllocationStringValueRenderer? ResolveStringValueMethod(Layout layout)
         {
             var stringValueRenderer = (layout is SimpleLayout simpleLayout && simpleLayout.LayoutRenderers.Count() == 1) ? simpleLayout.LayoutRenderers.First() as INoAllocationStringValueRenderer : null;
             if (stringValueRenderer != null)

--- a/src/NLog/Layouts/XML/XmlAttribute.cs
+++ b/src/NLog/Layouts/XML/XmlAttribute.cs
@@ -130,6 +130,30 @@ namespace NLog.Layouts
 
         internal bool RenderAppendXmlValue(LogEventInfo logEvent, StringBuilder builder)
         {
+            if (!Encode)
+            {
+                int orgLength = builder.Length;
+                Layout?.Render(logEvent, builder);
+                return IncludeEmptyValue || builder.Length > orgLength;
+            }
+
+            var simpleStringValue = _layoutInfo.SimpleStringValue;
+            if (simpleStringValue != null)
+            {
+                var stringValue = simpleStringValue.GetFormattedStringNoAllocation(logEvent);
+                if (stringValue != null)
+                {
+                    if (!IncludeEmptyValue && string.IsNullOrEmpty(stringValue))
+                    {
+                        return false;
+                    }
+
+                    XmlHelper.EscapeXmlWhenNeeded(stringValue, true, builder);
+                    return true;
+                }
+            }
+
+
             if (ValueType is null)
             {
                 int orgLength = builder.Length;
@@ -139,10 +163,7 @@ namespace NLog.Layouts
                     return false;
                 }
 
-                if (Encode)
-                {
-                    XmlHelper.PerformXmlEscapeWhenNeeded(builder, orgLength, true);
-                }
+                XmlHelper.EscapeXmlWhenNeeded(builder, orgLength, true);
             }
             else
             {
@@ -152,21 +173,29 @@ namespace NLog.Layouts
                     return false;
                 }
 
-                var convertibleValue = objectValue as IConvertible;
-                var objTypeCode = convertibleValue?.GetTypeCode() ?? (objectValue is null ? TypeCode.Empty : TypeCode.Object);
-                if (objTypeCode != TypeCode.Object)
-                {
-                    string xmlValueString = XmlHelper.XmlConvertToString(convertibleValue, objTypeCode, true);
-                    builder.Append(xmlValueString);
-                }
-                else
-                {
-                    string xmlValueString = XmlHelper.XmlConvertToStringSafe(objectValue);
-                    builder.Append(xmlValueString);
-                }
+                EscapeXmlWhenNeeded(objectValue, builder);
             }
 
             return true;
+        }
+
+        private static void EscapeXmlWhenNeeded(object? objectValue, StringBuilder builder)
+        {
+            var convertibleValue = objectValue as IConvertible;
+            var objTypeCode = convertibleValue?.GetTypeCode() ?? (objectValue is null ? TypeCode.Empty : TypeCode.Object);
+            if (objTypeCode != TypeCode.Object)
+            {
+                string xmlValueString = XmlHelper.XmlConvertToString(convertibleValue, objTypeCode, true);
+                if (objTypeCode == TypeCode.String || objTypeCode == TypeCode.Char)
+                    XmlHelper.EscapeXmlWhenNeeded(xmlValueString, true, builder);
+                else
+                    builder.Append(xmlValueString);
+            }
+            else
+            {
+                string xmlValueString = XmlHelper.XmlConvertToStringSafe(objectValue);
+                XmlHelper.EscapeXmlWhenNeeded(xmlValueString, true, builder);
+            }
         }
     }
 }

--- a/src/NLog/Layouts/XML/XmlElementBase.cs
+++ b/src/NLog/Layouts/XML/XmlElementBase.cs
@@ -695,7 +695,7 @@ namespace NLog.Layouts
             else
             {
                 sb.Append('>');
-                XmlHelper.EscapeXmlString(xmlValueString, false, sb);
+                XmlHelper.EscapeXmlWhenNeeded(xmlValueString, false, sb);
                 AppendClosingPropertyTag(propNameElement, sb, ignorePropertiesElementName);
             }
 
@@ -728,7 +728,7 @@ namespace NLog.Layouts
                 sb.Append(' ');
                 sb.Append(attributeName);
                 sb.Append("=\"");
-                XmlHelper.EscapeXmlString(value, true, sb);
+                XmlHelper.EscapeXmlWhenNeeded(value, true, sb);
                 sb.Append('\"');
                 return true;
             }

--- a/tests/NLog.UnitTests/LayoutRenderers/Wrappers/XmlEncodeTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/Wrappers/XmlEncodeTests.cs
@@ -33,6 +33,8 @@
 
 namespace NLog.UnitTests.LayoutRenderers.Wrappers
 {
+    using System;
+    using System.Collections.Generic;
     using NLog;
     using NLog.Layouts;
     using Xunit;
@@ -42,10 +44,105 @@ namespace NLog.UnitTests.LayoutRenderers.Wrappers
         [Fact]
         public void XmlEncodeTest1()
         {
-            ScopeContext.PushProperty("foo", " abc<>&'\"def ");
-            SimpleLayout l = "${xml-encode:${scopeproperty:foo}}";
+            var propertyValue = " abc<>&'\"def ";
+            using (ScopeContext.PushProperty("foo", propertyValue))
+            {
+                SimpleLayout l = "${xml-encode:${scopeproperty:foo}}";
 
-            Assert.Equal(" abc&lt;&gt;&amp;&apos;&quot;def ", l.Render(LogEventInfo.CreateNullEvent()));
+                Assert.Equal(" abc&lt;&gt;&amp;&apos;&quot;def ", l.Render(LogEventInfo.CreateNullEvent()));
+            }
+
+            SimpleLayout l2 = "${xml-encode:${event-properties:foo}}";
+            Assert.Equal(" abc&lt;&gt;&amp;&apos;&quot;def ", l2.Render(new LogEventInfo(LogLevel.Off, null, string.Empty, new[] { new NLog.MessageTemplates.MessageTemplateParameter("foo", propertyValue, null) })));
+        }
+
+        [Fact]
+        public void XmlEncodeBadStringTest1()
+        {
+            var sb = new System.Text.StringBuilder();
+
+            var forbidden = new HashSet<int>();
+            int start = 64976; int end = 65007;
+
+            for (int i = start; i <= end; i++)
+            {
+                forbidden.Add(i);
+            }
+
+            forbidden.Add(0xFFFE);
+            forbidden.Add(0xFFFF);
+
+            for (int i = char.MinValue; i <= char.MaxValue; i++)
+            {
+                char c = Convert.ToChar(i);
+                if (char.IsSurrogate(c))
+                {
+                    continue; // skip surrogates
+                }
+
+                if (forbidden.Contains(c))
+                {
+                    continue;
+                }
+
+                sb.Append(c);
+            }
+
+            var badString = sb.ToString();
+
+            using (ScopeContext.PushProperty("foo", badString))
+            {
+                SimpleLayout l = "${xml-encode:${scopeproperty:foo}}";
+
+                var goodString = l.Render(LogEventInfo.CreateNullEvent());
+                Assert.NotEmpty(goodString);
+                foreach (char c in goodString)
+                {
+                    Assert.True(System.Xml.XmlConvert.IsXmlChar(c), $"Invalid char {Convert.ToInt32(c)} was not removed");
+                }   
+            }
+
+            using (ScopeContext.PushProperty("foo", badString))
+            {
+                SimpleLayout l = "${xml-encode:${scopeproperty:foo}:CDataEncode=true}";
+
+                var goodString = l.Render(LogEventInfo.CreateNullEvent());
+                Assert.NotEmpty(goodString);
+                foreach (char c in goodString)
+                {
+                    Assert.True(System.Xml.XmlConvert.IsXmlChar(c), $"Invalid char {Convert.ToInt32(c)} was not removed");
+                }
+            }
+        }
+
+        [Fact]
+        public void XmlEncodeCDataTest1()
+        {
+            var propertyValue = " abc<>&'\"def ";
+            using (ScopeContext.PushProperty("foo", propertyValue))
+            {
+                SimpleLayout l = "${xml-encode:${scopeproperty:foo}:CDataEncode=true}";
+
+                Assert.Equal("<![CDATA[ abc<>&'\"def ]]>", l.Render(LogEventInfo.CreateNullEvent()));
+            }
+
+            SimpleLayout l2 = "${xml-encode:${event-properties:foo}:CDataEncode=true}";
+            Assert.Equal("<![CDATA[ abc<>&'\"def ]]>", l2.Render(new LogEventInfo(LogLevel.Off, null, string.Empty, new[] { new NLog.MessageTemplates.MessageTemplateParameter("foo", propertyValue, null) })));
+        }
+
+        [Fact]
+        public void XmlEncodeCDataTest2()
+        {
+            var propertyValue = " abc<]]>>&'\"def ";
+            using (ScopeContext.PushProperty("foo", propertyValue))
+            {
+                SimpleLayout l = "${xml-encode:${scopeproperty:foo}:CDataEncode=true}";
+
+                Assert.Equal("<![CDATA[ abc<]]]]><![CDATA[>>&'\"def ]]>", l.Render(LogEventInfo.CreateNullEvent()));
+            }
+
+            SimpleLayout l2 = "${xml-encode:${event-properties:foo}:CDataEncode=true}";
+            Assert.Equal("<![CDATA[ abc<]]]]><![CDATA[>>&'\"def ]]>", l2.Render(new LogEventInfo(LogLevel.Off, null, string.Empty, new[] { new NLog.MessageTemplates.MessageTemplateParameter("foo", propertyValue, null) })));
         }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -201,7 +201,7 @@ namespace NLog.UnitTests.Layouts
             };
 
             logEventInfo.Properties["prop1"] = "a";
-            logEventInfo.Properties["prop2"] = "b";
+            logEventInfo.Properties["prop2"] = "<b>";
             logEventInfo.Properties["prop3"] = "c";
 
             // Act
@@ -209,7 +209,7 @@ namespace NLog.UnitTests.Layouts
 
             // Assert
             const string expected =
-                @"<logevent><level>Debug</level><message>message 1</message><property key=""prop1"">a</property><property key=""prop2"">b</property><property key=""prop3"">c</property></logevent>";
+                @"<logevent><level>Debug</level><message>message 1</message><property key=""prop1"">a</property><property key=""prop2"">&lt;b&gt;</property><property key=""prop3"">c</property></logevent>";
 
             Assert.Equal(expected, result);
         }
@@ -233,7 +233,7 @@ namespace NLog.UnitTests.Layouts
                 Message = "message 1"
             };
             logEventInfo.Properties["prop1"] = "a";
-            logEventInfo.Properties["prop2"] = "b";
+            logEventInfo.Properties["prop2"] = "<b>";
             logEventInfo.Properties["prop3"] = "c";
 
             // Act
@@ -258,14 +258,14 @@ namespace NLog.UnitTests.Layouts
                 Message = "message 1"
             };
             logEventInfo.Properties["prop1"] = "a";
-            logEventInfo.Properties["prop2"] = "b";
+            logEventInfo.Properties["prop2"] = "<b>";
             logEventInfo.Properties["prop3"] = "c";
 
             // Act
             var result = xmlLayout.Render(logEventInfo);
 
             // Assert
-            const string expected = @"<logevent><property key=""prop1"">a</property><property key=""prop2"">b</property><property key=""prop3"">c</property></logevent>";
+            const string expected = @"<logevent><property key=""prop1"">a</property><property key=""prop2"">&lt;b&gt;</property><property key=""prop3"">c</property></logevent>";
             Assert.Equal(expected, result);
         }
 
@@ -311,7 +311,7 @@ namespace NLog.UnitTests.Layouts
                 Message = "message 1"
             };
             logEventInfo.Properties["1prop"] = "a";
-            logEventInfo.Properties["_2prop"] = "b";
+            logEventInfo.Properties["_2prop"] = "<b>";
             logEventInfo.Properties[" 3prop"] = "c";
             logEventInfo.Properties["_4 prop"] = "d";
 
@@ -319,7 +319,7 @@ namespace NLog.UnitTests.Layouts
             var result = xmlLayout.Render(logEventInfo);
 
             // Assert
-            const string expected = @"<logevent><_1prop>a</_1prop><_2prop>b</_2prop><_3prop>c</_3prop><_4_prop>d</_4_prop></logevent>";
+            const string expected = @"<logevent><_1prop>a</_1prop><_2prop>&lt;b&gt;</_2prop><_3prop>c</_3prop><_4_prop>d</_4_prop></logevent>";
             Assert.Equal(expected, result);
         }
 
@@ -340,13 +340,13 @@ namespace NLog.UnitTests.Layouts
                 Message = "message 1"
             };
             logEventInfo.Properties["prop1"] = "a";
-            logEventInfo.Properties["prop2"] = "b";
+            logEventInfo.Properties["prop2"] = "<b>";
 
             // Act
             var result = xmlLayout.Render(logEventInfo);
 
             // Assert
-            const string expected = @"<logevent><p k=""prop1"" v=""a""/><p k=""prop2"" v=""b""/></logevent>";
+            const string expected = @"<logevent><p k=""prop1"" v=""a""/><p k=""prop2"" v=""&lt;b&gt;""/></logevent>";
             Assert.Equal(expected, result);
         }
 
@@ -367,13 +367,13 @@ namespace NLog.UnitTests.Layouts
                 Message = "message 1"
             };
             logEventInfo.Properties["prop1"] = "a";
-            logEventInfo.Properties["prop2"] = "b";
+            logEventInfo.Properties["prop2"] = "<b>";
 
             // Act
             var result = xmlLayout.Render(logEventInfo);
 
             // Assert
-            const string expected = @"<logevent><prop1 v=""a""/><prop2 v=""b""/></logevent>";
+            const string expected = @"<logevent><prop1 v=""a""/><prop2 v=""&lt;b&gt;""/></logevent>";
             Assert.Equal(expected, result);
         }
 
@@ -403,13 +403,13 @@ namespace NLog.UnitTests.Layouts
                 Message = "message 1"
             };
             logEventInfo.Properties["prop1"] = "a";
-            logEventInfo.Properties["prop2"] = "b";
+            logEventInfo.Properties["prop2"] = "<b>";
 
             // Act
             var result = xmlLayout.Render(logEventInfo);
 
             // Assert
-            string expected = @"<logevent><message>message 1<level>Debug</level><property key=""prop1"">a</property><property key=""prop2"">b</property></message></logevent>";
+            string expected = @"<logevent><message>message 1<level>Debug</level><property key=""prop1"">a</property><property key=""prop2"">&lt;b&gt;</property></message></logevent>";
             Assert.Equal(expected, result);
         }
 


### PR DESCRIPTION
Followup to #5774 with faster XML encoding, by reducing enumeration of StringBuilders (faster to enumerate string)

Also optimized CData-encoding by reducing the number of StringBuilder-Index-Lookups.

Also improved xml-encoding when outputting Xml-Attribute-Values for correctness.