### PR TITLE
Replace ProcessInfoLayoutRenderer with ProcessStartLayoutRenderer

### DIFF
--- a/src/NLog/Config/AssemblyExtensionTypes.cs
+++ b/src/NLog/Config/AssemblyExtensionTypes.cs
@@ -144,6 +144,7 @@ namespace NLog.Config
             layoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessIdLayoutRenderer>("processid", checkTypeExists);
             layoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessInfoLayoutRenderer>("processinfo", checkTypeExists);
             layoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessNameLayoutRenderer>("processname", checkTypeExists);
+            layoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessStartLayoutRenderer>("processstart", checkTypeExists);
             layoutRendererFactory.RegisterType<NLog.LayoutRenderers.ProcessTimeLayoutRenderer>("processtime", checkTypeExists);
             layoutRendererFactory.RegisterType<NLog.LayoutRenderers.ScopeContextIndentLayoutRenderer>("scopeindent", checkTypeExists);
             layoutRendererFactory.RegisterType<NLog.LayoutRenderers.ScopeContextNestedStatesLayoutRenderer>("scopenested", checkTypeExists);

--- a/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessInfoLayoutRenderer.cs
@@ -39,19 +39,22 @@ namespace NLog.LayoutRenderers
     using System.Text;
     using NLog.Config;
     using NLog.Internal;
+    using NLog.Internal.Fakeables;
 
     /// <summary>
     /// The information about the running process.
+    ///
+    /// Obsolete because of AOT-filesize. Instead use ${processid} or ${processname} or ${processstart} or ${processtime} or ${gc}. 
     /// </summary>
     /// <remarks>
     /// <a href="https://github.com/NLog/NLog/wiki/ProcessInfo-Layout-Renderer">See NLog Wiki</a>
     /// </remarks>
     /// <seealso href="https://github.com/NLog/NLog/wiki/ProcessInfo-Layout-Renderer">Documentation on NLog Wiki</seealso>
+    [Obsolete("Alternative use ${processid} or ${processname} or ${processstart} or ${processtime} or ${gc}. Marked obsolete with NLog v6.2 because of AOT-filesize.")]
     [LayoutRenderer("processinfo")]
     public class ProcessInfoLayoutRenderer : LayoutRenderer
     {
-        private Process? _process;
-        private ReflectionHelpers.LateBoundMethod? _lateBoundPropertyGet;
+        private readonly IAppEnvironment _appEnvironment;
 
         /// <summary>
         /// Gets or sets the property to retrieve.
@@ -76,45 +79,119 @@ namespace NLog.LayoutRenderers
         /// <docgen category='Layout Options' order='100' />
         public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
 
-        /// <inheritdoc/>
-        protected override void InitializeLayoutRenderer()
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProcessInfoLayoutRenderer" /> class.
+        /// </summary>
+        public ProcessInfoLayoutRenderer() : this(LogFactory.DefaultAppEnvironment)
         {
-            base.InitializeLayoutRenderer();
-            var propertyInfo = typeof(Process).GetProperty(Property.ToString());
-            if (propertyInfo is null)
-            {
-                throw new ArgumentException($"Property '{Property}' not found in System.Diagnostics.Process");
-            }
-
-            var getGetMethodInfo = propertyInfo.GetGetMethod();
-            if (getGetMethodInfo is null)
-            {
-                throw new ArgumentException($"Property '{Property}' not found in System.Diagnostics.Process with valid getter-method");
-            }
-
-            _lateBoundPropertyGet = ReflectionHelpers.CreateLateBoundMethod(getGetMethodInfo);
-
-            _process = Process.GetCurrentProcess();
         }
 
-        /// <inheritdoc/>
-        protected override void CloseLayoutRenderer()
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProcessInfoLayoutRenderer" /> class.
+        /// </summary>
+        internal ProcessInfoLayoutRenderer(IAppEnvironment appEnvironment)
         {
-            _process?.Close();
-            _process = null;
-            base.CloseLayoutRenderer();
+            _appEnvironment = appEnvironment;
         }
 
         /// <inheritdoc/>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            if (_process is null || _lateBoundPropertyGet is null)
-                return;
-
-            var value = _lateBoundPropertyGet.Invoke(_process, ArrayHelper.Empty<object>());
-            if (value != null)
+            switch (Property)
             {
-                AppendFormattedValue(builder, logEvent, value, Format, Culture);
+                case ProcessInfoProperty.Id:
+                    if (string.IsNullOrEmpty(Format))
+                        builder.AppendInvariant(_appEnvironment.CurrentProcessId);
+                    else
+                        AppendFormattedValue(builder, logEvent, _appEnvironment.CurrentProcessId, Format, Culture);
+                    break;
+                case ProcessInfoProperty.ProcessName:
+                    builder.Append(_appEnvironment.CurrentProcessBaseName);
+                    break;
+                case ProcessInfoProperty.StartTime:
+                    var startTimeLocal = LogEventInfo.ZeroDate.ToLocalTime();
+                    AppendFormattedValue(builder, logEvent, startTimeLocal, Format, Culture);
+                    break;
+                case ProcessInfoProperty.StartTimeUtc:
+                    var startTimeUtc = LogEventInfo.ZeroDate.ToUniversalTime();
+                    AppendFormattedValue(builder, logEvent, startTimeUtc, Format, Culture);
+                    break;
+                case ProcessInfoProperty.TotalProcessorTime:
+                case ProcessInfoProperty.UserProcessorTime:
+                case ProcessInfoProperty.PrivilegedProcessorTime:
+                    var processorTime = DateTime.UtcNow - LogEventInfo.ZeroDate;
+                    AppendFormattedValue(builder, logEvent, processorTime, Format, Culture);
+                    break;
+                case ProcessInfoProperty.BasePriority:
+                    AppendFormattedValue(builder, logEvent, (int)ProcessPriorityClass.Normal, Format, Culture);
+                    break;
+                case ProcessInfoProperty.ExitCode:
+                    AppendFormattedValue(builder, logEvent, 0, Format, Culture);
+                    break;
+                case ProcessInfoProperty.ExitTime:
+                    AppendFormattedValue(builder, logEvent, DateTime.MinValue, Format, Culture);
+                    break;
+                case ProcessInfoProperty.HasExited:
+                    AppendFormattedValue(builder, logEvent, false, Format, Culture);
+                    break;
+                case ProcessInfoProperty.MachineName:
+                    builder.Append("");
+                    break;
+                case ProcessInfoProperty.MainWindowHandle:
+                case ProcessInfoProperty.Handle:
+                    AppendFormattedValue(builder, logEvent, 0L, Format, Culture);
+                    break;
+                case ProcessInfoProperty.HandleCount:
+                    AppendFormattedValue(builder, logEvent, 1, Format, Culture);
+                    break;
+                case ProcessInfoProperty.MainWindowTitle:
+                    builder.Append(_appEnvironment.CurrentProcessBaseName);
+                    break;
+                case ProcessInfoProperty.PeakVirtualMemorySize:
+                case ProcessInfoProperty.VirtualMemorySize:
+                    AppendFormattedValue(builder, logEvent, int.MaxValue, Format, Culture);
+                    break;
+                case ProcessInfoProperty.PeakVirtualMemorySize64:
+                case ProcessInfoProperty.VirtualMemorySize64:
+                    if (IntPtr.Size == 4)
+                        AppendFormattedValue(builder, logEvent, (long)int.MaxValue, Format, Culture);
+                    else
+                        AppendFormattedValue(builder, logEvent, long.MaxValue, Format, Culture);
+                    break;
+                case ProcessInfoProperty.MaxWorkingSet:
+                case ProcessInfoProperty.MinWorkingSet:
+                case ProcessInfoProperty.NonPagedSystemMemorySize:
+                case ProcessInfoProperty.PagedMemorySize:
+                case ProcessInfoProperty.PagedSystemMemorySize:
+                case ProcessInfoProperty.PeakPagedMemorySize:
+                case ProcessInfoProperty.PeakWorkingSet:
+                case ProcessInfoProperty.WorkingSet:
+                case ProcessInfoProperty.PrivateMemorySize:
+                    var currentMemorySize = (int)Environment.WorkingSet;
+                    AppendFormattedValue(builder, logEvent, currentMemorySize, Format, Culture);
+                    break;
+                case ProcessInfoProperty.NonPagedSystemMemorySize64:
+                case ProcessInfoProperty.PagedMemorySize64:
+                case ProcessInfoProperty.PagedSystemMemorySize64:
+                case ProcessInfoProperty.PeakPagedMemorySize64:
+                case ProcessInfoProperty.PeakWorkingSet64:
+                case ProcessInfoProperty.WorkingSet64:
+                case ProcessInfoProperty.PrivateMemorySize64:
+                    var currentMemorySize64 = Environment.WorkingSet;
+                    AppendFormattedValue(builder, logEvent, currentMemorySize64, Format, Culture);
+                    break;
+                case ProcessInfoProperty.PriorityBoostEnabled:
+                    AppendFormattedValue(builder, logEvent, true, Format, Culture);
+                    break;
+                case ProcessInfoProperty.PriorityClass:
+                    AppendFormattedValue(builder, logEvent, (int)ProcessPriorityClass.Normal, Format, Culture);
+                    break;
+                case ProcessInfoProperty.Responding:
+                    AppendFormattedValue(builder, logEvent, true, Format, Culture);
+                    break;
+                case ProcessInfoProperty.SessionId:
+                    AppendFormattedValue(builder, logEvent, 1, Format, Culture);
+                    break;
             }
         }
     }

--- a/src/NLog/LayoutRenderers/ProcessInfoProperty.cs
+++ b/src/NLog/LayoutRenderers/ProcessInfoProperty.cs
@@ -33,9 +33,12 @@
 
 namespace NLog.LayoutRenderers
 {
+    using System;
+
     /// <summary>
     /// Property of System.Diagnostics.Process to retrieve.
     /// </summary>
+    [Obsolete("Alternative use ${processid} or ${processname} or ${processstart} or ${processtime} or ${gc}. Marked obsolete with NLog v6.2 because of AOT-filesize.")]
     public enum ProcessInfoProperty
     {
         /// <summary>
@@ -199,7 +202,7 @@ namespace NLog.LayoutRenderers
         SessionId,
 
         /// <summary>
-        /// Process Start Time.
+        /// Process Start Time (Local).
         /// </summary>
         StartTime,
 
@@ -232,5 +235,10 @@ namespace NLog.LayoutRenderers
         /// Working Set Size (64-bit).
         /// </summary>
         WorkingSet64,
+
+        /// <summary>
+        /// Process Start Time (UTC).
+        /// </summary>
+        StartTimeUtc,
     }
 }

--- a/src/NLog/LayoutRenderers/ProcessStartLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/ProcessStartLayoutRenderer.cs
@@ -1,0 +1,93 @@
+﻿//
+// Copyright (c) 2004-2024 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of Jaroslaw Kowalski nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+namespace NLog.LayoutRenderers
+{
+    using System;
+    using System.Globalization;
+    using System.Text;
+    using NLog.Config;
+    using NLog.Internal;
+
+    /// <summary>
+    /// Process start time.
+    /// </summary>
+    /// <remarks>
+    /// <a href="https://github.com/NLog/NLog/wiki/ProcessStart-Layout-Renderer">See NLog Wiki</a>
+    /// </remarks>
+    /// <seealso href="https://github.com/NLog/NLog/wiki/ProcessStart-Layout-Renderer">Documentation on NLog Wiki</seealso>
+    [LayoutRenderer("processstart")]
+    [AppDomainFixedOutput]
+    [ThreadAgnostic]
+    public class ProcessStartLayoutRenderer : LayoutRenderer, IRawValue
+    {
+        /// <summary>
+        /// Gets or sets the culture used for rendering.
+        /// </summary>
+        /// <remarks>Default: <see cref="CultureInfo.InvariantCulture"/></remarks>
+        /// <docgen category='Layout Options' order='100' />
+        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+
+        /// <summary>
+        /// Gets or sets the date format. Can be any argument accepted by DateTime.ToString(format).
+        /// </summary>
+        /// <remarks>Default: <c>yyyy-MM-dd HH:mm:ss</c></remarks>
+        /// <docgen category='Layout Options' order='10' />
+        [DefaultParameter]
+        public string Format { get; set; } = "yyyy-MM-dd HH:mm:ss";
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to output UTC time instead of local time.
+        /// </summary>
+        /// <remarks>Default: <see langword="false"/></remarks>
+        /// <docgen category='Layout Options' order='50' />
+        public bool UniversalTime { get; set; }
+
+        /// <inheritdoc/>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            AppendFormattedValue(builder, logEvent, GetValue(), Format, Culture);
+        }
+
+        bool IRawValue.TryGetRawValue(LogEventInfo logEvent, out object? value)
+        {
+            value = GetValue();
+            return true;
+        }
+
+        private DateTime GetValue()
+        {
+            return UniversalTime ? NLog.LogEventInfo.ZeroDate.ToUniversalTime() : NLog.LogEventInfo.ZeroDate.ToLocalTime();
+        }
+    }
+}

--- a/tests/NLog.UnitTests/LayoutRenderers/ProcessInfoLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ProcessInfoLayoutRendererTests.cs
@@ -1,0 +1,57 @@
+﻿//
+// Copyright (c) 2004-2024 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of Jaroslaw Kowalski nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+namespace NLog.UnitTests.LayoutRenderers
+{
+    using System;
+    using NLog.LayoutRenderers;
+    using NLog.Layouts;
+    using Xunit;
+
+    [Obsolete("Alternative use ${processid} or ${processname} or ${processstart} or ${processtime} or ${gc}. Marked obsolete with NLog v6.2 because of AOT-filesize.")]
+    public class ProcessInfoLayoutRendererTests : NLogTestBase
+    {
+        [Fact]
+        public void ProcessInfoPropertyTest()
+        {
+            foreach (ProcessInfoProperty propertyType in Enum.GetValues(typeof(ProcessInfoProperty)))
+            {
+                if (propertyType == ProcessInfoProperty.MachineName)
+                    continue;
+                Layout layout = "${processinfo:property=" + propertyType + "}";
+                var result = layout.Render(LogEventInfo.CreateNullEvent());
+                Assert.NotEmpty(result);
+            }
+        }
+    }
+}

--- a/tests/NLog.UnitTests/LayoutRenderers/ProcessStartLayoutRendererTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/ProcessStartLayoutRendererTests.cs
@@ -1,0 +1,50 @@
+﻿//
+// Copyright (c) 2004-2024 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of Jaroslaw Kowalski nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+namespace NLog.UnitTests.LayoutRenderers
+{
+    using NLog.Layouts;
+    using Xunit;
+
+    public class ProcessStartLayoutRendererTests : NLogTestBase
+    {
+        [Fact]
+        public void RenderProcessStartLayoutRenderer()
+        {
+            Layout layout = "${processstart:Culture=InvariantCulture:UniversalTime=true}";
+            var timestamp = LogEventInfo.ZeroDate;
+            var expected = timestamp.ToString("yyyy-MM-dd HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture);
+            AssertLayoutRendererOutput(layout, LogEventInfo.CreateNullEvent(), expected);
+        }
+    }
+}


### PR DESCRIPTION
Replaced by #6231

NET11 reduces the AOT-filesize when not using exotic features from the Process-object.

Changed `${processinfo}` to only support Id + Name, and everything else are either hardcoded values or similar values.

Instead introduced `${processstart}` with the following options:
- Format
- UniversalTime
- Culture

`${processstart}` outputs the same value during the entire AppDomain-lifetime, which allows NLog to convert into literal for optimal performance.

And there is also the existing `${processid}` + `${processname}` + `${processtime}` + `${gc}`. And have now introduced support for `${gc:workingset}`