### PR TITLE
AppEnvironmentWrapper - Return Unknown_ProcessId when empty ProcessName

### DIFF
--- a/src/NLog/Common/InternalLogger.cs
+++ b/src/NLog/Common/InternalLogger.cs
@@ -491,7 +491,12 @@ namespace NLog.Common
                 if (ContainsSubStringIgnoreCase(internalLogFile, "${tempdir}", out var tempDirToken) && tempDirToken != null)
                     internalLogFile = internalLogFile.Replace(tempDirToken, LogManager.LogFactory.CurrentAppEnvironment.UserTempFilePath + System.IO.Path.DirectorySeparatorChar.ToString());
                 if (ContainsSubStringIgnoreCase(internalLogFile, "${processdir}", out var processDirToken) && processDirToken != null)
-                    internalLogFile = internalLogFile.Replace(processDirToken, System.IO.Path.GetDirectoryName(LogManager.LogFactory.CurrentAppEnvironment.CurrentProcessFilePath) + System.IO.Path.DirectorySeparatorChar.ToString());
+                {
+                    var processDir = System.IO.Path.GetDirectoryName(LogManager.LogFactory.CurrentAppEnvironment.CurrentProcessFilePath);
+                    if (string.IsNullOrEmpty(processDir))
+                        processDir = LogManager.LogFactory.CurrentAppEnvironment.AppDomainBaseDirectory;
+                    internalLogFile = internalLogFile.Replace(processDirToken, processDir + System.IO.Path.DirectorySeparatorChar.ToString());
+                }
                 if (ContainsSubStringIgnoreCase(internalLogFile, "${commonApplicationDataDir}", out var commonAppDataDirToken) && commonAppDataDirToken != null)
                     internalLogFile = internalLogFile.Replace(commonAppDataDirToken, NLog.LayoutRenderers.SpecialFolderLayoutRenderer.GetFolderPath(Environment.SpecialFolder.CommonApplicationData) + System.IO.Path.DirectorySeparatorChar.ToString());
                 if (ContainsSubStringIgnoreCase(internalLogFile, "${userApplicationDataDir}", out var appDataDirToken) && appDataDirToken != null)

--- a/src/NLog/Internal/AppEnvironmentWrapper.cs
+++ b/src/NLog/Internal/AppEnvironmentWrapper.cs
@@ -57,7 +57,7 @@ namespace NLog.Internal.Fakeables
         /// <inheritdoc/>
         public string EntryAssemblyLocation => _entryAssemblyLocation ?? (_entryAssemblyLocation = LookupEntryAssemblyLocation());
         /// <inheritdoc/>
-        public string EntryAssemblyFileName => _entryAssemblyFileName ?? (_entryAssemblyFileName = LookupEntryAssemblyFileName());
+        public string EntryAssemblyFileName => _entryAssemblyFileName ?? (_entryAssemblyFileName = LookupEntryAssemblyFileName() ?? (CurrentProcessBaseName + ".dll"));
         /// <inheritdoc/>
         public string CurrentProcessFilePath => _currentProcessFilePath ?? (_currentProcessFilePath = LookupCurrentProcessFilePathWithFallback());
         /// <inheritdoc/>
@@ -75,7 +75,7 @@ namespace NLog.Internal.Fakeables
         /// <inheritdoc/>
         public IEnumerable<string> AppDomainPrivateBinPath => _appDomainPrivateBinPath ?? (_appDomainPrivateBinPath = LookupAppDomainPrivateBinPathSafe());
         /// <inheritdoc/>
-        public IEnumerable<System.Reflection.Assembly> GetAppDomainRuntimeAssemblies() => AppDomain.CurrentDomain?.GetAssemblies() ?? ArrayHelper.Empty<System.Reflection.Assembly>();
+        public IEnumerable<System.Reflection.Assembly> GetAppDomainRuntimeAssemblies() => AppDomain.CurrentDomain.GetAssemblies() ?? ArrayHelper.Empty<System.Reflection.Assembly>();
         /// <inheritdoc/>
         public event EventHandler ProcessExit
         {
@@ -234,7 +234,12 @@ namespace NLog.Internal.Fakeables
         {
             try
             {
-                return System.Reflection.Assembly.GetEntryAssembly()?.GetName()?.Name;
+                var fileName = LookupEntryAssemblyFileName();
+                if (string.IsNullOrEmpty(fileName))
+                    return null;
+
+                var friendlyName = Path.GetFileNameWithoutExtension(fileName);
+                return string.IsNullOrEmpty(friendlyName) ? fileName : friendlyName;
             }
             catch
             {
@@ -252,7 +257,7 @@ namespace NLog.Internal.Fakeables
                 return string.Empty;
         }
 
-        private static string LookupEntryAssemblyFileName()
+        private static string? LookupEntryAssemblyFileName()
         {
             try
             {
@@ -266,7 +271,7 @@ namespace NLog.Internal.Fakeables
                 if (!string.IsNullOrEmpty(assemblyName))
                     return assemblyName + ".dll";
                 else
-                    return string.Empty;
+                    return null;
             }
             catch (Exception ex)
             {
@@ -274,7 +279,7 @@ namespace NLog.Internal.Fakeables
                     throw;
 
                 InternalLogger.Debug("LookupEntryAssemblyFileName Failed - {0}", ex.Message);
-                return string.Empty;
+                return null;
             }
         }
 
@@ -283,10 +288,13 @@ namespace NLog.Internal.Fakeables
             try
             {
                 var processFilePath = LookupCurrentProcessFilePath();
-                return processFilePath ?? LookupCurrentProcessFilePathNative();
+                if (string.IsNullOrEmpty(processFilePath))
+                    processFilePath = LookupCurrentProcessFilePathNative();
+                return processFilePath ?? string.Empty;
             }
             catch (Exception ex)
             {
+                // May throw a SecurityException if running from an IIS app. pool process (Cannot compile method)
                 if (ex.MustBeRethrownImmediately())
                     throw;
 
@@ -355,7 +363,22 @@ namespace NLog.Internal.Fakeables
             try
             {
                 var processName = LookupCurrentProcessName();
-                return processName ?? LookupCurrentProcessNameNative();
+                if (!string.IsNullOrEmpty(processName))
+                    return processName;
+
+                var currentProcessFilePath = LookupCurrentProcessFilePathWithFallback();
+                if (!string.IsNullOrEmpty(currentProcessFilePath))
+                {
+                    processName = Path.GetFileNameWithoutExtension(currentProcessFilePath);
+                    if (!string.IsNullOrEmpty(processName))
+                        return processName;
+                }
+
+                processName = LookupEntryAssemblyFriendlyName();
+                if (!string.IsNullOrEmpty(processName))
+                    return processName;
+
+                return null;
             }
             catch (Exception ex)
             {
@@ -364,7 +387,14 @@ namespace NLog.Internal.Fakeables
 
                 // May throw a SecurityException if running from an IIS app. pool process (Cannot compile method)
                 InternalLogger.Debug("LookupCurrentProcessName Failed - {0}", ex.Message);
-                return LookupCurrentProcessNameNative();
+                var filePath = LookupCurrentProcessFilePathNative();
+                if (!string.IsNullOrEmpty(filePath))
+                {
+                    filePath = Path.GetFileNameWithoutExtension(filePath);
+                    return string.IsNullOrEmpty(filePath) ? null : filePath;
+                }
+                var processName = LookupEntryAssemblyFriendlyName();
+                return string.IsNullOrEmpty(processName) ? null : processName;
             }
         }
 
@@ -383,27 +413,6 @@ namespace NLog.Internal.Fakeables
                     throw;
 
                 InternalLogger.Debug("LookupCurrentProcessName Managed Failed - {0}", ex.Message);
-            }
-
-            return null;
-        }
-
-        private static string? LookupCurrentProcessNameNative()
-        {
-            var currentProcessFilePath = LookupCurrentProcessFilePath();
-            if (!string.IsNullOrEmpty(currentProcessFilePath))
-            {
-                var currentProcessName = Path.GetFileNameWithoutExtension(currentProcessFilePath);
-                if (!string.IsNullOrEmpty(currentProcessName))
-                    return currentProcessName;
-            }
-
-            var entryAssemblyFileName = LookupEntryAssemblyFileName();
-            if (!string.IsNullOrEmpty(entryAssemblyFileName))
-            {
-                entryAssemblyFileName = Path.GetFileNameWithoutExtension(entryAssemblyFileName);
-                if (!string.IsNullOrEmpty(entryAssemblyFileName))
-                    return entryAssemblyFileName;
             }
 
             return null;

--- a/src/NLog/Internal/AppEnvironmentWrapper.cs
+++ b/src/NLog/Internal/AppEnvironmentWrapper.cs
@@ -43,8 +43,6 @@ namespace NLog.Internal.Fakeables
     {
         const string LongUNCPrefix = @"\\?\UNC\";
 
-        private const string UnknownProcessName = "[unknown]";
-
         private string? _entryAssemblyLocation;
         private string? _entryAssemblyFileName;
         private string? _currentProcessFilePath;
@@ -63,7 +61,7 @@ namespace NLog.Internal.Fakeables
         /// <inheritdoc/>
         public string CurrentProcessFilePath => _currentProcessFilePath ?? (_currentProcessFilePath = LookupCurrentProcessFilePathWithFallback());
         /// <inheritdoc/>
-        public string CurrentProcessBaseName => _currentProcessBaseName ?? (_currentProcessBaseName = LookupCurrentProcessNameWithFallback());
+        public string CurrentProcessBaseName => _currentProcessBaseName ?? (_currentProcessBaseName = LookupCurrentProcessNameWithFallback() ?? $"Unknown_ProcessId_{CurrentProcessId}");
         /// <inheritdoc/>
         public int CurrentProcessId => _currentProcessId ?? (_currentProcessId = LookupCurrentProcessIdWithFallback()).Value;
         /// <inheritdoc/>
@@ -213,12 +211,14 @@ namespace NLog.Internal.Fakeables
             }
         }
 
-        private static string LookupAppDomainFriendlyName()
+        private static string? LookupAppDomainFriendlyName()
         {
             try
             {
                 var friendlyName = AppDomain.CurrentDomain.FriendlyName;
-                return !string.IsNullOrEmpty(friendlyName) ? friendlyName : LookupEntryAssemblyFriendlyName();
+                if (string.IsNullOrEmpty(friendlyName))
+                    friendlyName = LookupEntryAssemblyFriendlyName();
+                return string.IsNullOrEmpty(friendlyName) ? null : friendlyName;
             }
             catch (Exception ex)
             {
@@ -230,16 +230,15 @@ namespace NLog.Internal.Fakeables
             }
         }
 
-        private static string LookupEntryAssemblyFriendlyName()
+        private static string? LookupEntryAssemblyFriendlyName()
         {
             try
             {
-                var assemblyName = System.Reflection.Assembly.GetEntryAssembly()?.GetName()?.Name;
-                return assemblyName ?? UnknownProcessName;
+                return System.Reflection.Assembly.GetEntryAssembly()?.GetName()?.Name;
             }
             catch
             {
-                return UnknownProcessName;
+                return null;
             }
         }
 
@@ -351,7 +350,7 @@ namespace NLog.Internal.Fakeables
             }
         }
 
-        private static string LookupCurrentProcessNameWithFallback()
+        private static string? LookupCurrentProcessNameWithFallback()
         {
             try
             {
@@ -389,7 +388,7 @@ namespace NLog.Internal.Fakeables
             return null;
         }
 
-        private static string LookupCurrentProcessNameNative()
+        private static string? LookupCurrentProcessNameNative()
         {
             var currentProcessFilePath = LookupCurrentProcessFilePath();
             if (!string.IsNullOrEmpty(currentProcessFilePath))
@@ -407,7 +406,7 @@ namespace NLog.Internal.Fakeables
                     return entryAssemblyFileName;
             }
 
-            return UnknownProcessName;
+            return null;
         }
 
 #if NETFRAMEWORK

--- a/src/NLog/LayoutRenderers/ProcessDirLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessDirLayoutRenderer.cs
@@ -83,7 +83,12 @@ namespace NLog.LayoutRenderers
         /// </summary>
         internal ProcessDirLayoutRenderer(IAppEnvironment appEnvironment)
         {
-            _processDir = Path.GetDirectoryName(appEnvironment.CurrentProcessFilePath) ?? string.Empty;
+            var processFilePath = appEnvironment.CurrentProcessFilePath;
+            if (!string.IsNullOrEmpty(processFilePath))
+                processFilePath = Path.GetDirectoryName(appEnvironment.CurrentProcessFilePath) ?? string.Empty;
+            if (string.IsNullOrEmpty(processFilePath))
+                processFilePath = appEnvironment.AppDomainBaseDirectory;
+            _processDir = processFilePath;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Mostly for restricted platforms (Ex. Android / iOS / etc.)
- [x] Waiting for NLog v6.2

Added `${basedir}` as fallback for `${processdir}` to increase chance of working on Linux.