### PR TITLE
TemplateEnumerator - MoveNext without upfront allocation of Hole-name

### DIFF
--- a/src/NLog/Internal/LogMessageTemplateFormatter.cs
+++ b/src/NLog/Internal/LogMessageTemplateFormatter.cs
@@ -189,7 +189,7 @@ namespace NLog.Internal
                             continue;
                         }
                     }
-                    messageTemplateParameters[holeIndex++] = new MessageTemplateParameter(hole.Name, holeParameter, hole.Format, hole.CaptureType);
+                    messageTemplateParameters[holeIndex++] = new MessageTemplateParameter(hole.GetName(template), holeParameter, hole.Format, hole.CaptureType);
                     RenderHole(sb, hole, formatProvider, holeParameter);
                 }
                 if (hole.Alignment != 0)
@@ -251,7 +251,7 @@ namespace NLog.Internal
                                 continue;
                             }
                         }
-                        messageTemplateParameters[holeIndex++] = new MessageTemplateParameter(hole.Name, holeParameter, hole.Format, hole.CaptureType);
+                        messageTemplateParameters[holeIndex++] = new MessageTemplateParameter(hole.GetName(template), holeParameter, hole.Format, hole.CaptureType);
                         RenderHole(sb, hole, formatProvider, holeParameter);
                     }
                     if (hole.Alignment != 0)

--- a/src/NLog/MessageTemplates/Hole.cs
+++ b/src/NLog/MessageTemplates/Hole.cs
@@ -45,19 +45,42 @@ namespace NLog.MessageTemplates
         /// <summary>
         /// Constructor
         /// </summary>
-        public Hole(string name, string? format, CaptureType captureType, short parameterIndex, short alignment)
+        public Hole(int nameStart, int nameLength, string? format, CaptureType captureType, short parameterIndex, short alignment)
         {
-            Name = name;
+            _nameStart = nameStart;
+            _nameLength = nameLength;
             Format = format;
             CaptureType = captureType;
             Index = parameterIndex;
             Alignment = alignment;
         }
 
-        /// <summary>Parameter name sent to structured loggers.</summary>
-        /// <remarks>This is everything between "{" and the first of ",:}".
-        /// Including surrounding spaces and names that are numbers.</remarks>
-        public readonly string Name;
+        private readonly int _nameStart;
+        private readonly int _nameLength;
+
+        /// <summary>Returns the parameter name.</summary>
+        /// <remarks>For positional holes the name is derived from <see cref="Index"/>.
+        /// For named holes it is sliced from <paramref name="template"/> on demand.</remarks>
+        public string GetName(string template) => (_nameLength == 0 && Index >= 0) ? ParameterIndexToString(Index) : template.Substring(_nameStart, _nameLength);
+
+        private static string ParameterIndexToString(int index)
+        {
+            switch (index)
+            {
+                case 0: return "0";
+                case 1: return "1";
+                case 2: return "2";
+                case 3: return "3";
+                case 4: return "4";
+                case 5: return "5";
+                case 6: return "6";
+                case 7: return "7";
+                case 8: return "8";
+                case 9: return "9";
+            }
+            return index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+
         /// <summary>Format to render the parameter.</summary>
         /// <remarks>This is everything between ":" and the first unescaped "}"</remarks>
         public readonly string? Format;
@@ -66,7 +89,7 @@ namespace NLog.MessageTemplates
         /// </summary>
         public readonly CaptureType CaptureType;
         /// <summary>When the template is positional, this is the parsed name of this parameter.</summary>
-        /// <remarks>For named templates, the value of Index is undefined.</remarks>
+        /// <remarks>For named templates, the value of Index is -1.</remarks>
         public readonly short Index;
         /// <summary>Alignment to render the parameter, by default 0.</summary>
         /// <remarks>This is the parsed value between "," and the first of ":}"</remarks>

--- a/src/NLog/MessageTemplates/MessageTemplateParameters.cs
+++ b/src/NLog/MessageTemplates/MessageTemplateParameters.cs
@@ -126,7 +126,7 @@ namespace NLog.MessageTemplates
                     {
                         holeIndex = GetMaxHoleIndex(holeIndex, hole.Index);
                         var value = GetHoleValueSafe(parameters, hole.Index, ref isValidTemplate);
-                        templateParameters.Add(new MessageTemplateParameter(hole.Name, value, hole.Format, hole.CaptureType));
+                        templateParameters.Add(new MessageTemplateParameter(hole.GetName(template), value, hole.Format, hole.CaptureType));
                     }
                     else
                     {
@@ -142,7 +142,7 @@ namespace NLog.MessageTemplates
 
                         isPositional = false;
                         var value = GetHoleValueSafe(parameters, holeIndex, ref isValidTemplate);
-                        templateParameters.Add(new MessageTemplateParameter(hole.Name, value, hole.Format, hole.CaptureType));
+                        templateParameters.Add(new MessageTemplateParameter(hole.GetName(template), value, hole.Format, hole.CaptureType));
                         holeIndex++;
                     }
                 }

--- a/src/NLog/MessageTemplates/TemplateEnumerator.cs
+++ b/src/NLog/MessageTemplates/TemplateEnumerator.cs
@@ -193,22 +193,19 @@ namespace NLog.MessageTemplates
         private void ParseHole(CaptureType type)
         {
             int literalOffset = -_position + (type == CaptureType.Normal ? 1 : 2); // Account for skipped '{', '{$' or '{@'
-            string name = ParseName(out var parameterIndex, out var alignment, out var format);
+            ParseName(out var parameterIndex, out var alignment, out var format, out var nameStart, out var nameLength);
             Skip('}');
 
-            _current = new LiteralHole(new Literal(_literalLength, _position + literalOffset), new Hole(
-                name,
-                format,
-                type,
-                (short)parameterIndex,
-                (short)alignment
-            ));
+            _current = new LiteralHole(new Literal(_literalLength, _position + literalOffset),
+                new Hole(nameStart, nameLength, format, type, (short)parameterIndex, (short)alignment));
             _literalLength = 0;
         }
 
-        private string ParseName(out int parameterIndex, out int alignment, out string? format)
+        private void ParseName(out int parameterIndex, out int alignment, out string? format, out int nameStart, out int nameLength)
         {
             parameterIndex = -1;
+            nameStart = 0;
+            nameLength = 0;
 
             char c = Peek();
             // If the name matches /^\d+ *$/ we consider it positional
@@ -222,7 +219,7 @@ namespace NLog.MessageTemplates
                     // Non-allocating positional hole-name-parsing
                     parameterIndex = parsedIndex;
                     ParseAlignmentAndFormat(c, out alignment, out format);
-                    return ParameterIndexToString(parameterIndex);
+                    return;
                 }
 
                 if (c == ' ')
@@ -236,9 +233,14 @@ namespace NLog.MessageTemplates
                 _position = start;
             }
 
-            string holeName = ReadUntil(HoleDelimiters);
+            // Record slice instead of allocating a string now
+            int i = _template.IndexOfAny(HoleDelimiters, _position);
+            if (i < 0)
+                throw new TemplateParserException("Reached end of template while expecting one of '}', ':', ','.", _position, _template);
+            nameStart = _position;
+            nameLength = i - _position;
+            _position = i;
             ParseAlignmentAndFormat(Peek(), out alignment, out format);
-            return holeName;
         }
 
         private void ParseAlignmentAndFormat(char c, out int alignment, out string? format)
@@ -253,25 +255,6 @@ namespace NLog.MessageTemplates
                 alignment = 0;
             }
             format = c == ':' ? ParseFormat() : null;
-        }
-
-        private static string ParameterIndexToString(int parameterIndex)
-        {
-            switch (parameterIndex)
-            {
-                case 0: return "0";
-                case 1: return "1";
-                case 2: return "2";
-                case 3: return "3";
-                case 4: return "4";
-                case 5: return "5";
-                case 6: return "6";
-                case 7: return "7";
-                case 8: return "8";
-                case 9: return "9";
-            }
-
-            return parameterIndex.ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/src/NLog/MessageTemplates/TemplateEnumerator.cs
+++ b/src/NLog/MessageTemplates/TemplateEnumerator.cs
@@ -214,26 +214,21 @@ namespace NLog.MessageTemplates
                 int start = _position;
                 int parsedIndex = ReadUnsignedInt(c);
                 c = Peek();
+                if (c == ' ')
+                {
+                    SkipSpaces();
+                    c = Peek();
+                }
                 if (c == '}' || c == ':' || c == ',')
                 {
-                    // Non-allocating positional hole-name-parsing
                     parameterIndex = parsedIndex;
                     ParseAlignmentAndFormat(c, out alignment, out format);
                     return;
                 }
 
-                if (c == ' ')
-                {
-                    SkipSpaces();
-                    c = Peek();
-                    if (c == '}' || c == ':' || c == ',')
-                        parameterIndex = parsedIndex;
-                }
-
                 _position = start;
             }
 
-            // Record slice instead of allocating a string now
             int i = _template.IndexOfAny(HoleDelimiters, _position);
             if (i < 0)
                 throw new TemplateParserException("Reached end of template while expecting one of '}', ':', ','.", _position, _template);


### PR DESCRIPTION
MoveNext() is used to probe the message-template. Reduce the overhead of the probe-logic.