### PR TITLE
SimpleLayout skip Precalculate when INoAllocationStringValueRenderer available

### DIFF
--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -407,17 +407,10 @@ namespace NLog.Layouts
                 ++layoutCount;
                 if (layout?.ThreadAgnostic == false || layout?.ThreadAgnosticImmutable == true)
                 {
-                    if (layout is SimpleLayout simpleLayout && simpleLayout.IsNoAllocationLayout)
+                    precalculateLayoutCount++;
+                    if (layout is SimpleLayout)
                     {
-                        // No-alloc layout can skip precalculation entirely — no need to count it
-                    }
-                    else
-                    {
-                        precalculateLayoutCount++;
-                        if (layout is SimpleLayout)
-                        {
-                            precalculateSimpleLayoutCount++;
-                        }
+                        precalculateSimpleLayoutCount++;
                     }
                 }
             }
@@ -428,8 +421,7 @@ namespace NLog.Layouts
             }
             else
             {
-                return allLayouts.Where(layout => (layout?.ThreadAgnostic == false || layout?.ThreadAgnosticImmutable == true) &&
-                                      !(layout is SimpleLayout sl && sl.IsNoAllocationLayout)).ToArray();
+                return allLayouts.Where(layout => layout?.ThreadAgnostic == false || layout?.ThreadAgnosticImmutable == true).ToArray();
             }
         }
 

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -93,7 +93,7 @@ namespace NLog.Layouts
         {
             if (text is null)
                 return new Layout<string>(null);
-            else 
+            else
                 return FromString(text, ConfigurationItemFactory.Default);
         }
 
@@ -407,10 +407,17 @@ namespace NLog.Layouts
                 ++layoutCount;
                 if (layout?.ThreadAgnostic == false || layout?.ThreadAgnosticImmutable == true)
                 {
-                    precalculateLayoutCount++;
-                    if (layout is SimpleLayout)
+                    if (layout is SimpleLayout simpleLayout && simpleLayout.IsNoAllocationLayout)
                     {
-                        precalculateSimpleLayoutCount++;
+                        // No-alloc layout can skip precalculation entirely — no need to count it
+                    }
+                    else
+                    {
+                        precalculateLayoutCount++;
+                        if (layout is SimpleLayout)
+                        {
+                            precalculateSimpleLayoutCount++;
+                        }
                     }
                 }
             }
@@ -421,7 +428,8 @@ namespace NLog.Layouts
             }
             else
             {
-                return allLayouts.Where(layout => layout?.ThreadAgnostic == false || layout?.ThreadAgnosticImmutable == true).ToArray();
+                return allLayouts.Where(layout => (layout?.ThreadAgnostic == false || layout?.ThreadAgnosticImmutable == true) &&
+                                      !(layout is SimpleLayout sl && sl.IsNoAllocationLayout)).ToArray();
             }
         }
 

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -337,7 +337,7 @@ namespace NLog.Layouts
                 return false;
 
             if (_rawValueRenderer != null && TryGetRawValue(logEvent, out var rawValue) && IsRawValueImmutable(rawValue))
-                return false; // If raw value is immutable, then we can skip precalculate-caching
+                return false;   // If raw value is immutable, then we can skip precalculate-caching
 
             if (logEvent.TryGetCachedLayoutValue(this, out var _))
                 return false;

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -126,14 +126,11 @@ namespace NLog.Layouts
                 else if (_layoutRenderers[0] is IStringValueRenderer stringValueRenderer)
                 {
                     _stringValueRenderer = stringValueRenderer;
+                    _noAllocRenderer = stringValueRenderer as INoAllocationStringValueRenderer;
                 }
                 if (_layoutRenderers[0] is IRawValue rawValueRenderer)
                 {
                     _rawValueRenderer = rawValueRenderer;
-                }
-                if (_layoutRenderers[0] is INoAllocationStringValueRenderer noAllocRenderer)
-                {
-                    _noAllocRenderer = noAllocRenderer;
                 }
             }
         }
@@ -344,13 +341,12 @@ namespace NLog.Layouts
             if (logEvent.TryGetCachedLayoutValue(this, out var _))
                 return false;
 
-            // No-allocation optimization takes priority over IStringValueRenderer fast-path
-            // since it can avoid both StringBuilder and AddCachedLayoutValue
-            if (_noAllocRenderer?.GetFormattedStringNoAllocation(logEvent) is not null)
-                return false;  
-
             if (IsSimpleStringText)
             {
+                // No-allocation optimization means it can skip both StringBuilder and precalculate-caching
+                if (_noAllocRenderer?.GetFormattedStringNoAllocation(logEvent) is not null)
+                    return false;
+            
                 var cachedLayout = GetFormattedMessage(logEvent);
                 logEvent.AddCachedLayoutValue(this, cachedLayout);
                 return false;

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -128,6 +128,7 @@ namespace NLog.Layouts
                     _stringValueRenderer = stringValueRenderer;
                     _noAllocRenderer = stringValueRenderer as INoAllocationStringValueRenderer;
                 }
+
                 if (_layoutRenderers[0] is IRawValue rawValueRenderer)
                 {
                     _rawValueRenderer = rawValueRenderer;

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -325,6 +325,7 @@ namespace NLog.Layouts
                 logEvent.AddCachedLayoutValue(this, target.ToString());
             }
         }
+
         private bool PrecalculateMustRenderLayoutValue(LogEventInfo logEvent)
         {
             if (!IsInitialized)

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -345,7 +345,7 @@ namespace NLog.Layouts
                 return false;
 
             // No-allocation optimization takes priority over IStringValueRenderer fast-path
-            // since it avoids both StringBuilder AND string allocation during preca
+            // since it can avoid both StringBuilder and AddCachedLayoutValue
             if (_noAllocRenderer?.GetFormattedStringNoAllocation(logEvent) is not null)
                 return false;  
 

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -60,6 +60,7 @@ namespace NLog.Layouts
     public sealed class SimpleLayout : Layout, IUsesStackTrace, IStringValueRenderer
     {
         private readonly IRawValue? _rawValueRenderer;
+        private readonly INoAllocationStringValueRenderer? _noAllocRenderer;
         private IStringValueRenderer? _stringValueRenderer;
 
         internal static SimpleLayout Default => (SimpleLayout)Layout.Empty;
@@ -126,10 +127,13 @@ namespace NLog.Layouts
                 {
                     _stringValueRenderer = stringValueRenderer;
                 }
-
                 if (_layoutRenderers[0] is IRawValue rawValueRenderer)
                 {
                     _rawValueRenderer = rawValueRenderer;
+                }
+                if (_layoutRenderers[0] is INoAllocationStringValueRenderer noAllocRenderer)
+                {
+                    _noAllocRenderer = noAllocRenderer;
                 }
             }
         }
@@ -340,6 +344,11 @@ namespace NLog.Layouts
             if (logEvent.TryGetCachedLayoutValue(this, out var _))
                 return false;
 
+            // No-allocation optimization takes priority over IStringValueRenderer fast-path
+            // since it avoids both StringBuilder AND string allocation during preca
+            if (_noAllocRenderer?.GetFormattedStringNoAllocation(logEvent) is not null)
+                return false;  
+
             if (IsSimpleStringText)
             {
                 var cachedLayout = GetFormattedMessage(logEvent);
@@ -347,48 +356,7 @@ namespace NLog.Layouts
                 return false;
             }
 
-            //  if every renderer can serve this event without allocation,
-            // there is no thread-context to capture — skip precalculation
-            if (AllRenderersAreNoAllocation(logEvent))
-                return false;
-
             return true;
-        }
-
-        private bool AllRenderersAreNoAllocation(LogEventInfo logEvent)
-        {
-            if (_layoutRenderers.Length == 0)
-                return true;
-
-            foreach (var renderer in _layoutRenderers)
-            {
-                if (renderer is INoAllocationStringValueRenderer noAllocRenderer)
-                {
-                    if (noAllocRenderer.GetFormattedStringNoAllocation(logEvent) is null)
-                        return false;  // renderer signals it cannot skip precalculation for this event
-                }
-                else if (renderer is not LiteralLayoutRenderer)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-        /// <summary>
-        /// Gets whether all renderers in this layout support no-allocation rendering.
-        /// </summary>
-        internal bool IsNoAllocationLayout
-        {
-            get
-            {
-                foreach (var renderer in _layoutRenderers)
-                {
-                    if (renderer is not INoAllocationStringValueRenderer && renderer is not LiteralLayoutRenderer)
-                        return false;
-                }
-                return true;
-            }
         }
         private static bool IsRawValueImmutable(object? value)
         {

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -354,6 +354,7 @@ namespace NLog.Layouts
 
             return true;
         }
+
         private static bool IsRawValueImmutable(object? value)
         {
             return value != null && (Convert.GetTypeCode(value) != TypeCode.Object || value.GetType().IsValueType);

--- a/src/NLog/Layouts/SimpleLayout.cs
+++ b/src/NLog/Layouts/SimpleLayout.cs
@@ -324,7 +324,6 @@ namespace NLog.Layouts
                 logEvent.AddCachedLayoutValue(this, target.ToString());
             }
         }
-
         private bool PrecalculateMustRenderLayoutValue(LogEventInfo logEvent)
         {
             if (!IsInitialized)
@@ -336,7 +335,7 @@ namespace NLog.Layouts
                 return false;
 
             if (_rawValueRenderer != null && TryGetRawValue(logEvent, out var rawValue) && IsRawValueImmutable(rawValue))
-                return false;   // If raw value is immutable, then we can skip precalculate-caching
+                return false; // If raw value is immutable, then we can skip precalculate-caching
 
             if (logEvent.TryGetCachedLayoutValue(this, out var _))
                 return false;
@@ -348,9 +347,49 @@ namespace NLog.Layouts
                 return false;
             }
 
+            //  if every renderer can serve this event without allocation,
+            // there is no thread-context to capture — skip precalculation
+            if (AllRenderersAreNoAllocation(logEvent))
+                return false;
+
             return true;
         }
 
+        private bool AllRenderersAreNoAllocation(LogEventInfo logEvent)
+        {
+            if (_layoutRenderers.Length == 0)
+                return true;
+
+            foreach (var renderer in _layoutRenderers)
+            {
+                if (renderer is INoAllocationStringValueRenderer noAllocRenderer)
+                {
+                    if (noAllocRenderer.GetFormattedStringNoAllocation(logEvent) is null)
+                        return false;  // renderer signals it cannot skip precalculation for this event
+                }
+                else if (renderer is not LiteralLayoutRenderer)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        /// <summary>
+        /// Gets whether all renderers in this layout support no-allocation rendering.
+        /// </summary>
+        internal bool IsNoAllocationLayout
+        {
+            get
+            {
+                foreach (var renderer in _layoutRenderers)
+                {
+                    if (renderer is not INoAllocationStringValueRenderer && renderer is not LiteralLayoutRenderer)
+                        return false;
+                }
+                return true;
+            }
+        }
         private static bool IsRawValueImmutable(object? value)
         {
             return value != null && (Convert.GetTypeCode(value) != TypeCode.Object || value.GetType().IsValueType);

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
@@ -289,59 +289,20 @@ namespace NLog.UnitTests.Layouts
             }
         }
         [Fact]
-        public void SimpleLayout_WithNoAllocationRenderer_SkipsPrecalculate()
+        public void SimpleLayout_WithMessageRenderer_SkipsPrecalculate()
         {
-            // Arrange - single no-alloc renderer, optimization applies
-            var renderer = new NoAllocTestRenderer(returnNull: false);
-            var layout = new SimpleLayout(new LayoutRenderer[] { renderer }, "${noalloc}");
+            // Arrange - MessageLayoutRenderer implements INoAllocationStringValueRenderer
+            var layout = new SimpleLayout("${message}");
             layout.Initialize(null);
-            var logEvent = LogEventInfo.CreateNullEvent();
+            var logEvent = LogEventInfo.Create(LogLevel.Info, "TestLogger", "test message");
 
             // Act
             layout.Precalculate(logEvent);
 
-            // Assert - no cached value because no-alloc renderer can skip precalculation
+            // Assert - no cached value because no-alloc path succeeded
             Assert.False(logEvent.TryGetCachedLayoutValue(layout, out _));
-            Assert.Equal("test", layout.Render(logEvent));
+            Assert.Equal("test message", layout.Render(logEvent));
         }
 
-        [Fact]
-        public void SimpleLayout_WithNoAllocationRenderer_WhenReturnsNull_DoesPrecalculate()
-        {
-            // Arrange - single no-alloc renderer that signals it cannot optimize
-            var noAllocRenderer = new NoAllocTestRenderer(returnNull: true);
-            var layout = new SimpleLayout(new LayoutRenderer[] { noAllocRenderer }, "${noalloc}");
-            layout.Initialize(null);
-            var logEvent = LogEventInfo.CreateNullEvent();
-
-            // Act
-            layout.Precalculate(logEvent);
-
-            // Assert - value should be cached because renderer returned null (optimization not possible)
-            Assert.True(logEvent.TryGetCachedLayoutValue(layout, out _));
-        }
-
-        [LayoutRenderer("noalloc")]
-        private sealed class NoAllocTestRenderer : LayoutRenderer, INoAllocationStringValueRenderer
-        {
-            private readonly bool _returnNull;
-
-            public NoAllocTestRenderer(bool returnNull = false)
-            {
-                _returnNull = returnNull;
-            }
-
-            protected override void Append(StringBuilder builder, LogEventInfo logEvent)
-            {
-                builder.Append("test");
-            }
-
-            public string GetFormattedString(LogEventInfo logEvent) => "test";
-
-            public string GetFormattedStringNoAllocation(LogEventInfo logEvent)
-            {
-                return _returnNull ? null : "test";
-            }
-        }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
@@ -288,5 +288,103 @@ namespace NLog.UnitTests.Layouts
                 return "foo";
             }
         }
+
+        [Fact]
+        public void SimpleLayout_WithNoAllocationRenderer_SkipsPrecalculate()
+        {
+            // Arrange - two renderers so IsSimpleStringText is false,
+            // forcing the code to reach AllRenderersAreNoAllocation
+            var renderer1 = new NoAllocTestRenderer(returnNull: false);
+            var renderer2 = new NoAllocTestRenderer(returnNull: false);
+            var layout = new SimpleLayout(new LayoutRenderer[] { renderer1, renderer2 }, "${noalloc}${noalloc}");
+            layout.Initialize(null);
+            var logEvent = LogEventInfo.CreateNullEvent();
+
+            // Act
+            layout.Precalculate(logEvent);
+
+            // Assert - no cached value should be stored because all renderers are no-alloc capable
+            Assert.False(logEvent.TryGetCachedLayoutValue(layout, out _));
+            Assert.Equal("testtest", layout.Render(logEvent));
+        }
+
+        [Fact]
+        public void SimpleLayout_WithNoAllocationRenderer_WhenReturnsNull_DoesPrecalculate()
+        {
+            // Arrange - use threadid (non-ThreadAgnostic) alongside our renderer
+            // so the layout itself is not ThreadAgnostic and reaches our check
+            var noAllocRenderer = new NoAllocTestRenderer(returnNull: true);
+            var threadIdRenderer = new NLog.LayoutRenderers.ThreadIdLayoutRenderer();
+            var layout = new SimpleLayout(new LayoutRenderer[] { noAllocRenderer, threadIdRenderer }, "${noalloc}${threadid}");
+            layout.Initialize(null);
+            var logEvent = LogEventInfo.CreateNullEvent();
+
+            // Act
+            layout.Precalculate(logEvent);
+
+            // Assert - value should be cached because renderer signaled it needs precalculation
+            Assert.True(logEvent.TryGetCachedLayoutValue(layout, out _));
+        }
+
+        [Fact]
+        public void SimpleLayout_WithNoAllocationRenderer_RendersCorrectly()
+        {
+            // Arrange
+            var renderer = new NoAllocTestRenderer(returnNull: false);
+            var layout = new SimpleLayout(new LayoutRenderer[] { renderer }, "${noalloc}");
+            layout.Initialize(null);
+            var logEvent = LogEventInfo.CreateNullEvent();
+
+            // Act
+            var result = layout.Render(logEvent);
+
+            // Assert
+            Assert.Equal("test", result);
+        }
+
+        [Fact]
+        public void SimpleLayout_IsNoAllocationLayout_TrueWhenAllRenderersAreNoAlloc()
+        {
+            // Arrange
+            var renderer = new NoAllocTestRenderer(returnNull: false);
+            var layout = new SimpleLayout(new LayoutRenderer[] { renderer }, "${noalloc}");
+
+            // Assert
+            Assert.True(layout.IsNoAllocationLayout);
+        }
+
+        [Fact]
+        public void SimpleLayout_IsNoAllocationLayout_FalseWhenRegularRenderer()
+        {
+            // Arrange - threadid does not implement INoAllocationStringValueRenderer
+            var layout = new SimpleLayout("${threadid}");
+            layout.Initialize(null);
+
+            // Assert
+            Assert.False(layout.IsNoAllocationLayout);
+        }
+
+        [LayoutRenderer("noalloc")]
+        private sealed class NoAllocTestRenderer : LayoutRenderer, INoAllocationStringValueRenderer
+        {
+            private readonly bool _returnNull;
+
+            public NoAllocTestRenderer(bool returnNull = false)
+            {
+                _returnNull = returnNull;
+            }
+
+            protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+            {
+                builder.Append("test");
+            }
+
+            public string GetFormattedString(LogEventInfo logEvent) => "test";
+
+            public string GetFormattedStringNoAllocation(LogEventInfo logEvent)
+            {
+                return _returnNull ? null : "test";
+            }
+        }
     }
 }

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
@@ -288,6 +288,7 @@ namespace NLog.UnitTests.Layouts
                 return "foo";
             }
         }
+
         [Fact]
         public void SimpleLayout_WithMessageRenderer_SkipsPrecalculate()
         {
@@ -303,6 +304,5 @@ namespace NLog.UnitTests.Layouts
             Assert.False(logEvent.TryGetCachedLayoutValue(layout, out _));
             Assert.Equal("test message", layout.Render(logEvent));
         }
-
     }
 }

--- a/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
+++ b/tests/NLog.UnitTests/Layouts/SimpleLayoutOutputTests.cs
@@ -288,80 +288,37 @@ namespace NLog.UnitTests.Layouts
                 return "foo";
             }
         }
-
         [Fact]
         public void SimpleLayout_WithNoAllocationRenderer_SkipsPrecalculate()
         {
-            // Arrange - two renderers so IsSimpleStringText is false,
-            // forcing the code to reach AllRenderersAreNoAllocation
-            var renderer1 = new NoAllocTestRenderer(returnNull: false);
-            var renderer2 = new NoAllocTestRenderer(returnNull: false);
-            var layout = new SimpleLayout(new LayoutRenderer[] { renderer1, renderer2 }, "${noalloc}${noalloc}");
+            // Arrange - single no-alloc renderer, optimization applies
+            var renderer = new NoAllocTestRenderer(returnNull: false);
+            var layout = new SimpleLayout(new LayoutRenderer[] { renderer }, "${noalloc}");
             layout.Initialize(null);
             var logEvent = LogEventInfo.CreateNullEvent();
 
             // Act
             layout.Precalculate(logEvent);
 
-            // Assert - no cached value should be stored because all renderers are no-alloc capable
+            // Assert - no cached value because no-alloc renderer can skip precalculation
             Assert.False(logEvent.TryGetCachedLayoutValue(layout, out _));
-            Assert.Equal("testtest", layout.Render(logEvent));
+            Assert.Equal("test", layout.Render(logEvent));
         }
 
         [Fact]
         public void SimpleLayout_WithNoAllocationRenderer_WhenReturnsNull_DoesPrecalculate()
         {
-            // Arrange - use threadid (non-ThreadAgnostic) alongside our renderer
-            // so the layout itself is not ThreadAgnostic and reaches our check
+            // Arrange - single no-alloc renderer that signals it cannot optimize
             var noAllocRenderer = new NoAllocTestRenderer(returnNull: true);
-            var threadIdRenderer = new NLog.LayoutRenderers.ThreadIdLayoutRenderer();
-            var layout = new SimpleLayout(new LayoutRenderer[] { noAllocRenderer, threadIdRenderer }, "${noalloc}${threadid}");
+            var layout = new SimpleLayout(new LayoutRenderer[] { noAllocRenderer }, "${noalloc}");
             layout.Initialize(null);
             var logEvent = LogEventInfo.CreateNullEvent();
 
             // Act
             layout.Precalculate(logEvent);
 
-            // Assert - value should be cached because renderer signaled it needs precalculation
+            // Assert - value should be cached because renderer returned null (optimization not possible)
             Assert.True(logEvent.TryGetCachedLayoutValue(layout, out _));
-        }
-
-        [Fact]
-        public void SimpleLayout_WithNoAllocationRenderer_RendersCorrectly()
-        {
-            // Arrange
-            var renderer = new NoAllocTestRenderer(returnNull: false);
-            var layout = new SimpleLayout(new LayoutRenderer[] { renderer }, "${noalloc}");
-            layout.Initialize(null);
-            var logEvent = LogEventInfo.CreateNullEvent();
-
-            // Act
-            var result = layout.Render(logEvent);
-
-            // Assert
-            Assert.Equal("test", result);
-        }
-
-        [Fact]
-        public void SimpleLayout_IsNoAllocationLayout_TrueWhenAllRenderersAreNoAlloc()
-        {
-            // Arrange
-            var renderer = new NoAllocTestRenderer(returnNull: false);
-            var layout = new SimpleLayout(new LayoutRenderer[] { renderer }, "${noalloc}");
-
-            // Assert
-            Assert.True(layout.IsNoAllocationLayout);
-        }
-
-        [Fact]
-        public void SimpleLayout_IsNoAllocationLayout_FalseWhenRegularRenderer()
-        {
-            // Arrange - threadid does not implement INoAllocationStringValueRenderer
-            var layout = new SimpleLayout("${threadid}");
-            layout.Initialize(null);
-
-            // Assert
-            Assert.False(layout.IsNoAllocationLayout);
         }
 
         [LayoutRenderer("noalloc")]


### PR DESCRIPTION
## Summary
Optimize async logging by skipping `Precalculate` when `INoAllocationStringValueRenderer` is available.

## Problem
When async logging is used, NLog calls `Precalculate` on the app thread to capture thread-context before handing the log event to a background thread. This causes memory allocations even when the layout renderers are capable of serving the value without allocations and without needing thread-context.

## Changes
- `SimpleLayout.PrecalculateMustRenderLayoutValue`: Skip precalculation when all renderers implement `INoAllocationStringValueRenderer` and return non-null for the current log event
- `SimpleLayout.AllRenderersAreNoAllocation`: New per-event runtime check
- `SimpleLayout.IsNoAllocationLayout`: New static structural check used by parent layouts
- `Layout.ResolveLayoutPrecalculation`: Skip no-alloc capable nested layouts when building the precalculate list

Fixes #6111