### PR TITLE
ScopeContext - Simplify CaptureContextProperties when only nested state

### DIFF
--- a/src/NLog/Internal/ScopeContextAsyncState.cs
+++ b/src/NLog/Internal/ScopeContextAsyncState.cs
@@ -80,6 +80,8 @@ namespace NLog.Internal
 
         public bool IsCollectorEmpty => _allProperties is null || (_allProperties.Count == 0 && _propertyCollector is null);
 
+        public bool IsCollectorInactive => _allProperties is null;
+
         public ScopeContextPropertyCollector(List<KeyValuePair<string, object?>> propertyCollector)
         {
             _allProperties = _propertyCollector = propertyCollector;
@@ -297,16 +299,18 @@ namespace NLog.Internal
 
             if (objectValue is not null)
                 contextCollector.CollectNestedState(objectValue);
-            return null;    // continue with parent
+            return null;    // Continue with Parent
         }
 
         IReadOnlyCollection<KeyValuePair<string, object?>>? IScopeContextAsyncState.CaptureContextProperties(ref ScopeContextPropertyCollector contextCollector)
         {
-            if (Parent is null)
-                return contextCollector.IsCollectorEmpty ? Array.Empty<KeyValuePair<string, object?>>() : contextCollector.CaptureCompleted(null);
+            if (contextCollector.IsCollectorInactive && Parent is not null)
+            {
+                contextCollector.AddProperties(Array.Empty<KeyValuePair<string, object?>>());    // Mark as active
+                return contextCollector.StartCaptureProperties(Parent);   // Start parent enumeration
+            }
 
-            contextCollector.AddProperties(Array.Empty<KeyValuePair<string, object?>>());    // Mark as active
-            return contextCollector.StartCaptureProperties(Parent);   // Start parent enumeration
+            return null;    // Continue with Parent
         }
 
         public override string ToString()

--- a/src/NLog/Internal/ScopeContextAsyncState.cs
+++ b/src/NLog/Internal/ScopeContextAsyncState.cs
@@ -80,8 +80,6 @@ namespace NLog.Internal
 
         public bool IsCollectorEmpty => _allProperties is null || (_allProperties.Count == 0 && _propertyCollector is null);
 
-        public bool IsCollectorInactive => _allProperties is null;
-
         public ScopeContextPropertyCollector(List<KeyValuePair<string, object?>> propertyCollector)
         {
             _allProperties = _propertyCollector = propertyCollector;
@@ -304,16 +302,11 @@ namespace NLog.Internal
 
         IReadOnlyCollection<KeyValuePair<string, object?>>? IScopeContextAsyncState.CaptureContextProperties(ref ScopeContextPropertyCollector contextCollector)
         {
-            if (contextCollector.IsCollectorInactive)
-            {
-                if (Parent is null)
-                    return Array.Empty<KeyValuePair<string, object?>>(); // We are done
+            if (Parent is null)
+                return contextCollector.IsCollectorEmpty ? Array.Empty<KeyValuePair<string, object?>>() : contextCollector.CaptureCompleted(null);
 
-                contextCollector.AddProperties(Array.Empty<KeyValuePair<string, object?>>());    // Mark as active
-                return contextCollector.StartCaptureProperties(Parent);   // Start parent enumeration
-            }
-
-            return null;    // Continue with Parent
+            contextCollector.AddProperties(Array.Empty<KeyValuePair<string, object?>>());    // Mark as active
+            return contextCollector.StartCaptureProperties(Parent);   // Start parent enumeration
         }
 
         public override string ToString()
@@ -465,18 +458,14 @@ namespace NLog.Internal
                 }
                 return _allProperties;  // We are done
             }
-            else
+
+            if (_allProperties is null)
             {
-                if (_allProperties is null)
-                {
-                    contextCollector.AddProperties(_scopeProperties as IReadOnlyCollection<KeyValuePair<string, object?>> ?? this);
-                    return null;    // Continue with Parent
-                }
-                else
-                {
-                    return contextCollector.CaptureCompleted(_allProperties);     // We are done
-                }
+                contextCollector.AddProperties(_scopeProperties as IReadOnlyCollection<KeyValuePair<string, object?>> ?? this);
+                return null;    // Continue with Parent
             }
+
+            return contextCollector.CaptureCompleted(_allProperties);     // We are done
         }
 
         public override string ToString()

--- a/tests/NLog.UnitTests/Contexts/ScopeContextTest.cs
+++ b/tests/NLog.UnitTests/Contexts/ScopeContextTest.cs
@@ -793,6 +793,26 @@ namespace NLog.UnitTests.Contexts
             Assert.Equal(scopeData, scopeNestedStates[0]);
         }
 
+        [Fact]
+        public void ScopeContextNestedStateWithParentProperties()
+        {
+            // Arrange
+            ScopeContext.Clear();
+
+            // Act
+            object propertyValue;
+            using (ScopeContext.PushProperty("Hello", "World"))
+            {
+                using (ScopeContext.PushNestedState("Hello World"))
+                {
+                    ScopeContext.TryGetProperty("Hello", out propertyValue);
+                }
+            }
+
+            // Assert
+            Assert.Equal("World", propertyValue);
+        }
+
 #if !NET35 && !NET40
         [Fact]
         public void ScopeContextPushWithoutStackOverflow3()


### PR DESCRIPTION
Maybe one should remove the ability of directly calling CaptureContextProperties, but instead always start out with StartCaptureProperties. Removing the complexity of CaptureContextProperties having to upgrade to StartCaptureProperties.