### PR TITLE
AtomicFileTarget - Improve recovery when file suddenly disappears

### DIFF
--- a/src/NLog/Targets/FileAppenders/ExclusiveFileLockingAppender.cs
+++ b/src/NLog/Targets/FileAppenders/ExclusiveFileLockingAppender.cs
@@ -45,7 +45,7 @@ namespace NLog.Targets.FileAppenders
     {
         private readonly FileTarget _fileTarget;
         private readonly string _filePath;
-        private Stream _fileStream;
+        private readonly Stream _fileStream;
         private DateTime _lastFileDeletedCheck;
         private long? _countedFileSize;
 
@@ -164,11 +164,9 @@ namespace NLog.Targets.FileAppenders
 
                 if (!SafeFileExists(_filePath))
                 {
-                    InternalLogger.Debug("{0}: Recreating FileStream because no longer File.Exists: '{1}'", _fileTarget, _filePath);
+                    InternalLogger.Info("{0}: Closing FileStream because it no longer File.Exists: '{1}'", _fileTarget, _filePath);
                     SafeCloseFile(_filePath, _fileStream);
-                    _fileStream = _fileTarget.CreateFileStreamWithRetry(this, _fileTarget.BufferSize, initialFileOpen: false);
-                    var fileInfoSize = RefreshFileBirthTimeUtc(false);
-                    _countedFileSize = RefreshCountedFileSize(_fileStream, fileInfoSize);
+                    throw new FileNotFoundException($"Could not find file: '{_filePath}'", _filePath);
                 }
             }
         }

--- a/src/NLog/Targets/FileArchiveHandlers/BaseFileArchiveHandler.cs
+++ b/src/NLog/Targets/FileArchiveHandlers/BaseFileArchiveHandler.cs
@@ -460,6 +460,19 @@ namespace NLog.Targets.FileArchiveHandlers
                     if (i >= 3 && ex.MustBeRethrown(_fileTarget))
                         throw;
                 }
+                catch (UnauthorizedAccessException ex)
+                {
+#if NET35
+                    var hResult = 0;
+#else
+                    var hResult = ex.HResult;
+#endif
+                    InternalLogger.Debug(ex, "{0}: Failed to delete old file HResult=0x{1:X8}, maybe file is locked: '{2}'", _fileTarget, hResult, filepath);
+                    if (!File.Exists(filepath))
+                        return true;
+
+                    return false;
+                }
                 catch (Exception ex)
                 {
                     InternalLogger.Warn(ex, "{0}: Failed to delete old archive file: '{1}'", _fileTarget, filepath);

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -788,13 +788,13 @@ namespace NLog.Targets
 
             for (int i = 0; i < 2; ++i)
             {
-                if (ArchiveAboveSize > 0 || ArchiveEvery != FileArchivePeriod.None || i != 0)
-                {
-                    openFile = RollArchiveFile(filename, openFile, firstLogEvent, hasWritten, i != 0);
-                }
-
                 try
                 {
+                    if (ArchiveAboveSize > 0 || ArchiveEvery != FileArchivePeriod.None || i != 0)
+                    {
+                        openFile = RollArchiveFile(filename, openFile, firstLogEvent, hasWritten, i != 0);
+                    }
+
                     openFile.FileAppender.Write(firstLogEvent.TimeStamp, ms.GetBuffer(), 0, (int)ms.Length);
                     if (AutoFlush)
                     {
@@ -805,13 +805,12 @@ namespace NLog.Targets
                 }
                 catch (IOException ex)
                 {
+                    CloseFile(filename, openFile);
                     if (i == 0 && KeepFileOpen)
                     {
                         InternalLogger.Info(ex, "{0}: Failed writing {1} bytes, will close and reopen file: {2}", this, ms.Length, openFile.FileAppender.FilePath);
                         continue;
                     }
-
-                    CloseFile(filename, openFile);
                     throw;
                 }
                 catch
@@ -836,20 +835,22 @@ namespace NLog.Targets
                 if (previousFileLastModified > openFile.FileAppender.LastWriteTime && (previousFileLastModified == openFile.FileAppender.OpenStreamTime || firstLogEvent.TimeStamp.Date == previousFileLastModified?.Date))
                     previousFileLastModified = openFile.FileAppender.LastWriteTime;
 
+                // Close file and roll to next file, and ensure File.Exists check works by closing file-handles first
+                if (!retryAfterError)
+                {
+                    if (hasWritten)
+                        CloseFileWithFooter(filename, openFile, true);
+                    else
+                        CloseFile(filename, openFile);
+                }
+
                 var nextSequenceNumber = openFile.SequenceNumber + 1;
                 if (nextSequenceNumber != 0 && (retryAfterError || !openFile.FileAppender.VerifyFileExists()))
                 {
-                    InternalLogger.Debug("{0}: Resets current archive sequence number, because of issues with file: '{1}'", this, openFile.FileAppender.FilePath);
-                    hasWritten = false;
+                    InternalLogger.Debug("{0}: Resets current archive sequence number, after issues with file: '{1}'", this, openFile.FileAppender.FilePath);
                     retryAfterError = false;
                     nextSequenceNumber = 0; // Signal that OpenFile must re-enumerate existing files to resolve next sequence-number
                 }
-
-                // Close file and roll to next file
-                if (hasWritten)
-                    CloseFileWithFooter(filename, openFile, true);
-                else
-                    CloseFile(filename, openFile);
 
                 hasWritten = false;
                 openFile = OpenFile(filename, firstLogEvent, previousFileLastModified, nextSequenceNumber);

--- a/src/NLog/Targets/FileTarget.cs
+++ b/src/NLog/Targets/FileTarget.cs
@@ -786,42 +786,64 @@ namespace NLog.Targets
                 openFile = OpenFile(filename, firstLogEvent, null);
             }
 
-            try
+            for (int i = 0; i < 2; ++i)
             {
-                if (ArchiveAboveSize > 0 || ArchiveEvery != FileArchivePeriod.None)
+                if (ArchiveAboveSize > 0 || ArchiveEvery != FileArchivePeriod.None || i != 0)
                 {
-                    openFile = RollArchiveFile(filename, openFile, firstLogEvent, hasWritten);
+                    openFile = RollArchiveFile(filename, openFile, firstLogEvent, hasWritten, i != 0);
                 }
 
-                openFile.FileAppender.Write(firstLogEvent.TimeStamp, ms.GetBuffer(), 0, (int)ms.Length);
-
-                if (AutoFlush)
+                try
                 {
-                    openFile.FileAppender.Flush();
+                    openFile.FileAppender.Write(firstLogEvent.TimeStamp, ms.GetBuffer(), 0, (int)ms.Length);
+                    if (AutoFlush)
+                    {
+                        openFile.FileAppender.Flush();
+                    }
+
+                    break;  // Succesful file-write
                 }
-            }
-            catch
-            {
-                // Close file (any retry-logic must happen inside the FileStream-implementation)
-                _openFileCache.Remove(filename);
-                openFile.FileAppender.Dispose();
-                throw;
+                catch (IOException ex)
+                {
+                    if (i == 0 && KeepFileOpen)
+                    {
+                        InternalLogger.Info(ex, "{0}: Failed writing {1} bytes, will close and reopen file: {2}", this, ms.Length, openFile.FileAppender.FilePath);
+                        continue;
+                    }
+
+                    CloseFile(filename, openFile);
+                    throw;
+                }
+                catch
+                {
+                    CloseFile(filename, openFile);
+                    throw;
+                }
             }
         }
 
-        private OpenFileAppender RollArchiveFile(string filename, OpenFileAppender openFile, LogEventInfo firstLogEvent, bool hasWritten)
+        private OpenFileAppender RollArchiveFile(string filename, OpenFileAppender openFile, LogEventInfo firstLogEvent, bool hasWritten, bool retryAfterError)
         {
             var lastSequenceNo = -1;
 
             bool skipFileLastModified = ArchiveFileName is null;
 
-            while (lastSequenceNo != openFile.SequenceNumber && MustArchiveFile(openFile.FileAppender, firstLogEvent))
+            while (lastSequenceNo != openFile.SequenceNumber && (retryAfterError || MustArchiveFile(openFile.FileAppender, firstLogEvent)))
             {
                 lastSequenceNo = openFile.SequenceNumber;
 
                 DateTime? previousFileLastModified = skipFileLastModified ? default(DateTime?) : openFile.FileAppender.FileLastModified;
                 if (previousFileLastModified > openFile.FileAppender.LastWriteTime && (previousFileLastModified == openFile.FileAppender.OpenStreamTime || firstLogEvent.TimeStamp.Date == previousFileLastModified?.Date))
                     previousFileLastModified = openFile.FileAppender.LastWriteTime;
+
+                var nextSequenceNumber = openFile.SequenceNumber + 1;
+                if (nextSequenceNumber != 0 && (retryAfterError || !openFile.FileAppender.VerifyFileExists()))
+                {
+                    InternalLogger.Debug("{0}: Resets current archive sequence number, because of issues with file: '{1}'", this, openFile.FileAppender.FilePath);
+                    hasWritten = false;
+                    retryAfterError = false;
+                    nextSequenceNumber = 0; // Signal that OpenFile must re-enumerate existing files to resolve next sequence-number
+                }
 
                 // Close file and roll to next file
                 if (hasWritten)
@@ -830,7 +852,7 @@ namespace NLog.Targets
                     CloseFile(filename, openFile);
 
                 hasWritten = false;
-                openFile = OpenFile(filename, firstLogEvent, previousFileLastModified, openFile.SequenceNumber + 1);
+                openFile = OpenFile(filename, firstLogEvent, previousFileLastModified, nextSequenceNumber);
             }
 
             return openFile;

--- a/tests/NLog.Targets.AtomicFile.Tests/AtomicFileTests.cs
+++ b/tests/NLog.Targets.AtomicFile.Tests/AtomicFileTests.cs
@@ -91,68 +91,82 @@ namespace NLog.Targets.AtomicFile.Tests
             var tempDir = Path.Combine(Path.GetTempPath(), "nlog_" + Guid.NewGuid().ToString());
             var logFileName = Path.Combine(tempDir, "log.txt");
 
-            var logFactoryFast = new LogFactory().Setup().LoadConfiguration(cfg =>
+            var logWriter = new StringWriter();
+
+            try
             {
-                cfg.ForLogger().WriteTo(new AtomicFileTarget()
+                LogManager.ThrowExceptions = false; // Windows sometimes allow an application to see deleted files after they have been deleted, when the application still has open file-handles. Repeated archive cleanup will experience that File.Delete throws on the second delete of the same file.
+
+                NLog.Common.InternalLogger.LogLevel = LogLevel.Debug;
+                NLog.Common.InternalLogger.LogWriter = logWriter;
+
+                var logFactoryFast = new LogFactory().Setup().LoadConfiguration(cfg =>
                 {
-                    FileName = logFileName,
-                    Layout = "${message}",
-                    LineEnding = LineEndingMode.LF,
-                    ArchiveAboveSize = 15,
-                    MaxArchiveFiles = 2,
-                });
-            }).LogFactory;
+                    cfg.ForLogger().WriteTo(new AtomicFileTarget()
+                    {
+                        Name = "FastFile",
+                        FileName = logFileName,
+                        Layout = "${message}",
+                        LineEnding = LineEndingMode.LF,
+                        ArchiveAboveSize = 15,
+                        MaxArchiveFiles = 2,
+                    });
+                }).LogFactory;
 
-            var logFactorySlow = new LogFactory().Setup().LoadConfiguration(cfg =>
-            {
-                cfg.ForLogger().WriteTo(new AtomicFileTarget()
+                var logFactorySlow = new LogFactory().Setup().LoadConfiguration(cfg =>
                 {
-                    FileName = logFileName,
-                    Layout = "${message}",
-                    LineEnding = LineEndingMode.LF,
-                    ArchiveAboveSize = 15,
-                    MaxArchiveFiles = 2,
-                });
-            }).LogFactory;
+                    cfg.ForLogger().WriteTo(new AtomicFileTarget()
+                    {
+                        Name = "SlowFile",
+                        FileName = logFileName,
+                        Layout = "${message}",
+                        LineEnding = LineEndingMode.LF,
+                        ArchiveAboveSize = 15,
+                        MaxArchiveFiles = 2,
+                    });
+                }).LogFactory;
 
-            logFactoryFast.GetCurrentClassLogger().Info("Fast1");
-            logFactorySlow.GetCurrentClassLogger().Info("Slow1");
+                logFactoryFast.GetCurrentClassLogger().Info("Fast1");
+                logFactorySlow.GetCurrentClassLogger().Info("Slow1");
 
-            using (var logFile = new StreamReader(new FileStream(logFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
-            {
-                Assert.Equal("Fast1", logFile.ReadLine());
-                Assert.Equal("Slow1", logFile.ReadLine());
-                Assert.Null(logFile.ReadLine());
+                logFactoryFast.GetCurrentClassLogger().Info("Fast2");
+                logFactoryFast.GetCurrentClassLogger().Info("Fast3");
+                logFactoryFast.GetCurrentClassLogger().Info("Fast4");
+                logFactoryFast.GetCurrentClassLogger().Info("Fast5");
+                logFactoryFast.GetCurrentClassLogger().Info("Fast6");
+                logFactoryFast.GetCurrentClassLogger().Info("Fast7");
+                logFactoryFast.GetCurrentClassLogger().Info("Fast8");
+                logFactoryFast.GetCurrentClassLogger().Info("Fast9");
+
+                logFactorySlow.GetCurrentClassLogger().Info("Slow2");
+
+                Assert.False(File.Exists(logFileName));
+                Assert.False(File.Exists(Path.Combine(tempDir, "log_01.txt")));
+                Assert.True(File.Exists(Path.Combine(tempDir, "log_02.txt")));
+                Assert.True(File.Exists(Path.Combine(tempDir, "log_03.txt")));
+
+                logFactoryFast.Shutdown();
+                logFactorySlow.Shutdown();
+
+                using (var logFile = new StreamReader(new FileStream(Path.Combine(tempDir, "log_03.txt"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
+                {
+                    Assert.Equal("Fast9", logFile.ReadLine());
+                    Assert.Equal("Slow2", logFile.ReadLine());
+                    Assert.Null(logFile.ReadLine());
+                }
+
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
             }
-
-            logFactoryFast.GetCurrentClassLogger().Info("Fast2");
-            logFactoryFast.GetCurrentClassLogger().Info("Fast3");
-            logFactoryFast.GetCurrentClassLogger().Info("Fast4");
-            logFactoryFast.GetCurrentClassLogger().Info("Fast5");
-            logFactoryFast.GetCurrentClassLogger().Info("Fast6");
-            logFactoryFast.GetCurrentClassLogger().Info("Fast7");
-            logFactoryFast.GetCurrentClassLogger().Info("Fast8");
-            logFactoryFast.GetCurrentClassLogger().Info("Fast9");
-
-            Assert.False(File.Exists(logFileName));
-            Assert.False(File.Exists(Path.Combine(tempDir, "log_01.txt")));
-            Assert.True(File.Exists(Path.Combine(tempDir, "log_02.txt")));
-            Assert.True(File.Exists(Path.Combine(tempDir, "log_03.txt")));
-
-            logFactorySlow.GetCurrentClassLogger().Info("Slow2");
-
-            logFactoryFast.Shutdown();
-            logFactorySlow.Shutdown();
-
-            using (var logFile = new StreamReader(new FileStream(Path.Combine(tempDir, "log_03.txt"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
+            catch (Exception ex)
             {
-                Assert.Equal("Fast9", logFile.ReadLine());
-                Assert.Equal("Slow2", logFile.ReadLine());
-                Assert.Null(logFile.ReadLine());
+                throw new Exception(logWriter.ToString(), ex);
             }
-
-            if (Directory.Exists(tempDir))
-                Directory.Delete(tempDir, true);
+            finally
+            {
+                NLog.Common.InternalLogger.LogWriter = null;
+                LogManager.ThrowExceptions = true;
+            }
         }
     }
 }

--- a/tests/NLog.Targets.AtomicFile.Tests/AtomicFileTests.cs
+++ b/tests/NLog.Targets.AtomicFile.Tests/AtomicFileTests.cs
@@ -84,5 +84,75 @@ namespace NLog.Targets.AtomicFile.Tests
                     Directory.Delete(tempDir, true);
             }
         }
+
+        [Fact]
+        public void FastAndSlowAtomicFileWriters()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "nlog_" + Guid.NewGuid().ToString());
+            var logFileName = Path.Combine(tempDir, "log.txt");
+
+            var logFactoryFast = new LogFactory().Setup().LoadConfiguration(cfg =>
+            {
+                cfg.ForLogger().WriteTo(new AtomicFileTarget()
+                {
+                    FileName = logFileName,
+                    Layout = "${message}",
+                    LineEnding = LineEndingMode.LF,
+                    ArchiveAboveSize = 15,
+                    MaxArchiveFiles = 2,
+                });
+            }).LogFactory;
+
+            var logFactorySlow = new LogFactory().Setup().LoadConfiguration(cfg =>
+            {
+                cfg.ForLogger().WriteTo(new AtomicFileTarget()
+                {
+                    FileName = logFileName,
+                    Layout = "${message}",
+                    LineEnding = LineEndingMode.LF,
+                    ArchiveAboveSize = 15,
+                    MaxArchiveFiles = 2,
+                });
+            }).LogFactory;
+
+            logFactoryFast.GetCurrentClassLogger().Info("Fast1");
+            logFactorySlow.GetCurrentClassLogger().Info("Slow1");
+
+            using (var logFile = new StreamReader(new FileStream(logFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
+            {
+                Assert.Equal("Fast1", logFile.ReadLine());
+                Assert.Equal("Slow1", logFile.ReadLine());
+                Assert.Null(logFile.ReadLine());
+            }
+
+            logFactoryFast.GetCurrentClassLogger().Info("Fast2");
+            logFactoryFast.GetCurrentClassLogger().Info("Fast3");
+            logFactoryFast.GetCurrentClassLogger().Info("Fast4");
+            logFactoryFast.GetCurrentClassLogger().Info("Fast5");
+            logFactoryFast.GetCurrentClassLogger().Info("Fast6");
+            logFactoryFast.GetCurrentClassLogger().Info("Fast7");
+            logFactoryFast.GetCurrentClassLogger().Info("Fast8");
+            logFactoryFast.GetCurrentClassLogger().Info("Fast9");
+
+            Assert.False(File.Exists(logFileName));
+            Assert.False(File.Exists(Path.Combine(tempDir, "log_01.txt")));
+            Assert.True(File.Exists(Path.Combine(tempDir, "log_02.txt")));
+            Assert.True(File.Exists(Path.Combine(tempDir, "log_03.txt")));
+
+            logFactorySlow.GetCurrentClassLogger().Info("Slow2");
+
+            logFactoryFast.Shutdown();
+            logFactorySlow.Shutdown();
+
+            using (var logFile = new StreamReader(new FileStream(Path.Combine(tempDir, "log_03.txt"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
+            {
+                Assert.Equal("Fast9", logFile.ReadLine());
+                Assert.Equal("Slow2", logFile.ReadLine());
+                Assert.Null(logFile.ReadLine());
+            }
+
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
     }
 }


### PR DESCRIPTION
When having a mixture of very busy and very slow writers. Then the busy writers will drive the rolling file-sequence-number up, and actually starts doing cleanup of log-files still open by slow-writers. Because the slow-writer still have the open file-handle, then the file is not actually fully deleted and one can query the filesize (but file is not visible).

This gives a combination of slow-writers that detects their log-file is gone, and slow-writers that detects their log-filesize has been breached, and both cases causes them to roll, but they fail to recognize that the file-sequence-number has jumped, and they actually must fallback to enumerating all files in the directory to catch up.