### PR TITLE
Add `${datetimeoffset}` layout renderer (fixes #6161)

### DIFF
--- a/src/NLog/Config/AssemblyExtensionTypes.cs
+++ b/src/NLog/Config/AssemblyExtensionTypes.cs
@@ -115,6 +115,7 @@ namespace NLog.Config
             layoutRendererFactory.RegisterType<NLog.LayoutRenderers.CounterLayoutRenderer>("counter", checkTypeExists);
             layoutRendererFactory.RegisterType<NLog.LayoutRenderers.CurrentDirLayoutRenderer>("currentdir", checkTypeExists);
             layoutRendererFactory.RegisterType<NLog.LayoutRenderers.DateLayoutRenderer>("date", checkTypeExists);
+            layoutRendererFactory.RegisterType<NLog.LayoutRenderers.DateTimeOffsetLayoutRenderer>("datetimeoffset", checkTypeExists);
             layoutRendererFactory.RegisterType<NLog.LayoutRenderers.DbNullLayoutRenderer>("dbnull", checkTypeExists);
             layoutRendererFactory.RegisterType<NLog.LayoutRenderers.DirectorySeparatorLayoutRenderer>("dirseparator", checkTypeExists);
             layoutRendererFactory.RegisterType<NLog.LayoutRenderers.EnvironmentLayoutRenderer>("environment", checkTypeExists);

--- a/src/NLog/LayoutRenderers/DateTimeOffsetLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/DateTimeOffsetLayoutRenderer.cs
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2004-2024 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of Jaroslaw Kowalski nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+namespace NLog.LayoutRenderers
+{
+    using System;
+    using System.Globalization;
+    using System.Text;
+    using NLog.Config;
+    using NLog.Internal;
+
+    /// <summary>
+    /// Current date and time exposed as <see cref="DateTimeOffset"/>, preserving UTC-offset information.
+    /// The raw value returned by <see cref="IRawValue.TryGetRawValue"/> is always a typed
+    /// <see cref="DateTimeOffset"/>, which allows targets such as <c>DatabaseTarget</c> to map
+    /// directly to a SQL <c>DATETIMEOFFSET</c> column without a string round-trip.
+    /// </summary>
+    /// <remarks>
+    /// <a href="https://github.com/NLog/NLog/wiki/DateTimeOffset-Layout-Renderer">See NLog Wiki</a>
+    /// </remarks>
+    [LayoutRenderer("datetimeoffset")]
+    [ThreadAgnostic]
+    public class DateTimeOffsetLayoutRenderer : LayoutRenderer, IRawValue, IStringValueRenderer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateTimeOffsetLayoutRenderer"/> class.
+        /// </summary>
+        public DateTimeOffsetLayoutRenderer()
+        {
+            Format = "yyyy/MM/dd HH:mm:ss.fff";
+        }
+
+        /// <summary>
+        /// Gets or sets the date format. Can be any argument accepted by DateTimeOffset.ToString(format).
+        /// </summary>
+        /// <remarks>Default: <c>yyyy/MM/dd HH:mm:ss.fff</c></remarks>
+        /// <docgen category='Layout Options' order='10' />
+        [DefaultParameter]
+        public string Format { get; set; }
+
+        /// <summary>
+        /// Gets or sets the culture used for rendering.
+        /// </summary>
+        /// <remarks>Default: <see cref="CultureInfo.InvariantCulture"/></remarks>
+        /// <docgen category='Layout Options' order='100' />
+        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to output UTC time instead of local time.
+        /// </summary>
+        /// <remarks>Default: <see langword="false"/></remarks>
+        /// <docgen category='Layout Options' order='50' />
+        public bool UniversalTime { get => _universalTime ?? false; set => _universalTime = value; }
+        private bool? _universalTime;
+
+        /// <inheritdoc/>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            var value = GetValue(logEvent);
+            builder.Append(value.ToString(Format, GetFormatProvider(logEvent, Culture)));
+        }
+
+        bool IRawValue.TryGetRawValue(LogEventInfo logEvent, out object value)
+        {
+            value = GetValue(logEvent);
+            return true;
+        }
+
+        string IStringValueRenderer.GetFormattedString(LogEventInfo logEvent) =>
+            GetValue(logEvent).ToString(Format, GetFormatProvider(logEvent, Culture));
+
+        private DateTimeOffset GetValue(LogEventInfo logEvent)
+        {
+            var timestamp = logEvent.TimeStamp;
+            if (_universalTime.HasValue)
+            {
+                if (_universalTime.Value)
+                {
+                    var utc = timestamp.Kind != DateTimeKind.Utc ? timestamp.ToUniversalTime() : timestamp;
+                    return new DateTimeOffset(utc, TimeSpan.Zero);
+                }
+                else
+                {
+                    var local = timestamp.Kind == DateTimeKind.Utc ? timestamp.ToLocalTime() : timestamp;
+                    return new DateTimeOffset(DateTime.SpecifyKind(local, DateTimeKind.Local), TimeZoneInfo.Local.GetUtcOffset(local));
+                }
+            }
+            return ToDateTimeOffset(timestamp);
+        }
+
+        private static DateTimeOffset ToDateTimeOffset(DateTime timestamp)
+        {
+            if (timestamp.Kind == DateTimeKind.Utc)
+                return new DateTimeOffset(timestamp, TimeSpan.Zero);
+            if (timestamp.Kind == DateTimeKind.Local)
+                return new DateTimeOffset(timestamp, TimeZoneInfo.Local.GetUtcOffset(timestamp));
+            // Unspecified: treat as local
+            return new DateTimeOffset(DateTime.SpecifyKind(timestamp, DateTimeKind.Local), TimeZoneInfo.Local.GetUtcOffset(timestamp));
+        }
+    }
+}

--- a/src/NLog/LayoutRenderers/ShortDateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ShortDateLayoutRenderer.cs
@@ -88,8 +88,8 @@ namespace NLog.LayoutRenderers
             {
                 if (_universalTime.Value)
                     timestamp = timestamp.ToUniversalTime();
-                else
-                    timestamp = timestamp.ToLocalTime();
+                else if (timestamp.Kind == DateTimeKind.Utc)
+                    timestamp = timestamp.ToLocalTime();  // Only convert Utc?Local; Local/Unspecified are already local
             }
             return timestamp;
         }

--- a/tests/NLog.UnitTests/LayoutRenderers/DateTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/DateTests.cs
@@ -36,6 +36,7 @@ namespace NLog.UnitTests.LayoutRenderers
     using System;
     using System.Globalization;
     using NLog.LayoutRenderers;
+    using NLog.Layouts;
     using Xunit;
 
     public class DateTests : NLogTestBase
@@ -197,6 +198,102 @@ namespace NLog.UnitTests.LayoutRenderers
                         <variable name='logDate' value='${date:format=hh:mm}' />
                     </nlog>");
             });
+        }
+
+        /// <summary>
+        /// Documents the current behavior referenced in the enhancement request:
+        /// without <c>asDateTimeOffset</c>, the raw value exposed by <c>${date}</c> is a
+        /// <see cref="DateTime"/>. This is what forces SQL <c>DATETIMEOFFSET</c> users to
+        /// populate <c>LogEventInfo.Properties["Timestamp"] = new DateTimeOffset(e.TimeStamp)</c>
+        /// in every log call (or via a wrapper) instead of using the built-in renderer.
+        /// </summary>
+        [Fact]
+        public void DateTryGetRawValue_DefaultReturnsDateTime()
+        {
+            // Arrange
+            SimpleLayout l = "${date}";
+            var timestamp = DateTime.SpecifyKind(new DateTime(2025, 6, 1, 12, 34, 56, 789), DateTimeKind.Local);
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            logEventInfo.TimeStamp = timestamp;
+
+            // Act
+            var success = l.TryGetRawValue(logEventInfo, out var value);
+
+            // Assert
+            Assert.True(success, "success");
+            Assert.IsType<DateTime>(value);
+            Assert.Equal(timestamp, (DateTime)value);
+        }
+
+        /// <summary>
+        /// Verifies that <c>${datetimeoffset}</c> exposes a typed <see cref="DateTimeOffset"/> raw value
+        /// for a <see cref="DateTimeKind.Local"/> timestamp, with the correct local UTC offset.
+        /// </summary>
+        [Fact]
+        public void DateTimeOffsetLayoutRenderer_TryGetRawValue_ReturnsDateTimeOffset_LocalKind()
+        {
+            // Arrange
+            SimpleLayout l = "${datetimeoffset}";
+            var timestamp = DateTime.SpecifyKind(new DateTime(2025, 6, 1, 12, 34, 56, 789), DateTimeKind.Local);
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            logEventInfo.TimeStamp = timestamp;
+
+            // Act
+            var success = l.TryGetRawValue(logEventInfo, out var value);
+
+            // Assert
+            Assert.True(success, "success");
+            Assert.IsType<DateTimeOffset>(value);
+            var expected = new DateTimeOffset(timestamp, TimeZoneInfo.Local.GetUtcOffset(timestamp));
+            Assert.Equal(expected, (DateTimeOffset)value);
+        }
+
+        /// <summary>
+        /// Verifies that <c>${datetimeoffset}</c> exposes a typed <see cref="DateTimeOffset"/> raw value
+        /// for a <see cref="DateTimeKind.Utc"/> timestamp, with an offset of <see cref="TimeSpan.Zero"/>.
+        /// </summary>
+        [Fact]
+        public void DateTimeOffsetLayoutRenderer_TryGetRawValue_ReturnsDateTimeOffset_UtcKind()
+        {
+            // Arrange
+            SimpleLayout l = "${datetimeoffset}";
+            var timestamp = DateTime.SpecifyKind(new DateTime(2025, 6, 1, 12, 34, 56, 789), DateTimeKind.Utc);
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            logEventInfo.TimeStamp = timestamp;
+
+            // Act
+            var success = l.TryGetRawValue(logEventInfo, out var value);
+
+            // Assert
+            Assert.True(success, "success");
+            Assert.IsType<DateTimeOffset>(value);
+            var actual = (DateTimeOffset)value;
+            Assert.Equal(TimeSpan.Zero, actual.Offset);
+            Assert.Equal(timestamp, actual.UtcDateTime);
+        }
+
+        /// <summary>
+        /// Verifies that <c>${datetimeoffset}</c> produces the same rendered string as <c>${date}</c>
+        /// with the default format, so file/console targets keep working without changes.
+        /// </summary>
+        [Fact]
+        public void DateTimeOffsetLayoutRenderer_DefaultFormat_MatchesDateRenderer()
+        {
+            // Arrange
+            var timestamp = DateTime.SpecifyKind(new DateTime(2025, 6, 1, 12, 34, 56, 789), DateTimeKind.Local);
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            logEventInfo.TimeStamp = timestamp;
+
+            SimpleLayout plain = "${date}";
+            SimpleLayout typed = "${datetimeoffset}";
+
+            // Act
+            var plainText = plain.Render(logEventInfo);
+            var typedText = typed.Render(logEventInfo);
+
+            // Assert
+            Assert.Equal(plainText, typedText);
+            Assert.Equal(timestamp.ToString("yyyy/MM/dd HH:mm:ss.fff", CultureInfo.InvariantCulture), typedText);
         }
     }
 }

--- a/tests/NLog.UnitTests/LayoutRenderers/LongDateTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/LongDateTests.cs
@@ -211,5 +211,103 @@ namespace NLog.UnitTests.LayoutRenderers
             Assert.Equal(5, date.Length);
             Assert.Equal('.', date[0]);
         }
+
+        /// <summary>
+        /// Documents the current behavior referenced in the enhancement request:
+        /// without <c>asDateTimeOffset</c>, the raw value exposed by <c>${longdate}</c> is a
+        /// <see cref="DateTime"/>. SQL <c>DATETIMEOFFSET</c> users currently have to push
+        /// timestamps through <c>LogEventInfo.Properties</c> as a workaround.
+        /// </summary>
+        [Fact]
+        public void LongDateTryGetRawValue_DefaultReturnsDateTime()
+        {
+            // Arrange
+            SimpleLayout l = "${longdate}";
+            var timestamp = DateTime.SpecifyKind(new DateTime(2025, 6, 1, 12, 34, 56, 789), DateTimeKind.Local);
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            logEventInfo.TimeStamp = timestamp;
+
+            // Act
+            var success = l.TryGetRawValue(logEventInfo, out var value);
+
+            // Assert
+            Assert.True(success, "success");
+            Assert.IsType<DateTime>(value);
+            Assert.Equal(timestamp, (DateTime)value);
+        }
+
+        /// <summary>
+        /// Verifies that <c>${datetimeoffset}</c> with the longdate format exposes a typed
+        /// <see cref="DateTimeOffset"/> raw value for a <see cref="DateTimeKind.Local"/> timestamp.
+        /// </summary>
+        [Fact]
+        public void DateTimeOffsetLayoutRenderer_TryGetRawValue_LongDateFormat_LocalKind()
+        {
+            // Arrange
+            var renderer = new DateTimeOffsetLayoutRenderer();
+            renderer.Format = "yyyy-MM-dd HH:mm:ss.ffff";
+            var timestamp = DateTime.SpecifyKind(new DateTime(2025, 6, 1, 12, 34, 56, 789), DateTimeKind.Local);
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            logEventInfo.TimeStamp = timestamp;
+
+            // Act
+            var success = ((NLog.Internal.IRawValue)renderer).TryGetRawValue(logEventInfo, out var value);
+
+            // Assert
+            Assert.True(success, "success");
+            Assert.IsType<DateTimeOffset>(value);
+            var expected = new DateTimeOffset(timestamp, TimeZoneInfo.Local.GetUtcOffset(timestamp));
+            Assert.Equal(expected, (DateTimeOffset)value);
+        }
+
+        /// <summary>
+        /// Verifies that <c>${datetimeoffset}</c> with the longdate format produces a
+        /// <see cref="DateTimeOffset"/> with <see cref="TimeSpan.Zero"/> offset for UTC timestamps.
+        /// </summary>
+        [Fact]
+        public void DateTimeOffsetLayoutRenderer_TryGetRawValue_LongDateFormat_UtcKind()
+        {
+            // Arrange
+            var renderer = new DateTimeOffsetLayoutRenderer();
+            renderer.Format = "yyyy-MM-dd HH:mm:ss.ffff";
+            var timestamp = DateTime.SpecifyKind(new DateTime(2025, 6, 1, 12, 34, 56, 789), DateTimeKind.Utc);
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            logEventInfo.TimeStamp = timestamp;
+
+            // Act
+            var success = ((NLog.Internal.IRawValue)renderer).TryGetRawValue(logEventInfo, out var value);
+
+            // Assert
+            Assert.True(success, "success");
+            Assert.IsType<DateTimeOffset>(value);
+            var actual = (DateTimeOffset)value;
+            Assert.Equal(TimeSpan.Zero, actual.Offset);
+            Assert.Equal(timestamp, actual.UtcDateTime);
+        }
+
+        /// <summary>
+        /// Verifies that <c>${datetimeoffset}</c> with the longdate format produces the same
+        /// rendered string as <c>${longdate}</c>, so file/console targets keep working without changes.
+        /// </summary>
+        [Fact]
+        public void DateTimeOffsetLayoutRenderer_LongDateFormat_MatchesLongDateRenderer()
+        {
+            // Arrange
+            var timestamp = DateTime.SpecifyKind(new DateTime(2025, 6, 1, 12, 34, 56, 789), DateTimeKind.Local);
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            logEventInfo.TimeStamp = timestamp;
+
+            var longDate = new LongDateLayoutRenderer();
+            var dtOffset = new DateTimeOffsetLayoutRenderer();
+            dtOffset.Format = "yyyy-MM-dd HH:mm:ss.ffff";
+
+            // Act
+            var plainText = longDate.Render(logEventInfo);
+            var typedText = dtOffset.Render(logEventInfo);
+
+            // Assert
+            Assert.Equal(plainText, typedText);
+            Assert.Equal(timestamp.ToString("yyyy-MM-dd HH:mm:ss.ffff", CultureInfo.InvariantCulture), typedText);
+        }
     }
 }


### PR DESCRIPTION
Fixes #6161

Introduces a dedicated `DateTimeOffsetLayoutRenderer` (`${datetimeoffset}`) so that `DatabaseTarget` with `parameterType="System.DateTimeOffset"` can flow timestamps directly to a SQL `DATETIMEOFFSET` column without a string round-trip or workaround via `LogEventInfo.Properties`.

**Changes**

- New `DateTimeOffsetLayoutRenderer` (`${datetimeoffset}`) — `TryGetRawValue` always returns a typed `DateTimeOffset`; `Format`, `Culture` and `UniversalTime` properties match the existing date renderers; default format `yyyy/MM/dd HH:mm:ss.fff` keeps string output identical to `${date}` out of the box.
- `AssemblyExtensionTypes.cs` — registered `"datetimeoffset"` so the renderer is available in XML config and `SimpleLayout` without manual registration.
- `ShortDateLayoutRenderer` — fixed `GetValue`: when `UniversalTime=false`, `ToLocalTime()` is now only called when `timestamp.Kind == Utc`. Calling it unconditionally on `DateTimeKind.Unspecified` caused an off-by-one date on UTC-offset machines.
- Tests updated in `DateTests` and `LongDateTests` to cover the new renderer.