### PR TITLE
JsonLayout - Escape lone surrogates so output stays valid UTF8

### DIFF
--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -620,15 +620,6 @@ namespace NLog.Targets
                     continue;
                 }
 
-                if (!escapeUnicode && char.IsHighSurrogate(ch) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]))
-                {
-                    // Valid surrogate-pair can be written as-is. Only lone surrogates need escaping,
-                    // since they cannot be encoded as UTF8 (and would corrupt the output)
-                    destination.Append(ch);
-                    destination.Append(text[++i]);
-                    continue;
-                }
-
                 switch (ch)
                 {
                     case '"':
@@ -660,10 +651,28 @@ namespace NLog.Targets
                         break;
 
                     default:
-                        destination.AppendFormat(CultureInfo.InvariantCulture, "\\u{0:x4}", (int)ch);
+                        if (escapeUnicode || !TryAppendSurrogatePair(destination, text, ref i))
+                            destination.AppendFormat(CultureInfo.InvariantCulture, "\\u{0:x4}", (int)ch);
                         break;
                 }
             }
+        }
+
+        /// <summary>
+        /// Writes a valid surrogate-pair as-is, since only lone surrogates need escaping.
+        /// A lone surrogate cannot be encoded as UTF8 (and would corrupt the output).
+        /// </summary>
+        /// <returns>Surrogate-pair written, and <paramref name="i"/> moved to its low surrogate.</returns>
+        private static bool TryAppendSurrogatePair(StringBuilder destination, string text, ref int i)
+        {
+            if (char.IsHighSurrogate(text[i]) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]))
+            {
+                destination.Append(text[i]);
+                destination.Append(text[++i]);
+                return true;
+            }
+
+            return false;
         }
 
         internal static void PerformJsonEscapeWhenNeeded(StringBuilder builder, int startPos, bool escapeUnicode)

--- a/src/NLog/Targets/DefaultJsonSerializer.cs
+++ b/src/NLog/Targets/DefaultJsonSerializer.cs
@@ -620,6 +620,15 @@ namespace NLog.Targets
                     continue;
                 }
 
+                if (!escapeUnicode && char.IsHighSurrogate(ch) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]))
+                {
+                    // Valid surrogate-pair can be written as-is. Only lone surrogates need escaping,
+                    // since they cannot be encoded as UTF8 (and would corrupt the output)
+                    destination.Append(ch);
+                    destination.Append(text[++i]);
+                    continue;
+                }
+
                 switch (ch)
                 {
                     case '"':
@@ -677,7 +686,7 @@ namespace NLog.Targets
             if (ch < 32)
                 return true;
             if (ch > 127)
-                return escapeUnicode;
+                return escapeUnicode || char.IsSurrogate(ch);
             return ch == '"' || ch == '\\';
         }
 

--- a/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
+++ b/tests/NLog.UnitTests/Layouts/JsonLayoutTests.cs
@@ -169,6 +169,28 @@ namespace NLog.UnitTests.Layouts
             Assert.Equal("{\"logger\":\"\\u00a9\",\"level\":\"Info\",\"message\":\"\u00a9\",\"a\":\"\\\\\",\"msg\":\"\u00a9\"}", jsonLayout.Render(logEventInfo));
         }
 
+        [Theory]
+        // Surrogates are built from char-codes, since a lone surrogate cannot survive as an InlineData string-literal
+        [InlineData("A{0}{1}B", "{\"msg\":\"A\ud83d\ude00B\"}")]   // Valid surrogate-pair is written as-is
+        [InlineData("A{0}B", "{\"msg\":\"A\\ud83dB\"}")]           // Lone high surrogate must be escaped
+        [InlineData("A{1}B", "{\"msg\":\"A\\ude00B\"}")]           // Lone low surrogate must be escaped
+        [InlineData("{0}", "{\"msg\":\"\\ud83d\"}")]
+        public void JsonLayoutRenderingLoneSurrogate(string messageFormat, string expected)
+        {
+            var message = string.Format(messageFormat, (char)0xd83d, (char)0xde00);
+
+            var jsonLayout = new JsonLayout()
+            {
+                Attributes = { new JsonAttribute("msg", "${message}") { EscapeUnicode = false } },
+            };
+
+            var logEventInfo = new LogEventInfo(LogLevel.Info, "logger1", message);
+            var result = jsonLayout.Render(logEventInfo);
+
+            Assert.Equal(expected, result);
+            new System.Text.UTF8Encoding(false, true).GetBytes(result);  // Must be encodable as UTF8
+        }
+
         [Fact]
         public void JsonLayoutRenderingAndEncodingSpecialCharacters()
         {


### PR DESCRIPTION
### Problem

An **unpaired surrogate** is written into JSON as-is, so the line is not UTF8-encodable — `RequiresJsonEscape` returns `EscapeUnicode` for every char > 127, and a lone surrogate has no UTF8 form. Easy to hit: truncating a message that ends mid-emoji leaves one.

```csharp
var layout = new JsonLayout { Attributes = { new JsonAttribute("msg", "${message}") } };
layout.Render(new LogEventInfo(LogLevel.Info, "l", "\ud83d"));
```

| | before | after |
|---|---|---|
| rendered | raw surrogate | `{"msg":"\ud83d"}` |
| strict UTF8 | **throws** | ok |
| lenient UTF8 | silently `�` | preserved |

### Why only JSON

`XmlHelper` already checks `XmlConvertIsXmlSurrogatePair` in three places. The JSON serializer was the one encoder without the check — same input and defaults, `XmlLayout` stays encodable, `JsonLayout` does not.

### Change

Escape lone surrogates as `\uXXXX`. **Valid pairs are still written as-is**, so existing output is byte-identical; only the broken case changes.

### Verified

- 4 new theory cases: fail 3/4 on `dev`, pass with the change.
- `dotnet test -f net8.0`, filtered to Layouts/Json/Xml/Csv/LayoutRenderers: **1259 passed, 0 failed**.
- Changing only the predicate (no pair passthrough) also stops the corruption, but escapes valid emoji too and changes existing output — hence the pair check.

Test builds surrogates from char-codes: a lone one cannot survive an `InlineData` literal.
