### PR TITLE
feat(LimitingWrapper): expose MessagesDroppedCount

### DIFF
--- a/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
+++ b/src/NLog/Targets/Wrappers/LimitingTargetWrapper.cs
@@ -113,7 +113,13 @@ namespace NLog.Targets.Wrappers
         public int MessagesWrittenCount { get; private set; }
 
         /// <summary>
-        /// Initializes the target and resets the current Interval and <see cref="MessagesWrittenCount"/>.
+        /// Gets the number of <see cref="AsyncLogEventInfo"/> discarded in the current <see cref="Interval"/> because <see cref="MessageLimit"/> was reached.
+        /// </summary>
+        /// <docgen category='General Options' order='10' />
+        public int MessagesDroppedCount { get; private set; }
+
+        /// <summary>
+        /// Initializes the target and resets the current Interval, <see cref="MessagesWrittenCount"/>, and <see cref="MessagesDroppedCount"/>.
         ///  </summary>
         protected override void InitializeTarget()
         {
@@ -151,6 +157,7 @@ namespace NLog.Targets.Wrappers
             }
             else
             {
+                MessagesDroppedCount++;
                 logEvent.Continuation(null);
                 InternalLogger.Trace("{0}: Discarded event, because MessageLimit of '{1}' was reached.", this, messageLimit);
             }
@@ -160,6 +167,7 @@ namespace NLog.Targets.Wrappers
         {
             _firstWriteInInterval = timestamp;
             MessagesWrittenCount = 0;
+            MessagesDroppedCount = 0;
         }
     }
 }

--- a/tests/NLog.UnitTests/Targets/Wrappers/LimitingTargetWrapperTests.cs
+++ b/tests/NLog.UnitTests/Targets/Wrappers/LimitingTargetWrapperTests.cs
@@ -151,8 +151,28 @@ namespace NLog.UnitTests.Targets.Wrappers
             }, LogLevel.Trace);
 
             Assert.Equal(5, wrappedTarget.WriteCount);
+            Assert.Equal(1, wrapper.MessagesDroppedCount);
             Assert.Contains("MessageLimit", internalLog);
             Assert.Null(lastException);
+        }
+
+        [Fact]
+        public void MessagesDroppedCountResetsWhenIntervalExpires()
+        {
+            MyTarget wrappedTarget = new MyTarget();
+            LimitingTargetWrapper wrapper = new LimitingTargetWrapper(wrappedTarget, 1, TimeSpan.FromMilliseconds(100));
+            InitializeTargets(wrappedTarget, wrapper);
+
+            WriteNumberAsyncLogEventsStartingAt(0, 1, wrapper);
+            wrapper.WriteAsyncLogEvent(
+                new LogEventInfo(LogLevel.Debug, "test", "dropped").WithContinuation(_ => { }));
+
+            Assert.Equal(1, wrapper.MessagesDroppedCount);
+
+            Thread.Sleep(100);
+
+            WriteNumberAsyncLogEventsStartingAt(0, 1, wrapper);
+            Assert.Equal(0, wrapper.MessagesDroppedCount);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

- Adds `MessagesDroppedCount` on `LimitingTargetWrapper`, incremented when a log event is discarded after `MessageLimit` is reached.
- Resets together with `MessagesWrittenCount` when the current interval expires.
- Adds unit tests for discard counting and interval reset.

Useful for monitoring how many events were suppressed between emails (e.g. read the property from code or target diagnostics).

## Test plan

- [x] `WriteMoreMessagesThanMessageLimitDiscardsExcessMessages` asserts `MessagesDroppedCount == 1`
- [x] `MessagesDroppedCountResetsWhenIntervalExpires`
- [ ] CI (no local .NET SDK in contributor environment)

Fixes #6173