### PR TITLE
PropertiesDictionary - Preserve MessageTemplate property details when adding extra properties

### DIFF
--- a/src/NLog/Internal/PropertiesDictionary.cs
+++ b/src/NLog/Internal/PropertiesDictionary.cs
@@ -451,7 +451,7 @@ namespace NLog.Internal
             public PropertyDictionaryEnumerator(PropertiesDictionary dictionary)
             {
                 _dictionary = dictionary;
-                _messagePropertiesIndex = (dictionary._messageProperties?.Count > 0 && dictionary._eventProperties is null) ? -1 : int.MinValue;
+                _messagePropertiesIndex = dictionary._messageProperties?.Count > 0 ? -1 : int.MinValue;
                 _eventEnumerator = dictionary._eventProperties?.GetEnumerator() ?? default(Dictionary<object, PropertyValue>.Enumerator);
             }
 
@@ -459,14 +459,14 @@ namespace NLog.Internal
             {
                 get
                 {
-                    if (_messagePropertiesIndex >= 0)
+                    if (_messagePropertiesIndex < 0)
                     {
-                        var property = _dictionary.MessageProperties[_messagePropertiesIndex];
-                        return new KeyValuePair<object, object?>(property.Name, property.Value);
+                        return new KeyValuePair<object, object?>(_eventEnumerator.Current.Key, _eventEnumerator.Current.Value.Value);
                     }
                     else
                     {
-                        return new KeyValuePair<object, object?>(_eventEnumerator.Current.Key, _eventEnumerator.Current.Value.Value);
+                        var property = _dictionary.MessageProperties[_messagePropertiesIndex];
+                        return new KeyValuePair<object, object?>(property.Name, property.Value);
                     }
                 }
             }
@@ -475,14 +475,14 @@ namespace NLog.Internal
             {
                 get
                 {
-                    if (_messagePropertiesIndex >= 0)
-                    {
-                        return _dictionary.MessageProperties[_messagePropertiesIndex];
-                    }
-                    else
+                    if (_messagePropertiesIndex < 0)
                     {
                         string parameterName = XmlHelper.XmlConvertToString(_eventEnumerator.Current.Key ?? string.Empty) ?? string.Empty;
                         return new MessageTemplateParameter(parameterName, _eventEnumerator.Current.Value.Value, null, CaptureType.Unknown);
+                    }
+                    else
+                    {
+                        return _dictionary.MessageProperties[_messagePropertiesIndex];
                     }
                 }
             }
@@ -491,15 +491,15 @@ namespace NLog.Internal
             {
                 get
                 {
-                    if (_messagePropertiesIndex >= 0)
-                    {
-                        var property = _dictionary.MessageProperties[_messagePropertiesIndex];
-                        return new KeyValuePair<string, object?>(property.Name, property.Value);
-                    }
-                    else
+                    if (_messagePropertiesIndex < 0)
                     {
                         string propertyName = XmlHelper.XmlConvertToString(_eventEnumerator.Current.Key ?? string.Empty) ?? string.Empty;
                         return new KeyValuePair<string, object?>(propertyName, _eventEnumerator.Current.Value.Value);
+                    }
+                    else
+                    {
+                        var property = _dictionary.MessageProperties[_messagePropertiesIndex];
+                        return new KeyValuePair<string, object?>(property.Name, property.Value);
                     }
                 }
             }
@@ -508,7 +508,7 @@ namespace NLog.Internal
 
             public bool MoveNext()
             {
-                if (_messagePropertiesIndex >= -1)
+                if (_dictionary._eventProperties is null)
                 {
                     if (_messagePropertiesIndex + 1 < _dictionary._messageProperties?.Count)
                     {
@@ -517,14 +517,45 @@ namespace NLog.Internal
                     }
                     return false;
                 }
-                else if (_dictionary._eventProperties is null)
-                {
-                    return false;
-                }
-                else
-                {
+
+                if (_dictionary._messageProperties is null)
                     return _eventEnumerator.MoveNext();
+
+                return MoveNextValidEventProperty();
+            }
+
+            private bool MoveNextValidEventProperty()
+            {
+                if (_messagePropertiesIndex >= -1 && MoveNextValidMessageParameter())
+                    return true;
+
+                while (_eventEnumerator.MoveNext())
+                {
+                    if (!_eventEnumerator.Current.Value.IsMessageProperty)
+                        return true;
                 }
+                return false;
+            }
+
+            private bool MoveNextValidMessageParameter()
+            {
+                if (_messagePropertiesIndex + 1 < _dictionary._messageProperties?.Count && _dictionary._eventProperties != null)
+                {
+                    var messageProperties = _dictionary._messageProperties;
+                    var eventProperties = _dictionary._eventProperties;
+
+                    for (int i = _messagePropertiesIndex + 1; i < messageProperties.Count; ++i)
+                    {
+                        if (eventProperties.TryGetValue(messageProperties[i].Name, out var valueItem) && valueItem.IsMessageProperty)
+                        {
+                            _messagePropertiesIndex = i;
+                            return true;
+                        }
+                    }
+                }
+
+                _messagePropertiesIndex = int.MinValue;
+                return false;
             }
 
             public void Dispose()
@@ -534,7 +565,7 @@ namespace NLog.Internal
 
             public void Reset()
             {
-                _messagePropertiesIndex = (_dictionary._messageProperties?.Count > 0 && _dictionary._eventProperties is null ) ? -1 : int.MinValue;
+                _messagePropertiesIndex = _dictionary._messageProperties?.Count > 0 ? -1 : int.MinValue;
                 _eventEnumerator = _dictionary._eventProperties?.GetEnumerator() ?? default(Dictionary<object, PropertyValue>.Enumerator);
             }
         }

--- a/tests/NLog.UnitTests/Internal/PropertiesDictionaryTests.cs
+++ b/tests/NLog.UnitTests/Internal/PropertiesDictionaryTests.cs
@@ -438,7 +438,7 @@ namespace NLog.UnitTests.Internal
             LogEventInfo logEvent = new LogEventInfo(LogLevel.Info, "MyLogger", string.Empty, new[]
             {
                 new MessageTemplateParameter("Hello World", 42, null, CaptureType.Normal),
-                new MessageTemplateParameter("Hello World", 666, null, CaptureType.Normal)
+                new MessageTemplateParameter("Hello World", 666, null, CaptureType.Serialize)
             });
             IDictionary<object, object> dictionary = logEvent.Properties;
 
@@ -455,6 +455,34 @@ namespace NLog.UnitTests.Internal
                 else
                     Assert.Null(property.Key);
             }
+
+            var enumerator = ((PropertiesDictionary)dictionary).GetPropertyEnumerator();
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("Hello World", enumerator.CurrentParameter.Name);
+            Assert.Equal(CaptureType.Normal, enumerator.CurrentParameter.CaptureType);
+            Assert.Equal(42, enumerator.CurrentParameter.Value);
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("Hello World_1", enumerator.CurrentParameter.Name);
+            Assert.Equal(CaptureType.Serialize, enumerator.CurrentParameter.CaptureType);
+            Assert.Equal(666, enumerator.CurrentParameter.Value);
+            Assert.False(enumerator.MoveNext());
+
+            dictionary["Hello World"] = 123;    // Mixed message template properties and event properties
+            enumerator.Reset();
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("Hello World_1", enumerator.CurrentParameter.Name);
+            Assert.Equal(CaptureType.Serialize, enumerator.CurrentParameter.CaptureType);
+            Assert.Equal(666, enumerator.CurrentParameter.Value);
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("Hello World", enumerator.CurrentParameter.Name);
+            Assert.Equal(CaptureType.Unknown, enumerator.CurrentParameter.CaptureType);
+            Assert.Equal(123, enumerator.CurrentParameter.Value);
+            Assert.False(enumerator.MoveNext());
+
+            ICollection<KeyValuePair<object, object>> collection = dictionary;
+            Assert.True(collection.Remove(new KeyValuePair<object, object>("Hello World", 123)));
+            Assert.True(collection.Remove(new KeyValuePair<object, object>("Hello World_1", 666)));
+            Assert.Empty(dictionary);
         }
 
 #if !NET35

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -556,28 +556,6 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal(ExpectedExcludeEmptyPropertiesWithExcludes, jsonLayout.Render(structuredLogEvent));
         }
 
-        [Fact]
-        public void IncludeAllJsonPropertiesMaxRecursionLimit()
-        {
-            var jsonLayout = new JsonLayout()
-            {
-                IncludeEventProperties = true,
-                MaxRecursionLimit = 1,
-            };
-
-            LogEventInfo logEventInfo = new LogEventInfo()
-            {
-                TimeStamp = new DateTime(2010, 01, 01, 12, 34, 56),
-                Level = LogLevel.Info,
-            };
-            logEventInfo.Properties["Message"] = new
-            {
-                data = new Dictionary<int, string>() { { 42, "Hello" } }
-            };
-
-            Assert.Equal(@"{""Message"":{""data"":{}}}", jsonLayout.Render(logEventInfo));
-        }
-
         [Theory]
         [InlineData("Hello World", @"{""stringifyMe"":""Hello World""}")]
         [InlineData("Hello\nWorld", @"{""stringifyMe"":""Hello\nWorld""}")]
@@ -1011,6 +989,20 @@ namespace NLog.UnitTests.Layouts
             logger.Debug(logEventInfo3);
 
             logFactory.AssertDebugLastMessage("{\"nestedObject\":[[\"{ val = 1, val2 = value2 }\"]]}");  // Allows nested collection, but then only ToString
+
+            var logEventInfo4 = new LogEventInfo();
+            logEventInfo4.Properties.Add("nestedObject", new
+            {
+                data = new Dictionary<int, string>() { { 42, "Hello" } }
+            });
+            logger.Debug(logEventInfo4);
+            logFactory.AssertDebugLastMessage(@"{""nestedObject"":{""data"":{}}}");  // Allows nested collection, but then only ToString
+
+            logger.WithProperty("Hello", "World").Debug("{@nestedObject}", new
+            {
+                data = new Dictionary<int, string>() { { 42, "Hello" } }
+            });
+            logFactory.AssertDebugLastMessage(@"{""nestedObject"":{""data"":{""42"":""Hello""}},""Hello"":""World""}");
         }
 
         [Fact]
@@ -1055,6 +1047,20 @@ namespace NLog.UnitTests.Layouts
             logger.Debug(logEventInfo3);
 
             logFactory.AssertDebugLastMessage("{\"nestedObject\":[[]]}");  // No support for nested collections
+
+            var logEventInfo4 = new LogEventInfo();
+            logEventInfo4.Properties.Add("nestedObject", new
+            {
+                data = new Dictionary<int, string>() { { 42, "Hello" } }
+            });
+            logger.Debug(logEventInfo4);
+            logFactory.AssertDebugLastMessage(@"{""nestedObject"":""{ data = System.Collections.Generic.Dictionary`2[System.Int32,System.String] }""}");  // Allows nested collection, but then only ToString
+
+            logger.WithProperty("Hello", "World").Debug("{@nestedObject}", new
+            {
+                data = new Dictionary<int, string>() { { 42, "Hello" } }
+            });
+            logFactory.AssertDebugLastMessage(@"{""nestedObject"":{""data"":{""42"":""Hello""}},""Hello"":""World""}");
         }
 
         [Fact]


### PR DESCRIPTION
Fixed bug introduced with #6061

Restored the mixed-property-handling-logic, but keeping the fast-code-path when not mixing property-types.