### PR TITLE
PropertyTypeConverter - Disable legacy TypeDescriptor when AOT

### DIFF
--- a/src/NLog/Config/PropertyTypeConverter.cs
+++ b/src/NLog/Config/PropertyTypeConverter.cs
@@ -58,7 +58,7 @@ namespace NLog.Config
 
         internal static bool IsComplexType(Type type)
         {
-            return !type.IsValueType && !typeof(IConvertible).IsAssignableFrom(type) && !HasConvertFromStringSupport(type) && type.GetFirstCustomAttribute<System.ComponentModel.TypeConverterAttribute>() is null;
+            return !type.IsValueType && !typeof(IConvertible).IsAssignableFrom(type) && !HasConvertFromStringSupport(type);
         }
 
         /// <inheritdoc/>
@@ -234,6 +234,14 @@ namespace NLog.Config
         [UnconditionalSuppressMessage("Trimming - Allow converting option-values from config", "IL2072")]
         private static bool TryConvertToType(object propertyValue, Type propertyType, out object? convertedValue)
         {
+#if NETSTANDARD2_1_OR_GREATER || NET
+            if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
+            {
+                convertedValue = null;
+                return false;   // System.ComponentModel.TypeDescriptor is legacy and increases AOT filesize with 500 KBytes.
+            }
+#endif
+
             if (propertyValue is null || propertyType.IsAssignableFrom(propertyValue.GetType()))
             {
                 convertedValue = null;

--- a/src/NLog/Internal/PropertyHelper.cs
+++ b/src/NLog/Internal/PropertyHelper.cs
@@ -513,6 +513,13 @@ namespace NLog.Internal
         internal static bool TryTypeConverterConversion(Type type, string value, out object? newValue)
         {
             InternalLogger.Debug("Object reflection needed for creating external type: {0} from string-value: {1}", type, value);
+#if NETSTANDARD2_1_OR_GREATER || NET
+            if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
+            {
+                newValue = null;
+                return false;   // System.ComponentModel.TypeDescriptor is legacy and increases AOT filesize with 500 KBytes.
+            }
+#endif
 
             try
             {


### PR DESCRIPTION
- [ ] Wait for NLog v6.2

NLog functionality should not rely on legacy TypeDescriptor. TypeDescriptor should be removed completely with NLog v7

Restore the revert made with #6226

**This PR**
`ProcessPath: 'C:\projects\nlog\Tests\TestTrimPublish\bin\release\net10.0\win-X64\publish\TestTrimPublish.exe' with FileSize: 4773888`

**NLog v6.1.4**
`ProcessPath: 'C:\projects\nlog\Tests\TestTrimPublish\bin\release\net10.0\win-X64\publish\TestTrimPublish.exe' with FileSize: 5384192`