### PR TITLE
TargetPropertyWithContext - Removed alias Key

### DIFF
--- a/src/NLog/Targets/TargetPropertyWithContext.cs
+++ b/src/NLog/Targets/TargetPropertyWithContext.cs
@@ -70,12 +70,6 @@ namespace NLog.Targets
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the property. Alias for <see cref="Name"/>
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public string Key { get => Name; set => Name = value; }
-
-        /// <summary>
         /// Gets or sets the layout used for rendering the property value.
         /// </summary>
         /// <remarks><b>[Required]</b> Default: <see cref="Layout.Empty"/></remarks>


### PR DESCRIPTION
"Key" never been used in NLog before, no need to start now. Followup to #6119