### PR TITLE
FileTarget - OpenFileCacheTimeout = 3500 secs should close file after 1 hour, but check every 5 min

### DIFF
--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -469,7 +469,7 @@ namespace NLog.Targets
             get
             {
                 if (OpenFileFlushTimeout <= 0 || AutoFlush || !KeepFileOpen)
-                    return (OpenFileCacheTimeout > 500 && OpenFileCacheTimeout < 3600) ? 300 : OpenFileCacheTimeout;
+                    return (OpenFileCacheTimeout > 600 && OpenFileCacheTimeout < 3600) ? 300 : OpenFileCacheTimeout;
                 else if (OpenFileCacheTimeout <= 0)
                     return OpenFileFlushTimeout;
                 else
@@ -1066,7 +1066,7 @@ namespace NLog.Targets
 
         private void PruneOpenFileCacheUsingTimeout()
         {
-            DateTime closeTime = Time.TimeSource.Current.Time.AddSeconds(-OpenFileCacheTimeout);
+            DateTime closeTime = Time.TimeSource.Current.Time.AddSeconds(-OpenFileCacheTimeout).AddSeconds(OpenFileCacheTimeout > OpenFileMonitorTimerInterval ? -OpenFileMonitorTimerInterval : 0);
             bool unusedFileMustBeClosed = false;
 
             foreach (var openFile in _openFileCache)


### PR DESCRIPTION
Support applications that are using hourly rolling files, but want to release file handles 5-10 mins after hour roll.

Ex. CommVault Backup will not perform backup of log-files, that NLog is currently writing to (requires exclusive file-lock, or VSS). But if having scheduled backup every 2 hours, then NLog should attempt to close its file-handles 5-10 mins after hour-roll. Thus allow CommVault to make backup "early" but without CommVault suddenly taking over still active log-files.