### PR TITLE
Reduce AOT file-size by changing PropertyTypeConverter to avoid Dictionary for conversion mapping

### DIFF
--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -851,45 +851,45 @@ namespace NLog.Config
 
         internal string ExpandSimpleVariables(string? input, out string? matchingVariableName)
         {
-            var output = input;
+            var output = input ?? string.Empty;
             matchingVariableName = null;
 
-            if (output != null && !StringHelpers.IsNullOrWhiteSpace(output) && Variables.Count > 0 && output.IndexOf('$') >= 0)
+            if (StringHelpers.IsNullOrWhiteSpace(output) || Variables.Count == 0 || output.IndexOf('$') < 0)
+                return output;
+
+            var culture = StringComparison.OrdinalIgnoreCase;
+
+            foreach (var kvp in _variables)
             {
-                var culture = StringComparison.OrdinalIgnoreCase;
+                var layout = kvp.Value;
 
-                foreach (var kvp in _variables)
+                if (layout is null)
                 {
-                    var layout = kvp.Value;
+                    continue;
+                }
 
-                    if (layout is null)
-                    {
-                        continue;
-                    }
+                var layoutText = string.Concat("${", kvp.Key, "}");
+                if (output.IndexOf(layoutText, culture) < 0)
+                {
+                    continue;
+                }
 
-                    var layoutText = string.Concat("${", kvp.Key, "}");
-                    if (output.IndexOf(layoutText, culture) < 0)
+                //this value is set from xml and that's a string. Because of that, we can use SimpleLayout here.
+                if (layout is SimpleLayout simpleLayout)
+                {
+                    output = StringHelpers.Replace(output, layoutText, simpleLayout.OriginalText, culture);
+                    matchingVariableName = null;
+                }
+                else
+                {
+                    if (string.Equals(layoutText, input?.Trim() ?? string.Empty, culture))
                     {
-                        continue;
-                    }
-
-                    //this value is set from xml and that's a string. Because of that, we can use SimpleLayout here.
-                    if (layout is SimpleLayout simpleLayout)
-                    {
-                        output = StringHelpers.Replace(output, layoutText, simpleLayout.OriginalText, culture);
-                        matchingVariableName = null;
-                    }
-                    else
-                    {
-                        if (string.Equals(layoutText, input?.Trim() ?? string.Empty, culture))
-                        {
-                            matchingVariableName = kvp.Key;
-                        }
+                        matchingVariableName = kvp.Key;
                     }
                 }
             }
 
-            return output ?? string.Empty;
+            return output;
         }
 
         /// <summary>

--- a/src/NLog/Config/PropertyTypeConverter.cs
+++ b/src/NLog/Config/PropertyTypeConverter.cs
@@ -34,7 +34,6 @@
 namespace NLog.Config
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using NLog.Internal;
@@ -49,25 +48,6 @@ namespace NLog.Config
         /// </summary>
         public static PropertyTypeConverter Instance { get; } = new PropertyTypeConverter();
 
-        private static Dictionary<Type, Func<string, string?, IFormatProvider?, object?>> StringConverterLookup => _stringConverters ?? (_stringConverters = BuildStringConverterLookup());
-        private static Dictionary<Type, Func<string, string?, IFormatProvider?, object?>>? _stringConverters;
-
-        private static Dictionary<Type, Func<string, string?, IFormatProvider?, object?>> BuildStringConverterLookup()
-        {
-            return new Dictionary<Type, Func<string, string?, IFormatProvider?, object?>>()
-            {
-                { typeof(System.Text.Encoding), (stringvalue, format, formatProvider) => ConvertToEncoding(stringvalue) },
-                { typeof(System.Globalization.CultureInfo), (stringvalue, format, formatProvider) => ConvertToCultureInfo(stringvalue) },
-                { typeof(Type), (stringvalue, format, formatProvider) => ConvertToType(stringvalue, true) },
-                { typeof(NLog.Targets.LineEndingMode), (stringvalue, format, formatProvider) => NLog.Targets.LineEndingMode.FromString(stringvalue) },
-                { typeof(LogLevel), (stringvalue, format, formatProvider) => LogLevel.FromString(stringvalue) },
-                { typeof(Uri), (stringvalue, format, formatProvider) => new Uri(stringvalue) },
-                { typeof(DateTime), (stringvalue, format, formatProvider) => ConvertToDateTime(format, formatProvider, stringvalue) },
-                { typeof(DateTimeOffset), (stringvalue, format, formatProvider) => ConvertToDateTimeOffset(format, formatProvider, stringvalue) },
-                { typeof(TimeSpan), (stringvalue, format, formatProvider) => ConvertToTimeSpan(format, formatProvider, stringvalue) },
-                { typeof(Guid), (stringvalue, format, formatProvider) => ConvertGuid(format, stringvalue) },
-            };
-        }
 
         [UnconditionalSuppressMessage("Trimming - Allow converting option-values from config", "IL2057")]
         internal static Type ConvertToType(string stringvalue, bool throwOnError)
@@ -77,7 +57,7 @@ namespace NLog.Config
 
         internal static bool IsComplexType(Type type)
         {
-            return !type.IsValueType && !typeof(IConvertible).IsAssignableFrom(type) && !StringConverterLookup.ContainsKey(type) && type.GetFirstCustomAttribute<System.ComponentModel.TypeConverterAttribute>() is null;
+            return !type.IsValueType && !typeof(IConvertible).IsAssignableFrom(type) && !HasConvertFromStringSupport(type) && type.GetFirstCustomAttribute<System.ComponentModel.TypeConverterAttribute>() is null;
         }
 
         /// <inheritdoc/>
@@ -113,25 +93,110 @@ namespace NLog.Config
             return ChangeObjectType(propertyValue, propertyType, format, formatProvider);
         }
 
-        private static bool TryConvertFromString(string propertyString, Type propertyType, string? format, IFormatProvider? formatProvider, out object? propertyValue)
+        /// <summary>
+        /// Remember to align with <see cref="TryConvertFromString"/>
+        /// </summary>
+        private static bool HasConvertFromStringSupport(Type type)
+        {
+            if (type == typeof(System.Text.Encoding))
+                return true;
+            if (type == typeof(System.Globalization.CultureInfo))
+                return true;
+            if (type == typeof(Type))
+                return true;
+            if (type == typeof(NLog.Targets.LineEndingMode))
+                return true;
+            if (type == typeof(LogLevel))
+                return true;
+            if (type == typeof(Uri))
+                return true;
+            if (type == typeof(DateTime))
+                return true;
+            if (type == typeof(DateTimeOffset))
+                return true;
+            if (type == typeof(TimeSpan))
+                return true;
+            if (type == typeof(Guid))
+                return true;
+            if (type.IsEnum)
+                return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Remember to align with <see cref="HasConvertFromStringSupport"/>
+        /// </summary>
+        internal static bool TryConvertFromString(string propertyString, Type propertyType, string? format, IFormatProvider? formatProvider, out object? propertyValue)
         {
             propertyValue = propertyString = propertyString.Trim();
 
-            if (StringConverterLookup.TryGetValue(propertyType, out var converter))
+            if (propertyType == typeof(System.Text.Encoding))
             {
-                propertyValue = converter.Invoke(propertyString, format, formatProvider);
+                propertyValue = ConvertToEncoding(propertyString);
+                return true;
+            }
+            if (propertyType == typeof(CultureInfo))
+            {
+                propertyValue = ConvertToCultureInfo(propertyString);
+                return true;
+            }
+            if (propertyType == typeof(Type))
+            {
+                propertyValue = ConvertToType(propertyString, true);
+                return true;
+            }
+            if (propertyType == typeof(NLog.Targets.LineEndingMode))
+            {
+                propertyValue = NLog.Targets.LineEndingMode.FromString(propertyString);
+                return true;
+            }
+            if (propertyType == typeof(LogLevel))
+            {
+                propertyValue = LogLevel.FromString(propertyString);
+                return true;
+            }
+            if (propertyType == typeof(Uri))
+            {
+                propertyValue = new Uri(propertyString);
+                return true;
+            }
+            if (propertyType == typeof(DateTime))
+            {
+                propertyValue = ConvertToDateTime(format, formatProvider, propertyString);
+                return true;
+            }
+            if (propertyType == typeof(DateTimeOffset))
+            {
+                propertyValue = ConvertToDateTimeOffset(format, formatProvider, propertyString);
+                return true;
+            }
+            if (propertyType == typeof(TimeSpan))
+            {
+                propertyValue = ConvertToTimeSpan(format, formatProvider, propertyString);
+                return true;
+            }
+            if (propertyType == typeof(Guid))
+            {
+                propertyValue = ConvertGuid(format, propertyString);
                 return true;
             }
 
             if (propertyType.IsEnum)
             {
-                return NLog.Common.ConversionHelpers.TryParseEnum(propertyString, propertyType, out propertyValue);
+                if (!NLog.Common.ConversionHelpers.TryParseEnum(propertyString, propertyType, out propertyValue))
+                {
+                    throw new ArgumentException($"Failed parsing Enum {propertyType.Name} from value: {propertyString}");
+                }
+                return true;
             }
 
-            if (PropertyHelper.TryTypeConverterConversion(propertyType, propertyString, out var convertedValue))
+            if (!typeof(IConvertible).IsAssignableFrom(propertyType) && !propertyType.IsAssignableFrom(typeof(string)))
             {
-                propertyValue = convertedValue;
-                return true;
+                if (PropertyHelper.TryTypeConverterConversion(propertyType, propertyString, out var convertedValue))
+                {
+                    propertyValue = convertedValue;
+                    return true;
+                }
             }
 
             return false;

--- a/src/NLog/Internal/PropertyHelper.cs
+++ b/src/NLog/Internal/PropertyHelper.cs
@@ -36,7 +36,6 @@ namespace NLog.Internal
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Reflection;
@@ -45,7 +44,6 @@ namespace NLog.Internal
     using NLog.Conditions;
     using NLog.Config;
     using NLog.Layouts;
-    using NLog.Targets;
 
     /// <summary>
     /// Reflection helpers for accessing properties.
@@ -53,7 +51,6 @@ namespace NLog.Internal
     internal static class PropertyHelper
     {
         private static readonly Dictionary<Type, Dictionary<string, PropertyInfo>?> _parameterInfoCache = new Dictionary<Type, Dictionary<string, PropertyInfo>?>();
-        private static readonly Dictionary<Type, Func<string, ConfigurationItemFactory, object?>> _propertyConversionMapper = BuildPropertyConversionMapper();
 
 #pragma warning disable S1144 // Unused private types or members should be removed. BUT they help CoreRT to provide config through reflection
         private static readonly ArrayParameterAttribute _arrayParameterAttribute = new ArrayParameterAttribute(typeof(string), string.Empty);
@@ -63,23 +60,6 @@ namespace NLog.Internal
         private static readonly FlagsAttribute _flagsAttribute = new FlagsAttribute();
 #pragma warning restore S1144 // Unused private types or members should be removed
 
-        private static Dictionary<Type, Func<string, ConfigurationItemFactory, object?>> BuildPropertyConversionMapper()
-        {
-            return new Dictionary<Type, Func<string, ConfigurationItemFactory, object?>>()
-            {
-                { typeof(Layout), TryParseLayoutValue },
-                { typeof(SimpleLayout), TryParseLayoutValue },
-                { typeof(ConditionExpression), TryParseConditionValue },
-                { typeof(Encoding), (stringvalue, factory) => PropertyTypeConverter.ConvertToEncoding(stringvalue) },
-                { typeof(string), (stringvalue, factory) => stringvalue },
-                { typeof(int), (stringvalue, factory) => Convert.ChangeType(stringvalue.Trim(), TypeCode.Int32, CultureInfo.InvariantCulture) },
-                { typeof(bool), (stringvalue, factory) => Convert.ChangeType(stringvalue.Trim(), TypeCode.Boolean, CultureInfo.InvariantCulture) },
-                { typeof(CultureInfo), (stringvalue, factory) =>  PropertyTypeConverter.ConvertToCultureInfo(stringvalue) },
-                { typeof(Type),  (stringvalue, factory) => PropertyTypeConverter.ConvertToType(stringvalue.Trim(), true) },
-                { typeof(LineEndingMode), (stringvalue, factory) => LineEndingMode.FromString(stringvalue.Trim()) },
-                { typeof(Uri), (stringvalue, factory) => new Uri(stringvalue.Trim()) }
-            };
-        }
 
         internal static void SetPropertyFromString(object targetObject, PropertyInfo propInfo, string stringValue, ConfigurationItemFactory configurationItemFactory)
         {
@@ -97,10 +77,8 @@ namespace NLog.Internal
                             throw new NotSupportedException($"'{targetObject?.GetType()?.Name}' cannot assign property '{propInfo.Name}', because property of type array and not scalar value: '{stringValue}'.");
                         }
 
-                        if (!(TryGetEnumValue(propertyType, stringValue, out propertyValue)
-                            || TryImplicitConversion(propertyType, stringValue, out propertyValue)
-                            || TryFlatListConversion(targetObject, propInfo, stringValue, configurationItemFactory, out propertyValue)
-                            || TryTypeConverterConversion(propertyType, stringValue, out propertyValue)))
+                        if (!(TryImplicitConversion(propertyType, stringValue, out propertyValue)
+                            || TryFlatListConversion(targetObject, propInfo, stringValue, configurationItemFactory, out propertyValue)))
                             propertyValue = Convert.ChangeType(stringValue, propertyType, CultureInfo.InvariantCulture);
                     }
                 }
@@ -253,21 +231,18 @@ namespace NLog.Internal
         {
             try
             {
-                if (IsSimplePropertyType(resultType))
+                if (Type.GetTypeCode(resultType) == TypeCode.Object && !typeof(IEnumerable).IsAssignableFrom(resultType))
                 {
-                    result = null;
-                    return false;
-                }
+                    var operatorImplicitMethod = resultType.GetMethod("op_Implicit", BindingFlags.Public | BindingFlags.Static, null, new Type[] { value.GetType() }, null);
+                    if (operatorImplicitMethod is null || !resultType.IsAssignableFrom(operatorImplicitMethod.ReturnType))
+                    {
+                        result = null;
+                        return false;
+                    }
 
-                var operatorImplicitMethod = resultType.GetMethod("op_Implicit", BindingFlags.Public | BindingFlags.Static, null, new Type[] { value.GetType() }, null);
-                if (operatorImplicitMethod is null || !resultType.IsAssignableFrom(operatorImplicitMethod.ReturnType))
-                {
-                    result = null;
-                    return false;
+                    result = operatorImplicitMethod.Invoke(null, new object[] { value });
+                    return true;
                 }
-
-                result = operatorImplicitMethod.Invoke(null, new object[] { value });
-                return true;
             }
             catch (Exception ex)
             {
@@ -280,12 +255,31 @@ namespace NLog.Internal
         [UnconditionalSuppressMessage("Trimming - Allow converting option-values from config", "IL2067")]
         private static bool TryNLogSpecificConversion(Type propertyType, string value, ConfigurationItemFactory configurationItemFactory, out object? newValue)
         {
-            if (_propertyConversionMapper.TryGetValue(propertyType, out var objectConverter))
+            if (propertyType == typeof(Layout) || propertyType == typeof(SimpleLayout))
             {
-                newValue = objectConverter.Invoke(value, configurationItemFactory);
+                newValue = TryParseLayoutValue(value, configurationItemFactory);
                 return true;
             }
-
+            if (propertyType == typeof(string))
+            {
+                newValue = value;
+                return true;
+            }
+            if (propertyType == typeof(int))
+            {
+                newValue = Convert.ChangeType(value.Trim(), TypeCode.Int32, CultureInfo.InvariantCulture);
+                return true;
+            }
+            if (propertyType == typeof(bool))
+            {
+                newValue = Convert.ChangeType(value.Trim(), TypeCode.Boolean, CultureInfo.InvariantCulture);
+                return true;
+            }
+            if (propertyType == typeof(ConditionExpression))
+            {
+                newValue = TryParseConditionValue(value, configurationItemFactory);
+                return true;
+            }
             if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(Layout<>))
             {
                 var simpleLayout = string.IsNullOrEmpty(value) ? SimpleLayout.Default : new SimpleLayout(value, configurationItemFactory);
@@ -293,36 +287,7 @@ namespace NLog.Internal
                 return true;
             }
 
-            newValue = null;
-            return false;
-        }
-
-        private static bool TryGetEnumValue(Type resultType, string value, out object? result)
-        {
-            if (!resultType.IsEnum)
-            {
-                result = null;
-                return false;
-            }
-
-            if (!StringHelpers.IsNullOrWhiteSpace(value))
-            {
-                // Note: .NET Standard 2.1 added a public Enum.TryParse(Type)
-                try
-                {
-                    result = (Enum)Enum.Parse(resultType, value, true);
-                    return true;
-                }
-                catch (ArgumentException ex)
-                {
-                    throw new ArgumentException($"Failed parsing Enum {resultType.Name} from value: {value}", ex);
-                }
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
+            return PropertyTypeConverter.TryConvertFromString(value, propertyType, null, CultureInfo.InvariantCulture, out newValue);
         }
 
         private static object TryParseLayoutValue(string stringValue, ConfigurationItemFactory configurationItemFactory)
@@ -365,9 +330,7 @@ namespace NLog.Internal
                     foreach (var value in values)
                     {
                         if (!(TryNLogSpecificConversion(propertyType, value, configurationItemFactory, out newValue)
-                              || TryGetEnumValue(propertyType, value, out newValue)
-                              || TryImplicitConversion(propertyType, value, out newValue)
-                              || TryTypeConverterConversion(propertyType, value, out newValue)))
+                              || TryImplicitConversion(propertyType, value, out newValue)))
                         {
                             newValue = Convert.ChangeType(value, propertyType, CultureInfo.InvariantCulture);
                         }
@@ -535,17 +498,11 @@ namespace NLog.Internal
         [UnconditionalSuppressMessage("Trimming - Allow converting option-values from config", "IL2072")]
         internal static bool TryTypeConverterConversion(Type type, string value, out object? newValue)
         {
-            if (typeof(IConvertible).IsAssignableFrom(type) || type.IsAssignableFrom(typeof(string)))
-            {
-                newValue = null;
-                return false;
-            }
-
             try
             {
                 InternalLogger.Debug("Object reflection needed for creating external type: {0} from string-value: {1}", type, value);
 
-                var converter = TypeDescriptor.GetConverter(type);
+                var converter = System.ComponentModel.TypeDescriptor.GetConverter(type);
                 if (converter.CanConvertFrom(typeof(string)))
                 {
                     newValue = converter.ConvertFromInvariantString(value);

--- a/src/NLog/LogLevel.cs
+++ b/src/NLog/LogLevel.cs
@@ -106,9 +106,9 @@ namespace NLog
         /// </summary>
         public static readonly LogLevel Off = new LogLevel("Off", 6);
 
-        private static readonly IList<LogLevel> allLevels = new List<LogLevel> { Trace, Debug, Info, Warn, Error, Fatal, Off }.AsReadOnly();
+        private static readonly LogLevel[] allLevels = { Trace, Debug, Info, Warn, Error, Fatal, Off };
 
-        private static readonly IList<LogLevel> allLoggingLevels = new List<LogLevel> { Trace, Debug, Info, Warn, Error, Fatal }.AsReadOnly();
+        private static readonly LogLevel[] allLoggingLevels = { Trace, Debug, Info, Warn, Error, Fatal };
 
         /// <summary>
         /// Gets all the available log levels (Trace, Debug, Info, Warn, Error, Fatal, Off).


### PR DESCRIPTION
Reducing upfront type-dependency resolving until actually needed (entering mapping-method)

Parsing Enum from empty string (or null) now fails upfront, instead of scanning for other conversions and casting.