### PR TITLE
Reduce AOT file-size by changing LogFactory PurgeObsoleteLoggers to clone Dictionary instead of ToList

### DIFF
--- a/src/NLog/Conditions/ConditionRelationalExpression.cs
+++ b/src/NLog/Conditions/ConditionRelationalExpression.cs
@@ -272,7 +272,7 @@ namespace NLog.Conditions
         /// <returns></returns>
         private static Dictionary<Type, int> BuildTypeOrderDictionary()
         {
-            var list = new List<Type>
+            var list = new []
             {
                 typeof(DateTime),
                 typeof(double),
@@ -285,8 +285,8 @@ namespace NLog.Conditions
                 typeof(string),
             };
 
-            var dict = new Dictionary<Type, int>(list.Count);
-            for (int i = 0; i < list.Count; i++)
+            var dict = new Dictionary<Type, int>(list.Length);
+            for (int i = 0; i < list.Length; i++)
             {
                 dict.Add(list[i], i);
             }

--- a/src/NLog/Config/ConfigurationItemFactory.cs
+++ b/src/NLog/Config/ConfigurationItemFactory.cs
@@ -262,7 +262,7 @@ namespace NLog.Config
         internal ICollection<Type> GetRegisteredItemTypes()
         {
             lock (SyncRoot)
-                return new List<Type>(_itemFactories.Keys);
+                return _itemFactories.Keys.ToArray();
         }
 
         /// <summary>

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -49,7 +49,6 @@ namespace NLog.Config
     /// <summary>
     /// Keeps logging configuration and provides simple API to modify it.
     /// </summary>
-    ///<remarks>This class is thread-safe.<c>.ToList()</c> is used for that purpose.</remarks>
     public class LoggingConfiguration
     {
         private readonly IDictionary<string, Target> _targets = new Dictionary<string, Target>(StringComparer.OrdinalIgnoreCase);
@@ -97,7 +96,7 @@ namespace NLog.Config
         /// <remarks>
         /// Unnamed targets (such as those wrapped by other targets) are not returned.
         /// </remarks>
-        public ReadOnlyCollection<Target> ConfiguredNamedTargets => GetAllTargetsThreadSafe().AsReadOnly();
+        public ReadOnlyCollection<Target> ConfiguredNamedTargets => new ReadOnlyCollection<Target>(GetAllTargetsThreadSafe());
 
         /// <summary>
         /// Gets the collection of file names which should be watched for changes by NLog.
@@ -109,6 +108,7 @@ namespace NLog.Config
         /// <summary>
         /// Gets the collection of logging rules.
         /// </summary>
+        /// <remarks>Enumeration and modifying the collection is not thread-safe. Consider using <see cref="AddRule(LoggingRule)"/> and <see cref="RemoveRuleByName(string)"/> methods.</remarks>
         public IList<LoggingRule> LoggingRules => _loggingRules;
         private readonly List<LoggingRule> _loggingRules = new List<LoggingRule>();
 
@@ -116,7 +116,7 @@ namespace NLog.Config
         private void AddLoggingRulesThreadSafe(LoggingRule rule) { lock (_loggingRules) _loggingRules.Add(rule); }
 
         private bool TryGetTargetThreadSafe(string name, out Target? target) { lock (_targets) return _targets.TryGetValue(name, out target); }
-        private List<Target> GetAllTargetsThreadSafe() { lock (_targets) return _targets.Values.ToList(); }
+        private IList<Target> GetAllTargetsThreadSafe() { lock (_targets) return _targets.Values.ToArray(); }
 
         private Target? RemoveTargetThreadSafe(string name)
         {
@@ -179,8 +179,13 @@ namespace NLog.Config
         {
             get
             {
-                var configTargets = new HashSet<Target>(_configItems.OfType<Target>().Concat(GetAllTargetsThreadSafe()), SingleItemOptimizedHashSet<Target>.ReferenceEqualityComparer.Default);
-                return configTargets.ToList().AsReadOnly();
+                var configTargets = new HashSet<Target>(GetAllTargetsThreadSafe(), SingleItemOptimizedHashSet<Target>.ReferenceEqualityComparer.Default);
+                foreach (var item in _configItems)
+                {
+                    if (item is Target target)
+                        configTargets.Add(target);
+                }
+                return new ReadOnlyCollection<Target>(configTargets.ToArray());
             }
         }
 

--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -193,7 +193,7 @@ namespace NLog.Config
             get => AutoReloadFileNames.Any();
             set
             {
-                var autoReloadFiles = _fileMustAutoReloadLookup.Keys.ToList();
+                var autoReloadFiles = _fileMustAutoReloadLookup.Keys.ToArray();
                 foreach (string nextFile in autoReloadFiles)
                     _fileMustAutoReloadLookup[nextFile] = value;
             }

--- a/src/NLog/Config/XmlParserConfigurationElement.cs
+++ b/src/NLog/Config/XmlParserConfigurationElement.cs
@@ -148,12 +148,12 @@ namespace NLog.Config
             if (childElements is null || childElements.Count == 0)
                 return ArrayHelper.Empty<XmlParserConfigurationElement>();
 
-            var children = new List<XmlParserConfigurationElement>();
+            var children = new XmlParserConfigurationElement[childElements.Count];
             for (int i = 0; i < childElements.Count; ++i)
             {
                 var child = childElements[i];
                 var nestedChild = nestedElement || !string.Equals(child.Name, "nlog", StringComparison.OrdinalIgnoreCase);
-                children.Add(new XmlParserConfigurationElement(child, nestedChild));
+                children[i] = new XmlParserConfigurationElement(child, nestedChild);
             }
             return children;
         }

--- a/src/NLog/Internal/CollectionExtensions.cs
+++ b/src/NLog/Internal/CollectionExtensions.cs
@@ -39,6 +39,20 @@ namespace NLog.Internal
     internal static class CollectionExtensions
     {
         /// <summary>
+        /// Optimized version of <see cref="System.Linq.Enumerable.ToArray{TSource}(IEnumerable{TSource})"/> for reducing AOT filesize.
+        /// </summary>
+        public static TItem[] ToArray<TItem>(this ICollection<TItem> items)
+        {
+            var itemCount = items.Count;
+            if (itemCount == 0)
+                return ArrayHelper.Empty<TItem>();
+
+            var array = new TItem[itemCount];
+            items.CopyTo(array, 0);
+            return array;
+        }
+
+        /// <summary>
         /// Memory optimized filtering
         /// </summary>
         /// <remarks>Passing state too avoid delegate capture and memory-allocations.</remarks>

--- a/src/NLog/Internal/ReflectionHelpers.cs
+++ b/src/NLog/Internal/ReflectionHelpers.cs
@@ -124,15 +124,14 @@ namespace NLog.Internal
 
         private static IEnumerable<Expression> BuildParameterList(MethodBase methodInfo, ParameterExpression parametersParameter)
         {
-            var parameterExpressions = new List<Expression>();
             var paramInfos = methodInfo.GetParameters();
+            var parameterExpressions = new Expression[paramInfos.Length];
             for (int i = 0; i < paramInfos.Length; i++)
             {
                 // (Ti)parameters[i]
                 var valueObj = Expression.ArrayIndex(parametersParameter, Expression.Constant(i));
-
                 var valueCast = CreateParameterExpression(paramInfos[i], valueObj);
-                parameterExpressions.Add(valueCast);
+                parameterExpressions[i] = valueCast;
             }
 
             return parameterExpressions;

--- a/src/NLog/Internal/StringBuilderExt.cs
+++ b/src/NLog/Internal/StringBuilderExt.cs
@@ -405,7 +405,15 @@ namespace NLog.Internal
                 builder.Append(_zeroPaddedDigits[number]);
             }
         }
-        private static readonly string[] _zeroPaddedDigits = Enumerable.Range(0, 60).Select(i => i.ToString("D2", CultureInfo.InvariantCulture)).ToArray();
+
+        private static readonly string[] _zeroPaddedDigits = {
+            "00","01","02","03","04","05","06","07","08","09",
+            "10","11","12","13","14","15","16","17","18","19",
+            "20","21","22","23","24","25","26","27","28","29",
+            "30","31","32","33","34","35","36","37","38","39",
+            "40","41","42","43","44","45","46","47","48","49",
+            "50","51","52","53","54","55","56","57","58","59",
+        };
 
         /// <summary>
         /// Append a number and pad with 0 to 4 digits

--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -1177,12 +1177,16 @@ namespace NLog
             /// </summary>
             public void PurgeObsoleteLoggers()
             {
-                foreach (var key in _loggerCache.Keys.ToList())
+                var aotFriendlyRemoval = new Dictionary<LoggerCacheKey, WeakReference>();
+                foreach (var item in _loggerCache)
                 {
-                    var logger = Retrieve(key);
-                    if (logger != null)
-                        continue;
-                    _loggerCache.Remove(key);
+                    if (item.Value.Target is null)
+                        aotFriendlyRemoval[item.Key] = item.Value;
+                }
+
+                foreach (var removeLogger in aotFriendlyRemoval)
+                {
+                    _loggerCache.Remove(removeLogger.Key);
                 }
             }
         }

--- a/src/NLog/ScopeContext.cs
+++ b/src/NLog/ScopeContext.cs
@@ -320,7 +320,7 @@ namespace NLog
                 if (nestedStates is object[] nestedArray)
                     return nestedArray;
                 else
-                    return Enumerable.ToArray(nestedStates);
+                    return nestedStates.ToArray();
             }
             return ArrayHelper.Empty<object>();
 #else

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -589,7 +589,8 @@ namespace NLog.Targets
 
             if (_openFileCache.Count > 0)
             {
-                foreach (var openFile in _openFileCache.ToList())
+                var aotFriendlyClone = new Dictionary<string, OpenFileAppender>(_openFileCache, _openFileCache.Comparer);
+                foreach (var openFile in aotFriendlyClone)
                 {
                     CloseFileWithFooter(openFile.Key, openFile.Value, false);
                 }
@@ -1082,7 +1083,8 @@ namespace NLog.Targets
 
             if (unusedFileMustBeClosed)
             {
-                foreach (var openFile in _openFileCache.ToList())
+                var aotFriendlyClone = new Dictionary<string, OpenFileAppender>(_openFileCache, _openFileCache.Comparer);
+                foreach (var openFile in aotFriendlyClone)
                 {
                     if (openFile.Value.FileAppender.LastWriteTime < closeTime)
                     {


### PR DESCRIPTION
AOT file-size increase with every declared generic-type-instance, along with bonus code from System.Linq.