### PR TITLE
MemoryTarget: add INotifyCollectionChanged support via ObservableLogs

### DIFF
--- a/src/NLog/Targets/MemoryTarget.cs
+++ b/src/NLog/Targets/MemoryTarget.cs
@@ -88,6 +88,14 @@ namespace NLog.Targets
         /// </remarks>
         public IList<string> Logs => _logs;
 
+#if !NET35
+        /// <summary>
+        /// Gets <see cref="Logs"/> as <see cref="System.Collections.Specialized.INotifyCollectionChanged"/>
+        /// to support GUI data binding (e.g. WPF, MAUI).
+        /// </summary>
+        public System.Collections.Specialized.INotifyCollectionChanged ObservableLogs => _logs;
+#endif
+
         /// <summary>
         /// Gets or sets the max number of items to have in memory. Zero or Negative means no limit.
         /// </summary>
@@ -127,9 +135,20 @@ namespace NLog.Targets
         }
 
         private sealed class ThreadSafeList<T> : IList<T>
+#if !NET35
+            , System.Collections.Specialized.INotifyCollectionChanged
+#endif
         {
             private readonly List<T> _list = new List<T>();
+#if !NET35
 
+            public event System.Collections.Specialized.NotifyCollectionChangedEventHandler? CollectionChanged;
+            private void OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+            {
+            CollectionChanged?.Invoke(this, e);
+            }
+
+#endif
             public T this[int index]
             {
                 get
@@ -157,19 +176,45 @@ namespace NLog.Targets
                 {
                     _list.Add(item);
                 }
+#if !NET35
+                OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                    System.Collections.Specialized.NotifyCollectionChangedAction.Add, item));
+#endif
+
+
             }
 
             public void Add(T item, int maxListCount)
             {
+#if !NET35
+                bool itemsRemoved = false;
+#endif
                 lock (_list)
                 {
                     if (maxListCount > 0)
                     {
                         while (_list.Count >= maxListCount)
+                        {
                             _list.RemoveAt(0);
+#if !NET35
+                 itemsRemoved = true;
+#endif
+                        }
                     }
                     _list.Add(item);
                 }
+#if !NET35
+               if (itemsRemoved)
+               {
+                   OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                       System.Collections.Specialized.NotifyCollectionChangedAction.Reset));
+               }
+               else
+               {
+                   OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                       System.Collections.Specialized.NotifyCollectionChangedAction.Add, item));
+               }
+#endif
             }
 
             void ICollection<T>.Clear()

--- a/src/NLog/Targets/MemoryTarget.cs
+++ b/src/NLog/Targets/MemoryTarget.cs
@@ -91,8 +91,14 @@ namespace NLog.Targets
 #if !NET35
         /// <summary>
         /// Gets <see cref="Logs"/> as <see cref="System.Collections.Specialized.INotifyCollectionChanged"/>
-        /// to support GUI data binding (e.g. WPF, MAUI).
+        /// to support GUI data binding.
         /// </summary>
+        /// <remarks>
+        /// cref="System.Collections.Specialized.INotifyCollectionChanged.CollectionChanged"
+        /// When binding to a UI framework such as WPF or MAUI, the consumer is responsible for
+        /// marshaling to the UI thread. For WPF, use <c>BindingOperations.EnableCollectionSynchronization</c>.
+        /// For MAUI/other, dispatch via <c>SynchronizationContext</c> or <c>MainThread.BeginInvokeOnMainThread</c>.
+        /// </remarks>
         public System.Collections.Specialized.INotifyCollectionChanged ObservableLogs => _logs;
 #endif
 
@@ -145,7 +151,7 @@ namespace NLog.Targets
             public event System.Collections.Specialized.NotifyCollectionChangedEventHandler? CollectionChanged;
             private void OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
             {
-            CollectionChanged?.Invoke(this, e);
+                CollectionChanged?.Invoke(this, e);
             }
 
 #endif
@@ -160,35 +166,28 @@ namespace NLog.Targets
                 }
                 set
                 {
+                    T oldItem;
                     lock (_list)
                     {
+                        oldItem = _list[index];
                         _list[index] = value;
                     }
+#if !NET35
+                OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                         System.Collections.Specialized.NotifyCollectionChangedAction.Replace, value, oldItem, index));
+#endif
                 }
             }
 
             public int Count => _list.Count;
             bool ICollection<T>.IsReadOnly => ((ICollection<T>)_list).IsReadOnly;
 
-            public void Add(T item)
-            {
-                lock (_list)
-                {
-                    _list.Add(item);
-                }
-#if !NET35
-                OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
-                    System.Collections.Specialized.NotifyCollectionChangedAction.Add, item));
-#endif
-
-
-            }
-
             public void Add(T item, int maxListCount)
             {
 #if !NET35
                 bool itemsRemoved = false;
 #endif
+                int newIndex;
                 lock (_list)
                 {
                     if (maxListCount > 0)
@@ -197,33 +196,52 @@ namespace NLog.Targets
                         {
                             _list.RemoveAt(0);
 #if !NET35
-                 itemsRemoved = true;
+                            itemsRemoved = true;
 #endif
                         }
                     }
                     _list.Add(item);
+                    newIndex = _list.Count - 1;
                 }
 #if !NET35
-               if (itemsRemoved)
-               {
-                   OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
-                       System.Collections.Specialized.NotifyCollectionChangedAction.Reset));
-               }
-               else
-               {
-                   OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
-                       System.Collections.Specialized.NotifyCollectionChangedAction.Add, item));
-               }
+                if (itemsRemoved)
+                {
+                    OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                        System.Collections.Specialized.NotifyCollectionChangedAction.Reset));
+                }
+                else
+                {
+                    OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                        System.Collections.Specialized.NotifyCollectionChangedAction.Add, item, newIndex));
+                }
 #endif
             }
 
+            public void Add(T item)
+            {
+                int newIndex;
+                lock (_list)
+                {
+                    _list.Add(item);
+                    newIndex = _list.Count - 1;
+                }
+#if !NET35
+             OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                        System.Collections.Specialized.NotifyCollectionChangedAction.Add, item, newIndex));
+#endif
+            }
             void ICollection<T>.Clear()
             {
                 lock (_list)
                 {
                     _list.Clear();
                 }
+#if !NET35
+                OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                          System.Collections.Specialized.NotifyCollectionChangedAction.Reset));
+#endif
             }
+
 
             bool ICollection<T>.Contains(T item)
             {
@@ -255,22 +273,40 @@ namespace NLog.Targets
                 {
                     _list.Insert(index, item);
                 }
+#if !NET35
+            OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                     System.Collections.Specialized.NotifyCollectionChangedAction.Add, item, index));
+#endif
             }
 
             bool ICollection<T>.Remove(T item)
             {
+                int index;
                 lock (_list)
                 {
-                    return _list.Remove(item);
+                    index = _list.IndexOf(item);
+                    if (index < 0) return false;
+                    _list.RemoveAt(index);
                 }
+#if !NET35
+             OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                   System.Collections.Specialized.NotifyCollectionChangedAction.Remove, item, index));
+#endif
+                return true;
             }
 
             public void RemoveAt(int index)
             {
+                T item;
                 lock (_list)
                 {
+                    item = _list[index];
                     _list.RemoveAt(index);
                 }
+#if !NET35
+            OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                  System.Collections.Specialized.NotifyCollectionChangedAction.Remove, item, index));
+#endif
             }
 
             public IEnumerator<T> GetEnumerator()

--- a/src/NLog/Targets/MemoryTarget.cs
+++ b/src/NLog/Targets/MemoryTarget.cs
@@ -142,19 +142,19 @@ namespace NLog.Targets
 
         private sealed class ThreadSafeList<T> : IList<T>
 #if !NET35
-            , System.Collections.Specialized.INotifyCollectionChanged
+         , System.Collections.Specialized.INotifyCollectionChanged
 #endif
         {
             private readonly List<T> _list = new List<T>();
+
 #if !NET35
-
-            public event System.Collections.Specialized.NotifyCollectionChangedEventHandler? CollectionChanged;
-            private void OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-            {
-                CollectionChanged?.Invoke(this, e);
-            }
-
+        public event System.Collections.Specialized.NotifyCollectionChangedEventHandler? CollectionChanged;   
+        private void OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            CollectionChanged?.Invoke(this, e);
+        }
 #endif
+
             public T this[int index]
             {
                 get
@@ -173,8 +173,9 @@ namespace NLog.Targets
                         _list[index] = value;
                     }
 #if !NET35
+            if (CollectionChanged != null)
                 OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
-                         System.Collections.Specialized.NotifyCollectionChangedAction.Replace, value, oldItem, index));
+                    System.Collections.Specialized.NotifyCollectionChangedAction.Replace, value, oldItem, index));
 #endif
                 }
             }
@@ -204,16 +205,19 @@ namespace NLog.Targets
                     newIndex = _list.Count - 1;
                 }
 #if !NET35
-                if (itemsRemoved)
-                {
-                    OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
-                        System.Collections.Specialized.NotifyCollectionChangedAction.Reset));
-                }
-                else
-                {
-                    OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
-                        System.Collections.Specialized.NotifyCollectionChangedAction.Add, item, newIndex));
-                }
+             if (CollectionChanged != null)
+             {
+                 if (itemsRemoved)
+                 {
+                     OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                         System.Collections.Specialized.NotifyCollectionChangedAction.Reset));
+                 }
+                 else
+                 {
+                     OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                         System.Collections.Specialized.NotifyCollectionChangedAction.Add, item, newIndex));
+                 }
+              }
 #endif
             }
 
@@ -226,22 +230,21 @@ namespace NLog.Targets
                     newIndex = _list.Count - 1;
                 }
 #if !NET35
-             OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
-                        System.Collections.Specialized.NotifyCollectionChangedAction.Add, item, newIndex));
-#endif
-            }
-            void ICollection<T>.Clear()
-            {
-                lock (_list)
-                {
-                    _list.Clear();
-                }
-#if !NET35
+            if (CollectionChanged != null)
                 OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
-                          System.Collections.Specialized.NotifyCollectionChangedAction.Reset));
+                   System.Collections.Specialized.NotifyCollectionChangedAction.Add, item, newIndex));
 #endif
             }
 
+            void ICollection<T>.Clear()
+            {
+                lock (_list) _list.Clear();
+#if !NET35
+            if (CollectionChanged != null)
+                OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                    System.Collections.Specialized.NotifyCollectionChangedAction.Reset));
+#endif
+            }
 
             bool ICollection<T>.Contains(T item)
             {
@@ -274,8 +277,9 @@ namespace NLog.Targets
                     _list.Insert(index, item);
                 }
 #if !NET35
-            OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
-                     System.Collections.Specialized.NotifyCollectionChangedAction.Add, item, index));
+            if (CollectionChanged != null)
+                 OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                       System.Collections.Specialized.NotifyCollectionChangedAction.Add, item, index));
 #endif
             }
 
@@ -289,8 +293,9 @@ namespace NLog.Targets
                     _list.RemoveAt(index);
                 }
 #if !NET35
-             OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
-                   System.Collections.Specialized.NotifyCollectionChangedAction.Remove, item, index));
+            if (CollectionChanged != null)
+                 OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                    System.Collections.Specialized.NotifyCollectionChangedAction.Remove, item, index));
 #endif
                 return true;
             }
@@ -304,8 +309,9 @@ namespace NLog.Targets
                     _list.RemoveAt(index);
                 }
 #if !NET35
-            OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
-                  System.Collections.Specialized.NotifyCollectionChangedAction.Remove, item, index));
+            if (CollectionChanged != null)
+                OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+                    System.Collections.Specialized.NotifyCollectionChangedAction.Remove, item, index));
 #endif
             }
 

--- a/tests/NLog.UnitTests/Targets/MemoryTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MemoryTargetTests.cs
@@ -224,6 +224,8 @@ namespace NLog.UnitTests.Targets
             Assert.Equal("Error EEE", memoryTarget.Logs[4]);
         }
 
+
+#if !NET35
         [Fact]
         public void MemoryTarget_ObservableLogs_FiresEventOnWrite()
         {
@@ -289,4 +291,5 @@ namespace NLog.UnitTests.Targets
             Assert.Equal(3, memoryTarget.Logs.Count); // still capped at 3
         }
     }
+#endif
 }

--- a/tests/NLog.UnitTests/Targets/MemoryTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MemoryTargetTests.cs
@@ -223,5 +223,70 @@ namespace NLog.UnitTests.Targets
             Assert.Equal("Warn ", memoryTarget.Logs[3]);
             Assert.Equal("Error EEE", memoryTarget.Logs[4]);
         }
+
+        [Fact]
+        public void MemoryTarget_ObservableLogs_FiresEventOnWrite()
+        {
+            var memoryTarget = new MemoryTarget
+            {
+                Layout = "${level} ${message}"
+            };
+
+            var logger = new LogFactory().Setup().LoadConfiguration(builder =>
+            {
+                builder.ForLogger().WriteTo(memoryTarget);
+            }).GetCurrentClassLogger();
+
+            int eventCount = 0;
+            memoryTarget.ObservableLogs.CollectionChanged += (s, e) =>
+            {
+                eventCount++;
+            };
+
+            logger.Info("AAA");
+            logger.Warn("BBB");
+            logger.Error("CCC");
+
+            logger.Factory.Configuration = null;
+
+            Assert.Equal(3, eventCount);
+            Assert.Equal(3, memoryTarget.Logs.Count);
+        }
+
+
+        [Fact]
+        public void MemoryTarget_ObservableLogs_FiresResetEventWhenMaxLogsCountReached()
+        {
+            var memoryTarget = new MemoryTarget
+            {
+                Layout = "${level} ${message}",
+                MaxLogsCount = 3
+            };
+
+            var logger = new LogFactory().Setup().LoadConfiguration(builder =>
+            {
+                builder.ForLogger().WriteTo(memoryTarget);
+            }).GetCurrentClassLogger();
+
+            var actions = new System.Collections.Generic.List<System.Collections.Specialized.NotifyCollectionChangedAction>();
+            memoryTarget.ObservableLogs.CollectionChanged += (s, e) =>
+            {
+                actions.Add(e.Action);
+            };
+
+            logger.Info("AAA");
+            logger.Info("BBB");
+            logger.Info("CCC");
+            logger.Info("DDD"); // this one pushes over the limit
+
+            logger.Factory.Configuration = null;
+
+            // First 3 are simple Add, the 4th triggers a Reset (because old items were removed)
+            Assert.Equal(System.Collections.Specialized.NotifyCollectionChangedAction.Add, actions[0]);
+            Assert.Equal(System.Collections.Specialized.NotifyCollectionChangedAction.Add, actions[1]);
+            Assert.Equal(System.Collections.Specialized.NotifyCollectionChangedAction.Add, actions[2]);
+            Assert.Equal(System.Collections.Specialized.NotifyCollectionChangedAction.Reset, actions[3]);
+            Assert.Equal(3, memoryTarget.Logs.Count); // still capped at 3
+        }
     }
 }

--- a/tests/NLog.UnitTests/Targets/MemoryTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MemoryTargetTests.cs
@@ -290,6 +290,7 @@ namespace NLog.UnitTests.Targets
             Assert.Equal(System.Collections.Specialized.NotifyCollectionChangedAction.Reset, actions[3]);
             Assert.Equal(3, memoryTarget.Logs.Count); // still capped at 3
         }
-    }
 #endif
+
+    }
 }

--- a/tests/NLog.UnitTests/Targets/MemoryTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/MemoryTargetTests.cs
@@ -281,7 +281,7 @@ namespace NLog.UnitTests.Targets
 
             logger.Factory.Configuration = null;
 
-            // First 3 are simple Add, the 4th triggers a Reset (because old items were removed)
+            Assert.Equal(4, actions.Count);
             Assert.Equal(System.Collections.Specialized.NotifyCollectionChangedAction.Add, actions[0]);
             Assert.Equal(System.Collections.Specialized.NotifyCollectionChangedAction.Add, actions[1]);
             Assert.Equal(System.Collections.Specialized.NotifyCollectionChangedAction.Add, actions[2]);


### PR DESCRIPTION
Closes #6124
Added INotifyCollectionChanged support to MemoryTarget via a new ObservableLogs property, making it easier to bind NLog output to a GUI (WPF, MAUI, etc).

Changes:

ThreadSafeList<T> now implements INotifyCollectionChanged (guarded with #if !NET35)
New ObservableLogs property exposed on MemoryTarget
Two unit tests added covering Add and Reset events
