### PR TITLE
ScopeContext - Optimize collection of properties in reverse order

### DIFF
--- a/src/NLog/Internal/ScopeContextAsyncState.cs
+++ b/src/NLog/Internal/ScopeContextAsyncState.cs
@@ -113,7 +113,7 @@ namespace NLog.Internal
                         return _allProperties = MergeUniqueProperties(_allProperties, properties);
                     }
 
-                    AddProperties(properties);
+                    CollectProperties(properties, _propertyCollector);
                 }
 
                 return _allProperties = EnsureUniqueProperties(_allProperties);

--- a/src/NLog/Internal/ScopeContextAsyncState.cs
+++ b/src/NLog/Internal/ScopeContextAsyncState.cs
@@ -36,6 +36,7 @@
 namespace NLog.Internal
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
 
     /// <summary>
@@ -76,15 +77,16 @@ namespace NLog.Internal
     struct ScopeContextPropertyCollector
     {
         IReadOnlyCollection<KeyValuePair<string, object?>>? _allProperties;
-        List<KeyValuePair<string, object?>> _propertyCollector;
+        ICollection<KeyValuePair<string, object?>>? _propertyCollector;
 
         public bool IsCollectorEmpty => _allProperties is null || (_allProperties.Count == 0 && _propertyCollector is null);
 
         public bool IsCollectorInactive => _allProperties is null;
 
-        public ScopeContextPropertyCollector(List<KeyValuePair<string, object?>> propertyCollector)
+        public ScopeContextPropertyCollector(IReadOnlyCollection<KeyValuePair<string, object?>> allProperties, ICollection<KeyValuePair<string, object?>> propertyCollector)
         {
-            _allProperties = _propertyCollector = propertyCollector;
+            _allProperties = allProperties;
+            _propertyCollector = propertyCollector;
         }
 
         public IReadOnlyCollection<KeyValuePair<string, object?>> StartCaptureProperties(IScopeContextAsyncState? state)
@@ -125,11 +127,11 @@ namespace NLog.Internal
             }
         }
 
-        private static Dictionary<string, object?> MergeUniqueProperties(IReadOnlyCollection<KeyValuePair<string, object?>> currentProperties, IReadOnlyCollection<KeyValuePair<string, object?>> properties)
+        private static Dictionary<string, object?> MergeUniqueProperties(IReadOnlyCollection<KeyValuePair<string, object?>> newProperties, IReadOnlyCollection<KeyValuePair<string, object?>> existingProperties)
         {
-            var scopeProperties = new Dictionary<string, object?>(currentProperties.Count + properties.Count, ScopeContext.DefaultComparer);
-            ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(properties, scopeProperties);
-            ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(currentProperties, scopeProperties);
+            var scopeProperties = new Dictionary<string, object?>(newProperties.Count + existingProperties.Count, ScopeContext.DefaultComparer);
+            ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(newProperties, scopeProperties);
+            ScopeContextPropertyEnumerator<object>.TryAddScopePropertiesToDictionary(existingProperties, scopeProperties);
             return scopeProperties;
         }
 
@@ -145,8 +147,9 @@ namespace NLog.Internal
             // Must validate that collected properties are unique
             if (scopePropertyCount > 10 || !ScopeContextPropertyEnumerator<object?>.HasUniqueCollectionKeys(properties, ScopeContext.DefaultComparer))
             {
+                // The newest properties are added first, so do not overwrite with old values
                 var scopeProperties = new Dictionary<string, object?>(Math.Min(scopePropertyCount, 10), ScopeContext.DefaultComparer);
-                ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(properties, scopeProperties);
+                ScopeContextPropertyEnumerator<object>.TryAddScopePropertiesToDictionary(properties, scopeProperties);
                 return scopeProperties;
             }
 
@@ -163,14 +166,15 @@ namespace NLog.Internal
             {
                 if (_propertyCollector is null)
                 {
-                    _propertyCollector = new List<KeyValuePair<string, object?>>(Math.Max(4, _allProperties.Count + 1));
-                    _propertyCollector.Add(new KeyValuePair<string, object?>(propertyName, propertyValue));
-                    CollectProperties(_allProperties);
-                    _allProperties = _propertyCollector;
+                    var propertyCollector = new List<KeyValuePair<string, object?>>(Math.Max(4, _allProperties.Count + 1));
+                    _propertyCollector = propertyCollector;
+                    CollectProperties(_allProperties, propertyCollector);
+                    propertyCollector.Add(new KeyValuePair<string, object?>(propertyName, propertyValue));
+                    _allProperties = propertyCollector;
                 }
                 else
                 {
-                    _propertyCollector.Insert(0, new KeyValuePair<string, object?>(propertyName, propertyValue));
+                    _propertyCollector.Add(new KeyValuePair<string, object?>(propertyName, propertyValue));
                 }
             }
         }
@@ -185,38 +189,27 @@ namespace NLog.Internal
             {
                 if (_propertyCollector is null)
                 {
-                    _propertyCollector = new List<KeyValuePair<string, object?>>(Math.Max(4, _allProperties.Count + properties.Count));
-                    CollectProperties(properties);
-                    CollectProperties(_allProperties);
-                    _allProperties = _propertyCollector;
-                }
-                else if (_propertyCollector.Count == 0)
-                {
-                    CollectProperties(properties);
+                    var propertyCollector = new List<KeyValuePair<string, object?>>(Math.Max(4, _allProperties.Count + properties.Count));
+                    _propertyCollector = propertyCollector;
+                    CollectProperties(_allProperties, propertyCollector);
+                    CollectProperties(properties, propertyCollector);
+                    _allProperties = propertyCollector;
                 }
                 else
                 {
-                    int insertPosition = 0;
-                    using (var scopeEnumerator = new ScopeContextPropertyEnumerator<object?>(properties))
-                    {
-                        while (scopeEnumerator.MoveNext())
-                        {
-                            var property = scopeEnumerator.Current;
-                            _propertyCollector.Insert(insertPosition++, property);
-                        }
-                    }
+                    CollectProperties(properties, _propertyCollector);
                 }
             }
         }
 
-        private void CollectProperties(IReadOnlyCollection<KeyValuePair<string, object?>> properties)
+        private static void CollectProperties(IReadOnlyCollection<KeyValuePair<string, object?>> properties, ICollection<KeyValuePair<string, object?>> propertyCollector)
         {
             using (var scopeEnumerator = new ScopeContextPropertyEnumerator<object?>(properties))
             {
                 while (scopeEnumerator.MoveNext())
                 {
                     var property = scopeEnumerator.Current;
-                    _propertyCollector.Add(property);
+                    propertyCollector.Add(property);
                 }
             }
         }
@@ -277,6 +270,7 @@ namespace NLog.Internal
     /// </summary>
     internal interface IScopeContextPropertiesAsyncState : IScopeContextAsyncState
     {
+        int PropertyCount { get; }
     }
 
     /// <summary>
@@ -327,6 +321,7 @@ namespace NLog.Internal
     {
         long IScopeContextAsyncState.NestedStateTimestamp => 0;
         object? IScopeContextAsyncState.NestedState => null;
+        int IScopeContextPropertiesAsyncState.PropertyCount => _allProperties?.Count ?? 1;
         public string Name { get; }
         public TValue? Value { get; }
         private IReadOnlyCollection<KeyValuePair<string, object?>>? _allProperties;
@@ -373,29 +368,96 @@ namespace NLog.Internal
     /// <summary>
     /// Immutable state for ScopeContext Multiple Properties (MDLC)
     /// </summary>
+    internal sealed class ScopeContextMergeAsyncState : ScopeContextAsyncState, IScopeContextPropertiesAsyncState, ICollection<KeyValuePair<string, object?>>, IReadOnlyCollection<KeyValuePair<string, object?>>
+    {
+        int IScopeContextPropertiesAsyncState.PropertyCount => MergedProperties.Count;
+
+        public long NestedStateTimestamp { get; }
+        public object? NestedState { get; }
+        public Dictionary<string, object?> MergedProperties { get; }
+
+        public int Count => MergedProperties.Count;
+
+        public ScopeContextMergeAsyncState(IScopeContextAsyncState? parent, int initialCapacity)
+          : base(parent)
+        {
+            MergedProperties = new Dictionary<string, object?>(initialCapacity, ScopeContext.DefaultComparer);
+        }
+
+        public ScopeContextMergeAsyncState(IScopeContextAsyncState? parent, int initialCapacity, object? nestedState)
+            : base(parent)
+        {
+            MergedProperties = new Dictionary<string, object?>(initialCapacity, ScopeContext.DefaultComparer);
+            NestedState = nestedState;
+            NestedStateTimestamp = ScopeContext.GetNestedContextTimestampNow();
+        }
+
+        public IReadOnlyCollection<KeyValuePair<string, object?>>? CaptureContextProperties(ref ScopeContextPropertyCollector contextCollector)
+        {
+            return contextCollector.CaptureCompleted(MergedProperties);     // We are done
+        }
+
+        public IList<object>? CloneNestedContext(ref ScopeContextNestedStateCollector contextCollector)
+        {
+            return contextCollector.CollectNestedStates(NestedState, Parent);
+        }
+
+        public void Add(KeyValuePair<string, object?> item)
+        {
+            // Newest properties are added first, so do not overwrite with old values
+#if NETSTANDARD2_1_OR_GREATER || NET
+            MergedProperties.TryAdd(item.Key, item.Value);
+#else
+            if (!MergedProperties.ContainsKey(item.Key))
+                MergedProperties.Add(item.Key, item.Value);
+#endif
+        }
+
+        void ICollection<KeyValuePair<string, object?>>.Clear()
+        {
+            MergedProperties.Clear();
+        }
+
+        bool ICollection<KeyValuePair<string, object?>>.Contains(KeyValuePair<string, object?> item)
+        {
+            return MergedProperties.ContainsKey(item.Key);
+        }
+
+        void ICollection<KeyValuePair<string, object?>>.CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex)
+        {
+            ((ICollection<KeyValuePair<string, object?>>)MergedProperties).CopyTo(array, arrayIndex);
+        }
+
+        bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item)
+        {
+            return MergedProperties.Remove(item.Key);
+        }
+
+        bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => ((ICollection<KeyValuePair<string, object?>>)MergedProperties).IsReadOnly;
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            return MergedProperties.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable)MergedProperties).GetEnumerator();
+        }
+    }
+
+    /// <summary>
+    /// Immutable state for ScopeContext Multiple Properties (MDLC)
+    /// </summary>
     internal sealed class ScopeContextPropertiesAsyncState<TValue> : ScopeContextAsyncState, IScopeContextPropertiesAsyncState, IReadOnlyCollection<KeyValuePair<string, object?>>
     {
+        int IScopeContextPropertiesAsyncState.PropertyCount => _allProperties?.Count ?? _scopeProperties.Count;
+
         public long NestedStateTimestamp { get; }
         public object? NestedState { get; }
 
         private readonly IReadOnlyCollection<KeyValuePair<string, TValue?>> _scopeProperties;
         private IReadOnlyCollection<KeyValuePair<string, object?>>? _allProperties;
-
-        public ScopeContextPropertiesAsyncState(IScopeContextAsyncState? parent, Dictionary<string, object?> allProperties)
-            : base(parent)
-        {
-            _allProperties = allProperties; // Collapsed dictionary that includes all properties from parent scopes with case-insensitive-comparer
-            _scopeProperties = Array.Empty<KeyValuePair<string, TValue?>>();
-        }
-
-        public ScopeContextPropertiesAsyncState(IScopeContextAsyncState? parent, Dictionary<string, object?> allProperties, object? nestedState)
-            : base(parent)
-        {
-            _allProperties = allProperties; // Collapsed dictionary that includes all properties from parent scopes with case-insensitive-comparer
-            _scopeProperties = Array.Empty<KeyValuePair<string, TValue?>>();
-            NestedState = nestedState;
-            NestedStateTimestamp = ScopeContext.GetNestedContextTimestampNow();
-        }
 
         public ScopeContextPropertiesAsyncState(IScopeContextAsyncState? parent, IReadOnlyCollection<KeyValuePair<string, TValue?>> scopeProperties)
             : base(parent)

--- a/src/NLog/Internal/ScopeContextAsyncState.cs
+++ b/src/NLog/Internal/ScopeContextAsyncState.cs
@@ -36,7 +36,6 @@
 namespace NLog.Internal
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
 
     /// <summary>
@@ -368,63 +367,6 @@ namespace NLog.Internal
     /// <summary>
     /// Immutable state for ScopeContext Multiple Properties (MDLC)
     /// </summary>
-    internal sealed class ScopeContextMergeAsyncState : ScopeContextAsyncState, IScopeContextPropertiesAsyncState, ICollection<KeyValuePair<string, object?>>, IReadOnlyCollection<KeyValuePair<string, object?>>
-    {
-        int IScopeContextPropertiesAsyncState.PropertyCount => MergedProperties.Count;
-
-        public long NestedStateTimestamp { get; }
-        public object? NestedState { get; }
-        public Dictionary<string, object?> MergedProperties { get; }
-
-        public int Count => MergedProperties.Count;
-
-        public ScopeContextMergeAsyncState(IScopeContextAsyncState? parent, int initialCapacity)
-          : base(parent)
-        {
-            MergedProperties = new Dictionary<string, object?>(initialCapacity, ScopeContext.DefaultComparer);
-        }
-
-        public ScopeContextMergeAsyncState(IScopeContextAsyncState? parent, int initialCapacity, object? nestedState)
-            : base(parent)
-        {
-            MergedProperties = new Dictionary<string, object?>(initialCapacity, ScopeContext.DefaultComparer);
-            NestedState = nestedState;
-            NestedStateTimestamp = ScopeContext.GetNestedContextTimestampNow();
-        }
-
-        public IReadOnlyCollection<KeyValuePair<string, object?>>? CaptureContextProperties(ref ScopeContextPropertyCollector contextCollector)
-        {
-            return contextCollector.CaptureCompleted(MergedProperties);     // We are done
-        }
-
-        public IList<object>? CloneNestedContext(ref ScopeContextNestedStateCollector contextCollector)
-        {
-            return contextCollector.CollectNestedStates(NestedState, Parent);
-        }
-
-        public void Add(KeyValuePair<string, object?> item)
-        {
-            // Newest properties are added first, so do not overwrite with old values
-#if NETSTANDARD2_1_OR_GREATER || NET
-            MergedProperties.TryAdd(item.Key, item.Value);
-#else
-            if (!MergedProperties.ContainsKey(item.Key))
-                MergedProperties.Add(item.Key, item.Value);
-#endif
-        }
-
-        void ICollection<KeyValuePair<string, object?>>.Clear() => MergedProperties.Clear();
-        bool ICollection<KeyValuePair<string, object?>>.Contains(KeyValuePair<string, object?> item) => MergedProperties.ContainsKey(item.Key);
-        void ICollection<KeyValuePair<string, object?>>.CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex) => ((ICollection<KeyValuePair<string, object?>>)MergedProperties).CopyTo(array, arrayIndex);
-        bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item) => MergedProperties.Remove(item.Key);
-        bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => ((ICollection<KeyValuePair<string, object?>>)MergedProperties).IsReadOnly;
-        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => MergedProperties.GetEnumerator();
-        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)MergedProperties).GetEnumerator();
-    }
-
-    /// <summary>
-    /// Immutable state for ScopeContext Multiple Properties (MDLC)
-    /// </summary>
     internal sealed class ScopeContextPropertiesAsyncState<TValue> : ScopeContextAsyncState, IScopeContextPropertiesAsyncState, IReadOnlyCollection<KeyValuePair<string, object?>>
     {
         int IScopeContextPropertiesAsyncState.PropertyCount => _allProperties?.Count ?? _scopeProperties.Count;
@@ -485,6 +427,72 @@ namespace NLog.Internal
         IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() => new ScopeContextPropertyEnumerator<TValue?>(_scopeProperties);
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => new ScopeContextPropertyEnumerator<TValue?>(_scopeProperties);
+    }
+
+    /// <summary>
+    /// Special merged state that can collapse multiple property-scopes into single scope (Avoid huge object-graphs)
+    /// </summary>
+    internal sealed class ScopeContextMergeAsyncState : ScopeContextAsyncState, IScopeContextPropertiesAsyncState, ICollection<KeyValuePair<string, object?>>, IReadOnlyCollection<KeyValuePair<string, object?>>
+    {
+        int IScopeContextPropertiesAsyncState.PropertyCount => MergedProperties.Count;
+
+        public long NestedStateTimestamp { get; }
+        public object? NestedState { get; }
+        public Dictionary<string, object?> MergedProperties { get; }
+
+        public int Count => MergedProperties.Count;
+
+        public ScopeContextMergeAsyncState(IScopeContextAsyncState? parent, int initialCapacity)
+          : base(parent)
+        {
+            MergedProperties = new Dictionary<string, object?>(initialCapacity, ScopeContext.DefaultComparer);
+        }
+
+        public ScopeContextMergeAsyncState(IScopeContextAsyncState? parent, int initialCapacity, object? nestedState)
+            : base(parent)
+        {
+            MergedProperties = new Dictionary<string, object?>(initialCapacity, ScopeContext.DefaultComparer);
+            NestedState = nestedState;
+            NestedStateTimestamp = ScopeContext.GetNestedContextTimestampNow();
+        }
+
+        public void CollectMergedProperties<TValue>(IReadOnlyCollection<KeyValuePair<string, TValue?>> properties, IScopeContextAsyncState? parent)
+        {
+            ScopeContextPropertyEnumerator<TValue>.CopyScopePropertiesToDictionary(properties, MergedProperties);
+            var propertyCollector = new ScopeContextPropertyCollector(MergedProperties, this);
+            var allProperties = propertyCollector.StartCaptureProperties(parent);
+            if (MergedProperties.Count == 0)
+                ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(allProperties, MergedProperties);
+        }
+
+        public IReadOnlyCollection<KeyValuePair<string, object?>>? CaptureContextProperties(ref ScopeContextPropertyCollector contextCollector)
+        {
+            return contextCollector.CaptureCompleted(MergedProperties);     // We are done
+        }
+
+        public IList<object>? CloneNestedContext(ref ScopeContextNestedStateCollector contextCollector)
+        {
+            return contextCollector.CollectNestedStates(NestedState, Parent);
+        }
+
+        public void Add(KeyValuePair<string, object?> item)
+        {
+            // Newest properties are added first, so do not overwrite with old values
+#if NETSTANDARD2_1_OR_GREATER || NET
+            MergedProperties.TryAdd(item.Key, item.Value);
+#else
+            if (!MergedProperties.ContainsKey(item.Key))
+                MergedProperties.Add(item.Key, item.Value);
+#endif
+        }
+
+        void ICollection<KeyValuePair<string, object?>>.Clear() => MergedProperties.Clear();
+        bool ICollection<KeyValuePair<string, object?>>.Contains(KeyValuePair<string, object?> item) => MergedProperties.ContainsKey(item.Key);
+        void ICollection<KeyValuePair<string, object?>>.CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex) => ((ICollection<KeyValuePair<string, object?>>)MergedProperties).CopyTo(array, arrayIndex);
+        bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item) => MergedProperties.Remove(item.Key);
+        bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => ((ICollection<KeyValuePair<string, object?>>)MergedProperties).IsReadOnly;
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => MergedProperties.GetEnumerator();
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => ((System.Collections.IEnumerable)MergedProperties).GetEnumerator();
     }
 
     /// <summary>

--- a/src/NLog/Internal/ScopeContextAsyncState.cs
+++ b/src/NLog/Internal/ScopeContextAsyncState.cs
@@ -413,37 +413,13 @@ namespace NLog.Internal
 #endif
         }
 
-        void ICollection<KeyValuePair<string, object?>>.Clear()
-        {
-            MergedProperties.Clear();
-        }
-
-        bool ICollection<KeyValuePair<string, object?>>.Contains(KeyValuePair<string, object?> item)
-        {
-            return MergedProperties.ContainsKey(item.Key);
-        }
-
-        void ICollection<KeyValuePair<string, object?>>.CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex)
-        {
-            ((ICollection<KeyValuePair<string, object?>>)MergedProperties).CopyTo(array, arrayIndex);
-        }
-
-        bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item)
-        {
-            return MergedProperties.Remove(item.Key);
-        }
-
+        void ICollection<KeyValuePair<string, object?>>.Clear() => MergedProperties.Clear();
+        bool ICollection<KeyValuePair<string, object?>>.Contains(KeyValuePair<string, object?> item) => MergedProperties.ContainsKey(item.Key);
+        void ICollection<KeyValuePair<string, object?>>.CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex) => ((ICollection<KeyValuePair<string, object?>>)MergedProperties).CopyTo(array, arrayIndex);
+        bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item) => MergedProperties.Remove(item.Key);
         bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => ((ICollection<KeyValuePair<string, object?>>)MergedProperties).IsReadOnly;
-
-        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
-        {
-            return MergedProperties.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return ((IEnumerable)MergedProperties).GetEnumerator();
-        }
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => MergedProperties.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)MergedProperties).GetEnumerator();
     }
 
     /// <summary>

--- a/src/NLog/Internal/ScopeContextPropertyEnumerator.cs
+++ b/src/NLog/Internal/ScopeContextPropertyEnumerator.cs
@@ -91,6 +91,23 @@ namespace NLog.Internal
                 }
             }
         }
+
+        public static void TryAddScopePropertiesToDictionary(IReadOnlyCollection<KeyValuePair<string, TValue?>> parentContext, Dictionary<string, object?> scopeDictionary)
+        {
+            using (var propertyEnumerator = new ScopeContextPropertyEnumerator<TValue?>(parentContext))
+            {
+                while (propertyEnumerator.MoveNext())
+                {
+                    var item = propertyEnumerator.Current;
+#if NETSTANDARD2_1_OR_GREATER || NET
+                    scopeDictionary.TryAdd(item.Key, item.Value);
+#else
+                    if (!scopeDictionary.ContainsKey(item.Key))
+                        scopeDictionary.Add(item.Key, item.Value);
+#endif
+                }
+            }
+        }
 #endif
 
         public static bool HasUniqueCollectionKeys(IEnumerable<KeyValuePair<string, TValue>> scopeProperties, IEqualityComparer<string> keyComparer)

--- a/src/NLog/ScopeContext.cs
+++ b/src/NLog/ScopeContext.cs
@@ -73,13 +73,13 @@ namespace NLog
                 var parent = GetAsyncLocalContext();
                 if (nestedState is null)
                 {
-                    var allProperties = ScopeContextPropertiesCollapsed.BuildCollapsedDictionary(parent, properties.Count);
-                    if (allProperties != null)
+                    var existingPropertyCount = ScopeContextPropertiesCollapsed.TryCollapseExistingProperties(parent);
+                    if (existingPropertyCount.HasValue)
                     {
-                        // Collapse all 3 property-scopes into a collapsed scope, and return bookmark that can restore original parent (Avoid huge object-graphs)
-                        ScopeContextPropertyEnumerator<object?>.CopyScopePropertiesToDictionary(properties, allProperties);
-
-                        var collapsedState = new ScopeContextPropertiesAsyncState<object>(parent?.Parent?.Parent, allProperties, nestedState);
+                        var collapsedState = new ScopeContextMergeAsyncState(parent?.Parent?.Parent, existingPropertyCount.Value + properties.Count, nestedState);
+                        ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(properties, collapsedState.MergedProperties);
+                        var propertyCollector = new ScopeContextPropertyCollector(collapsedState.MergedProperties, collapsedState);
+                        propertyCollector.StartCaptureProperties(parent);
                         SetAsyncLocalContext(collapsedState);
                         return new ScopeContextPropertiesCollapsed(parent, collapsedState);
                     }
@@ -124,13 +124,14 @@ namespace NLog
 #if !NET45
             var parent = GetAsyncLocalContext();
 
-            var allProperties = ScopeContextPropertiesCollapsed.BuildCollapsedDictionary(parent, properties.Count);
-            if (allProperties != null)
+            var existingPropertyCount = ScopeContextPropertiesCollapsed.TryCollapseExistingProperties(parent);
+            if (existingPropertyCount.HasValue)
             {
                 // Collapse all 3 property-scopes into a collapsed scope, and return bookmark that can restore original parent (Avoid huge object-graphs)
-                ScopeContextPropertyEnumerator<TValue>.CopyScopePropertiesToDictionary(properties, allProperties);
-
-                var collapsedState = new ScopeContextPropertiesAsyncState<object>(parent?.Parent?.Parent, allProperties);
+                var collapsedState = new ScopeContextMergeAsyncState(parent?.Parent?.Parent, existingPropertyCount.Value + properties.Count);
+                ScopeContextPropertyEnumerator<TValue>.CopyScopePropertiesToDictionary(properties, collapsedState.MergedProperties);
+                var propertyCollector = new ScopeContextPropertyCollector(collapsedState.MergedProperties, collapsedState);
+                propertyCollector.StartCaptureProperties(parent);
                 SetAsyncLocalContext(collapsedState);
                 return new ScopeContextPropertiesCollapsed(parent, collapsedState);
             }
@@ -158,13 +159,14 @@ namespace NLog
 #if !NET35 && !NET40 && !NET45
             var parent = GetAsyncLocalContext();
 
-            var allProperties = ScopeContextPropertiesCollapsed.BuildCollapsedDictionary(parent, 1);
-            if (allProperties != null)
+            var existingPropertyCount = ScopeContextPropertiesCollapsed.TryCollapseExistingProperties(parent);
+            if (existingPropertyCount.HasValue)
             {
                 // Collapse all 3 property-scopes into a collapsed scope, and return bookmark that can restore original parent (Avoid huge object-graphs)
-                allProperties[key] = value;
-
-                var collapsedState = new ScopeContextPropertiesAsyncState<object>(parent?.Parent?.Parent, allProperties);
+                var collapsedState = new ScopeContextMergeAsyncState(parent?.Parent?.Parent, existingPropertyCount.Value + 1);
+                collapsedState.MergedProperties[key] = value;
+                var propertyCollector = new ScopeContextPropertyCollector(collapsedState.MergedProperties, collapsedState);
+                propertyCollector.StartCaptureProperties(parent);
                 SetAsyncLocalContext(collapsedState);
                 return new ScopeContextPropertiesCollapsed(parent, collapsedState);
             }
@@ -493,20 +495,15 @@ namespace NLog
                 _collapsed = collapsed;
             }
 
-            public static Dictionary<string, object?>? BuildCollapsedDictionary(IScopeContextAsyncState? parent, int initialCapacity)
+            public static int? TryCollapseExistingProperties(IScopeContextAsyncState? parent)
             {
                 if (parent is IScopeContextPropertiesAsyncState parentProperties && parentProperties.Parent is IScopeContextPropertiesAsyncState grandParentProperties)
                 {
                     if (parentProperties.NestedState is null && grandParentProperties.NestedState is null)
                     {
-                        var propertyCollectorList = new List<KeyValuePair<string, object?>>();   // Marks the collector as active
-                        var propertyCollector = new ScopeContextPropertyCollector(propertyCollectorList);
-                        var propertyCollection = propertyCollector.StartCaptureProperties(parent);
-                        if (propertyCollectorList.Count > 0 && propertyCollection is Dictionary<string, object?> propertyDictionary)
-                            return propertyDictionary;  // New property collector was built from the list
-                        propertyDictionary = new Dictionary<string, object?>(propertyCollection.Count + initialCapacity, ScopeContext.DefaultComparer);
-                        ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(propertyCollection, propertyDictionary);
-                        return propertyDictionary;
+                        var parentPropertyCount = parentProperties.PropertyCount;
+                        var grandParentPropertyCount = grandParentProperties.PropertyCount;
+                        return (parentPropertyCount > 1 && grandParentPropertyCount < parentPropertyCount) ? parentPropertyCount : (parentPropertyCount + grandParentPropertyCount);
                     }
                 }
 

--- a/src/NLog/ScopeContext.cs
+++ b/src/NLog/ScopeContext.cs
@@ -76,12 +76,9 @@ namespace NLog
                     var existingPropertyCount = ScopeContextPropertiesCollapsed.TryCollapseExistingProperties(parent);
                     if (existingPropertyCount.HasValue)
                     {
+                        // Collapse all 3 property-scopes into a collapsed scope, and return bookmark that can restore original parent (Avoid huge object-graphs)
                         var collapsedState = new ScopeContextMergeAsyncState(parent?.Parent?.Parent, existingPropertyCount.Value + properties.Count, nestedState);
-                        ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(properties, collapsedState.MergedProperties);
-                        var propertyCollector = new ScopeContextPropertyCollector(collapsedState.MergedProperties, collapsedState);
-                        var allProperties = propertyCollector.StartCaptureProperties(parent);
-                        if (collapsedState.MergedProperties.Count == 0)
-                            ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(allProperties, collapsedState.MergedProperties);
+                        collapsedState.CollectMergedProperties(properties, parent);
                         SetAsyncLocalContext(collapsedState);
                         return new ScopeContextPropertiesCollapsed(parent, collapsedState);
                     }
@@ -131,11 +128,7 @@ namespace NLog
             {
                 // Collapse all 3 property-scopes into a collapsed scope, and return bookmark that can restore original parent (Avoid huge object-graphs)
                 var collapsedState = new ScopeContextMergeAsyncState(parent?.Parent?.Parent, existingPropertyCount.Value + properties.Count);
-                ScopeContextPropertyEnumerator<TValue>.CopyScopePropertiesToDictionary(properties, collapsedState.MergedProperties);
-                var propertyCollector = new ScopeContextPropertyCollector(collapsedState.MergedProperties, collapsedState);
-                var allProperties = propertyCollector.StartCaptureProperties(parent);
-                if (collapsedState.MergedProperties.Count == 0)
-                    ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(allProperties, collapsedState.MergedProperties);
+                collapsedState.CollectMergedProperties(properties, parent);
                 SetAsyncLocalContext(collapsedState);
                 return new ScopeContextPropertiesCollapsed(parent, collapsedState);
             }
@@ -735,7 +728,7 @@ namespace NLog
         private static Dictionary<string, object?>? PushPropertiesCallContext<TValue>(IReadOnlyCollection<KeyValuePair<string, TValue>> properties)
         {
             var oldContext = GetMappedContextCallContext();
-            var newContext = oldContext?.Count > 0 ? new Dictionary<string, object?>(oldContext.Count + properties.Count, DefaultComparer) : new Dictionary<string, object?>(properties.Count, DefaultComparer);
+            var newContext = new Dictionary<string, object?>((oldContext?.Count ?? 0) + properties.Count, DefaultComparer);
             using (var scopeEnumerator = new ScopeContextPropertyEnumerator<TValue>(properties))
             {
                 while (scopeEnumerator.MoveNext())
@@ -760,7 +753,7 @@ namespace NLog
         private static Dictionary<string, object?>? PushPropertyCallContext<TValue>(string propertyName, TValue propertyValue)
         {
             var oldContext = GetMappedContextCallContext();
-            var newContext = oldContext?.Count > 0 ? new Dictionary<string, object?>(oldContext.Count + 1, DefaultComparer) : new Dictionary<string, object?>(DefaultComparer);
+            var newContext = new Dictionary<string, object?>((oldContext?.Count ?? 0) + 1, DefaultComparer);
             SetPropertyCallContext(propertyName, propertyValue, newContext);
             if (oldContext?.Count > 0)
             {

--- a/src/NLog/ScopeContext.cs
+++ b/src/NLog/ScopeContext.cs
@@ -609,7 +609,9 @@ namespace NLog
             var oldContext = GetMappedContextCallContext();
             if (oldContext?.ContainsKey(key) == true)
             {
-                var newContext = CloneMappedContext(oldContext, 0);
+                var newContext = new Dictionary<string, object?>(oldContext.Count, DefaultComparer);
+                foreach (var item in oldContext)
+                    newContext.Add(item.Key, item.Value);
                 newContext.Remove(key);
                 SetMappedContextCallContext(newContext);
             }
@@ -729,13 +731,21 @@ namespace NLog
         private static Dictionary<string, object?>? PushPropertiesCallContext<TValue>(IReadOnlyCollection<KeyValuePair<string, TValue>> properties)
         {
             var oldContext = GetMappedContextCallContext();
-            var newContext = CloneMappedContext(oldContext, properties.Count);
+            var newContext = oldContext?.Count > 0 ? new Dictionary<string, object?>(oldContext.Count + properties.Count, DefaultComparer) : new Dictionary<string, object?>(properties.Count, DefaultComparer);
             using (var scopeEnumerator = new ScopeContextPropertyEnumerator<TValue>(properties))
             {
                 while (scopeEnumerator.MoveNext())
                 {
                     var item = scopeEnumerator.Current;
                     SetPropertyCallContext(item.Key, item.Value, newContext);
+                }
+            }
+            if (oldContext?.Count > 0)
+            {
+                foreach (var item in oldContext)
+                {
+                    if (!newContext.ContainsKey(item.Key))
+                        newContext.Add(item.Key, item.Value);
                 }
             }
             SetMappedContextCallContext(newContext);
@@ -746,8 +756,24 @@ namespace NLog
         private static Dictionary<string, object?>? PushPropertyCallContext<TValue>(string propertyName, TValue propertyValue)
         {
             var oldContext = GetMappedContextCallContext();
-            var newContext = CloneMappedContext(oldContext, 1);
+            var newContext = oldContext?.Count > 0 ? new Dictionary<string, object?>(oldContext.Count + 1, DefaultComparer) : new Dictionary<string, object?>(DefaultComparer);
             SetPropertyCallContext(propertyName, propertyValue, newContext);
+            if (oldContext?.Count > 0)
+            {
+                if (!oldContext.ContainsKey(propertyName))
+                {
+                    foreach (var item in oldContext)
+                        newContext.Add(item.Key, item.Value);
+                }
+                else
+                {
+                    foreach (var item in oldContext)
+                    {
+                        if (!DefaultComparer.Equals(item.Key, propertyName))
+                            newContext.Add(item.Key, item.Value);
+                    }
+                }
+            }
             SetMappedContextCallContext(newContext);
             return oldContext;
         }
@@ -770,19 +796,6 @@ namespace NLog
                     yield return item;
                 }
             }
-        }
-
-        private static Dictionary<string, object?> CloneMappedContext(Dictionary<string, object?>? oldContext, int initialCapacity = 0)
-        {
-            if (oldContext?.Count > 0)
-            {
-                var dictionary = new Dictionary<string, object?>(oldContext.Count + initialCapacity, DefaultComparer);
-                foreach (var keyValue in oldContext)
-                    dictionary[keyValue.Key] = keyValue.Value;
-                return dictionary;
-            }
-
-            return new Dictionary<string, object?>(initialCapacity, DefaultComparer);
         }
 
         private static void SetPropertyCallContext<TValue>(string item, TValue? value, Dictionary<string, object?> mappedContext)

--- a/src/NLog/ScopeContext.cs
+++ b/src/NLog/ScopeContext.cs
@@ -79,7 +79,9 @@ namespace NLog
                         var collapsedState = new ScopeContextMergeAsyncState(parent?.Parent?.Parent, existingPropertyCount.Value + properties.Count, nestedState);
                         ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(properties, collapsedState.MergedProperties);
                         var propertyCollector = new ScopeContextPropertyCollector(collapsedState.MergedProperties, collapsedState);
-                        propertyCollector.StartCaptureProperties(parent);
+                        var allProperties = propertyCollector.StartCaptureProperties(parent);
+                        if (collapsedState.MergedProperties.Count == 0)
+                            ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(allProperties, collapsedState.MergedProperties);
                         SetAsyncLocalContext(collapsedState);
                         return new ScopeContextPropertiesCollapsed(parent, collapsedState);
                     }
@@ -131,7 +133,9 @@ namespace NLog
                 var collapsedState = new ScopeContextMergeAsyncState(parent?.Parent?.Parent, existingPropertyCount.Value + properties.Count);
                 ScopeContextPropertyEnumerator<TValue>.CopyScopePropertiesToDictionary(properties, collapsedState.MergedProperties);
                 var propertyCollector = new ScopeContextPropertyCollector(collapsedState.MergedProperties, collapsedState);
-                propertyCollector.StartCaptureProperties(parent);
+                var allProperties = propertyCollector.StartCaptureProperties(parent);
+                if (collapsedState.MergedProperties.Count == 0)
+                    ScopeContextPropertyEnumerator<object>.CopyScopePropertiesToDictionary(allProperties, collapsedState.MergedProperties);
                 SetAsyncLocalContext(collapsedState);
                 return new ScopeContextPropertiesCollapsed(parent, collapsedState);
             }

--- a/tests/NLog.UnitTests/Contexts/MappedDiagnosticsContextTests.cs
+++ b/tests/NLog.UnitTests/Contexts/MappedDiagnosticsContextTests.cs
@@ -222,7 +222,7 @@ namespace NLog.UnitTests.Contexts
             MappedDiagnosticsContext.Set(itemNotRemovedKey, "itemNotRemoved");
             using (MappedDiagnosticsContext.SetScoped(itemRemovedKey, "itemRemoved"))
             {
-                Assert.Equal(MappedDiagnosticsContext.GetNames(), new[] { itemNotRemovedKey, itemRemovedKey });
+                Assert.Equal(MappedDiagnosticsContext.GetNames(), new[] { itemRemovedKey, itemNotRemovedKey });
             }
 
             Assert.Equal(MappedDiagnosticsContext.GetNames(), new[] { itemNotRemovedKey });

--- a/tests/NLog.UnitTests/Contexts/MappedDiagnosticsLogicalContextTests.cs
+++ b/tests/NLog.UnitTests/Contexts/MappedDiagnosticsLogicalContextTests.cs
@@ -336,7 +336,7 @@ namespace NLog.UnitTests.Contexts
             MappedDiagnosticsLogicalContext.Set(itemNotRemovedKey, "itemNotRemoved");
             using (MappedDiagnosticsLogicalContext.SetScoped(itemRemovedKey, "itemRemoved"))
             {
-                Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[] { itemNotRemovedKey, itemRemovedKey });
+                Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[] { itemRemovedKey, itemNotRemovedKey });
             }
 
             Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[] { itemNotRemovedKey });
@@ -378,7 +378,7 @@ namespace NLog.UnitTests.Contexts
                 new KeyValuePair<string, object>(item2Key, "2")
             }))
             {
-                Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[] { itemNotRemovedKey, item1Key, item2Key });
+                Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[] { item1Key, item2Key, itemNotRemovedKey });
             }
 
             Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[] { itemNotRemovedKey });
@@ -391,7 +391,7 @@ namespace NLog.UnitTests.Contexts
                 new KeyValuePair<string, object>(item4Key, "4")
             }))
             {
-                Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[] { itemNotRemovedKey, item1Key, item2Key, item3Key, item4Key });
+                Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[] { item1Key, item2Key, item3Key, item4Key, itemNotRemovedKey });
             }
 
             Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[] { itemNotRemovedKey });
@@ -414,7 +414,7 @@ namespace NLog.UnitTests.Contexts
                 new KeyValuePair<string, object>(item2Key, "2")
             }))
             {
-                Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[] { itemNotRemovedKey, item1Key, item2Key });
+                Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[] { item1Key, item2Key, itemNotRemovedKey });
             }
 
             Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[] { itemNotRemovedKey });
@@ -452,7 +452,7 @@ namespace NLog.UnitTests.Contexts
 
                 Assert.Equal(MappedDiagnosticsLogicalContext.GetNames(), new[]
                 {
-                    itemNotRemovedKey, item1Key, item2Key, item3Key, item4Key
+                    item1Key, item2Key, item3Key, item4Key, itemNotRemovedKey
                 });
 
                 Assert.Equal("itemNotRemoved", MappedDiagnosticsLogicalContext.Get(itemNotRemovedKey));

--- a/tests/NLog.UnitTests/Contexts/ScopeContextTest.cs
+++ b/tests/NLog.UnitTests/Contexts/ScopeContextTest.cs
@@ -905,7 +905,6 @@ namespace NLog.UnitTests.Contexts
 
                         using (ScopeContext.PushProperties(new[] { new KeyValuePair<string, object>("Scope8", "World8"), new KeyValuePair<string, object>("Scope7", "World7") }))
                         {
-                            // Scope4 is top-of-stack and its parent contains the collapsed properties.
                             collection1 = ScopeContext.GetAllProperties();
                             collection2 = ScopeContext.GetAllProperties();
                             Assert.Same(collection1, collection2);

--- a/tests/NLog.UnitTests/Contexts/ScopeContextTest.cs
+++ b/tests/NLog.UnitTests/Contexts/ScopeContextTest.cs
@@ -830,18 +830,14 @@ namespace NLog.UnitTests.Contexts
                 {
                     var collection1 = ScopeContext.GetAllProperties();
                     var collection2 = ScopeContext.GetAllProperties();
-#if !NET35 && !NET40 && !NET45
                     Assert.Same(collection1, collection2);
-#endif
                     twoProperties = collection1.ToList();
 
                     using (ScopeContext.PushProperty("Scope3", "World3"))
                     {
                         collection1 = ScopeContext.GetAllProperties();
                         collection2 = ScopeContext.GetAllProperties();
-#if !NET35 && !NET40 && !NET45
                         Assert.Same(collection1, collection2);
-#endif
                         threeProperties = collection1.ToList();
 
                         using (ScopeContext.PushProperty("Scope4", "World4"))
@@ -849,9 +845,7 @@ namespace NLog.UnitTests.Contexts
                             // Scope4 is top-of-stack and its parent contains the collapsed properties.
                             collection1 = ScopeContext.GetAllProperties();
                             collection2 = ScopeContext.GetAllProperties();
-#if !NET35 && !NET40 && !NET45
                             Assert.Same(collection1, collection2);
-#endif
                             fourProperties = collection1.ToList();
                         }
                     }
@@ -860,20 +854,98 @@ namespace NLog.UnitTests.Contexts
 
             // Assert
             Assert.Equal(2, twoProperties.Count);
-            Assert.Equal("Scope2", twoProperties[0].Key);  // Newest scope added first, since top of stack, so most optimal
+            Assert.Equal("Scope2", twoProperties[0].Key);   // Newest scope added first, since top of stack, so most optimal
             Assert.Equal("Scope1", twoProperties[1].Key);
 
             Assert.Equal(3, threeProperties.Count);
-            Assert.Equal("Scope3", threeProperties[0].Key);  // Newest scope added first, since top of stack, so most optimal
+            Assert.Equal("Scope3", threeProperties[0].Key); // Newest scope added first, since top of stack, so most optimal
             Assert.Equal("Scope2", threeProperties[1].Key);
             Assert.Equal("Scope1", threeProperties[2].Key);
+
+            Assert.Equal(4, fourProperties.Count);
+            Assert.Equal("Scope4", fourProperties[0].Key);  // Newest scope added first, since top of stack, so most optimal
+            Assert.Equal("Scope3", fourProperties[1].Key);
+            Assert.Equal("Scope2", fourProperties[2].Key);
+            Assert.Equal("Scope1", fourProperties[3].Key);
+        }
+
+#if !NET35 && !NET40
+        [Fact]
+        public void ScopeContextMultiPropertiesCollapseObjectGraph()
+        {
+            // Arrange
+            ScopeContext.Clear();
+
+            // Act
+            List<KeyValuePair<string, object>> twoProperties;
+            List<KeyValuePair<string, object>> fourProperties;
+            List<KeyValuePair<string, object>> sixProperties;
+            List<KeyValuePair<string, object>> eightProperties;
+
+            using (ScopeContext.PushProperties(new[] { new KeyValuePair<string, object>("Scope2", "World2"), new KeyValuePair<string, object>("Scope1", "World1") }))
+            {
+                var collection1 = ScopeContext.GetAllProperties();
+                var collection2 = ScopeContext.GetAllProperties();
+                Assert.Same(collection1, collection2);
+                twoProperties = collection1.ToList();
+
+                using (ScopeContext.PushProperties(new[] { new KeyValuePair<string, object>("Scope4", "World4"), new KeyValuePair<string, object>("Scope3", "World3") }))
+                {
+                    collection1 = ScopeContext.GetAllProperties();
+                    collection2 = ScopeContext.GetAllProperties();
+                    Assert.Same(collection1, collection2);
+                    fourProperties = collection1.ToList();
+
+                    using (ScopeContext.PushProperties(new[] { new KeyValuePair<string, object>("Scope6", "World6"), new KeyValuePair<string, object>("Scope5", "World5") }))
+                    {
+                        collection1 = ScopeContext.GetAllProperties();
+                        collection2 = ScopeContext.GetAllProperties();
+                        Assert.Same(collection1, collection2);
+                        sixProperties = collection1.ToList();
+
+                        using (ScopeContext.PushProperties(new[] { new KeyValuePair<string, object>("Scope8", "World8"), new KeyValuePair<string, object>("Scope7", "World7") }))
+                        {
+                            // Scope4 is top-of-stack and its parent contains the collapsed properties.
+                            collection1 = ScopeContext.GetAllProperties();
+                            collection2 = ScopeContext.GetAllProperties();
+                            Assert.Same(collection1, collection2);
+                            eightProperties = collection1.ToList();
+                        }
+                    }
+                }
+            }
+
+            // Assert
+            Assert.Equal(2, twoProperties.Count);
+            Assert.Equal("Scope2", twoProperties[0].Key);   // First scope in original order
+            Assert.Equal("Scope1", twoProperties[1].Key);
 
             Assert.Equal(4, fourProperties.Count);
             Assert.Equal("Scope4", fourProperties[0].Key);   // Newest scope added first, since top of stack, so most optimal
             Assert.Equal("Scope3", fourProperties[1].Key);
             Assert.Equal("Scope2", fourProperties[2].Key);
             Assert.Equal("Scope1", fourProperties[3].Key);
+
+            Assert.Equal(6, sixProperties.Count);
+            Assert.Equal("Scope6", sixProperties[0].Key);   // Newest scope added first, since top of stack, so most optimal
+            Assert.Equal("Scope5", sixProperties[1].Key);
+            Assert.Equal("Scope4", sixProperties[2].Key);
+            Assert.Equal("Scope3", sixProperties[3].Key);
+            Assert.Equal("Scope2", sixProperties[4].Key);
+            Assert.Equal("Scope1", sixProperties[5].Key);
+
+            Assert.Equal(8, eightProperties.Count);
+            Assert.Equal("Scope8", eightProperties[0].Key);   // Newest scope added first, since top of stack, so most optimal
+            Assert.Equal("Scope7", eightProperties[1].Key);
+            Assert.Equal("Scope6", eightProperties[2].Key);
+            Assert.Equal("Scope5", eightProperties[3].Key);
+            Assert.Equal("Scope4", eightProperties[4].Key);
+            Assert.Equal("Scope3", eightProperties[5].Key);
+            Assert.Equal("Scope2", eightProperties[6].Key);
+            Assert.Equal("Scope1", eightProperties[7].Key);
         }
+#endif
+
 
 #if !NET35 && !NET40
         [Fact]

--- a/tests/NLog.UnitTests/Contexts/ScopeContextTest.cs
+++ b/tests/NLog.UnitTests/Contexts/ScopeContextTest.cs
@@ -813,6 +813,68 @@ namespace NLog.UnitTests.Contexts
             Assert.Equal("World", propertyValue);
         }
 
+        [Fact]
+        public void ScopeContextPropertiesCollapseObjectGraph()
+        {
+            // Arrange
+            ScopeContext.Clear();
+
+            // Act
+            List<KeyValuePair<string, object>> twoProperties;
+            List<KeyValuePair<string, object>> threeProperties;
+            List<KeyValuePair<string, object>> fourProperties;
+
+            using (ScopeContext.PushProperty("Scope1", "World1"))
+            {
+                using (ScopeContext.PushProperty("Scope2", "World2"))
+                {
+                    var collection1 = ScopeContext.GetAllProperties();
+                    var collection2 = ScopeContext.GetAllProperties();
+#if !NET35 && !NET40 && !NET45
+                    Assert.Same(collection1, collection2);
+#endif
+                    twoProperties = collection1.ToList();
+
+                    using (ScopeContext.PushProperty("Scope3", "World3"))
+                    {
+                        collection1 = ScopeContext.GetAllProperties();
+                        collection2 = ScopeContext.GetAllProperties();
+#if !NET35 && !NET40 && !NET45
+                        Assert.Same(collection1, collection2);
+#endif
+                        threeProperties = collection1.ToList();
+
+                        using (ScopeContext.PushProperty("Scope4", "World4"))
+                        {
+                            // Scope4 is top-of-stack and its parent contains the collapsed properties.
+                            collection1 = ScopeContext.GetAllProperties();
+                            collection2 = ScopeContext.GetAllProperties();
+#if !NET35 && !NET40 && !NET45
+                            Assert.Same(collection1, collection2);
+#endif
+                            fourProperties = collection1.ToList();
+                        }
+                    }
+                }
+            }
+
+            // Assert
+            Assert.Equal(2, twoProperties.Count);
+            Assert.Equal("Scope2", twoProperties[0].Key);  // Newest scope added first, since top of stack, so most optimal
+            Assert.Equal("Scope1", twoProperties[1].Key);
+
+            Assert.Equal(3, threeProperties.Count);
+            Assert.Equal("Scope3", threeProperties[0].Key);  // Newest scope added first, since top of stack, so most optimal
+            Assert.Equal("Scope2", threeProperties[1].Key);
+            Assert.Equal("Scope1", threeProperties[2].Key);
+
+            Assert.Equal(4, fourProperties.Count);
+            Assert.Equal("Scope4", fourProperties[0].Key);   // Newest scope added first, since top of stack, so most optimal
+            Assert.Equal("Scope3", fourProperties[1].Key);
+            Assert.Equal("Scope2", fourProperties[2].Key);
+            Assert.Equal("Scope1", fourProperties[3].Key);
+        }
+
 #if !NET35 && !NET40
         [Fact]
         public void ScopeContextPushWithoutStackOverflow3()

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -599,9 +599,8 @@ namespace NLog.UnitTests.Layouts
             var logEventInfo = CreateLogEventWithExcluded();
 
             MappedDiagnosticsContext.Clear();
-            foreach (var prop in logEventInfo.Properties)
-                if (prop.Key.ToString() != "Excluded1" && prop.Key.ToString() != "Excluded2")
-                    MappedDiagnosticsContext.Set(prop.Key.ToString(), prop.Value);
+            foreach (var prop in logEventInfo.Properties.Reverse())
+                MappedDiagnosticsContext.Set(prop.Key.ToString(), prop.Value);
             logEventInfo.Properties.Clear();
 
             logger.Debug(logEventInfo);
@@ -640,9 +639,8 @@ namespace NLog.UnitTests.Layouts
             logEventInfo.Properties.Add("NoEmptyProp4", new DummyContextLogger() { Value = "hello\"" });
 
             MappedDiagnosticsContext.Clear();
-            foreach (var prop in logEventInfo.Properties)
-                if (prop.Key.ToString() != "Excluded1" && prop.Key.ToString() != "Excluded2")
-                    MappedDiagnosticsContext.Set(prop.Key.ToString(), prop.Value);
+            foreach (var prop in logEventInfo.Properties.Reverse())
+                MappedDiagnosticsContext.Set(prop.Key.ToString(), prop.Value);
             logEventInfo.Properties.Clear();
 
             logger.Debug(logEventInfo);
@@ -751,9 +749,8 @@ namespace NLog.UnitTests.Layouts
             var logEventInfo = CreateLogEventWithExcluded();
 
             MappedDiagnosticsLogicalContext.Clear();
-            foreach (var prop in logEventInfo.Properties)
-                if (prop.Key.ToString() != "Excluded1" && prop.Key.ToString() != "Excluded2")
-                    MappedDiagnosticsLogicalContext.Set(prop.Key.ToString(), prop.Value);
+            foreach (var prop in logEventInfo.Properties.Reverse())
+                MappedDiagnosticsLogicalContext.Set(prop.Key.ToString(), prop.Value);
             logEventInfo.Properties.Clear();
 
             logger.Debug(logEventInfo);
@@ -792,9 +789,8 @@ namespace NLog.UnitTests.Layouts
             logEventInfo.Properties.Add("NoEmptyProp4", new DummyContextLogger() { Value = "hello\"" });
 
             MappedDiagnosticsLogicalContext.Clear();
-            foreach (var prop in logEventInfo.Properties)
-                if (prop.Key.ToString() != "Excluded1" && prop.Key.ToString() != "Excluded2")
-                    MappedDiagnosticsLogicalContext.Set(prop.Key.ToString(), prop.Value);
+            foreach (var prop in logEventInfo.Properties.Reverse())
+                MappedDiagnosticsLogicalContext.Set(prop.Key.ToString(), prop.Value);
             logEventInfo.Properties.Clear();
 
             logger.Debug(logEventInfo);
@@ -831,7 +827,7 @@ namespace NLog.UnitTests.Layouts
             var logEventInfo = CreateLogEventWithExcluded();
 
             MappedDiagnosticsLogicalContext.Clear();
-            foreach (var prop in logEventInfo.Properties)
+            foreach (var prop in logEventInfo.Properties.Reverse())
                 if (prop.Key.ToString() != "Excluded1" && prop.Key.ToString() != "Excluded2")
                     MappedDiagnosticsLogicalContext.Set(prop.Key.ToString(), prop.Value);
             logEventInfo.Properties.Clear();

--- a/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/XmlLayoutTests.cs
@@ -91,9 +91,9 @@ namespace NLog.UnitTests.Layouts
 
             ScopeContext.Clear();
 
-            ScopeContext.PushProperty("foo1", "bar1");
-            ScopeContext.PushProperty("foo2", "bar2");
             ScopeContext.PushProperty("foo3", "bar3");
+            ScopeContext.PushProperty("foo2", "bar2");
+            ScopeContext.PushProperty("foo1", "bar1");
 
             var logger = logFactory.GetLogger("hello");
 


### PR DESCRIPTION
- [ ] Wait for NLog v6.2

NLog v5 introduced the ScopeContext using a "lazy" stack, compared to NLog v4 that maintained property-dictionary upfront. The "lazy" stack is much faster, when not all the scopes produce log-output with scope-properties (Ex. only logging scope on Error)

The initial NLog v5.0 had an optimization where it tried to guess the number of properties in a scope, so it could allocate a collection with the expected initial capacity. But this optimization was implemented so it enumerated the "lazy" stack using recursion. This caused NLog v5 to explode with stack-overflow when the object-graph grew too long. The recursion-logic was fixed with NLog v5.1.3 but to avoid rocking the boat, then it was decided to keep the reverse-stack-ordering (oldest first). 

The oldest first ordering introduces a performance hit. Because the newest property is at the top of the "lazy" stack. When NLog collects scope-properties, then it must perform list-insert-first and move all existing items in the list (expensive).

Spending time of on ensuring special ordering for something that operates as Dictionary-collection seems like a waste of time. Instead of having oldest first, then it is more optimal to have newest first.

This includes a bonus-optimization in the merge/collapse logic of the "lazy"-stack (reducing the object-graph), where it would first allocate List (for ordering) and then convert into Dictionary. Now it will just add directly to the Dictionary, so skipping extra List-allocation and double-insert.