### PR TITLE
Reduce AOT file-size by changing to use yield instead of Linq

### DIFF
--- a/src/NLog/Config/LoggingConfigurationElementExtensions.cs
+++ b/src/NLog/Config/LoggingConfigurationElementExtensions.cs
@@ -36,7 +36,6 @@ namespace NLog.Config
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.Linq;
     using NLog.Common;
     using NLog.Internal;
 
@@ -78,9 +77,12 @@ namespace NLog.Config
 
         public static string? GetOptionalValue(this ILoggingConfigurationElement element, string attributeName, string? defaultValue)
         {
-            return element.Values
-                .Where(configItem => string.Equals(configItem.Key, attributeName, StringComparison.OrdinalIgnoreCase))
-                .Select(configItem => configItem.Value).FirstOrDefault() ?? defaultValue;
+            foreach (var configItem in element.Values)
+            {
+                if (string.Equals(configItem.Key, attributeName, StringComparison.OrdinalIgnoreCase))
+                    return configItem.Value ?? defaultValue;
+            }
+            return defaultValue;
         }
 
         /// <summary>

--- a/src/NLog/Config/XmlLoggingConfigurationElement.cs
+++ b/src/NLog/Config/XmlLoggingConfigurationElement.cs
@@ -37,7 +37,6 @@ namespace NLog.Config
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Xml;
     using NLog.Internal;
 
@@ -92,11 +91,10 @@ namespace NLog.Config
             {
                 for (int i = 0; i < Children.Count; ++i)
                 {
-                    var child = Children[i];
-                    if (SingleValueElement(child))
+                    if (SingleValueElement(Children[i]))
                     {
                         // Values assigned using nested node-elements. Maybe in combination with attributes
-                        return AttributeValues.Concat(Children.Where(item => SingleValueElement(item)).Select(item => new KeyValuePair<string, string?>(item.Name, item.Value ?? string.Empty)));
+                        return GetValues();
                     }
                 }
                 return AttributeValues;
@@ -117,28 +115,33 @@ namespace NLog.Config
                 {
                     var child = Children[i];
                     if (!SingleValueElement(child))
-                        return Children.Where(item => !SingleValueElement(item)).Cast<ILoggingConfigurationElement>();
+                        return GetChildElements();
                 }
 
                 return ArrayHelper.Empty<ILoggingConfigurationElement>();
             }
         }
 
-        /// <summary>
-        /// Asserts that the name of the element is among specified element names.
-        /// </summary>
-        /// <param name="allowedNames">The allowed names.</param>
-        public void AssertName(params string[] allowedNames)
+        private IEnumerable<KeyValuePair<string, string?>> GetValues()
         {
-            foreach (var elementName in allowedNames)
+            for (int i = 0; i < AttributeValues.Count; ++i)
+                yield return AttributeValues[i];
+            for (int i = 0; i < Children.Count; ++i)
             {
-                if (LocalName.Equals(elementName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return;
-                }
+                var child = Children[i];
+                if (SingleValueElement(child))
+                    yield return new KeyValuePair<string, string?>(child.Name, child.Value ?? string.Empty);
             }
+        }
 
-            throw new InvalidOperationException($"Assertion failed. Expected element name '{string.Join("|", allowedNames)}', actual: '{LocalName}'.");
+        private IEnumerable<ILoggingConfigurationElement> GetChildElements()
+        {
+            for (int i = 0; i < Children.Count; ++i)
+            {
+                var child = Children[i];
+                if (!SingleValueElement(child))
+                    yield return child;
+            }
         }
 
         private static IList<XmlLoggingConfigurationElement> ParseChildren(XmlReader reader, bool nestedElement, out string? innerText)

--- a/src/NLog/Config/XmlParserConfigurationElement.cs
+++ b/src/NLog/Config/XmlParserConfigurationElement.cs
@@ -35,7 +35,6 @@ namespace NLog.Config
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using NLog.Internal;
 
     internal sealed class XmlParserConfigurationElement : ILoggingConfigurationElement
@@ -66,14 +65,25 @@ namespace NLog.Config
             {
                 for (int i = 0; i < Children.Count; ++i)
                 {
-                    var child = Children[i];
-                    if (SingleValueElement(child))
+                    if (SingleValueElement(Children[i]))
                     {
                         // Values assigned using nested node-elements. Maybe in combination with attributes
-                        return AttributeValues.Concat(Children.Where(item => SingleValueElement(item)).Select(item => new KeyValuePair<string, string?>(item.Name, item.Value ?? string.Empty)));
+                        return GetValues();
                     }
                 }
                 return AttributeValues;
+            }
+        }
+
+        private IEnumerable<KeyValuePair<string, string?>> GetValues()
+        {
+            for (int i = 0; i < AttributeValues.Count; ++i)
+                yield return AttributeValues[i];
+            for (int i = 0; i < Children.Count; ++i)
+            {
+                var child = Children[i];
+                if (SingleValueElement(child))
+                    yield return new KeyValuePair<string, string?>(child.Name, child.Value ?? string.Empty);
             }
         }
 
@@ -85,10 +95,20 @@ namespace NLog.Config
                 {
                     var child = Children[i];
                     if (!SingleValueElement(child))
-                        return Children.Where(item => !SingleValueElement(item)).Cast<ILoggingConfigurationElement>();
+                        return GetChildElements();
                 }
 
                 return ArrayHelper.Empty<ILoggingConfigurationElement>();
+            }
+        }
+
+        private IEnumerable<ILoggingConfigurationElement> GetChildElements()
+        {
+            for (int i = 0; i < Children.Count; ++i)
+            {
+                var child = Children[i];
+                if (!SingleValueElement(child))
+                    yield return child;
             }
         }
 

--- a/src/NLog/Layouts/Layout.cs
+++ b/src/NLog/Layouts/Layout.cs
@@ -388,7 +388,7 @@ namespace NLog.Layouts
 
             // determine the max StackTraceUsage, to decide if Logger needs to capture callsite
             StackTraceUsage = StackTraceUsage.None;    // In case this Layout should implement IUsesStackTrace
-            StackTraceUsage = objectGraphScannerList.OfType<IUsesStackTrace>().DefaultIfEmpty().Aggregate(StackTraceUsage.None, (usage, item) => usage | item?.StackTraceUsage ?? StackTraceUsage.None);
+            StackTraceUsage = objectGraphScannerList.OfType<IUsesStackTrace>().Aggregate(StackTraceUsage.None, (usage, item) => usage | item?.StackTraceUsage ?? StackTraceUsage.None);
 
             _scannedForObjects = true;
         }

--- a/src/NLog/Layouts/XML/XmlElementBase.cs
+++ b/src/NLog/Layouts/XML/XmlElementBase.cs
@@ -36,7 +36,6 @@ namespace NLog.Layouts
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
-    using System.Linq;
     using System.Text;
     using NLog.Config;
     using NLog.Internal;
@@ -280,7 +279,29 @@ namespace NLog.Layouts
             }
 
             var innerLayouts = LayoutWrapper.Inner is null ? ArrayHelper.Empty<Layout>() : new[] { LayoutWrapper.Inner };
-            _precalculateLayouts = (IncludeEventProperties || IncludeScopeProperties) ? null : ResolveLayoutPrecalculation(_attributes.Select(atr => atr.Layout).Concat(_elements.Where(elm => elm.Layout != null).Select(elm => elm.Layout)).Concat(ContextProperties?.Select(ctx => ctx.Layout) ?? Enumerable.Empty<Layout>()).Concat(innerLayouts));
+            _precalculateLayouts = (IncludeEventProperties || IncludeScopeProperties) ? null : ResolveLayoutPrecalculation(GetAllLayouts(innerLayouts));
+        }
+
+        private IEnumerable<Layout> GetAllLayouts(Layout[] innerLayouts)
+        {
+            for (int i = 0; i < _attributes.Count; ++i)
+                yield return _attributes[i].Layout;
+
+            for (int i = 0; i < _elements.Count; ++i)
+            {
+                var layout = _elements[i].Layout;
+                if (layout != null)
+                    yield return layout;
+            }
+
+            if (ContextProperties != null)
+            {
+                for (int i = 0; i < ContextProperties.Count; ++i)
+                    yield return ContextProperties[i].Layout;
+            }
+
+            for (int i = 0; i < innerLayouts.Length; ++i)
+                yield return innerLayouts[i];
         }
 
         /// <inheritdoc/>

--- a/tests/TestTrimPublish/TestTrimPublish.csproj
+++ b/tests/TestTrimPublish/TestTrimPublish.csproj
@@ -20,6 +20,7 @@
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <PublishAot>true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <IlcGenerateDgmlFile>true</IlcGenerateDgmlFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Focus on not using System.Linq on generic-collections with non-standard item-type.

**After:**
`ProcessPath: 'C:\projects\nlog\tests\TestTrimPublish\bin\release\net8.0\win-x64\publish\TestTrimPublish.exe' with FileSize: 4927488`

**Before:**
`ProcessPath: 'C:\projects\nlog\tests\TestTrimPublish\bin\release\net8.0\win-x64\publish\TestTrimPublish.exe' with FileSize: 4982272`

**NLog v6.1.3**
`ProcessPath: 'C:\projects\nlog\tests\TestTrimPublish\bin\release\net8.0\win-x64\publish\TestTrimPublish.exe' with FileSize: 5486592`