### PR TITLE
Improve StringHelpers.Join test coverage (empty, single and multiple …

### DIFF
--- a/tests/NLog.UnitTests/Internal/StringHelpersTests.cs
+++ b/tests/NLog.UnitTests/Internal/StringHelpersTests.cs
@@ -33,6 +33,7 @@
 
 
 using System;
+using System.Collections.Generic;
 using NLog.Internal;
 using Xunit;
 
@@ -102,6 +103,36 @@ namespace NLog.UnitTests.Internal
         public void ReplaceTestThrowsNullException(string input, string search, string replace, StringComparison comparer)
         {
             Assert.Throws<ArgumentNullException>(() => StringHelpers.Replace(input, search, replace, comparer));
+        }
+
+        [Fact]
+        public void Join_ShouldConcatenateValuesWithSeparator()
+        {
+            var input = new List<string> { "a", "b", "c" };
+
+            var result = StringHelpers.Join(",", input);
+
+            Assert.Equal("a,b,c", result);
+        }
+
+        [Fact]
+        public void Join_EmptyCollection_ReturnsEmptyString()
+        {
+            var input = new List<string>();
+
+            var result = StringHelpers.Join(",", input);
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void Join_SingleElement_ReturnsSameValue()
+        {
+            var input = new List<string> { "a" };
+
+            var result = StringHelpers.Join(",", input);
+
+            Assert.Equal("a", result);
         }
     }
 }


### PR DESCRIPTION
This PR adds additional unit tests for StringHelpers.Join.

It covers:
- empty collection case
- single element case
- multiple elements concatenation

These tests improve coverage and ensure consistent behavior across edge cases for string joining logic.

All tests pass on net8.0.


### Checklist

- [x] Create PR with unit tests