### PR TITLE
FileTarget - Make FileLifeCycleTest more stable by using isolated dir

### DIFF
--- a/tests/NLog.UnitTests/Targets/FileTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/FileTargetTests.cs
@@ -113,7 +113,9 @@ namespace NLog.UnitTests.Targets
         [Fact]
         public void FileLifeCycleTest()
         {
-            var logFile = Path.GetTempFileName();
+            var tempDir = Path.Combine(Path.GetTempPath(), "nlog_" + Guid.NewGuid());
+            var logFile = Path.Combine(tempDir, "FileLifeCycleTest.log");
+
             try
             {
                 var callRecording = new List<string>();
@@ -157,14 +159,17 @@ namespace NLog.UnitTests.Targets
             {
                 if (File.Exists(logFile))
                     File.Delete(logFile);
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
             }
         }
-
 
         [Fact]
         public void FileLifeCycle_ErrorHandlingTest()
         {
-            var logFile = Path.GetTempFileName();
+            var tempDir = Path.Combine(Path.GetTempPath(), "nlog_" + Guid.NewGuid());
+            var logFile = Path.Combine(tempDir, "FileLifeCycleTest.log");
+
             try
             {
                 var callRecording = new List<string>();
@@ -201,6 +206,8 @@ namespace NLog.UnitTests.Targets
             {
                 if (File.Exists(logFile))
                     File.Delete(logFile);
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
             }
         }
 


### PR DESCRIPTION
See also #6215  and this build-server errror:
```
[xUnit.net 00:01:46.51]     NLog.UnitTests.Targets.FileTargetTests.FileLifeCycleTest [FAIL]
  Failed NLog.UnitTests.Targets.FileTargetTests.FileLifeCycleTest [33 ms]
  Error Message:
   Assert.Equal() Failure: Collections differ
                                               ↓ (pos 1)
Expected: ["hooks_OnTargetInitialize_my-file", "hooks_OnFileOpened_/tmp/tmp28279786.tmp_FileStream", "hooks_OnFileClosed_/tmp/tmp28279786.tmp", "hooks_OnFileDeleting_/tmp/tmp28279786.tmp", "hooks_OnFileOpened_/tmp/tmp28279786.tmp_FileStream", ···]
Actual:   ["hooks_OnTargetInitialize_my-file", "hooks_OnFileDeleting_/tmp/tmp28279786.tmp", "hooks_OnFileOpened_/tmp/tmp28279786.tmp_FileStream", "hooks_OnFileClosed_/tmp/tmp28279786.tmp", "hooks_OnFileDeleting_/tmp/tmp28279786.tmp", ···]
                                               ↑ (pos 1)
  Stack Trace:
    at NLog.UnitTests.Targets.FileTargetTests.FileLifeCycleTest () [0x0016a] in <2403ac62305144fe81eed77083d7cbd4>:0 
  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <d636f104d58046fd9b195699bcb1a744>:0 
```

When writing to the global tmp-dir instead of an isolated test-directory, then the archive-logic can get affected by other tmp-files.