### PR TITLE
Reduce AOT build size by excluding legacy ComponentModel.TypeDescriptor

### DIFF
--- a/src/NLog/Config/Factory.cs
+++ b/src/NLog/Config/Factory.cs
@@ -151,7 +151,7 @@ namespace NLog.Config
             Func<TBaseType?> typeCreator = () =>
             {
                 var type = typeLookup();
-                return type != null ? (TBaseType)Activator.CreateInstance(type) : null;
+                return type != null ? (TBaseType?)Activator.CreateInstance(type) : null;
             };
 
             lock (ConfigurationItemFactory.SyncRoot)
@@ -187,7 +187,7 @@ namespace NLog.Config
         {
             typeAlias = FactoryExtensions.NormalizeName(typeAlias);
 
-            Func<TBaseType> itemCreator = () => (TBaseType)Activator.CreateInstance(itemType);
+            Func<TBaseType?> itemCreator = () => (TBaseType?)Activator.CreateInstance(itemType);
             lock (ConfigurationItemFactory.SyncRoot)
             {
                 _parentFactory.RegisterTypeProperties(itemType, () => itemCreator.Invoke());

--- a/src/NLog/Config/PropertyTypeConverter.cs
+++ b/src/NLog/Config/PropertyTypeConverter.cs
@@ -36,6 +36,7 @@ namespace NLog.Config
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
+    using NLog.Common;
     using NLog.Internal;
 
     /// <summary>
@@ -57,7 +58,7 @@ namespace NLog.Config
 
         internal static bool IsComplexType(Type type)
         {
-            return !type.IsValueType && !typeof(IConvertible).IsAssignableFrom(type) && !HasConvertFromStringSupport(type) && type.GetFirstCustomAttribute<System.ComponentModel.TypeConverterAttribute>() is null;
+            return !type.IsValueType && !typeof(IConvertible).IsAssignableFrom(type) && !HasConvertFromStringSupport(type);
         }
 
         /// <inheritdoc/>
@@ -227,30 +228,45 @@ namespace NLog.Config
                 if (typeCode == TypeCode.DateTime && typeof(DateTimeOffset) == propertyType)
                     return new DateTimeOffset(convertibleValue.ToDateTime(formatProvider));
             }
-            else if (TryConvertToType(propertyValue, propertyType, out var convertedValue))
+            else
             {
-                return convertedValue;
+                if (TryConvertToType(propertyValue, propertyType, out var convertedValue))
+                    return convertedValue;
             }
 
             return System.Convert.ChangeType(propertyValue, propertyType, formatProvider);
         }
 
+        //[RequiresDynamicCode("TypeDescriptor requires dynamic code")]
         [UnconditionalSuppressMessage("Trimming - Allow converting option-values from config", "IL2026")]
         [UnconditionalSuppressMessage("Trimming - Allow converting option-values from config", "IL2067")]
         [UnconditionalSuppressMessage("Trimming - Allow converting option-values from config", "IL2072")]
         private static bool TryConvertToType(object propertyValue, Type propertyType, out object? convertedValue)
         {
+#if NETSTANDARD2_1_OR_GREATER || NET
+            if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
+#else
             if (propertyValue is null || propertyType.IsAssignableFrom(propertyValue.GetType()))
+#endif
             {
                 convertedValue = null;
                 return false;
             }
 
-            var typeConverter = System.ComponentModel.TypeDescriptor.GetConverter(propertyValue.GetType());
-            if (typeConverter != null && typeConverter.CanConvertTo(propertyType))
+            try
             {
-                convertedValue = typeConverter.ConvertTo(propertyValue, propertyType);
-                return true;
+                var typeConverter = System.ComponentModel.TypeDescriptor.GetConverter(propertyValue.GetType());
+                if (typeConverter != null && typeConverter.CanConvertTo(propertyType))
+                {
+                    convertedValue = typeConverter.ConvertTo(propertyValue, propertyType);
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Error(ex, "Error in lookup of TypeDescriptor for type={0} to convert value '{1}'", propertyValue.GetType(), propertyValue);
+                convertedValue = null;
+                return false;
             }
 
             convertedValue = null;

--- a/src/NLog/Internal/PropertyHelper.cs
+++ b/src/NLog/Internal/PropertyHelper.cs
@@ -498,10 +498,17 @@ namespace NLog.Internal
         [UnconditionalSuppressMessage("Trimming - Allow converting option-values from config", "IL2072")]
         internal static bool TryTypeConverterConversion(Type type, string value, out object? newValue)
         {
+            InternalLogger.Debug("Object reflection needed for creating external type: {0} from string-value: {1}", type, value);
+#if NETSTANDARD2_1_OR_GREATER || NET
+            if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
+            {
+                newValue = null;
+                return false;
+            }
+#endif
+
             try
             {
-                InternalLogger.Debug("Object reflection needed for creating external type: {0} from string-value: {1}", type, value);
-
                 var converter = System.ComponentModel.TypeDescriptor.GetConverter(type);
                 if (converter.CanConvertFrom(typeof(string)))
                 {
@@ -512,7 +519,7 @@ namespace NLog.Internal
                 newValue = null;
                 return false;
             }
-            catch (MissingMethodException ex)
+            catch (Exception ex)
             {
                 InternalLogger.Error(ex, "Error in lookup of TypeDescriptor for type={0} to convert value '{1}'", type, value);
                 newValue = null;

--- a/src/NLog/Internal/ReflectionHelpers.cs
+++ b/src/NLog/Internal/ReflectionHelpers.cs
@@ -151,7 +151,7 @@ namespace NLog.Internal
         {
             Type parameterType = parameterInfo.ParameterType;
             if (parameterType.IsByRef)
-                parameterType = parameterType.GetElementType();
+                parameterType = parameterType.GetElementType() ?? parameterType;
 
             var valueCast = Expression.Convert(expression, parameterType);
             return valueCast;

--- a/src/NLog/LayoutRenderers/CounterLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/CounterLayoutRenderer.cs
@@ -122,8 +122,7 @@ namespace NLog.LayoutRenderers
             if (globalSequence is null)
             {
                 globalSequence = new GlobalSequence(sequenceName, Value);
-                Interlocked.CompareExchange(ref _firstSequence, globalSequence, null);
-                globalSequence = _firstSequence;
+                globalSequence = Interlocked.CompareExchange(ref _firstSequence, globalSequence, null) ?? globalSequence;
             }
             if (globalSequence.Name.Equals(sequenceName, StringComparison.Ordinal))
                 return globalSequence.NextValue(Increment);
@@ -143,7 +142,8 @@ namespace NLog.LayoutRenderers
                 globalSequence = new GlobalSequence(sequenceName, Value);
                 if (!Sequences.TryAdd(sequenceName, globalSequence))
                 {
-                    Sequences.TryGetValue(sequenceName, out globalSequence);
+                    Sequences.TryGetValue(sequenceName, out var existingSequence);
+                    globalSequence = existingSequence ?? globalSequence;
                 }
             }
 #endif

--- a/src/NLog/LayoutRenderers/InstallContextLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/InstallContextLayoutRenderer.cs
@@ -68,7 +68,7 @@ namespace NLog.LayoutRenderers
 
         private object? GetValue(LogEventInfo logEvent)
         {
-            return !logEvent.Properties.TryGetValue(Parameter, out var value) ? null : value;
+            return logEvent.Properties.TryGetValue(Parameter, out var value) ? value : null;
         }
     }
 }

--- a/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
+++ b/src/NLog/Layouts/Typed/ValueTypeLayoutInfo.cs
@@ -110,7 +110,7 @@ namespace NLog.Layouts
             }
         }
         private Type? _valueType;
-        private Func<object>? _createDefaultValue;
+        private Func<object?>? _createDefaultValue;
 
         /// <summary>
         /// Gets or sets the fallback value when result value is not available
@@ -253,7 +253,7 @@ namespace NLog.Layouts
             public ILayoutTypeValue InnerLayout => this;
             public Type? InnerType => _fixedValue?.GetType();
 
-            public FixedLayoutTypeValue(object fixedValue)
+            public FixedLayoutTypeValue(object? fixedValue)
             {
                 _fixedValue = fixedValue;
             }


### PR DESCRIPTION
**After:**
`ProcessPath: 'C:\projects\nlog\tests\TestTrimPublish\bin\release\net8.0\win-x64\publish\TestTrimPublish.exe' with FileSize: 4982272`
**Before:**
`ProcessPath: 'C:\projects\nlog\tests\TestTrimPublish\bin\release\net8.0\win-x64\publish\TestTrimPublish.exe' with FileSize: 5448192`
**NLog v6.1.3**
`ProcessPath: 'C:\projects\nlog\tests\TestTrimPublish\bin\release\net8.0\win-x64\publish\TestTrimPublish.exe' with FileSize: 5486592`

Good result. Seems ComponentModel TypeDescriptor was inviting a lot of dependencies (And legacy collection types)

This ofcourse means that when using NLog with AOT-builds, then NLog will behave different (No support for conversions with TypeDescriptor). But think that TypeDescriptor is legacy, and NLog should not rely on this exotic feature.