### PR TITLE
Reduce AOT file-size by changing XmlLoggingConfiguration AutoReloadFileNames to use yield instead of Linq

### DIFF
--- a/src/NLog/Config/XmlLoggingConfiguration.cs
+++ b/src/NLog/Config/XmlLoggingConfiguration.cs
@@ -211,7 +211,16 @@ namespace NLog.Config
                 if (_fileMustAutoReloadLookup.Count == 0)
                     return ArrayHelper.Empty<string>();
                 else
-                    return _fileMustAutoReloadLookup.Where(entry => entry.Value).Select(entry => entry.Key);
+                    return GetAutoReloadFileNames();
+            }
+        }
+
+        private IEnumerable<string> GetAutoReloadFileNames()
+        {
+            foreach (var entry in _fileMustAutoReloadLookup)
+            {
+                if (entry.Value)
+                    yield return entry.Key;
             }
         }
 


### PR DESCRIPTION
**After:**
`ProcessPath: 'C:\projects\nlog\Tests\TestTrimPublish\bin\release\net8.0\win-X64\publish\TestTrimPublish.exe' with FileSize: 4850688`
**Before:**
`ProcessPath: 'C:\projects\nlog\Tests\TestTrimPublish\bin\release\net8.0\win-X64\publish\TestTrimPublish.exe' with FileSize: 4897792`
**NLog v6.1.3**
`ProcessPath: 'C:\projects\nlog\tests\TestTrimPublish\bin\release\net8.0\win-x64\publish\TestTrimPublish.exe' with FileSize: 5486592`