### PR TITLE
LogFactory - Flush / FlushAsync asynchronous completion outside Target lock

### DIFF
--- a/src/NLog/Common/AsyncHelpers.cs
+++ b/src/NLog/Common/AsyncHelpers.cs
@@ -183,12 +183,8 @@ namespace NLog.Common
         /// <param name="action">The action to invoke for each item.</param>
         public static void ForEachItemInParallel<T>(IEnumerable<T> values, AsyncContinuation asyncContinuation, AsynchronousAction<T> action)
         {
-            action = ExceptionGuard(action);
-
             var items = new List<T>(values);
             int remaining = items.Count;
-            var exceptions = new List<Exception>();
-
             InternalLogger.Trace("ForEachItemInParallel() {0} items", items.Count);
 
             if (remaining == 0)
@@ -197,6 +193,10 @@ namespace NLog.Common
                 return;
             }
 
+            action = ExceptionGuard(action);
+
+            IList<Exception>? exceptions = null;
+
             AsyncContinuation continuation =
                 ex =>
                 {
@@ -204,6 +204,10 @@ namespace NLog.Common
 
                     if (ex != null)
                     {
+                        if (exceptions is null)
+                        {
+                            Interlocked.CompareExchange(ref exceptions, new List<Exception>(), null);
+                        }
                         lock (exceptions)
                         {
                             exceptions.Add(ex);
@@ -214,7 +218,23 @@ namespace NLog.Common
                     InternalLogger.Trace("Parallel task completed. {0} items remaining", r);
                     if (r == 0)
                     {
-                        asyncContinuation(GetCombinedException(exceptions));
+                        var combinedException = GetCombinedException(exceptions ?? ArrayHelper.Empty<Exception>());
+
+                        // The flush callback happens while holding target lock, so execute the flush completion asynchronously to avoid potential deadlocks.
+                        if (combinedException is null)
+                        {
+                            AsyncHelpers.StartAsyncTask(s =>
+                            {
+                                ((AsyncContinuation)s).Invoke(null);
+                            }, asyncContinuation);
+                        }
+                        else
+                        {
+                            AsyncHelpers.StartAsyncTask(s =>
+                            {
+                                ((AsyncContinuation)s).Invoke(combinedException);
+                            }, asyncContinuation);
+                        }
                     }
                 };
 

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -976,11 +976,23 @@ namespace NLog.Config
                 }
                 if (completed)
                 {
+                    // The flush callback happens while holding target lock, so execute the flush completion asynchronously to avoid potential deadlocks.
                     if (lastException != null)
+                    {
                         InternalLogger.Warn("Flush completed with errors");
+                        AsyncHelpers.StartAsyncTask(s =>
+                        {
+                            ((AsyncContinuation)s).Invoke(lastException);
+                        }, flushCompletion);
+                    }
                     else
+                    {
                         InternalLogger.Debug("Flush completed");
-                    flushCompletion.Invoke(lastException);
+                        AsyncHelpers.StartAsyncTask(s =>
+                        {
+                            ((AsyncContinuation)s).Invoke(null);
+                        }, flushCompletion);
+                    }
                 }
             };
 

--- a/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
+++ b/src/NLog/Targets/Wrappers/SplitGroupTarget.cs
@@ -165,13 +165,17 @@ namespace NLog.Targets.Wrappers
 
         private static AsyncContinuation CreateCountedContinuation(AsyncContinuation originalContinuation, int targetCounter)
         {
-            var exceptions = new List<Exception>();
+            IList<Exception>? exceptions = null;
 
             AsyncContinuation wrapper =
                 ex =>
                 {
                     if (ex != null)
                     {
+                        if (exceptions is null)
+                        {
+                            Interlocked.CompareExchange(ref exceptions, new List<Exception>(), null);
+                        }
                         lock (exceptions)
                         {
                             exceptions.Add(ex);
@@ -179,10 +183,9 @@ namespace NLog.Targets.Wrappers
                     }
 
                     int pendingTargets = Interlocked.Decrement(ref targetCounter);
-
                     if (pendingTargets == 0)
                     {
-                        var combinedException = AsyncHelpers.GetCombinedException(exceptions);
+                        var combinedException = AsyncHelpers.GetCombinedException(exceptions ?? Internal.ArrayHelper.Empty<Exception>());
                         InternalLogger.Trace("SplitGroup: Combined exception: {0}", combinedException);
                         originalContinuation(combinedException);
                     }

--- a/tests/NLog.UnitTests/LogFactoryTests.cs
+++ b/tests/NLog.UnitTests/LogFactoryTests.cs
@@ -72,6 +72,34 @@ namespace NLog.UnitTests
             Assert.NotNull(timeoutException);
         }
 
+        [Fact]
+        public void Flush_NestedFlushInsideCallback_NoDeadlock()
+        {
+            // Arrange
+            // Before the fix, the Flush completion callback was invoked while the target SyncRoot
+            // was held. A nested synchronous Flush in the callback dispatches a new thread that
+            // blocks trying to acquire the same SyncRoot, causing a deadlock (up to 15s timeout).
+            var logFactory = new LogFactory();
+            logFactory.Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteToMethodCall((evt, parms) => { }));
+            logFactory.GetCurrentClassLogger().Info("Test message");
+
+            Exception nestedFlushError = null;
+            bool callbackFired = false;
+
+            // Act
+            logFactory.Flush(ex =>
+            {
+                callbackFired = true;
+                // Nested synchronous Flush: with old code this deadlocks because the current
+                // thread holds the target SyncRoot and the dispatched thread waits for it.
+                logFactory.Flush(ex2 => nestedFlushError = ex2, TimeSpan.FromSeconds(5));
+            }, TimeSpan.FromSeconds(10));
+
+            // Assert
+            Assert.True(callbackFired, "Flush callback was not invoked");
+            Assert.Null(nestedFlushError); // Would be a timeout NLogRuntimeException with old code
+        }
+
 #if !NET35 && !NET40
         [Fact]
         public void FlushAsync_NoConfig_IsCompleted()
@@ -111,6 +139,40 @@ namespace NLog.UnitTests
             System.Threading.Tasks.Task.Run(() => logFactory.GetCurrentClassLogger().Info("Sleep")).Wait(50);
             var task = logFactory.FlushAsync(new CancellationTokenSource(100).Token);
             Assert.Throws<System.Threading.Tasks.TaskCanceledException>(() => task.GetAwaiter().GetResult());
+        }
+
+        [Fact]
+        public void FlushAsync_NestedFlushInSynchronousContinuation_NoDeadlock()
+        {
+            // Arrange
+            // Before the fix, FlushAsync signaled the TaskCompletionSource while holding the
+            // target SyncRoot. A synchronous continuation on the FlushAsync task that performs
+            // a blocking Flush would deadlock: it dispatches a new thread that blocks waiting
+            // for the same SyncRoot that the continuation's thread holds.
+            var logFactory = new LogFactory();
+            logFactory.Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteToMethodCall((evt, parms) => { }));
+            logFactory.GetCurrentClassLogger().Info("Test message");
+
+            Exception nestedFlushError = null;
+            bool continuationFired = false;
+            var continuationCompleted = new ManualResetEvent(false);
+
+            // Act
+            // ExecuteSynchronously forces the continuation to run on the thread that calls
+            // TaskCompletionSource.SetResult (i.e., the flush-completion thread).
+            // Before the fix that thread held the target SyncRoot, causing a deadlock.
+            logFactory.FlushAsync(CancellationToken.None)
+                .ContinueWith(t =>
+                {
+                    continuationFired = true;
+                    logFactory.Flush(ex2 => nestedFlushError = ex2, TimeSpan.FromSeconds(5));
+                    continuationCompleted.Set();
+                }, System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously);
+
+            // Assert
+            Assert.True(continuationCompleted.WaitOne(TimeSpan.FromSeconds(10)), "FlushAsync continuation did not complete");
+            Assert.True(continuationFired);
+            Assert.Null(nestedFlushError); // Would be a timeout NLogRuntimeException with old code
         }
 #endif
 


### PR DESCRIPTION
Trying to resolve https://github.com/NLog/NLog.Web/issues/1118