### PR TITLE
DateLayoutRenderer - Changed default Format to yyyy-MM-dd HH:mm:ss.ffff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Date format: (year/month/day)
 
 ## Change Log
 
+### Version 7.0 (Unreleased)
+**Breaking Changes**
+- [#6232](https://github.com/NLog/NLog/issues/6232) DateLayoutRenderer - Changed default Format to `yyyy-MM-dd HH:mm:ss.ffff` for consistency with rest of NLog (breaking change, was `yyyy/MM/dd HH:mm:ss.fff`).
+
 ### Version 6.2 (2026/08/16)
 **Improvements**
 - [#6215](https://github.com/NLog/NLog/pull/6215) FileTarget - Added FileLifecycleHooks for extending archive logic. (@Dave-Senn)

--- a/src/NLog/LayoutRenderers/DateLayoutRenderer.cs
+++ b/src/NLog/LayoutRenderers/DateLayoutRenderer.cs
@@ -55,7 +55,7 @@ namespace NLog.LayoutRenderers
         /// </summary>
         public DateLayoutRenderer()
         {
-            _format = Format = "yyyy/MM/dd HH:mm:ss.fff";
+            _format = Format = "yyyy-MM-dd HH:mm:ss.ffff";
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace NLog.LayoutRenderers
         /// <summary>
         /// Gets or sets the date format. Can be any argument accepted by DateTime.ToString(format).
         /// </summary>
-        /// <remarks>Default: <c>yyyy/MM/dd HH:mm:ss.fff</c></remarks>
+        /// <remarks>Default: <c>yyyy-MM-dd HH:mm:ss.ffff</c></remarks>
         /// <docgen category='Layout Options' order='10' />
         [DefaultParameter]
         public string Format

--- a/tests/NLog.UnitTests/LayoutRenderers/DateTests.cs
+++ b/tests/NLog.UnitTests/LayoutRenderers/DateTests.cs
@@ -51,12 +51,12 @@ namespace NLog.UnitTests.LayoutRenderers
                 </rules>
             </nlog>").LogFactory;
 
-            var ei = new LogEventInfo(LogLevel.Info, "logger", "msg");
+            var ei = new LogEventInfo(LogLevel.Info, "logger", "msg")
+            {
+                TimeStamp = new DateTime(2026, 1, 2, 3, 4, 5).AddTicks(1234000)
+            };
             logFactory.GetLogger("d").Debug(ei);
-            DateTime dt = DateTime.ParseExact(GetDebugLastMessage("debug", logFactory), "yyyy/MM/dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
-            DateTime now = ei.TimeStamp;
-
-            Assert.True(Math.Abs((dt - now).TotalSeconds) < 1);
+            Assert.Equal("2026-01-02 03:04:05.1234", GetDebugLastMessage("debug", logFactory));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #6232.

## Background / breaking-change tradeoff

This issue is tagged `breaking change` / `breaking behavior change`. Investigation showed `DateLayoutRenderer.Culture` already defaults to `CultureInfo.InvariantCulture` (via #5740, already on `dev`), so `${date}` output was already stable across thread/system culture — there was no live culture-dependency bug to fix.

I posted a scoping comment on the issue asking whether the maintainer wanted (a) a straight default change, (b) a non-breaking opt-in flag, or (c) something else, since the actual remaining gap is just the default `Format` *string* itself being inconsistent with the rest of NLog. @snakefoot responded that there's no bug — it's "just a funny default value" — and that this targets the **NLog v7 milestone**, so a straight default change is fine there.

This PR implements that straight change:

## Changes

- `DateLayoutRenderer`'s default `Format` changed from `yyyy/MM/dd HH:mm:ss.fff` to `yyyy-MM-dd HH:mm:ss.ffff`, matching the convention used elsewhere in NLog (`${longdate}`, `InternalLogger`'s internal timestamp format).
- Updated `DefaultDateTest` in `DateTests.cs` to assert the new default output.
- Added a `CHANGELOG.md` entry under a new "Version 7.0 (Unreleased)" / "Breaking Changes" section.

This is a **breaking behavior change**: anyone using `${date}` without an explicit `Format` will see different default output. Users who already set `Format` explicitly are unaffected.

## Testing

- `dotnet build src/NLog/NLog.csproj -c Debug` — succeeds.
- `dotnet test tests/NLog.UnitTests/NLog.UnitTests.csproj --filter "FullyQualifiedName~DateTests"` — 27/27 pass (net10.0 and net462).
- Full `NLog.UnitTests` suite (net10.0) — 2587/2589 pass (2 skipped, unrelated to this change); the run's final "Out of memory" test-host crash is from an unrelated memory-heavy test, not exercised by or related to this change.
