### PR TITLE
docs: document default values for Filters properties in XML docs

### DIFF
--- a/src/NLog/Filters/ConditionBasedFilter.cs
+++ b/src/NLog/Filters/ConditionBasedFilter.cs
@@ -50,6 +50,7 @@ namespace NLog.Filters
         /// <summary>
         /// Gets or sets the condition expression.
         /// </summary>
+        /// <remarks><b>[Required]</b> Default: <see langword="null"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public ConditionExpression Condition { get; set; } = ConditionLiteralExpression.Null;
 

--- a/src/NLog/Filters/Filter.cs
+++ b/src/NLog/Filters/Filter.cs
@@ -53,6 +53,7 @@ namespace NLog.Filters
         /// <summary>
         /// Gets or sets the action to be taken when filter matches.
         /// </summary>
+        /// <remarks>Default: <see cref="FilterResult.Neutral"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public FilterResult Action { get; set; }
 

--- a/src/NLog/Filters/LayoutBasedFilter.cs
+++ b/src/NLog/Filters/LayoutBasedFilter.cs
@@ -51,6 +51,7 @@ namespace NLog.Filters
         /// Gets or sets the layout to be used to filter log messages.
         /// </summary>
         /// <value>The layout.</value>
+        /// <remarks><b>[Required]</b> Default: <see cref="Layout.Empty"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public Layout Layout { get; set; } = Layout.Empty;
     }

--- a/src/NLog/Filters/WhenContainsFilter.cs
+++ b/src/NLog/Filters/WhenContainsFilter.cs
@@ -45,12 +45,14 @@ namespace NLog.Filters
         /// <summary>
         /// Gets or sets a value indicating whether to ignore case when comparing strings.
         /// </summary>
+        /// <remarks>Default: <see langword="false"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public bool IgnoreCase { get; set; }
 
         /// <summary>
         /// Gets or sets the substring to be matched.
         /// </summary>
+        /// <remarks><b>[Required]</b> Default: <see cref="string.Empty"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public string Substring { get; set; } = string.Empty;
 

--- a/src/NLog/Filters/WhenEqualFilter.cs
+++ b/src/NLog/Filters/WhenEqualFilter.cs
@@ -45,12 +45,14 @@ namespace NLog.Filters
         /// <summary>
         /// Gets or sets a value indicating whether to ignore case when comparing strings.
         /// </summary>
+        /// <remarks>Default: <see langword="false"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public bool IgnoreCase { get; set; }
 
         /// <summary>
         /// Gets or sets a string to compare the layout to.
         /// </summary>
+        /// <remarks>Default: <see cref="string.Empty"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public string CompareTo { get; set; } = string.Empty;
 

--- a/src/NLog/Filters/WhenNotContainsFilter.cs
+++ b/src/NLog/Filters/WhenNotContainsFilter.cs
@@ -45,12 +45,14 @@ namespace NLog.Filters
         /// <summary>
         /// Gets or sets the substring to be matched.
         /// </summary>
+        /// <remarks><b>[Required]</b> Default: <see cref="string.Empty"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public string Substring { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets a value indicating whether to ignore case when comparing strings.
         /// </summary>
+        /// <remarks>Default: <see langword="false"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public bool IgnoreCase { get; set; }
 

--- a/src/NLog/Filters/WhenNotEqualFilter.cs
+++ b/src/NLog/Filters/WhenNotEqualFilter.cs
@@ -52,12 +52,14 @@ namespace NLog.Filters
         /// <summary>
         /// Gets or sets a string to compare the layout to.
         /// </summary>
+        /// <remarks>Default: <see cref="string.Empty"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public string CompareTo { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets a value indicating whether to ignore case when comparing strings.
         /// </summary>
+        /// <remarks>Default: <see langword="false"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public bool IgnoreCase { get; set; }
 

--- a/src/NLog/Filters/WhenRepeatedFilter.cs
+++ b/src/NLog/Filters/WhenRepeatedFilter.cs
@@ -54,12 +54,14 @@ namespace NLog.Filters
         /// <summary>
         /// How long before a filter expires, and logging is accepted again
         /// </summary>
+        /// <remarks>Default: <c>10</c></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public int TimeoutSeconds { get; set; } = 10;
 
         /// <summary>
         /// Max length of filter values, will truncate if above limit
         /// </summary>
+        /// <remarks>Default: <c>1000</c></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public int MaxLength { get; set; } = 1000;
 
@@ -67,30 +69,35 @@ namespace NLog.Filters
         /// Applies the configured action to the initial logevent that starts the timeout period.
         /// Used to configure that it should ignore all events until timeout.
         /// </summary>
+        /// <remarks>Default: <see langword="false"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public bool IncludeFirst { get; set; }
 
         /// <summary>
         /// Max number of unique filter values to expect simultaneously
         /// </summary>
+        /// <remarks>Default: <c>50000</c></remarks>
         /// <docgen category='Filtering Options' order='100' />
         public int MaxFilterCacheSize { get; set; } = 50000;
 
         /// <summary>
         /// Default number of unique filter values to expect, will automatically increase if needed
         /// </summary>
+        /// <remarks>Default: <c>1000</c></remarks>
         /// <docgen category='Filtering Options' order='100' />
         public int DefaultFilterCacheSize { get; set; } = 1000;
 
         /// <summary>
         /// Insert FilterCount value into <see cref="LogEventInfo.Properties"/> when an event is no longer filtered
         /// </summary>
+        /// <remarks>Default: <see cref="string.Empty"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public string FilterCountPropertyName { get; set; } = string.Empty;
 
         /// <summary>
         /// Append FilterCount to the <see cref="LogEventInfo.Message"/> when an event is no longer filtered
         /// </summary>
+        /// <remarks>Default: <see cref="string.Empty"/></remarks>
         /// <docgen category='Filtering Options' order='10' />
         public string FilterCountMessageAppendFormat { get; set; } = string.Empty;
 
@@ -106,6 +113,7 @@ namespace NLog.Filters
         /// <summary>
         /// Default buffer size for the internal buffers
         /// </summary>
+        /// <remarks>Default: <c>1000</c></remarks>
         /// <docgen category='Filtering Options' order='100' />
         public int OptimizeBufferDefaultLength { get; set; } = 1000;
 


### PR DESCRIPTION

## Problem

Base: `NLog:dev` <- `dualfroz:feat/filters-default-value-xml-docs-5917`

Refs #5917

## Summary

#5917 asked for property default values to be visible in the generated XML
docs (Sandcastle docs / IntelliSense), not just in the source code. Three
PRs already landed for this (#5919 Targets and Layouts, #5922
LayoutRenderers, #5925 Target Wrappers), but the issue itself is still
open and the `NLog.Filters` namespace was never covered - none of its
properties document a default value.

This PR applies the same documented convention (`<remarks>Default: ...`,
and `<b>[Required]</b>` for properties a filter cannot function without)
to every settable property in `NLog.Filters`:

- `Filter.Action`
- `ConditionBasedFilter.Condition`
- `LayoutBasedFilter.Layout`
- `WhenContainsFilter.IgnoreCase`, `.Substring`
- `WhenEqualFilter.IgnoreCase`, `.CompareTo`
- `WhenNotContainsFilter.Substring`, `.IgnoreCase`
- `WhenNotEqualFilter.CompareTo`, `.IgnoreCase`
- `WhenRepeatedFilter.TimeoutSeconds`, `.MaxLength`, `.IncludeFirst`,
  `.MaxFilterCacheSize`, `.DefaultFilterCacheSize`,
  `.FilterCountPropertyName`, `.FilterCountMessageAppendFormat`,
  `.OptimizeBufferDefaultLength`

`WhenRepeatedFilter.OptimizeBufferReuse` is intentionally left alone -
it's `[Obsolete]` since NLog 5.0 and always returns `true`, so there is
no meaningful default left to document.

## Regression test

`FilterDefaultValueDocsTests.SettablePropertiesDocumentDefaultValue`
loads the XML doc file generated alongside `NLog.dll`
(`GenerateDocumentationFile` is already on for the project), then
reflects over every public settable property under `NLog.Filters` and
asserts its doc entry contains `Default:`. It fails for any current or
future property in that namespace that skips documenting its default,
not just the ones touched here.

## How to verify

```
dotnet test tests/NLog.UnitTests/NLog.UnitTests.csproj -f net8.0 -c Debug --filter "FullyQualifiedName~FilterDefaultValueDocsTests"
```

SDK: 9.0.317 (net8.0 runtime 8.0.30 installed alongside for the test host).

Result: 1/1 passed with the fix in place. Reverting the `src/NLog/Filters/*.cs`
changes (test file kept) makes the same test fail with 19 missing
properties reported, confirming it actually catches the regression.
