### PR TITLE
LoggingRule - Update FinalMinLevel to match NLog.config

### DIFF
--- a/src/NLog/Config/LoggingRule.cs
+++ b/src/NLog/Config/LoggingRule.cs
@@ -174,7 +174,12 @@ namespace NLog.Config
         public LogLevel? FinalMinLevel
         {
             get => _logLevelFilter.FinalMinLevel;
-            set => _logLevelFilter = _logLevelFilter.GetSimpleFilterForUpdate().SetFinalMinLevel(value);
+            set
+            {
+                if (ReferenceEquals(_logLevelFilter, LoggingRuleLevelFilter.Off) && !ReferenceEquals(value, null))
+                    MinLevel = value;
+                _logLevelFilter = _logLevelFilter.GetSimpleFilterForUpdate().SetFinalMinLevel(value);
+            }
         }
 
         /// <summary>

--- a/tests/NLog.UnitTests/Config/ConfigApiTests.cs
+++ b/tests/NLog.UnitTests/Config/ConfigApiTests.cs
@@ -341,6 +341,20 @@ namespace NLog.UnitTests.Config
         }
 
         [Fact]
+        public void LogRuleFinalMinLevel_enables()
+        {
+            var rule = new LoggingRule();
+            Assert.Equal(ArrayHelper.Empty<LogLevel>(), rule.Levels);
+            Assert.Equal(LogLevel.Off, rule.MinLevel);
+            rule.FinalMinLevel = LogLevel.Warn; // FinalMinLevel should implicitly assign MinLevel when unassigned
+            Assert.Equal(new[] { LogLevel.Warn, LogLevel.Error, LogLevel.Fatal }, rule.Levels);
+            Assert.Equal(LogLevel.Warn, rule.MinLevel);
+            rule.FinalMinLevel = LogLevel.Error;// FinalMinLevel should only assign MinLevel when unassigned
+            Assert.Equal(new[] { LogLevel.Warn, LogLevel.Error, LogLevel.Fatal }, rule.Levels);
+            Assert.Equal(LogLevel.Warn, rule.MinLevel);
+        }
+
+        [Fact]
         public void LogRuleSetLoggingLevels_disables()
         {
             var rule = new LoggingRule();


### PR DESCRIPTION
When specifying FinalMinLevel in Nlog.config, then it also implicitly assigns MinLevel (unless explicitly assigned).