### PR TITLE
ScopeContext - Rename CaptureNestedContext to CloneNestedContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ build/
 .vs
 .cr
 /artifacts
+/.github/copilot-instructions.md

--- a/src/NLog/Internal/ScopeContextAsyncState.cs
+++ b/src/NLog/Internal/ScopeContextAsyncState.cs
@@ -70,7 +70,7 @@ namespace NLog.Internal
         object? NestedState { get; }
         long NestedStateTimestamp { get; }
         IReadOnlyCollection<KeyValuePair<string, object?>>? CaptureContextProperties(ref ScopeContextPropertyCollector contextCollector);
-        IList<object>? CaptureNestedContext(ref ScopeContextNestedStateCollector contextCollector);
+        IList<object>? CloneNestedContext(ref ScopeContextNestedStateCollector contextCollector);
     }
 
     struct ScopeContextPropertyCollector
@@ -225,19 +225,18 @@ namespace NLog.Internal
     struct ScopeContextNestedStateCollector
     {
         private IList<object> _allNestedStates;
-        private List<object> _nestedStateCollector;
 
-        public bool IsCollectorEmpty => _allNestedStates is null || (_allNestedStates.Count == 0 && _nestedStateCollector is null);
+        public bool IsCollectorEmpty => _allNestedStates is null || _allNestedStates.Count == 0;
 
         public bool IsCollectorInactive => _allNestedStates is null;
 
-        public IList<object> StartCaptureNestedStates(IScopeContextAsyncState? state)
+        public IList<object> StartCloneNestedContext(IScopeContextAsyncState? state)
         {
             _allNestedStates = _allNestedStates ?? Array.Empty<object>();
 
             while (state != null)
             {
-                var result = state.CaptureNestedContext(ref this);
+                var result = state.CloneNestedContext(ref this);
                 if (result != null)
                     return result;
                 state = state.Parent;
@@ -248,17 +247,11 @@ namespace NLog.Internal
 
         public void CollectNestedState(object state)
         {
-            if (_nestedStateCollector is null)
+            if (_allNestedStates is null || _allNestedStates.Count == 0)
             {
-                _nestedStateCollector = new List<object>(Math.Max(4, (_allNestedStates?.Count ?? 0) + 1));
-                if (_allNestedStates?.Count > 0)
-                {
-                    for (int i = 0; i < _allNestedStates.Count; ++i)
-                        _nestedStateCollector.Add(_allNestedStates[i]);
-                }
-                _allNestedStates = _nestedStateCollector;
+                _allNestedStates = new List<object>();
             }
-            _nestedStateCollector.Add(state);    // Collected in "reversed" order
+            _allNestedStates.Add(state);    // Collected in "reversed" order
         }
     }
 
@@ -287,7 +280,7 @@ namespace NLog.Internal
 
         public long NestedStateTimestamp { get; }
 
-        IList<object>? IScopeContextAsyncState.CaptureNestedContext(ref ScopeContextNestedStateCollector contextCollector)
+        IList<object>? IScopeContextAsyncState.CloneNestedContext(ref ScopeContextNestedStateCollector contextCollector)
         {
             object? objectValue = _value;
 
@@ -300,7 +293,7 @@ namespace NLog.Internal
                 {
                     if (objectValue is not null)
                         contextCollector.CollectNestedState(objectValue);   // Mark as active
-                    return contextCollector.StartCaptureNestedStates(Parent);
+                    return contextCollector.StartCloneNestedContext(Parent);
                 }
             }
 
@@ -347,7 +340,7 @@ namespace NLog.Internal
             Value = value;
         }
 
-        IList<object>? IScopeContextAsyncState.CaptureNestedContext(ref ScopeContextNestedStateCollector contextCollector)
+        IList<object>? IScopeContextAsyncState.CloneNestedContext(ref ScopeContextNestedStateCollector contextCollector)
         {
             if (contextCollector.IsCollectorInactive)
             {
@@ -357,7 +350,7 @@ namespace NLog.Internal
                 }
                 else
                 {
-                    return contextCollector.StartCaptureNestedStates(Parent);
+                    return contextCollector.StartCloneNestedContext(Parent);
                 }
             }
 
@@ -432,12 +425,12 @@ namespace NLog.Internal
             NestedStateTimestamp = ScopeContext.GetNestedContextTimestampNow();
         }
 
-        IList<object>? IScopeContextAsyncState.CaptureNestedContext(ref ScopeContextNestedStateCollector contextCollector)
+        IList<object>? IScopeContextAsyncState.CloneNestedContext(ref ScopeContextNestedStateCollector contextCollector)
         {
             if (NestedState is null)
             {
                 if (contextCollector.IsCollectorInactive)
-                    return contextCollector.StartCaptureNestedStates(Parent);
+                    return contextCollector.StartCloneNestedContext(Parent);
                 else
                     return null;    // continue with parent
             }
@@ -452,7 +445,7 @@ namespace NLog.Internal
                     else if (contextCollector.IsCollectorInactive)
                     {
                         contextCollector.CollectNestedState(NestedState);  // Mark as active
-                        return contextCollector.StartCaptureNestedStates(Parent);
+                        return contextCollector.StartCloneNestedContext(Parent);
                     }
                 }
 
@@ -520,7 +513,7 @@ namespace NLog.Internal
         {
             var nestedStateCollector = new ScopeContextNestedStateCollector();
             var propertyCollector = new ScopeContextPropertyCollector();
-            var nestedStates = contextState?.CaptureNestedContext(ref nestedStateCollector) ?? Array.Empty<object>();
+            var nestedStates = contextState?.CloneNestedContext(ref nestedStateCollector) ?? Array.Empty<object>();
             var scopeProperties = contextState?.CaptureContextProperties(ref propertyCollector) ?? Array.Empty<KeyValuePair<string, object?>>();
             allProperties = new Dictionary<string, object?>(scopeProperties.Count, ScopeContext.DefaultComparer);
             ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(scopeProperties, allProperties);
@@ -549,7 +542,7 @@ namespace NLog.Internal
 
         object? IScopeContextAsyncState.NestedState => NestedContext?.Length > 0 ? NestedContext[0] : null;
 
-        IList<object> IScopeContextAsyncState.CaptureNestedContext(ref ScopeContextNestedStateCollector contextCollector)
+        IList<object> IScopeContextAsyncState.CloneNestedContext(ref ScopeContextNestedStateCollector contextCollector)
         {
             if (contextCollector.IsCollectorEmpty)
             {
@@ -559,7 +552,7 @@ namespace NLog.Internal
             {
                 for (int i = 0; i < NestedContext.Length; ++i)
                     contextCollector.CollectNestedState(NestedContext[i]);
-                return contextCollector.StartCaptureNestedStates(null); // We are done
+                return contextCollector.StartCloneNestedContext(null); // We are done
             }
         }
 

--- a/src/NLog/ScopeContext.cs
+++ b/src/NLog/ScopeContext.cs
@@ -315,7 +315,7 @@ namespace NLog
         {
 #if !NET35 && !NET40 && !NET45
             var nestedStates = GetAllNestedStateList();
-            if (nestedStates?.Count > 0)
+            if (nestedStates.Count > 0)
             {
                 if (nestedStates is object[] nestedArray)
                     return nestedArray;
@@ -347,7 +347,7 @@ namespace NLog
         {
             var parent = GetAsyncLocalContext();
             var nestedStateCollector = new ScopeContextNestedStateCollector();
-            return parent?.CaptureNestedContext(ref nestedStateCollector) ?? ArrayHelper.Empty<object>();
+            return parent?.CloneNestedContext(ref nestedStateCollector) ?? ArrayHelper.Empty<object>();
         }
 #else
         internal static IList<object> GetAllNestedStateList()
@@ -629,7 +629,7 @@ namespace NLog
                 if ((contextState.Parent is null && contextState is ScopeContextLegacyAsyncState) || contextState.NestedState is null)
                 {
                     var nestedStateCollector = new ScopeContextNestedStateCollector();
-                    var nestedStates = contextState.CaptureNestedContext(ref nestedStateCollector) ?? ArrayHelper.Empty<object>();
+                    var nestedStates = contextState.CloneNestedContext(ref nestedStateCollector) ?? ArrayHelper.Empty<object>();
                     if (nestedStates.Count == 0)
                         return null;    // Nothing to pop, just leave scope alone
 

--- a/src/NLog/Targets/TargetWithContext.cs
+++ b/src/NLog/Targets/TargetWithContext.cs
@@ -520,7 +520,7 @@ namespace NLog.Targets
         {
             var stack = ScopeContext.GetAllNestedStateList();
             if (stack.Count == 0)
-                return stack;
+                return ArrayHelper.Empty<object>();
 
             List<object>? filteredStack = null;
             for (int i = 0; i < stack.Count; ++i)


### PR DESCRIPTION
ScopeContext GetAllNestedStates always converts the ScopeContext-chain into a newly allocated array or list.

Right now every LogEvent written within the same nested ScopeContext will allocate their own nested-state-collection.

The ScopeContextNestedStateCollector becomes armed when the first item is added, and there is no caching/capture of previous nested-state-collections in the ScopeContext-chain.