### PR TITLE
Improve TypedGetLoggerTest coverage for different logger names

### DIFF
--- a/tests/NLog.UnitTests/GetLoggerTests.cs
+++ b/tests/NLog.UnitTests/GetLoggerTests.cs
@@ -64,15 +64,18 @@ namespace NLog.UnitTests
             Logger l3 = lf.GetLogger("AAA", typeof(Logger));
             Logger l5 = lf.GetLogger("AAA");
             Logger l6 = lf.GetLogger("AAA");
+            Logger otherLogger = lf.GetLogger("BBB");
 
             Assert.Same(l1, l2);
             Assert.Same(l5, l6);
             Assert.Same(l3, l5);
 
             Assert.NotSame(l1, l3);
+            Assert.NotSame(l5, otherLogger);
 
             Assert.Equal("AAA", l1.Name);
             Assert.Equal("AAA", l3.Name);
+            Assert.Equal("BBB", otherLogger.Name);
         }
 
         [Fact]


### PR DESCRIPTION
### Summary

Improves unit test coverage for `TypedGetLoggerTest` by adding validation for different logger names.

### Changes

- Added assertion to verify that loggers with different names do not share the same instance
- Added assertion to validate correct logger name assignment

### Motivation

Ensures that the `LogFactory` caching mechanism correctly distinguishes loggers by name.

### Notes

- No functional changes
- Test-only improvement

### Checklist

- [x] Create PR with unit tests