### PR TITLE
NLog.Targets.AtomicFile v6.1.5

### DIFF
--- a/src/NLog.Targets.AtomicFile/NLog.Targets.AtomicFile.csproj
+++ b/src/NLog.Targets.AtomicFile/NLog.Targets.AtomicFile.csproj
@@ -29,6 +29,7 @@
 
     <SignAssembly>true</SignAssembly>
     <AssemblyVersion>6.0.0.0</AssemblyVersion>
+    <Version>6.1.5</Version>
     <AssemblyOriginatorKeyFile>..\NLog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 
@@ -88,7 +89,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NLog\NLog.csproj" />
+    <PackageReference Include="NLog" Version="6.1.4" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Hotfix with #6237 to improve MacOSX and Arm64 support.