### PR TITLE
AsyncTaskTarget - Fixed bug when using BatchSize=1 and doing explicit flush and next LogEvent fails

### DIFF
--- a/src/NLog/Targets/AsyncTaskTarget.cs
+++ b/src/NLog/Targets/AsyncTaskTarget.cs
@@ -78,7 +78,7 @@ namespace NLog.Targets
     {
         private readonly Timer _taskTimeoutTimer;
         private CancellationTokenSource _cancelTokenSource;
-        AsyncRequestQueueBase _requestQueue;
+        private AsyncRequestQueueBase _requestQueue;
         private readonly Action _taskCancelledTokenReInit;
         private readonly Action<Task, object?> _taskCompletion;
         private Task? _previousTask;
@@ -496,6 +496,7 @@ namespace NLog.Targets
                         {
                             if (TaskCreation(logEvents))
                                 return;
+                            _previousTask = null;   // Completed flush, and previous task has completed, but check queue for more.
                         }
                         else
                         {
@@ -556,16 +557,7 @@ namespace NLog.Targets
                         {
                             retryTask = StartWriteAsyncTask(logEvents, _cancelTokenSource.Token);
                         }
-                        if (retryTask != null)
-                        {
-                            return WriteAsyncTaskWithRetry(retryTask, logEvents, _cancelTokenSource.Token, retryCount - 1);
-                        }
-
-#if !NET45
-                        return System.Threading.Tasks.Task.CompletedTask;
-#else
-                        return System.Threading.Tasks.Task.FromResult<object?>(null);
-#endif
+                        return WriteAsyncTaskWithRetry(retryTask, logEvents, _cancelTokenSource.Token, retryCount - 1);
                     }, cancellationToken, TaskContinuationOptions.DenyChildAttach, TaskScheduler).Unwrap();
                 }
 
@@ -645,7 +637,6 @@ namespace NLog.Targets
             }
             catch (Exception ex)
             {
-                _previousTask = null;
                 InternalLogger.Error(ex, "{0}: WriteAsyncTask failed on creation", this);
                 NotifyTaskCompletion(reusableLogEvents?.Item2 ?? (IList<AsyncContinuation>)ArrayHelper.Empty<AsyncContinuation>(), ex);
             }

--- a/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
+++ b/tests/NLog.UnitTests/Targets/AsyncTaskTargetTest.cs
@@ -586,7 +586,7 @@ namespace NLog.UnitTests.Targets
         }
 
         [Fact]
-        public void AsynTaskTarget_AutoFlushWrapper()
+        public void AsyncTaskTarget_AutoFlushWrapper()
         {
             var asyncTarget = new AsyncTaskBatchTestTarget
             {
@@ -634,6 +634,40 @@ namespace NLog.UnitTests.Targets
 
             // Assert
             Assert.Equal(1, asyncTarget.WriteTasks);
+        }
+
+        [Fact]
+        public void AsyncTaskTarget_TestFlushAfterWriteFailure()
+        {
+            var asyncTarget = new AsyncTaskTestTarget
+            {
+                Layout = "${message}",
+                TaskDelayMilliseconds = 750,    // Large enough that Flush() is always enqueued before the timer fires
+                BatchSize = 1,
+            };
+
+            var logFactory = new LogFactory().Setup().LoadConfiguration(builder =>
+            {
+                builder.ForLogger().WriteTo(asyncTarget);
+            }).LogFactory;
+            var logger = logFactory.GetCurrentClassLogger();
+
+            // Step 1: Write event that will fail when timer fires for background-writer.
+            logger.Info("EXCEPTION");
+
+            // Step 2: Flush that triggers timer immediately, and because BatchSize=1 then it first writes the failing LogEvent, and afterwards handles the synthetic flush-event in next batch.
+            logFactory.Flush(TimeSpan.FromSeconds(5));
+
+            // Step 3: Write next event.
+            logger.Info("INFO");
+
+            // Assert the INFO event is processed by the background-writer timer WITHOUT an explicit Flush.
+            Assert.True(asyncTarget.WaitForWriteEvent(), "INFO event should be processed by the background-writer timer after failed task + flush");
+            Assert.Single(asyncTarget.Logs);
+            asyncTarget.Logs.TryDequeue(out var message);
+            Assert.Equal("INFO", message);
+
+            logFactory.Configuration = null;
         }
 
         [Fact]


### PR DESCRIPTION
AsyncTaskTarget handles explicit flush by posting synthetic flush-logevent to the queue for the background-writer. When the background-writer gets to to the flush-logevent then it is silently thrown away, but still signals that flush completed.

But there was a bug when the explicit flush was inserted after normal-logevent where the write-task would fail. Because when silently throwing away the synthetic flush-logevent, then it forgot to clear the previous failed task (so it remained "in-progress").